### PR TITLE
feat(clipboard): add set_clipboard_text + PyObjC acceleration for picture paste

### DIFF
--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -1,15 +1,12 @@
-"""Clipboard image extraction for macOS, Windows, Linux, and WSL2.
+"""Clipboard image extraction and text writing for macOS, Windows, Linux, WSL2.
 
-Provides a single function `save_clipboard_image(dest)` that checks the
-system clipboard for image data, saves it to *dest* as PNG, and returns
-True on success.  No external Python dependencies — uses only OS-level
-CLI tools that ship with the platform (or are commonly installed).
+Public API:
+  save_clipboard_image(dest)  — extract image → PNG file, returns True on success
+  has_clipboard_image()       — quick check: is there an image on the clipboard?
+  set_clipboard_text(text)    — replace clipboard content with *text*
 
-Platform support:
-  macOS   — osascript (always available), pngpaste (if installed)
-  Windows — PowerShell via WinForms, Get-Clipboard, file-drop fallback
-  WSL2    — powershell.exe via WinForms, Get-Clipboard, file-drop fallback
-  Linux   — wl-paste (Wayland), xclip (X11)
+macOS uses PyObjC (AppKit) when available for zero-subprocess clipboard access,
+falling back to osascript/pngpaste.  No external Python dependencies required.
 """
 
 import base64
@@ -23,6 +20,18 @@ from hermes_constants import is_wsl as _is_wsl
 
 logger = logging.getLogger(__name__)
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def set_clipboard_text(text: str) -> bool:
+    """Replace the system clipboard content with *text*.
+
+    Returns True on success, False if the clipboard could not be set.
+    """
+    if sys.platform == "darwin":
+        return _macos_set_text(text)
+    if sys.platform == "win32":
+        return _windows_set_text(text)
+    return _linux_set_text(text)
 
 
 def save_clipboard_image(dest: Path) -> bool:
@@ -492,3 +501,158 @@ def _xclip_save(dest: Path) -> bool:
         logger.debug("xclip image extraction failed: %s", e)
         dest.unlink(missing_ok=True)
     return False
+
+
+# ── set_clipboard_text implementations ──────────────────────────────────
+
+def _macos_set_text(text: str) -> bool:
+    """Set macOS clipboard to *text* using PyObjC, falling back to osascript."""
+    # Prefer PyObjC — no subprocess, no terminal flicker
+    try:
+        from AppKit import NSPasteboard, NSPasteboardTypeString
+        pb = NSPasteboard.generalPasteboard()
+        pb.clearContents()
+        pb.setString_forType_(text, NSPasteboardTypeString)
+        return True
+    except ImportError:
+        pass
+    except Exception as e:
+        logger.debug("PyObjC set_clipboard_text failed: %s", e)
+
+    # Fallback: osascript
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    try:
+        r = subprocess.run(
+            ["osascript", "-e", f'set the clipboard to "{escaped}"'],
+            capture_output=True, timeout=3,
+        )
+        return r.returncode == 0
+    except Exception as e:
+        logger.debug("osascript set clipboard text failed: %s", e)
+    return False
+
+
+def _windows_set_text(text: str) -> bool:
+    """Set Windows clipboard to *text* via PowerShell."""
+    ps = _get_ps_exe()
+    if ps is None:
+        return False
+    # Escape for PowerShell string (double quotes → backtick-double-quote)
+    safe = text.replace('"', '`"')
+    try:
+        r = _run_powershell(ps,
+            f'Set-Clipboard -Value "{safe}"',
+            timeout=5,
+        )
+        return r.returncode == 0
+    except Exception as e:
+        logger.debug("Windows set clipboard text failed: %s", e)
+    return False
+
+
+def _linux_set_text(text: str) -> bool:
+    """Set Linux clipboard to *text* using wl-copy or xclip."""
+    if os.environ.get("WAYLAND_DISPLAY"):
+        try:
+            r = subprocess.run(
+                ["wl-copy"],
+                input=text, text=True, capture_output=True, timeout=3,
+            )
+            if r.returncode == 0:
+                return True
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logger.debug("wl-copy set clipboard failed: %s", e)
+
+    try:
+        r = subprocess.run(
+            ["xclip", "-selection", "clipboard", "-in"],
+            input=text, text=True, capture_output=True, timeout=3,
+        )
+        return r.returncode == 0
+    except FileNotFoundError:
+        pass
+    except Exception as e:
+        logger.debug("xclip set clipboard failed: %s", e)
+    return False
+
+
+# ── macOS PyObjC acceleration ───────────────────────────────────────────
+
+def _macos_pyobjc_save(dest: Path) -> bool:
+    """Save clipboard image via PyObjC — faster than osascript, no flicker.
+
+    Tries PNG first, then TIFF (NSTIFFPboardType), matching the original
+    osascript fallback that handles both formats.
+    """
+    try:
+        from AppKit import NSPasteboard, NSPasteboardTypePNG
+        pb = NSPasteboard.generalPasteboard()
+        # Try PNG first
+        data = pb.dataForType_(NSPasteboardTypePNG)
+        if data is not None and data.length() > 0:
+            data.writeToFile_atomically_(str(dest), True)
+            if dest.exists() and dest.stat().st_size > 0:
+                return True
+        # Try TIFF — osascript handles it, so should PyObjC
+        try:
+            from AppKit import NSTIFFPboardType
+            tiff_data = pb.dataForType_(NSTIFFPboardType)
+            if tiff_data is not None and tiff_data.length() > 0:
+                tiff_data.writeToFile_atomically_(str(dest), True)
+                return dest.exists() and dest.stat().st_size > 0
+        except ImportError:
+            pass
+    except ImportError:
+        pass
+    except Exception as e:
+        logger.debug("PyObjC clipboard save failed: %s", e)
+    return False
+
+
+def _macos_pyobjc_has_image() -> bool:
+    """Check for clipboard image via PyObjC — checks both PNG and TIFF."""
+    try:
+        from AppKit import NSPasteboard, NSPasteboardTypePNG
+        pb = NSPasteboard.generalPasteboard()
+        data = pb.dataForType_(NSPasteboardTypePNG)
+        if data is not None and data.length() > 0:
+            return True
+        try:
+            from AppKit import NSTIFFPboardType
+            tiff_data = pb.dataForType_(NSTIFFPboardType)
+            if tiff_data is not None and tiff_data.length() > 0:
+                return True
+        except ImportError:
+            pass
+    except ImportError:
+        pass
+    except Exception:
+        pass
+    return False  # signal "not determined" — caller should fall back
+
+
+# ── Patch macOS save/has_image to prefer PyObjC ─────────────────────────
+
+# Override the module-level functions to try PyObjC first.
+# Preserves original osascript/pngpaste as fallback.
+_macos_has_image_orig = _macos_has_image
+_macos_save_orig = _macos_save
+
+
+def _macos_has_image() -> bool:
+    """Check for clipboard image — PyObjC fast path, osascript fallback."""
+    if _macos_pyobjc_has_image():
+        return True
+    # PyObjC said no or not installed — fall back to osascript.
+    # Always try osascript because it can detect edge cases that
+    # PyObjC might miss (e.g. pasted image in a format not covered).
+    return _macos_has_image_orig()
+
+
+def _macos_save(dest: Path) -> bool:
+    """Save clipboard image — PyObjC fast path, pngpaste/osascript fallback."""
+    if _macos_pyobjc_save(dest):
+        return True
+    return _macos_save_orig(dest)

--- a/tests/tools/test_clipboard.py
+++ b/tests/tools/test_clipboard.py
@@ -120,21 +120,24 @@ class TestMacosPngpaste:
 
 class TestMacosHasImage:
     def test_png_detected(self):
-        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+        with patch("hermes_cli.clipboard._macos_pyobjc_has_image", return_value=False), \
+             patch("hermes_cli.clipboard.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 stdout="«class PNGf», «class ut16»", returncode=0
             )
             assert _macos_has_image() is True
 
     def test_tiff_detected(self):
-        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+        with patch("hermes_cli.clipboard._macos_pyobjc_has_image", return_value=False), \
+             patch("hermes_cli.clipboard.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 stdout="«class TIFF»", returncode=0
             )
             assert _macos_has_image() is True
 
     def test_text_only(self):
-        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+        with patch("hermes_cli.clipboard._macos_pyobjc_has_image", return_value=False), \
+             patch("hermes_cli.clipboard.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 stdout="«class ut16», «class utf8»", returncode=0
             )
@@ -143,14 +146,16 @@ class TestMacosHasImage:
 
 class TestMacosOsascript:
     def test_no_image_type_in_clipboard(self, tmp_path):
-        with patch("hermes_cli.clipboard.subprocess.run") as mock_run:
+        with patch("hermes_cli.clipboard._macos_pyobjc_has_image", return_value=False), \
+             patch("hermes_cli.clipboard.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 stdout="«class ut16», «class utf8»", returncode=0
             )
             assert _macos_osascript(tmp_path / "out.png") is False
 
     def test_clipboard_info_fails(self, tmp_path):
-        with patch("hermes_cli.clipboard.subprocess.run", side_effect=Exception("fail")):
+        with patch("hermes_cli.clipboard._macos_pyobjc_has_image", return_value=False), \
+             patch("hermes_cli.clipboard.subprocess.run", side_effect=Exception("fail")):
             assert _macos_osascript(tmp_path / "out.png") is False
 
     def test_success_with_png(self, tmp_path):
@@ -162,7 +167,8 @@ class TestMacosOsascript:
                 return MagicMock(stdout="«class PNGf», «class ut16»", returncode=0)
             dest.write_bytes(FAKE_PNG)
             return MagicMock(stdout="", returncode=0)
-        with patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
+        with patch("hermes_cli.clipboard._macos_pyobjc_has_image", return_value=False), \
+             patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
             assert _macos_osascript(dest) is True
         assert dest.stat().st_size > 0
 
@@ -175,7 +181,8 @@ class TestMacosOsascript:
                 return MagicMock(stdout="«class TIFF»", returncode=0)
             dest.write_bytes(FAKE_PNG)
             return MagicMock(stdout="", returncode=0)
-        with patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
+        with patch("hermes_cli.clipboard._macos_pyobjc_has_image", return_value=False), \
+             patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
             assert _macos_osascript(dest) is True
 
     def test_extraction_returns_fail(self, tmp_path):
@@ -186,7 +193,8 @@ class TestMacosOsascript:
             if len(calls) == 1:
                 return MagicMock(stdout="«class PNGf»", returncode=0)
             return MagicMock(stdout="fail", returncode=0)
-        with patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
+        with patch("hermes_cli.clipboard._macos_pyobjc_has_image", return_value=False), \
+             patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
             assert _macos_osascript(dest) is False
 
     def test_extraction_writes_empty_file(self, tmp_path):
@@ -198,7 +206,8 @@ class TestMacosOsascript:
                 return MagicMock(stdout="«class PNGf»", returncode=0)
             dest.write_bytes(b"")
             return MagicMock(stdout="", returncode=0)
-        with patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
+        with patch("hermes_cli.clipboard._macos_pyobjc_has_image", return_value=False), \
+             patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
             assert _macos_osascript(dest) is False
 
 


### PR DESCRIPTION
- Add set_clipboard_text() — cross-platform clipboard text write (macOS: PyObjC → osascript fallback; Windows: PowerShell; Linux: wl-copy → xclip)
- Add PyObjC (AppKit) path for macOS clipboard operations: save, has_image, set_text — zero subprocess, no terminal flicker
- PyObjC is optional — clean fallback to osascript/pngpaste when not installed
- Keep existing public API unchanged (save_clipboard_image, has_clipboard_image are backward-compatible)

This enables background clipboard watching daemons to save screenshot images silently and replace clipboard content with file paths — no osascript subprocess, no UI flicker.

## What does this PR do?

Adds `set_clipboard_text()` for writing text to the system clipboard across macOS/Windows/Linux, and accelerates macOS clipboard read/write with PyObjC (AppKit) to eliminate subprocess overhead. The osascript approach used previously spawns a subprocess for every clipboard check, causing visible terminal flicker — PyObjC calls NSPasteboard API directly with zero subprocess cost. All existing public API is backward-compatible; PyObjC is optional with clean fallback.

## Related Issue

Fixes # (N/A)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/clipboard.py`:
  - New public API `set_clipboard_text(text)` → `bool` with `_macos_set_text`, `_windows_set_text`, `_linux_set_text` implementations
  - New `_macos_pyobjc_save()` — save clipboard image via NSPasteboard (PNG + TIFF)
  - New `_macos_pyobjc_has_image()` — check for PNG/TIFF via NSPasteboard
  - Patched `_macos_has_image()` and `_macos_save()` to prefer PyObjC fast path with osascript/pngpaste fallback preserved
  - Updated module docstring listing full public API
- `tests/tools/test_clipboard.py`:
  - Added `_macos_pyobjc_has_image` mock to all `TestMacosHasImage` and `TestMacosOsascript` tests to isolate the osascript fallback path from PyObjC

## How to Test

1. `python -m pytest tests/tools/test_clipboard.py -q` — 107 passed
2. macOS write: `set_clipboard_text('hello')` → Cmd+V to verify
3. macOS read: screenshot to clipboard → `save_clipboard_image('/tmp/test.png')` → verify file
4. Fallback: `pip uninstall pyobjc-framework-Cocoa -y` → retry steps 2-3 → confirm osascript path works
5. Linux: `echo "test" | xclip -selection clipboard -out` after `set_clipboard_text("test")`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (clipboard: 107/107)
- [x] I've added tests for my changes (updated osascript fallback tests with PyObjC mock)
- [x] I've tested on my platform: macOS 15.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module docstring + new function docstrings updated
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — all three platforms implemented
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

(N/A — this is a clipboard module change, not a skill)

## Screenshots / Logs

```
$ python -m pytest tests/tools/test_clipboard.py -q
........................................................................ [ 67%]
...................................                                      [100%]
107 passed in 1.03s
```
