### PR TITLE
fix(auxiliary): respect auxiliary.title_generation.enabled config

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12658,7 +12658,19 @@ class HermesCLI:
             response = result.get("final_response", "") if result else ""
 
             # Auto-generate session title after first exchange (non-blocking)
-            if response and result and not result.get("failed") and not result.get("partial"):
+            # Respect auxiliary.title_generation.enabled config (#41744)
+            _title_gen_enabled = True
+            try:
+                _aux_cfg = self.config.get("auxiliary", {}) if hasattr(self, "config") and self.config else {}
+                if isinstance(_aux_cfg, dict):
+                    for _key in ("title", "title_generation"):
+                        _sub = _aux_cfg.get(_key, {})
+                        if isinstance(_sub, dict) and "enabled" in _sub:
+                            _title_gen_enabled = bool(_sub["enabled"])
+                            break
+            except Exception:
+                pass
+            if _title_gen_enabled and response and result and not result.get("failed") and not result.get("partial"):
                 try:
                     from agent.title_generator import maybe_auto_title
                     # Route title-generation failures through the agent's

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18680,7 +18680,20 @@ class GatewayRunner:
             _effective_history_offset = 0 if _session_was_split else len(agent_history)
 
             # Auto-generate session title after first exchange (non-blocking)
-            if final_response and self._session_db:
+            # Respect auxiliary.title_generation.enabled config (#41744)
+            _title_gen_enabled = True
+            try:
+                from hermes_cli.config import load_config as _load_full_cfg
+                _aux = _load_full_cfg().get("auxiliary", {})
+                if isinstance(_aux, dict):
+                    for _key in ("title", "title_generation"):
+                        _sub = _aux.get(_key, {})
+                        if isinstance(_sub, dict) and "enabled" in _sub:
+                            _title_gen_enabled = bool(_sub["enabled"])
+                            break
+            except Exception:
+                pass
+            if _title_gen_enabled and final_response and self._session_db:
                 try:
                     from agent.title_generator import maybe_auto_title
                     all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1279,6 +1279,7 @@ DEFAULT_CONFIG = {
             "extra_body": {},
         },
         "title_generation": {
+            "enabled": True,    # set false to disable auto-title generation
             "provider": "auto",
             "model": "",
             "base_url": "",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4314,6 +4314,90 @@ def test_prompt_submit_skips_auto_title_when_response_empty(monkeypatch):
     mock_title.assert_not_called()
 
 
+def test_prompt_submit_skips_auto_title_when_disabled_in_config(monkeypatch):
+    """maybe_auto_title must NOT be called when auxiliary.title_generation.enabled is False."""
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            return {
+                "final_response": "Rome was founded in 753 BC.",
+                "messages": [
+                    {"role": "user", "content": "Tell me about Rome"},
+                    {"role": "assistant", "content": "Rome was founded in 753 BC."},
+                ],
+            }
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"auxiliary": {"title_generation": {"enabled": False}}},
+    )
+
+    with patch("agent.title_generator.maybe_auto_title") as mock_title:
+        server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "Tell me about Rome"},
+            }
+        )
+
+    mock_title.assert_not_called()
+
+
+def test_prompt_submit_skips_auto_title_when_disabled_via_title_key(monkeypatch):
+    """maybe_auto_title must NOT be called when auxiliary.title.enabled is False."""
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            return {
+                "final_response": "Rome was founded in 753 BC.",
+                "messages": [
+                    {"role": "user", "content": "Tell me about Rome"},
+                    {"role": "assistant", "content": "Rome was founded in 753 BC."},
+                ],
+            }
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"auxiliary": {"title": {"enabled": False}}},
+    )
+
+    with patch("agent.title_generator.maybe_auto_title") as mock_title:
+        server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "Tell me about Rome"},
+            }
+        )
+
+    mock_title.assert_not_called()
+
+
 def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):
     """When the backend fails with no visible response (e.g. invalid model slug
     → provider 4xx), the TUI must surface result['error'] as visible text

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4882,8 +4882,22 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         # Transient DB failure — keep pending_title for retry.
                         pass
 
+            # Respect auxiliary.title_generation.enabled config (#41744)
+            _title_gen_enabled = True
+            try:
+                from hermes_cli.config import load_config as _load_full_cfg
+                _aux = _load_full_cfg().get("auxiliary", {})
+                if isinstance(_aux, dict):
+                    for _key in ("title", "title_generation"):
+                        _sub = _aux.get(_key, {})
+                        if isinstance(_sub, dict) and "enabled" in _sub:
+                            _title_gen_enabled = bool(_sub["enabled"])
+                            break
+            except Exception:
+                pass
             if (
-                status == "complete"
+                _title_gen_enabled
+                and status == "complete"
                 and isinstance(raw, str)
                 and raw.strip()
                 and isinstance(text, str)


### PR DESCRIPTION
## What does this PR do?

The `auxiliary.title_generation.enabled` config key was not checked before calling `maybe_auto_title()`. Setting it to `false` in `config.yaml` had no effect — title generation still fired unconditionally on the first exchange. This PR adds the missing config check at all three call sites (CLI, Gateway, TUI/Desktop).

## Related Issue

Fixes #41744

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: Add `enabled: True` default to `auxiliary.title_generation` config block
- `cli.py`: Check `auxiliary.title_generation.enabled` (or `auxiliary.title.enabled`) before calling `maybe_auto_title()` in CLI session handler
- `gateway/run.py`: Same config check in Gateway's `_process_message_background()` 
- `tui_gateway/server.py`: Same config check in TUI/Desktop's `_run_prompt_submit()`
- `tests/test_tui_gateway_server.py`: Two new tests — one for `title_generation.enabled: False`, one for `title.enabled: False`

## How to Test

1. Set `auxiliary.title_generation.enabled: false` in `~/.hermes/config.yaml`
2. Start a new CLI session (`hermes chat`) and send a message
3. Verify no title is auto-generated (check with `/status`)
4. Remove the `enabled: false` line and restart — title should generate again
5. Run `pytest tests/test_tui_gateway_server.py -k "auto_title_when_disabled" -xvs` to verify the new tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `maybe_auto_title` callers (3 sites: cli.py:12661, gateway/run.py:18683, tui_gateway/server.py:4885)
- Checked: `auxiliary.title_generation` config definition (hermes_cli/config.py:1281)
- Blast radius: LOW — adds a guard before an existing call; no control-flow change when `enabled` is True (default)
- Related patterns: `compression.enabled` pattern in `agent/agent_init.py:1306`
