### PR TITLE
feat(desktop): route explicit-link preview targets through file tab system

### DIFF
--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -120,6 +120,45 @@ describe('preview store', () => {
     expect($previewTarget.get()).toEqual(withRenderMode(preview, 'preview'))
   })
 
+  it('routes explicit-link previews through file tabs instead of legacy target', () => {
+    const a = previewTarget('/work/plan.md')
+    const b = previewTarget('/work/script.md')
+
+    setCurrentSessionPreviewTarget(a, 'explicit-link')
+
+    expect($filePreviewTabs.get()).toHaveLength(1)
+    expect($filePreviewTarget.get()).toEqual(withRenderMode(a, 'preview'))
+    expect($previewTarget.get()).toBeNull()
+
+    setCurrentSessionPreviewTarget(b, 'explicit-link')
+
+    expect($filePreviewTabs.get()).toHaveLength(2)
+    expect($filePreviewTabs.get().map(tab => tab.target.url)).toEqual([
+      'file:///work/plan.md',
+      'file:///work/script.md'
+    ])
+    expect($filePreviewTarget.get()).toEqual(withRenderMode(b, 'preview'))
+  })
+
+  it('re-selects existing tab when explicit-link opens same file again', () => {
+    const target = previewTarget('/work/plan.md')
+
+    setCurrentSessionPreviewTarget(target, 'explicit-link')
+    setCurrentSessionPreviewTarget(target, 'explicit-link')
+
+    expect($filePreviewTabs.get()).toHaveLength(1)
+    expect($filePreviewTarget.get()).toEqual(withRenderMode(target, 'preview'))
+  })
+
+  it('keeps tool-result on legacy single-target path', () => {
+    const target = previewTarget('/work/output.html')
+
+    setCurrentSessionPreviewTarget(target, 'tool-result')
+
+    expect($filePreviewTabs.get()).toHaveLength(0)
+    expect($previewTarget.get()).toEqual(withRenderMode(target, 'preview'))
+  })
+
   it('keeps file tabs when a live preview opens', () => {
     const file = previewTarget('/work/file.html')
     const live = previewTarget('/work/live.html')

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -113,9 +113,10 @@ function openFilePreviewTarget(target: PreviewTarget) {
   selectRightRailTab(id)
 }
 
-// Manual/file-browser opens are "peeking at a file" → source view in the file
-// pane. Tool/explicit-link opens are runnable artifacts → live preview pane.
-function isFilePreviewSource(source: PreviewRecordSource): boolean {
+// File-pane opens get the source-text view (peeking at a file). Other sources
+// that route through the file tab system (explicit-link from assistant) get
+// the rendered preview view.
+function isSourceViewSource(source: PreviewRecordSource): boolean {
   return source === 'file-browser' || source === 'manual'
 }
 
@@ -124,13 +125,16 @@ function previewTargetForSource(target: PreviewTarget, source: PreviewRecordSour
     return target
   }
 
-  return { ...target, renderMode: isFilePreviewSource(source) ? 'source' : 'preview' }
+  return { ...target, renderMode: isSourceViewSource(source) ? 'source' : 'preview' }
 }
 
+// Route file-kind targets through the file tab system so each distinct file
+// gets its own tab (new file = new tab; same file URL replaces in place).
+// tool-result is kept on the legacy single-target path to avoid auto-spamming
+// tabs from background tool output.
 function tryOpenFilePreview(target: PreviewTarget, source: PreviewRecordSource): boolean {
-  if (target.kind !== 'file' || !isFilePreviewSource(source)) {
-    return false
-  }
+  if (target.kind !== 'file') return false
+  if (source === 'tool-result') return false
 
   openFilePreviewTarget(previewTargetForSource(target, source))
 


### PR DESCRIPTION
## Problem

In the Desktop right-rail preview pane, `explicit-link` sources (Preview links emitted in assistant messages, e.g. `[Preview: foo.md](#preview/file:///...)`) go through the legacy single `$previewTarget` atom instead of the file-tab system. Each new Preview link **clobbers the previous one** — if the agent surfaces three files in a row, only the last is visible.

This is especially painful in workflows where the assistant emits multiple Preview links per turn (note-taking, code review, multi-file artifacts).

## Solution

Route all file-kind preview targets through the existing `openFilePreviewTarget` tab system, **except** `tool-result` (which would auto-spam tabs from background tool output).

| Source | Before | After |
|---|---|---|
| `file-browser` / `manual` | File tab ✅ | File tab ✅ (unchanged) |
| `explicit-link` | Legacy single target ❌ | File tab ✅ |
| `tool-result` | Legacy single target | Legacy single target (unchanged) |

Behaviour after the change:
- Click `[Preview: a.md]` → new tab, `a.md` selected
- Click `[Preview: b.md]` → new tab next to `a.md`, `b.md` selected (a.md still there)
- Click `[Preview: a.md]` again → existing tab re-selected (idempotent, no duplicate)
- Tool-result preview → still single-target (unchanged)

## Changes

- **`preview.ts`**: Renamed `isFilePreviewSource` → `isSourceViewSource` (no longer gates tab routing, only render mode). Updated `tryOpenFilePreview` to exclude `tool-result` instead of requiring `file-browser`/`manual`.
- **`preview.test.ts`**: Added 3 tests — explicit-link creates file tabs, same-file re-select is idempotent, tool-result stays on legacy path.

## Relationship to #41702

- **#41702** (Auto-open assistant-message preview attachments): controls **whether** a Preview link auto-opens (renderer mount-time). This PR controls **how** the open is routed (single-target vs. tab system). Both are needed for the full workflow.

Closes #41736
