### PR TITLE
fix(gateway): isolate DM sessions on user_id when chat_id is absent

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -635,6 +635,22 @@ def build_session_key(
             if source.thread_id:
                 return f"agent:main:{platform}:dm:{dm_chat_id}:{source.thread_id}"
             return f"agent:main:{platform}:dm:{dm_chat_id}"
+        # No chat_id — fall back to the sender's own identifier before the
+        # bare per-platform sink.  Without this, every DM from every user that
+        # arrives without a chat_id (non-standard adapters / synthetic sources)
+        # collapses into one shared "agent:main:<platform>:dm" session, and a
+        # single cached agent ends up serving multiple people's conversations —
+        # cross-user history bleed.  participant_id keeps DMs isolated per user.
+        dm_participant_id = source.user_id_alt or source.user_id
+        if dm_participant_id and source.platform == Platform.WHATSAPP:
+            dm_participant_id = (
+                canonical_whatsapp_identifier(str(dm_participant_id))
+                or dm_participant_id
+            )
+        if dm_participant_id:
+            if source.thread_id:
+                return f"agent:main:{platform}:dm:{dm_participant_id}:{source.thread_id}"
+            return f"agent:main:{platform}:dm:{dm_participant_id}"
         if source.thread_id:
             return f"agent:main:{platform}:dm:{source.thread_id}"
         return f"agent:main:{platform}:dm"

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -784,6 +784,53 @@ class TestWhatsAppSessionKeyConsistency:
         assert build_session_key(second) == "agent:main:telegram:dm:100"
         assert build_session_key(first) != build_session_key(second)
 
+    def test_dm_without_chat_id_falls_back_to_user_id(self):
+        """A DM source missing chat_id must isolate on the sender's user_id
+        rather than collapsing into the shared per-platform sink."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="",
+            chat_type="dm",
+            user_id="jordan",
+        )
+        assert build_session_key(source) == "agent:main:telegram:dm:jordan"
+
+    def test_dm_without_chat_id_distinct_users_do_not_collide(self):
+        """Two different DM senders without chat_id must not share one
+        session (the cross-user history-bleed footgun)."""
+        first = SessionSource(
+            platform=Platform.TELEGRAM, chat_id="", chat_type="dm", user_id="jordan"
+        )
+        second = SessionSource(
+            platform=Platform.TELEGRAM, chat_id="", chat_type="dm", user_id="dima"
+        )
+        assert build_session_key(first) != build_session_key(second)
+        assert build_session_key(first) == "agent:main:telegram:dm:jordan"
+        assert build_session_key(second) == "agent:main:telegram:dm:dima"
+
+    def test_dm_without_chat_id_prefers_user_id_alt(self):
+        """user_id_alt wins over user_id for the DM fallback, matching the
+        group-path participant precedence."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="",
+            chat_type="dm",
+            user_id="primary",
+            user_id_alt="alt",
+        )
+        assert build_session_key(source) == "agent:main:telegram:dm:alt"
+
+    def test_dm_without_chat_id_or_user_id_falls_back_to_thread_then_sink(self):
+        """With neither chat_id nor user identifiers, thread_id is the next
+        discriminator; only a completely identifier-less DM hits the sink."""
+        threaded = SessionSource(
+            platform=Platform.TELEGRAM, chat_id="", chat_type="dm", thread_id="7"
+        )
+        assert build_session_key(threaded) == "agent:main:telegram:dm:7"
+
+        bare = SessionSource(platform=Platform.TELEGRAM, chat_id="", chat_type="dm")
+        assert build_session_key(bare) == "agent:main:telegram:dm"
+
     def test_discord_group_includes_chat_id(self):
         """Group/channel keys include chat_type and chat_id."""
         source = SessionSource(


### PR DESCRIPTION
## Summary
DMs that arrive without a `chat_id` no longer collapse into one shared session — they isolate on the sender's `user_id`, so a single cached agent can't serve multiple users' conversations.

Root cause: `build_session_key()` had a fallback sink — any DM `SessionSource` with a falsy `chat_id` (and no `thread_id`) returned the bare `agent:main:<platform>:dm` key. Every such DM, regardless of sender, mapped to the same key → the same cached `AIAgent` (and its `self.messages`) → cross-user history bleed. Telegram's normal event path always sets `chat_id`, so this hardens synthetic sources and non-standard/custom adapters that don't.

## Changes
- `gateway/session.py`: DM branch falls back to `user_id_alt`/`user_id` (with WhatsApp identifier canonicalization, matching the group path) before the bare per-platform sink. `thread_id` remains the next discriminator; only a fully identifier-less DM hits the sink.
- `tests/gateway/test_session.py`: 4 regression tests — user_id fallback, distinct users don't collide, `user_id_alt` precedence, and thread/sink fallback ordering.

## Validation
| DM source (no chat_id) | Before | After |
|---|---|---|
| user_id=jordan | `agent:main:telegram:dm` | `agent:main:telegram:dm:jordan` |
| user_id=dima | `agent:main:telegram:dm` (collides) | `agent:main:telegram:dm:dima` (isolated) |
| no user_id, thread_id=7 | `agent:main:telegram:dm:7` | `agent:main:telegram:dm:7` (unchanged) |
| no identifiers | `agent:main:telegram:dm` | `agent:main:telegram:dm` (unchanged) |

`tests/gateway/test_session.py` — 27 passed (4 new).

## Scope note (re #37555)
This closes the cross-user session-collision footgun. It does **not** address the reporter's other observations: the user↔user "blend" in a Telegram forum topic is the by-design shared-thread session (`thread_sessions_per_user=False`), and the "tool-trace leakage" is `tool_progress` display mode rendering tool bubbles — both configurable/intended, not bugs.

Refs #37555

## Infographic

![dm-session-isolation](https://v3b.fal.media/files/b/0a9d6bfc/iRHm5Oni_u3e7QKfnA9UP_BLNun2vS.png)
