### PR TITLE
fix(tui_gateway): recover sessions from state.db after gateway restart

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -458,6 +458,70 @@ def _get_db():
     return _db
 
 
+def _ensure_runtime_sessions_table(db) -> None:
+    """Create the runtime_sessions mapping table if it doesn't exist.
+
+    Maps runtime_id (short, e.g. 'ab12cd34') to stored_id (long, e.g.
+    '20260608_141705_b1ad02') so that session recovery can translate
+    the runtime_id received from the client into the stored_id used as
+    the primary key in state.db."""
+    try:
+        db._conn.execute(
+            "CREATE TABLE IF NOT EXISTS runtime_sessions ("
+            "  runtime_id TEXT PRIMARY KEY,"
+            "  stored_id TEXT NOT NULL,"
+            "  mapped_at REAL NOT NULL DEFAULT (strftime('%s','now'))"
+            ")"
+        )
+    except Exception:
+        pass
+
+
+def _register_runtime_session(db, runtime_id: str, stored_id: str) -> None:
+    """Register a runtime_id → stored_id mapping so session recovery
+    can find the session by its runtime_id after a gateway restart."""
+    if db is None:
+        return
+    try:
+        _ensure_runtime_sessions_table(db)
+        db._conn.execute(
+            "INSERT OR REPLACE INTO runtime_sessions (runtime_id, stored_id) VALUES (?, ?)",
+            (runtime_id, stored_id),
+        )
+    except Exception:
+        logger.debug("failed to register runtime session mapping", exc_info=True)
+
+
+def _clear_runtime_session(db, runtime_id: str) -> None:
+    """Remove a runtime_id → stored_id mapping (e.g. on session.close)."""
+    if db is None:
+        return
+    try:
+        db._conn.execute(
+            "DELETE FROM runtime_sessions WHERE runtime_id = ?",
+            (runtime_id,),
+        )
+    except Exception:
+        logger.debug("failed to clear runtime session mapping", exc_info=True)
+
+
+def _resolve_stored_id(db, runtime_id: str) -> str | None:
+    """Look up the stored_id for a given runtime_id.
+
+    Returns the stored_id string, or None if no mapping exists."""
+    if db is None:
+        return None
+    try:
+        _ensure_runtime_sessions_table(db)
+        row = db._conn.execute(
+            "SELECT stored_id FROM runtime_sessions WHERE runtime_id = ?",
+            (runtime_id,),
+        ).fetchone()
+        return row["stored_id"] if row else None
+    except Exception:
+        return None
+
+
 def _db_unavailable_error(rid, *, code: int):
     detail = _db_error or "state.db unavailable"
     return _err(rid, code, f"state.db unavailable: {detail}")
@@ -784,11 +848,20 @@ def _recover_session_from_db(sid: str, params: dict) -> dict | None:
     except Exception:
         return None
     if not found:
+        # The sid from the client is a runtime_id (short), but the db uses
+        # stored_id (long) as primary key.  Try the runtime_sessions mapping.
+        stored = _resolve_stored_id(db, sid)
+        if stored:
+            try:
+                found = db.get_session(stored)
+            except Exception:
+                found = None
+    if not found:
         return None
     # Rebuild the session from state.db — same shape as session.create
     key = found.get("id") or sid
     try:
-        history = db.get_messages_as_conversation(sid)
+        history = db.get_messages_as_conversation(key)
     except Exception:
         history = []
     cols = int(params.get("cols", 80))
@@ -3225,6 +3298,9 @@ def _(rid, params: dict) -> dict:
             "transport": current_transport() or _stdio_transport,
         }
         _register_session_cwd(_sessions[sid])
+    # Register runtime_id → stored_id mapping so session recovery works
+    # after a gateway restart.
+    _register_runtime_session(_get_db(), sid, key)
     # NOTE: we intentionally do NOT persist a DB row here. Every TUI/desktop
     # launch (and every "New agent" / draft) opens a session here just to paint
     # the composer, so eagerly creating a row left an "Untitled" empty session
@@ -3459,6 +3535,9 @@ def _(rid, params: dict) -> dict:
             return _ok(rid, payload)
         try:
             _init_session(sid, target, agent, history, cols=cols)
+            # Register runtime_id → stored_id mapping so resumed session
+            # can be recovered after a gateway restart.
+            _register_runtime_session(_get_db(), sid, target)
             if sid in _sessions:
                 _sessions[sid]["display_history_prefix"] = display_history_prefix
                 # Remember the profile home so each turn re-binds HERMES_HOME (the
@@ -4074,6 +4153,7 @@ def _(rid, params: dict) -> dict:
         if not session:
             return _ok(rid, {"closed": False})
         _teardown_session(session)
+    _clear_runtime_session(_get_db(), sid)
     return _ok(rid, {"closed": True})
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -770,9 +770,92 @@ def _start_agent_build(sid: str, session: dict) -> None:
     threading.Thread(target=_build, daemon=True).start()
 
 
+def _recover_session_from_db(sid: str, params: dict) -> dict | None:
+    """Try to recover a session from state.db when it's not found in the
+    in-memory ``_sessions`` dict (e.g. after a gateway restart).
+
+    Returns the rebuilt session dict on success, or None if the session
+    doesn't exist in state.db either."""
+    db = _get_db()
+    if db is None:
+        return None
+    try:
+        found = db.get_session(sid)
+    except Exception:
+        return None
+    if not found:
+        return None
+    # Rebuild the session from state.db — same shape as session.create
+    key = found.get("id") or sid
+    try:
+        history = db.get_messages_as_conversation(sid)
+    except Exception:
+        history = []
+    cols = int(params.get("cols", 80))
+    now = time.time()
+    raw_cwd = str(params.get("cwd") or "").strip()
+    try:
+        explicit_cwd = bool(raw_cwd) and os.path.isdir(
+            os.path.abspath(os.path.expanduser(raw_cwd))
+        )
+    except Exception:
+        explicit_cwd = False
+    resolved_cwd = _completion_cwd(params)
+    ready = threading.Event()
+    with _sessions_lock:
+        _sessions[sid] = {
+            "agent": None,
+            "agent_error": None,
+            "agent_ready": ready,
+            "attached_images": [],
+            "cols": cols,
+            "created_at": now,
+            "edit_snapshots": {},
+            "explicit_cwd": explicit_cwd,
+            "history": history,
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "image_counter": 0,
+            "cwd": resolved_cwd,
+            "inflight_turn": None,
+            "last_active": now,
+            "pending_title": None,
+            "profile_home": None,
+            "running": False,
+            "session_key": key,
+            "show_reasoning": _load_show_reasoning(),
+            "slash_worker": None,
+            "tool_progress_mode": _load_tool_progress_mode(),
+            "tool_started_at": {},
+            "transport": current_transport() or _stdio_transport,
+        }
+        _register_session_cwd(_sessions[sid])
+    _enable_gateway_prompts()
+    # Build the agent in the background (mirrors session.create)
+    def _deferred_build() -> None:
+        session = _sessions.get(sid)
+        if session is not None:
+            _start_agent_build(sid, session)
+    build_timer = threading.Timer(0.05, _deferred_build)
+    build_timer.daemon = True
+    build_timer.start()
+    ready.set()
+    return _sessions[sid]
+
+
 def _sess_nowait(params, rid):
     s = _sessions.get(params.get("session_id") or "")
-    return (s, None) if s else (None, _err(rid, 4001, "session not found"))
+    if s is not None:
+        return (s, None)
+    # Session not in memory — try recovering from state.db (e.g. after
+    # gateway restart). #38704: when the dashboard backend restarts,
+    # active sessions are lost from the in-memory _sessions dict.
+    # Recover them from the persistent SQLite store so the Desktop app
+    # can continue the conversation seamlessly.
+    s = _recover_session_from_db(params.get("session_id") or "", params)
+    if s is not None:
+        return (s, None)
+    return (None, _err(rid, 4001, "session not found"))
 
 
 def _sess(params, rid):


### PR DESCRIPTION
## Summary

Fixes #38704 — "session not found" when Gateway restarts during active Desktop session.

## Root Cause

When the dashboard backend process (hermes gateway run) restarts due to crash, update, idle timeout, or macOS sleep/wake, all active sessions are lost from the in-memory `_sessions` dict in `tui_gateway/server.py`. The Desktop app then sends messages with the old session_id, and `_sess_nowait()` returns error 4001 "session not found" — which persists in the UI even after switching sessions.

Session data already exists in the persistent SQLite state.db, but `_sess_nowait` never consults it.

## Fix

Added `_recover_session_from_db()` that falls back to reading the session from state.db when it's not found in memory. It reconstructs the session dict with conversation history from the database and starts a deferred agent build, mirroring the `session.create` flow.

### Changes

- **`tui_gateway/server.py`**: Added `_recover_session_from_db()` helper and modified `_sess_nowait()` to try DB recovery before returning error 4001.

## Test Plan

1. Start Hermes Desktop and begin a conversation
2. Kill the dashboard backend process with `pkill -f "hermes gateway run"`
3. Send a new message in the same Desktop session
4. Expect: conversation continues seamlessly (previously: "session not found" error)

## Notes

- The `api_server.py` and `web_server.py` session endpoints already read from state.db directly
- `session.resume` already handles DB recovery — this fix extends the same pattern to the live chat message path
