### PR TITLE
feat: add Imgflip meme generator skill

### DIFF
--- a/optional-skills/creative/imgflip-meme-generator/SKILL.md
+++ b/optional-skills/creative/imgflip-meme-generator/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: imgflip-meme-generator
+description: Create memes with Imgflip's free API.
+version: 1.0.0
+author: Groot-claw (Groot-claw), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: IMGFLIP_USERNAME
+    prompt: Imgflip username
+    help: Use a throwaway Imgflip account. The free creation API uses account credentials, not an API key.
+    required_for: meme creation
+  - name: IMGFLIP_PASSWORD
+    prompt: Imgflip password
+    help: Store this in the local Hermes environment. Never paste it into chat.
+    required_for: meme creation
+metadata:
+  hermes:
+    tags: [creative, memes, imgflip, image-generation, api]
+    related_skills: [meme-generation]
+    category: creative
+---
+
+# Imgflip Meme Generator Skill
+
+Create hosted meme images through Imgflip's documented free-tier API. This skill is for classic Imgflip template captions, not private/internal memes or local-only rendering.
+
+## When to Use
+
+- The user asks to make a meme on the fly with Imgflip.
+- The user wants a classic meme template generated quickly.
+- The user asks what the Imgflip free API can do.
+
+## Prerequisites
+
+- `terminal` tool access.
+- Network access to `https://api.imgflip.com`.
+- For creation, `IMGFLIP_USERNAME` and `IMGFLIP_PASSWORD` must be available in the runtime environment.
+
+Imgflip's free creation endpoint does not use an API key. It uses account username/password in the POST body. Use a throwaway Imgflip account and never ask the user to paste credentials into chat.
+
+Generated Imgflip URLs are publicly accessible to anyone with the exact URL. Do not send private, customer, credential, or internal-sensitive content to Imgflip.
+
+## How to Run
+
+Use the helper script from this skill directory through the `terminal` tool:
+
+```bash
+python scripts/imgflip_free_tier.py list --limit 10
+```
+
+For creation, run with credentials already present in the environment:
+
+```bash
+python scripts/imgflip_free_tier.py make --template-id 181913649 --text0 "WRITING LONG PROMPTS" --text1 "MAKING ONE MEME COMMAND" --output meme.jpg
+```
+
+## Quick Reference
+
+Free-tier endpoints verified from `https://imgflip.com/api`:
+
+- `GET https://api.imgflip.com/get_memes`
+  - Free.
+  - No authentication required.
+  - Optional query parameter: `type=image`, `type=gif`, or `type=gif,image`; default is `image`.
+  - Returns popular captionable templates with fields such as `id`, `name`, `url`, `width`, `height`, and `box_count`.
+
+- `POST https://api.imgflip.com/caption_image`
+  - Free for creating watermarked meme images.
+  - Requires `template_id`, `username`, and `password` in the POST body.
+  - Simple mode: `text0` and `text1`.
+  - Multi-box mode: `boxes[0][text]`, `boxes[1][text]`, etc., up to 20 boxes.
+  - Optional parameters include `font` and `max_font_size`.
+  - `no_watermark` is Premium-only.
+
+Premium-only endpoints:
+
+- `POST /caption_gif`
+- `POST /search_memes`
+- `POST /get_meme`
+- `POST /automeme`
+- `POST /ai_meme`
+- `no_watermark` on creation
+
+## Procedure
+
+1. Determine the meme intent and joke structure.
+2. Fetch current popular templates if a template ID is needed:
+   ```bash
+   python scripts/imgflip_free_tier.py list --limit 20
+   ```
+3. Pick a known template ID or top-template name match.
+4. Keep captions short. Classic meme captions should usually be uppercase.
+5. Generate the image:
+   ```bash
+   python scripts/imgflip_free_tier.py make --template-name "Drake" --text0 "MANUAL IMAGE EDITING" --text1 "API MEMES ON DEMAND" --output meme.jpg
+   ```
+6. For templates with more than two text areas, use custom boxes:
+   ```bash
+   python scripts/imgflip_free_tier.py make --template-id 87743020 --boxes '[{"text":"OPTION A"},{"text":"OPTION B"},{"text":"ME"}]' --output meme.jpg
+   ```
+7. Return the generated image URL, or save the file to a platform-appropriate local path and return it as a `MEDIA:` attachment when needed.
+
+## Pitfalls
+
+- There is no official free-tier API key flow in the Imgflip docs; the creation endpoint uses account credentials.
+- The full template search endpoint is Premium-only. For free tier, use top templates or known template IDs.
+- Generated image URLs are not private.
+- When `boxes` is used, `text0` and `text1` are ignored and text is not automatically uppercased.
+- Long captions often make bad memes. Shorten before generating.
+
+## Verification
+
+Run the helper list command and verify it returns JSON with `success: true`:
+
+```bash
+python scripts/imgflip_free_tier.py list --limit 3
+```
+
+For creation, verify `POST /caption_image` returns `success: true`, the returned image URL downloads with an `image/*` content type, and the final response includes either the generated URL or a `MEDIA:` path.

--- a/optional-skills/creative/imgflip-meme-generator/scripts/imgflip_free_tier.py
+++ b/optional-skills/creative/imgflip-meme-generator/scripts/imgflip_free_tier.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Imgflip free-tier helper.
+
+Documented free-tier endpoints used:
+- GET /get_memes
+- POST /caption_image
+
+Credentials are read from IMGFLIP_USERNAME and IMGFLIP_PASSWORD. The script never
+prints credential values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, NoReturn
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlparse
+from urllib.request import Request, urlopen
+
+API_BASE = "https://api.imgflip.com"
+
+
+def die(message: str, code: int = 1) -> NoReturn:
+    print(json.dumps({"success": False, "error": message}, indent=2))
+    raise SystemExit(code)
+
+
+def http_get_json(url: str, params: dict[str, str] | None = None, timeout: int = 20) -> dict[str, Any]:
+    if params:
+        url = f"{url}?{urlencode(params)}"
+    request = Request(url, headers={"User-Agent": "Hermes-Agent-Imgflip-Skill/1.0"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            body = response.read()
+            status = response.status
+    except HTTPError as exc:
+        die(f"GET failed: HTTP {exc.code}: {exc.reason}")
+    except URLError as exc:
+        die(f"GET failed: {exc.reason}")
+    try:
+        data = json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        die(f"GET returned non-JSON response: HTTP {status}: {exc}")
+    if status != 200:
+        die(f"GET failed: HTTP {status}: {data}")
+    return data
+
+
+def http_post_json(url: str, payload: dict[str, Any], timeout: int = 30) -> dict[str, Any]:
+    encoded = urlencode({k: str(v) for k, v in payload.items()}).encode("utf-8")
+    request = Request(url, data=encoded, method="POST", headers={"User-Agent": "Hermes-Agent-Imgflip-Skill/1.0"})
+    request.add_header("Content-Type", "application/x-www-form-urlencoded")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            body = response.read()
+            status = response.status
+    except HTTPError as exc:
+        die(f"POST failed: HTTP {exc.code}: {exc.reason}")
+    except URLError as exc:
+        die(f"POST failed: {exc.reason}")
+    try:
+        data = json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        die(f"POST returned non-JSON response: HTTP {status}: {exc}")
+    if status != 200:
+        die(f"POST failed: HTTP {status}: {data}")
+    return data
+
+
+def validate_imgflip_image_url(url: str) -> None:
+    parsed = urlparse(url)
+    hostname = parsed.hostname or ""
+    if parsed.scheme != "https" or not (hostname == "imgflip.com" or hostname.endswith(".imgflip.com")):
+        die("Imgflip returned an unexpected image URL host; refusing to download it")
+
+
+def download(url: str, timeout: int = 20) -> tuple[int, str, bytes]:
+    validate_imgflip_image_url(url)
+    request = Request(url, headers={"User-Agent": "Hermes-Agent-Imgflip-Skill/1.0"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return response.status, response.headers.get("content-type", ""), response.read()
+    except HTTPError as exc:
+        die(f"Image download failed: HTTP {exc.code}: {exc.reason}")
+    except URLError as exc:
+        die(f"Image download failed: {exc.reason}")
+
+
+def get_memes(template_type: str = "image") -> list[dict[str, Any]]:
+    params = {"type": template_type} if template_type else {}
+    data = http_get_json(f"{API_BASE}/get_memes", params=params)
+    if not data.get("success"):
+        die(f"GET /get_memes failed: {data.get('error_message') or data}")
+    return data.get("data", {}).get("memes", [])
+
+
+def resolve_template(template_id: str | None, template_name: str | None, template_type: str) -> dict[str, Any]:
+    memes = get_memes(template_type)
+    if template_id:
+        for meme in memes:
+            if str(meme.get("id")) == str(template_id):
+                return meme
+        # Known IDs can still work even when they are not in the current top list.
+        return {"id": template_id, "name": None, "url": None, "box_count": None}
+
+    if template_name:
+        query = template_name.lower()
+        for meme in memes:
+            if query in meme.get("name", "").lower():
+                return meme
+        die(
+            f"No top-template match for {template_name!r}. "
+            "Free tier has no /search_memes; use a known template ID or Premium search."
+        )
+
+    die("Provide --template-id or --template-name")
+
+
+def list_templates(args: argparse.Namespace) -> None:
+    memes = get_memes(args.type)
+    print(json.dumps({"success": True, "count": len(memes), "templates": memes[: args.limit]}, indent=2))
+
+
+def load_credentials() -> tuple[str, str]:
+    username = os.getenv("IMGFLIP_USERNAME")
+    password = os.getenv("IMGFLIP_PASSWORD")
+    if not username or not password:
+        die("Missing IMGFLIP_USERNAME/IMGFLIP_PASSWORD. Load credentials from environment variables.", code=2)
+    return str(username), str(password)
+
+
+def add_boxes_to_payload(payload: dict[str, Any], boxes_json: str) -> None:
+    try:
+        boxes = json.loads(boxes_json)
+    except json.JSONDecodeError as exc:
+        die(f"--boxes must be valid JSON: {exc}")
+    if not isinstance(boxes, list):
+        die("--boxes must be a JSON list")
+    if len(boxes) > 20:
+        die("Imgflip currently limits caption_image to 20 text boxes per image")
+    for index, box in enumerate(boxes):
+        if not isinstance(box, dict) or "text" not in box:
+            die("Each box must be an object with at least a text field")
+        for key, value in box.items():
+            payload[f"boxes[{index}][{key}]"] = value
+
+
+def make_meme(args: argparse.Namespace) -> None:
+    username, password = load_credentials()
+    template = resolve_template(args.template_id, args.template_name, "image")
+    payload: dict[str, Any] = {
+        "template_id": str(template["id"]),
+        "username": username,
+        "password": password,
+    }
+
+    if args.boxes:
+        add_boxes_to_payload(payload, args.boxes)
+    else:
+        if args.text0 is None and args.text1 is None:
+            die("Provide --text0/--text1 or --boxes")
+        payload["text0"] = args.text0 or ""
+        payload["text1"] = args.text1 or ""
+
+    if args.font:
+        payload["font"] = args.font
+    if args.max_font_size:
+        payload["max_font_size"] = str(args.max_font_size)
+
+    data = http_post_json(f"{API_BASE}/caption_image", payload)
+    if not data.get("success"):
+        die(f"POST /caption_image failed: {data.get('error_message') or data}")
+
+    result = data.get("data", {})
+    verification: dict[str, Any] = {}
+    if result.get("url") and args.verify_download:
+        status, content_type, content = download(result["url"])
+        looks_like_image = status == 200 and content_type.startswith("image/")
+        verification = {
+            "download_status": status,
+            "content_type": content_type,
+            "bytes": len(content),
+            "looks_like_image": looks_like_image,
+        }
+        if args.output and looks_like_image:
+            output = Path(args.output).expanduser()
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_bytes(content)
+            verification["saved_to"] = str(output)
+
+    print(
+        json.dumps(
+            {
+                "success": True,
+                "template": {key: template.get(key) for key in ("id", "name", "url", "box_count")},
+                "url": result.get("url"),
+                "page_url": result.get("page_url"),
+                "verified": verification,
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Imgflip free-tier meme helper")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="List popular captionable templates via GET /get_memes")
+    list_parser.add_argument("--type", default="image", choices=["image", "gif", "gif,image", "image,gif"])
+    list_parser.add_argument("--limit", type=int, default=10)
+    list_parser.set_defaults(func=list_templates)
+
+    make_parser = subparsers.add_parser("make", help="Caption an image template via POST /caption_image")
+    template_group = make_parser.add_mutually_exclusive_group(required=True)
+    template_group.add_argument("--template-id")
+    template_group.add_argument("--template-name")
+    make_parser.add_argument("--text0")
+    make_parser.add_argument("--text1")
+    make_parser.add_argument("--boxes", help='JSON list of box objects, for example: [{"text":"TOP"},{"text":"BOTTOM"}]')
+    make_parser.add_argument("--font", default="impact")
+    make_parser.add_argument("--max-font-size", type=int)
+    make_parser.add_argument("--verify-download", action=argparse.BooleanOptionalAction, default=True)
+    make_parser.add_argument("--output", help="Optional local path to save the returned image")
+    make_parser.set_defaults(func=make_meme)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_imgflip_meme_generator_skill.py
+++ b/tests/skills/test_imgflip_meme_generator_skill.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from urllib.parse import parse_qs
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "creative"
+    / "imgflip-meme-generator"
+    / "scripts"
+    / "imgflip_free_tier.py"
+)
+
+
+class FakeHeaders(dict):
+    def get(self, key, default=None):
+        return super().get(key.lower(), default)
+
+
+class FakeResponse:
+    def __init__(self, payload: bytes, status: int = 200, content_type: str = "application/json"):
+        self._payload = payload
+        self.status = status
+        self.headers = FakeHeaders({"content-type": content_type})
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("imgflip_free_tier", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def json_response(payload: dict) -> FakeResponse:
+    return FakeResponse(json.dumps(payload).encode("utf-8"))
+
+
+def test_get_memes_lists_templates(monkeypatch):
+    module = load_module()
+
+    def fake_urlopen(request, timeout=20):
+        assert "get_memes" in request.full_url
+        return json_response(
+            {
+                "success": True,
+                "data": {
+                    "memes": [
+                        {
+                            "id": "181913649",
+                            "name": "Drake Hotline Bling",
+                            "url": "https://i.imgflip.com/30b1gx.jpg",
+                            "width": 1200,
+                            "height": 1200,
+                            "box_count": 2,
+                        }
+                    ]
+                },
+            }
+        )
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+    memes = module.get_memes()
+    assert memes[0]["id"] == "181913649"
+    assert memes[0]["box_count"] == 2
+
+
+def test_make_requires_environment_credentials(monkeypatch):
+    module = load_module()
+    monkeypatch.delenv("IMGFLIP_USERNAME", raising=False)
+    monkeypatch.delenv("IMGFLIP_PASSWORD", raising=False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.load_credentials()
+
+    assert exc_info.value.code == 2
+
+
+def test_download_rejects_unexpected_image_host(monkeypatch, capsys):
+    module = load_module()
+
+    def fake_urlopen(request, timeout=20):
+        raise AssertionError("download should be rejected before network access")
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.download("https://example.com/meme.jpg")
+
+    result = json.loads(capsys.readouterr().out)
+    assert exc_info.value.code == 1
+    assert result["success"] is False
+    assert "unexpected image URL host" in result["error"]
+
+
+def test_http_errors_return_json(monkeypatch, capsys):
+    module = load_module()
+
+    def fake_urlopen(request, timeout=20):
+        raise module.HTTPError(request.full_url, 403, "Forbidden", {}, None)
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.get_memes()
+
+    result = json.loads(capsys.readouterr().out)
+    assert exc_info.value.code == 1
+    assert result["success"] is False
+    assert "HTTP 403" in result["error"]
+
+
+def test_make_meme_posts_form_and_verifies_download(monkeypatch, tmp_path, capsys):
+    module = load_module()
+    monkeypatch.setenv("IMGFLIP_USERNAME", "example-user")
+    monkeypatch.setenv("IMGFLIP_PASSWORD", "example-password")
+
+    output_path = tmp_path / "meme.jpg"
+    calls = []
+
+    def fake_urlopen(request, timeout=20):
+        calls.append(request)
+        if "get_memes" in request.full_url:
+            return json_response(
+                {
+                    "success": True,
+                    "data": {
+                        "memes": [
+                            {
+                                "id": "181913649",
+                                "name": "Drake Hotline Bling",
+                                "url": "https://i.imgflip.com/30b1gx.jpg",
+                                "width": 1200,
+                                "height": 1200,
+                                "box_count": 2,
+                            }
+                        ]
+                    },
+                }
+            )
+        if "caption_image" in request.full_url:
+            form = parse_qs(request.data.decode("utf-8"))
+            assert form["username"] == ["example-user"]
+            assert form["password"] == ["example-password"]
+            assert form["template_id"] == ["181913649"]
+            assert form["text0"] == ["TOP"]
+            assert form["text1"] == ["BOTTOM"]
+            return json_response(
+                {
+                    "success": True,
+                    "data": {
+                        "url": "https://i.imgflip.com/example.jpg",
+                        "page_url": "https://imgflip.com/i/example",
+                    },
+                }
+            )
+        if "example.jpg" in request.full_url:
+            return FakeResponse(b"fake-jpeg", content_type="image/jpeg")
+        raise AssertionError(f"unexpected request: {request.full_url}")
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+    args = type(
+        "Args",
+        (),
+        {
+            "template_id": "181913649",
+            "template_name": None,
+            "boxes": None,
+            "text0": "TOP",
+            "text1": "BOTTOM",
+            "font": "impact",
+            "max_font_size": None,
+            "verify_download": True,
+            "output": str(output_path),
+        },
+    )()
+
+    module.make_meme(args)
+    result = json.loads(capsys.readouterr().out)
+
+    assert result["success"] is True
+    assert result["verified"]["content_type"] == "image/jpeg"
+    assert result["verified"]["looks_like_image"] is True
+    assert output_path.read_bytes() == b"fake-jpeg"
+    assert len(calls) == 3


### PR DESCRIPTION
## Summary
- Adds a new optional creative skill for generating Imgflip memes on the fly.
- Documents Imgflip's free-tier endpoints: `GET /get_memes` and `POST /caption_image`.
- Adds a stdlib-only helper script that lists templates, captions images, validates returned Imgflip image URLs, verifies image downloads, and saves the result locally when requested.
- Adds unit tests for template listing, missing credential handling, HTTP error handling, returned URL validation, and successful caption-image generation using mocked network calls.

## Privacy / safety
- No personal credentials, usernames, secret-manager details, local usernames, or local paths are included.
- The helper reads `IMGFLIP_USERNAME` and `IMGFLIP_PASSWORD` from the runtime environment and never prints them.
- The skill warns that generated Imgflip URLs are publicly accessible to anyone with the exact URL.
- Tests use mocked network calls and do not require live credentials.

## Verification
- `python3 -m py_compile optional-skills/creative/imgflip-meme-generator/scripts/imgflip_free_tier.py`
- `python3 optional-skills/creative/imgflip-meme-generator/scripts/imgflip_free_tier.py list --limit 1`
  - returned `success: true`
  - returned 100 templates
- `scripts/run_tests.sh tests/skills/test_imgflip_meme_generator_skill.py`
  - `5 tests passed`
- `python3 scripts/check-windows-footguns.py --diff origin/main`
  - no Windows footguns found
- `.venv/bin/python -m pytest tests/skills/test_imgflip_meme_generator_skill.py -o 'addopts=' -q`
  - `5 passed`
- Staged-file scan checked for personal markers and was clean.
