### PR TITLE
fix(status): always redact API keys

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -165,12 +165,12 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -14,6 +14,42 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     assert "tvly...cdef" in output
 
 
+def test_show_status_all_keeps_api_keys_redacted(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    google_key = "AIzaSyDXjAdMYZrhdXsEM_hvEcWX6XrYT_L7Eec"
+    github_key = "github-token-for-redaction-regression-value-1234567890"
+    anthropic_key = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890"
+
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_anthropic_key", lambda: anthropic_key, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+    monkeypatch.setenv("GOOGLE_API_KEY", google_key)
+    monkeypatch.setenv("GITHUB_TOKEN", github_key)
+
+    status_mod.show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert google_key not in output
+    assert github_key not in output
+    assert anthropic_key not in output
+    assert "AIza...7Eec" in output
+    assert "gith...7890" in output
+    assert "sk-a...7890" in output
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## Summary
- keep API key rows redacted even when `hermes status --all` is used
- add a regression test covering Google, GitHub, Anthropic, and `--all`

## Verification
- `git diff --check`
- `/home/clawd/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts=\"\" tests/hermes_cli/test_status.py -q`
- worktree `PYTHONPATH` status smoke confirmed raw key prefixes are absent