### PR TITLE
[verified] fix: allow multiple custom provider keys per endpoint

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4287,8 +4287,9 @@ def _save_custom_provider(
 ):
     """Save a custom endpoint to custom_providers in config.yaml.
 
-    Deduplicates by base_url — if the URL already exists, updates the
-    model name, context_length, and api_mode but doesn't add a duplicate entry.
+    Deduplicates by both ``base_url`` and ``api_key`` — if both match, updates
+    the existing entry's model and context settings. This allows multiple
+    keys for the same endpoint.
     Uses *name* when provided, otherwise auto-generates from the URL.
     """
     from hermes_cli.config import load_config, save_config
@@ -4298,33 +4299,48 @@ def _save_custom_provider(
     if not isinstance(providers, list):
         providers = []
 
-    # Check if this URL is already saved — update model/context_length if so
+    normalized_url = base_url.rstrip("/")
+
+    # Check if this exact endpoint credential pair is already saved.
     for entry in providers:
-        if isinstance(entry, dict) and entry.get("base_url", "").rstrip(
-            "/"
-        ) == base_url.rstrip("/"):
-            changed = False
-            if model and entry.get("model") != model:
-                entry["model"] = model
-                changed = True
-            if model and context_length:
-                models_cfg = entry.get("models", {})
-                if not isinstance(models_cfg, dict):
-                    models_cfg = {}
+        if not isinstance(entry, dict):
+            continue
+
+        entry_url = entry.get("base_url", "").rstrip("/")
+        entry_api_key = entry.get("api_key", "")
+        if entry_url != normalized_url or entry_api_key != api_key:
+            continue
+
+        changed = False
+        if model and entry.get("model") != model:
+            entry["model"] = model
+            changed = True
+
+        if model and context_length:
+            models_cfg = entry.get("models", {})
+            if not isinstance(models_cfg, dict):
+                models_cfg = {}
+            if models_cfg.get(model, {}).get("context_length") != context_length:
                 models_cfg[model] = {"context_length": context_length}
                 entry["models"] = models_cfg
                 changed = True
-            if api_mode:
-                if entry.get("api_mode") != api_mode:
-                    entry["api_mode"] = api_mode
-                    changed = True
-            elif "api_mode" in entry:
-                entry.pop("api_mode", None)
+
+        if name and entry.get("name") != name:
+            entry["name"] = name
+            changed = True
+
+        if api_mode:
+            if entry.get("api_mode") != api_mode:
+                entry["api_mode"] = api_mode
                 changed = True
-            if changed:
-                cfg["custom_providers"] = providers
-                save_config(cfg)
-            return  # already saved, updated if needed
+        elif "api_mode" in entry:
+            entry.pop("api_mode", None)
+            changed = True
+
+        if changed:
+            cfg["custom_providers"] = providers
+            save_config(cfg)
+        return  # already saved, updated if needed
 
     # Use provided name or auto-generate from URL
     if not name:
@@ -4344,7 +4360,6 @@ def _save_custom_provider(
     cfg["custom_providers"] = providers
     save_config(cfg)
     print(f'  💾 Saved to custom providers as "{name}" (edit in config.yaml)')
-
 
 def _model_flow_azure_foundry(config, current_model=""):
     """Azure Foundry provider: configure endpoint, auth mode, API mode, and model.

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -344,7 +344,7 @@ def test_model_flow_nous_offers_tool_gateway_prompt_when_unconfigured(monkeypatc
         "hermes_cli.auth.resolve_nous_runtime_credentials",
         lambda *args, **kwargs: {
             "base_url": "https://inference.example.com/v1",
-            "api_key": "***",
+            "api_key": "KEY1",
         },
     )
     monkeypatch.setattr(
@@ -711,11 +711,89 @@ def test_save_custom_provider_uses_provided_name(monkeypatch, tmp_path):
         "hermes_cli.config.load_config", lambda: yaml.safe_load(cfg_path.read_text()) or {},
     )
     saved = {}
+
     def _save(cfg):
         saved.update(cfg)
+
     monkeypatch.setattr("hermes_cli.config.save_config", _save)
 
     _save_custom_provider("http://localhost:11434/v1", name="Ollama")
     entries = saved.get("custom_providers", [])
     assert len(entries) == 1
     assert entries[0]["name"] == "Ollama"
+
+
+def test_save_custom_provider_updates_matching_base_url_and_api_key(monkeypatch):
+    """Reusing the same endpoint+key updates that entry instead of duplicating."""
+    from hermes_cli.main import _save_custom_provider
+
+    cfg = {
+        "custom_providers": [
+            {
+                "name": "Ollama",
+                "base_url": "https://api.example.com/v1",
+                "api_key": "KEY1",
+                "model": "old-model",
+            }
+        ]
+    }
+    saved = {}
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+
+    def _save(new_cfg):
+        saved.update(new_cfg)
+
+    monkeypatch.setattr("hermes_cli.config.save_config", _save)
+
+    _save_custom_provider(
+        "https://api.example.com/v1",
+        api_key="KEY1",
+        model="new-model",
+        context_length=8192,
+    )
+
+    entries = saved["custom_providers"]
+    assert len(entries) == 1
+    assert entries[0]["name"] == "Ollama"
+    assert entries[0]["model"] == "new-model"
+    assert entries[0]["models"]["new-model"]["context_length"] == 8192
+
+
+def test_save_custom_provider_allows_multiple_keys_for_same_base_url(monkeypatch):
+    """Each distinct API key should get its own custom provider entry."""
+    from hermes_cli.main import _save_custom_provider
+
+    cfg = {
+        "custom_providers": [
+            {
+                "name": "Ollama",
+                "base_url": "https://api.example.com/v1",
+                "api_key": "KEY1",
+                "model": "old-model",
+            }
+        ]
+    }
+    saved = {}
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+
+    def _save(new_cfg):
+        saved.update(new_cfg)
+
+    monkeypatch.setattr("hermes_cli.config.save_config", _save)
+
+    _save_custom_provider(
+        "https://api.example.com/v1",
+        api_key="KEY2",
+        model="new-model",
+    )
+
+    entries = saved["custom_providers"]
+    assert len(entries) == 2
+    keys = {entry.get("api_key") for entry in entries}
+    assert keys == {"KEY1", "KEY2"}
+    assert any(
+        entry["api_key"] == "KEY2" and entry["model"] == "new-model"
+        for entry in entries
+    )


### PR DESCRIPTION
## Summary
Fix duplicate custom provider handling so entries are deduplicated by endpoint+API key instead of endpoint URL alone.

This updates `_save_custom_provider` to match existing providers only when both:
- normalized `base_url` matches
- `api_key` matches

Behavior changes:
- Re-adding the same endpoint with the same key updates model/context in place.
- Re-adding the same endpoint with a different key now creates a separate provider entry.

## Test Plan
- `python3 -m py_compile hermes_cli/main.py tests/cli/test_cli_provider_resolution.py`
- `python3 -m pytest -o addopts='' tests/cli/test_cli_provider_resolution.py -q`
- `python3 -m pytest -o addopts='' tests/cli/test_cli_provider_resolution.py`
- `ruff check hermes_cli/main.py tests/cli/test_cli_provider_resolution.py`

Closes #40977
