### PR TITLE
fix(desktop): recover root boundary from transient render races

### DIFF
--- a/apps/desktop/src/components/error-boundary.test.tsx
+++ b/apps/desktop/src/components/error-boundary.test.tsx
@@ -1,0 +1,112 @@
+import {
+  AssistantRuntimeProvider,
+  ThreadPrimitive,
+  type ThreadMessage,
+  useAuiState,
+  useExternalStoreRuntime
+} from '@assistant-ui/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { useEffect, useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ErrorBoundary } from './error-boundary'
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+function assistantMessage(index: number): ThreadMessage {
+  return {
+    id: `message-${index}`,
+    role: 'assistant',
+    content: [{ type: 'text', text: `message-${index}` }],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
+function messageList(count: number) {
+  return Array.from({ length: count }, (_, index) => assistantMessage(index))
+}
+
+function AssistantMessageProbe() {
+  const messageId = useAuiState(s => s.message.id)
+
+  return <div>{messageId}</div>
+}
+
+function UserMessageProbe() {
+  const messageId = useAuiState(s => s.message.id)
+
+  return <div>{messageId}</div>
+}
+
+function TransientTapClientLookupScenario() {
+  const [messages, setMessages] = useState<ThreadMessage[]>(() => messageList(24))
+  const [visibleIndex, setVisibleIndex] = useState(23)
+
+  useEffect(() => {
+    setMessages(messageList(18))
+
+    const timer = window.setTimeout(() => {
+      setVisibleIndex(17)
+    }, 0)
+
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [])
+
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    isRunning: false,
+    messages,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ErrorBoundary label="root">
+        <ThreadPrimitive.MessageByIndex
+          components={{ AssistantMessage: AssistantMessageProbe, UserMessage: UserMessageProbe }}
+          index={visibleIndex}
+        />
+      </ErrorBoundary>
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('ErrorBoundary', () => {
+  it('auto-recovers the root boundary from tapClientLookup stale-index races', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    render(<TransientTapClientLookupScenario />)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Reload window' })).toBeNull()
+      expect(screen.getByText('message-17')).toBeTruthy()
+    })
+
+    const errorLines = errorSpy.mock.calls.flatMap(call =>
+      call.map(value => {
+        if (value instanceof Error) {
+          return value.message
+        }
+
+        return typeof value === 'string' ? value : String(value)
+      })
+    )
+
+    expect(errorLines.some(line => line.includes('tapClientLookup: Index 23 out of bounds (length: 18)'))).toBe(true)
+    expect(
+      warnSpy.mock.calls.some(call =>
+        call.some(value => String(value).includes('auto-recovering from transient render error'))
+      )
+    ).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/error-boundary.tsx
+++ b/apps/desktop/src/components/error-boundary.tsx
@@ -20,8 +20,19 @@ interface ErrorBoundaryState {
   error: Error | null
 }
 
+const RECOVERABLE_ERROR_PATTERNS = [
+  /tapClientLookup: Index \d+\s+out of bounds \(length:\s*\d+\)/i,
+  /Cannot read properties of undefined \(reading 'type'\)/i,
+  /Tried to unmount a fiber that is already unmounted/i
+]
+
+function isRecoverableDesktopRenderError(error: Error): boolean {
+  return RECOVERABLE_ERROR_PATTERNS.some(pattern => pattern.test(error.message))
+}
+
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null }
+  private recoverTimer: null | ReturnType<typeof globalThis.setTimeout> = null
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     return { error }
@@ -31,10 +42,35 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     const tag = this.props.label ? `[error-boundary:${this.props.label}]` : '[error-boundary]'
     console.error(tag, error, info.componentStack)
     this.props.onError?.(error, info)
+
+    if (this.props.label === 'root' && isRecoverableDesktopRenderError(error)) {
+      console.warn(`${tag} auto-recovering from transient render error`, error.message)
+      this.scheduleRecover()
+    }
+  }
+
+  componentWillUnmount() {
+    this.clearRecoverTimer()
   }
 
   reset = () => {
+    this.clearRecoverTimer()
     this.setState({ error: null })
+  }
+
+  private clearRecoverTimer() {
+    if (this.recoverTimer !== null) {
+      window.clearTimeout(this.recoverTimer)
+      this.recoverTimer = null
+    }
+  }
+
+  private scheduleRecover() {
+    this.clearRecoverTimer()
+    this.recoverTimer = globalThis.setTimeout(() => {
+      this.recoverTimer = null
+      this.reset()
+    }, 0)
   }
 
   render() {


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes Desktop from getting stuck on the root "Reload window" screen when assistant-ui hits a transient stale-index render race.

The root `ErrorBoundary` now treats a small set of known renderer errors as recoverable, logs them, and resets itself on the next tick so React can re-render against fresh state instead of leaving the whole app latched on the fallback screen.

This intentionally implements the smallest mitigation proposed in #41693 (option A). It does not yet try to reorder the underlying session / message teardown path.

## Related Issue

Fixes #41693

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/components/error-boundary.tsx`: add root-only recoverable error matching for `tapClientLookup: Index ... out of bounds`, `Cannot read properties of undefined (reading 'type')`, and `Tried to unmount a fiber that is already unmounted`; schedule a next-tick `reset()`; clear pending recovery timers on reset/unmount.
- `apps/desktop/src/components/error-boundary.test.tsx`: add a component test that reproduces a `tapClientLookup` stale-index race through `AssistantRuntimeProvider` + `ThreadPrimitive.MessageByIndex` and verifies the boundary recovers instead of leaving the `Reload window` fallback on screen.

## How to Test

1. `cd apps/desktop`
2. Run `npm run type-check`
3. Run `npm run test:ui -- --run src/components/error-boundary.test.tsx`
4. Run `npm run test:ui -- --run src/components/assistant-ui/streaming.test.tsx -t "renders assistant text incrementally before completion"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (targeted desktop type-check + Vitest)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
