### PR TITLE
fix(agent): tolerate deleted cwd in codex app server bootstrap

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -17,7 +17,6 @@ compatibility.
 from __future__ import annotations
 
 import logging
-import os
 import time
 from types import SimpleNamespace
 from typing import Any, Dict, List
@@ -41,13 +40,20 @@ def run_codex_app_server_turn(
     Called from run_conversation() when agent.api_mode == "codex_app_server".
     Returns the same dict shape as the chat_completions path.
     """
-    from agent.transports.codex_app_server_session import CodexAppServerSession
+    from agent.transports.codex_app_server_session import (
+        CodexAppServerSession,
+        _safe_getcwd,
+    )
 
     # Lazy session: one CodexAppServerSession per AIAgent instance.
     # Spawned on first turn, reused across turns, closed at AIAgent
     # shutdown (see _cleanup hook).
     if not hasattr(agent, "_codex_session") or agent._codex_session is None:
-        cwd = getattr(agent, "session_cwd", None) or os.getcwd()
+        # Resolve the thread cwd via _safe_getcwd() (not a bare os.getcwd()):
+        # this bootstrap runs before the run_turn() try/except below, so a CWD
+        # deleted out from under the process must degrade gracefully instead
+        # of crashing the turn with FileNotFoundError.
+        cwd = getattr(agent, "session_cwd", None) or _safe_getcwd()
         # Approval callback: defer to Hermes' standard prompt flow if a
         # CLI thread has installed one. Gateway / cron contexts get the
         # codex-side fail-closed default.

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -42,6 +42,24 @@ from agent.transports.codex_event_projector import CodexEventProjector
 logger = logging.getLogger(__name__)
 
 
+def _safe_getcwd() -> str:
+    """Return the current working directory, tolerating a deleted CWD.
+
+    ``os.getcwd()`` raises :class:`FileNotFoundError` when the process's
+    working directory has been removed out from under it (e.g. a scratch
+    workspace that was cleaned up mid-session). The codex app-server
+    bootstrap resolves the thread cwd *before* the per-turn ``try`` in
+    ``run_codex_app_server_turn``, so an unguarded ``os.getcwd()`` there
+    would crash the whole turn instead of degrading. Fall back to
+    ``TERMINAL_CWD`` then the user's home directory so a stale CWD never
+    takes the runtime down. Mirrors ``tools.terminal_tool._safe_getcwd``.
+    """
+    try:
+        return os.getcwd()
+    except FileNotFoundError:
+        return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
+
+
 # How many tailing stderr lines from the codex subprocess to attach to a
 # user-facing error when we don't have a more specific classification (OAuth,
 # wedge watchdog, etc.). Small enough to keep error messages legible, large
@@ -206,7 +224,7 @@ class CodexAppServerSession:
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
     ) -> None:
-        self._cwd = cwd or os.getcwd()
+        self._cwd = cwd or _safe_getcwd()
         self._codex_bin = codex_bin
         self._codex_home = codex_home
         self._permission_profile = (

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -136,6 +136,57 @@ class TestTurnInputCoercion:
         assert text == "caption\n\n[image attached]"
 
 
+# ---- deleted-CWD tolerance ----
+
+class TestSafeGetcwd:
+    """`_safe_getcwd()` must tolerate a CWD that was deleted out from under
+    the process. `os.getcwd()` raises FileNotFoundError in that case, and the
+    codex bootstrap resolves the cwd before any try/except, so an unguarded
+    call would crash the whole turn. Mirrors tools.terminal_tool._safe_getcwd."""
+
+    def test_returns_real_cwd_normally(self):
+        import os
+        assert session_mod._safe_getcwd() == os.getcwd()
+
+    def test_falls_back_to_terminal_cwd_when_cwd_deleted(self, monkeypatch, tmp_path):
+        def _deleted():
+            raise FileNotFoundError("[Errno 2] No such file or directory")
+        monkeypatch.setattr(session_mod.os, "getcwd", _deleted)
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        assert session_mod._safe_getcwd() == str(tmp_path)
+
+    def test_falls_back_to_home_when_no_terminal_cwd(self, monkeypatch):
+        import os
+        def _deleted():
+            raise FileNotFoundError()
+        monkeypatch.setattr(session_mod.os, "getcwd", _deleted)
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        assert session_mod._safe_getcwd() == os.path.expanduser("~")
+
+
+class TestConstructorToleratesDeletedCwd:
+    def test_constructor_falls_back_when_cwd_none_and_getcwd_raises(
+        self, monkeypatch, tmp_path
+    ):
+        """A direct CodexAppServerSession(cwd=None) must not crash when the
+        process CWD has been deleted — the constructor's fallback resolves
+        through _safe_getcwd()."""
+        def _deleted():
+            raise FileNotFoundError()
+        monkeypatch.setattr(session_mod.os, "getcwd", _deleted)
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        sess = CodexAppServerSession(cwd=None)
+        assert sess._cwd == str(tmp_path)
+
+    def test_explicit_cwd_bypasses_resolver(self, monkeypatch):
+        """An explicit cwd is honored verbatim and never calls os.getcwd()."""
+        def _boom():
+            raise AssertionError("os.getcwd() must not be called when cwd is set")
+        monkeypatch.setattr(session_mod.os, "getcwd", _boom)
+        sess = CodexAppServerSession(cwd="/explicit/path")
+        assert sess._cwd == "/explicit/path"
+
+
 # ---- lifecycle ----
 
 class TestLifecycle:

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -233,6 +233,48 @@ class TestRunConversationCodexPath:
         assert not client_mock.chat.completions.create.called
 
 
+class TestBootstrapToleratesDeletedCwd:
+    """Regression: run_codex_app_server_turn resolves the thread cwd in its
+    lazy-session bootstrap, which runs BEFORE the per-turn try/except. A bare
+    os.getcwd() there crashes the whole turn when the process CWD has been
+    deleted out from under it (FileNotFoundError). The bootstrap must route
+    cwd resolution through the deleted-CWD-tolerant _safe_getcwd() resolver
+    instead. (_safe_getcwd's own FileNotFoundError handling is covered by the
+    unit tests in test_codex_app_server_session.py.)"""
+
+    def test_bootstrap_resolves_cwd_via_safe_getcwd(
+        self, monkeypatch, fake_session, tmp_path
+    ):
+        import agent.transports.codex_app_server_session as session_mod
+
+        fallback = str(tmp_path)
+        called = {"n": 0}
+
+        def _fake_safe_getcwd():
+            # Stand in for the real resolver having tolerated a deleted CWD
+            # and fallen back. If the bootstrap still called a bare
+            # os.getcwd() (the bug), this is never invoked.
+            called["n"] += 1
+            return fallback
+
+        monkeypatch.setattr(session_mod, "_safe_getcwd", _fake_safe_getcwd)
+
+        agent = _make_codex_agent()
+        # No session_cwd → the bootstrap must resolve the cwd itself, which
+        # must go through _safe_getcwd().
+        agent.session_cwd = None
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hi from a deleted cwd")
+
+        # The turn completed normally and the session was created with the
+        # resolver's value rather than a raw os.getcwd().
+        assert called["n"] >= 1, "bootstrap did not route cwd through _safe_getcwd()"
+        assert result["completed"] is True
+        assert result["final_response"] == "echo: hi from a deleted cwd"
+        assert agent._codex_session is not None
+        assert agent._codex_session._cwd == fallback
+
+
 class TestReviewForkApiModeDowngrade:
     """When the parent agent runs on codex_app_server, the background
     review fork must downgrade to codex_responses — otherwise the fork


### PR DESCRIPTION
## What does this PR do?

The `codex_app_server` runtime crashes the entire turn when the process's current working directory has been deleted out from under it (e.g. a scratch workspace cleaned up mid-session).

In `run_codex_app_server_turn`, the lazy-session bootstrap resolves the thread cwd with a bare `os.getcwd()`:

```python
cwd = getattr(agent, "session_cwd", None) or os.getcwd()
```

This runs **before** the `try`/`except` that wraps `run_turn()`, so when `os.getcwd()` raises `FileNotFoundError` (a deleted CWD), the exception propagates straight up and tears down the turn instead of degrading. The `CodexAppServerSession` constructor repeats the same unguarded fallback (`self._cwd = cwd or os.getcwd()`), so a directly-constructed session hits the identical crash.

The repo already treats this exact crash class as real — `tools/terminal_tool.py` ships a `_safe_getcwd()` helper for it. This PR brings the codex bootstrap in line with that established pattern: both callsites now resolve the cwd through a deleted-CWD-tolerant resolver (`os.getcwd()` → `TERMINAL_CWD` → `~`).

Behavior is **unchanged on the happy path** — the resolver only diverges from `os.getcwd()` when the CWD has actually been removed, in which case it falls back gracefully instead of crashing.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/codex_app_server_session.py` — add module-level `_safe_getcwd()` (tolerates a deleted CWD: `os.getcwd()` → `TERMINAL_CWD` → `~`, mirroring `tools.terminal_tool._safe_getcwd`); the `CodexAppServerSession` constructor now uses `cwd or _safe_getcwd()`.
- `agent/codex_runtime.py` — the lazy-session bootstrap now resolves the thread cwd via `getattr(agent, "session_cwd", None) or _safe_getcwd()` instead of a bare `os.getcwd()`; removed the now-unused `import os`.
- `tests/agent/transports/test_codex_app_server_session.py` — unit tests for `_safe_getcwd()` (normal, `TERMINAL_CWD` fallback, `~` fallback) and for the constructor tolerating a deleted CWD / honoring an explicit cwd.
- `tests/run_agent/test_codex_app_server_integration.py` — regression test that the bootstrap routes cwd resolution through the safe resolver (fails against the old bare-`os.getcwd()` code).

## How to Test

1. Run the new regression tests:

   ```bash
   pytest tests/agent/transports/test_codex_app_server_session.py tests/run_agent/test_codex_app_server_integration.py -q
   ```

   Result:

   ```
   78 passed
   ```

2. Run the full affected surface (codex transports + runtime + cron codex paths):

   ```bash
   pytest tests/agent/transports/ tests/run_agent/test_codex_app_server_integration.py tests/run_agent/test_codex_no_tools_nonetype.py tests/run_agent/test_codex_silent_hang_hint.py tests/cron/test_codex_execution_paths.py -q
   ```

   Result:

   ```
   360 passed
   ```

3. Confirm the test genuinely guards the bug — with the fix reverted to a bare `os.getcwd()` in the bootstrap, the regression test fails:

   ```bash
   pytest "tests/run_agent/test_codex_app_server_integration.py::TestBootstrapToleratesDeletedCwd::test_bootstrap_resolves_cwd_via_safe_getcwd" -q
   ```

   ```
   1 failed   # before the fix
   1 passed   # after the fix
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and all pass (scoped to the affected codex surface — see *How to Test*)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the resolver mirrors the existing `_safe_getcwd` and adds no OS-specific primitives
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — covered by the regression tests above.