### PR TITLE
feat(cli): preflight writable runtime paths before interactive session

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2014,7 +2014,7 @@ def _preflight_runtime_paths() -> list[str]:
                 parent.mkdir(parents=True, exist_ok=True)
                 if path.exists():
                     # File exists — try appending
-                    with open(path, "a") as f:
+                    with open(path, "a", encoding="utf-8") as f:
                         f.write("")
                 else:
                     # File doesn't exist — try creating and removing

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1978,9 +1978,72 @@ def _resolve_use_tui(args) -> bool:
         return False
 
 
+def _preflight_runtime_paths() -> list[str]:
+    """Check that key runtime paths under HERMES_HOME are writable.
+
+    Returns a list of human-readable warnings for paths that fail the
+    writability check.  An empty list means everything is fine.
+
+    This is a lightweight best-effort diagnostic — it creates and deletes
+    tiny probe files to verify actual write permission.  It never raises.
+    """
+    warnings: list[str] = []
+    try:
+        from hermes_constants import get_hermes_home
+        home = get_hermes_home()
+    except Exception:
+        return warnings  # can't even resolve home — skip silently
+
+    # Each entry: (label, path, is_dir)
+    paths: list[tuple[str, Path, bool]] = [
+        ("history file", home / ".hermes_history", False),
+        ("log directory", home / "logs", True),
+        ("pastes directory", home / "pastes", True),
+    ]
+
+    for label, path, is_dir in paths:
+        try:
+            if is_dir:
+                path.mkdir(parents=True, exist_ok=True)
+                probe = path / ".hermes_write_probe"
+                probe.write_text("ok")
+                probe.unlink(missing_ok=True)
+            else:
+                # For files, probe the parent directory
+                parent = path.parent
+                parent.mkdir(parents=True, exist_ok=True)
+                if path.exists():
+                    # File exists — try appending
+                    with open(path, "a") as f:
+                        f.write("")
+                else:
+                    # File doesn't exist — try creating and removing
+                    path.write_text("")
+                    path.unlink()
+        except PermissionError:
+            warnings.append(
+                f"  ⚠ {label}: {path} is not writable (PermissionError).\n"
+                f"    Fix: sudo chown -R $(whoami) {path.parent}"
+            )
+        except Exception:
+            pass  # Other errors are non-fatal for this check
+
+    return warnings
+
+
 def cmd_chat(args):
     """Run interactive chat CLI."""
     use_tui = _resolve_use_tui(args)
+
+    # Preflight: verify runtime paths are writable before entering the
+    # interactive event loop (where PermissionError causes "input stuck").
+    _preflight_warnings = _preflight_runtime_paths()
+    if _preflight_warnings:
+        print("\033[33m⚠ Writable-path preflight detected problems:\033[0m")
+        for _w in _preflight_warnings:
+            print(_w)
+        print("\033[2m  Interactive features (history, logging, paste) may fail.\033[0m")
+        print()
 
     # Resolve --continue into --resume with the latest session or by name
     continue_val = getattr(args, "continue_last", None)

--- a/tests/hermes_cli/test_preflight_runtime_paths.py
+++ b/tests/hermes_cli/test_preflight_runtime_paths.py
@@ -1,0 +1,140 @@
+"""Tests for _preflight_runtime_paths() in hermes_cli.main."""
+
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _import_preflight():
+    from hermes_cli.main import _preflight_runtime_paths
+
+    return _preflight_runtime_paths
+
+
+def test_all_paths_writable(tmp_path, monkeypatch):
+    """No warnings when all runtime paths are writable."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _preflight = _import_preflight()
+    warnings = _preflight()
+    assert warnings == []
+
+
+def test_log_dir_not_writable(tmp_path, monkeypatch):
+    """Warning when logs/ directory is not writable."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove write permission
+    log_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+
+    try:
+        _preflight = _import_preflight()
+        warnings = _preflight()
+        assert len(warnings) == 1
+        assert "log directory" in warnings[0]
+        assert str(log_dir) in warnings[0]
+        assert "PermissionError" in warnings[0]
+    finally:
+        # Restore permissions so tmp_path cleanup works
+        log_dir.chmod(stat.S_IRWXU)
+
+
+def test_history_file_not_writable(tmp_path, monkeypatch):
+    """Warning when .hermes_history file is not writable."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    history_file = tmp_path / ".hermes_history"
+    history_file.write_text("old content")
+
+    # Remove write permission from the file
+    history_file.chmod(stat.S_IRUSR)
+
+    try:
+        _preflight = _import_preflight()
+        warnings = _preflight()
+        assert len(warnings) == 1
+        assert "history file" in warnings[0]
+    finally:
+        history_file.chmod(stat.S_IRWXU)
+
+
+def test_pastes_dir_not_writable(tmp_path, monkeypatch):
+    """Warning when pastes/ directory is not writable."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    pastes_dir = tmp_path / "pastes"
+    pastes_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove write permission
+    pastes_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+
+    try:
+        _preflight = _import_preflight()
+        warnings = _preflight()
+        assert len(warnings) == 1
+        assert "pastes directory" in warnings[0]
+    finally:
+        pastes_dir.chmod(stat.S_IRWXU)
+
+
+def test_multiple_paths_not_writable(tmp_path, monkeypatch):
+    """Multiple warnings when multiple paths are not writable."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    pastes_dir = tmp_path / "pastes"
+    pastes_dir.mkdir(parents=True, exist_ok=True)
+
+    log_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    pastes_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+
+    try:
+        _preflight = _import_preflight()
+        warnings = _preflight()
+        assert len(warnings) == 2
+        labels = [w for w in warnings]
+        assert any("log directory" in w for w in labels)
+        assert any("pastes directory" in w for w in labels)
+    finally:
+        log_dir.chmod(stat.S_IRWXU)
+        pastes_dir.chmod(stat.S_IRWXU)
+
+
+def test_history_file_does_not_exist_is_ok(tmp_path, monkeypatch):
+    """No warning when .hermes_history does not exist (will be created on demand)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert not (tmp_path / ".hermes_history").exists()
+
+    _preflight = _import_preflight()
+    warnings = _preflight()
+    assert warnings == []
+
+
+def test_home_resolution_failure_is_silent(monkeypatch):
+    """Returns empty list when get_hermes_home() fails."""
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home",
+        lambda: (_ for _ in ()).throw(RuntimeError("no home")),
+    )
+    _preflight = _import_preflight()
+    warnings = _preflight()
+    assert warnings == []
+
+
+def test_fix_hint_includes_chown(tmp_path, monkeypatch):
+    """Warning message includes a sudo chown fix hint."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+
+    try:
+        _preflight = _import_preflight()
+        warnings = _preflight()
+        assert len(warnings) == 1
+        assert "chown" in warnings[0]
+    finally:
+        log_dir.chmod(stat.S_IRWXU)


### PR DESCRIPTION
## Problem

In Docker / containerized environments, Hermes CLI runtime paths (`~/.hermes_history`, `logs/`, `pastes/`) can become unwritable due to bind-mount permission drift or UID/GID changes. When this happens, `PermissionError` bubbles up into the `prompt_toolkit` event loop, manifesting as "input stuck" or "key delay before echo" — the user thinks Hermes is frozen.

## Solution

Add `_preflight_runtime_paths()` — a lightweight startup check that probes writability of three key runtime paths (history file, log directory, pastes directory) by creating and deleting tiny probe files. If any path fails the check, prints a clear warning with an actionable `sudo chown` fix hint *before* the interactive event loop starts.

The check is:
- **Non-blocking** — warns but doesn't prevent startup
- **Best-effort** — wraps everything in try/except, never crashes
- **Fast** — three file probes, negligible overhead

## Files Changed

- `hermes_cli/main.py` — `_preflight_runtime_paths()` function + call in `cmd_chat()`
- `tests/hermes_cli/test_preflight_runtime_paths.py` — 8 tests covering all paths, multiple failures, missing files, and silent fallback

## Test Plan

```
8 tests, all passing:
- test_all_paths_writable — no warnings on fresh tmp_path
- test_log_dir_not_writable — detects unwritable logs/
- test_history_file_not_writable — detects unwritable .hermes_history
- test_pastes_dir_not_writable — detects unwritable pastes/
- test_multiple_paths_not_writable — reports all failures
- test_history_file_does_not_exist_is_ok — no false positive for missing file
- test_home_resolution_failure_is_silent — graceful on get_hermes_home() failure
- test_fix_hint_includes_chown — warning includes sudo chown hint
```

Closes #41683
