### PR TITLE
Reduce tool schema overhead with core tool deferral

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2105,6 +2105,16 @@ DEFAULT_CONFIG = {
             "search_default_limit": 5,
             # Hard upper bound the model can request via ``limit``. Range 1..50.
             "max_search_limit": 20,
+            # Opt-in: also defer non-essential Hermes core tools. Defaults off
+            # for provider/model compatibility. On large-window GPT-5.x/Codex
+            # routes this can cut the fixed tool schema tax substantially while
+            # keeping local inspection/editing and skill-loading tools direct.
+            "defer_core": False,
+            "core_visible_tools": [
+                "terminal", "process",
+                "read_file", "search_files", "patch", "write_file",
+                "todo", "skills_list", "skill_view",
+            ],
         },
     },
 

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -82,6 +82,22 @@ class TestConfigParsing:
         assert cfg.max_search_limit == 50
         assert cfg.search_default_limit <= cfg.max_search_limit
 
+    def test_core_defer_defaults_off_with_bootstrap_allowlist(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw(None)
+        assert cfg.defer_core is False
+        assert "terminal" in cfg.core_visible_tools
+        assert "skill_view" in cfg.core_visible_tools
+
+    def test_core_visible_tools_configurable(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw({
+            "defer_core": True,
+            "core_visible_tools": ["terminal", "read_file"],
+        })
+        assert cfg.defer_core is True
+        assert cfg.core_visible_tools == frozenset({"terminal", "read_file"})
+
 
 # ---------------------------------------------------------------------------
 # Classification — the hard invariant: core tools NEVER defer.
@@ -89,8 +105,8 @@ class TestConfigParsing:
 
 
 class TestClassification:
-    def test_core_tools_never_defer(self):
-        """The critical invariant from the OpenClaw report."""
+    def test_core_tools_never_defer_by_default(self):
+        """Default behavior preserves the historical core-tool invariant."""
         from tools.tool_search import is_deferrable_tool_name
         # Sample of core tools from _HERMES_CORE_TOOLS.
         for core_name in ["terminal", "read_file", "write_file", "patch",
@@ -98,8 +114,17 @@ class TestClassification:
                           "web_search", "session_search", "clarify",
                           "execute_code", "delegate_task", "send_message"]:
             assert not is_deferrable_tool_name(core_name), (
-                f"Core tool '{core_name}' must NEVER be deferrable"
+                f"Core tool '{core_name}' must not be deferrable by default"
             )
+
+    def test_core_defer_mode_hides_nonessential_core_only(self):
+        from tools.tool_search import ToolSearchConfig, is_deferrable_tool_name
+        cfg = ToolSearchConfig.from_raw({"defer_core": True})
+        assert not is_deferrable_tool_name("terminal", config=cfg)
+        assert not is_deferrable_tool_name("skill_view", config=cfg)
+        assert is_deferrable_tool_name("web_search", config=cfg)
+        assert is_deferrable_tool_name("browser_navigate", config=cfg)
+        assert is_deferrable_tool_name("send_message", config=cfg)
 
     def test_bridge_tools_never_defer(self):
         from tools.tool_search import is_deferrable_tool_name, BRIDGE_TOOL_NAMES
@@ -239,7 +264,7 @@ class TestRetrieval:
 
 class TestAssembly:
     def test_no_deferrable_returns_unchanged(self):
-        """Pure-core toolset: pass-through, no bridge tools added."""
+        """Pure-core toolset: pass-through by default, no bridge tools added."""
         from tools.tool_search import assemble_tool_defs, ToolSearchConfig
         defs = [_td("terminal", "Run shell"), _td("read_file", "Read a file")]
         result = assemble_tool_defs(
@@ -249,6 +274,26 @@ class TestAssembly:
         )
         assert not result.activated
         assert {t["function"]["name"] for t in result.tool_defs} == {"terminal", "read_file"}
+
+    def test_core_defer_activates_for_nonessential_core(self):
+        from tools.tool_search import assemble_tool_defs, ToolSearchConfig, BRIDGE_TOOL_NAMES
+        defs = [
+            _td("terminal", "Run shell"),
+            _td("read_file", "Read a file"),
+            _td("web_search", "Search web"),
+            _td("browser_navigate", "Open browser"),
+        ]
+        result = assemble_tool_defs(
+            defs,
+            context_length=200_000,
+            config=ToolSearchConfig.from_raw({"enabled": "on", "defer_core": True}),
+        )
+        names = {t["function"]["name"] for t in result.tool_defs}
+        assert result.activated
+        assert {"terminal", "read_file"} <= names
+        assert "web_search" not in names
+        assert "browser_navigate" not in names
+        assert BRIDGE_TOOL_NAMES <= names
 
     def test_below_threshold_returns_unchanged(self):
         """Tiny deferrable surface: don't bother."""

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -2,13 +2,18 @@
 
 When enabled, MCP and non-core plugin tools are replaced in the model-visible
 tools array by three bridge tools — ``tool_search``, ``tool_describe``,
-``tool_call`` — and surfaced on demand. Core Hermes tools never defer.
+``tool_call`` — and surfaced on demand. Core Hermes tools stay visible by
+default, with an opt-in ``defer_core`` mode for large-window models where the
+fixed schema tax dominates every turn.
 
 Design constraints this module is built around (see ``openclaw-tool-search-report``
 for the full rationale):
 
-* Core tools defined in ``toolsets._HERMES_CORE_TOOLS`` are *never* deferred.
-  Always-load means always-load. No exceptions.
+* Core tools defined in ``toolsets._HERMES_CORE_TOOLS`` are visible by default.
+  If ``tools.tool_search.defer_core`` is explicitly enabled, only the small
+  essentials allowlist remains visible and the rest of core is routed through
+  the same bridge. This is opt-in because hidden core tools add one extra
+  bridge round trip the first time they are needed.
 * The threshold gate runs every assembly: when deferrable tools would consume
   less than ``threshold_pct`` of the model's context window (default 10%),
   tool search is a no-op and the tools array passes through unchanged.
@@ -68,6 +73,8 @@ class ToolSearchConfig:
     threshold_pct: float  # 0..100 — only used when enabled == "auto"
     search_default_limit: int
     max_search_limit: int
+    defer_core: bool
+    core_visible_tools: frozenset[str]
 
     @classmethod
     def from_raw(cls, raw: Any) -> "ToolSearchConfig":
@@ -81,13 +88,16 @@ class ToolSearchConfig:
         """
         if raw is True:
             return cls(enabled="auto", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+                       search_default_limit=5, max_search_limit=20,
+                       defer_core=False, core_visible_tools=_default_core_visible_tools())
         if raw is False:
             return cls(enabled="off", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+                       search_default_limit=5, max_search_limit=20,
+                       defer_core=False, core_visible_tools=_default_core_visible_tools())
         if not isinstance(raw, dict):
             return cls(enabled="auto", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+                       search_default_limit=5, max_search_limit=20,
+                       defer_core=False, core_visible_tools=_default_core_visible_tools())
 
         enabled_raw = str(raw.get("enabled", "auto")).strip().lower()
         if enabled_raw in ("true", "1", "yes"):
@@ -105,12 +115,22 @@ class ToolSearchConfig:
         max_search_limit = max(1, min(50, _safe_int(raw.get("max_search_limit"), 20)))
         search_default_limit = max(1, min(max_search_limit,
                                           _safe_int(raw.get("search_default_limit"), 5)))
+        defer_core = str(raw.get("defer_core", False)).strip().lower() in {"true", "1", "yes", "on"}
+        core_visible_raw = raw.get("core_visible_tools")
+        if isinstance(core_visible_raw, list):
+            core_visible_tools = frozenset(
+                str(name).strip() for name in core_visible_raw if str(name).strip()
+            )
+        else:
+            core_visible_tools = _default_core_visible_tools()
 
         return cls(
             enabled=enabled,
             threshold_pct=threshold_pct,
             search_default_limit=search_default_limit,
             max_search_limit=max_search_limit,
+            defer_core=defer_core,
+            core_visible_tools=core_visible_tools,
         )
 
 
@@ -126,6 +146,21 @@ def _safe_float(value: Any, fallback: float) -> float:
         return float(value)
     except (TypeError, ValueError):
         return fallback
+
+
+def _default_core_visible_tools() -> frozenset[str]:
+    """Small core surface that stays directly callable in core-defer mode."""
+    return frozenset({
+        "terminal",
+        "process",
+        "read_file",
+        "search_files",
+        "patch",
+        "write_file",
+        "todo",
+        "skills_list",
+        "skill_view",
+    })
 
 
 def load_config() -> ToolSearchConfig:
@@ -148,7 +183,7 @@ def load_config() -> ToolSearchConfig:
 
 
 def _core_tool_names() -> frozenset[str]:
-    """Return the set of tool names that must NEVER be deferred.
+    """Return the set of tool names that belong to Hermes' core surface.
 
     Imported lazily because ``toolsets`` imports from ``tools.registry``
     and we don't want a hard cycle.
@@ -160,18 +195,19 @@ def _core_tool_names() -> frozenset[str]:
         return frozenset()
 
 
-def is_deferrable_tool_name(name: str) -> bool:
+def is_deferrable_tool_name(name: str, config: Optional[ToolSearchConfig] = None) -> bool:
     """Return True if a tool with this name is *eligible* for deferral.
 
-    A tool is deferrable iff it is registered with an MCP toolset prefix
-    OR it is not in ``_HERMES_CORE_TOOLS``. Core tools are never deferred
-    even when their toolset is technically plugin-provided (this protects
-    against accidental shadowing).
+    A tool is deferrable iff it is registered with an MCP toolset prefix, it is
+    a non-core plugin tool, or core deferral is explicitly enabled and the core
+    tool is not in the visible bootstrap allowlist.
     """
     if name in BRIDGE_TOOL_NAMES:
         return False
     if name in _core_tool_names():
-        return False
+        if config is None:
+            config = load_config()
+        return bool(config.defer_core and name not in config.core_visible_tools)
     # Check registry toolset for MCP prefix.
     try:
         from tools.registry import registry
@@ -186,12 +222,14 @@ def is_deferrable_tool_name(name: str) -> bool:
         return False
 
 
-def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+def classify_tools(
+    tool_defs: List[Dict[str, Any]],
+    config: Optional[ToolSearchConfig] = None,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Split a tool-defs list into (visible, deferrable).
 
-    ``visible`` retains every tool that must stay in the model-facing array:
-    every core tool, plus any tool we can't classify. ``deferrable`` is the
-    candidate set for catalog entry.
+    ``visible`` retains every tool that must stay in the model-facing array;
+    ``deferrable`` is the candidate set for catalog entry.
     """
     visible: List[Dict[str, Any]] = []
     deferrable: List[Dict[str, Any]] = []
@@ -202,7 +240,7 @@ def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]
             # Should never happen — bridge tools are added after classification —
             # but be defensive.
             continue
-        if is_deferrable_tool_name(name):
+        if is_deferrable_tool_name(name, config=config):
             deferrable.append(td)
         else:
             visible.append(td)
@@ -551,7 +589,7 @@ def assemble_tool_defs(
     incoming = [td for td in tool_defs
                 if (td.get("function") or {}).get("name") not in BRIDGE_TOOL_NAMES]
 
-    visible, deferrable = classify_tools(incoming)
+    visible, deferrable = classify_tools(incoming, config=config)
     if not deferrable:
         return AssemblyResult(tool_defs=incoming, activated=False)
 
@@ -619,7 +657,7 @@ def dispatch_tool_search(args: Dict[str, Any],
     else:
         limit = max(1, min(config.max_search_limit, _safe_int(raw_limit, config.search_default_limit)))
 
-    _, deferrable = classify_tools(current_tool_defs)
+    _, deferrable = classify_tools(current_tool_defs, config=config)
     catalog = build_catalog(deferrable)
     hits = search_catalog(catalog, query, limit=limit)
     return json.dumps({
@@ -631,19 +669,22 @@ def dispatch_tool_search(args: Dict[str, Any],
 
 def dispatch_tool_describe(args: Dict[str, Any],
                            *,
-                           current_tool_defs: List[Dict[str, Any]]) -> str:
+                           current_tool_defs: List[Dict[str, Any]],
+                           config: Optional[ToolSearchConfig] = None) -> str:
     """Execute the ``tool_describe`` bridge tool. Returns a JSON string."""
+    if config is None:
+        config = load_config()
     name = str(args.get("name") or "").strip()
     if not name:
         return json.dumps({"error": "name is required"}, ensure_ascii=False)
-    if not is_deferrable_tool_name(name):
+    if not is_deferrable_tool_name(name, config=config):
         return json.dumps({
             "error": (
                 f"'{name}' is not a deferrable tool. If you see it in the tools list "
                 "already, call it directly; otherwise check the spelling against tool_search."
             ),
         }, ensure_ascii=False)
-    _, deferrable = classify_tools(current_tool_defs)
+    _, deferrable = classify_tools(current_tool_defs, config=config)
     for td in deferrable:
         fn = td.get("function") or {}
         if fn.get("name") == name:
@@ -669,10 +710,11 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
     ``tool_executor`` unwrap so a restricted-toolset session can never invoke
     an out-of-scope tool via the bridge.
     """
+    config = load_config()
     names: set[str] = set()
     for td in tool_defs:
         name = (td.get("function") or {}).get("name", "")
-        if name and is_deferrable_tool_name(name):
+        if name and is_deferrable_tool_name(name, config=config):
             names.add(name)
     return frozenset(names)
 

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -5,23 +5,22 @@ sidebar_position: 95
 
 # Tool Search
 
-When you have many MCP servers or non-core plugin tools attached to a
-session, their JSON schemas can consume a substantial fraction of the
-context window on every turn — even when only a few of them are relevant
-to what the user actually asked for.
+When you have many MCP servers, plugin tools, or a broad Hermes core toolset
+attached to a session, their JSON schemas can consume a substantial fraction
+of the context window on every turn — even when only a few of them are
+relevant to what the user actually asked for.
 
-**Tool Search** is Hermes' opt-in progressive-disclosure layer for that
-problem. When activated, MCP and plugin tools are replaced in the
-model-visible tools array by three bridge tools, and the model loads each
-specific tool's schema on demand.
+**Tool Search** is Hermes' progressive-disclosure layer for that problem.
+When activated, deferrable tools are replaced in the model-visible tools array
+by three bridge tools, and the model loads each specific tool's schema on
+demand.
 
-:::info Built-in Hermes tools never defer
-The tools that make up Hermes' core capability set (`terminal`,
-`read_file`, `write_file`, `patch`, `search_files`, `todo`, `memory`,
-`browser_*`, `web_search`, `web_extract`, `clarify`, `execute_code`,
-`delegate_task`, `session_search`, `send_message`, and the rest of
-`_HERMES_CORE_TOOLS`) are *always* loaded directly. Only MCP tools and
-non-core plugin tools are eligible for deferral.
+:::info Core tools stay direct unless you opt in
+Hermes keeps core tools direct by default for maximum model/provider
+compatibility. Set `defer_core: true` to hide non-essential core tools behind
+Tool Search while keeping the bootstrap allowlist (`terminal`, `read_file`,
+`search_files`, `patch`, `write_file`, `todo`, `skills_list`, `skill_view`,
+and `process`) directly callable.
 :::
 
 ## How it works
@@ -78,6 +77,17 @@ tools:
     threshold_pct: 10   # percentage of context — only used in auto mode
     search_default_limit: 5
     max_search_limit: 20
+    defer_core: false   # opt-in: also defer non-essential Hermes core tools
+    core_visible_tools:
+      - terminal
+      - process
+      - read_file
+      - search_files
+      - patch
+      - write_file
+      - todo
+      - skills_list
+      - skill_view
 ```
 
 | Key | Default | Meaning |
@@ -86,6 +96,8 @@ tools:
 | `threshold_pct` | `10` | Percentage of context length at which `auto` mode kicks in. Range 0–100. |
 | `search_default_limit` | `5` | Hits returned when the model calls `tool_search` without a `limit`. |
 | `max_search_limit` | `20` | Hard upper bound the model can request via `limit`. Range 1–50. |
+| `defer_core` | `false` | Also defer Hermes core tools not listed in `core_visible_tools`. Use on large-window models/profiles where fixed tool schemas dominate. |
+| `core_visible_tools` | bootstrap allowlist | Core tools that remain directly callable when `defer_core` is true. Keep enough tools here for local inspection/editing and skill loading. |
 
 You can also flip the legacy boolean shape:
 


### PR DESCRIPTION
## Summary
- add opt-in core tool deferral to Hermes Tool Search while keeping a bootstrap allowlist direct
- document defer_core/core_visible_tools configuration
- enable safer prompt-size reduction path for large-window Codex/GPT-5.x profiles

## Verification
- PYTEST_ADDOPTS='' python -m pytest -o addopts='' tests/tools/test_tool_search.py tests/hermes_cli/test_prompt_size.py tests/test_model_tools.py -q
- hermes -p worker-c prompt-size --platform telegram

## Local impact
- worker-c configured with tool_search defer_core=true, threshold_pct=0, and bootstrap visible tools