### PR TITLE
fix(qqbot): treat DM chat_type same as C2C for approval buttons and message delivery

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1092,7 +1092,11 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        # QQ private-message session keys may be recorded as "dm" while
+        # C2C button events authorize against the same user_openid. Treat
+        # both spellings as the same private chat, otherwise approval clicks
+        # from QQ DMs are incorrectly rejected as unauthorized.
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:
@@ -2472,7 +2476,7 @@ class QQAdapter(BasePlatformAdapter):
 
         for attempt in range(3):
             try:
-                if chat_type == "c2c":
+                if chat_type in {"c2c", "dm"}:
                     return await self._send_c2c_text(chat_id, content, reply_to)
                 elif chat_type == "group":
                     return await self._send_group_text(chat_id, content, reply_to)
@@ -2599,7 +2603,7 @@ class QQAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         truncated = formatted[: self.MAX_MESSAGE_LENGTH]
         try:
-            if chat_type == "c2c":
+            if chat_type in {"c2c", "dm"}:
                 return await self._send_c2c_text(
                     chat_id, truncated, reply_to, keyboard=keyboard,
                 )
@@ -2921,7 +2925,7 @@ class QQAdapter(BasePlatformAdapter):
                 "POST",
                 (
                     f"/v2/users/{chat_id}/messages"
-                    if chat_type == "c2c"
+                    if chat_type in {"c2c", "dm"}
                     else f"/v2/groups/{chat_id}/messages"
                 ),
                 body,

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2371,7 +2371,7 @@ class QQAdapter(BasePlatformAdapter):
         """Upload media and return file_info."""
         path = (
             f"/v2/users/{target_id}/files"
-            if target_type == "c2c"
+            if target_type in {"c2c", "dm"}
             else f"/v2/groups/{target_id}/files"
         )
 
@@ -3058,7 +3058,7 @@ class QQAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
-        """Send an input notify to a C2C user (only supported for C2C).
+        """Send an input notify to a C2C/DM user (only supported for C2C and DM).
 
         Debounced to one request per ~50s (the API sets a 60s indicator).
         The QQ API requires the originating message ID — retrieved from
@@ -3068,7 +3068,7 @@ class QQAdapter(BasePlatformAdapter):
             return
 
         chat_type = self._guess_chat_type(chat_id)
-        if chat_type != "c2c":
+        if chat_type not in {"c2c", "dm"}:
             return
 
         msg_id = self._last_msg_id.get(chat_id)


### PR DESCRIPTION
## Problem

QQ Bot adapter's  only checks for , but QQ DM session keys are recorded as . This causes:

1. **Approval buttons rejected** — users in QQ DMs see  when trying to approve agent actions
2. **Message delivery failures** —  and  don't handle  chat_type, causing  errors or wrong API paths

## Fix

Treat  the same as  in 4 locations:

| Location | Function | Change |
|----------|----------|--------|
| Line 1095 |  | `== "c2c"` → `in {"c2c", "dm"}` |
| Line 2476 | `_send_chunk` (text) | same |
| Line 2603 | `_send_chunk` (keyboard) | same |
| Line 2928 | `_send_media` | same |

## Context

- QQ Bot's C2C private messages use  and the adapter stores `chat_type="c2c"` in `_chat_type_map`
- But guild DM messages go through `_handle_dm_message` which stores `chat_type="dm"`
- The MessageEvent itself always passes `chat_type="dm"` for both paths
- This mismatch causes approval authorization to fail and message delivery to use wrong API paths