### PR TITLE
fix(tui_gateway): persist regenerated turn after history truncation

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4371,6 +4371,19 @@ def _(rid, params: dict) -> dict:
                     db.replace_messages(session["session_key"], truncated)
                 except Exception as exc:
                     print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
+            # After truncating the transcript we must reset the agent's DB-flush
+            # watermark, or _flush_messages_to_session_db (run_agent.py) keeps the
+            # stale `_last_flushed_db_idx` from before the truncation and skips
+            # persisting the regenerated turn: flush_from = max(len(history),
+            # stale_idx) overshoots the now-shorter message list. The classic CLI
+            # already does this after its rewrite ops (cli.py:
+            # `_last_flushed_db_idx = len(self.conversation_history)`); this
+            # truncate path was the one rewrite site that missed it. Without the
+            # reset, regenerate / edit-resend looks fine live but the new turn is
+            # silently lost on cold resume.
+            agent = session.get("agent")
+            if agent is not None and hasattr(agent, "_last_flushed_db_idx"):
+                agent._last_flushed_db_idx = len(truncated)
         session["running"] = True
         session["last_active"] = time.time()
         _start_inflight_turn(session, text)


### PR DESCRIPTION
### What

`prompt.submit` with `truncate_before_user_ordinal` (used by the UI's **regenerate** /
**edit-resend**) rewrites the transcript via `replace_messages`, but never resets the
agent's `_last_flushed_db_idx` watermark. As a result the regenerated turn is **never
persisted to the session DB** — it looks correct in the live view but is silently lost on
cold resume / reconnect.

### Root cause

`_flush_messages_to_session_db` (`run_agent.py`) guards against double writes with:

```python
flush_from = max(len(conversation_history), self._last_flushed_db_idx)
```

After a truncation, `replace_messages` shortens the transcript but the watermark still
points *past* the now-shorter list, so `messages[flush_from:]` is empty and the new
(regenerated) turn is skipped.

- regenerate at **ordinal 0** → whole session persists empty
- regenerate at **ordinal N** → only the first N turns survive; the regenerated turn is lost

### Fix

Reset the watermark to `len(truncated)` immediately after the truncation, so the next
flush re-persists from the truncation point.

This mirrors the **classic CLI**, which already resets `_last_flushed_db_idx` after each
of its rewrite ops (`/retry`, `/undo`, `/compress` — `cli.py`:
`_last_flushed_db_idx = len(self.conversation_history)`). The `prompt.submit` truncate path
was the one rewrite site that missed it.

```python
agent = session.get("agent")
if agent is not None and hasattr(agent, "_last_flushed_db_idx"):
    agent._last_flushed_db_idx = len(truncated)
```

(Guarded with `hasattr` so it's a no-op for any agent type that doesn't track the
watermark.)

### Testing

Verified locally against the session DB (`hermes_state`):

| scenario | before fix | after fix |
|---|---|---|
| normal turn, cold reload | 2 rows (ok) | 2 rows (ok) |
| regenerate @ ordinal 0 | **0 rows (lost)** | 2 rows (persisted) |
| regenerate @ ordinal 1 (2 turns) | **4 rows = first turn only (regen lost)** | 6 rows (persisted) |

After the fix the regenerated turn survives a cold reload / reconnect.

### Scope

One-line behavioral fix in the existing truncate branch; no API or schema change. Benefits
every consumer of `truncate_before_user_ordinal`.
