### PR TITLE
fix(state): sanitize session_id in transcript file cleanup

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -14,6 +14,7 @@ Key design decisions:
 - Session source tagging ('cli', 'telegram', 'discord', etc.) for filtering
 """
 
+import glob
 import json
 import logging
 import random
@@ -3371,22 +3372,40 @@ class SessionDB:
         ``request_dump_{session_id}_*.json`` files left by the gateway.
         Silently skips files that don't exist and swallows OSError so a
         filesystem hiccup never blocks a DB operation.
+
+        ``session_id`` is not constrained to a safe charset (gateway/platform
+        code derives it from external input), so it is treated as untrusted
+        here: glob metacharacters are escaped so they can't match files
+        belonging to *other* sessions, and every candidate is confirmed to
+        resolve directly inside *sessions_dir* before unlinking so a
+        separator/``..`` in the id can't delete files outside it.
         """
         if sessions_dir is None:
             return
-        for suffix in (".json", ".jsonl"):
-            p = sessions_dir / f"{session_id}{suffix}"
+
+        try:
+            resolved_dir = sessions_dir.resolve()
+        except OSError:
+            return
+
+        def _safe_unlink(p: Path) -> None:
             try:
+                # Only delete files that live directly in sessions_dir — this
+                # rejects ids containing path separators or ``..``.
+                if p.resolve().parent != resolved_dir:
+                    return
                 p.unlink(missing_ok=True)
             except OSError:
                 pass
-        # request_dump files use session_id as a prefix component
+
+        for suffix in (".json", ".jsonl"):
+            _safe_unlink(sessions_dir / f"{session_id}{suffix}")
+        # request_dump files use session_id as a prefix component. Escape it so
+        # glob wildcards in the id are matched literally rather than expanding.
         try:
-            for p in sessions_dir.glob(f"request_dump_{session_id}_*.json"):
-                try:
-                    p.unlink(missing_ok=True)
-                except OSError:
-                    pass
+            pattern = f"request_dump_{glob.escape(session_id)}_*.json"
+            for p in sessions_dir.glob(pattern):
+                _safe_unlink(p)
         except OSError:
             pass
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4006,3 +4006,46 @@ class TestListCronJobRuns:
         detail = " ".join(row[-1] for row in plan)
         assert "USING INDEX" in detail or "USING COVERING INDEX" in detail, detail
         assert "idx_sessions_source" in detail, detail
+
+
+class TestRemoveSessionFiles:
+    """_remove_session_files must treat session_id as untrusted."""
+
+    def test_removes_own_files(self, tmp_path):
+        """The normal happy path still deletes the session's own files."""
+        sid = "abc123"
+        own = tmp_path / f"{sid}.json"
+        own_jsonl = tmp_path / f"{sid}.jsonl"
+        dump = tmp_path / f"request_dump_{sid}_001.json"
+        for f in (own, own_jsonl, dump):
+            f.write_text("{}", encoding="utf-8")
+
+        SessionDB._remove_session_files(tmp_path, sid)
+
+        assert not own.exists()
+        assert not own_jsonl.exists()
+        assert not dump.exists()
+
+    def test_glob_metacharacters_do_not_match_other_sessions(self, tmp_path):
+        """A '*' in session_id must not expand and delete other sessions' dumps."""
+        victim = tmp_path / "request_dump_other_001.json"
+        victim.write_text("{}", encoding="utf-8")
+        # An id whose glob would otherwise match request_dump_other_001.json.
+        own = tmp_path / "request_dump_*_001.json"
+        own.write_text("{}", encoding="utf-8")
+
+        SessionDB._remove_session_files(tmp_path, "*")
+
+        assert victim.exists(), "wildcard id wrongly deleted another session's dump"
+
+    def test_path_traversal_stays_inside_sessions_dir(self, tmp_path):
+        """Separators / '..' in session_id must not escape sessions_dir."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        outside = tmp_path / "secret.json"
+        outside.write_text("{}", encoding="utf-8")
+
+        # sessions_dir / "../secret.json" resolves to tmp_path/secret.json.
+        SessionDB._remove_session_files(sessions_dir, "../secret")
+
+        assert outside.exists(), "path-traversal id escaped sessions_dir"


### PR DESCRIPTION
_remove_session_files() built its unlink path and request_dump glob from
a raw session_id. session_id is never validated and gateway/platform code
derives it from external input, so a wildcard would delete other sessions'
dumps and a separator/`..` would unlink files outside sessions_dir.

Treat session_id as untrusted at the deletion boundary: escape glob
metacharacters and unlink only files that resolve directly inside
sessions_dir.

## What does this PR do?

Hardens SessionDB transcript cleanup against malformed session ids. A
glob wildcard in `session_id` deleted other sessions' `request_dump`
files; a path separator or `..` deleted files outside `sessions_dir`.
Both paths run in the default prune/delete maintenance sweep.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `hermes_state.py`: `_remove_session_files()` now escapes glob
  metacharacters in `session_id` and unlinks only paths that resolve
  directly inside `sessions_dir`.
- `tests/test_hermes_state.py`: added `TestRemoveSessionFiles` covering
  the happy path, glob-wildcard collateral deletion, and `..` traversal.

## How to Test

1. `scripts/run_tests.sh tests/test_hermes_state.py::TestRemoveSessionFiles`
2. All 3 pass; they fail against the pre-fix code (victim/outside files deleted).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A