### PR TITLE
fix(security): block shell-collapse rm -rf / spellings at the hardline floor

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -31,6 +31,16 @@ _HARDLINE_BLOCK = [
     # rm -rf targeting root / system dirs / home
     "rm -rf /",
     "rm -rf /*",
+    # Shell-equivalent spellings of "rm -rf /": repeated slashes and
+    # current/parent-dir segments all collapse back to root, so they must
+    # hit the hardline floor too (regression: these used to slip through).
+    "rm -rf //",
+    "rm -rf /.",
+    "rm -rf /./",
+    "rm -rf /..",
+    "rm -rf //*",
+    "rm -fr /./",
+    "ls && rm -rf //",
     "rm -rf /home",
     "rm -rf /home/*",
     "rm -rf /etc",
@@ -197,6 +207,24 @@ def test_yolo_env_var_cannot_bypass_hardline(clean_session, monkeypatch):
         r2 = check_all_command_guards(cmd, "local")
         assert r2["approved"] is False, f"yolo leaked hardline on {cmd!r} (check_all_command_guards)"
         assert r2.get("hardline") is True
+
+
+def test_root_collapse_forms_cannot_bypass_hardline(clean_session, monkeypatch):
+    """Shell-equivalent spellings of "rm -rf /" stay blocked under yolo.
+
+    "//", "/.", "/./", "/..", "//*" all collapse to the root filesystem in
+    the shell. They previously matched only the softer DANGEROUS_PATTERNS
+    rule, which yolo bypasses — leaving the hardline floor open to a full
+    root wipe under --yolo / approvals.mode=off / cron approve-mode.
+    """
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+    for cmd in ["rm -rf //", "rm -rf /.", "rm -rf /./", "rm -rf /..", "rm -rf //*"]:
+        is_hl, _ = detect_hardline_command(cmd)
+        assert is_hl, f"{cmd!r} should be hardline-blocked"
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"yolo leaked hardline on {cmd!r}"
+        assert result.get("hardline") is True
 
 
 def test_session_yolo_cannot_bypass_hardline(clean_session):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -247,8 +247,18 @@ _CMDPOS = (
 )
 
 HARDLINE_PATTERNS = [
-    # rm recursive targeting the root filesystem or protected roots
-    (r'\brm\s+(-[^\s]*\s+)*(/|/\*|/ \*)(\s|$)', "recursive delete of root filesystem"),
+    # rm recursive targeting the root filesystem or protected roots.
+    # The target group matches any root-anchored path whose components
+    # collapse back to "/" in the shell: a bare "/", repeated slashes
+    # ("//"), and "."/".." current/parent segments ("/.", "/./", "/..")
+    # all resolve to root, optionally followed by a trailing glob
+    # ("/*", "//*"). The earlier "(/|/\*|/ \*)" form only caught the
+    # literal "/" / "/*" spellings, so "rm -rf //", "rm -rf /.", and
+    # "rm -rf /./" silently slipped the hardline floor and executed under
+    # --yolo / approvals.mode=off / cron approve-mode. A trailing non-"/."
+    # segment (e.g. "/tmp", "/home") still fails to match here and stays
+    # with the softer DANGEROUS_PATTERNS / system-directory rules.
+    (r'\brm\s+(-[^\s]*\s+)*/[/.]*\**(\s|$)', "recursive delete of root filesystem"),
     (r'\brm\s+(-[^\s]*\s+)*(/home|/home/\*|/root|/root/\*|/etc|/etc/\*|/usr|/usr/\*|/var|/var/\*|/bin|/bin/\*|/sbin|/sbin/\*|/boot|/boot/\*|/lib|/lib/\*)(\s|$)', "recursive delete of system directory"),
     (r'\brm\s+(-[^\s]*\s+)*(~|\$HOME)(/?|/\*)?(\s|$)', "recursive delete of home directory"),
     # Filesystem format


### PR DESCRIPTION
## What does this PR do?

`rm -rf //`, `rm -rf /.`, `rm -rf /./`, `rm -rf /..` and `rm -rf //*` wiped
the entire root filesystem but slipped straight past the hardline blocklist.
The hardline floor is the one layer that is supposed to hold even under
`--yolo`, `/yolo`, `approvals.mode=off`, and cron approve-mode — yet running
`HERMES_YOLO_MODE=1` and feeding it `rm -rf //` returned `approved=True`,
while the literal `rm -rf /` was correctly blocked. To the shell `//`, `/.`,
`/./`, `/..` and `//*` all resolve to `/`, so these are the same catastrophic,
no-recovery command in a different spelling.

The root cause is the root-filesystem hardline pattern, whose target group
`(/|/\*|/ \*)` only recognised the literal `/` and `/*` tokens. The collapse
spellings fell through to the softer `DANGEROUS_PATTERNS` "delete in root
path" rule, which yolo / mode=off / cron approve-mode are designed to bypass —
leaving the floor wide open.

The fix broadens the target group to `/[/.]*\**`, matching any root-anchored
path whose components collapse back to `/` (repeated slashes plus `.`/`..`
segments) and an optional trailing glob. A trailing real segment such as
`/tmp` or `/home` still fails to match, so legitimate paths and the
system-directory rules are untouched.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/approval.py`: broaden the "recursive delete of root filesystem"
  `HARDLINE_PATTERNS` entry from `(/|/\*|/ \*)` to `/[/.]*\**` so the
  shell-equivalent `//`, `/.`, `/./`, `/..`, `//*` spellings of `rm -rf /`
  are caught by the unconditional hardline floor.
- `tests/tools/test_hardline_blocklist.py`: add the collapse spellings to the
  `_HARDLINE_BLOCK` parametrize set, and add
  `test_root_collapse_forms_cannot_bypass_hardline` asserting they stay
  blocked with `HERMES_YOLO_MODE=1`.

## How to Test

1. Before the fix, with `HERMES_YOLO_MODE=1`:
   `check_all_command_guards("rm -rf //", "local")` returns
   `{"approved": True}` while `rm -rf /` returns a hardline block.
2. After the fix, `detect_hardline_command("rm -rf //")` returns
   `(True, "recursive delete of root filesystem")` and
   `check_all_command_guards("rm -rf //", "local")` returns
   `{"approved": False, "hardline": True}` even under yolo.
3. Run `scripts/run_tests.sh tests/tools/test_hardline_blocklist.py` — all
   pass, including the new collapse-form cases; benign paths such as
   `rm -rf /tmp/foo`, `rm -rf ./build` and `rm -rf /.config` remain unflagged.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pattern is shell-string only, no OS-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A