### PR TITLE
feat(agent): add xiaomi MiMo v2.5 pricing entries

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -533,6 +533,44 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source="official_docs_snapshot",
         pricing_version="minimax-pricing-2026-04",
     ),
+    # ── Xiaomi MiMo ───────────────────────────────────────────────────
+    # Source: https://platform.xiaomimimo.com/docs/en-US/news/v2.5-price-update
+    # Permanent price reduction effective May 27, 2026 (global sync).
+    # mimo-v2-pro auto-routes to mimo-v2.5-pro pricing (deprecated alias).
+    # Cache write is temporarily free — omitted.
+    (
+        "xiaomi",
+        "mimo-v2.5-pro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.0036"),
+        source="official_docs_snapshot",
+        source_url="https://platform.xiaomimimo.com/docs/en-US/news/v2.5-price-update",
+        pricing_version="xiaomi-pricing-2026-05-27",
+    ),
+    (
+        "xiaomi",
+        "mimo-v2-pro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.0036"),
+        source="official_docs_snapshot",
+        source_url="https://platform.xiaomimimo.com/docs/en-US/news/v2.5-price-update",
+        pricing_version="xiaomi-pricing-2026-05-27",
+    ),
+    (
+        "xiaomi",
+        "mimo-v2.5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://platform.xiaomimimo.com/docs/en-US/news/v2.5-price-update",
+        pricing_version="xiaomi-pricing-2026-05-27",
+    ),
 }
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from agent.usage_pricing import (
     CanonicalUsage,
     estimate_usage_cost,
@@ -224,3 +226,68 @@ def test_deepseek_v4_pro_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
     assert float(result.amount_usd) == 3.48
+
+
+def test_xiaomi_mimo_v2_5_pro_pricing_entry_exists():
+    """Regression test: mimo-v2.5-pro must have a pricing entry.
+
+    Before this fix, xiaomi/mimo-v2.5-pro sessions showed as unknown cost
+    because _OFFICIAL_DOCS_PRICING had no xiaomi entries.  See #41731.
+    """
+    entry = get_pricing_entry("mimo-v2.5-pro", provider="xiaomi")
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.435
+    assert float(entry.output_cost_per_million) == 0.87
+    assert float(entry.cache_read_cost_per_million) == 0.0036
+
+
+def test_xiaomi_mimo_v2_5_pricing_entry_exists():
+    """Regression test: mimo-v2.5 must have a pricing entry."""
+    entry = get_pricing_entry("mimo-v2.5", provider="xiaomi")
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.14
+    assert float(entry.output_cost_per_million) == 0.28
+    assert float(entry.cache_read_cost_per_million) == 0.0028
+
+
+def test_xiaomi_mimo_v2_pro_pricing_entry_exists():
+    """Regression test: mimo-v2-pro (alias for v2.5-pro) must have a pricing entry."""
+    entry = get_pricing_entry("mimo-v2-pro", provider="xiaomi")
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.435
+    assert float(entry.output_cost_per_million) == 0.87
+
+
+def test_xiaomi_mimo_v2_5_pro_estimate_cost():
+    """Full cost estimation for mimo-v2.5-pro with mixed token usage."""
+    result = estimate_usage_cost(
+        "mimo-v2.5-pro",
+        CanonicalUsage(input_tokens=1000, output_tokens=500, cache_read_tokens=2000),
+        provider="xiaomi",
+    )
+
+    assert result.status == "estimated"
+    # input: 1000 * 0.435 / 1M = 0.000435
+    # output: 500 * 0.87 / 1M = 0.000435
+    # cache_read: 2000 * 0.0036 / 1M = 0.0000072
+    # total = 0.0008772
+    assert float(result.amount_usd) == pytest.approx(0.0008772, abs=1e-6)
+
+
+def test_xiaomi_mimo_v2_5_estimate_cost():
+    """Full cost estimation for mimo-v2.5 with mixed token usage."""
+    result = estimate_usage_cost(
+        "mimo-v2.5",
+        CanonicalUsage(input_tokens=1000, output_tokens=500, cache_read_tokens=2000),
+        provider="xiaomi",
+    )
+
+    assert result.status == "estimated"
+    # input: 1000 * 0.14 / 1M = 0.00014
+    # output: 500 * 0.28 / 1M = 0.00014
+    # cache_read: 2000 * 0.0028 / 1M = 0.0000056
+    # total = 0.0002856
+    assert float(result.amount_usd) == pytest.approx(0.0002856, abs=1e-6)


### PR DESCRIPTION
## What

Add `_OFFICIAL_DOCS_PRICING` entries for the `xiaomi` provider so MiMo sessions report real cost instead of $0/unknown.

Models added:
- `mimo-v2.5` — $0.14/M input, $0.28/M output, $0.0028/M cache-read
- `mimo-v2.5-pro` — $0.435/M input, $0.87/M output, $0.0036/M cache-read
- `mimo-v2-pro` — alias for v2.5-pro (deprecated, auto-routes to v2.5 pricing)

Prices from Xiaomi's permanent May 27, 2026 reduction: https://platform.xiaomimimo.com/docs/en-US/news/v2.5-price-update

## How to test

```bash
# Verify pricing entries resolve correctly
venv/bin/python -c "
from agent.usage_pricing import get_pricing_entry, estimate_usage_cost, CanonicalUsage
for m in ['mimo-v2.5', 'mimo-v2.5-pro', 'mimo-v2-pro']:
    e = get_pricing_entry(m, provider='xiaomi')
    print(f'{m}: input=\${e.input_cost_per_million}, output=\${e.output_cost_per_million}')
result = estimate_usage_cost('mimo-v2.5-pro', CanonicalUsage(input_tokens=5000, output_tokens=1500, cache_read_tokens=10000), provider='xiaomi')
print(f'Example: {result.label} ({result.status})')
"

# Run pricing tests
venv/bin/python -m pytest tests/agent/test_usage_pricing.py -v
```

## Checklist

- [x] Single logical change
- [x] Conventional commit format
- [x] Tests updated/passing (16/16)
- [x] Platforms tested: Linux (WSL)

Fixes #41731