### PR TITLE
fix(skills): prevent skills hub hang on network timeout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+# Fork CI-equivalent pre-commit hooks — matches upstream blocking checks:
+#   https://github.com/NousResearch/hermes-agent/blob/main/.github/workflows/lint.yml
+#
+# The global hook (~/.git-hooks/pre-commit) chains to this via
+# `pre-commit run --config .pre-commit-config.yaml`, so both run.
+#
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: ruff enforcement (blocking)
+        description: "Matches upstream 'ruff enforcement (blocking)' CI job"
+        entry: .venv/bin/ruff check .
+        language: system
+        files: \.py$
+        pass_filenames: false
+
+      - id: windows-footguns
+        name: Windows footguns (blocking)
+        description: "Matches upstream 'Windows footguns (blocking)' CI job"
+        entry: .venv/bin/python scripts/check-windows-footguns.py --all
+        language: system
+        files: \.py$
+        pass_filenames: false

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -65,6 +65,8 @@ AUTHOR_MAP = {
     "dirtyren@users.noreply.github.com": "dirtyren",
     "zhaolei.vc@bytedance.com": "zhaoleibd",
     "jeffrobodie@gmail.com": "jeffrobodie-glitch",
+    "lgray95@alumni.cmu.edu": "LiamDGray",
+    "liamdgray@gmail.com": "LiamDGray",
     "kyssta-exe@users.noreply.github.com": "kyssta-exe",
     "ali.zakaee.1997@gmail.com": "ITheEqualizer",
     "copii.list@gmail.com": "stremtec",

--- a/tests/tools/test_skills_hub_timeout.py
+++ b/tests/tools/test_skills_hub_timeout.py
@@ -1,0 +1,106 @@
+"""
+Test that parallel_search_sources respects the overall_timeout even when
+source threads block on network calls (ThreadPoolExecutor shutdown hang).
+"""
+import time
+from typing import List
+
+import pytest
+
+from tools.skills_hub import (
+    SkillSource,
+    SkillMeta,
+    SkillBundle,
+    parallel_search_sources,
+)
+
+
+class BlockingSource(SkillSource):
+    """A source that blocks forever in search(), simulating a network hang."""
+
+    def source_id(self) -> str:
+        return "blocking"
+
+    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+        # Simulate a hanging network call — blocks indefinitely
+        time.sleep(9999)
+        return []
+
+    def fetch(self, identifier: str) -> SkillBundle | None:
+        return None
+
+    def inspect(self, identifier: str) -> SkillMeta | None:
+        return None
+
+
+class FastSource(SkillSource):
+    """A fast source that returns results immediately."""
+
+    def source_id(self) -> str:
+        return "fast"
+
+    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+        return [
+            SkillMeta(
+                name="test-skill",
+                description="A test skill",
+                source="fast",
+                identifier="fast/test-skill",
+                trust_level="community",
+            )
+        ]
+
+    def fetch(self, identifier: str) -> SkillBundle | None:
+        return None
+
+    def inspect(self, identifier: str) -> SkillMeta | None:
+        return None
+
+
+class TestParallelSearchSourcesTimeout:
+    """Verify that parallel_search_sources returns within the overall_timeout,
+    even when some source threads are blocked on network I/O."""
+
+    def test_returns_within_timeout_when_source_hangs(self):
+        """A hanging source must not block shutdown past overall_timeout."""
+        sources = [BlockingSource(), FastSource()]
+        overall_timeout = 2.0  # seconds
+
+        start = time.monotonic()
+        all_results, source_counts, timed_out_ids = parallel_search_sources(
+            sources,
+            query="test",
+            overall_timeout=overall_timeout,
+        )
+        elapsed = time.monotonic() - start
+
+        # Must return within a reasonable margin above the timeout
+        # (2s timeout + 2s grace for thread cleanup)
+        assert elapsed < overall_timeout + 2.0, (
+            f"parallel_search_sources took {elapsed:.1f}s, "
+            f"expected < {overall_timeout + 2.0}s"
+        )
+
+        # The fast source should have completed
+        assert "fast" in source_counts
+        assert source_counts["fast"] >= 1
+
+        # The blocking source should be in timed_out_ids
+        assert "blocking" in timed_out_ids
+
+    def test_all_sources_fast_returns_full_results(self):
+        """When all sources are fast, all results should be returned."""
+        sources = [FastSource(), FastSource()]
+        overall_timeout = 5.0
+
+        start = time.monotonic()
+        all_results, source_counts, timed_out_ids = parallel_search_sources(
+            sources,
+            query="test",
+            overall_timeout=overall_timeout,
+        )
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 2.0, "Should complete quickly when sources are fast"
+        assert len(timed_out_ids) == 0
+        assert len(all_results) == 2  # one from each FastSource

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3692,7 +3692,8 @@ def parallel_search_sources(
     if not active:
         return all_results, source_counts, timed_out_ids
 
-    with ThreadPoolExecutor(max_workers=min(len(active), 8)) as pool:
+    pool = ThreadPoolExecutor(max_workers=min(len(active), 8))
+    try:
         futures = {}
         for src in active:
             lim = per_source_limits.get(src.source_id(), 50)
@@ -3718,6 +3719,11 @@ def parallel_search_sources(
                     "Skills browse timed out waiting for: %s",
                     ", ".join(timed_out_ids),
                 )
+    finally:
+        # Shutdown WITHOUT waiting — hanging threads (e.g. blocked network
+        # calls) must not block the caller past overall_timeout.
+        # cancel_futures=True (Python 3.9+) prevents queued-but-unstarted work.
+        pool.shutdown(wait=False, cancel_futures=True)
 
     return all_results, source_counts, timed_out_ids
 


### PR DESCRIPTION
## Root Cause

`parallel_search_sources` in `tools/skills_hub.py` uses `ThreadPoolExecutor` as a context manager. On exit, `__exit__` calls `shutdown(wait=True)` which blocks until every thread completes. When external registries are unreachable, HTTP threads block indefinitely in `httpx.get()`. The `overall_timeout` only times out the `as_completed()` iteration — not the thread-pool shutdown.

## Fix

Replace context-manager form with explicit `pool.shutdown(wait=False, cancel_futures=True)` in a `finally` block. Hanging threads are abandoned; they hold no critical resources.

**Changed:** `tools/skills_hub.py` — `parallel_search_sources()` (1 line restructure)

## Tests

`tests/tools/test_skills_hub_timeout.py`:
- **Hanging source** → returns in ~2.5s (was: hangs forever)
- **Fast source** → all results returned, no timeouts

## Verification

```
ruff check .                    → All checks passed
Windows footguns (555 files)    → 0 found
pytest tests/tools/             → 436 passed

Tested on Debian 13.
```

Closes #41053
