### PR TITLE
fix(gateway): reject non-image uploads in image.attach_bytes

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5972,6 +5972,41 @@ def test_image_attach_bytes_rejects_unsupported_extension(monkeypatch, tmp_path)
     assert resp["error"]["code"] == 4016
 
 
+def test_image_attach_bytes_rejects_non_image_bytes(monkeypatch, tmp_path):
+    """Valid base64 of non-image bytes is rejected (mirrors pdf.attach's %PDF-
+    guard). Without this, _sniff_image_ext relabels unknown bytes as ".png" and
+    the junk is written + queued, then fails opaquely at vision time."""
+    import base64 as _b64
+
+    _attach_bytes_cli(monkeypatch)
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    server._sessions["abx7"] = _session()
+
+    not_image = _b64.b64encode(b"this is plainly not an image").decode("ascii")
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.attach_bytes",
+            "params": {"session_id": "abx7", "content_base64": not_image},
+        }
+    )
+    assert "error" in resp
+    assert resp["error"]["code"] == 4017
+    # Nothing must have been written or queued for the junk upload.
+    assert server._sessions["abx7"].get("attached_images", []) == []
+    assert not (tmp_path / "images").exists() or not list((tmp_path / "images").iterdir())
+
+
+def test_is_decodable_image_helper():
+    import base64 as _b64
+
+    png = _b64.b64decode(_PNG_1X1_B64)
+    assert server._is_decodable_image(png) is True
+    assert server._is_decodable_image(b"not an image at all") is False
+    # A ".png"-looking header that is not a real PNG is still rejected.
+    assert server._is_decodable_image(b"\x89PNG\r\n\x1a\n" + b"0" * 32) is False
+
+
 def test_pdf_attach_requires_poppler(monkeypatch, tmp_path):
     """Without pdftoppm on PATH, pdf.attach returns a clear 5028."""
     _attach_bytes_cli(monkeypatch)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5156,6 +5156,36 @@ def _sniff_image_ext(img_bytes: bytes, filename: str = "") -> str:
     return ".png"
 
 
+def _is_decodable_image(img_bytes: bytes) -> bool:
+    """Return True only when *img_bytes* is an actual, decodable image.
+
+    ``_sniff_image_ext`` deliberately falls back to ``.png`` for any leading
+    bytes it does not recognise, so on its own it never rejects a payload — an
+    ``image.attach_bytes`` upload of arbitrary non-image bytes would be stored
+    in the gateway's images dir as a ``.png`` and queued for the next turn,
+    where it fails opaquely at vision time ("[analysis failed]" / a provider
+    HTTP 400). This is the image-side analogue of the ``%PDF-`` magic guard
+    ``pdf.attach`` already applies to its payload. Pillow is a core dependency
+    and is already used by ``_image_meta``; when it is genuinely unavailable we
+    fail OPEN (return True) rather than rejecting every upload.
+    """
+    try:
+        from PIL import Image
+    except Exception:
+        return True  # Pillow missing — can't validate, don't block the upload
+    from io import BytesIO
+
+    try:
+        # ``load()`` (not ``verify()``) — it actually decodes the pixel data,
+        # matching what the vision pipeline does downstream, and tolerates the
+        # minor CRC quirks real encoders emit that ``verify()`` rejects.
+        with Image.open(BytesIO(img_bytes)) as _probe:
+            _probe.load()
+        return True
+    except Exception:
+        return False
+
+
 def _allowed_image_extensions() -> frozenset[str]:
     try:
         from cli import _IMAGE_EXTENSIONS
@@ -5219,6 +5249,12 @@ def _(rid, params: dict) -> dict:
     if len(img_bytes) > _ATTACH_BYTES_MAX_BYTES:
         mb = _ATTACH_BYTES_MAX_BYTES // (1024 * 1024)
         return _err(rid, 4018, f"image too large ({len(img_bytes)} bytes; cap is {mb} MB)")
+    # Reject payloads that are not actually a decodable image before we write
+    # them to disk and queue them — _sniff_image_ext would otherwise relabel
+    # unknown bytes as ".png" and hand junk to the vision model. Mirrors the
+    # %PDF- guard pdf.attach applies above.
+    if not _is_decodable_image(img_bytes):
+        return _err(rid, 4017, "uploaded bytes are not a decodable image")
 
     filename = str(params.get("filename", "") or "")
     ext_hint = str(params.get("ext", "") or "").strip().lower()


### PR DESCRIPTION
## What does this PR do?

The remote-media-relay feature (#16786bb) added two sibling JSON-RPC byte
upload handlers to `tui_gateway/server.py`: `pdf.attach` and
`image.attach_bytes`. They share the `_decode_attach_base64` /
`_queue_attached_image` helpers but diverged on input validation.

`pdf.attach` guards its payload with a `%PDF-` magic-byte check and returns
`4017` for anything that is not a PDF. `image.attach_bytes` has no equivalent
content check: it sniffs an extension via `_sniff_image_ext`, which by design
falls back to `.png` for any leading bytes it does not recognise (locked in by
`test_sniff_image_ext_magic_and_filename`). Because `.png` is always in the
allowed-extension set, the `ext not in _allowed_image_extensions()` gate never
fires for unrecognised bytes, so a remote client can push arbitrary non-image
bytes that get base64-decoded, written into the gateway's images dir as a
`.png`, and appended to `session["attached_images"]`. The junk only fails on
the *next* `prompt.submit`, where `_enrich_with_attached_images` /
`build_native_content_parts` -> `_file_to_data_url` hand it to the model and
the vision call degrades to "[analysis failed]" or a provider HTTP 400.

This adds `_is_decodable_image()` — the image-side analogue of `pdf.attach`'s
`%PDF-` guard — and calls it in `image.attach_bytes` right after the size cap,
before the file is written or queued. It uses Pillow's `Image.open(...).load()`
(Pillow is a core dependency, already used by `_image_meta`) so it accepts the
exact format set the downstream vision path can decode while rejecting genuine
non-image payloads with a clear `4017`. `load()` is used rather than `verify()`
because `verify()` rejects the tolerable CRC quirks real encoders emit (e.g.
the 1x1 PNG test fixture). If Pillow is somehow absent the helper fails OPEN,
preserving prior behaviour rather than blocking every upload.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: add `_is_decodable_image(img_bytes)` (Pillow
  `Image.open(...).load()`, fail-open when Pillow is missing); call it in the
  `image.attach_bytes` handler after the `_ATTACH_BYTES_MAX_BYTES` check and
  before `_sniff_image_ext` / `_queue_attached_image`, returning `4017`
  ("uploaded bytes are not a decodable image") for non-image payloads.
- `tests/test_tui_gateway_server.py`: add
  `test_image_attach_bytes_rejects_non_image_bytes` (valid base64 of non-image
  bytes -> `4017`, nothing written or queued) and `test_is_decodable_image_helper`
  (real PNG passes; plain garbage and a fake-`\x89PNG`-header payload are rejected).

## How to Test

1. `scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k "attach_bytes or is_decodable or sniff_image or decode_attach or pdf_attach"`
2. The two new tests confirm a non-image base64 upload now returns error
   `4017` and leaves `session["attached_images"]` and the images dir empty,
   instead of writing a mislabeled `.png`.
3. Regression guard: the existing `image.attach_bytes` happy-path,
   data-URL-prefix, magic-sniff, unsupported-extension, and `_sniff_image_ext`
   fallback tests still pass unchanged.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A