### PR TITLE
feat(desktop): add switch-to-profile button in Profiles settings view

### DIFF
--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -1,6 +1,7 @@
 import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { useStore } from '@nanostores/react'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
 import {
@@ -24,9 +25,10 @@ import {
   updateProfileSoul
 } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { AlertTriangle, Pencil, Save, Terminal, Trash2, Users } from '@/lib/icons'
+import { AlertTriangle, LogIn, Pencil, Save, Terminal, Trash2, Users } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
+import { $activeGatewayProfile, normalizeProfileKey, selectProfile } from '@/store/profile'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { OverlayMain, OverlayNewButton, OverlaySidebar, OverlaySplitLayout } from '../overlays/overlay-split-layout'
@@ -50,6 +52,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
   const [createOpen, setCreateOpen] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<null | ProfileInfo>(null)
   const [deleting, setDeleting] = useState(false)
+  const gatewayProfile = useStore($activeGatewayProfile)
 
   const refresh = useCallback(async () => {
     try {
@@ -162,8 +165,13 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
             {selected ? (
               <ProfileDetail
                 key={selected.name}
+                isActive={normalizeProfileKey(selected.name) === normalizeProfileKey(gatewayProfile)}
                 onDelete={() => setPendingDelete(selected)}
                 onRename={newName => handleRename(selected.name, newName)}
+                onSwitch={() => {
+                  selectProfile(selected.name)
+                  onClose()
+                }}
                 profile={selected}
               />
             ) : (
@@ -240,12 +248,16 @@ function ProfileRow({ active, onSelect, profile }: { active: boolean; onSelect: 
 }
 
 function ProfileDetail({
+  isActive,
   onDelete,
   onRename,
+  onSwitch,
   profile
 }: {
+  isActive: boolean
   onDelete: () => void
   onRename: (newName: string) => Promise<void>
+  onSwitch: () => void
   profile: ProfileInfo
 }) {
   const { t } = useI18n()
@@ -292,6 +304,12 @@ function ProfileDetail({
                 </p>
               </div>
               <div className="flex shrink-0 items-center gap-1">
+                {!isActive && (
+                  <Button onClick={onSwitch} size="sm">
+                    <LogIn />
+                    {p.switchToProfile(profile.name)}
+                  </Button>
+                )}
                 {!profile.is_default && (
                   <Button onClick={() => setRenameOpen(true)} size="sm" variant="outline">
                     <Pencil />


### PR DESCRIPTION
## Summary

Add a "Switch to \<name\>" button in the **ProfileDetail** panel of the Profiles settings page, so users can activate a profile directly from the management view without needing to discover the sidebar ProfileRail.

## Motivation

The Profiles page (`/profiles`) lets users create, rename, delete profiles, and edit their SOUL.md — but there's no way to **switch** to a profile from there. Users must go back to the sidebar's ProfileRail (colored squares at the bottom) to change the active profile. This is unintuitive, especially for users who navigate to Profiles specifically to manage their setup.

Fixes #41807

## Changes

**File:** `apps/desktop/src/app/profiles/index.tsx` (+19 lines, −1 line)

- Import `useStore` from `@nanostores/react`, `LogIn` icon, and `$activeGatewayProfile` / `normalizeProfileKey` / `selectProfile` from the profile store
- In `ProfilesView`, read the current active gateway profile via `useStore($activeGatewayProfile)`
- Pass `isActive` and `onSwitch` props to `ProfileDetail`
- In `ProfileDetail`, render a primary "Switch to \<name\>" button (using the existing `switchToProfile` i18n key) when the viewed profile is not the current active one
- Clicking the button calls `selectProfile(name)` and closes the overlay, landing the user on a fresh chat in the selected profile

## Behavior

| Scenario | Button shown? |
|----------|--------------|
| Viewing the currently active profile | No |
| Viewing a different profile | Yes — primary button with LogIn icon |
| Viewing the default profile (when it's not active) | Yes |

## Screenshots

The button appears as the leftmost primary action in the ProfileDetail header, before Rename / Copy Setup / Delete.

## Testing

- TypeScript compiles cleanly (`tsc --noEmit`)
- The `switchToProfile` i18n key already exists in all 4 locales (en, zh, zh-hant, ja)
- `selectProfile()` is the same function used by the sidebar ProfileRail — well-tested in production
