### PR TITLE
fix(tools): preserve userinfo while normalizing IDN hosts

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -42,6 +42,28 @@ class TestNormalizeUrlForRequest:
             == "https://xn--mnich-kva.example/K%C3%B6ln"
         )
 
+    def test_idna_encodes_uppercase_hostname(self):
+        # urlsplit lowercases parsed.hostname but parsed.netloc keeps the original case, so a
+        # case-sensitive substitution silently no-ops for any capitalized IDN host.
+        assert (
+            normalize_url_for_request("https://Köln.de/wetter")
+            == "https://xn--kln-sna.de/wetter"
+        )
+
+    def test_idna_encodes_hostname_with_userinfo_and_port(self):
+        assert (
+            normalize_url_for_request("https://user:pw@Köln.de:8443/x")
+            == "https://user:pw@xn--kln-sna.de:8443/x"
+        )
+
+    def test_idna_preserves_malformed_port(self):
+        # a malformed port must survive normalization so it is still rejected downstream,
+        # not silently dropped to the default port.
+        assert (
+            normalize_url_for_request("https://münich.example:bad/x")
+            == "https://xn--mnich-kva.example:bad/x"
+        )
+
 
 class TestIsSafeUrl:
     def test_public_url_allowed(self):

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -47,6 +47,10 @@ class TestNormalizeUrlForRequest:
         ("https://wttr.in/K%C3%B6ln", "https://wttr.in/K%C3%B6ln"),
         # hostname is IDNA-encoded
         ("https://münich.example/Köln", "https://xn--mnich-kva.example/K%C3%B6ln"),
+        ("https://Köln.de/wetter", "https://xn--kln-sna.de/wetter"),
+        ("https://user:pw@Köln.de:8443/x", "https://user:pw@xn--kln-sna.de:8443/x"),
+        ("https://köln.de@Köln.de:8443/x", "https://köln.de@xn--kln-sna.de:8443/x"),
+        ("https://münich.example:bad/x", "https://xn--mnich-kva.example:bad/x"),
     ])
     def test_encodes_url_parts(self, raw, expected):
         assert normalize_url_for_request(raw) == expected

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -67,7 +67,16 @@ def normalize_url_for_request(url: str) -> str:
         except UnicodeError:
             ascii_host = hostname
         if ascii_host != hostname:
-            netloc = netloc.replace(hostname, ascii_host, 1)
+            # parsed.hostname is lowercased by urlsplit while parsed.netloc preserves the
+            # original case, so str.replace() of the lowercased hostname silently no-ops for
+            # any host with an uppercase letter (e.g. https://Köln.de). Rebuild netloc from
+            # structural parts so the IDNA host substitution is case-insensitive, never
+            # collides with matching text in userinfo, and preserves the raw port text
+            # verbatim (including a malformed port, which must still be rejected downstream).
+            # The rebuild only runs for IDNA-encodable hosts, never IP/IPv6 literals.
+            userinfo, at, host_port = parsed.netloc.rpartition("@")
+            _, colon, port = host_port.partition(":")
+            netloc = userinfo + at + ascii_host + colon + port
 
     path = quote(parsed.path, safe="/%:@!$&'()*+,;=")
     query = quote(parsed.query, safe="/%:@!$&'()*+,;=?")

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -58,7 +58,11 @@ def normalize_url_for_request(url: str) -> str:
         except UnicodeError:
             ascii_host = hostname
         if ascii_host != hostname:
-            netloc = netloc.replace(hostname, ascii_host, 1)
+            # Rebuild the authority so lowercased hostname text cannot replace
+            # userinfo or miss a differently cased host. Preserve the raw port.
+            userinfo, at, host_port = parsed.netloc.rpartition("@")
+            _, colon, port = host_port.partition(":")
+            netloc = userinfo + at + ascii_host + colon + port
     safe = "/%:@!$&'()*+,;="
     return urlunsplit((parsed.scheme, netloc, quote(parsed.path, safe=safe),
                        quote(parsed.query, safe=safe + "?"), quote(parsed.fragment, safe=safe + "?")))


### PR DESCRIPTION
Fix URL normalization for capitalized internationalized hosts and for host text that also appears in userinfo.

The authority is rebuilt from its structural parts, preserving userinfo and raw port text while IDNA-encoding only the hostname. Existing path/query escaping and ASCII/IPv6 behavior are unchanged.

Rebased onto current main and added the requested `https://köln.de@Köln.de:8443/x` regression to the existing parameterized tests. It preserves `köln.de` as userinfo and normalizes the authority host to `xn--kln-sna.de`.

Validation: the canonical URL safety suite passes 65 tests; the uppercase/userinfo regression cases fail on current main. Ruff and `git diff --check` pass. Related to #41430.
