### PR TITLE
fix(terminal): collapse CWD-only overrides to shared container

### DIFF
--- a/tests/tools/test_shared_container_task_id.py
+++ b/tests/tools/test_shared_container_task_id.py
@@ -105,3 +105,49 @@ def test_get_active_env_honours_rl_override():
         terminal_tool.clear_task_env_overrides("rl-42")
         terminal_tool._active_environments.pop("default", None)
         terminal_tool._active_environments.pop("rl-42", None)
+
+
+def test_cwd_only_override_collapses_to_default():
+    """CWD-only overrides (ACP adapter workspace tracking) must NOT trigger
+    container isolation — they should collapse to the shared 'default'
+    container so all surfaces (TUI, gateway, dashboard) share one sandbox.
+    Regression for #37361."""
+    terminal_tool.register_task_env_overrides(
+        "acp-session-abc", {"cwd": "/home/user/project"}
+    )
+    try:
+        assert (
+            terminal_tool._resolve_container_task_id("acp-session-abc")
+            == "default"
+        )
+    finally:
+        terminal_tool.clear_task_env_overrides("acp-session-abc")
+
+
+def test_cwd_plus_docker_image_keeps_own_id():
+    """When overrides include both cwd AND docker_image, isolation must
+    still be honoured (RL/benchmark pattern with explicit cwd)."""
+    terminal_tool.register_task_env_overrides(
+        "rl-with-cwd", {"docker_image": "myimg:latest", "cwd": "/workspace"}
+    )
+    try:
+        assert (
+            terminal_tool._resolve_container_task_id("rl-with-cwd")
+            == "rl-with-cwd"
+        )
+    finally:
+        terminal_tool.clear_task_env_overrides("rl-with-cwd")
+
+
+def test_env_type_override_keeps_own_id():
+    """env_type is an isolation key — must trigger per-task container."""
+    terminal_tool.register_task_env_overrides(
+        "bench-env", {"env_type": "sandbox", "cwd": "/work"}
+    )
+    try:
+        assert (
+            terminal_tool._resolve_container_task_id("bench-env")
+            == "bench-env"
+        )
+    finally:
+        terminal_tool.clear_task_env_overrides("bench-env")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1006,9 +1006,20 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     task_id, we honour it by returning the task_id unchanged -- those
     rollouts need their own isolated sandbox, which is the whole point of
     the override.
+
+    CWD-only overrides (registered by the ACP adapter for workspace
+    tracking) are *not* isolation signals — they should not cause each
+    session to spin up its own container.  Only overrides containing
+    backend-specific image keys or ``env_type`` trigger isolation.
     """
+    _ISOLATION_KEYS = frozenset({
+        "docker_image", "modal_image", "singularity_image",
+        "daytona_image", "env_type",
+    })
     if task_id and task_id in _task_env_overrides:
-        return task_id
+        overrides = _task_env_overrides[task_id]
+        if set(overrides.keys()) & _ISOLATION_KEYS:
+            return task_id
     return "default"
 
 


### PR DESCRIPTION
## Summary
TUI, gateway, and dashboard now share one long-lived Docker container, so auth (gcloud/AWS/gh), installed packages, and filesystem state written in one surface are visible in all of them.

Root cause: `_resolve_container_task_id` returned the `task_id` for *any* registered env override. The ACP adapter (`acp_adapter/session.py`) and tui_gateway (`tui_gateway/server.py`) register CWD-only annotations for workspace tracking — those accidentally tripped the per-task container isolation meant only for RL/benchmark rollouts. With `docker_persist_across_processes: true`, every session got its own container keyed by session ID and was never reused across surfaces.

## Changes
- `tools/terminal_tool.py`: add an `_ISOLATION_KEYS` allowlist (`docker_image`, `modal_image`, `singularity_image`, `daytona_image`, `env_type`). Only overrides containing one of those keys get an isolated container; CWD-only overrides collapse to the shared `"default"` container.
- `tests/tools/test_shared_container_task_id.py`: 3 regression tests (CWD-only collapse, cwd+docker_image isolation, env_type isolation).

## Validation
| Override shape | Before | After |
|---|---|---|
| CWD-only (ACP / gateway / dashboard) | own container | `default` (shared) |
| `docker_image`+`cwd` (RL/benchmark) | own container | own container |
| `None` (top-level agent) | `default` | `default` |

- `pytest tests/tools/test_shared_container_task_id.py` → 12 passed.
- E2E with real imports: ACP and gateway CWD-only annotations collapse to `default`; batch_runner-shape image overrides keep their isolated container. The benchmark path (`batch_runner.py`) registers all four image keys, all in the allowlist, so RL/benchmark isolation is preserved.

Salvaged from #37372 by @liuhao1024 (authorship preserved via cherry-pick). Fixes #37361.

## Infographic

![shared-docker-container-across-surfaces](https://v3b.fal.media/files/b/0a9d6e99/BNflXgG8h0f8r0ubHwO03_GvFk4VSw.png)
