### PR TITLE
feat(delegation): add per-task model override for delegate_task

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2795,5 +2795,212 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIsNone(kwargs["fallback_model"])
 
 
+class TestModelOverride(unittest.TestCase):
+    """Tests for per-task and top-level model override in delegate_task."""
+
+    def test_schema_has_model_top_level(self):
+        """The schema must expose a top-level 'model' property."""
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("model", props)
+        self.assertEqual(props["model"]["type"], "object")
+        self.assertIn("provider", props["model"]["properties"])
+        self.assertIn("model", props["model"]["properties"])
+
+    def test_schema_has_model_per_task(self):
+        """The schema must expose a 'model' property in task items."""
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        task_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+        self.assertIn("model", task_props)
+        self.assertEqual(task_props["model"]["type"], "object")
+
+    def test_resolve_model_override_none_returns_none(self):
+        """None or empty dict returns None (no override)."""
+        parent = _make_mock_parent()
+        from tools.delegate_tool import _resolve_model_override
+        self.assertIsNone(_resolve_model_override(None, parent))
+        self.assertIsNone(_resolve_model_override({}, parent))
+        self.assertIsNone(_resolve_model_override({"model": "", "provider": ""}, parent))
+
+    def test_resolve_model_override_model_only_inherits_parent_provider(self):
+        """Model-only override keeps the parent's provider and credentials."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_mode = "chat_completions"
+        from tools.delegate_tool import _resolve_model_override
+        creds = _resolve_model_override({"model": "deepseek/deepseek-chat"}, parent)
+        self.assertEqual(creds["model"], "deepseek/deepseek-chat")
+        self.assertEqual(creds["provider"], "openrouter")
+        self.assertEqual(creds["base_url"], "https://openrouter.ai/api/v1")
+        self.assertIsNone(creds["api_key"])  # inherit from parent
+
+    def test_resolve_model_override_bare_custom_ignored(self):
+        """Bare 'custom' provider is treated as no provider (inherits parent)."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        from tools.delegate_tool import _resolve_model_override
+        creds = _resolve_model_override({"provider": "custom", "model": "test"}, parent)
+        self.assertEqual(creds["provider"], "openrouter")
+
+    def test_resolve_model_override_with_provider_resolves_credentials(self):
+        """Provider-specified override resolves full credentials."""
+        parent = _make_mock_parent()
+        from tools.delegate_tool import _resolve_model_override
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_resolve:
+            mock_resolve.return_value = {
+                "provider": "anthropic",
+                "base_url": "https://api.anthropic.com",
+                "api_key": "test-key",
+                "api_mode": "anthropic_messages",
+            }
+            creds = _resolve_model_override(
+                {"provider": "anthropic", "model": "claude-sonnet-4"}, parent
+            )
+        self.assertEqual(creds["model"], "claude-sonnet-4")
+        self.assertEqual(creds["provider"], "anthropic")
+        self.assertEqual(creds["api_key"], "test-key")
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+
+    def test_resolve_model_override_provider_no_key_raises(self):
+        """Provider with no API key raises ValueError."""
+        parent = _make_mock_parent()
+        from tools.delegate_tool import _resolve_model_override
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_resolve:
+            mock_resolve.return_value = {
+                "provider": "anthropic",
+                "base_url": "https://api.anthropic.com",
+                "api_key": "",
+                "api_mode": "anthropic_messages",
+            }
+            with self.assertRaises(ValueError) as ctx:
+                _resolve_model_override({"provider": "anthropic"}, parent)
+            self.assertIn("no API key", str(ctx.exception))
+
+    def test_resolve_model_override_invalid_provider_raises(self):
+        """Unresolvable provider raises ValueError."""
+        parent = _make_mock_parent()
+        from tools.delegate_tool import _resolve_model_override
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_resolve:
+            mock_resolve.side_effect = RuntimeError("unknown provider")
+            with self.assertRaises(ValueError) as ctx:
+                _resolve_model_override({"provider": "nonexistent"}, parent)
+            self.assertIn("Cannot resolve", str(ctx.exception))
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_top_level_model_override_used_for_child(self, mock_creds, mock_cfg):
+        """Top-level model override is passed to _build_child_agent."""
+        mock_creds.return_value = {
+            "model": None, "provider": None, "base_url": None,
+            "api_key": None, "api_mode": None,
+        }
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_mode = "chat_completions"
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {"status": "completed", "summary": "ok"}
+            delegate_task(
+                goal="test task",
+                model={"model": "cheap-model"},
+                parent_agent=parent,
+            )
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "cheap-model")
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_model_overrides_top_level(self, mock_creds, mock_cfg):
+        """Per-task model override takes precedence over top-level."""
+        mock_creds.return_value = {
+            "model": None, "provider": None, "base_url": None,
+            "api_key": None, "api_mode": None,
+        }
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_mode = "chat_completions"
+
+        def _fake_run(task_index, goal, child, parent_agent):
+            return {"task_index": task_index, "status": "completed", "summary": "ok", "_child_role": "leaf"}
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child", side_effect=_fake_run) as mock_run:
+            mock_build.return_value = MagicMock()
+            delegate_task(
+                tasks=[
+                    {"goal": "task A", "model": {"model": "per-task-model"}},
+                    {"goal": "task B"},
+                ],
+                model={"model": "top-level-model"},
+                parent_agent=parent,
+            )
+        # First call: per-task model wins
+        _, kwargs_a = mock_build.call_args_list[0]
+        self.assertEqual(kwargs_a["model"], "per-task-model")
+        # Second call: top-level model used (no per-task override)
+        _, kwargs_b = mock_build.call_args_list[1]
+        self.assertEqual(kwargs_b["model"], "top-level-model")
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_no_model_override_uses_delegation_config(self, mock_creds, mock_cfg):
+        """Without model override, delegation config credentials are used."""
+        mock_creds.return_value = {
+            "model": "delegation-model", "provider": "openrouter",
+            "base_url": None, "api_key": None, "api_mode": None,
+        }
+        parent = _make_mock_parent()
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {"status": "completed", "summary": "ok"}
+            delegate_task(goal="test task", parent_agent=parent)
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "delegation-model")
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_batch_per_task_model_with_provider(self, mock_creds, mock_cfg):
+        """Per-task model with provider resolves credentials independently."""
+        mock_creds.return_value = {
+            "model": None, "provider": None, "base_url": None,
+            "api_key": None, "api_mode": None,
+        }
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_mode = "chat_completions"
+
+        def _fake_run(task_index, goal, child, parent_agent):
+            return {"task_index": task_index, "status": "completed", "summary": "ok", "_child_role": "leaf"}
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child", side_effect=_fake_run) as mock_run, \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_resolve:
+            mock_build.return_value = MagicMock()
+            mock_resolve.return_value = {
+                "provider": "anthropic",
+                "base_url": "https://api.anthropic.com",
+                "api_key": "ant-key",
+                "api_mode": "anthropic_messages",
+            }
+            delegate_task(
+                tasks=[
+                    {"goal": "reasoning task", "model": {"provider": "anthropic", "model": "claude-sonnet-4"}},
+                ],
+                parent_agent=parent,
+            )
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "claude-sonnet-4")
+        self.assertEqual(kwargs["override_provider"], "anthropic")
+        self.assertEqual(kwargs["override_api_key"], "ant-key")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1967,11 +1967,79 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+def _resolve_model_override(
+    model_obj: Any,
+    parent_agent,
+) -> Optional[Dict[str, Any]]:
+    """Resolve a per-task/top-level model override into a credential dict.
+
+    ``model_obj`` is a dict with optional ``provider`` and ``model`` keys,
+    matching the cron job model override pattern.  Returns a credential dict
+    (model, provider, base_url, api_key, api_mode) or ``None`` when no
+    override is requested.
+
+    Raises ``ValueError`` on unresolvable provider references.
+    """
+    if not model_obj or not isinstance(model_obj, dict):
+        return None
+
+    model_name = str(model_obj.get("model") or "").strip() or None
+    provider_name = str(model_obj.get("provider") or "").strip() or None
+
+    # Bare "custom" is incomplete — ignore so it doesn't break resolution.
+    if provider_name == "custom":
+        provider_name = None
+
+    if not model_name and not provider_name:
+        return None
+
+    if not provider_name:
+        # Model-only override — use parent's provider credentials, just swap
+        # the model name.  This is the common "use a cheaper model for this
+        # task" pattern.
+        return {
+            "model": model_name,
+            "provider": getattr(parent_agent, "provider", None),
+            "base_url": getattr(parent_agent, "base_url", None),
+            "api_key": None,  # inherit from parent
+            "api_mode": getattr(parent_agent, "api_mode", None),
+        }
+
+    # Provider specified — resolve full credentials via the runtime system.
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(
+            requested=provider_name, target_model=model_name
+        )
+    except Exception as exc:
+        raise ValueError(
+            f"Cannot resolve model override provider '{provider_name}': {exc}. "
+            f"Check that the provider is configured (API key set, valid provider name)."
+        ) from exc
+
+    api_key = runtime.get("api_key", "")
+    if not api_key:
+        raise ValueError(
+            f"Model override provider '{provider_name}' resolved but has no API key. "
+            f"Set the API key for this provider first."
+        )
+
+    return {
+        "model": model_name or runtime.get("model"),
+        "provider": runtime.get("provider", provider_name),
+        "base_url": runtime.get("base_url"),
+        "api_key": api_key,
+        "api_mode": runtime.get("api_mode", "chat_completions"),
+    }
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
+    model: Optional[Dict[str, Any]] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
@@ -2050,6 +2118,15 @@ def delegate_task(
     except ValueError as exc:
         return tool_error(str(exc))
 
+    # Top-level model override (from tool call argument) overrides delegation
+    # config credentials.  Per-task overrides take further precedence.
+    top_model_creds = None
+    if model:
+        try:
+            top_model_creds = _resolve_model_override(model, parent_agent)
+        except ValueError as exc:
+            return tool_error(str(exc))
+
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
@@ -2111,26 +2188,37 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+
+            # Per-task model override > top-level model override > delegation config.
+            task_model_creds = None
+            if "model" in t:
+                task_model_creds = _resolve_model_override(t["model"], parent_agent)
+                if task_model_creds is None:
+                    return tool_error(
+                        f"Task {i}: 'model' must have at least 'model' or 'provider' key."
+                    )
+            effective_creds = task_model_creds or top_model_creds or creds
+
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=effective_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=effective_creds["provider"],
+                override_base_url=effective_creds["base_url"],
+                override_api_key=effective_creds["api_key"],
+                override_api_mode=effective_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or effective_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else effective_creds.get("args"))
                 ),
                 role=effective_role,
             )
@@ -2816,6 +2904,19 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "object",
+                "properties": {
+                    "provider": {"type": "string", "description": "Provider name (e.g. 'anthropic', 'openrouter', 'xiaomi'). If omitted, inherits the parent's provider."},
+                    "model": {"type": "string", "description": "Model ID (e.g. 'claude-sonnet-4', 'deepseek/deepseek-chat'). If omitted, uses the provider's default."},
+                },
+                "description": (
+                    "Optional model override for all child agents. "
+                    "Overrides delegation.* config for this call. "
+                    "Per-task 'model' in the tasks array takes further precedence. "
+                    "Use for routing delegation to a different model tier."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -2848,6 +2949,19 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
+                        },
+                        "model": {
+                            "type": "object",
+                            "properties": {
+                                "provider": {"type": "string", "description": "Provider name (e.g. 'anthropic', 'openrouter', 'xiaomi'). If omitted, inherits the parent's provider."},
+                                "model": {"type": "string", "description": "Model ID (e.g. 'claude-sonnet-4', 'deepseek/deepseek-chat'). If omitted, uses the provider's default."},
+                            },
+                            "description": (
+                                "Per-task model override. Overrides both the top-level 'model' "
+                                "and the delegation.* config for this task only. "
+                                "Use for routing different tasks to different model tiers "
+                                "(e.g. expensive model for reasoning, cheap model for formatting)."
+                            ),
                         },
                     },
                     "required": ["goal"],
@@ -2902,6 +3016,7 @@ registry.register(
         context=args.get("context"),
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
+        model=args.get("model"),
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),


### PR DESCRIPTION
## Problem

`delegate_task` currently uses a single global model configured via `delegation.model` / `delegation.provider` in `config.yaml`. All delegated subagents run on the same model regardless of task complexity.

This limits a common pattern: using different model tiers for different subtasks — e.g. a smart/expensive model for hard reasoning tasks, a cheap/fast model for mechanical work, and a medium-tier model as the default.

## Solution

Add an optional `model` parameter to `delegate_task` that overrides the global `delegation.*` config for that specific invocation. Supports both **top-level** (applies to all children) and **per-task** (individual tasks in batch mode) overrides.

**Precedence**: per-task model > top-level model > delegation.* config

### API

```python
# Top-level: all children use this model
delegate_task(
    goal="Analyze this complex codebase architecture",
    model={"provider": "anthropic", "model": "claude-sonnet-4"}
)

# Per-task: different models for different tasks
delegate_task(
    tasks=[
        {"goal": "Complex reasoning task", "model": {"provider": "anthropic", "model": "claude-sonnet-4"}},
        {"goal": "Format 50 files with black", "model": {"provider": "openrouter", "model": "deepseek/deepseek-chat"}},
    ]
)

# Model-only: inherit parent's provider, just swap the model
delegate_task(goal="Quick task", model={"model": "cheap-model"})
```

### Implementation

- `_resolve_model_override()` — resolves a model dict into a credential dict (provider, base_url, api_key, api_mode), following the same pattern as cron job model overrides
- When only `model` is specified (no `provider`), the child inherits the parent's provider credentials — the common "use a cheaper model" pattern
- When `provider` is specified, full credentials are resolved via the runtime provider system
- Bare `"custom"` provider is treated as no provider (inherits parent) — prevents LLM hallucinated custom providers from breaking resolution

## Changes

- `tools/delegate_tool.py`: +122 lines (new `_resolve_model_override` helper, schema additions, handler update)
- `tests/tools/test_delegate.py`: +207 lines (12 new tests covering schema validation, credential resolution, precedence ordering)

## Tests

```
tests/tools/test_delegate.py::TestModelOverride::test_schema_has_model_top_level PASSED
tests/tools/test_delegate.py::TestModelOverride::test_schema_has_model_per_task PASSED
tests/tools/test_delegate.py::TestModelOverride::test_resolve_model_override_none_returns_none PASSED
tests/tools/test_delegate.py::TestModelOverride::test_resolve_model_override_model_only_inherits_parent_provider PASSED
tests/tools/test_delegate.py::TestModelOverride::test_resolve_model_override_bare_custom_ignored PASSED
tests/tools/test_delegate.py::TestModelOverride::test_resolve_model_override_with_provider_resolves_credentials PASSED
tests/tools/test_delegate.py::TestModelOverride::test_resolve_model_override_provider_no_key_raises PASSED
tests/tools/test_delegate.py::TestModelOverride::test_resolve_model_override_invalid_provider_raises PASSED
tests/tools/test_delegate.py::TestModelOverride::test_top_level_model_override_used_for_child PASSED
tests/tools/test_delegate.py::TestModelOverride::test_per_task_model_overrides_top_level PASSED
tests/tools/test_delegate.py::TestModelOverride::test_no_model_override_uses_delegation_config PASSED
tests/tools/test_delegate.py::TestModelOverride::test_batch_per_task_model_with_provider PASSED
```

Fixes #41814
