### PR TITLE
fix(agent): respect auxiliary.title_generation.timeout config for title generation

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -29,7 +29,7 @@ _TITLE_PROMPT = (
 def generate_title(
     user_message: str,
     assistant_response: str,
-    timeout: float = 30.0,
+    timeout: Optional[float] = None,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
 ) -> Optional[str]:
@@ -38,6 +38,11 @@ def generate_title(
     Uses the main runtime's model when available, falling back to the
     auxiliary LLM client (cheapest/fastest available model).
     Returns the title string or None on failure.
+
+    ``timeout`` defaults to ``None``, which delegates to
+    ``call_llm``'s config-driven resolution (reads
+    ``auxiliary.title_generation.timeout`` from config.yaml).
+    An explicit value overrides the config.
 
     ``failure_callback`` is invoked with ``(task, exception)`` when the
     auxiliary call raises — the caller typically wires this to

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -93,6 +93,44 @@ class TestGenerateTitle:
         with patch("agent.title_generator.call_llm", side_effect=RuntimeError("nope")):
             assert generate_title("q", "a") is None
 
+    def test_default_timeout_delegates_to_config(self):
+        """Regression: timeout=None delegates to call_llm config resolution (#41812).
+
+        Previously generate_title defaulted to timeout=30.0, which caused
+        call_llm to use that hardcoded value instead of reading
+        auxiliary.title_generation.timeout from config.yaml.
+        """
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Config-Aware Title"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title("question", "answer")
+
+        # Default must be None so call_llm reads from config
+        assert captured_kwargs.get("timeout") is None
+
+    def test_explicit_timeout_is_forwarded(self):
+        """When an explicit timeout is passed, it must reach call_llm."""
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Explicit Timeout"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title("question", "answer", timeout=120.0)
+
+        assert captured_kwargs.get("timeout") == 120.0
+
     def test_truncates_long_messages(self):
         """Long user/assistant messages should be truncated in the LLM request."""
         captured_kwargs = {}


### PR DESCRIPTION
## What does this PR do?

Fixes `generate_title()` to respect the `auxiliary.title_generation.timeout` config setting instead of always using a hardcoded 30-second timeout.

## Related Issue

Fixes #41812

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/title_generator.py`: Changed `generate_title()` default `timeout` from `30.0` to `None`, so `call_llm()` reads `auxiliary.title_generation.timeout` from config.yaml via its built-in `_get_task_timeout()` resolution.
- `tests/agent/test_title_generator.py`: Added 2 regression tests — one verifying the default timeout is `None` (delegates to config), and one verifying an explicit timeout value is forwarded correctly.

## How to Test

1. Set `auxiliary.title_generation.timeout: 300` in config.yaml
2. Start a new session with a slow local model (e.g., Ollama)
3. Title generation should now wait up to 300s instead of timing out at 30s
4. Run `pytest tests/agent/test_title_generator.py -v` — all 22 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_title_generator.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/title_generator.py::generate_title` (callers: 1 via `auto_title_session`)
- Analyzed: `agent/auxiliary_client.py::call_llm` (timeout resolution: `_get_task_timeout()`)
- Blast radius: LOW — only affects title generation timeout, no control-flow changes
- Related patterns: `call_llm` config-driven timeout resolution (`timeout=None` → `_get_task_timeout(task)`)
