### PR TITLE
feat(plugins): add rich cron delivery hooks

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -721,6 +721,56 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
+def _apply_cron_delivery_transform(
+    *,
+    job: dict,
+    content: str,
+    delivery_content: str,
+    target: dict,
+) -> tuple[str, dict]:
+    """Let plugins rewrite one cron delivery payload.
+
+    The hook is intentionally small: plugins can replace the text that will be
+    sent and attach platform metadata. Invalid returns are ignored so cron
+    delivery remains fail-open.
+    """
+    try:
+        from hermes_cli.plugins import discover_plugins, has_hook, invoke_hook
+
+        discover_plugins()
+        if not has_hook("transform_cron_delivery"):
+            return delivery_content, {}
+        hook_results = invoke_hook(
+            "transform_cron_delivery",
+            job=job,
+            content=content,
+            delivery_content=delivery_content,
+            target=dict(target),
+        )
+    except Exception as exc:
+        logger.debug("transform_cron_delivery hook error: %s", exc)
+        return delivery_content, {}
+
+    for hook_result in hook_results:
+        if not isinstance(hook_result, dict):
+            continue
+        transformed_content = delivery_content
+        if hook_result.get("content") is not None:
+            transformed_content = str(hook_result["content"])
+        metadata = hook_result.get("metadata")
+        transformed_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        return transformed_content, transformed_metadata
+
+    return delivery_content, {}
+
+
+def _delivery_metadata_for_target(metadata: dict, thread_id: Optional[str]) -> Optional[dict]:
+    merged = dict(metadata or {})
+    if thread_id:
+        merged.setdefault("thread_id", thread_id)
+    return merged or None
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -766,10 +816,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     else:
         delivery_content = content
 
-    # Extract MEDIA: tags so attachments are forwarded as files, not raw text
     from gateway.platforms.base import BasePlatformAdapter
-    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
     try:
         config = load_gateway_config()
@@ -784,6 +831,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
+        target_delivery_content, delivery_metadata = _apply_cron_delivery_transform(
+            job=job,
+            content=content,
+            delivery_content=delivery_content,
+            target=target,
+        )
+
+        # Extract MEDIA: tags so attachments are forwarded as files, not raw text
+        media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(target_delivery_content)
+        media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
@@ -822,7 +879,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
+            send_metadata = _delivery_metadata_for_target(delivery_metadata, thread_id)
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
@@ -885,7 +942,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            send_metadata = _delivery_metadata_for_target(delivery_metadata, thread_id)
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                media_files=media_files,
+                metadata=send_metadata,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError:
@@ -895,7 +961,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # fresh thread that has no running loop.
                 coro.close()
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                    future = pool.submit(
+                        asyncio.run,
+                        _send_to_platform(
+                            platform,
+                            pconfig,
+                            chat_id,
+                            cleaned_delivery_content,
+                            thread_id=thread_id,
+                            media_files=media_files,
+                            metadata=send_metadata,
+                        ),
+                    )
                     result = future.result(timeout=30)
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -168,6 +168,7 @@ class PlatformRegistry:
 
     def __init__(self) -> None:
         self._entries: dict[str, PlatformEntry] = {}
+        self._card_action_handlers: dict[tuple[str, str], Callable[..., Any]] = {}
 
     def register(self, entry: PlatformEntry) -> None:
         """Register a platform adapter entry.
@@ -254,6 +255,48 @@ class PlatformRegistry:
                 exc_info=True,
             )
             return None
+
+    def register_card_action_handler(
+        self,
+        platform_name: str,
+        action_type: str,
+        handler: Callable[..., Any],
+    ) -> None:
+        """Register a plugin handler for an interactive card action.
+
+        The registry is intentionally platform-neutral. Adapters own the shape
+        of the callback kwargs and the response contract they accept.
+        """
+        platform_key = str(platform_name or "").strip().lower()
+        action_key = str(action_type or "").strip()
+        if not platform_key:
+            raise ValueError("platform_name is required")
+        if not action_key:
+            raise ValueError("action_type is required")
+        if not callable(handler):
+            raise TypeError("handler must be callable")
+        self._card_action_handlers[(platform_key, action_key)] = handler
+        logger.debug(
+            "Registered %s card action handler: %s",
+            platform_key,
+            action_key,
+        )
+
+    def unregister_card_action_handler(self, platform_name: str, action_type: str) -> bool:
+        """Remove a card-action handler. Returns True if it existed."""
+        platform_key = str(platform_name or "").strip().lower()
+        action_key = str(action_type or "").strip()
+        return self._card_action_handlers.pop((platform_key, action_key), None) is not None
+
+    def get_card_action_handler(
+        self,
+        platform_name: str,
+        action_type: str,
+    ) -> Optional[Callable[..., Any]]:
+        """Return the registered handler for a platform card action."""
+        platform_key = str(platform_name or "").strip().lower()
+        action_key = str(action_type or "").strip()
+        return self._card_action_handlers.get((platform_key, action_key))
 
 
 # Module-level singleton

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -51,6 +51,7 @@ import asyncio
 import collections
 import hashlib
 import hmac
+import inspect
 import itertools
 import json
 import logging
@@ -214,6 +215,7 @@ _FEISHU_WEBHOOK_BODY_TIMEOUT_SECONDS = 30          # max seconds to read request
 _FEISHU_WEBHOOK_ANOMALY_THRESHOLD = 25             # consecutive error responses before WARNING log
 _FEISHU_WEBHOOK_ANOMALY_TTL_SECONDS = 6 * 60 * 60  # anomaly tracker TTL (6 hours) — matches openclaw
 _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS = 15 * 60    # card action token dedup window (15 min)
+_CARD_ACTION_NOT_HANDLED = object()
 
 _APPROVAL_CHOICE_MAP: Dict[str, str] = {
     "approve_once": "once",
@@ -2549,11 +2551,101 @@ class FeishuAdapter(BasePlatformAdapter):
                 action_value=action_value,
                 loop=loop,
             )
+        plugin_action = (
+            action_value.get("hermes_card_action")
+            if isinstance(action_value, dict)
+            else None
+        )
+        if not plugin_action and isinstance(action_value, dict):
+            plugin_action = self._registered_card_action_key(action_value)
+        if plugin_action:
+            plugin_response = self._handle_registered_card_action(
+                data=data,
+                event=event,
+                action_value=action_value,
+                loop=loop,
+                action_type=str(plugin_action),
+            )
+            if plugin_response is not _CARD_ACTION_NOT_HANDLED:
+                return plugin_response
 
         self._submit_on_loop(loop, self._handle_card_action_event(data))
         if P2CardActionTriggerResponse is None:
             return None
         return P2CardActionTriggerResponse()
+
+    @staticmethod
+    def _registered_card_action_key(action_value: Dict[str, Any]) -> Optional[str]:
+        """Return a registered handler key present directly in action_value."""
+        try:
+            from gateway.platform_registry import platform_registry
+        except Exception:
+            return None
+        for key in action_value:
+            try:
+                if platform_registry.get_card_action_handler("feishu", str(key)) is not None:
+                    return str(key)
+            except Exception:
+                continue
+        return None
+
+    def _handle_registered_card_action(
+        self,
+        *,
+        data: Any,
+        event: Any,
+        action_value: Dict[str, Any],
+        loop: Any,
+        action_type: str,
+    ) -> Any:
+        """Delegate plugin-owned card actions registered for Feishu."""
+        try:
+            from gateway.platform_registry import platform_registry
+            handler = platform_registry.get_card_action_handler("feishu", action_type)
+        except Exception:
+            logger.debug("[Feishu] Failed to resolve card action handler", exc_info=True)
+            handler = None
+        if handler is None:
+            return _CARD_ACTION_NOT_HANDLED
+
+        try:
+            result = handler(
+                adapter=self,
+                data=data,
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        except Exception:
+            logger.warning(
+                "[Feishu] Card action handler %s failed",
+                action_type,
+                exc_info=True,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if inspect.isawaitable(result):
+            self._submit_on_loop(loop, result)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        return self._build_registered_card_action_response(result)
+
+    @staticmethod
+    def _build_registered_card_action_response(result: Any) -> Any:
+        """Build the SDK callback response from a plugin handler return."""
+        if P2CardActionTriggerResponse is None:
+            return None
+        if result is not None and not isinstance(result, dict):
+            return result
+
+        response = P2CardActionTriggerResponse()
+        card_payload = result.get("card") if isinstance(result, dict) else None
+        if card_payload is not None and CallBackCard is not None:
+            card = CallBackCard()
+            card.type = str(result.get("card_type", "raw")) if isinstance(result, dict) else "raw"
+            card.data = card_payload
+            response.card = card
+        return response
 
     @staticmethod
     def _loop_accepts_callbacks(loop: Any) -> bool:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -153,6 +153,12 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Cron delivery transform hook. Fired once per delivery target after the
+    # scheduler has produced the user-facing delivery text and before sending.
+    # Plugins may return a dict with:
+    #   {"content": "...", "metadata": {...}}
+    # Non-dict returns are ignored; the first valid dict wins.
+    "transform_cron_delivery",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).
@@ -819,6 +825,30 @@ class PluginContext:
             "Plugin %s registered platform: %s",
             self.manifest.name,
             name,
+        )
+
+    def register_card_action_handler(
+        self,
+        platform: str,
+        action_type: str,
+        handler: Callable,
+    ) -> None:
+        """Register a platform card-action handler.
+
+        Platform adapters that support interactive cards can look up handlers
+        by platform/action_type and delegate plugin-owned button clicks without
+        translating them into synthetic slash commands. The handler contract is
+        platform-owned; Feishu passes ``adapter``, ``data``, ``event``,
+        ``action_value``, and ``loop`` keyword arguments.
+        """
+        from gateway.platform_registry import platform_registry
+
+        platform_registry.register_card_action_handler(platform, action_type, handler)
+        logger.debug(
+            "Plugin %s registered %s card action handler: %s",
+            self.manifest.name,
+            platform,
+            action_type,
         )
 
     # -- hook registration --------------------------------------------------

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -70,6 +70,84 @@ class TestResolveOrigin:
         assert _resolve_origin(job) is None
 
 
+class TestCronDeliveryTransformHook:
+    def test_transform_hook_can_rewrite_content_and_attach_metadata(self, monkeypatch):
+        from cron import scheduler as sched
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        job = {"id": "job-transform", "name": "Monitor", "deliver": "feishu"}
+        target = {"platform": "feishu", "chat_id": "oc_home", "thread_id": "thread-1"}
+        sent = []
+
+        async def fake_send_to_platform(
+            platform,
+            pconfig,
+            chat_id,
+            message,
+            thread_id=None,
+            media_files=None,
+            force_document=False,
+            metadata=None,
+        ):
+            sent.append(
+                {
+                    "platform": platform,
+                    "chat_id": chat_id,
+                    "message": message,
+                    "thread_id": thread_id,
+                    "media_files": media_files,
+                    "metadata": metadata,
+                }
+            )
+            return {"success": True, "message_id": "om_card"}
+
+        def fake_invoke_hook(hook_name, **kwargs):
+            assert hook_name == "transform_cron_delivery"
+            assert kwargs["job"] is job
+            assert kwargs["content"] == "raw monitor digest"
+            assert kwargs["delivery_content"] == "raw monitor digest"
+            assert kwargs["target"] == target
+            return [
+                {
+                    "content": "interactive fallback text",
+                    "metadata": {
+                        "rich_delivery_example": {
+                            "batch_id": "batch-1",
+                        }
+                    },
+                }
+            ]
+
+        monkeypatch.setattr(sched, "_resolve_delivery_targets", lambda _job: [target])
+        monkeypatch.setattr(sched, "load_config", lambda: {"cron": {"wrap_response": False}})
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config",
+            lambda: GatewayConfig(platforms={Platform.FEISHU: PlatformConfig(enabled=True)}),
+        )
+        monkeypatch.setattr("tools.send_message_tool._send_to_platform", fake_send_to_platform)
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda hook_name: hook_name == "transform_cron_delivery")
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+        assert _deliver_result(job, "raw monitor digest") is None
+
+        assert sent == [
+            {
+                "platform": Platform.FEISHU,
+                "chat_id": "oc_home",
+                "message": "interactive fallback text",
+                "thread_id": "thread-1",
+                "media_files": [],
+                "metadata": {
+                    "thread_id": "thread-1",
+                    "rich_delivery_example": {
+                        "batch_id": "batch-1",
+                    },
+                },
+            }
+        ]
+
+
 class TestResolveDeliveryTarget:
     def test_origin_delivery_preserves_thread_id(self):
         job = {

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -549,6 +549,89 @@ class TestCardActionCallbackResponse:
         assert response is not None
         assert response.card is None
 
+    def test_registered_plugin_card_action_returns_inline_card(self, _patch_callback_card_types):
+        from gateway.platform_registry import platform_registry
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        data = _make_card_action_data(
+            {
+                "hermes_card_action": "example_card_action",
+                "decision": "ignored",
+            }
+        )
+        card = {
+            "header": {
+                "template": "green",
+                "title": {"tag": "plain_text", "content": "Handled"},
+            },
+            "elements": [{"tag": "markdown", "content": "Plugin handled the click."}],
+        }
+        calls = []
+
+        def handler(**kwargs):
+            calls.append(kwargs)
+            return {"card": card}
+
+        platform_registry.register_card_action_handler(
+            "feishu",
+            "example_card_action",
+            handler,
+        )
+        try:
+            response = adapter._on_card_action_trigger(data)
+        finally:
+            platform_registry.unregister_card_action_handler(
+                "feishu",
+                "example_card_action",
+            )
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
+        assert response.card.data == card
+        assert calls
+        assert calls[0]["adapter"] is adapter
+        assert calls[0]["action_value"]["decision"] == "ignored"
+
+    def test_registered_plugin_card_action_can_match_legacy_value_key(self, _patch_callback_card_types):
+        from gateway.platform_registry import platform_registry
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        data = _make_card_action_data(
+            {
+                "example_card_action": "confirm",
+                "pending_id": "pending-1",
+            }
+        )
+        card = {
+            "header": {
+                "template": "green",
+                "title": {"tag": "plain_text", "content": "Handled"},
+            },
+            "elements": [],
+        }
+
+        platform_registry.register_card_action_handler(
+            "feishu",
+            "example_card_action",
+            lambda **_kwargs: {"card": card},
+        )
+        try:
+            response = adapter._on_card_action_trigger(data)
+        finally:
+            platform_registry.unregister_card_action_handler(
+                "feishu",
+                "example_card_action",
+            )
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.data == card
+
     def test_falls_back_to_open_id_when_name_not_cached(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -6,6 +6,7 @@ human-friendly channel names to IDs. Works in both CLI and gateway contexts.
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -494,6 +495,7 @@ async def _send_via_adapter(
     thread_id=None,
     media_files=None,
     force_document=False,
+    metadata=None,
 ):
     """Send a message via a live gateway adapter, with a standalone fallback
     for out-of-process callers (e.g. cron running separately from the gateway).
@@ -521,14 +523,14 @@ async def _send_via_adapter(
             adapter = None
         if adapter is not None:
             try:
-                metadata = {}
+                send_metadata = dict(metadata or {})
                 if thread_id:
-                    metadata["thread_id"] = thread_id
+                    send_metadata.setdefault("thread_id", thread_id)
                 if platform_name == "ntfy" and chat_id:
-                    metadata["publish_topic"] = chat_id
-                if not metadata:
-                    metadata = None
-                result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
+                    send_metadata["publish_topic"] = chat_id
+                if not send_metadata:
+                    send_metadata = None
+                result = await adapter.send(chat_id=chat_id, content=chunk, metadata=send_metadata)
             except asyncio.CancelledError:
                 raise
             except Exception as e:
@@ -546,13 +548,28 @@ async def _send_via_adapter(
 
     if entry is not None and entry.standalone_sender_fn is not None:
         try:
+            sender_kwargs = {
+                "thread_id": thread_id,
+                "media_files": media_files,
+                "force_document": force_document,
+            }
+            if metadata:
+                try:
+                    signature = inspect.signature(entry.standalone_sender_fn)
+                    parameters = signature.parameters
+                    accepts_metadata = "metadata" in parameters or any(
+                        param.kind is inspect.Parameter.VAR_KEYWORD
+                        for param in parameters.values()
+                    )
+                except (TypeError, ValueError):
+                    accepts_metadata = False
+                if accepts_metadata:
+                    sender_kwargs["metadata"] = metadata
             result = await entry.standalone_sender_fn(
                 pconfig,
                 chat_id,
                 chunk,
-                thread_id=thread_id,
-                media_files=media_files,
-                force_document=force_document,
+                **sender_kwargs,
             )
         except asyncio.CancelledError:
             raise
@@ -580,7 +597,16 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    metadata=None,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -650,6 +676,38 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         chunks = BasePlatformAdapter.truncate_message(message, max_len, len_fn=_len_fn)
     else:
         chunks = [message]
+
+    # If a built-in platform has been re-registered by a plugin and the caller
+    # supplied plugin metadata, let the registry path handle the send. This is
+    # how out-of-process cron delivery can use plugin-owned rich payloads while
+    # ordinary built-in text sends keep their existing fast paths.
+    has_plugin_metadata = isinstance(metadata, dict) and any(
+        key != "thread_id" for key in metadata
+    )
+    if has_plugin_metadata:
+        try:
+            from gateway.platform_registry import platform_registry
+            entry = platform_registry.get(platform.value if hasattr(platform, "value") else str(platform))
+        except Exception:
+            entry = None
+        if entry is not None and entry.standalone_sender_fn is not None:
+            last_result = None
+            for i, chunk in enumerate(chunks):
+                is_last = (i == len(chunks) - 1)
+                result = await _send_via_adapter(
+                    platform,
+                    pconfig,
+                    chat_id,
+                    chunk,
+                    thread_id=thread_id,
+                    media_files=media_files if is_last else [],
+                    force_document=force_document,
+                    metadata=metadata,
+                )
+                if isinstance(result, dict) and result.get("error"):
+                    return result
+                last_result = result
+            return last_result
 
     # --- Telegram: special handling for media attachments ---
     if platform == Platform.TELEGRAM:
@@ -815,6 +873,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document,
+                metadata=metadata,
             )
 
         if isinstance(result, dict) and result.get("error"):


### PR DESCRIPTION
• ## What does this PR do?

  Adds generic extension points for plugin-owned rich cron delivery and interactive platform callbacks.

  The change introduces:

  - A `transform_cron_delivery` hook that lets plugins adjust cron delivery content and attach metadata before a message is sent.
  - Metadata propagation through cron delivery, live gateway adapters, and standalone sender paths.
  - A platform-neutral card action handler registry keyed by `(platform, action_type)`.
  - Feishu callback delegation for plugin-registered card actions, including inline card update responses.

  This keeps rich cron delivery and card callbacks extensible without hardcoding individual workflows in Hermes core. Feishu is the first adapter wired into the card-
  action registry; other platform adapters can use the same registry when they add their own callback bridge.

  ## Related Issue

  N/A

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - `hermes_cli/plugins.py`: adds the `transform_cron_delivery` hook and plugin card action registration API.
  - `cron/scheduler.py`: invokes the cron delivery transform hook per target and forwards returned metadata.
  - `tools/send_message_tool.py`: propagates metadata through live adapter and standalone sender paths.
  - `gateway/platform_registry.py`: adds card action handler registration and lookup.
  - `gateway/platforms/feishu.py`: delegates registered card actions to plugin handlers.
  - `tests/cron/test_scheduler.py`: covers cron delivery transforms.
  - `tests/gateway/test_feishu_approval_buttons.py`: covers plugin card action callback delegation.

  ## How to Test

  1. `python -m py_compile cron/scheduler.py gateway/platform_registry.py gateway/platforms/feishu.py hermes_cli/plugins.py tools/send_message_tool.py`
  2. `python -m pytest -o addopts='' tests/cron/test_scheduler.py -q`
  3. `python -m pytest -o addopts='' tests/gateway/test_feishu_approval_buttons.py tests/gateway/test_plugin_platform_interface.py -q`
  4. `python -m pytest -o addopts='' tests/tools/test_send_message_tool.py::TestSendMessageTool -q`

  Note: I attempted `pytest tests/ -q` with the full optional dependency set via `uv run --all-extras`; the full suite did not complete cleanly due to existing/
  global-state-sensitive failures outside this PR's touched areas. The targeted test groups above pass.

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Ubuntu/WSL

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/
  CONTRIBUTING.md#cross-platform-compatibility)
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

  ## For New Skills

  N/A

  ## Screenshots / Logs

  N/A. Covered by the tests above.