### PR TITLE
feat(x_search): read X status URLs through Jina

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -62,7 +62,7 @@ CONFIGURABLE_TOOLSETS = [
     ("video",           "🎬 Video Analysis",            "video_analyze (requires video-capable model)"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
     ("video_gen",       "🎬 Video Generation",          "video_generate (text-to-video + image-to-video)"),
-    ("x_search",        "🐦 X (Twitter) Search",        "x_search (requires xAI OAuth or XAI_API_KEY)"),
+    ("x_search",        "🐦 X (Twitter) Search",        "x_search (Jina for status URLs; xAI creds for broad search)"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),
@@ -106,13 +106,10 @@ def gui_toolset_label(label: str) -> str:
 # who want it opt in via `hermes tools` → Video Generation, which walks
 # them through provider + model selection.
 #
-# X search is off by default for users without xAI credentials, but
-# auto-enables when SuperGrok OAuth tokens are stored OR XAI_API_KEY is
-# set — mirroring the HASS_TOKEN → homeassistant auto-enable below. The
-# `hermes tools` → X (Twitter) Search setup walks users through credential
-# setup. The tool's check_fn means the schema still won't appear to the
-# model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+# X search is on by default because direct X/Twitter status URLs can be read
+# through r.jina.ai without credentials. Broader X searches still require xAI
+# credentials at runtime and return a clear tool error if absent.
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen"}
 
 
 def _xai_credentials_present() -> bool:
@@ -409,13 +406,13 @@ TOOL_CATEGORIES = {
     },
     "x_search": {
         "name": "X (Twitter) Search",
-        "setup_title": "Select xAI Credential Source",
+        "setup_title": "Select X Search Enhancement Source",
         "setup_note": (
-            "Hermes routes X searches through xAI's built-in x_search "
-            "Responses tool. Both credential sources hit the same "
-            "https://api.x.ai/v1/responses endpoint — pick whichever you "
-            "already have. SuperGrok OAuth is preferred when both are set "
-            "(uses your subscription quota instead of API spend)."
+            "Hermes can read direct X/Twitter status URLs through r.jina.ai "
+            "with no local credentials. For broad X searches, profiles, and "
+            "filtered timeline queries, configure xAI's built-in x_search "
+            "Responses tool here. SuperGrok OAuth is preferred when both are "
+            "set (uses your subscription quota instead of API spend)."
         ),
         "icon": "🐦",
         "providers": [
@@ -1296,6 +1293,7 @@ def _get_platform_tools(
 
     platform_toolsets = config.get("platform_toolsets") or {}
     toolset_names = platform_toolsets.get(platform)
+    platform_toolsets_explicit = isinstance(platform_toolsets, dict) and platform in platform_toolsets
 
     if toolset_names is None or not isinstance(toolset_names, list):
         plat_info = PLATFORMS.get(platform)
@@ -1373,19 +1371,26 @@ def _get_platform_tools(
             if ts_tools and ts_tools.issubset(all_tool_names):
                 enabled_toolsets.add(ts_key)
 
-        # Auto-enable ``x_search`` when xAI credentials are configured.
+        # Auto-enable ``x_search`` on first install. Direct X/Twitter status
+        # URLs can be read through r.jina.ai without credentials; broader
+        # searches still runtime-gate on xAI credentials and return a clear
+        # error when absent.
         # Unlike ``homeassistant`` (whose ``ha_*`` tools live inside the
         # platform composite and thus pass the subset check above),
         # ``x_search`` is its own one-tool toolset that the composite does
         # NOT include, so the subset loop never picks it up. Inject it
         # directly here, mirroring the HASS_TOKEN → ``homeassistant`` rule
-        # below: once you have working creds, you don't have to also click
-        # through ``hermes tools`` to flip the toolset on. Only fires when
-        # the user has not yet saved an explicit toolset list — once they
-        # do, the saved list is authoritative.
+        # below: you don't have to also click through ``hermes tools`` to
+        # flip the toolset on. Preserve the explicit empty-list contract: once
+        # a user saves no configurable tools for the platform, nothing from the
+        # configurable checklist should reappear implicitly.
         x_search_auto_enabled = (
-            _toolset_allowed_for_platform("x_search", platform)
-            and _xai_credentials_present()
+            not (
+                platform_toolsets_explicit
+                and isinstance(platform_toolsets.get(platform), list)
+                and not toolset_names
+            )
+            and _toolset_allowed_for_platform("x_search", platform)
         )
         if x_search_auto_enabled:
             enabled_toolsets.add("x_search")
@@ -1446,6 +1451,12 @@ def _get_platform_tools(
             enabled_toolsets.add(ts_key)
             claimed.update(ts_tools)
 
+    explicit_empty_selection = (
+        platform_toolsets_explicit
+        and isinstance(platform_toolsets.get(platform), list)
+        and not toolset_names
+    )
+
     # Plugin toolsets: enabled by default unless explicitly disabled, or
     # unless the toolset is in _DEFAULT_OFF_TOOLSETS (e.g. spotify —
     # shipped as a bundled plugin but user must opt in via `hermes tools`
@@ -1463,8 +1474,9 @@ def _get_platform_tools(
             elif pts in _DEFAULT_OFF_TOOLSETS:
                 # Opt-in plugin toolset — stay off until user picks it
                 continue
-            elif pts not in known_for_platform:
-                # New plugin not yet seen by hermes tools — default enabled
+            elif pts not in known_for_platform and not explicit_empty_selection:
+                # New plugin not yet seen by hermes tools — default enabled,
+                # unless the user explicitly saved an empty selection for this platform.
                 enabled_toolsets.add(pts)
             # else: known but not in config = user disabled it
 
@@ -1478,11 +1490,6 @@ def _get_platform_tools(
     if not isinstance(context_cfg, dict):
         context_cfg = {}
     context_engine_name = str(context_cfg.get("engine") or "compressor").strip().lower()
-    explicit_empty_selection = (
-        platform in platform_toolsets
-        and isinstance(platform_toolsets.get(platform), list)
-        and not toolset_names
-    )
     if context_engine_name and context_engine_name != "compressor" and not explicit_empty_selection:
         enabled_toolsets.add("context_engine")
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -206,16 +206,15 @@ def test_get_platform_tools_x_search_auto_enabled_when_xai_api_key_present(monke
     assert "x_search" in cli_enabled
 
 
-def test_get_platform_tools_x_search_off_when_no_xai_credentials(monkeypatch):
-    """Without any xAI credentials, x_search stays off — preserves the
-    "don't ship the schema to users who can't use it" default."""
+def test_get_platform_tools_x_search_on_without_xai_credentials_for_jina_urls(monkeypatch):
+    """x_search stays available without xAI creds so direct status URLs can use Jina."""
     monkeypatch.delenv("XAI_API_KEY", raising=False)
     monkeypatch.setattr(
         "hermes_cli.tools_config._xai_credentials_present", lambda: False
     )
 
     cli_enabled = _get_platform_tools({}, "cli")
-    assert "x_search" not in cli_enabled
+    assert "x_search" in cli_enabled
 
 
 def test_get_platform_tools_x_search_respects_explicit_config(monkeypatch):

--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -36,6 +36,7 @@ class _FakeResponse:
 # default resolver path.
 # ---------------------------------------------------------------------------
 
+
 def test_x_search_posts_responses_request(monkeypatch):
     from tools.x_search_tool import x_search_tool
     from hermes_cli import __version__
@@ -47,12 +48,12 @@ def test_x_search_posts_responses_request(monkeypatch):
         captured["headers"] = headers
         captured["json"] = json
         captured["timeout"] = timeout
-        return _FakeResponse(
-            {
-                "output_text": "People on X are discussing xAI's latest launch.",
-                "citations": [{"url": "https://x.com/example/status/1", "title": "Example post"}],
-            }
-        )
+        return _FakeResponse({
+            "output_text": "People on X are discussing xAI's latest launch.",
+            "citations": [
+                {"url": "https://x.com/example/status/1", "title": "Example post"}
+            ],
+        })
 
     monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
     monkeypatch.setattr("requests.post", _fake_post)
@@ -94,37 +95,38 @@ def test_x_search_rejects_conflicting_handle_filters(monkeypatch):
         )
     )
 
-    assert result["error"] == "allowed_x_handles and excluded_x_handles cannot be used together"
+    assert (
+        result["error"]
+        == "allowed_x_handles and excluded_x_handles cannot be used together"
+    )
 
 
 def test_x_search_extracts_inline_url_citations(monkeypatch):
     from tools.x_search_tool import x_search_tool
 
     def _fake_post(url, headers=None, json=None, timeout=None):
-        return _FakeResponse(
-            {
-                "output": [
-                    {
-                        "type": "message",
-                        "content": [
-                            {
-                                "type": "output_text",
-                                "text": "xAI posted an update on X.",
-                                "annotations": [
-                                    {
-                                        "type": "url_citation",
-                                        "url": "https://x.com/xai/status/123",
-                                        "title": "xAI update",
-                                        "start_index": 0,
-                                        "end_index": 3,
-                                    }
-                                ],
-                            }
-                        ],
-                    }
-                ]
-            }
-        )
+        return _FakeResponse({
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "xAI posted an update on X.",
+                            "annotations": [
+                                {
+                                    "type": "url_citation",
+                                    "url": "https://x.com/xai/status/123",
+                                    "title": "xAI update",
+                                    "start_index": 0,
+                                    "end_index": 3,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        })
 
     monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
     monkeypatch.setattr("requests.post", _fake_post)
@@ -182,12 +184,10 @@ def test_x_search_retries_read_timeout_then_succeeds(monkeypatch):
         calls["count"] += 1
         if calls["count"] == 1:
             raise requests.ReadTimeout("timed out")
-        return _FakeResponse(
-            {
-                "output_text": "Recovered after retry.",
-                "citations": [],
-            }
-        )
+        return _FakeResponse({
+            "output_text": "Recovered after retry.",
+            "citations": [],
+        })
 
     monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
     monkeypatch.setattr("requests.post", _fake_post)
@@ -228,6 +228,7 @@ def test_x_search_retries_5xx_then_succeeds(monkeypatch):
 # ---------------------------------------------------------------------------
 # Credential-resolution coverage — the OAuth-or-API-key gating contract.
 # ---------------------------------------------------------------------------
+
 
 def _no_xai_env(monkeypatch):
     """Strip any XAI_* env vars so the resolver doesn't see a leaked dev key."""
@@ -350,8 +351,11 @@ def test_x_search_prefers_oauth_when_both_available(monkeypatch):
     assert captured["headers"]["Authorization"] == "Bearer oauth-bearer-token"
 
 
-def test_x_search_returns_tool_error_when_no_credentials(monkeypatch):
-    """No credentials anywhere: tool returns a clear error, not a 401 from xAI."""
+def test_x_search_returns_tool_error_for_non_url_search_when_no_credentials(
+    monkeypatch,
+):
+    """No xAI creds: tool still registers for Jina URL reads; broad search errors cleanly."""
+
     from tools.registry import invalidate_check_fn_cache
     from tools.x_search_tool import check_x_search_requirements, x_search_tool
 
@@ -369,17 +373,17 @@ def test_x_search_returns_tool_error_when_no_credentials(monkeypatch):
     )
     invalidate_check_fn_cache()
 
-    assert check_x_search_requirements() is False
+    assert check_x_search_requirements() is True
 
-    # If a model somehow invokes the tool despite a False check_fn, the call
-    # surfaces a friendly error rather than an HTTP exception.
+    # Broad search still needs xAI credentials; only direct status URLs use Jina.
     result = x_search_tool(query="anything")
     assert "No xAI credentials available" in result
     assert "hermes auth add xai-oauth" in result
 
 
-def test_x_search_check_fn_false_when_resolver_raises(monkeypatch):
-    """Resolver exceptions (e.g. expired token + failed refresh) gate the tool out."""
+def test_x_search_check_fn_true_when_resolver_raises(monkeypatch):
+    """Resolver failures no longer gate out direct Jina URL reads."""
+
     from tools.registry import invalidate_check_fn_cache
     from tools.x_search_tool import check_x_search_requirements
 
@@ -388,12 +392,10 @@ def test_x_search_check_fn_false_when_resolver_raises(monkeypatch):
     def _boom():
         raise RuntimeError("token revoked and refresh failed")
 
-    monkeypatch.setattr(
-        "tools.x_search_tool.resolve_xai_http_credentials", _boom
-    )
+    monkeypatch.setattr("tools.x_search_tool.resolve_xai_http_credentials", _boom)
     invalidate_check_fn_cache()
 
-    assert check_x_search_requirements() is False
+    assert check_x_search_requirements() is True
 
 
 def test_x_search_honors_config_model_and_timeout(monkeypatch, tmp_path):
@@ -434,8 +436,89 @@ def test_x_search_registered_in_registry_with_check_fn():
     assert entry.toolset == "x_search"
     assert entry.check_fn is not None
     assert entry.check_fn.__name__ == "check_x_search_requirements"
-    assert "XAI_API_KEY" in entry.requires_env
+    assert entry.requires_env == []
     assert entry.emoji == "🐦"
+
+
+def test_x_search_reads_status_url_via_jina_without_xai_credentials(monkeypatch):
+    """Direct tweet URLs should be readable through r.jina.ai without xAI auth."""
+    from tools.registry import invalidate_check_fn_cache
+    from tools.x_search_tool import check_x_search_requirements, x_search_tool
+
+    _no_xai_env(monkeypatch)
+
+    def _fake_resolve():
+        return {"provider": "xai", "api_key": "", "base_url": "https://api.x.ai/v1"}
+
+    monkeypatch.setattr(
+        "tools.x_search_tool.resolve_xai_http_credentials", _fake_resolve
+    )
+    invalidate_check_fn_cache()
+
+    captured = {}
+
+    def _fake_get(url, headers=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _FakeResponse(
+            None,
+            text=(
+                "Title: Bob on X\n\n"
+                "URL Source: https://x.com/zapabob_ouj/status/123\n\n"
+                "ボブにゃん posted a useful Hermes update."
+            ),
+        )
+
+    monkeypatch.setattr("requests.get", _fake_get)
+
+    assert check_x_search_requirements() is True
+
+    result = json.loads(x_search_tool(query="https://x.com/zapabob_ouj/status/123"))
+
+    assert result["success"] is True
+    assert result["provider"] == "jina"
+    assert result["tool"] == "x_jina_reader"
+    assert captured["url"] == "https://r.jina.ai/https://x.com/zapabob_ouj/status/123"
+    assert "ボブにゃん posted" in result["answer"]
+    assert result["citations"] == [
+        {
+            "url": "https://x.com/zapabob_ouj/status/123",
+            "title": "X status via r.jina.ai",
+        }
+    ]
+
+
+def test_x_search_uses_jina_when_query_mentions_status_url_inside_text(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    def _fake_get(url, headers=None, timeout=None):
+        return _FakeResponse(None, text="tweet body from reader")
+
+    monkeypatch.setattr("requests.get", _fake_get)
+
+    result = json.loads(
+        x_search_tool(
+            query="このツイート読んで https://twitter.com/example/status/456?s=20"
+        )
+    )
+
+    assert result["success"] is True
+    assert result["provider"] == "jina"
+    assert result["query"] == "https://x.com/example/status/456"
+
+
+def test_x_search_jina_status_url_extractor_rejects_non_x_handle_shapes():
+    """Only canonical X/Twitter status URLs should reach the public reader."""
+    from tools.x_search_tool import _extract_x_status_url
+
+    assert (
+        _extract_x_status_url("https://x.com/good_handle/status/123")
+        == "https://x.com/good_handle/status/123"
+    )
+    assert _extract_x_status_url("https://x.com/evil.com@x/status/123") is None
+    assert _extract_x_status_url("https://x.com/%2f/status/123") is None
+    assert _extract_x_status_url("https://x.com/too_long_handle_123/status/123") is None
 
 
 # ---------------------------------------------------------------------------
@@ -445,10 +528,14 @@ def test_x_search_registered_in_registry_with_check_fn():
 # callers to distinguish from a real result.
 # ---------------------------------------------------------------------------
 
+
 def _no_post_allowed(monkeypatch):
     """Guard: any test that should fail before HTTP can hit this fence."""
+
     def _fail(*_, **__):
-        raise AssertionError("requests.post must not be called — validation should reject first")
+        raise AssertionError(
+            "requests.post must not be called — validation should reject first"
+        )
 
     monkeypatch.setattr("requests.post", _fail)
 
@@ -489,7 +576,10 @@ def test_x_search_rejects_inverted_date_range(monkeypatch):
         )
     )
 
-    assert "from_date (2026-05-10) must be on or before to_date (2026-05-01)" in result["error"]
+    assert (
+        "from_date (2026-05-10) must be on or before to_date (2026-05-01)"
+        in result["error"]
+    )
 
 
 def test_x_search_rejects_future_from_date(monkeypatch):
@@ -529,9 +619,10 @@ def test_x_search_allows_future_to_date(monkeypatch):
     monkeypatch.setattr("tools.x_search_tool.datetime", _FrozenDateTime)
 
     def _fake_post(url, headers=None, json=None, timeout=None):
-        return _FakeResponse(
-            {"output_text": "future to_date is allowed", "citations": []}
-        )
+        return _FakeResponse({
+            "output_text": "future to_date is allowed",
+            "citations": [],
+        })
 
     monkeypatch.setattr("requests.post", _fake_post)
 
@@ -576,6 +667,7 @@ def test_x_search_accepts_today_as_from_date(monkeypatch):
 # unsourced fluff when narrowing filters returned nothing.
 # ---------------------------------------------------------------------------
 
+
 def test_x_search_marks_degraded_when_handle_filter_returns_no_citations(monkeypatch):
     """allowed_x_handles set + zero citations → degraded=True."""
     from tools.x_search_tool import x_search_tool
@@ -583,13 +675,16 @@ def test_x_search_marks_degraded_when_handle_filter_returns_no_citations(monkeyp
     monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
     monkeypatch.setattr(
         "requests.post",
-        lambda *a, **k: _FakeResponse(
-            {"output_text": "Generic encyclopedic answer with no citations.", "citations": []}
-        ),
+        lambda *a, **k: _FakeResponse({
+            "output_text": "Generic encyclopedic answer with no citations.",
+            "citations": [],
+        }),
     )
 
     result = json.loads(
-        x_search_tool(query="what has @ghostuser posted", allowed_x_handles=["ghostuser"])
+        x_search_tool(
+            query="what has @ghostuser posted", allowed_x_handles=["ghostuser"]
+        )
     )
 
     assert result["success"] is True
@@ -643,30 +738,28 @@ def test_x_search_not_degraded_when_filter_returns_inline_citations(monkeypatch)
     monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
     monkeypatch.setattr(
         "requests.post",
-        lambda *a, **k: _FakeResponse(
-            {
-                "output": [
-                    {
-                        "type": "message",
-                        "content": [
-                            {
-                                "type": "output_text",
-                                "text": "Real post from xai.",
-                                "annotations": [
-                                    {
-                                        "type": "url_citation",
-                                        "url": "https://x.com/xai/status/1",
-                                        "title": "xAI post",
-                                        "start_index": 0,
-                                        "end_index": 4,
-                                    }
-                                ],
-                            }
-                        ],
-                    }
-                ]
-            }
-        ),
+        lambda *a, **k: _FakeResponse({
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Real post from xai.",
+                            "annotations": [
+                                {
+                                    "type": "url_citation",
+                                    "url": "https://x.com/xai/status/1",
+                                    "title": "xAI post",
+                                    "start_index": 0,
+                                    "end_index": 4,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }),
     )
 
     result = json.loads(
@@ -686,17 +779,15 @@ def test_x_search_not_degraded_when_filter_returns_top_level_citations(monkeypat
     monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
     monkeypatch.setattr(
         "requests.post",
-        lambda *a, **k: _FakeResponse(
-            {
-                "output_text": "Found discussion.",
-                "citations": [{"url": "https://x.com/example/status/1", "title": "Example"}],
-            }
-        ),
+        lambda *a, **k: _FakeResponse({
+            "output_text": "Found discussion.",
+            "citations": [
+                {"url": "https://x.com/example/status/1", "title": "Example"}
+            ],
+        }),
     )
 
-    result = json.loads(
-        x_search_tool(query="anything", allowed_x_handles=["xai"])
-    )
+    result = json.loads(x_search_tool(query="anything", allowed_x_handles=["xai"]))
 
     assert result["degraded"] is False
     assert result["degraded_reason"] is None
@@ -722,4 +813,3 @@ def test_x_search_not_degraded_when_no_filters_active(monkeypatch):
     assert result["success"] is True
     assert result["degraded"] is False
     assert result["degraded_reason"] is None
-

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from datetime import date, datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
@@ -60,11 +61,17 @@ DEFAULT_X_SEARCH_MODEL = "grok-4.20-reasoning"
 DEFAULT_X_SEARCH_TIMEOUT_SECONDS = 180
 DEFAULT_X_SEARCH_RETRIES = 2
 MAX_HANDLES = 10
+JINA_READER_BASE_URL = "https://r.jina.ai/"
+X_STATUS_URL_RE = re.compile(
+    r"https?://(?:www\.)?(?:x|twitter)\.com/([A-Za-z0-9_]{1,15})/status/(\d{1,30})(?=$|[\s?#/])",
+    re.IGNORECASE,
+)
 
 
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
+
 
 def _load_x_search_config() -> Dict[str, Any]:
     try:
@@ -77,7 +84,7 @@ def _load_x_search_config() -> Dict[str, Any]:
 
 def _get_x_search_model() -> str:
     cfg = _load_x_search_config()
-    return (str(cfg.get("model") or "").strip() or DEFAULT_X_SEARCH_MODEL)
+    return str(cfg.get("model") or "").strip() or DEFAULT_X_SEARCH_MODEL
 
 
 def _get_x_search_timeout_seconds() -> int:
@@ -101,6 +108,7 @@ def _get_x_search_retries() -> int:
 # ---------------------------------------------------------------------------
 # Credential resolution
 # ---------------------------------------------------------------------------
+
 
 def _resolve_xai_bearer() -> Tuple[str, str, str]:
     """Return ``(api_key, base_url, source)``.
@@ -134,14 +142,20 @@ def check_x_search_requirements() -> bool:
     """
     try:
         creds = resolve_xai_http_credentials()
-        return bool(str(creds.get("api_key") or "").strip())
+        if bool(str(creds.get("api_key") or "").strip()):
+            return True
     except Exception:
-        return False
+        pass
+    # r.jina.ai is public and requires no local credential. Keeping the tool
+    # registered lets agents read direct X status URLs even when xAI x_search
+    # credentials are absent.
+    return True
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _normalize_handles(handles: Optional[List[str]], field_name: str) -> List[str]:
     cleaned: List[str] = []
@@ -168,9 +182,7 @@ def _parse_iso_date(value: str, field_name: str) -> date:
     try:
         return datetime.strptime(raw, "%Y-%m-%d").date()
     except ValueError as exc:
-        raise ValueError(
-            f"{field_name} must be YYYY-MM-DD (got {raw!r})"
-        ) from exc
+        raise ValueError(f"{field_name} must be YYYY-MM-DD (got {raw!r})") from exc
 
 
 def _validate_date_range(from_date: str, to_date: str) -> None:
@@ -232,14 +244,12 @@ def _extract_inline_citations(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
             for annotation in content.get("annotations", []) or []:
                 if annotation.get("type") != "url_citation":
                     continue
-                citations.append(
-                    {
-                        "url": annotation.get("url", ""),
-                        "title": annotation.get("title", ""),
-                        "start_index": annotation.get("start_index"),
-                        "end_index": annotation.get("end_index"),
-                    }
-                )
+                citations.append({
+                    "url": annotation.get("url", ""),
+                    "title": annotation.get("title", ""),
+                    "start_index": annotation.get("start_index"),
+                    "end_index": annotation.get("end_index"),
+                })
     return citations
 
 
@@ -267,9 +277,44 @@ def _http_error_message(exc: requests.HTTPError) -> str:
     return str(exc)
 
 
+def _extract_x_status_url(query: str) -> Optional[str]:
+    match = X_STATUS_URL_RE.search(query or "")
+    if not match:
+        return None
+    handle, status_id = match.groups()
+    return f"https://x.com/{handle}/status/{status_id}"
+
+
+def _read_x_status_via_jina(status_url: str) -> str:
+    timeout_seconds = _get_x_search_timeout_seconds()
+    reader_url = f"{JINA_READER_BASE_URL}{status_url}"
+    response = requests.get(
+        reader_url,
+        headers={"User-Agent": hermes_xai_user_agent()},
+        timeout=timeout_seconds,
+    )
+    response.raise_for_status()
+    answer = str(getattr(response, "text", "") or "").strip()
+    return json.dumps(
+        {
+            "success": True,
+            "provider": "jina",
+            "tool": "x_jina_reader",
+            "query": status_url,
+            "answer": answer,
+            "citations": [{"url": status_url, "title": "X status via r.jina.ai"}],
+            "inline_citations": [],
+            "degraded": False,
+            "degraded_reason": None,
+        },
+        ensure_ascii=False,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Tool implementation
 # ---------------------------------------------------------------------------
+
 
 def x_search_tool(
     query: str,
@@ -283,6 +328,37 @@ def x_search_tool(
     if not query or not query.strip():
         return tool_error("query is required for x_search")
 
+    status_url = _extract_x_status_url(query.strip())
+    if status_url:
+        try:
+            return _read_x_status_via_jina(status_url)
+        except requests.HTTPError as e:
+            logger.error("x_jina_reader failed: %s", e, exc_info=True)
+            return json.dumps(
+                {
+                    "success": False,
+                    "provider": "jina",
+                    "tool": "x_jina_reader",
+                    "query": status_url,
+                    "error": _http_error_message(e),
+                    "error_type": type(e).__name__,
+                },
+                ensure_ascii=False,
+            )
+        except Exception as e:
+            logger.error("x_jina_reader failed: %s", e, exc_info=True)
+            return json.dumps(
+                {
+                    "success": False,
+                    "provider": "jina",
+                    "tool": "x_jina_reader",
+                    "query": status_url,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+                ensure_ascii=False,
+            )
+
     try:
         api_key, base_url, source = _resolve_xai_bearer()
     except RuntimeError as exc:
@@ -292,7 +368,9 @@ def x_search_tool(
         allowed = _normalize_handles(allowed_x_handles, "allowed_x_handles")
         excluded = _normalize_handles(excluded_x_handles, "excluded_x_handles")
         if allowed and excluded:
-            return tool_error("allowed_x_handles and excluded_x_handles cannot be used together")
+            return tool_error(
+                "allowed_x_handles and excluded_x_handles cannot be used together"
+            )
 
         try:
             _validate_date_range(from_date, to_date)
@@ -455,10 +533,10 @@ def x_search_tool(
 X_SEARCH_SCHEMA = {
     "name": "x_search",
     "description": (
-        "Search X (Twitter) posts, profiles, and threads using xAI's built-in "
-        "X Search tool. Use this for current discussion, reactions, or claims "
-        "on X rather than general web pages. Available when xAI credentials "
-        "are configured (SuperGrok OAuth or XAI_API_KEY)."
+        "Search X (Twitter) posts, profiles, and threads. Direct X/Twitter "
+        "status URLs are read through r.jina.ai without credentials; broader "
+        "searches use xAI's built-in X Search tool when SuperGrok OAuth or "
+        "XAI_API_KEY credentials are configured."
     ),
     "parameters": {
         "type": "object",
@@ -519,7 +597,7 @@ registry.register(
     schema=X_SEARCH_SCHEMA,
     handler=_handle_x_search,
     check_fn=check_x_search_requirements,
-    requires_env=["XAI_API_KEY"],
+    requires_env=[],
     emoji="🐦",
     max_result_size_chars=100_000,
 )


### PR DESCRIPTION
## Summary
- route direct X/Twitter status URLs through Jina Reader so `x_search` can read a single public status without local xAI credentials
- keep broad X searches on the existing xAI Responses `x_search` path, returning a clear tool error when no xAI credential is available
- canonicalize accepted status links to `https://x.com/<handle>/status/<id>` before calling Jina
- preserve explicit empty per-platform tool selections, so users who disabled configurable toolsets do not get `x_search` re-enabled implicitly
- fix the Jina Reader URL construction to use `https://r.jina.ai/https://...` instead of the duplicated `http://https://...` prefix

## Security notes
- the public Jina path is limited to canonical `x.com` / `twitter.com` status URLs extracted by handle and numeric status id
- rejected cases include encoded path tricks, overlong handles, and `evil.com@x`-style non-handle shapes
- non-status and broad search queries still require xAI credentials; they do not silently fall back to a public reader
- returned citations point at the canonical X status URL, not arbitrary user-provided input

## Validation
- `uv run --with pytest python -m pytest -o addopts='' tests/tools/test_x_search_tool.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_tools_disable_enable.py -q` (`144 passed`)
- `ruff check tools/x_search_tool.py tests/tools/test_x_search_tool.py hermes_cli/tools_config.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_tools_disable_enable.py`
- `ruff format --check tools/x_search_tool.py tests/tools/test_x_search_tool.py`
- `python -m py_compile tools/x_search_tool.py hermes_cli/tools_config.py`
- `git diff --check`