### PR TITLE
fix(agent): rotate credential pool on first 429 instead of retrying same key

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -609,10 +609,11 @@ def recover_with_credential_pool(
         return False, has_retried_429
 
     if effective_reason == FailoverReason.rate_limit:
-        # If current credential is already marked exhausted, skip retry and
-        # rotate immediately. This prevents the "cancel-between-429s" trap
-        # where has_retried_429 (a local var) gets reset on each new prompt,
-        # causing the pool to retry the same exhausted credential forever.
+        # FIX: On first 429, immediately mark exhausted and rotate instead
+        # of retrying the same key. The old logic set has_retried_429=True
+        # on first 429 and only rotated on second 429, but has_retried_429
+        # is a local var reset per-prompt, so single-429 prompts never
+        # triggered rotation.
         current_entry = pool.current()
         current_last_status = getattr(current_entry, "last_status", None) if current_entry else None
         if current_last_status == STATUS_EXHAUSTED:
@@ -642,9 +643,17 @@ def recover_with_credential_pool(
                 or "usage limit reached" in context_message
                 or "usage limit has been reached" in context_message
             )
-        if not has_retried_429 and not usage_limit_reached:
-            return False, True
+        # FIX: Always mark exhausted and rotate on first 429.
+        # The old `if not has_retried_429` guard was meant to retry once
+        # before rotating, but has_retried_429 resets per-prompt, causing
+        # the same key to be retried forever across prompts.
         rotate_status = status_code if status_code is not None else 429
+        _ra().logger.info(
+            "Credential %s (rate limit) — marking exhausted and rotating (has_retried_429=%s, usage_limit=%s)",
+            getattr(current_entry, "id", "?") if current_entry else "none",
+            has_retried_429,
+            usage_limit_reached,
+        )
         next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
         if next_entry is not None:
             _ra().logger.info(

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -173,15 +173,17 @@ class TestPoolRotationCycle:
 
         return agent, pool, entries
 
-    def test_first_429_sets_retry_flag_no_rotation(self):
-        """First 429 should just set has_retried_429=True, no rotation."""
-        agent, pool, _ = self._make_agent_with_pool(3)
+    def test_first_429_rotates_immediately(self):
+        """First 429 should mark exhausted and rotate immediately (not retry same key)."""
+        agent, pool, entries = self._make_agent_with_pool(3)
+        pool.mark_exhausted_and_rotate.return_value = entries[1]
         recovered, has_retried = agent._recover_with_credential_pool(
             status_code=429, has_retried_429=False
         )
-        assert recovered is False
-        assert has_retried is True
-        pool.mark_exhausted_and_rotate.assert_not_called()
+        assert recovered is True
+        assert has_retried is False  # reset after rotation
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429, error_context=None)
+        agent._swap_credential.assert_called_once_with(entries[1])
 
     def test_second_429_rotates_to_next(self):
         """Second consecutive 429 should rotate to next credential."""

--- a/tests/run_agent/test_credential_pool_interrupt.py
+++ b/tests/run_agent/test_credential_pool_interrupt.py
@@ -38,7 +38,9 @@ def test_rotate_immediately_when_credential_already_exhausted():
     pool.mark_exhausted_and_rotate.return_value = entries[1]
 
     from run_agent import AIAgent
-    with patch("run_agent.get_tool_definitions", return_value=[]),          patch("run_agent.check_toolset_requirements", return_value={}),          patch("run_agent.OpenAI"):
+    with patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI"):
         agent = MagicMock(spec=AIAgent)
         agent._credential_pool = pool
         agent._swap_credential = MagicMock()
@@ -55,15 +57,24 @@ def test_rotate_immediately_when_credential_already_exhausted():
     agent._swap_credential.assert_called_once_with(entries[1])
 
 
-def test_normal_retry_when_credential_not_exhausted():
-    """When credential is active, first 429 should still retry (existing behavior)."""
+def test_first_429_rotates_immediately_when_not_exhausted():
+    """When credential is active, first 429 should rotate immediately.
+
+    The old 'retry once' guard (has_retried_429) was a local var that reset
+    per-prompt, so single-429 prompts never triggered rotation — the same
+    exhausted key was retried forever. Now we always rotate on first 429.
+    """
     entries = [_make_entry(0, last_status=None), _make_entry(1)]
     pool = _make_pool(entries)
+    pool.mark_exhausted_and_rotate.return_value = entries[1]
 
     from run_agent import AIAgent
-    with patch("run_agent.get_tool_definitions", return_value=[]),          patch("run_agent.check_toolset_requirements", return_value={}),          patch("run_agent.OpenAI"):
+    with patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI"):
         agent = MagicMock(spec=AIAgent)
         agent._credential_pool = pool
+        agent._swap_credential = MagicMock()
         recovered, retried = AIAgent._recover_with_credential_pool(
             agent,
             status_code=429,
@@ -71,9 +82,10 @@ def test_normal_retry_when_credential_not_exhausted():
             classified_reason=FailoverReason.rate_limit,
         )
 
-    assert recovered is False
-    assert retried is True
-    pool.mark_exhausted_and_rotate.assert_not_called()
+    assert recovered is True
+    assert retried is False  # reset after rotation
+    pool.mark_exhausted_and_rotate.assert_called_once()
+    agent._swap_credential.assert_called_once_with(entries[1])
 
 
 def test_rotate_on_second_429_when_not_exhausted():
@@ -83,7 +95,9 @@ def test_rotate_on_second_429_when_not_exhausted():
     pool.mark_exhausted_and_rotate.return_value = entries[1]
 
     from run_agent import AIAgent
-    with patch("run_agent.get_tool_definitions", return_value=[]),          patch("run_agent.check_toolset_requirements", return_value={}),          patch("run_agent.OpenAI"):
+    with patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI"):
         agent = MagicMock(spec=AIAgent)
         agent._credential_pool = pool
         agent._swap_credential = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Fix credential pool 429 recovery so that the first rate-limit hit immediately marks the credential exhausted and rotates to the next one, instead of retrying the same key.

### Root cause

`has_retried_429` in `recover_with_credential_pool()` is a **local variable** that resets to `False` on every new prompt. The existing guard:

```python
if not has_retried_429 and not usage_limit_reached:
    return False, True  # retry same key
```

was designed to retry once then rotate on the second 429. But since `has_retried_429` is never persisted across prompts, **single-429 prompts retry the same rate-limited key forever**.

### Fix

Remove the `if not has_retried_429` guard. On the first 429:
1. Mark the credential exhausted via `pool.mark_exhausted_and_rotate()`
2. Swap to the next credential in the pool
3. Return `recovered=True`

The pre-existing fast-path for credentials already marked `STATUS_EXHAUSTED` is preserved unchanged.

## Related Issue

Fixes the credential pool rotation bug where `has_retried_429` local-variable semantics prevent rotation across prompts.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py`: Remove `if not has_retried_429 and not usage_limit_reached` retry guard; always call `mark_exhausted_and_rotate()` on first 429. Added diagnostic logging.
- `tests/agent/test_credential_pool_routing.py`: Renamed `test_first_429_sets_retry_flag_no_rotation` → `test_first_429_rotates_immediately`; updated assertions to expect rotation.
- `tests/run_agent/test_credential_pool_interrupt.py`: Renamed `test_normal_retry_when_credential_not_exhausted` → `test_first_429_rotates_immediately_when_not_exhausted`; updated assertions to expect rotation.

## How to Test

1. Configure a credential pool with 2+ credentials
2. Trigger a 429 on the first credential
3. Verify the agent rotates to the next credential immediately (not after a second 429)
4. Run: `pytest tests/agent/test_credential_pool_routing.py tests/run_agent/test_credential_pool_interrupt.py -v` — all 12 tests pass

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass (12/12 credential pool tests pass; 1 unrelated pre-existing failure from prompt_toolkit/Python 3.14 env issue)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10 (WSL2)