### PR TITLE
fix(cli): handle gh execution errors in doctor

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -78,6 +78,19 @@ def _safe_which(cmd: str) -> str | None:
         return None
 
 
+def _gh_authenticated() -> bool:
+    """Check if gh CLI is authenticated via token file or device flow."""
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status", "--json", "authenticated"],
+            capture_output=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     steps: list[str] = []
     step = 1
@@ -1866,17 +1879,6 @@ def run_doctor(args):
         check_warn("Skills Hub directory not initialized", "(run: hermes skills list)")
 
     from hermes_cli.config import get_env_value
-
-    def _gh_authenticated() -> bool:
-        """Check if gh CLI is authenticated via token file or device flow."""
-        try:
-            result = subprocess.run(
-                ["gh", "auth", "status", "--json", "authenticated"],
-                capture_output=True, timeout=10,
-            )
-            return result.returncode == 0
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            return False
 
     github_token = get_env_value("GITHUB_TOKEN") or get_env_value("GH_TOKEN")
     if github_token:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -102,6 +102,16 @@ class TestDoctorEnvFileEncoding:
             doctor_mod.run_doctor(Namespace(fix=False))
 
 
+class TestDoctorGithubAuth:
+    def test_gh_authenticated_returns_false_when_gh_cannot_execute(self, monkeypatch):
+        def raise_permission_error(*args, **kwargs):
+            raise PermissionError("permission denied: 'gh'")
+
+        monkeypatch.setattr(doctor.subprocess, "run", raise_permission_error)
+
+        assert doctor._gh_authenticated() is False
+
+
 class TestDoctorToolAvailabilityOverrides:
     def test_marks_honcho_available_when_configured(self, monkeypatch):
         monkeypatch.setattr(doctor, "_honcho_is_configured_for_doctor", lambda: True)


### PR DESCRIPTION
## Summary
- Move the GitHub CLI authentication probe into a small helper so it can be tested directly.
- Treat `OSError` from `gh auth status` as unauthenticated instead of letting `hermes doctor` crash. This covers `PermissionError`, non-executable `gh`, and WSL/path interop edge cases.

Fixes #39540

## Test Plan
- `venv/bin/python -m pytest tests/hermes_cli/test_doctor.py -q -o 'addopts='`\n- `python -m py_compile hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`\n- `git diff --check`\n\n## Notes\n- Also tried `venv/bin/python -m pytest tests/hermes_cli -q -o 'addopts='`; this hit pre-existing unrelated failures in gateway/model-picker/update-hangup tests on macOS, while the doctor test file passes cleanly.