### PR TITLE
fix(desktop): keep in-progress assistant bubbles visible across window switches

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.hidden-window-repro.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.hidden-window-repro.test.tsx
@@ -1,0 +1,255 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $messages, $turnStartedAt, setAwaitingResponse, setBusy, setMessages, setTurnStartedAt } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './use-message-stream'
+import { useSessionStateCache } from './use-session-state-cache'
+
+type StreamApi = ReturnType<typeof useMessageStream>
+
+const SESSION_ID = 'runtime-session-1'
+const STORED_SESSION_ID = 'stored-session-1'
+
+interface HarnessProps {
+  onReady: (api: StreamApi) => void
+}
+
+function Harness({ onReady }: HarnessProps) {
+  const busyRef: MutableRefObject<boolean> = { current: false }
+
+  const { activeSessionIdRef, updateSessionState } = useSessionStateCache({
+    activeSessionId: SESSION_ID,
+    busyRef,
+    selectedStoredSessionId: STORED_SESSION_ID,
+    setAwaitingResponse,
+    setBusy,
+    setMessages
+  })
+
+  const api = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: async () => undefined,
+    queryClient: { invalidateQueries: async () => undefined } as never,
+    refreshHermesConfig: async () => undefined,
+    refreshSessions: async () => undefined,
+    updateSessionState
+  })
+
+  onReady(api)
+
+  return null
+}
+
+function event(type: string, payload?: Record<string, unknown>): RpcEvent {
+  return {
+    type,
+    session_id: SESSION_ID,
+    payload
+  }
+}
+
+describe('useMessageStream hidden-window repro', () => {
+  let originalHiddenDescriptor: PropertyDescriptor | undefined
+  let isDocumentHidden: boolean
+  let queuedFrames: Array<{ callback: FrameRequestCallback; id: number }>
+  let cancelledFrames: Set<number>
+  let nextFrameHandle: number
+  let now: number
+
+  beforeEach(() => {
+    cleanup()
+    setMessages([])
+    setBusy(false)
+    setAwaitingResponse(false)
+    setTurnStartedAt(null)
+    isDocumentHidden = false
+    queuedFrames = []
+    cancelledFrames = new Set()
+    nextFrameHandle = 1
+    now = 100
+
+    originalHiddenDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'hidden')
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => isDocumentHidden
+    })
+
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) => {
+      const id = nextFrameHandle++
+      queuedFrames.push({ callback, id })
+
+      return id
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id: number) => {
+      cancelledFrames.add(id)
+      queuedFrames = queuedFrames.filter(frame => frame.id !== id)
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    setMessages([])
+    setBusy(false)
+    setAwaitingResponse(false)
+    setTurnStartedAt(null)
+
+    if (originalHiddenDescriptor) {
+      Object.defineProperty(Document.prototype, 'hidden', originalHiddenDescriptor)
+    } else {
+      delete (document as Document & { hidden?: boolean }).hidden
+    }
+  })
+
+  async function flushAnimationFrame() {
+    await act(async () => {
+      const callbacks = [...queuedFrames]
+      queuedFrames = []
+      now += 16
+
+      for (const { callback, id } of callbacks) {
+        if (!cancelledFrames.has(id)) {
+          callback(now)
+        }
+      }
+    })
+  }
+
+  it('keeps the visible transcript empty until completion when view-sync rAF is paused', async () => {
+    let api: StreamApi | null = null
+
+    render(<Harness onReady={ready => (api = ready)} />)
+
+    isDocumentHidden = true
+
+    await act(async () => {
+      api!.handleGatewayEvent(event('message.start'))
+      api!.handleGatewayEvent(event('message.delta', { text: 'thinking out loud' }))
+      api!.handleGatewayEvent(event('reasoning.delta', { text: 'planning' }))
+    })
+
+    // The turn is alive, but the shared transcript never sees the queued state
+    // because both the delta flush and the session->view publish are waiting on
+    // a requestAnimationFrame callback that never fires in this repro harness.
+    expect($turnStartedAt.get()).not.toBeNull()
+    expect($messages.get()).toEqual([])
+
+    await act(async () => {
+      api!.handleGatewayEvent(event('message.complete', { text: 'final answer' }))
+    })
+
+    // Completion finalizes the session state immediately, but the visible
+    // transcript is still blocked behind the stalled hidden-window rAF.
+    expect($messages.get()).toEqual([])
+
+    await flushAnimationFrame()
+
+    expect($messages.get()).toHaveLength(1)
+    expect($messages.get()[0]?.role).toBe('assistant')
+    expect($messages.get()[0]?.pending).toBe(false)
+    expect($messages.get()[0]?.parts).toEqual([
+      { type: 'reasoning', text: 'planning' },
+      { type: 'text', text: 'final answer' }
+    ])
+  })
+
+  it('can require a second foreground frame after returning, even before the next bubble completes', async () => {
+    let api: StreamApi | null = null
+
+    render(<Harness onReady={ready => (api = ready)} />)
+
+    await act(async () => {
+      api!.handleGatewayEvent(event('message.start'))
+    })
+
+    await flushAnimationFrame()
+    expect($messages.get()).toEqual([])
+
+    isDocumentHidden = true
+
+    await act(async () => {
+      api!.handleGatewayEvent(event('message.delta', { text: 'draft answer' }))
+      api!.handleGatewayEvent(event('reasoning.delta', { text: 'thinking' }))
+    })
+
+    expect($messages.get()).toEqual([])
+
+    isDocumentHidden = false
+
+    await flushAnimationFrame()
+
+    // First foreground frame only drains the queued stream deltas into the
+    // per-session cache. Publishing that cache into the visible transcript is
+    // itself staged behind the NEXT frame.
+    expect($messages.get()).toEqual([])
+
+    await flushAnimationFrame()
+
+    expect($messages.get()).toHaveLength(1)
+    expect($messages.get()[0]?.role).toBe('assistant')
+    expect($messages.get()[0]?.pending).toBe(true)
+    expect($messages.get()[0]?.parts).toEqual([
+      { type: 'text', text: 'draft answer' },
+      { type: 'reasoning', text: 'thinking' }
+    ])
+  })
+
+  it('does not need another gateway event once the queued foreground publish frame runs', async () => {
+    let api: StreamApi | null = null
+
+    render(<Harness onReady={ready => (api = ready)} />)
+
+    await act(async () => {
+      api!.handleGatewayEvent(event('message.start'))
+    })
+
+    await flushAnimationFrame()
+
+    isDocumentHidden = true
+
+    await act(async () => {
+      api!.handleGatewayEvent(event('message.delta', { text: 'draft answer' }))
+    })
+
+    isDocumentHidden = false
+
+    await flushAnimationFrame()
+    expect($messages.get()).toEqual([])
+
+    await flushAnimationFrame()
+
+    expect($messages.get()).toHaveLength(1)
+    expect($messages.get()[0]?.parts).toEqual([{ type: 'text', text: 'draft answer' }])
+  })
+
+  it('publishes hidden-window progress via timer fallback even if no animation frame runs', async () => {
+    let api: StreamApi | null = null
+
+    render(<Harness onReady={ready => (api = ready)} />)
+
+    isDocumentHidden = true
+
+    await act(async () => {
+      api!.handleGatewayEvent(event('message.start'))
+      api!.handleGatewayEvent(event('message.delta', { text: 'draft answer' }))
+      api!.handleGatewayEvent(event('reasoning.delta', { text: 'thinking' }))
+    })
+
+    expect($messages.get()).toEqual([])
+
+    await waitFor(() => {
+      expect($messages.get()).toHaveLength(1)
+    })
+
+    expect($messages.get()[0]?.pending).toBe(true)
+    expect($messages.get()[0]?.parts).toEqual([
+      { type: 'text', text: 'draft answer' },
+      { type: 'reasoning', text: 'thinking' }
+    ])
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -256,9 +256,30 @@ export function useMessageStream({
   )
 
   const queuedDeltasRef = useRef<Map<string, QueuedStreamDeltas>>(new Map())
-  const flushHandleRef = useRef<number | null>(null)
+  const flushRafRef = useRef<number | null>(null)
+  const flushTimeoutRef = useRef<number | null>(null)
   const lastFlushAtRef = useRef<number>(0)
   const nativeSubagentSessionsRef = useRef<Set<string>>(new Set())
+
+  const clearScheduledDeltaFlush = useCallback(() => {
+    if (typeof window === 'undefined') {
+      flushRafRef.current = null
+      flushTimeoutRef.current = null
+
+      return
+    }
+
+    if (flushRafRef.current !== null && typeof window.cancelAnimationFrame === 'function') {
+      window.cancelAnimationFrame(flushRafRef.current)
+    }
+
+    if (flushTimeoutRef.current !== null) {
+      window.clearTimeout(flushTimeoutRef.current)
+    }
+
+    flushRafRef.current = null
+    flushTimeoutRef.current = null
+  }, [])
 
   const flushQueuedDeltas = useCallback(
     (sessionId?: string) => {
@@ -294,8 +315,14 @@ export function useMessageStream({
     [mutateStream]
   )
 
+  const runScheduledDeltaFlush = useCallback(() => {
+    clearScheduledDeltaFlush()
+    lastFlushAtRef.current = performance.now()
+    flushQueuedDeltas()
+  }, [clearScheduledDeltaFlush, flushQueuedDeltas])
+
   const scheduleDeltaFlush = useCallback(() => {
-    if (flushHandleRef.current !== null) {
+    if (flushRafRef.current !== null || flushTimeoutRef.current !== null) {
       return
     }
 
@@ -314,20 +341,18 @@ export function useMessageStream({
     // to ~1/5s on big sessions (see scripts/profile-typing-lag.md).
     const sinceLast = performance.now() - lastFlushAtRef.current
 
-    const runFlush = () => {
-      flushHandleRef.current = null
-      lastFlushAtRef.current = performance.now()
-      flushQueuedDeltas()
-    }
-
     if (sinceLast >= STREAM_DELTA_FLUSH_MS && typeof window.requestAnimationFrame === 'function') {
-      flushHandleRef.current = window.requestAnimationFrame(runFlush)
+      // Hidden or de-prioritized windows can starve rAF indefinitely. Keep the
+      // paint-aligned path for foreground smoothness, but arm a timer so the
+      // stream still advances and doesn't wait for some unrelated future frame.
+      flushTimeoutRef.current = window.setTimeout(runScheduledDeltaFlush, STREAM_DELTA_FLUSH_MS)
+      flushRafRef.current = window.requestAnimationFrame(runScheduledDeltaFlush)
 
       return
     }
 
-    flushHandleRef.current = window.setTimeout(runFlush, Math.max(0, STREAM_DELTA_FLUSH_MS - sinceLast))
-  }, [flushQueuedDeltas])
+    flushTimeoutRef.current = window.setTimeout(runScheduledDeltaFlush, Math.max(0, STREAM_DELTA_FLUSH_MS - sinceLast))
+  }, [flushQueuedDeltas, runScheduledDeltaFlush])
 
   const queueDelta = useCallback(
     (sessionId: string, key: keyof QueuedStreamDeltas, delta: string) => {
@@ -345,19 +370,29 @@ export function useMessageStream({
 
   useEffect(
     () => () => {
-      if (flushHandleRef.current !== null && typeof window !== 'undefined') {
-        if (typeof window.cancelAnimationFrame === 'function') {
-          window.cancelAnimationFrame(flushHandleRef.current)
-        } else {
-          window.clearTimeout(flushHandleRef.current)
-        }
-      }
-
-      flushHandleRef.current = null
+      clearScheduledDeltaFlush()
       flushQueuedDeltas()
     },
-    [flushQueuedDeltas]
+    [clearScheduledDeltaFlush, flushQueuedDeltas]
   )
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined
+    }
+
+    const onVisible = () => {
+      if (document.visibilityState === 'visible' && (flushRafRef.current !== null || flushTimeoutRef.current !== null)) {
+        runScheduledDeltaFlush()
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisible)
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [runScheduledDeltaFlush])
 
   const appendAssistantDelta = useCallback(
     (sessionId: string, delta: string) => {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -55,6 +55,7 @@ export function useSessionStateCache({
   const runtimeIdByStoredSessionIdRef = useRef(new Map<string, string>())
   const pendingViewStateRef = useRef<{ sessionId: string; state: ClientSessionState } | null>(null)
   const viewSyncRafRef = useRef<number | null>(null)
+  const viewSyncTimeoutRef = useRef<number | null>(null)
 
   useEffect(() => {
     activeSessionIdRef.current = activeSessionId
@@ -133,6 +134,31 @@ export function useSessionStateCache({
     setTurnStartedAt(pending.state.turnStartedAt)
   }, [busyRef, setAwaitingResponse, setBusy, setMessages])
 
+  const clearScheduledViewSync = useCallback(() => {
+    if (typeof window === 'undefined') {
+      viewSyncRafRef.current = null
+      viewSyncTimeoutRef.current = null
+
+      return
+    }
+
+    if (viewSyncRafRef.current !== null) {
+      window.cancelAnimationFrame(viewSyncRafRef.current)
+    }
+
+    if (viewSyncTimeoutRef.current !== null) {
+      window.clearTimeout(viewSyncTimeoutRef.current)
+    }
+
+    viewSyncRafRef.current = null
+    viewSyncTimeoutRef.current = null
+  }, [])
+
+  const runScheduledViewSync = useCallback(() => {
+    clearScheduledViewSync()
+    flushPendingViewState()
+  }, [clearScheduledViewSync, flushPendingViewState])
+
   const syncSessionStateToView = useCallback(
     (sessionId: string, state: ClientSessionState) => {
       // Only the currently-viewed session may stage into the shared `$messages`
@@ -150,7 +176,7 @@ export function useSessionStateCache({
 
       pendingViewStateRef.current = { sessionId, state }
 
-      if (viewSyncRafRef.current !== null) {
+      if (viewSyncRafRef.current !== null || viewSyncTimeoutRef.current !== null) {
         return
       }
 
@@ -160,23 +186,39 @@ export function useSessionStateCache({
         return
       }
 
-      viewSyncRafRef.current = window.requestAnimationFrame(() => {
-        viewSyncRafRef.current = null
-        flushPendingViewState()
-      })
+      // Foreground frames keep scroll/measurement work aligned to paint, but a
+      // timer fallback ensures hidden or throttled windows still publish the
+      // newest transcript state without waiting for an unrelated later frame.
+      viewSyncTimeoutRef.current = window.setTimeout(runScheduledViewSync, 16)
+      viewSyncRafRef.current = window.requestAnimationFrame(runScheduledViewSync)
     },
-    [flushPendingViewState]
+    [flushPendingViewState, runScheduledViewSync]
   )
 
   useEffect(
     () => () => {
-      if (viewSyncRafRef.current !== null && typeof window !== 'undefined') {
-        window.cancelAnimationFrame(viewSyncRafRef.current)
-        viewSyncRafRef.current = null
-      }
+      clearScheduledViewSync()
     },
-    []
+    [clearScheduledViewSync]
   )
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined
+    }
+
+    const onVisible = () => {
+      if (document.visibilityState === 'visible' && pendingViewStateRef.current) {
+        runScheduledViewSync()
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisible)
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [runScheduledViewSync])
 
   const updateSessionState = useCallback(
     (


### PR DESCRIPTION
## What does this PR do?

Fixes a Hermes Desktop renderer bug where an in-progress assistant bubble can disappear from the visible transcript if the user switches away from the window and returns while the response is still streaming.

The root cause was that the desktop chat pipeline had two separate `requestAnimationFrame`-gated publish steps:

1. stream deltas were coalesced and flushed into the per-session cache in `use-message-stream.ts`
2. the active session cache was then published into the shared visible transcript in `use-session-state-cache.ts`

If the window was hidden, background-throttled, or otherwise missed foreground frames mid-stream, one or both of those publishes could stall. The turn kept running, but the visible transcript stopped updating, which could make the current assistant bubble appear to disappear until a later visible flush.

This PR keeps the existing paint-aligned fast path for foreground smoothness, but adds timer-backed fallback scheduling so hidden/throttled windows do not strand active stream state indefinitely.

## Related Issue

Fixes #41838

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a dual-scheduler flush path in `apps/desktop/src/app/session/hooks/use-message-stream.ts`
  - keep `requestAnimationFrame` for foreground paint alignment
  - add `setTimeout` fallback so hidden or throttled windows still flush queued stream deltas
  - drain any pending stream flush when the document becomes visible again
- Added the same fallback strategy to `apps/desktop/src/app/session/hooks/use-session-state-cache.ts`
  - active-session state no longer depends on a future foreground frame to publish into `$messages`
  - pending transcript state is drained on `visibilitychange` when the window returns to `visible`
- Added a targeted repro/coverage test at `apps/desktop/src/app/session/hooks/use-message-stream.hidden-window-repro.test.tsx`
  - models hidden-window/frame-starvation behavior
  - proves visible transcript updates can stall while the turn continues
  - proves the hidden-window path now publishes via timer fallback without needing a later bubble/update

## How to Test

1. Run the targeted UI tests:
   ```bash
   cd apps/desktop
   npm run test:ui -- use-message-stream.hidden-window-repro.test.tsx use-session-state-cache.test.tsx
   ```
2. Run Hermes Desktop in dev mode:
   ```bash
   cd apps/desktop
   npm run dev
   ```
3. Open a desktop chat and send a prompt that streams for a few seconds.
4. Once the assistant bubble is actively streaming, switch to another app/window at the OS level.
5. Wait a few seconds, then return to Hermes Desktop before the turn completes.
6. Confirm the current in-progress assistant bubble remains visible or resumes immediately without waiting for final completion or a later bubble/update.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not included yet.

The strongest validation for this fix is currently:
- the source-level repro analysis
- the new hidden-window desktop UI test coverage
- manual dev-mode verification on macOS that switching away and back mid-stream no longer hides the active assistant bubble
