### PR TITLE
fix(title_gen): honor auxiliary.title_generation.timeout config setting (#41812)

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -29,7 +29,7 @@ _TITLE_PROMPT = (
 def generate_title(
     user_message: str,
     assistant_response: str,
-    timeout: float = 30.0,
+    timeout: Optional[float] = None,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
 ) -> Optional[str]:
@@ -92,6 +92,7 @@ def auto_title_session(
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
+    timeout: Optional[float] = None,
 ) -> None:
     """Generate and set a session title if one doesn't already exist.
 
@@ -113,7 +114,7 @@ def auto_title_session(
         return
 
     title = generate_title(
-        user_message, assistant_response, failure_callback=failure_callback, main_runtime=main_runtime
+        user_message, assistant_response, timeout=timeout, failure_callback=failure_callback, main_runtime=main_runtime
     )
     if not title:
         return
@@ -139,6 +140,7 @@ def maybe_auto_title(
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
+    timeout: Optional[float] = None,
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
 
@@ -164,6 +166,7 @@ def maybe_auto_title(
             "failure_callback": failure_callback,
             "main_runtime": main_runtime,
             "title_callback": title_callback,
+            "timeout": timeout,
         },
         daemon=True,
         name="auto-title",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18731,8 +18731,12 @@ class GatewayRunner:
                             "Gateway auto-title failure suppressed (not user-visible): %s: %s",
                             task, exc,
                         )
+                    from agent.auxiliary_client import _get_task_timeout
+                    _title_timeout = _get_task_timeout("title_generation")
+
                     maybe_auto_title_kwargs = {
                         "failure_callback": _title_failure_cb,
+                        "timeout": _title_timeout,
                         "main_runtime": {
                             "model": getattr(agent, "model", None),
                             "provider": getattr(agent, "provider", None),

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -93,6 +93,38 @@ class TestGenerateTitle:
         with patch("agent.title_generator.call_llm", side_effect=RuntimeError("nope")):
             assert generate_title("q", "a") is None
 
+    def test_default_timeout_is_none(self):
+        """generate_title defaults timeout to None so call_llm reads config."""
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Title"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title("q", "a")
+
+        assert captured["timeout"] is None
+
+    def test_explicit_timeout_passed_to_call_llm(self):
+        """An explicit timeout value is forwarded to call_llm."""
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Title"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title("q", "a", timeout=120.0)
+
+        assert captured["timeout"] == 120.0
+
     def test_truncates_long_messages(self):
         """Long user/assistant messages should be truncated in the LLM request."""
         captured_kwargs = {}
@@ -157,6 +189,28 @@ class TestAutoTitleSession:
             auto_title_session(db, "sess-1", "hi", "hello")
             db.set_session_title.assert_not_called()
 
+    def test_forwards_timeout_to_generate_title(self):
+        """auto_title_session must forward timeout to generate_title."""
+        db = MagicMock()
+        db.get_session_title.return_value = None
+
+        with patch("agent.title_generator.generate_title", return_value="T") as gen:
+            auto_title_session(db, "sess-1", "hi", "hello", timeout=60.0)
+            gen.assert_called_once_with(
+                "hi", "hello", timeout=60.0, failure_callback=None, main_runtime=None
+            )
+
+    def test_default_timeout_is_none(self):
+        """auto_title_session defaults timeout to None."""
+        db = MagicMock()
+        db.get_session_title.return_value = None
+
+        with patch("agent.title_generator.generate_title", return_value="T") as gen:
+            auto_title_session(db, "sess-1", "hi", "hello")
+            gen.assert_called_once_with(
+                "hi", "hello", timeout=None, failure_callback=None, main_runtime=None
+            )
+
 
 class TestMaybeAutoTitle:
     """Tests for maybe_auto_title() — the fire-and-forget entry point."""
@@ -202,6 +256,7 @@ class TestMaybeAutoTitle:
                 failure_callback=None,
                 main_runtime=None,
                 title_callback=None,
+                timeout=None,
             )
 
     def test_forwards_failure_callback_to_worker(self):
@@ -228,6 +283,31 @@ class TestMaybeAutoTitle:
                 failure_callback=_cb,
                 main_runtime=None,
                 title_callback=None,
+                timeout=None,
+            )
+
+    def test_forwards_timeout_to_worker(self):
+        """maybe_auto_title must forward timeout into the thread."""
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            maybe_auto_title(db, "sess-1", "hello", "hi there", history, timeout=120.0)
+            import time
+            time.sleep(0.3)
+            mock_auto.assert_called_once_with(
+                db,
+                "sess-1",
+                "hello",
+                "hi there",
+                failure_callback=None,
+                main_runtime=None,
+                title_callback=None,
+                timeout=120.0,
             )
 
     def test_skips_if_no_response(self):


### PR DESCRIPTION
## Summary

Title generation ignored the `auxiliary.title_generation.timeout` config value, always using a hardcoded 30s default. Users with slow local models (e.g. Ollama on CPU) who set `auxiliary.title_generation.timeout: 300` still saw timeouts at 30s.

## Root Cause

The call chain `maybe_auto_title()` → `auto_title_session()` → `generate_title(timeout=30.0)` → `call_llm(timeout=30.0)` never read the config value. `call_llm()` already supports `timeout=None` → `_get_task_timeout(task)` which reads `auxiliary.<task>.timeout`, but the hardcoded `30.0` default overrode it.

## Changes

- **`agent/title_generator.py`**: Changed `generate_title()` default from `timeout: float = 30.0` to `timeout: Optional[float] = None`. Thread `timeout` through `maybe_auto_title()` and `auto_title_session()`.
- **`gateway/run.py`**: Read `auxiliary.title_generation.timeout` via `_get_task_timeout("title_generation")` and pass it as `timeout` to `maybe_auto_title()`.
- **`tests/agent/test_title_generator.py`**: 5 new tests covering default-None behavior, explicit timeout forwarding through all three layers.

## Validation

- 25/25 title generator tests pass
- 209/209 auxiliary client tests pass

Fixes #41812