### PR TITLE
fix(delegate): require work item and honor model override

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5002,6 +5002,7 @@ class AIAgent:
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             toolsets=function_args.get("toolsets"),
+            model=function_args.get("model"),
             tasks=function_args.get("tasks"),
             max_iterations=function_args.get("max_iterations"),
             acp_command=function_args.get("acp_command"),

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -69,11 +69,18 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("model", props)
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
         self.assertNotIn("max_iterations", props)
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
+
+        self.assertEqual(
+            DELEGATE_TASK_SCHEMA["parameters"].get("anyOf"),
+            [{"required": ["goal"]}, {"required": ["tasks"]}],
+        )
+        self.assertIn("model", props["tasks"]["items"]["properties"])
 
     def test_schema_description_advertises_runtime_limits(self):
         """The model must see the user's actual concurrency / spawn-depth caps,
@@ -2299,6 +2306,71 @@ class TestOrchestratorRoleSchema(unittest.TestCase):
         task_props = props["tasks"]["items"]["properties"]
         self.assertIn("role", task_props)
         self.assertEqual(task_props["role"]["enum"], ["leaf", "orchestrator"])
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_top_level_model_override_reaches_child(self, mock_cfg, mock_creds):
+        mock_creds.return_value = {
+            "provider": None, "base_url": None, "api_key": None, "api_mode": None, "model": None,
+        }
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True,
+                "api_calls": 1, "messages": [],
+            }
+            mock_child._delegate_saved_tool_names = []
+            mock_child._credential_pool = None
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="use a specific child model",
+                model="openrouter/qwen3-coder",
+                parent_agent=parent,
+            )
+
+        self.assertEqual(MockAgent.call_args.kwargs["model"], "openrouter/qwen3-coder")
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_per_task_model_override_beats_top_level_model(self, mock_cfg, mock_creds):
+        mock_creds.return_value = {
+            "provider": None, "base_url": None, "api_key": None, "api_mode": None, "model": "config-model",
+        }
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True,
+                "api_calls": 1, "messages": [],
+            }
+            mock_child._delegate_saved_tool_names = []
+            mock_child._credential_pool = None
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                model="top-model",
+                tasks=[{"goal": "task", "model": "task-model"}],
+                parent_agent=parent,
+            )
+
+        self.assertEqual(MockAgent.call_args.kwargs["model"], "task-model")
+
+    def test_run_agent_dispatch_forwards_model(self):
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+        with patch("tools.delegate_tool.delegate_task", return_value='{"results": []}') as mock_delegate:
+            result = AIAgent._dispatch_delegate_task(agent, {"goal": "x", "model": "child-model"})
+
+        self.assertEqual(result, '{"results": []}')
+        self.assertEqual(mock_delegate.call_args.kwargs["model"], "child-model")
+        self.assertIs(mock_delegate.call_args.kwargs["parent_agent"], agent)
 
     def test_acp_command_description_has_do_not_set_guidance(self):
         # acp_command/acp_args descriptions must NOT bias the model toward

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1971,6 +1971,7 @@ def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
+    model: Optional[str] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
@@ -1982,8 +1983,8 @@ def delegate_task(
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, toolsets, model, role)
+      - Batch:  provide tasks array [{goal, context, toolsets, model, role}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
@@ -2004,8 +2005,9 @@ def delegate_task(
             "(`p` in /agents) or the `delegation.pause` RPC before retrying."
         )
 
-    # Normalise the top-level role once; per-task overrides re-normalise.
+    # Normalise top-level overrides once; per-task overrides re-normalise.
     top_role = _normalize_role(role)
+    top_model = model.strip() if isinstance(model, str) and model.strip() else None
 
     # Depth limit — configurable via delegation.max_spawn_depth,
     # default 2 for parity with the original MAX_DEPTH constant.
@@ -2070,7 +2072,13 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "model": top_model,
+                "role": top_role,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2111,12 +2119,18 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            task_model = t.get("model")
+            effective_model = (
+                task_model.strip()
+                if isinstance(task_model, str) and task_model.strip()
+                else top_model or creds["model"]
+            )
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=effective_model,
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
@@ -2816,6 +2830,14 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional model override for child agents. When omitted, "
+                    "the child uses delegation.model from config.yaml if set, "
+                    "otherwise the parent agent's current model."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -2830,6 +2852,13 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Model override for this specific task. "
+                                "Overrides top-level model for this task only."
+                            ),
                         },
                         "acp_command": {
                             "type": "string",
@@ -2885,7 +2914,10 @@ DELEGATE_TASK_SCHEMA = {
                 ),
             },
         },
-        "required": [],
+        "anyOf": [
+            {"required": ["goal"]},
+            {"required": ["tasks"]},
+        ],
     },
 }
 
@@ -2901,6 +2933,7 @@ registry.register(
         goal=args.get("goal"),
         context=args.get("context"),
         toolsets=args.get("toolsets"),
+        model=args.get("model"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),


### PR DESCRIPTION
## Summary
- require delegate_task callers to provide either `goal` or `tasks` at the JSON schema level
- expose and forward a `model` override for single and batch delegated tasks
- keep per-task model overrides higher priority than top-level/configured delegation model

Fixes #41823.
Fixes #41821.

## Tests
- python -m pytest -o addopts= -p no:timeout tests/tools/test_delegate.py
- python -m py_compile tools/delegate_tool.py run_agent.py