### PR TITLE
fix(title): honor configured auxiliary timeout

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -29,7 +29,7 @@ _TITLE_PROMPT = (
 def generate_title(
     user_message: str,
     assistant_response: str,
-    timeout: float = 30.0,
+    timeout: Optional[float] = None,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
 ) -> Optional[str]:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -22,6 +22,37 @@ class TestGenerateTitle:
             title = generate_title("help me fix this import", "Sure, let me check...")
             assert title == "Debugging Python Import Errors"
 
+    def test_default_timeout_delegates_to_auxiliary_config(self):
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Configured Timeout"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("question", "answer") == "Configured Timeout"
+
+        assert captured_kwargs["task"] == "title_generation"
+        assert captured_kwargs["timeout"] is None
+
+    def test_explicit_timeout_still_overrides_config(self):
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Explicit Timeout"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("question", "answer", timeout=123.0) == "Explicit Timeout"
+
+        assert captured_kwargs["timeout"] == 123.0
+
     def test_strips_quotes(self):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]


### PR DESCRIPTION
## Summary
- stop forcing title generation to pass the 30s default timeout into `call_llm`
- let `call_llm(task="title_generation")` resolve `auxiliary.title_generation.timeout` from config when no explicit timeout is provided
- add coverage for default-config timeout delegation and explicit timeout overrides

Fixes #41812.

## Tests
- python -m pytest -o addopts= -p no:timeout tests/agent/test_title_generator.py tests/hermes_cli/test_aux_config.py::test_title_generation_present_in_default_config
- python -m py_compile agent/title_generator.py