### PR TITLE
fix(delegation): make goal required in delegate_task schema

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -75,6 +75,14 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertNotIn("max_iterations", props)
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
 
+    def test_schema_requires_goal(self):
+        """goal must be required so weak models cannot generate empty {} calls.
+
+        See https://github.com/NousResearch/hermes-agent/issues/41823
+        """
+        required = DELEGATE_TASK_SCHEMA["parameters"].get("required", [])
+        self.assertIn("goal", required)
+
     def test_schema_description_advertises_runtime_limits(self):
         """The model must see the user's actual concurrency / spawn-depth caps,
         not the framework defaults. Without this, models that read 'default 3'

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2648,7 +2648,7 @@ def _build_top_level_description() -> str:
         "Each subagent gets its own conversation, terminal session, and toolset. "
         "Only the final summary is returned -- intermediate tool results "
         "never enter your context window.\n\n"
-        "TWO MODES (one of 'goal' or 'tasks' is required):\n"
+        "TWO MODES ('goal' is always required; optionally add 'tasks' for batch):\n"
         "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
         f"2. Batch (parallel): provide 'tasks' array with up to {max_children} "
         f"items concurrently for this user (configured via "
@@ -2885,7 +2885,7 @@ DELEGATE_TASK_SCHEMA = {
                 ),
             },
         },
-        "required": [],
+        "required": ["goal"],
     },
 }
 


### PR DESCRIPTION
## What does this PR do?

Makes `goal` a required field in the `delegate_task` tool schema, preventing weak models from generating empty `{}` calls that fail at runtime.

## Related Issue

Fixes #41823

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py`: Changed `"required": []` to `"required": ["goal"]` in `DELEGATE_TASK_SCHEMA`; updated description to reflect that `goal` is always required
- `tests/tools/test_delegate.py`: Added `test_schema_requires_goal` regression test

## How to Test

1. Run `pytest tests/tools/test_delegate.py -k "test_schema_requires_goal or test_schema_valid" -v` — both should pass
2. Verify the schema: `python -c "from tools.delegate_tool import DELEGATE_TASK_SCHEMA; print(DELEGATE_TASK_SCHEMA['parameters']['required'])"` — should output `['goal']`
3. Confirm batch mode still works: models providing both `goal` and `tasks` should have `tasks` take precedence (handler logic unchanged)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## Code Intelligence

- Analyzed: `DELEGATE_TASK_SCHEMA` in `tools/delegate_tool.py` (used by registry handler + `_dispatch_delegate_task` in `run_agent.py`)
- Blast radius: LOW — schema change only; handler validation logic unchanged; `goal` is already provided by all capable models
- Related patterns: `anyOf`/`oneOf` breaks Anthropic/Fireworks APIs; making one field required + handler validation is the safe alternative
