### PR TITLE
fix(memory): bump hindsight-client pin to >=0.7.2,<0.8 for Hindsight server v0.7.x compatibility

### DIFF
--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.4.22"
+  - "hindsight-client>=0.7.2,<0.8"
 requires_env: []
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ fal = ["fal-client==0.13.1"]
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client>=0.7.2,<0.8"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==82.0.1"]  # starlette: CVE-2026-48710
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.3", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat


### PR DESCRIPTION
## Summary

The Hindsight memory plugin's `hindsight-client` pin (`==0.6.1` in `pyproject.toml`, `>=0.4.22` in the plugin manifest) is too old for the Hindsight server v0.7.x that ships with current self-hosted installs. The 0.6.x SDK calls a legacy endpoint path that v0.7.x servers have removed (HTTP 404 from `POST /v1/retain`), so `hindsight_retain` silently fails. In `local_embedded` mode, the embedded daemon also cannot start because 0.6.1 lacks the `86f7a033d372` Alembic migration.

Bump the floor to `>=0.7.2,<0.8` to match the current server.

## Changes

- `pyproject.toml`: `hindsight = ["hindsight-client==0.6.1"]` → `hindsight = ["hindsight-client>=0.7.2,<0.8"]`
- `plugins/memory/hindsight/plugin.yaml`: `hindsight-client>=0.4.22` → `hindsight-client>=0.7.2,<0.8`

Net: 2 files, +2 / -2.

## Verification

In an active venv pointing at a Hindsight 0.7.2 server on `localhost:8888`:

1. `pip install --upgrade hindsight-client==0.7.2` succeeds
2. `from hindsight_client import Hindsight; c.retain(bank_id='hermes', content='probe', retain_async=True)` returns HTTP 200 with an `operation_id`
3. The same call against SDK 0.6.0 returns HTTP 404 on the legacy path (reproduces the failure mode in #39424)

> Note: server-side LLM-backed fact extraction can still be slow / hang if the worker's queue is saturated. That's a server-side concern, not a client pin issue. The PR fixes the client/server protocol mismatch, which is the prerequisite for any further work on retain reliability.

## Test Plan

- [x] `pip install --upgrade hindsight-client==0.7.2` in a working venv
- [x] Direct SDK call submits to v0.7.2 server (HTTP 200)
- [x] Direct SDK call to legacy endpoint returns 404 (confirms the bug is reproducible with old pin)
- [ ] `pip install -e .[hindsight]` from a clean venv installs the new pin and `hermes memory status` shows the daemon reachable

Closes #39424
