### PR TITLE
fix(tui): honor configured tool preview length

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -722,6 +722,30 @@ def test_config_roundtrip(server, tmp_path):
     assert server._load_cfg()["model"] == "test/model"
 
 
+def test_config_load_syncs_tui_tool_preview_length(server, tmp_path):
+    import yaml
+    from agent.display import get_tool_preview_max_len, set_tool_preview_max_len
+
+    server._hermes_home = tmp_path
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"display": {"tool_preview_length": 200}}),
+        encoding="utf-8",
+    )
+    set_tool_preview_max_len(0)
+
+    try:
+        assert server._load_cfg()["display"]["tool_preview_length"] == 200
+        assert get_tool_preview_max_len() == 200
+
+        command = "x" * 120
+        assert server._tool_ctx("terminal", {"command": command}) == command
+    finally:
+        set_tool_preview_max_len(0)
+
+
 # ── _cli_exec_blocked ────────────────────────────────────────────────
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -968,6 +968,23 @@ _INDICATOR_STYLES: tuple[str, ...] = ("ascii", "emoji", "kaomoji", "unicode")
 _INDICATOR_DEFAULT = "kaomoji"
 
 
+def _sync_tool_preview_length(cfg: dict) -> None:
+    try:
+        display = cfg.get("display") if isinstance(cfg, dict) else {}
+        if not isinstance(display, dict):
+            display = {}
+        raw = display.get("tool_preview_length", 0)
+        try:
+            value = int(raw) if raw else 0
+        except (TypeError, ValueError):
+            value = 0
+        from agent.display import set_tool_preview_max_len
+
+        set_tool_preview_max_len(value)
+    except Exception:
+        pass
+
+
 def _load_cfg() -> dict:
     global _cfg_cache, _cfg_mtime, _cfg_path
     try:
@@ -983,7 +1000,9 @@ def _load_cfg() -> dict:
         mtime = p.stat().st_mtime if p.exists() else None
         with _cfg_lock:
             if _cfg_cache is not None and _cfg_mtime == mtime and _cfg_path == p:
-                return copy.deepcopy(_cfg_cache)
+                data = copy.deepcopy(_cfg_cache)
+                _sync_tool_preview_length(data)
+                return data
         if p.exists():
             with open(p, encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
@@ -993,6 +1012,7 @@ def _load_cfg() -> dict:
             _cfg_cache = copy.deepcopy(data)
             _cfg_mtime = mtime
             _cfg_path = p
+        _sync_tool_preview_length(data)
         return data
     except Exception:
         pass
@@ -1013,6 +1033,7 @@ def _save_cfg(cfg: dict):
             _cfg_mtime = path.stat().st_mtime
         except Exception:
             _cfg_mtime = None
+    _sync_tool_preview_length(cfg)
 
 
 def _cwd_for_session_key(session_key: str) -> str:
@@ -1898,7 +1919,7 @@ def _tool_ctx(name: str, args: dict) -> str:
     try:
         from agent.display import build_tool_preview
 
-        return build_tool_preview(name, args, max_len=80) or ""
+        return build_tool_preview(name, args) or ""
     except Exception:
         return ""
 


### PR DESCRIPTION
## Summary
- sync `display.tool_preview_length` into the TUI gateway's tool preview setting when config is loaded or saved
- stop forcing TUI tool previews through a fixed 80-character cap
- add a regression test that keeps a configured 200-character preview intact

Fixes #41846.

## Tests
- `python -m pytest -o addopts= -p no:timeout tests/tui_gateway/test_protocol.py`
- `python -m py_compile tui_gateway/server.py`
- `git diff --check`