### PR TITLE
fix(tui): respect display.tool_preview_length config in TUI mode

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6046,3 +6046,29 @@ def test_sniff_image_ext_magic_and_filename():
     assert server._sniff_image_ext(b"unknown") == ".png"  # fallback
     # filename hint wins over magic bytes
     assert server._sniff_image_ext(b"\x89PNG", "photo.jpeg") == ".jpeg"
+
+
+def test_tool_ctx_respects_global_preview_length():
+    """_tool_ctx should defer to the global _tool_preview_max_len, not hardcode 80."""
+    from agent.display import set_tool_preview_max_len
+
+    long_cmd = "a" * 200
+
+    # With global set to 0 (unlimited), preview should contain the full command
+    set_tool_preview_max_len(0)
+    result = server._tool_ctx("terminal", {"command": long_cmd})
+    assert long_cmd in result
+
+    # With global set to 50, preview should be truncated
+    set_tool_preview_max_len(50)
+    result = server._tool_ctx("terminal", {"command": long_cmd})
+    assert long_cmd not in result
+    assert "..." in result
+
+    # Cleanup
+    set_tool_preview_max_len(0)
+
+
+def test_tool_ctx_empty_args_returns_empty():
+    """_tool_ctx returns empty string for tools with no args."""
+    assert server._tool_ctx("terminal", {}) == ""

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -263,6 +263,15 @@ def main():
         global _mcp_discovery_thread
         _mcp_discovery_thread = _mcp_thread
 
+    # Initialize tool preview length from config (mirrors cli.py startup).
+    try:
+        from agent.display import set_tool_preview_max_len
+        from hermes_cli.config import read_raw_config as _read_cfg
+        _tpl = (_read_cfg() or {}).get("display", {}).get("tool_preview_length", 0)
+        set_tool_preview_max_len(int(_tpl) if _tpl else 0)
+    except Exception:
+        pass
+
     if not write_json({
         "jsonrpc": "2.0",
         "method": "event",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1898,7 +1898,7 @@ def _tool_ctx(name: str, args: dict) -> str:
     try:
         from agent.display import build_tool_preview
 
-        return build_tool_preview(name, args, max_len=80) or ""
+        return build_tool_preview(name, args, max_len=None) or ""
     except Exception:
         return ""
 


### PR DESCRIPTION
## Problem

In TUI mode (`hermes --tui`), the `display.tool_preview_length` config setting is ignored. Tool call previews are always truncated to ~40 characters regardless of the user's configured value.

**Root cause**: Two issues:
1. `tui_gateway/entry.py` never calls `set_tool_preview_max_len()` at startup (unlike `cli.py` and `gateway/run.py`)
2. `_tool_ctx()` in `tui_gateway/server.py` hardcodes `max_len=80`, bypassing the global config entirely

## Fix

1. **`tui_gateway/entry.py`** — Initialize `set_tool_preview_max_len()` from `display.tool_preview_length` config during startup, mirroring the `cli.py` pattern
2. **`tui_gateway/server.py`** — Change `_tool_ctx()` to pass `max_len=None` so `build_tool_preview()` defers to the global config value

## Testing

- Added 2 tests in `tests/test_tui_gateway_server.py`:
  - `test_tool_ctx_respects_global_preview_length` — verifies truncation respects the global setting
  - `test_tool_ctx_empty_args_returns_empty` — verifies empty args handling

Fixes #41846
