### PR TITLE
fix(cli): display background process notifications directly to terminal

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15079,7 +15079,7 @@ class HermesCLI:
                             try:
                                 from tools.process_registry import process_registry
                                 for _evt, _synth in process_registry.drain_notifications():
-                                    self._pending_input.put(_synth)
+                                    _cprint(f"\n  {_synth}\n")
                             except Exception:
                                 pass
                         continue
@@ -15207,7 +15207,7 @@ class HermesCLI:
                         try:
                             from tools.process_registry import process_registry
                             for _evt, _synth in process_registry.drain_notifications():
-                                self._pending_input.put(_synth)
+                                _cprint(f"\n  {_synth}\n")
                         except Exception:
                             pass  # Non-fatal — don't break the main loop
 


### PR DESCRIPTION
## Fix: 2 lines

Background process notifications (`notify_on_complete`) were injected into `_pending_input` as pseudo-user-input, where they were silently consumed by the agent as chat messages. The user never saw a visible notification.

## Root Cause

`cli.py` had two `_pending_input.put(_synth)` calls where `_cprint()` should have been used:

- **Line 15082** (idle drain): `self._pending_input.put(_synth)` → `_cprint(f"\n  {_synth}\n")`
- **Line 15210** (post-agent drain): same fix

## Impact

Every CLI user who uses `terminal(background=true, notify_on_complete=true)` — currently the notification is invisible.

## Related

- Closes #41851
- Related: #21904, #15248, #10760 (long-standing notification issues)