### PR TITLE
fix(research): preserve trajectories on summarization timeout

### DIFF
--- a/tests/test_trajectory_compressor_async.py
+++ b/tests/test_trajectory_compressor_async.py
@@ -172,6 +172,60 @@ async def test_generate_summary_async_public_moonshot_kimi_k2_5_omits_temperatur
     assert "temperature" not in async_client.chat.completions.create.call_args.kwargs
 
 
+def test_per_trajectory_timeout_preserves_original_entry(tmp_path):
+    """A summarization timeout must NOT delete the trajectory from the output.
+
+    Regression: the asyncio.TimeoutError branch in _process_directory_async used
+    to set results[...] = None, and the writer filtered None entries out — so any
+    trajectory whose processing exceeded per_trajectory_timeout (transient
+    summarizer slowness/rate-limiting under concurrency) was permanently dropped
+    from the training data. A timeout is a transient failure, so the original
+    (uncompressed) entry must be preserved, matching the generic-exception branch.
+    """
+    import asyncio
+    import json
+
+    from trajectory_compressor import (
+        AggregateMetrics,
+        CompressionConfig,
+        TrajectoryCompressor,
+    )
+
+    input_dir = tmp_path / "in"
+    output_dir = tmp_path / "out"
+    input_dir.mkdir()
+
+    entry = {"conversations": [{"from": "human", "value": "hello"}]}
+    (input_dir / "data.jsonl").write_text(
+        json.dumps(entry) + "\n", encoding="utf-8"
+    )
+
+    # Tiny timeout so the (intentionally slow) entry processing always trips it.
+    config = CompressionConfig(per_trajectory_timeout=1, metrics_enabled=False)
+
+    comp = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    comp.config = config
+    comp.logger = MagicMock()
+    comp.aggregate_metrics = AggregateMetrics()
+
+    async def _never_returns(_entry):
+        await asyncio.sleep(60)
+
+    comp.process_entry_async = _never_returns
+
+    comp.process_directory(input_dir, output_dir)
+
+    out_file = output_dir / "data.jsonl"
+    assert out_file.exists()
+    lines = [l for l in out_file.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+    # The trajectory survived the timeout, unmodified.
+    assert len(lines) == 1, "timed-out trajectory was silently dropped"
+    assert json.loads(lines[0]) == entry
+    # And it was accounted for as a failure, not a success.
+    assert comp.aggregate_metrics.trajectories_failed == 1
+
+
 @pytest.mark.asyncio
 async def test_generate_summary_async_public_moonshot_cn_kimi_k2_5_omits_temperature():
     """kimi-k2.5 on api.moonshot.cn should not get a forced temperature."""

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -1165,8 +1165,11 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                             description=f"[dim]✅ {compressed_count} compressed | ⏭️ {skipped_count} skipped | ⏱️ {timeout_count} timeout | 🔄 {api_calls} API calls | ⚡ {in_flight} in-flight[/dim]"
                         )
                     
-                    # Skip this entry entirely (don't include in output)
-                    results[file_path][entry_idx] = None
+                    # Keep the original (uncompressed) entry on timeout instead of
+                    # dropping it. A summarizer timeout is a transient failure, not a
+                    # reason to permanently delete valid training data — mirror the
+                    # generic-exception branch below, which also preserves the original.
+                    results[file_path][entry_idx] = (entry, TrajectoryMetrics())
                     
                 except Exception as e:
                     self.logger.error(f"Error processing entry from {file_path}:{entry_idx}: {e}")
@@ -1224,7 +1227,9 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             output_path = output_dir / file_path.name
             file_results = results[file_path]
             
-            # Sort by original entry index to preserve order, skip None (timed out) entries
+            # Sort by original entry index to preserve order; the `is not None`
+            # guard is defensive — every entry is now retained (compressed,
+            # skipped, or preserved-on-failure), so nothing is silently dropped.
             sorted_entries = [
                 file_results[idx][0] 
                 for idx in sorted(file_results.keys()) 


### PR DESCRIPTION
## What does this PR do?

The async trajectory compressor permanently deleted any trajectory whose
processing exceeded `per_trajectory_timeout` (default 300s). In
`_process_directory_async`, the `asyncio.TimeoutError` branch set
`results[file_path][entry_idx] = None`, and the output writer filtered out
`None` entries — so the trajectory was dropped from the output JSONL with
only a WARNING line.

Why this matters: the timeout wraps the whole chain
(`process_entry_async` -> `compress_trajectory_async` ->
`_generate_summary_async`), so it includes the summarizer API call, which
itself retries up to ~3x with backoff. With the default
`max_concurrent_requests=50` hammering one summarization model, a slow or
rate-limited response readily blows the 300s budget on otherwise valid
trajectories — and that valid training data is then silently lost.

Why this approach: a timeout is a transient failure, not a corrupt input.
The generic `except Exception` branch right below already does the right
thing — it preserves the original entry via `(entry, TrajectoryMetrics())`.
The timeout branch was simply asymmetric. The fix makes it preserve the
original (uncompressed) entry too, so nothing is ever silently deleted.
The trajectory is still counted as a failure (`trajectories_failed`,
`timeout_count`), so accounting and the progress display are unchanged —
only the destructive drop is removed.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `trajectory_compressor.py`: in `_process_directory_async`, the
  `asyncio.TimeoutError` handler now stores `(entry, TrajectoryMetrics())`
  instead of `None`, mirroring the generic-exception handler so the original
  trajectory is retained.
- `trajectory_compressor.py`: updated the output-writer comment — the
  `is not None` guard is now purely defensive since no path produces `None`.
- `tests/test_trajectory_compressor_async.py`: added
  `test_per_trajectory_timeout_preserves_original_entry`, which drives a real
  directory run with a 1s timeout against a deliberately slow
  `process_entry_async` and asserts the entry survives unmodified and is
  counted as a failure.

## How to Test

1. Check out this branch.
2. Run `pytest tests/test_trajectory_compressor_async.py -q` — all tests pass.
3. To see the regression: revert the timeout branch to
   `results[file_path][entry_idx] = None` and re-run
   `test_per_trajectory_timeout_preserves_original_entry` — it fails because
   the timed-out trajectory is dropped from the output JSONL.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A