### PR TITLE
fix(batch_runner): preserve duplicate prompts on resume

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import time
+from collections import Counter
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Tuple
 from datetime import datetime
@@ -729,67 +730,81 @@ class BatchRunner:
         else:
             atomic_json_write(self.checkpoint_file, checkpoint_data)
     
-    def _scan_completed_prompts_by_content(self) -> set:
+    def _scan_completed_prompts_by_content(self) -> Counter:
         """
         Scan all batch files and extract completed prompts by their actual content.
-        
+
         This provides a more robust resume mechanism that matches on prompt text
         rather than indices, allowing recovery even if indices don't match.
-        
+
+        Multiplicity is preserved: a prompt that legitimately appears more than
+        once in the dataset (common in RL/MoA sampling, where the same task is run
+        several times for distribution diversity) is counted once per completed
+        copy. Returning a plain set here would collapse those duplicates and cause
+        every remaining copy to be dropped on resume — silent trajectory loss.
+
         Returns:
-            set: Set of prompt texts that have been successfully processed
+            Counter: prompt text -> number of completed copies found
         """
-        completed_prompts = set()
+        completed_prompts = Counter()
         batch_files = sorted(self.output_dir.glob("batch_*.jsonl"))
-        
+
         if not batch_files:
             return completed_prompts
-        
+
         print(f"📂 Scanning {len(batch_files)} batch files for completed prompts...")
-        
+
         for batch_file in batch_files:
             try:
                 with open(batch_file, 'r', encoding='utf-8') as f:
                     for line in f:
                         try:
                             entry = json.loads(line.strip())
-                            
+
                             # Skip failed entries - we want to retry these
                             if entry.get("failed", False):
                                 continue
-                            
+
                             # Extract the human/user prompt from conversations
                             conversations = entry.get("conversations", [])
                             for msg in conversations:
                                 if msg.get("from") == "human":
                                     prompt_text = msg.get("value", "").strip()
                                     if prompt_text:
-                                        completed_prompts.add(prompt_text)
+                                        completed_prompts[prompt_text] += 1
                                     break  # Only need the first human message
                         except json.JSONDecodeError:
                             continue
             except Exception as e:
                 print(f"  ⚠️  Warning: Error reading {batch_file.name}: {e}")
-        
+
         return completed_prompts
     
-    def _filter_dataset_by_completed(self, completed_prompts: set) -> Tuple[List[Dict], List[int]]:
+    def _filter_dataset_by_completed(self, completed_prompts: Counter) -> Tuple[List[Dict], List[int]]:
         """
         Filter the dataset to exclude prompts that have already been completed.
-        
+
+        Skipping is multiplicity-aware: each completed copy of a prompt removes at
+        most one matching dataset entry. A dataset containing the same prompt N
+        times only has the copies that were actually completed skipped; the rest
+        are still scheduled for processing on resume.
+
         Args:
-            completed_prompts: Set of prompt texts that have been completed
-            
+            completed_prompts: Counter mapping completed prompt text -> count
+
         Returns:
             Tuple of (filtered_dataset, skipped_indices)
         """
         filtered_dataset = []
         skipped_indices = []
-        
+
+        # Work on a copy so we can decrement remaining credit as we consume it.
+        remaining = Counter(completed_prompts)
+
         for idx, entry in enumerate(self.dataset):
             # Extract prompt from the dataset entry
             prompt_text = entry.get("prompt", "").strip()
-            
+
             # Also check conversations format
             if not prompt_text:
                 conversations = entry.get("conversations", [])
@@ -798,13 +813,14 @@ class BatchRunner:
                     if role in {"user", "human"}:
                         prompt_text = (msg.get("content") or msg.get("value", "")).strip()
                         break
-            
-            if prompt_text in completed_prompts:
+
+            if prompt_text and remaining[prompt_text] > 0:
+                remaining[prompt_text] -= 1
                 skipped_indices.append(idx)
             else:
                 # Keep original index for tracking
                 filtered_dataset.append((idx, entry))
-        
+
         return filtered_dataset, skipped_indices
     
     def run(self, resume: bool = False):
@@ -819,11 +835,13 @@ class BatchRunner:
         print("=" * 70)
         
         # Smart resume: scan batch files by content to find completed prompts
-        completed_prompt_texts = set()
+        completed_prompt_texts = Counter()
         if resume:
             completed_prompt_texts = self._scan_completed_prompts_by_content()
             if completed_prompt_texts:
-                print(f"   Found {len(completed_prompt_texts)} already-completed prompts by content matching")
+                # sum() over the counter values, not len(), so duplicate prompts
+                # are reported by their true completed count.
+                print(f"   Found {sum(completed_prompt_texts.values())} already-completed prompts by content matching")
         
         # Filter dataset to only include unprocessed prompts
         if resume and completed_prompt_texts:

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -1,6 +1,7 @@
 """Tests for batch_runner checkpoint behavior — incremental writes, resume, atomicity."""
 
 import json
+from collections import Counter
 from pathlib import Path
 from threading import Lock
 
@@ -248,3 +249,101 @@ class TestFinalCheckpointNoDuplicates:
             buggy.extend(br.get("completed_prompts", []))
         # Every index appears twice
         assert len(buggy) == 2 * len(set(buggy))
+
+
+def _dataset_entry(prompt_text):
+    """A minimal dataset row carrying a single prompt string."""
+    return {"prompt": prompt_text}
+
+
+def _completed_entry(prompt_text):
+    """A minimal saved batch trajectory entry carrying one human prompt."""
+    return {"conversations": [{"from": "human", "value": prompt_text}]}
+
+
+def _make_resume_runner(tmp_path, dataset):
+    """BatchRunner stub with just the attributes the resume helpers touch."""
+    r = BatchRunner.__new__(BatchRunner)
+    r.run_name = "dup_run"
+    r.output_dir = tmp_path
+    r.dataset = dataset
+    return r
+
+
+class TestResumeDuplicatePrompts:
+    """Regression: resume must preserve prompt multiplicity.
+
+    Content-based resume previously collected completed prompts into a ``set``
+    (`_scan_completed_prompts_by_content`) and dropped every dataset entry whose
+    text was a member (`_filter_dataset_by_completed`).  When a dataset
+    legitimately repeats the same prompt — common in RL/MoA sampling where one
+    task is run several times for distribution diversity — completing a single
+    copy silently discarded all remaining copies on resume, producing fewer
+    trajectories than requested with no warning and no way to recover on a
+    second resume.  The fix counts completed copies and skips at most that many
+    matching entries.
+    """
+
+    def test_scan_counts_completed_copies(self, tmp_path):
+        """The scan reports multiplicity, not mere membership."""
+        runner = _make_resume_runner(tmp_path, dataset=[])
+        batch_file = tmp_path / "batch_0.jsonl"
+        batch_file.write_text(
+            "\n".join(json.dumps(_completed_entry(t)) for t in ("P", "P", "Q")) + "\n",
+            encoding="utf-8",
+        )
+
+        completed = runner._scan_completed_prompts_by_content()
+
+        assert isinstance(completed, Counter)
+        assert completed["P"] == 2
+        assert completed["Q"] == 1
+
+    def test_only_completed_copies_are_skipped(self, tmp_path):
+        """Dataset has prompt P three times; one copy completed -> two remain."""
+        dataset = [_dataset_entry("P"), _dataset_entry("P"), _dataset_entry("P")]
+        runner = _make_resume_runner(tmp_path, dataset)
+
+        completed = Counter({"P": 1})
+        filtered, skipped = runner._filter_dataset_by_completed(completed)
+
+        # Exactly one copy skipped; the other two are still scheduled.
+        assert len(skipped) == 1
+        assert [idx for idx, _ in filtered] == [1, 2]
+
+    def test_all_completed_copies_are_skipped(self, tmp_path):
+        """When every copy is already done, all of them are skipped."""
+        dataset = [_dataset_entry("P"), _dataset_entry("P"), _dataset_entry("P")]
+        runner = _make_resume_runner(tmp_path, dataset)
+
+        completed = Counter({"P": 3})
+        filtered, skipped = runner._filter_dataset_by_completed(completed)
+
+        assert skipped == [0, 1, 2]
+        assert filtered == []
+
+    def test_distinct_prompts_still_filtered(self, tmp_path):
+        """The common case (unique prompts) keeps working as before."""
+        dataset = [_dataset_entry("A"), _dataset_entry("B"), _dataset_entry("C")]
+        runner = _make_resume_runner(tmp_path, dataset)
+
+        completed = Counter({"A": 1, "C": 1})
+        filtered, skipped = runner._filter_dataset_by_completed(completed)
+
+        assert skipped == [0, 2]
+        assert [idx for idx, _ in filtered] == [1]
+
+    def test_end_to_end_scan_then_filter_preserves_duplicates(self, tmp_path):
+        """Full resume path: a dataset of three identical prompts with only one
+        completed copy on disk leaves two to process."""
+        dataset = [_dataset_entry("same"), _dataset_entry("same"), _dataset_entry("same")]
+        runner = _make_resume_runner(tmp_path, dataset)
+        (tmp_path / "batch_0.jsonl").write_text(
+            json.dumps(_completed_entry("same")) + "\n", encoding="utf-8"
+        )
+
+        completed = runner._scan_completed_prompts_by_content()
+        filtered, skipped = runner._filter_dataset_by_completed(completed)
+
+        assert len(skipped) == 1
+        assert len(filtered) == 2


### PR DESCRIPTION
## What does this PR do?

Content-based resume silently dropped legitimately repeated prompts. On
`--resume`, `_scan_completed_prompts_by_content()` collected every completed
prompt into a Python `set`, and `_filter_dataset_by_completed()` excluded each
dataset row whose text was a member of that set. Membership carries no
multiplicity, so completing a single copy of a prompt caused all remaining
copies to be filtered out. Datasets that intentionally repeat the same prompt —
common in RL/MoA sampling, where one task is run several times for distribution
diversity — therefore produced fewer trajectories than requested, with no
warning, and a second `--resume` could never recover them.

The fix keeps the robust content-matching approach but makes it
multiplicity-aware: the scan counts completed copies, and the filter consumes
one unit of that credit per matching dataset row, so it skips at most as many
copies as were actually completed and schedules the rest.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `batch_runner.py`: `_scan_completed_prompts_by_content()` now returns a
  `collections.Counter` keyed on prompt text (counting completed copies) instead
  of a `set`.
- `batch_runner.py`: `_filter_dataset_by_completed()` decrements a working copy
  of that counter per match, skipping at most as many duplicate rows as were
  completed rather than every row sharing the text.
- `batch_runner.py`: `run()` initializes the resume accumulator as a `Counter`
  and reports the true completed count via `sum(...values())` rather than the
  number of distinct prompts.
- `tests/test_batch_runner_checkpoint.py`: added `TestResumeDuplicatePrompts`
  covering multiplicity-aware scanning and filtering, the all-completed case,
  the distinct-prompt case, and the end-to-end scan→filter path.

## How to Test

1. Build a dataset that repeats one prompt three times and run a batch so a
   single copy completes; on `--resume` the two remaining copies are still
   scheduled instead of being discarded.
2. Run the regression tests: `scripts/run_tests.sh tests/test_batch_runner_checkpoint.py`
   (21 passed locally on macOS 15 / Python 3.12).
3. Gates: `ruff check batch_runner.py tests/test_batch_runner_checkpoint.py` and
   `python scripts/check-windows-footguns.py --all` both pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A