### PR TITLE
fix(gateway): persist compressed transcript before repointing /compress session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13381,15 +13381,28 @@ class GatewayRunner:
                 # (preserving its full transcript in SQLite) and creates a new
                 # session_id for the continuation.  Write the compressed messages
                 # into the NEW session so the original history stays searchable.
+                #
+                # Order matters: persist the compressed transcript BEFORE
+                # repointing the live session onto the new session_id.  If we
+                # repointed first and the canonical DB write then failed (lock
+                # contention under concurrent writes, ENOSPC, a disk/IO error),
+                # the session entry would already reference a brand-new, empty
+                # session_id while the handler still reported success — the
+                # user's active conversation would silently vanish from view.
+                # Writing first, and treating a write failure as fatal, keeps the
+                # old history reachable (the entry still points at it) and lets
+                # the outer handler surface a "compress failed" banner instead.
                 new_session_id = tmp_agent.session_id
+                if not self.session_store.rewrite_transcript(new_session_id, compressed):
+                    raise RuntimeError(
+                        f"failed to persist compressed transcript for session {new_session_id}"
+                    )
                 if new_session_id != session_entry.session_id:
                     session_entry.session_id = new_session_id
                     self.session_store._save()
                     self._sync_telegram_topic_binding(
                         source, session_entry, reason="compress-command",
                     )
-
-                self.session_store.rewrite_transcript(new_session_id, compressed)
                 # Reset stored token count — transcript changed, old value is stale
                 self.session_store.update_session(
                     session_entry.session_key, last_prompt_tokens=0

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1298,17 +1298,27 @@ class SessionStore:
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
     
-    def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+    def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> bool:
         """Replace the entire transcript for a session with new messages.
 
         Used by /retry, /undo, and /compress to persist modified conversation
         history. state.db is the canonical store.
+
+        Returns ``True`` when the write lands (or there is no DB to write to)
+        and ``False`` when the canonical write fails. Most callers can ignore
+        the result, but callers that would otherwise commit a destructive state
+        change on top of a failed write — e.g. /compress repointing the live
+        session onto a fresh session_id — must check it so they can surface an
+        error instead of silently dropping the conversation.
         """
-        if self._db:
-            try:
-                self._db.replace_messages(session_id, messages)
-            except Exception as e:
-                logger.debug("Failed to rewrite transcript in DB: %s", e)
+        if not self._db:
+            return True
+        try:
+            self._db.replace_messages(session_id, messages)
+            return True
+        except Exception as e:
+            logger.debug("Failed to rewrite transcript in DB: %s", e)
+            return False
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -185,6 +185,60 @@ async def test_compress_command_appends_warning_when_compression_aborts():
 
 
 @pytest.mark.asyncio
+async def test_compress_command_does_not_repoint_session_when_transcript_write_fails():
+    """If the canonical transcript write fails after compression produces a new
+    continuation session_id, /compress must NOT repoint the live session onto
+    that empty session_id, and must report the failure instead of a success
+    banner. Otherwise a transient DB/IO error during compression would silently
+    drop the user's active conversation while still claiming success."""
+    history = _make_history()
+    compressed = [
+        history[0],
+        {"role": "assistant", "content": "summary"},
+        history[-1],
+    ]
+    runner = _make_runner(history)
+    session_entry = runner.session_store.get_or_create_session.return_value
+    # Simulate the canonical DB write failing (lock contention, ENOSPC, ...).
+    runner.session_store.rewrite_transcript = MagicMock(return_value=False)
+    # Telegram topic re-binding must never run on the failure path.
+    runner._sync_telegram_topic_binding = MagicMock()
+
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    # Compression rotated the session: the agent now holds a NEW session_id.
+    agent_instance.session_id = "sess-2"
+    agent_instance._compress_context.return_value = (compressed, "")
+
+    def _estimate(messages, **_kwargs):
+        return 100
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+        patch("agent.model_metadata.estimate_request_tokens_rough", side_effect=_estimate),
+    ):
+        result = await runner._handle_compress_command(_make_event())
+
+    # The user sees a failure banner, not a success banner.
+    assert "Compression failed" in result
+    assert "Compressed:" not in result
+    # The live session was NOT repointed onto the empty new session_id, so the
+    # original conversation stays reachable.
+    assert session_entry.session_id == "sess-1"
+    runner.session_store._save.assert_not_called()
+    runner._sync_telegram_topic_binding.assert_not_called()
+    # Resources are still cleaned up even though the command errored.
+    agent_instance.shutdown_memory_provider.assert_called_once()
+    agent_instance.close.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_compress_command_surfaces_aux_model_failure_even_when_recovered():
     """When the user's configured ``auxiliary.compression.model`` errors out
     but compression recovers by retrying on the main model, /compress must


### PR DESCRIPTION
## What does this PR do?

This fixes a silent loss of an active conversation that can happen when a
user runs `/compress` on the messaging gateway and the underlying database
write fails transiently.

When `/compress` runs, `_compress_context` ends the current session
(its full transcript is preserved in SQLite under the old session_id) and
hands back a brand-new continuation session_id. The handler in
`gateway/run.py` was repointing the live session entry onto that new,
still-empty session_id and persisting that change with `_save()` *before*
it ever wrote the compressed messages into the new session. The actual
write, `SessionStore.rewrite_transcript`, swallowed any failure from the
canonical store at DEBUG level and returned normally. So if the write
failed for a transient reason — the SQLite database being locked under
concurrent writes, `ENOSPC`, or any other disk/IO error — the session
entry had already been moved onto an empty session_id while the handler
went on to report a cheerful "Compressed: N → M messages" banner. The
user's live conversation effectively vanished from view (the old
transcript still existed in the DB, but nothing referenced it anymore),
and nothing surfaced the error.

The fix reorders the two operations so the compressed transcript is
persisted *first* and a write failure is treated as fatal: `/compress`
no longer repoints the session unless the write actually landed, and on
failure it reports a "Compression failed" banner instead of a false
success. Because the entry is left pointing at the old session_id on
failure, the original history stays reachable.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py`: `SessionStore.rewrite_transcript` now returns a
  `bool` — `True` when the canonical DB write lands (or there is no DB),
  `False` when it fails. Existing callers (`/retry`, `/undo`, yuanbao
  recall) ignore the result, so their behavior is unchanged; callers that
  must not commit a destructive state change on top of a failed write can
  now check it.
- `gateway/run.py`: in `_handle_compress_command`, write the compressed
  transcript into the new continuation session before repointing the live
  session onto it, and raise (surfacing the existing "Compression failed"
  banner via the handler's outer `except`) when the write fails, so the
  session is never moved onto an empty session_id.
- `tests/gateway/test_compress_command.py`: add a regression test that
  simulates a failing transcript write after a session rotation and
  asserts the session is not repointed, `_save()` is not called, and the
  user sees a failure banner rather than a success banner.

## How to Test

1. Run the gateway compress tests:
   `scripts/run_tests.sh tests/gateway/test_compress_command.py`.
2. The new test
   `test_compress_command_does_not_repoint_session_when_transcript_write_fails`
   reproduces the bug: with the old ordering it fails because the handler
   returns a "Compressed: 4 → 3 messages" success banner even though the
   write failed; with the fix it passes, asserting a "Compression failed"
   banner, an unchanged session_id, and no `_save()` call.
3. Full session suite stays green:
   `scripts/run_tests.sh tests/gateway/test_session.py`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the `rewrite_transcript` docstring; otherwise N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A