### PR TITLE
fix(gateway): declare supports_code_blocks on the DingTalk adapter

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -159,6 +159,7 @@ class DingTalkAdapter(BasePlatformAdapter):
     """
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+    supports_code_blocks = True  # DingTalk markdown renders fenced code blocks (see _normalize_markdown)
 
     @property
     def SUPPORTS_MESSAGE_EDITING(self) -> bool:  # noqa: N802

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -147,6 +147,27 @@ class TestDingTalkAdapterInit:
         assert adapter._client_id == "env-id"
         assert adapter._client_secret == "env-secret"
 
+    def test_declares_code_block_support(self):
+        """DingTalk sends ``msgtype: markdown`` and renders ``` fences, so the
+        ``supports_code_blocks`` capability must be True. ``GatewayRunner``'s
+        ``progress_callback`` gates the terminal-command-as-```bash block on this
+        flag; with it left at the base-class default of False, terminal tool
+        calls on DingTalk silently fall back to the compact preview line.
+        """
+        from gateway.platforms.base import BasePlatformAdapter
+        from gateway.platforms.dingtalk import DingTalkAdapter
+
+        assert DingTalkAdapter.supports_code_blocks is True
+        # The capability must be a genuine override, not the inherited default.
+        assert BasePlatformAdapter.supports_code_blocks is False
+
+        # The flag is only honest if _normalize_markdown preserves a fenced
+        # block end-to-end (DingTalk's renderer only dedents the fence markers).
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        rendered = adapter._normalize_markdown("```bash\nls -la /tmp\n```")
+        assert "```bash" in rendered
+        assert "ls -la /tmp" in rendered
+
 
 # ---------------------------------------------------------------------------
 # Message text extraction


### PR DESCRIPTION
## What does this PR do?

PR #41215 (`feat(gateway): render terminal tool calls as native bash code
blocks on markdown platforms`) replaced the noisy `terminal: "cmd…"`
progress line with a `\`\`\`bash` fenced block, gated on a new
`BasePlatformAdapter.supports_code_blocks` capability rather than a
hardcoded platform list. `GatewayRunner.progress_callback` in
`gateway/run.py` reads `getattr(adapter, "supports_code_blocks", False)`
and only emits the fenced block when that flag is truthy.

That commit set `supports_code_blocks = True` on seven adapters
(Telegram, Slack, Matrix, WhatsApp, Feishu, Weixin, Discord) but missed
`DingTalkAdapter`, which inherits the base-class default of `False`.
DingTalk is unambiguously a markdown platform: `send()` posts
`{"msgtype": "markdown", ...}` and `_normalize_markdown` already
special-cases `\`\`\`` fences (it dedents the fence markers so they render
correctly). Because the flag is missing, every terminal tool call shown
to DingTalk users silently falls back to the truncated 40-char preview
line instead of the full fenced command — the feature is off for an
entire markdown-capable platform.

This sets `supports_code_blocks = True` on `DingTalkAdapter` so it gets
parity with the other markdown adapters.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/dingtalk.py`: declare `supports_code_blocks = True`
  as a class attribute on `DingTalkAdapter` (alongside
  `MAX_MESSAGE_LENGTH`), overriding the `BasePlatformAdapter` default so
  `progress_callback` renders terminal commands as `\`\`\`bash` blocks.
- `tests/gateway/test_dingtalk.py`: add `test_declares_code_block_support`
  asserting the capability is a genuine override (`True` on
  `DingTalkAdapter`, `False` on `BasePlatformAdapter`) and that
  `_normalize_markdown` preserves a fenced `\`\`\`bash` block end-to-end,
  which is the rendering guarantee the flag depends on.

## How to Test

1. Reproduce: on `main`, `DingTalkAdapter.supports_code_blocks` resolves
   to the inherited `False`, so `gateway/run.py`'s `progress_callback`
   skips the `_bash_block` branch and a `terminal` tool call renders as
   the compact `terminal: "…"` preview on DingTalk.
2. Apply this change, then run
   `scripts/run_tests.sh tests/gateway/test_dingtalk.py` — all 69 tests
   pass, including the new `test_declares_code_block_support`.
3. `ruff check gateway/platforms/dingtalk.py tests/gateway/test_dingtalk.py`
   and `python scripts/check-windows-footguns.py
   gateway/platforms/dingtalk.py tests/gateway/test_dingtalk.py` both pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A