### PR TITLE
fix(model): restore single-model context shortcut for slash-style endpoint ids

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -807,8 +807,19 @@ def _resolve_endpoint_context_length(
     endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
     matched = endpoint_metadata.get(model)
     if not matched:
-        if len(endpoint_metadata) == 1:
-            matched = next(iter(endpoint_metadata.values()))
+        # Count DISTINCT models, not dict keys.  fetch_endpoint_model_metadata
+        # builds the cache via _add_model_aliases, which registers both the
+        # full ``publisher/slug`` id and the bare ``slug`` as separate keys
+        # pointing at the SAME entry object.  So a single-model endpoint whose
+        # id contains a "/" has len(endpoint_metadata) == 2, which used to skip
+        # the "only one model served, just use it" shortcut and fall through to
+        # the fragile substring match below — returning None whenever the
+        # configured model name didn't substring-match either alias key.  This
+        # broke the common org/name id format (HuggingFace, LM Studio
+        # publisher/slug, OpenRouter-style ids).
+        distinct_entries = list({id(e): e for e in endpoint_metadata.values()}.values())
+        if len(distinct_entries) == 1:
+            matched = distinct_entries[0]
         else:
             for key, entry in endpoint_metadata.items():
                 if model in key or key in model:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -812,6 +812,38 @@ class TestGetModelContextLength:
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_custom_endpoint_single_slash_model_fallback(self, mock_endpoint_fetch, mock_fetch):
+        """Single-model server whose id contains a '/' must still hit the
+        "only one model served" shortcut.
+
+        Regression: fetch_endpoint_model_metadata registers a ``publisher/slug``
+        model under BOTH the full id and the bare ``slug`` (via
+        _add_model_aliases), so the cache has two keys pointing at one entry.
+        The resolver counted keys, saw len == 2, skipped the single-model
+        shortcut, and fell through to the substring match — which returned
+        None when the configured name matched neither key. We now count
+        distinct entries, so the only served model's window is used.
+        """
+        mock_fetch.return_value = {}
+        # Mirror what fetch_endpoint_model_metadata builds for one slash-id model:
+        # the full id and the bare slug both point at the SAME entry object.
+        entry = {"context_length": 262144}
+        mock_endpoint_fetch.return_value = {
+            "Org/Big-Model-V2": entry,
+            "Big-Model-V2": entry,
+        }
+
+        # Configured name matches neither key (e.g. a renamed deployment alias).
+        result = get_model_context_length(
+            "my-deployment",
+            base_url="http://myserver.example.com:8080/v1",
+            api_key="test-key",
+        )
+
+        assert result == 262144
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
     def test_custom_endpoint_fuzzy_substring_match(self, mock_endpoint_fetch, mock_fetch):
         """Fuzzy match: configured model name is substring of endpoint model."""
         mock_fetch.return_value = {}


### PR DESCRIPTION
## What does this PR do?

When Hermes resolves a model's context window from a custom endpoint's
live `/models` listing, there's a deliberately forgiving shortcut in
`_resolve_endpoint_context_length`: if the endpoint serves exactly one
model, just use that model's window even when the configured model name
doesn't match the served id. That's the right call — a single-model
server is unambiguous.

The catch is how the metadata cache is built. `fetch_endpoint_model_metadata`
runs every model id through `_add_model_aliases`, which registers a
`publisher/slug` id under BOTH the full id and the bare `slug`, with both
keys pointing at the same entry object. So a single-model endpoint whose id
contains a `/` ends up with two keys in the dict, not one. The shortcut was
gated on `len(endpoint_metadata) == 1`, so it silently never fired for those
ids and execution fell through to the fragile substring match — which returns
`None` whenever the configured name matches neither key. The model then drops
to the generic 256K fallback instead of its real window.

It only bites the `org/name` id format, which is exactly the common case:
HuggingFace ids, LM Studio `publisher/slug`, OpenRouter-style ids. A
single-model server with a bare id (no slash) worked fine, which is why this
hid for so long.

The fix is to count distinct models instead of dict keys — dedupe the entries
by object identity before checking for the single-model case. One served model
now reads as one model regardless of how many alias keys point at it.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`: in `_resolve_endpoint_context_length`, count
  distinct entry objects (`{id(e): e for e in endpoint_metadata.values()}`)
  instead of `len(endpoint_metadata)` so the single-model shortcut fires for
  slash-style ids whose alias keys double the dict length. The multi-model
  substring path is untouched.
- `tests/agent/test_model_metadata.py`: add
  `test_custom_endpoint_single_slash_model_fallback`, a regression test for a
  one-model endpoint serving `Org/Big-Model-V2` (both the full id and bare
  slug present, as the real cache builds it) with a configured name that
  matches neither key.

## How to Test

1. `pytest tests/agent/test_model_metadata.py -q` — 99 pass.
2. To see the bug, revert `agent/model_metadata.py` and run just the new test:
   it fails returning `256000` (the 256K fallback) instead of `262144`,
   because the doubled keys skip the shortcut and the substring match misses.
3. Re-apply the fix and the test returns the model's real `262144` window.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A