### PR TITLE
fix(delegate): honor model parameter end-to-end (fixes #41821, closes #41814)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5007,6 +5007,7 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+            model=function_args.get("model"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2795,5 +2795,135 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIsNone(kwargs["fallback_model"])
 
 
+class TestDelegateModelOverride(unittest.TestCase):
+    """Coverage for the ``model`` parameter on ``delegate_task``.
+
+    Regression for #41821 (model param silently ignored) and #41814
+    (per-task model override). The contract:
+
+      1. Schema exposes ``model`` at the top level AND per-task.
+      2. Top-level ``model`` is forwarded to ``_build_child_agent``.
+      3. Per-task ``model`` (in ``tasks[]``) beats the top-level value.
+      4. When neither is set, the child uses the config-resolved
+         delegation model (``creds["model"]``) — existing behaviour.
+      5. Whitespace-only ``model`` is treated as omitted so it can't
+         silently override a real config value with an empty string.
+    """
+
+    def test_schema_exposes_model_top_level_and_per_task(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("model", props, "top-level 'model' missing from schema")
+        self.assertEqual(props["model"]["type"], "string")
+
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("model", task_props, "per-task 'model' missing from schema")
+        self.assertEqual(task_props["model"]["type"], "string")
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_top_level_model_forwarded_to_child(self, mock_build, mock_run):
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+        override = "anthropic/claude-haiku-4"
+
+        delegate_task(goal="t", model=override, parent_agent=parent)
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        self.assertEqual(
+            kwargs["model"], override,
+            "top-level model= must reach _build_child_agent",
+        )
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_per_task_model_beats_top_level(self, mock_build, mock_run):
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+
+        delegate_task(
+            tasks=[{"goal": "g", "model": "openrouter/x-ai/grok-4"}],
+            model="anthropic/claude-haiku-4",
+            parent_agent=parent,
+        )
+
+        _, kwargs = mock_build.call_args
+        self.assertEqual(
+            kwargs["model"], "openrouter/x-ai/grok-4",
+            "per-task model must beat top-level model",
+        )
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_no_model_falls_back_to_creds(self, mock_build, mock_run):
+        """When neither top-level nor per-task model is set, the child
+        must receive the config-resolved delegation model — i.e. the
+        pre-existing behaviour is preserved.
+        """
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={
+                "model": "configured/model",
+                "provider": None,
+                "base_url": None,
+                "api_key": None,
+                "api_mode": None,
+                "command": None,
+                "args": None,
+            },
+        ):
+            delegate_task(goal="g", parent_agent=parent)
+
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "configured/model")
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_whitespace_model_treated_as_omitted(self, mock_build, mock_run):
+        """A whitespace-only model string must NOT clobber the configured
+        delegation model. Otherwise a model-emitted ``"model": "  "`` would
+        silently break delegation for users who rely on config-resolved
+        credentials.
+        """
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={
+                "model": "configured/model",
+                "provider": None,
+                "base_url": None,
+                "api_key": None,
+                "api_mode": None,
+                "command": None,
+                "args": None,
+            },
+        ):
+            delegate_task(goal="g", model="   ", parent_agent=parent)
+
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "configured/model")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1976,6 +1976,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2070,7 +2071,7 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role, "model": model}
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2111,12 +2112,22 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task model beats top-level model, which beats config-resolved
+            # delegation model. Whitespace-only strings are treated as omitted
+            # so the next level can supply a value.
+            task_model_raw = t.get("model") if isinstance(t.get("model"), str) else None
+            top_model_raw = model if isinstance(model, str) else None
+            effective_model = (
+                (task_model_raw.strip() if task_model_raw else None)
+                or (top_model_raw.strip() if top_model_raw else None)
+                or creds["model"]
+            )
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=effective_model,
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
@@ -2849,6 +2860,15 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override (e.g. 'anthropic/claude-haiku-4', "
+                                "'openrouter/x-ai/grok-4'). Overrides the top-level 'model' "
+                                "for this task only. When omitted, inherits the top-level "
+                                "model or the configured delegation model."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -2861,6 +2881,17 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Override the model used by child agents for this call "
+                    "(e.g. 'anthropic/claude-haiku-4', 'openrouter/x-ai/grok-4'). "
+                    "Overrides the configured delegation model. Per-task 'model' "
+                    "in 'tasks[]' beats this top-level value. When omitted, "
+                    "children use delegation.model from config.yaml (or inherit "
+                    "from the parent when no delegation model is configured)."
+                ),
             },
             "acp_command": {
                 "type": "string",
@@ -2906,6 +2937,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        model=args.get("model"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## Summary

Fixes a bug where `delegate_task`'s `model` parameter was silently dropped, so every child agent inherited the parent's model regardless of what the caller asked for. The fix also delivers the per-task model override requested in #41814 — both fall out of the same change once `model` is wired through end-to-end.

## The bug

`model` was missing from **five** places:

1. The `delegate_task()` function signature (`tools/delegate_tool.py`).
2. The `DELEGATE_TASK_SCHEMA` JSON schema seen by the model — top-level **and** per-task in `tasks[].items`.
3. The registry-handler lambda that maps tool-call args → `delegate_task(...)`.
4. `AIAgent._dispatch_delegate_task` (`run_agent.py`), the single dispatch site that all invocation paths (concurrent / sequential / inline) flow through.
5. Credential resolution: even if `model` had been passed, the child build always used `creds["model"]`.

Result: callers (and weak models, and Kanban workers, and any user who tried to route subagents to a cheaper model) had no way to override the inherited model, contradicting the docstring's "role-specific model" framing.

## The fix

Wire `model` through all five sites with a clear precedence:

```
per-task model  >  top-level model  >  config-resolved delegation model
```

Whitespace-only values are treated as omitted, so a model-emitted `"model": "  "` cannot silently break delegation for users who depend on config-resolved credentials.

## Tests

5 new tests in `TestDelegateModelOverride` (`tests/tools/test_delegate.py`):

| Test | Asserts |
|------|---------|
| `test_schema_exposes_model_top_level_and_per_task` | `model` is in the schema at both levels |
| `test_top_level_model_forwarded_to_child` | `delegate_task(model=X)` reaches `_build_child_agent(model=X)` |
| `test_per_task_model_beats_top_level` | per-task `model` wins over top-level `model` |
| `test_no_model_falls_back_to_creds` | existing behaviour preserved when neither is set |
| `test_whitespace_model_treated_as_omitted` | `"   "` does not clobber the configured model |

Full delegate test suite passes (140 passed, 5 deselected for the pre-existing timing-flaky `TestDelegateHeartbeat::test_heartbeat_does_not_trip_idle_stale_while_inside_tool` that also fails on `main` on this machine and is unrelated to this change).

## Backward compatibility

Pure addition. Existing callers that don't pass `model` see no behaviour change — they still get the config-resolved delegation model. The schema gains an optional `model` property; no required fields move.

## Issues

Fixes #41821
Closes #41814
