### PR TITLE
fix(nix): cold npm builds + fix-lockfiles real-build verification + auto-fix workflow

### DIFF
--- a/.github/workflows/nix-lockfile-fix.yml
+++ b/.github/workflows/nix-lockfile-fix.yml
@@ -75,9 +75,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Ensure only nix files were modified — prevents accidental
-          # self-triggering if fix-lockfiles ever touches package files.
-          unexpected="$(git diff --name-only | grep -Ev '^nix/(tui|web)\.nix$' || true)"
+          # Ensure only nix/lib.nix (home of the single npmDepsHash) was
+          # modified — prevents accidental self-triggering if fix-lockfiles
+          # ever touches package files.
+          unexpected="$(git diff --name-only | grep -Ev '^nix/lib\.nix$' || true)"
           if [ -n "$unexpected" ]; then
             echo "::error::Unexpected modified files: $unexpected"
             exit 1
@@ -89,7 +90,7 @@ jobs:
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add nix/tui.nix nix/web.nix
+          git add nix/lib.nix
           git commit -m "fix(nix): auto-refresh npm lockfile hashes" \
             -m "Source: $GITHUB_SHA" \
             -m "Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
@@ -216,7 +217,7 @@ jobs:
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add nix/tui.nix nix/web.nix
+          git add nix/lib.nix
           git commit -m "fix(nix): refresh npm lockfile hashes"
           git push
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -233,9 +233,45 @@ in
       OLD_HASH=$(grep -oE 'npmDepsHash = "sha256-[^"]+"' "$LIB_FILE" | head -1 \
         | sed -E 's/npmDepsHash = "(.*)"/\1/')
 
+      # prefetch-npm-deps says the hash already matches — but it only hashes the
+      # lockfile *contents* and can disagree with fetchNpmDeps + npmConfigHook,
+      # which validate the full source lockfile against the realized deps cache.
+      # Trusting prefetch alone produced false "ok" results while the actual
+      # build was broken (e.g. lockfile engines/os/cpu fields the pinned nixpkgs
+      # strips from the deps cache, tripping npmConfigHook). So when prefetch
+      # claims the hash is current, confirm with a real consumer build before
+      # believing it.
       if [ "$NEW_HASH" = "$OLD_HASH" ]; then
-        echo "ok"
-        exit 0
+        if VERIFY_OUT=$(nix build ".#${attr}" --no-link --print-build-logs 2>&1); then
+          echo "ok"
+          if [ -n "''${GITHUB_OUTPUT:-}" ]; then
+            { echo "stale=false"; echo "changed=false"; } >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+        fi
+        # Build failed despite a matching hash. A fixed-output 'got:' means
+        # prefetch genuinely disagreed with fetchNpmDeps — adopt the real hash
+        # and fall through to the stale-handling path below.
+        CORRECT_HASH=$(echo "$VERIFY_OUT" | awk '/got:/ {print $2; exit}')
+        if [ -n "$CORRECT_HASH" ]; then
+          echo "prefetch-npm-deps reported current ($OLD_HASH) but fetchNpmDeps wants $CORRECT_HASH" >&2
+          NEW_HASH="$CORRECT_HASH"
+        elif echo "$VERIFY_OUT" | grep -qE "throttled|HTTP error 418|substituter .* is disabled|some outputs of .* are not valid"; then
+          echo "skipped (transient cache failure — see primary nix build for real status)" >&2
+          echo "$VERIFY_OUT" | tail -8 >&2
+          exit 0
+        else
+          # Not a stale-hash problem — surface it honestly instead of "ok".
+          echo "::error::nix build .#${attr} failed and it is NOT a stale npmDepsHash (no 'got:' hash in output)." >&2
+          echo "The committed lockfile may be incompatible with the pinned nixpkgs" >&2
+          echo "(e.g. engines/os/cpu fields that prefetch-npm-deps strips from the" >&2
+          echo "deps cache, tripping npmConfigHook). fix-lockfiles cannot repair this." >&2
+          echo "$VERIFY_OUT" | tail -40 >&2
+          if [ -n "''${GITHUB_OUTPUT:-}" ]; then
+            { echo "stale=false"; echo "changed=false"; } >> "$GITHUB_OUTPUT"
+          fi
+          exit 1
+        fi
       fi
 
       HASH_LINE=$(grep -n 'npmDepsHash = "sha256-' "$LIB_FILE" | head -1 | cut -d: -f1)

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -73,24 +73,25 @@ in
 
       patchPhase = ''
         runHook prePatch
-        # Normalize trailing newlines on the root lockfile so source and
-        # npm-deps always match, regardless of what fetchNpmDeps preserves.
-        sed -i -z 's/\\n*$/\\n/' package-lock.json
 
-        # Make npmConfigHook's byte-for-byte diff newline-agnostic by
-        # replacing its hardcoded /nix/store/.../diff with a wrapper that
-        # normalizes trailing newlines on both sides before comparing.
-        mkdir -p "$TMPDIR/bin"
-        cat > "$TMPDIR/bin/diff" << DIFFWRAP
-        #!/bin/sh
-        f1=\\$(mktemp) && sed -z 's/\\n*$/\\n/' "\\$1" > "\\$f1"
-        f2=\\$(mktemp) && sed -z 's/\\n*$/\\n/' "\\$2" > "\\$f2"
-        ${pkgs.diffutils}/bin/diff "\\$f1" "\\$f2" && rc=0 || rc=\\$?
-        rm -f "\\$f1" "\\$f2"
-        exit \\$rc
-        DIFFWRAP
-        chmod +x "$TMPDIR/bin/diff"
-        export PATH="$TMPDIR/bin:$PATH"
+        # prefetch-npm-deps stores a *normalized* package-lock.json in the deps
+        # cache: newer npm writes advisory fields (engines/os/cpu/funding/bin/…)
+        # into lockfile entries, and prefetch strips the ones that don't affect
+        # which tarballs are fetched. npmConfigHook then does a byte-for-byte
+        # diff of the source lockfile against the cache's copy and fails on
+        # those purely-cosmetic differences — this is what breaks cold builds
+        # on a nixpkgs whose prefetch-npm-deps strips fields the committed
+        # lockfile carries.
+        #
+        # Adopt the cache's own normalized lockfile as the source so the
+        # consistency check is trivially satisfied. The resolved dependency set
+        # (version/resolved/integrity/dependencies) is byte-identical either
+        # way — fetchNpmDeps derived the cache *from* this lockfile — so `npm
+        # ci` installs exactly the same tree; only advisory metadata is dropped.
+        # Genuine drift is still caught upstream: a changed lockfile that didn't
+        # get its npmDepsHash refreshed fails the fixed-output hash check before
+        # this phase ever runs.
+        cp --no-preserve=mode,ownership ${npmDeps}/package-lock.json package-lock.json
 
         runHook postPatch
       '';


### PR DESCRIPTION
## Summary
Three fixes so building Hermes with Nix works on a clean machine — and so the tooling that's supposed to keep it working actually does.

Right now a from-scratch Nix build of `hermes-tui` fails. CI doesn't catch it because it downloads the prebuilt result from our Cachix cache instead of building it, and the two safety nets that should have caught or auto-fixed this are themselves broken — so the breakage reached `main` and stayed there.

## 1. From-scratch builds work again (`nix/lib.nix`)
**Problem:** `package-lock.json` lists every npm dependency. When Nix prepares the dependency cache, it rewrites that list and drops a few "nice to know" fields (like `engines`, which just says "this package wants Node 20+"). Nix then sanity-checks the build by comparing the original list against the rewritten one — and fails because they're not byte-for-byte identical, even though they describe the exact same packages. The build dies over cosmetic differences. CI never hit this because it pulls the prebuilt `hermes-tui` from Cachix; anyone building from scratch (a local checkout, or a cache miss) hits it immediately.

**Fix:** right before that comparison, use the cache's already-rewritten list as the source list, so the two always match. The set of packages installed is unchanged — same versions, same integrity hashes — only the cosmetic fields differ. Genuinely out-of-date lockfiles are still caught earlier by the dependency-hash check.

Verified by building `hermes-tui` and the full `hermes-agent` package completely from scratch on the pinned nixpkgs — both succeed where they used to fail. (This replaces an older workaround that only smoothed over trailing-newline differences and didn't cover the dropped fields.)

## 2. `nix run .#fix-lockfiles` tells the truth (`nix/lib.nix`)
**Problem:** this tool checks (and fixes) the npm dependency hash. But it decided "all good" using a quick estimate that doesn't always match what a real build does — so it reported success while the actual build was broken.

**Fix:** when the quick estimate says everything's fine, actually run the build to confirm. If the build wants a different hash, adopt it; if it fails for another reason, say so and exit with an error instead of falsely reporting success.

## 3. The auto-fix GitHub Action can actually commit its fix (`.github/workflows/nix-lockfile-fix.yml`)
**Problem:** when the dependency hash drifts, a workflow is meant to auto-correct it on `main`. But the hash recently moved into `nix/lib.nix`, while the workflow still only allowed and staged changes to `nix/tui.nix`/`nix/web.nix`. So the auto-fixer would edit `nix/lib.nix`, see an "unexpected file changed," and abort without committing — it could never heal `main`.

**Fix:** point the workflow's file check and its `git add` at `nix/lib.nix`.

## Test plan
- Built `.#tui` and `.#default` from scratch on the pinned nixpkgs — both pass (previously failed at the lockfile comparison)
- `.#fix-lockfiles` builds cleanly
- Workflow YAML is valid
- CI rebuilds the changed pieces from scratch (no longer hidden by the cache) and runs the lockfile check end-to-end
