### PR TITLE
fix(kanban): stop hard billing/quota walls from respawning workers forever

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1178,6 +1178,12 @@ def run_conversation(
                             "completed": False,
                             "failed": True,
                             "error": _nous_msg,
+                            # Preserve the same transient-quota contract as a
+                            # reactive 429. Kanban workers use this reason to
+                            # exit with EX_TEMPFAIL instead of counting a task
+                            # failure when the proactive cross-session guard
+                            # skips the API call entirely (#41805).
+                            "failure_reason": "rate_limit",
                         }
                 except ImportError:
                     pass
@@ -4010,6 +4016,20 @@ def run_conversation(
                         "completed": False,
                         "failed": True,
                         "error": _nonretryable_summary,
+                        # Surface the classified reason here too — this is the
+                        # TERMINAL non-retryable path that hard billing errors
+                        # (HTTP 402, or a 429 carrying billing vocabulary like
+                        # "insufficient balance") fall through to once credential
+                        # rotation and fallback are exhausted (``is_client_error``
+                        # includes ``billing``; see the comment block above).
+                        # Without this, a kanban worker that hits a hard billing
+                        # wall before any tool work exits a generic ``1`` instead
+                        # of the billing-blocker sentinel, so the dispatcher
+                        # records a bare crash and re-spawns it against a depleted
+                        # balance (#41805). The retry-exhaustion return below
+                        # already stamps this; mirror it so the worker exit code
+                        # reflects the cause.
+                        "failure_reason": classified.reason.value,
                     }
 
                 if retry_count >= max_retries:

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -180,6 +180,8 @@ _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "try again",
     "retry",
     "resets at",
+    "reset at",
+    "resets in",
     "reset in",
     "wait",
     "requests remaining",
@@ -987,6 +989,26 @@ def _classify_by_status(
                 FailoverReason.overloaded,
                 retryable=True,
             )
+        # Most 429s are ordinary throttling (transient — resets on a timer), but
+        # some providers return a 429 for a HARD billing / account wall
+        # ("Insufficient balance … please recharge", "payment required",
+        # "credits exhausted") or a bare exhausted usage limit that will NOT
+        # clear without an account reset or operator action. Treating those as
+        # transient makes a kanban worker probe the wall every cooldown forever
+        # and burn paid requests (#41805, #31273). Disambiguate usage-limit
+        # wording the same way 402 and message-only errors already do: an
+        # explicit reset/retry/window signal stays transient; otherwise it is a
+        # hard billing/account wall. A plain 429 with no usage-limit or billing
+        # vocabulary remains rate_limit.
+        # Checked before the OpenRouter-upstream branch so a hard billing wall
+        # wrapped in an aggregator error isn't retried against a depleted balance.
+        if any(p in error_msg for p in _BILLING_PATTERNS):
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
+            )
         # Distinguish an OpenRouter-aggregator upstream 429 (an upstream model
         # like DeepSeek rate-limited OpenRouter's aggregate traffic) from an
         # account-level 429 (the user's key is actually throttled). OpenRouter
@@ -1002,6 +1024,23 @@ def _classify_by_status(
                 should_rotate_credential=False,
                 should_fallback=True,
                 error_context=ctx,
+            )
+        # A structured Codex ``usage_limit_reached`` is a confirmed account
+        # wall. Bare words such as "quota" are not: Gemini/Vertex use them for
+        # ordinary RESOURCE_EXHAUSTED throttles, so ambiguous text stays on the
+        # retryable rate-limit path unless billing vocabulary matched above.
+        has_transient_signal = any(
+            p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS
+        )
+        if (
+            error_code.lower() == "usage_limit_reached"
+            and not has_transient_signal
+        ):
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
             )
         return result_fn(
             FailoverReason.rate_limit,
@@ -1292,6 +1331,21 @@ def _classify_by_error_code(
             should_rotate_credential=True,
         )
 
+    if code_lower == "usage_limit_reached":
+        if any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS):
+            return result_fn(
+                FailoverReason.rate_limit,
+                retryable=True,
+                should_rotate_credential=True,
+                should_fallback=True,
+            )
+        return result_fn(
+            FailoverReason.billing,
+            retryable=False,
+            should_rotate_credential=True,
+            should_fallback=True,
+        )
+
     if code_lower in {
         "insufficient_quota",
         "billing_not_active",
@@ -1366,27 +1420,6 @@ def _classify_by_message(
             retryable=True,
         )
 
-    # Usage-limit patterns need the same disambiguation as 402: some providers
-    # surface "usage limit" errors without an HTTP status code.  A transient
-    # signal ("try again", "resets at", …) means it's a periodic quota, not
-    # billing exhaustion.
-    has_usage_limit = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
-    if has_usage_limit:
-        has_transient_signal = any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS)
-        if has_transient_signal:
-            return result_fn(
-                FailoverReason.rate_limit,
-                retryable=True,
-                should_rotate_credential=True,
-                should_fallback=True,
-            )
-        return result_fn(
-            FailoverReason.billing,
-            retryable=False,
-            should_rotate_credential=True,
-            should_fallback=True,
-        )
-
     # Overloaded / server-busy patterns — must come BEFORE the rate_limit and
     # billing checks so that a message-only "overloaded" (no 503/529 status,
     # e.g. some Anthropic-compatible proxies) classifies as a transient
@@ -1403,6 +1436,18 @@ def _classify_by_message(
         return result_fn(
             FailoverReason.billing,
             retryable=False,
+            should_rotate_credential=True,
+            should_fallback=True,
+        )
+
+    # Unstructured usage/quota wording is ambiguous. Gemini/Vertex use bare
+    # "quota" text for ordinary transient RESOURCE_EXHAUSTED responses, so
+    # only structured ``usage_limit_reached`` (handled above) or explicit
+    # billing vocabulary may become a hard wall.
+    if any(p in error_msg for p in _USAGE_LIMIT_PATTERNS):
+        return result_fn(
+            FailoverReason.rate_limit,
+            retryable=True,
             should_rotate_credential=True,
             should_fallback=True,
         )

--- a/cli.py
+++ b/cli.py
@@ -15841,7 +15841,45 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 # Main Entry Point
 # ============================================================================
 
-def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
+def _single_query_failure_exit_code(result: object) -> int:
+    """Return the automation exit code and preserve kanban billing detail."""
+    if not isinstance(result, dict) or not result.get("failed"):
+        return 0
+
+    task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
+    if not task_id:
+        return 1
+
+    try:
+        from hermes_cli.kanban_db import (
+            kanban_worker_exit_code_for_failure,
+            record_kanban_worker_failure_error,
+        )
+
+        failure_reason = result.get("failure_reason")
+        exit_code = kanban_worker_exit_code_for_failure(failure_reason)
+        if failure_reason == "billing":
+            try:
+                record_kanban_worker_failure_error(
+                    task_id,
+                    os.environ.get("HERMES_KANBAN_CLAIM_LOCK", ""),
+                    result.get("error"),
+                )
+            except Exception as persist_exc:
+                # Preserve the sentinel even when the best-effort detail write
+                # loses a DB race or the board is unavailable.
+                logger.debug(
+                    "kanban worker failure detail persistence failed: %s",
+                    persist_exc,
+                )
+        return exit_code
+    except Exception:
+        return 1
+
+
+def _run_kanban_goal_loop_q(
+    cli: "HermesCLI", first_response: str,
+) -> "dict | None":
     """Drive a kanban goal_mode worker through the Ralph-style goal loop.
 
     Called from the quiet single-query path AFTER the worker's first turn,
@@ -15882,8 +15920,14 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
 
     max_turns = task.goal_max_turns or _DEF_TURNS
 
+    terminal_failure: dict | None = None
+
+    class _GoalTurnFailed(RuntimeError):
+        """Stop the goal loop so the CLI can emit the worker sentinel."""
+
     def _run_turn(prompt: str) -> str:
-        result = cli.agent.run_conversation(
+        nonlocal terminal_failure
+        turn_result = cli.agent.run_conversation(
             user_message=prompt,
             conversation_history=cli.conversation_history,
         )
@@ -15893,9 +15937,18 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
             and cli.agent.session_id != cli.session_id
         ):
             cli.session_id = cli.agent.session_id
-        resp = result.get("final_response", "") if isinstance(result, dict) else str(result)
+        resp = (
+            turn_result.get("final_response", "")
+            if isinstance(turn_result, dict)
+            else str(turn_result)
+        )
         if resp:
             print(resp)
+        if isinstance(turn_result, dict) and turn_result.get("failed"):
+            terminal_failure = turn_result
+            raise _GoalTurnFailed(
+                str(turn_result.get("failure_reason") or "provider failure")
+            )
         return resp or ""
 
     def _task_status() -> "str | None":
@@ -15929,6 +15982,7 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
         first_response=first_response or "",
         log=lambda m: logger.info("%s", m),
     )
+    return terminal_failure
 
 
 def main(
@@ -16375,9 +16429,19 @@ def main(
                         # out (→ sticky block). Gated on the env vars the
                         # dispatcher sets in `_default_spawn`; a no-op for every
                         # normal worker and every non-kanban `-q` run.
-                        if os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1":
+                        if (
+                            os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1"
+                            and not (
+                                isinstance(result, dict)
+                                and result.get("failed")
+                            )
+                        ):
                             try:
-                                _run_kanban_goal_loop_q(cli, response)
+                                _goal_failure = _run_kanban_goal_loop_q(
+                                    cli, response
+                                )
+                                if _goal_failure is not None:
+                                    result = _goal_failure
                             except Exception as _goal_exc:
                                 logger.debug("kanban goal loop failed: %s", _goal_exc)
 
@@ -16386,30 +16450,19 @@ def main(
 
                         # Ensure proper exit code for automation wrappers.
                         #
-                        # Kanban workers get a special case: when the run failed
-                        # purely because the provider rate-limited / exhausted
-                        # quota (not because the task itself is broken), exit with
-                        # the EX_TEMPFAIL sentinel instead of the generic 1. The
-                        # dispatcher's reap classifier maps that code to a
-                        # ``rate_limited`` exit and releases the task back to
-                        # ``ready`` WITHOUT incrementing the failure counter, so a
-                        # 5-hour quota window can't trip the circuit breaker and
-                        # permanently block the card. Non-kanban runs keep the
-                        # plain 0/1 contract automation wrappers expect.
-                        _exit_code = 0
-                        if isinstance(result, dict) and result.get("failed"):
-                            _exit_code = 1
-                            if os.environ.get("HERMES_KANBAN_TASK") and result.get(
-                                "failure_reason"
-                            ) in ("rate_limit", "billing"):
-                                try:
-                                    from hermes_cli.kanban_db import (
-                                        KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE,
-                                    )
-                                    _exit_code = _RL_CODE
-                                except Exception:
-                                    _exit_code = 1
-                        sys.exit(_exit_code)
+                        # Kanban workers get a special case keyed on the run's
+                        # classified ``failure_reason`` so the dispatcher can tell a
+                        # transient throttle from a hard wall. The exit code carries
+                        # the category; hard-billing workers also persist the actual
+                        # provider error on their active run before exiting:
+                        #   - ``rate_limit`` -> EX_TEMPFAIL sentinel -> released back to
+                        #     ``ready`` WITHOUT counting a failure and cheap-probed on
+                        #     a cooldown (a 5-hour quota window can't trip the breaker).
+                        #   - ``billing``    -> hard-blocker sentinel -> auto-blocked with
+                        #     the cause surfaced; retrying/probing a depleted balance
+                        #     just burns paid requests and loops forever (#41805).
+                        # Non-kanban runs keep the plain 0/1 contract wrappers expect.
+                        sys.exit(_single_query_failure_exit_code(result))
 
                 # Exit with error code if credentials or agent init fails
                 sys.exit(1)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -235,6 +235,88 @@ DEFAULT_CRASH_GRACE_SECONDS = 30
 KANBAN_RATE_LIMIT_EXIT_CODE = 75
 
 
+# Sentinel exit code a kanban worker uses to signal "I bailed on a HARD billing
+# / account wall (insufficient balance, payment required, credits exhausted),
+# not a transient throttle." Unlike ``KANBAN_RATE_LIMIT_EXIT_CODE`` this will
+# NOT clear by waiting, so the dispatcher must NOT cheap-probe it on a cooldown
+# (that just burns paid requests and loops forever — #41805, #31273). The reap
+# classifier maps this to a ``billing_blocked`` exit kind, which stamps the real
+# cause and auto-blocks the task immediately for human attention. 77 == BSD
+# ``EX_NOPERM`` (sysexits.h) — "permission denied", the closest conventional
+# code for "the account lacks the credits/entitlement to proceed".
+KANBAN_BILLING_BLOCKER_EXIT_CODE = 77
+
+
+def kanban_worker_exit_code_for_failure(failure_reason: Optional[str]) -> int:
+    """Map a run's classified ``failure_reason`` to a kanban worker exit code.
+
+    Centralises the worker-side exit-code contract so it can be unit-tested
+    without driving a full conversation (the cli.py kanban single-query path
+    calls this):
+
+    * ``"rate_limit"`` → ``KANBAN_RATE_LIMIT_EXIT_CODE`` (transient throttle —
+      released without counting a failure, cheap-probed on a cooldown).
+    * ``"billing"``    → ``KANBAN_BILLING_BLOCKER_EXIT_CODE`` (hard wall —
+      auto-blocked with the cause surfaced; retrying won't help).
+    * anything else / ``None`` → ``1`` (ordinary failure — counts toward the
+      circuit breaker via the normal crashed path).
+    """
+    if failure_reason == "rate_limit":
+        return KANBAN_RATE_LIMIT_EXIT_CODE
+    if failure_reason == "billing":
+        return KANBAN_BILLING_BLOCKER_EXIT_CODE
+    return 1
+
+
+def record_kanban_worker_failure_error(
+    task_id: str,
+    claim_lock: str,
+    error: Optional[str],
+) -> bool:
+    """Preserve a terminal worker error for dispatcher-side crash handling.
+
+    The worker and dispatcher are separate processes, so an exit sentinel can
+    carry the failure category but not the provider's actual message. Store the
+    truncated message on the active run (and task snapshot) before exit. The
+    claim-lock CAS prevents a stale worker from overwriting a newer attempt.
+
+    Returns ``True`` only when the active run for this exact claim was updated.
+    """
+    task_id = (task_id or "").strip()
+    claim_lock = (claim_lock or "").strip()
+    error_text = str(error or "").strip()[:500]
+    if not task_id or not claim_lock or not error_text:
+        return False
+
+    conn = connect()
+    try:
+        with write_txn(conn):
+            row = conn.execute(
+                "SELECT current_run_id FROM tasks "
+                "WHERE id = ? AND status = 'running' AND claim_lock = ?",
+                (task_id, claim_lock),
+            ).fetchone()
+            if row is None or row["current_run_id"] is None:
+                return False
+            run_id = int(row["current_run_id"])
+            cur = conn.execute(
+                "UPDATE task_runs SET error = ? "
+                "WHERE id = ? AND ended_at IS NULL AND claim_lock = ?",
+                (error_text, run_id, claim_lock),
+            )
+            if cur.rowcount != 1:
+                return False
+            conn.execute(
+                "UPDATE tasks SET last_failure_error = ? "
+                "WHERE id = ? AND status = 'running' AND claim_lock = ? "
+                "AND current_run_id = ?",
+                (error_text, task_id, claim_lock, run_id),
+            )
+            return True
+    finally:
+        conn.close()
+
+
 def _resolve_crash_grace_seconds() -> int:
     """Return the crash-detection grace period in seconds.
 
@@ -3242,16 +3324,16 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Return True when ``task_id`` is sticky-blocked by an explicit
-    worker/operator ``kanban_block`` call (#28712).
+    """Return True when ``task_id`` has an explicit, human-action block.
 
     A ``blocked`` status can come from two very different sources:
 
-    * **Worker- or operator-initiated** — a worker called
+    * **Explicit human-action block** — a worker called
       ``kanban_block(reason="review-required: ...")`` (or somebody ran
-      ``hermes kanban block <id>``).  This is a deliberate handoff that
-      should stay blocked until an operator unblocks it.  The block tool
-      emits a ``"blocked"`` event row in ``task_events``.
+      ``hermes kanban block <id>``), or the dispatcher detected a hard
+      billing wall that cannot clear without adding credits.  These should
+      stay blocked until an operator unblocks them.  Both paths emit a
+      ``"blocked"`` event row in ``task_events``.
 
     * **Circuit-breaker** — ``_record_task_failure`` tripped after
       repeated crashes / spawn failures / timeouts.  This emits
@@ -3291,9 +3373,9 @@ def recompute_ready(
     blocked purely by a parent dependency unblocks itself when the
     parent completes), *except* in two cases:
 
-    1. The most recent block event was a worker-initiated
-       ``kanban_block`` — those stay blocked until an explicit
-       ``kanban_unblock`` (#28712).
+    1. The most recent block event was an explicit human-action block
+       (worker/operator ``kanban_block`` or a hard billing wall) — those stay
+       blocked until an explicit ``kanban_unblock`` (#28712, #41805).
 
     2. The task's ``consecutive_failures`` has reached the effective
        failure limit.  This prevents infinite retry loops when a task
@@ -5880,9 +5962,25 @@ KANBAN_TERMINAL_TIMEOUT_GRACE_SECONDS = 30
 
 # Patterns in last_failure_error that indicate a quota / auth blocker.
 # These errors won't resolve by retrying immediately — auto-block instead.
+#
+# The second line mirrors the hard usage-limit / billing wording recognised by
+# ``agent.error_classifier`` (``_BILLING_PATTERNS`` / ``_USAGE_LIMIT_PATTERNS``).
+# Hard quota/billing 429s ("the usage limit has been reached", "Insufficient
+# balance or no resource package. Please recharge.") otherwise slip past the
+# bare ``quota|429|billing`` set, so a worker that bails on them before any tool
+# work looks like a generic crash and the dispatcher re-spawns it forever
+# (#41805). Keep these anchored to billing/quota vocabulary to avoid widening
+# into ordinary transient errors.
 _RESPAWN_BLOCKER_RE = re.compile(
     r"\b(quota|rate[\s_\-]?limit|429|403|auth\w*|"
     r"unauthorized|forbidden|billing|subscription|"
+    # Hard billing/account vocabulary (anchored — NOT bare ``insufficient`` /
+    # ``recharge``, which match benign task text like "insufficient tests" or
+    # "recharge battery" and would wrongly defer a real crash from the breaker).
+    r"usage[\s_-]limit|"
+    r"insufficient[\s_-]+(?:balance|credits?|quota|funds)|"
+    r"resource[\s_-]package|out[\s_-]of[\s_-]funds|"
+    r"payment[\s_-]required|balance[\s_-]?depleted|please[\s_-]+recharge|"
     r"access[\s_]denied|permission[\s_]denied|"
     r"invalid[\s_]api[\s_]key)\b",
     re.IGNORECASE,
@@ -5943,9 +6041,9 @@ class DispatchResult:
     telemetry / dashboards can show "this profile is busy" vs
     "task is genuinely stuck"."""
     crashed: list[str] = field(default_factory=list)
-    """Task ids reclaimed because their worker PID disappeared."""
+    """Task ids whose worker exited as a crash or hard billing block."""
     auto_blocked: list[str] = field(default_factory=list)
-    """Task ids auto-blocked by the spawn-failure circuit breaker."""
+    """Task ids auto-blocked by failure handling or a hard billing wall."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
     stale: list[str] = field(default_factory=list)
@@ -6020,6 +6118,11 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
       provider rate-limited / exhausted quota, NOT because the task failed.
       ``detect_crashed_workers`` releases the task back to ``ready`` without
       counting a failure, so a long quota window can't trip the breaker.
+    * ``"billing_blocked"`` — ``WIFEXITED`` with status
+      ``KANBAN_BILLING_BLOCKER_EXIT_CODE``. The worker bailed on a HARD billing
+      / account wall (insufficient balance, payment required). This won't clear
+      by waiting, so ``detect_crashed_workers`` stamps the cause and auto-blocks
+      the task immediately rather than cheap-probing it forever (#41805).
     * ``"nonzero_exit"`` — ``WIFEXITED`` with non-zero status. Real error.
     * ``"signaled"`` — ``WIFSIGNALED`` (OOM killer, SIGKILL, etc). Real crash.
     * ``"unknown"`` — pid was not in the reap registry (either reaped by
@@ -6041,6 +6144,8 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
                 return ("clean_exit", 0)
             if code == KANBAN_RATE_LIMIT_EXIT_CODE:
                 return ("rate_limited", code)
+            if code == KANBAN_BILLING_BLOCKER_EXIT_CODE:
+                return ("billing_blocked", code)
             return ("nonzero_exit", code)
         if os.WIFSIGNALED(raw):
             return ("signaled", os.WTERMSIG(raw))
@@ -6641,9 +6746,9 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
 def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
-    Appends a ``crashed`` event and drops the task back to ``ready``.
-    Different from ``release_stale_claims``: this checks liveness
-    immediately rather than waiting for the claim TTL.
+    Appends a ``crashed`` event and normally drops the task back to ``ready``.
+    Different from ``release_stale_claims``: this checks liveness immediately
+    rather than waiting for the claim TTL.
 
     Only considers tasks claimed by *this host* — PIDs from other hosts
     are meaningless here. The host-local check is enough because
@@ -6665,21 +6770,31 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     ``check_respawn_guard`` defers their respawn until the window clears.
     The ids are returned via the ``_last_rate_limited`` function attribute
     (the public return stays the crashed-only ``list[str]``).
+
+    A hard billing sentinel (``KANBAN_BILLING_BLOCKER_EXIT_CODE``) instead
+    creates an explicit sticky block immediately. This account-level stop
+    bypasses ``max_retries`` and remains blocked across readiness recomputation
+    until an operator restores credits and unblocks the task.
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
+    auto_blocked: list[str] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the
     # clean-exit-but-still-running case, which is accounted against its
     # own bounded violation streak instead of the unified failure
-    # counter (see the post-txn loop below).
+    # counter (see the post-txn loop below). Hard billing walls bypass
+    # this list entirely: they are explicit human-action blocks made
+    # sticky in the txn above, independent of the task's retry budget.
     crash_details: list[tuple[str, int, str, bool, str]] = []
     # (task_id, pid, claimer, protocol_violation, error_text)
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
-            "WHERE status = 'running' AND worker_pid IS NOT NULL"
+            "SELECT t.id, t.worker_pid, t.claim_lock, t.started_at, "
+            "r.error AS worker_failure_error FROM tasks AS t "
+            "LEFT JOIN task_runs AS r ON r.id = t.current_run_id "
+            "WHERE t.status = 'running' AND t.worker_pid IS NOT NULL"
         ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
         for row in rows:
@@ -6701,6 +6816,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
+            billing_blocked = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
@@ -6748,6 +6864,31 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     "claimer": row["claim_lock"],
                     "exit_code": code,
                 }
+            elif kind == "billing_blocked":
+                # Worker bailed on a HARD billing / account wall (insufficient
+                # balance, payment required) — distinct from a transient
+                # throttle. This won't clear by waiting, so cheap-probing it on
+                # a cooldown just burns paid requests and loops forever (#41805,
+                # #31273). Treat it as a deterministic crash: stamp the real
+                # cause (so ``check_respawn_guard`` recognises it and the board
+                # shows WHY) and force an immediate auto-block for human
+                # attention, rather than respawning ``DEFAULT_FAILURE_LIMIT``
+                # times against a depleted balance first.
+                protocol_violation = False
+                billing_blocked = True
+                preserved_error = str(row["worker_failure_error"] or "").strip()
+                error_text = preserved_error or (
+                    f"pid {pid} exited on a hard billing/quota wall "
+                    f"(insufficient balance or account limit) — auto-blocked; "
+                    f"resolve billing/credits then unblock the task"
+                )
+                event_kind = "crashed"
+                event_payload = {
+                    "pid": pid,
+                    "claimer": row["claim_lock"],
+                    "exit_kind": kind,
+                    "exit_code": code,
+                }
             else:
                 protocol_violation = False
                 if kind == "nonzero_exit":
@@ -6762,13 +6903,29 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
 
-            cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
-                "WHERE id = ? AND status = 'running' "
-                "  AND worker_pid = ? AND claim_lock IS ?",
-                (row["id"], pid, row["claim_lock"]),
-            )
+            if billing_blocked:
+                # This sentinel is an account-level hard stop, not another
+                # attempt in the card's normal retry budget. Block directly so
+                # tasks with max_retries > 1 cannot override the decision.
+                # Emit a sticky ``blocked`` event below so the same dispatch
+                # tick's recompute_ready() pass cannot promote it again.
+                cur = conn.execute(
+                    "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL, "
+                    "consecutive_failures = COALESCE(consecutive_failures, 0) + 1, "
+                    "last_failure_error = ? "
+                    "WHERE id = ? AND status = 'running' "
+                    "  AND worker_pid = ? AND claim_lock IS ?",
+                    (error_text[:500], row["id"], pid, row["claim_lock"]),
+                )
+            else:
+                cur = conn.execute(
+                    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL "
+                    "WHERE id = ? AND status = 'running' "
+                    "  AND worker_pid = ? AND claim_lock IS ?",
+                    (row["id"], pid, row["claim_lock"]),
+                )
             if cur.rowcount == 1:
                 # Rate-limited requeues are a clean release, not a crash —
                 # record the run outcome as ``rate_limited`` so the board
@@ -6785,7 +6942,21 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload,
                     run_id=run_id,
                 )
-                if rate_limited_exit:
+                if billing_blocked:
+                    _append_event(
+                        conn,
+                        row["id"],
+                        "blocked",
+                        {
+                            "reason": error_text,
+                            "source": "billing_blocked",
+                            "exit_code": code,
+                        },
+                        run_id=run_id,
+                    )
+                    crashed.append(row["id"])
+                    auto_blocked.append(row["id"])
+                elif rate_limited_exit:
                     # Stamp the failure-error column so ``check_respawn_guard``
                     # recognizes this as a quota blocker and defers the
                     # respawn until the window clears — WITHOUT touching
@@ -6829,8 +7000,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # ``consecutive_failures`` counter, so the two budgets stay independent.
     # A per-task ``max_retries`` overrides the violation bound with the same
     # top precedence it has for every other failure kind. Systemic same-error
-    # crashes still trip immediately.
-    auto_blocked: list[str] = []
+    # crashes still trip immediately. Hard billing/quota walls never reach this
+    # loop — they were made sticky explicit blocks in the txn above (appending
+    # to ``auto_blocked`` there), because neither a per-task retry override nor
+    # the later readiness recomputation may reopen an account-level hard stop
+    # (#41805).
     if crash_details:
         # Fingerprint errors to detect systemic failures.
         _fp_counts: dict[str, int] = {}

--- a/tests/agent/test_conversation_loop_failure_reason.py
+++ b/tests/agent/test_conversation_loop_failure_reason.py
@@ -1,0 +1,82 @@
+"""Regression tests for #41805 — the terminal non-retryable return in
+``agent.conversation_loop.run_conversation`` must surface ``failure_reason``.
+
+A hard usage-limit / billing 429 (HTTP 402/429 classified as
+``FailoverReason.billing``) is treated as a non-retryable *client* error: once
+credential-pool rotation and fallback are exhausted it returns from the
+``is_client_error`` branch, NOT from the retry-exhaustion branch. Only the
+latter used to stamp ``failure_reason``, so a kanban worker that hit a hard
+quota wall before any tool work exited a generic ``1`` instead of the
+rate-limit sentinel — and the dispatcher then re-spawned it indefinitely.
+
+These tests follow the source-inspection pattern already used for this
+function (see ``test_nous_oauth_401_guidance.py``); ``run_conversation`` needs a
+fully-constructed agent + live API client to drive end-to-end, so we assert on
+the structure of the terminal returns instead.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from agent import conversation_loop
+
+
+def test_terminal_returns_stamp_failure_reason():
+    """Both terminal failure returns surface ``failure_reason``.
+
+    There are two terminal ``"failed": True`` returns that a hard quota/billing
+    error can reach: the non-retryable ``is_client_error`` abort and the
+    retry-exhaustion abort. Both must carry ``failure_reason`` so the kanban
+    worker can pick the rate-limit sentinel exit code (#41805).
+    """
+    source = inspect.getsource(conversation_loop.run_conversation)
+    occurrences = source.count('"failure_reason": classified.reason.value')
+    assert occurrences >= 2, (
+        "Expected the non-retryable client-error return AND the retry-"
+        "exhaustion return to both stamp failure_reason; found "
+        f"{occurrences}. A hard billing/usage-limit 429 exits via the "
+        "non-retryable path, so it must surface failure_reason too (#41805)."
+    )
+
+
+def test_non_retryable_client_error_return_carries_failure_reason():
+    """The non-retryable terminal return block includes ``failure_reason``.
+
+    Pin the fix to the specific return that hard billing errors take: the
+    terminal non-retryable client-error return whose error payload is the
+    summarized ``_nonretryable_summary`` (as opposed to the retry-exhaustion
+    path below).
+    """
+    source = inspect.getsource(conversation_loop.run_conversation)
+    marker = '"error": _nonretryable_summary,'
+    idx = source.find(marker)
+    assert idx != -1, "non-retryable client-error return not found"
+    # failure_reason should appear within the same return dict, i.e. after the
+    # error line and before the NEXT return statement opens. (A comment block
+    # may sit between the two lines, so scope to the dict, not a fixed offset.)
+    next_return = source.find("return {", idx + len(marker))
+    window = source[idx : next_return if next_return != -1 else idx + 1500]
+    assert '"failure_reason": classified.reason.value' in window, (
+        "non-retryable client-error return must stamp failure_reason so a "
+        "hard billing/usage-limit 429 exits with the rate-limit sentinel "
+        "rather than a generic crash (#41805)."
+    )
+
+
+def test_proactive_nous_rate_limit_guard_carries_failure_reason():
+    """The pre-API Nous guard reports a transient rate-limit failure.
+
+    This return bypasses ``classify_api_error`` entirely, so it must stamp the
+    reason directly for Kanban's worker-exit contract.
+    """
+    source = inspect.getsource(conversation_loop.run_conversation)
+    marker = '"error": _nous_msg,'
+    idx = source.find(marker)
+    assert idx != -1, "proactive Nous rate-limit return not found"
+    next_return = source.find("return {", idx + len(marker))
+    window = source[idx : next_return if next_return != -1 else idx + 1000]
+    assert '"failure_reason": "rate_limit"' in window, (
+        "proactive Nous rate-limit guard must use the transient quota exit "
+        "contract instead of counting a generic task failure (#41805)"
+    )

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -291,6 +291,100 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.retryable is True
 
+    # ── 429 billing wall vs transient throttle (#41805) ──
+
+    def test_429_insufficient_balance_classified_as_billing(self):
+        """A 429 carrying hard billing vocabulary is billing, not a transient
+        throttle — otherwise a kanban worker probes a depleted balance on a
+        cooldown forever (#41805). Mirrors the 402/403 billing carve-outs."""
+        e = MockAPIError(
+            "HTTP 429: Insufficient balance or no resource package. "
+            "Please recharge.",
+            status_code=429,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+    def test_429_credits_exhausted_classified_as_billing(self):
+        e = MockAPIError("credits have been exhausted", status_code=429)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+    def test_429_plain_throttle_stays_rate_limit(self):
+        """An ordinary 429 with no billing vocabulary stays a transient rate
+        limit — the common case must be unchanged."""
+        e = MockAPIError("Too Many Requests", status_code=429)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_429_bare_usage_limit_without_reset_classified_as_billing(self):
+        """A bare exhausted usage limit has no evidence it will clear on a
+        timer, so treat it as a hard account wall instead of probing forever.
+
+        This is the exact OpenAI Codex wording reported in #41805.
+        """
+        e = MockAPIError(
+            "HTTP 429: The usage limit has been reached",
+            status_code=429,
+            body={
+                "error": {
+                    "message": "The usage limit has been reached",
+                    "type": "usage_limit_reached",
+                }
+            },
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+    def test_429_bare_quota_without_reset_stays_rate_limit(self):
+        e = MockAPIError("Quota exceeded", status_code=429)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_429_gemini_resource_exhausted_stays_rate_limit(self):
+        e = MockAPIError(
+            "Resource has been exhausted (e.g. check quota).",
+            status_code=429,
+            body={
+                "error": {
+                    "code": 429,
+                    "message": "Resource has been exhausted (e.g. check quota).",
+                    "status": "RESOURCE_EXHAUSTED",
+                }
+            },
+        )
+        result = classify_api_error(e, provider="gemini")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_429_usage_limit_with_reset_stays_rate_limit(self):
+        """A time-windowed usage limit ('resets at ...') is transient — it WILL
+        clear, so it stays rate_limit and is cheap-probed on a cooldown rather
+        than hard-blocked (#41805). Only explicit billing vocabulary blocks."""
+        e = MockAPIError(
+            "HTTP 429: Usage limit reached for 5 hour. Your limit will reset "
+            "at 2026-05-30 22:00:45",
+            status_code=429,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_429_usage_limit_resets_in_stays_rate_limit(self):
+        """Plural ``resets in`` also proves a quota is time-windowed."""
+        e = MockAPIError(
+            "HTTP 429: Usage limit reached. Quota resets in 24 hours.",
+            status_code=429,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
     def test_403_plan_entitlement_billing(self):
         e = MockAPIError("This plan does not include the requested model", status_code=403)
         result = classify_api_error(e)
@@ -1100,13 +1194,43 @@ class TestClassifyApiError:
         assert result.should_rotate_credential is True
         assert result.should_fallback is True
 
-    def test_message_usage_limit_no_retry_signal_is_billing(self):
-        """'usage limit' with no transient signal and no status code → billing."""
+    def test_message_usage_limit_no_structured_code_stays_rate_limit(self):
+        """Ambiguous status-less usage text must not become hard billing."""
         e = Exception("usage limit reached")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+        assert result.should_rotate_credential is True
+
+    def test_message_structured_usage_limit_reached_is_billing(self):
+        e = MockAPIError(
+            "The usage limit has been reached",
+            body={
+                "error": {
+                    "message": "The usage limit has been reached",
+                    "type": "usage_limit_reached",
+                }
+            },
+        )
         result = classify_api_error(e)
         assert result.reason == FailoverReason.billing
         assert result.retryable is False
-        assert result.should_rotate_credential is True
+
+    def test_message_structured_usage_limit_with_reset_stays_rate_limit(self):
+        e = MockAPIError(
+            "The usage limit has been reached and resets in 24 hours",
+            body={
+                "error": {
+                    "message": (
+                        "The usage limit has been reached and resets in 24 hours"
+                    ),
+                    "type": "usage_limit_reached",
+                }
+            },
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
 
     def test_message_quota_with_reset_window_is_rate_limit(self):
         """'quota' + 'resets at' with no status code → rate_limit."""
@@ -1918,6 +2042,27 @@ class TestOpenRouterUpstreamRateLimit:
         assert result.should_rotate_credential is False
         assert result.should_fallback is True
         assert result.error_context.get("upstream_provider") == "DeepSeek"
+
+    def test_openrouter_wrapped_billing_wall_stays_billing(self):
+        """Explicit billing vocabulary wins over an aggregator wrapper."""
+        e = MockAPIError(
+            "Provider returned error: Insufficient balance or no resource "
+            "package. Please recharge.",
+            status_code=429,
+            body={
+                "error": {
+                    "message": "Provider returned error: Insufficient balance",
+                    "code": 429,
+                    "metadata": {
+                        "provider_name": "DeepSeek",
+                        "raw": '{"error":{"message":"Insufficient balance"}}',
+                    },
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
 
     def test_upstream_429_metadata_shape_without_explicit_provider(self):
         """metadata.raw shape alone (provider != openrouter literal) still detected."""

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -200,6 +200,107 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
     ]
 
 
+def test_kanban_billing_failure_preserves_error_and_uses_sentinel(monkeypatch):
+    import cli as cli_mod
+    from hermes_cli import kanban_db as kb
+
+    calls = []
+    provider_error = "HTTP 429: Insufficient balance. Please recharge."
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_billing")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "host:worker")
+    monkeypatch.setattr(
+        kb,
+        "record_kanban_worker_failure_error",
+        lambda task_id, claim_lock, error: calls.append(
+            (task_id, claim_lock, error)
+        ) or True,
+    )
+
+    exit_code = cli_mod._single_query_failure_exit_code(
+        {
+            "failed": True,
+            "failure_reason": "billing",
+            "error": provider_error,
+        }
+    )
+
+    assert exit_code == kb.KANBAN_BILLING_BLOCKER_EXIT_CODE
+    assert calls == [("t_billing", "host:worker", provider_error)]
+
+
+def test_kanban_rate_limit_failure_uses_sentinel_without_persisting(monkeypatch):
+    import cli as cli_mod
+    from hermes_cli import kanban_db as kb
+
+    calls = []
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_rate_limit")
+    monkeypatch.setattr(
+        kb,
+        "record_kanban_worker_failure_error",
+        lambda *args: calls.append(args) or True,
+    )
+
+    exit_code = cli_mod._single_query_failure_exit_code(
+        {"failed": True, "failure_reason": "rate_limit", "error": "HTTP 429"}
+    )
+
+    assert exit_code == kb.KANBAN_RATE_LIMIT_EXIT_CODE
+    assert calls == []
+
+
+def test_goal_mode_midloop_billing_failure_reaches_sentinel(tmp_path, monkeypatch):
+    import cli as cli_mod
+    from hermes_cli import goals
+    from hermes_cli import kanban_db as kb
+
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    claim_lock = "host:goal-worker"
+    provider_error = "HTTP 429: Insufficient balance. Please recharge."
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="finish the goal", assignee="a")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+        conn.commit()
+        assert kb.claim_task(conn, task_id, claimer=claim_lock) is not None
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claim_lock)
+    monkeypatch.setattr(
+        goals,
+        "judge_goal",
+        lambda *_args, **_kwargs: ("continue", "not done", False, False),
+    )
+
+    failure = {
+        "failed": True,
+        "failure_reason": "billing",
+        "error": provider_error,
+        "final_response": "Billing or credits exhausted",
+    }
+    calls = []
+    fake_cli = SimpleNamespace(
+        session_id="goal-session",
+        conversation_history=[],
+        agent=SimpleNamespace(
+            session_id="goal-session",
+            run_conversation=lambda **kwargs: calls.append(kwargs) or failure,
+        ),
+    )
+
+    returned = cli_mod._run_kanban_goal_loop_q(fake_cli, "starting work")
+    assert returned is failure
+    assert len(calls) == 1
+    assert cli_mod._single_query_failure_exit_code(returned) == (
+        kb.KANBAN_BILLING_BLOCKER_EXIT_CODE
+    )
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task.status == "running"
+        assert task.last_failure_error == provider_error
+
+
 def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatch):
     calls = []
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -981,6 +981,144 @@ def test_real_crash_still_counts_and_trips_breaker(kanban_home, monkeypatch):
         )
 
 
+def test_classify_worker_exit_recognizes_billing_blocker_sentinel(kanban_home):
+    """The hard-billing sentinel maps to a distinct ``billing_blocked`` kind,
+    separate from the transient ``rate_limited`` sentinel (#41805)."""
+    import hermes_cli.kanban_db as _kb
+
+    pid = 41805
+    _kb._record_worker_exit(
+        pid, _exited_status(_kb.KANBAN_BILLING_BLOCKER_EXIT_CODE)
+    )
+    kind, code = _kb._classify_worker_exit(pid)
+    assert kind == "billing_blocked"
+    assert code == _kb.KANBAN_BILLING_BLOCKER_EXIT_CODE
+
+    # The two sentinels must be distinct so they route differently.
+    assert _kb.KANBAN_BILLING_BLOCKER_EXIT_CODE != _kb.KANBAN_RATE_LIMIT_EXIT_CODE
+
+
+def test_billing_blocker_exit_auto_blocks_immediately(kanban_home, monkeypatch):
+    """A hard-billing sentinel exit auto-blocks the task on the FIRST hit
+    even when the card's ordinary retry budget is higher, and stamps the cause
+    — it must NOT loop/probe forever the way a transient rate-limit requeue
+    does (#41805).
+
+    Contrast with ``test_rate_limit_exit_requeues_without_counting_failure``
+    (transient → released to ``ready``, no failure counted) and
+    ``test_real_crash_still_counts_and_trips_breaker`` (generic crash → blocks
+    only after DEFAULT_FAILURE_LIMIT == 2 hits).
+    """
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        claim_lock = f"{host}:w0"
+        tid = kb.create_task(
+            conn,
+            title="billing-wall",
+            assignee="a",
+            max_retries=4,
+        )
+
+        pid = 41806
+        conn.execute(
+            "UPDATE tasks SET status='ready' WHERE id=?",
+            (tid,),
+        )
+        conn.commit()
+        assert kb.claim_task(conn, tid, claimer=claim_lock) is not None
+        _kb._set_worker_pid(conn, tid, pid)
+
+        provider_error = (
+            "HTTP 429: Insufficient balance or no resource package. "
+            "Please recharge."
+        )
+        assert not kb.record_kanban_worker_failure_error(
+            tid, f"{host}:stale", "must not overwrite the active claim"
+        )
+        assert kb.record_kanban_worker_failure_error(
+            tid, claim_lock, provider_error
+        )
+        _kb._record_worker_exit(
+            pid, _exited_status(_kb.KANBAN_BILLING_BLOCKER_EXIT_CODE)
+        )
+
+        spawned_ids = []
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _workspace: spawned_ids.append(task.id),
+        )
+        # Hard billing IS a (deterministic) crash — counted, unlike rate-limit.
+        assert tid in result.crashed
+        assert tid in result.auto_blocked
+        rl = getattr(_kb.detect_crashed_workers, "_last_rate_limited", [])
+        assert tid not in rl, "hard billing must NOT be a transient requeue"
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        # Blocked on the FIRST hit despite max_retries=4. dispatch_once has
+        # already run recompute_ready(), so this also proves the same tick
+        # cannot silently reopen and respawn the card.
+        assert task.status == "blocked", (
+            f"hard billing should auto-block immediately, got {task.status}"
+        )
+        assert task.max_retries == 4
+        assert task.consecutive_failures == 1
+        assert result.promoted == 0
+        assert spawned_ids == []
+        # Cause is surfaced (not a bare 'pid not alive') and matches the
+        # respawn-blocker vocabulary.
+        assert task.last_failure_error == provider_error
+        assert kb._RESPAWN_BLOCKER_RE.search(task.last_failure_error)
+
+        blocked_events = [
+            event for event in kb.list_events(conn, tid)
+            if event.kind == "blocked"
+        ]
+        assert blocked_events
+        assert blocked_events[-1].payload["source"] == "billing_blocked"
+        assert blocked_events[-1].payload["reason"] == provider_error
+
+        runs = kb.list_runs(conn, tid)
+        assert runs[-1].error == provider_error
+
+        # The explicit block is sticky on subsequent dispatcher ticks too;
+        # only an operator unblock may retry after credits are restored.
+        second = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _workspace: spawned_ids.append(task.id),
+        )
+        assert second.promoted == 0
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert spawned_ids == []
+
+
+@pytest.mark.parametrize(
+    "failure_reason,expected_attr",
+    [
+        ("rate_limit", "KANBAN_RATE_LIMIT_EXIT_CODE"),
+        ("billing", "KANBAN_BILLING_BLOCKER_EXIT_CODE"),
+    ],
+)
+def test_kanban_worker_exit_code_for_failure_sentinels(failure_reason, expected_attr):
+    """The worker exit-code contract: transient vs hard wall get distinct
+    sentinels so the dispatcher can route them differently (#41805)."""
+    assert kb.kanban_worker_exit_code_for_failure(failure_reason) == getattr(
+        kb, expected_attr
+    )
+
+
+@pytest.mark.parametrize("failure_reason", [None, "auth", "content_policy_blocked", ""])
+def test_kanban_worker_exit_code_for_failure_generic(failure_reason):
+    """Non-quota reasons (and absent reason) fall back to the generic ``1`` so
+    they count toward the circuit breaker via the normal crashed path."""
+    assert kb.kanban_worker_exit_code_for_failure(failure_reason) == 1
+
+
 def test_respawn_guard_defers_rate_limited_within_cooldown(
     kanban_home, monkeypatch,
 ):
@@ -1863,6 +2001,77 @@ def test_respawn_guard_blocker_auth_on_authorization_error(kanban_home):
         )
         reason = kb.check_respawn_guard(conn, t)
     assert reason == "blocker_auth"
+
+
+@pytest.mark.parametrize(
+    "error_text",
+    [
+        # Exact strings from the worker logs in #41805 (hard usage-limit /
+        # quota / billing 429s that previously slipped past the blocker regex).
+        "The usage limit has been reached",
+        "HTTP 429: The usage limit has been reached",
+        "HTTP 429: Usage limit reached for 5 hour. Your limit will reset at "
+        "2026-05-30 22:00:45",
+        "HTTP 429: Insufficient balance or no resource package. Please recharge.",
+        "API call failed after 3 retries: HTTP 429: Usage limit reached for 5 hour",
+        # error_classifier billing vocabulary (underscore + spaced forms).
+        "insufficient_quota",
+        "payment required",
+        "out of funds",
+    ],
+)
+def test_respawn_guard_blocker_auth_on_hard_usage_limit(kanban_home, error_text):
+    """Hard usage-limit / quota / billing errors trigger blocker_auth (#41805).
+
+    Before the fix these phrasings ("usage limit", "insufficient balance",
+    "recharge", "no resource package", ...) were absent from
+    ``_RESPAWN_BLOCKER_RE``, so a worker that bailed on a hard quota wall before
+    any tool work was re-spawned indefinitely instead of being deferred.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="quota-wall", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            (error_text, t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "blocker_auth"
+
+
+@pytest.mark.parametrize(
+    "error_text",
+    [
+        # Generic crash symptoms must NOT be mistaken for a quota blocker —
+        # guarding these would mask real crashes from the circuit breaker.
+        "pid 12345 not alive",
+        "pid 12345 exited with code 1",
+        "pid 12345 killed by signal 9",
+        "connection reset by peer",
+        "protocol_violation",
+        "Request timed out.",
+        # Benign task-level text that the previous over-broad patterns
+        # (bare ``insufficient\\w*`` / ``recharge``) wrongly matched.
+        "insufficient tests",
+        "insufficient data",
+        "insufficient coverage",
+        "recharge battery",
+        "time to recharge before the next run",
+    ],
+)
+def test_respawn_guard_not_blocked_on_generic_crash(kanban_home, error_text):
+    """Generic crash text does not match the widened blocker regex (#41805).
+
+    Confirms Layer B stayed anchored to billing/quota vocabulary and did not
+    broaden into ordinary transient/crash errors.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="real-crash", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            (error_text, t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
 
 
 def test_respawn_guard_recent_success(kanban_home):


### PR DESCRIPTION
Fixes #41805.

## Problem

When a Kanban worker hits a **hard** provider usage-limit / quota / billing 429 *before doing any tool work* — e.g. `Insufficient balance or no resource package. Please recharge.`, `the usage limit has been reached` — it exits before it can call `kanban_complete` / `kanban_block`. The dispatcher records only a generic crash symptom (`pid N not alive` / `protocol_violation`), so the existing `blocker_auth` respawn guard never sees the real cause and the task **re-spawns indefinitely** against a wall that won't clear without operator action (burning paid requests; cf. #31273).

## Root cause

The rate-limit safety net had two independent gaps for *hard* walls:

1. `agent/error_classifier.py` classified **all** HTTP 429s as `rate_limit` (the status check is authoritative and runs before message-pattern billing detection), so a billing 429 never reached the non-retryable path.
2. Even a true billing exit was mapped to the *transient* rate-limit sentinel, which the dispatcher cheap-probes on a cooldown **forever** — it never blocks.

## Changes

- **Classifier** (`error_classifier.py`): disambiguate 429 the same way 402/403 already do — `429 + billing vocabulary → billing`; ordinary throttles and time-windowed usage limits (`resets at …`) stay `rate_limit` (they reset on a timer).
- **Conversation loop** (`conversation_loop.py`): stamp `failure_reason` on the terminal non-retryable client-error return — the path a hard billing error falls through to once credential rotation and fallback are exhausted.
- **Worker exit contract** (`cli.py` + `kanban_db.py`): new `KANBAN_BILLING_BLOCKER_EXIT_CODE` (77, `EX_NOPERM`) distinct from the transient `EX_TEMPFAIL` (75), centralized in `kanban_worker_exit_code_for_failure()`.
- **Dispatcher** (`kanban_db.py`): a `billing_blocked` reap kind stamps the real cause and auto-blocks the task immediately (`failure_limit=1`) for operator attention — transient rate limits keep the cooldown-probe behavior unchanged.
- **Respawn guard**: widen `_RESPAWN_BLOCKER_RE` to billing/account vocabulary, anchored to avoid matching benign task text (`insufficient tests`, `recharge battery`).

Net effect: transient throttles still cool down and retry cheaply; hard billing walls stop looping and surface a clear, operator-actionable reason.

## Tests

- 429 billing-vs-transient disambiguation (`test_error_classifier.py`)
- billing sentinel → immediate auto-block, end-to-end, contrasted with the rate-limit requeue and generic-crash paths (`test_kanban_db.py`)
- exit-code helper mapping (`rate_limit` / `billing` / other)
- benign-text negatives for the widened regex
- `failure_reason` surfaced on the non-retryable return (`test_conversation_loop_failure_reason.py`)

`ruff check` clean; the changed-area suites pass (567 passed locally).
