### PR TITLE
fix(cli): dispatch /indicator to set the busy-indicator style

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9175,6 +9175,8 @@ class HermesCLI:
             self._handle_voice_command(cmd_original)
         elif canonical == "busy":
             self._handle_busy_command(cmd_original)
+        elif canonical == "indicator":
+            self._handle_indicator_command(cmd_original)
         else:
             # Check for user-defined quick commands (bypass agent loop, no LLM call)
             base_cmd = cmd_lower.split()[0]
@@ -10333,6 +10335,45 @@ class HermesCLI:
             _cprint(f"  {_DIM}{behavior}{_RST}")
         else:
             _cprint(f"  {_ACCENT}✓ Busy input mode set to '{arg}' (session only){_RST}")
+
+    def _handle_indicator_command(self, cmd: str):
+        """Handle /indicator — pick the TUI busy-indicator style.
+
+        Usage:
+            /indicator              Show the current busy-indicator style
+            /indicator status       Show the current busy-indicator style
+            /indicator kaomoji      Animated kaomoji faces (default)
+            /indicator emoji        Emoji spinner
+            /indicator unicode      Braille spinner
+            /indicator ascii        Plain ASCII spinner
+
+        Persists to ``display.tui_status_indicator`` — the same config key the
+        TUI reads — so the change is picked up the next time the TUI renders.
+        """
+        # Keep in sync with tui_gateway/server.py:_INDICATOR_STYLES.
+        styles = ("kaomoji", "emoji", "unicode", "ascii")
+        current = (
+            (self.config.get("display") or {}).get("tui_status_indicator", "kaomoji")
+        )
+
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or parts[1].strip().lower() == "status":
+            _cprint(f"  {_ACCENT}Busy-indicator style: {current}{_RST}")
+            _cprint(f"  {_DIM}Usage: /indicator [{'|'.join(styles)}]{_RST}")
+            return
+
+        arg = parts[1].strip().lower()
+        if arg not in styles:
+            _cprint(f"  {_DIM}(._.) Unknown indicator style: {arg}{_RST}")
+            _cprint(f"  {_DIM}Usage: /indicator [{'|'.join(styles)}]{_RST}")
+            return
+
+        self.config.setdefault("display", {})["tui_status_indicator"] = arg
+        if save_config_value("display.tui_status_indicator", arg):
+            _cprint(f"  {_ACCENT}✓ Busy-indicator style set to '{arg}' (saved to config){_RST}")
+            _cprint(f"  {_DIM}The TUI picks up the new style on its next render.{_RST}")
+        else:
+            _cprint(f"  {_ACCENT}✓ Busy-indicator style set to '{arg}' (session only){_RST}")
 
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode)."""

--- a/tests/cli/test_indicator_command.py
+++ b/tests/cli/test_indicator_command.py
@@ -1,0 +1,147 @@
+"""Tests for the /indicator CLI command and busy-indicator style config.
+
+The /indicator command is registered in COMMAND_REGISTRY (and advertised by
+/help, tab-completion and the tips system) but used to have no dispatch branch
+in HermesCLI.process_command — so typing it printed "Unknown command:
+/indicator". These tests lock in the dispatch wiring and the handler behavior.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _import_cli():
+    import hermes_cli.config as config_mod
+
+    if not hasattr(config_mod, "save_env_value_secure"):
+        config_mod.save_env_value_secure = lambda key, value: {
+            "success": True,
+            "stored_as": key,
+            "validated": False,
+        }
+
+    import cli as cli_mod
+
+    return cli_mod
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {}
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj.conversation_history = []
+    cli_obj.session_id = None
+    cli_obj._pending_input = MagicMock()
+    return cli_obj
+
+
+class TestIndicatorDispatch(unittest.TestCase):
+    """The command must route to its handler — not fall through to "Unknown"."""
+
+    def test_indicator_dispatches_to_handler(self):
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_handle_indicator_command") as mock_handler:
+            result = cli_obj.process_command("/indicator emoji")
+
+        mock_handler.assert_called_once_with("/indicator emoji")
+        self.assertTrue(result)
+
+    def test_indicator_is_not_unknown_command(self):
+        cli_obj = _make_cli()
+        with (
+            patch("cli._cprint") as mock_cprint,
+            patch("cli.save_config_value", return_value=True),
+        ):
+            result = cli_obj.process_command("/indicator emoji")
+
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertNotIn("Unknown command", printed)
+        self.assertTrue(result)
+
+
+class TestHandleIndicatorCommand(unittest.TestCase):
+    def _stub(self, current=None):
+        config = {}
+        if current is not None:
+            config["display"] = {"tui_status_indicator": current}
+        return SimpleNamespace(config=config)
+
+    def test_no_args_shows_status(self):
+        cli_mod = _import_cli()
+        stub = self._stub("emoji")
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator")
+
+        mock_save.assert_not_called()
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("emoji", printed)
+
+    def test_status_argument_shows_status(self):
+        cli_mod = _import_cli()
+        stub = self._stub()  # no display config -> default kaomoji
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator status")
+
+        mock_save.assert_not_called()
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("kaomoji", printed)
+
+    def test_valid_style_saves_to_config_key(self):
+        cli_mod = _import_cli()
+        stub = self._stub("kaomoji")
+        with (
+            patch.object(cli_mod, "_cprint"),
+            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator unicode")
+
+        # Persists to the SAME key the TUI reads, and mirrors it in memory.
+        mock_save.assert_called_once_with("display.tui_status_indicator", "unicode")
+        self.assertEqual(stub.config["display"]["tui_status_indicator"], "unicode")
+
+    def test_invalid_style_prints_usage_and_does_not_save(self):
+        cli_mod = _import_cli()
+        stub = self._stub("kaomoji")
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator rainbow")
+
+        mock_save.assert_not_called()
+        # The stored value must be untouched.
+        self.assertEqual(stub.config["display"]["tui_status_indicator"], "kaomoji")
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("Usage: /indicator", printed)
+
+
+class TestIndicatorRegistry(unittest.TestCase):
+    def test_indicator_in_registry(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+
+        names = [c.name for c in COMMAND_REGISTRY]
+        self.assertIn("indicator", names)
+
+    def test_indicator_subcommands_match_handler(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+
+        indicator = next(c for c in COMMAND_REGISTRY if c.name == "indicator")
+        self.assertEqual(indicator.category, "Configuration")
+        # The registered styles are what the handler accepts.
+        self.assertEqual(
+            set(indicator.subcommands), {"kaomoji", "emoji", "unicode", "ascii"}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The /indicator command was registered in COMMAND_REGISTRY, listed in /help,
offered by tab-completion, recommended by the tips system, and even documented
in config.py ("Live-swappable via `/indicator <style>`") — but process_command
had no branch for it. Typing /indicator (or /indicator emoji) fell through to
the prefix matcher and printed "Unknown command: /indicator", leaving no CLI
way to change display.tui_status_indicator short of hand-editing config.yaml.

The styles feature (#17150) shipped the registry entry, config key, tip, and
TUI/JSON-RPC wiring, but never added the CLI handler. This adds it.

## What does this PR do?

Wires the advertised /indicator slash command to a real handler so it sets the
TUI busy-indicator style from the CLI. /indicator (or /indicator status) shows
the current style; /indicator <kaomoji|emoji|unicode|ascii> validates the choice
and persists it to display.tui_status_indicator — the same key the TUI reads —
so the next render picks it up. Unknown styles print usage and change nothing.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: add `_handle_indicator_command` (status view, style validation,
  persistence via `save_config_value("display.tui_status_indicator", ...)` with
  in-memory mirror), modeled on `_handle_busy_command`.
- `cli.py`: add the `elif canonical == "indicator"` dispatch branch in
  `process_command`, so the command resolves and the REPL stays alive.
- `tests/cli/test_indicator_command.py`: dispatch wiring, handler behavior, and
  registry consistency coverage.

## How to Test

1. `scripts/run_tests.sh tests/cli/test_indicator_command.py` — 8 tests pass.
2. In the CLI, run `/indicator emoji` — prints a saved-to-config confirmation
   (previously printed "Unknown command: /indicator").
3. Run `/indicator` — shows the current style; `/indicator rainbow` — prints
   usage and leaves the stored value untouched.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the test suite and the affected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — handler docstring added
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (key already existed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A