### PR TITLE
feat(utils): add safe_expanduser() — crash-free path expansion for HOME-unset environments

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -19,6 +19,8 @@ import shlex
 from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
+from utils import safe_expanduser
+
 from agent.prompt_builder import _scan_context_content
 
 logger = logging.getLogger(__name__)
@@ -127,7 +129,7 @@ class SubdirectoryHintTracker:
         ``project/src/`` has no hint files of its own.
         """
         try:
-            p = Path(raw_path).expanduser()
+            p = safe_expanduser(raw_path)
             if not p.is_absolute():
                 p = self.working_dir / p
             p = p.resolve()

--- a/tests/test_utils_expanduser.py
+++ b/tests/test_utils_expanduser.py
@@ -1,0 +1,72 @@
+"""Tests for safe_expanduser path helper."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from utils import safe_expanduser
+
+
+class TestSafeExpanduser:
+    """safe_expanduser should resolve ~/ normally but survive a missing HOME."""
+
+    def test_expands_tilde_with_home(self):
+        """When HOME is set, ~/ is resolved just like Path.expanduser()."""
+        result = safe_expanduser("~/foo/bar")
+        assert isinstance(result, Path)
+        assert result.is_absolute()
+        assert str(result).startswith("/")
+        assert result.name == "bar"
+
+    def test_returns_path_for_plain_path(self):
+        """A path without ~ is returned unchanged."""
+        result = safe_expanduser("/tmp/test")
+        assert result == Path("/tmp/test")
+
+    def test_accepts_path_instance(self):
+        """A Path instance is treated the same as a string."""
+        result = safe_expanduser(Path("/some/path"))
+        assert result == Path("/some/path")
+
+    def test_respects_default(self):
+        """If default is provided, it is returned on expansion failure."""
+        result = safe_expanduser("~/x", default="/fallback")
+        # With HOME normally set this won't hit the except branch, so
+        # we can only verify the default is a Path.
+        assert isinstance(result, Path)
+
+    def test_default_is_path_coerced(self):
+        """default=string is coerced to Path just like the path arg."""
+        result = safe_expanduser("~/x", default="/fallback")
+        assert isinstance(result, Path)
+
+    def test_no_crash_when_home_unset_and_passwd_fails(self, monkeypatch):
+        """When HOME is empty and pwd lookup fails, safe_expanduser returns
+        the literal path instead of raising RuntimeError."""
+        # Unset HOME so expanduser triggers its lookup.
+        monkeypatch.delenv("HOME", raising=False)
+        # Monkeypatch pwd.getpwuid to raise KeyError, simulating an
+        # unmapped uid — the exact condition that produces RuntimeError.
+        import pwd
+
+        orig_getpwuid = pwd.getpwuid
+        monkeypatch.setattr(pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(
+            KeyError(f"uid {uid} not found")
+        ))
+        # Now expanduser should raise RuntimeError, but safe_expanduser
+        # catches it and returns the unexpanded path.
+        result = safe_expanduser("~/some_dir")
+        assert str(result) == "~/some_dir"
+        # Restore original (not strictly necessary, monkeypatch handles it).
+        monkeypatch.setattr(pwd, "getpwuid", orig_getpwuid)
+
+    def test_default_on_expand_failure(self, monkeypatch):
+        """When HOME is unset and pwd fails, default is returned."""
+        monkeypatch.delenv("HOME", raising=False)
+        import pwd
+        monkeypatch.setattr(pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(
+            KeyError(f"uid {uid} not found")
+        ))
+        result = safe_expanduser("~/some_dir", default="/tmp/hermes_fallback")
+        assert result == Path("/tmp/hermes_fallback")

--- a/utils.py
+++ b/utils.py
@@ -374,3 +374,53 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     if not domain:
         return False
     return hostname == domain or hostname.endswith("." + domain)
+
+
+# ─── Path Helpers ─────────────────────────────────────────────────────────────
+
+
+def safe_expanduser(path: Union[str, Path], default: Union[str, Path, None] = None) -> Path:
+    """Expand ``~`` in a path without crashing when HOME cannot be resolved.
+
+    ``pathlib.Path.expanduser()`` and ``os.path.expanduser()`` raise
+    ``RuntimeError`` ("Could not determine home directory") when the
+    process has no ``HOME`` env var **and** ``pwd.getpwuid()`` fails to
+    look up the current uid. Both conditions show up in real deployments:
+
+      * launchd-spawned daemons that omit ``HOME`` from
+        ``EnvironmentVariables`` (every macOS Hermes gateway install
+        before the plist HOME fix; logs surface this as repeated
+        "Could not determine home directory" RuntimeError stacks from
+        ``subdirectory_hints.py``).
+      * Containerized runs (Docker/k8s) where the image's passwd entry
+        was stripped or the uid is unmapped.
+      * ``sudo -E`` invocations that drop ``HOME`` without restoring it.
+
+    The vast majority of callers in this codebase want a best-effort
+    expansion — if HOME cannot be resolved they would rather get back the
+    original path (or an explicit fallback) than crash a background task.
+    Use ``Path.expanduser()`` directly only when an unresolvable HOME is
+    a genuine fatal condition the caller wants to surface.
+
+    Args:
+        path: The path-like value to expand. Strings and ``Path``
+            instances are accepted; non-string non-Path inputs are
+            coerced via ``str()``.
+        default: Value returned (coerced to ``Path``) when expansion
+            fails. When ``None`` (the default), the original ``path``
+            argument is returned unexpanded — preserving the literal
+            ``~`` so callers that later log the value still see the
+            user's intent.
+
+    Returns:
+        A ``Path`` instance. Never raises ``RuntimeError`` from a
+        failed HOME lookup; other ``OSError`` subclasses from filesystem
+        access are also swallowed in favor of *default*.
+    """
+    p = path if isinstance(path, Path) else Path(str(path))
+    try:
+        return p.expanduser()
+    except (RuntimeError, OSError):
+        if default is None:
+            return p
+        return default if isinstance(default, Path) else Path(str(default))


### PR DESCRIPTION
## What does this PR do?

Adds a shared `safe_expanduser()` helper to `utils.py` and adopts it in `agent/subdirectory_hints.py` as the first production caller. The helper wraps `Path.expanduser()` so it never raises `RuntimeError("Could not determine home directory")` — instead it returns the original path (or an explicit `default`) when HOME cannot be resolved.

## Related Issue

No existing issue. Surfaced in real `gateway.log` traces on a fresh macOS install of Hermes — `agent/subdirectory_hints.py:130` crashes whenever a tool call passes a `~/`-prefixed path through `SubdirectoryHintTracker._add_path_candidates` from a context where Python cannot determine HOME. Concrete trigger seen locally:

```
RuntimeError: Could not determine home directory.
  File "agent/subdirectory_hints.py", line 130, in _add_path_candidates
    p = Path(raw_path).expanduser()
```

This happens when the macOS launchd-spawned gateway daemon's plist lacks `HOME` in `EnvironmentVariables`, AND `pwd.getpwuid()` lookup fails (rare uid mapping issue). The same class of crash hits Docker/k8s containers with stripped passwd entries and `sudo -E` invocations.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ♻️ Refactor (introduces shared helper for sweep PR)

## Changes Made

- `utils.py` (+50 lines): new `safe_expanduser(path, default=None) -> Path` under a new "Path Helpers" section. Catches `RuntimeError` and `OSError`; returns the original path by default, or a caller-provided `default` when supplied.
- `agent/subdirectory_hints.py` (+3, -1): import `safe_expanduser` from `utils`; replace the bare `Path(raw_path).expanduser()` at line 130 with `safe_expanduser(raw_path)`. The surrounding `try/except (OSError, ValueError)` is left in place — `safe_expanduser` only neutralizes the HOME-resolution failure mode, not the subsequent `resolve()` and ancestor-walk errors.
- `tests/test_utils_expanduser.py` (+72 lines): 7 tests covering:
  - normal `~/` expansion when HOME is set
  - non-`~` paths pass through unchanged
  - `Path` instances accepted alongside strings
  - `default` parameter honored (and coerced to `Path`)
  - **regression test**: HOME unset + `pwd.getpwuid` monkeypatched to raise `KeyError` → original path returned (not a crash)
  - same setup with explicit `default` → default returned

## How to Test

```bash
# Run the new tests
pytest tests/test_utils_expanduser.py -v

# Reproduce the original crash and verify the fix
python -c "
import os, pwd
from pathlib import Path
os.environ.pop('HOME', None)
pwd.getpwuid = lambda uid: (_ for _ in ()).throw(KeyError('nope'))

# Old code crashes:
try:
    Path('~/.hermes').expanduser()
    print('ORIGINAL: no crash')
except RuntimeError as e:
    print(f'ORIGINAL: CRASHED — {e}')

# New helper does not:
from utils import safe_expanduser
result = safe_expanduser('~/.hermes')
print(f'SAFE: returned {result!r}')
"
```

Expected output:
```
ORIGINAL: CRASHED — Could not determine home directory.
SAFE: returned PosixPath('~/.hermes')
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`feat(utils): ...`)
- [x] I searched for existing PRs — no duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/test_utils_expanduser.py tests/test_utils_truthy_values.py tests/agent/` — 11 utils tests pass, all agent tests pass except one pre-existing failure on main unrelated to this change (`test_anthropic_adapter.py::test_prefers_oauth_token_over_api_key` is environment-sensitive to host `~/.claude/` state)
- [x] I've added tests for my changes — 7 new tests including the regression case
- [x] I've tested on my platform: macOS 26.5.1, Python 3.13

### Documentation & Housekeeping

- [x] Helper has a full docstring explaining the failure mode and when to use it vs bare `Path.expanduser()` — N/A for separate docs file
- [x] No config keys added — N/A for `cli-config.yaml.example`
- [x] No architecture change — N/A for `CONTRIBUTING.md`/`AGENTS.md`
- [x] Cross-platform: helper is platform-agnostic; failure mode is more common on Unix but `Path.expanduser()` on Windows can also raise when `USERPROFILE`/`HOMEDRIVE`+`HOMEPATH` are all missing — same catch handles it.
- [x] No tool descriptions changed — N/A

## Follow-up

This PR is intentionally narrow — it ships the helper + one adopter so the API can be reviewed in isolation. A follow-up PR will sweep the ~49 other bare `Path().expanduser()` / `os.path.expanduser()` call sites across `hermes_cli/`, `agent/`, `cron/`, `gateway/`, `tools/`, `acp_adapter/`, and `plugins/`. Splitting it avoids a giant unreviewable diff and lets the API land first.
