### PR TITLE
fix(whatsapp): reuse shared JID normalizer in bridge so group @mentions and replies-to-bot match

### DIFF
--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -17,6 +17,23 @@ test('normalizeWhatsAppIdentifier strips jid syntax and plus prefix', () => {
   assert.equal(normalizeWhatsAppIdentifier('19175395595:12@s.whatsapp.net'), '19175395595');
 });
 
+test('normalizeWhatsAppIdentifier: device-suffixed bot id matches a suffix-less mention (group @mention / reply-to-bot regression)', () => {
+  // A bot self-id (sock.user.id / .lid) arrives WITH a device suffix, while a
+  // mentionedJid / quotedParticipant usually arrives WITHOUT one. Both must
+  // collapse to the same bare id, or mention-gated groups and reply-to-bot
+  // detection silently never match.
+  assert.equal(
+    normalizeWhatsAppIdentifier('15551234567:46@s.whatsapp.net'),
+    normalizeWhatsAppIdentifier('15551234567@s.whatsapp.net'),
+  );
+  assert.equal(
+    normalizeWhatsAppIdentifier('99887766554433:46@lid'),
+    normalizeWhatsAppIdentifier('99887766554433@lid'),
+  );
+  // and both reduce to the bare id
+  assert.equal(normalizeWhatsAppIdentifier('15551234567:46@s.whatsapp.net'), '15551234567');
+});
+
 test('expandWhatsAppIdentifiers resolves phone and lid aliases from session files', () => {
   const sessionDir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-allowlist-'));
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -28,7 +28,7 @@ import { randomBytes } from 'crypto';
 import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
-import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { matchesAllowedUser, normalizeWhatsAppIdentifier, parseAllowedUsers } from './allowlist.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -117,11 +117,6 @@ function trackSentMessageId(sent) {
       recentlySentIds.delete(recentlySentIds.values().next().value);
     }
   }
-}
-
-function normalizeWhatsAppId(value) {
-  if (!value) return '';
-  return String(value).replace(':', '@');
 }
 
 function getMessageContent(msg) {
@@ -242,8 +237,8 @@ async function startSocket() {
     if (type !== 'notify' && type !== 'append') return;
 
     const botIds = Array.from(new Set([
-      normalizeWhatsAppId(sock.user?.id),
-      normalizeWhatsAppId(sock.user?.lid),
+      normalizeWhatsAppIdentifier(sock.user?.id),
+      normalizeWhatsAppIdentifier(sock.user?.lid),
     ].filter(Boolean)));
 
     for (const msg of messages) {
@@ -316,10 +311,10 @@ async function startSocket() {
 
       const messageContent = getMessageContent(msg);
       const contextInfo = getContextInfo(messageContent);
-      const mentionedIds = Array.from(new Set((contextInfo?.mentionedJid || []).map(normalizeWhatsAppId).filter(Boolean)));
+      const mentionedIds = Array.from(new Set((contextInfo?.mentionedJid || []).map(normalizeWhatsAppIdentifier).filter(Boolean)));
       const quotedMessageId = contextInfo?.stanzaId || null;
-      const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || '') || null;
-      const quotedRemoteJid = normalizeWhatsAppId(contextInfo?.remoteJid || '') || null;
+      const quotedParticipant = normalizeWhatsAppIdentifier(contextInfo?.participant || '') || null;
+      const quotedRemoteJid = normalizeWhatsAppIdentifier(contextInfo?.remoteJid || '') || null;
       const hasQuotedMessage = !!contextInfo?.quotedMessage;
 
       // Extract message body


### PR DESCRIPTION
## What does this PR do?

Fixes the WhatsApp bridge **silently ignoring group `@mentions` and replies-to-bot**.

`scripts/whatsapp-bridge/bridge.js` carries a second, divergent copy of JID normalization:

```js
function normalizeWhatsAppId(value) {
  if (!value) return '';
  return String(value).replace(':', '@');   // only swaps the first ':' for '@'
}
```

It leaves the device suffix and domain in place, so `<id>:NN@s.whatsapp.net` becomes `<id>@NN@s.whatsapp.net`. `botIds` are built from `sock.user.id` / `sock.user.lid`, which **carry a device suffix**, whereas an incoming `mentionedJid` / `quotedParticipant` usually does **not**. After this broken normalization the two forms can never compare equal (placeholder ids):

| value | role | normalized (buggy) |
|---|---|---|
| `1234567890:12@s.whatsapp.net` | bot id | `1234567890@12@s.whatsapp.net` |
| `1234567890@s.whatsapp.net` | mention jid | `1234567890@s.whatsapp.net` |

→ `mentionedIds & botIds` is always empty (mention-gated groups never trigger), and `quotedParticipant ∈ botIds` is always false (reply-to-bot never fires).

`allowlist.js` in the same directory already exports the **correct, unit-tested** `normalizeWhatsAppIdentifier()` (strips device suffix, domain, leading `+`), and `bridge.js` already imports from that file. This PR **deletes the buggy duplicate and reuses the shared function** at every call site — one source of truth.

## Related Issue

No existing tracked issue — found while debugging group `@mention` non-response on a linked-device deployment. Adjacent WhatsApp JID/LID normalization work (allowlist side): #17189.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/whatsapp-bridge/bridge.js`
  - import `normalizeWhatsAppIdentifier` from `./allowlist.js`
  - remove the local `normalizeWhatsAppId()` duplicate (`String(value).replace(':', '@')`)
  - repoint all call sites — `botIds`, the `mentionedJid` map, `quotedParticipant`, `quotedRemoteJid` — to the shared normalizer
- `scripts/whatsapp-bridge/allowlist.test.mjs`
  - regression test: a device-suffixed id must equal its suffix-less form (the exact mention / reply-to-bot mismatch)

## How to Test

**Before:** in a mention-gated group, tag the bot (or reply to its message) → no response. Bridge log shows `botIds` like `<id>@NN@s.whatsapp.net` while `mentionedIds` are bare, so they never intersect.

**After:**
```
$ node --test scripts/whatsapp-bridge/allowlist.test.mjs
# tests 6
# pass  6
# fail  0
$ node --check scripts/whatsapp-bridge/bridge.js     # parses OK
```
Live linked-device run: `botIds` now normalize to the bare id; group `@mention` and reply-to-bot matching fire.

## Suggested triage

`type/bug` · `comp/gateway` · `platform/whatsapp` · **P1** — a core feature (group mention + reply-to-bot) is silently broken with no config workaround; only a code change restores it.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(whatsapp): ...`)
- [x] I searched existing PRs — not a duplicate
- [x] PR contains **only** changes related to this fix
- [x] Added a regression test
- [x] `pytest tests/ -q` — N/A: change is confined to the Node WhatsApp bridge; no Python touched. Ran the bridge's Node suite instead (`node --test`, 6/6 pass).
