### PR TITLE
feat: add MiMo to OPENAI_MODEL_EXECUTION_GUIDANCE injection list

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -179,7 +179,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # Also applied to xAI Grok — same failure modes (claims completion
             # without tool calls, suggests workarounds instead of using
             # existing tools, replies with plans instead of executing).
-            if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
+            if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower or "mimo" in _model_lower:
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 
     has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])


### PR DESCRIPTION
## Problem

Xiaomi MiMo models exhibit the same tool-calling failure modes as GPT/Grok:
- Stopping after a stub (writes a plan instead of executing)
- Describing intended actions without making tool calls
- Answering from memory instead of using tools (math, system state, etc.)

Currently MiMo only receives the generic `TOOL_USE_ENFORCEMENT_GUIDANCE` (3 sentences), while GPT/Grok get the full `OPENAI_MODEL_EXECUTION_GUIDANCE` with `<tool_persistence>` and `<mandatory_tool_use>` sections.

## Change

Add `"mimo"` to the model-name check in `build_system_prompt_parts()` so MiMo receives the same execution discipline guidance.

```diff
-            if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
+            if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower or "mimo" in _model_lower:
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
```

## Testing

Verified locally with `hermes config set model.default xiaomi/mimo-v2.5-pro` — the execution guidance now appears in the system prompt and tool-calling behavior is noticeably more proactive.