### PR TITLE
fix(cli): display background process notifications directly to terminal

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15079,7 +15079,7 @@ class HermesCLI:
                             try:
                                 from tools.process_registry import process_registry
                                 for _evt, _synth in process_registry.drain_notifications():
-                                    self._pending_input.put(_synth)
+                                    _cprint(f"\n  {_synth}\n")
                             except Exception:
                                 pass
                         continue
@@ -15207,7 +15207,7 @@ class HermesCLI:
                         try:
                             from tools.process_registry import process_registry
                             for _evt, _synth in process_registry.drain_notifications():
-                                self._pending_input.put(_synth)
+                                _cprint(f"\n  {_synth}\n")
                         except Exception:
                             pass  # Non-fatal — don't break the main loop
 


### PR DESCRIPTION
## Fix: 2 lines

Background process notifications (`notify_on_complete`) were injected into `_pending_input` as pseudo-user-input and silently consumed by the agent. This replaces `_pending_input.put()` with `_cprint()` so notifications appear immediately in the terminal.

## Architecture Review

| Platform | Notification path | Status |
|----------|-------------------|--------|
| **CLI** | `cli.py` → `_pending_input` | ❌ Invisible to user |
| **TUI** | `tui_gateway/server.py:4873` → re-queues if agent busy | Independent path |
| **Gateway** | `gateway/run.py:9646` → `completion_queue` direct | Independent path |

This fix is **scoped to CLI only** — TUI and Gateway have their own notification handlers and are unaffected.

## Why replace, not add?

Adding `_cprint` while keeping `_pending_input.put` causes double output: terminal notification + agent response. The notification is a user-facing signal, not agent input.

## Related

- Closes #41851
- Related: #21904, #15248, #10760, #15276 (long-standing notification area)