### PR TITLE
fix(gateway): hide Always Allow for Tirith session-only findings (#41769)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18376,19 +18376,26 @@ class GatewayRunner:
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                has_tirith = approval_data.get("has_tirith", False)
 
                 # Prefer button-based approval when the adapter supports it.
                 # Check the *class* for the method, not the instance — avoids
                 # false positives from MagicMock auto-attribute creation in tests.
                 if getattr(type(_status_adapter), "send_exec_approval", None) is not None:
                     try:
+                        # Inject has_tirith into metadata so adapters
+                        # (e.g. Discord) can hide "Always Allow" for
+                        # Tirith findings that are session-only.
+                        _approval_meta = dict(_status_thread_metadata or {})
+                        if has_tirith:
+                            _approval_meta["has_tirith"] = True
                         _approval_fut = safe_schedule_threadsafe(
                             _status_adapter.send_exec_approval(
                                 chat_id=_status_chat_id,
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata=_approval_meta,
                             ),
                             _loop_for_step,
                             logger=logger,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4309,6 +4309,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 session_key=session_key,
                 allowed_user_ids=self._allowed_user_ids,
                 allowed_role_ids=self._allowed_role_ids,
+                has_tirith=(metadata or {}).get("has_tirith", False),
             )
 
             msg = await channel.send(embed=embed, view=view)
@@ -5275,12 +5276,19 @@ def _define_discord_view_classes() -> None:
             session_key: str,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
+            has_tirith: bool = False,
         ):
             super().__init__(timeout=300)  # 5-minute timeout
             self.session_key = session_key
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
             self.resolved = False
+            # When Tirith security findings are present, "Always Allow"
+            # is misleading — the backend only persists Tirith approvals
+            # for the current session, not permanently.  Hide the button
+            # so the UI matches the backend behavior (#41769).
+            if has_tirith:
+                self.allow_always.hidden = True
 
         def _check_auth(self, interaction: discord.Interaction) -> bool:
             """Verify the user clicking is authorized."""

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -933,6 +933,41 @@ class TeamsAdapter(BasePlatformAdapter):
             "desc": description,
         }
 
+        has_tirith = (metadata or {}).get("has_tirith", False)
+        actions = [
+            ExecuteAction(
+                title="Allow Once",
+                verb="hermes_approve",
+                data={**btn_data_base, "hermes_action": "approve_once"},
+                style="positive",
+            ),
+            ExecuteAction(
+                title="Allow Session",
+                verb="hermes_approve",
+                data={**btn_data_base, "hermes_action": "approve_session"},
+            ),
+        ]
+        # When Tirith security findings are present, "Always Allow" is
+        # misleading — the backend only persists Tirith approvals for the
+        # current session, not permanently.  Hide the button so the UI
+        # matches the backend behavior (#41769).
+        if not has_tirith:
+            actions.append(
+                ExecuteAction(
+                    title="Always Allow",
+                    verb="hermes_approve",
+                    data={**btn_data_base, "hermes_action": "approve_always"},
+                ),
+            )
+        actions.append(
+            ExecuteAction(
+                title="Deny",
+                verb="hermes_approve",
+                data={**btn_data_base, "hermes_action": "deny"},
+                style="destructive",
+            ),
+        )
+
         card = (
             AdaptiveCard()
             .with_version("1.4")
@@ -941,30 +976,7 @@ class TeamsAdapter(BasePlatformAdapter):
                 TextBlock(text=f"```\n{cmd_preview}\n```", wrap=True),
                 TextBlock(text=f"Reason: {description}", wrap=True, isSubtle=True),
             ])
-            .with_actions([
-                ExecuteAction(
-                    title="Allow Once",
-                    verb="hermes_approve",
-                    data={**btn_data_base, "hermes_action": "approve_once"},
-                    style="positive",
-                ),
-                ExecuteAction(
-                    title="Allow Session",
-                    verb="hermes_approve",
-                    data={**btn_data_base, "hermes_action": "approve_session"},
-                ),
-                ExecuteAction(
-                    title="Always Allow",
-                    verb="hermes_approve",
-                    data={**btn_data_base, "hermes_action": "approve_always"},
-                ),
-                ExecuteAction(
-                    title="Deny",
-                    verb="hermes_approve",
-                    data={**btn_data_base, "hermes_action": "deny"},
-                    style="destructive",
-                ),
-            ])
+            .with_actions(actions)
         )
 
         try:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1381,6 +1381,7 @@ def check_all_command_guards(command: str, env_type: str,
                 "pattern_key": primary_key,
                 "pattern_keys": all_keys,
                 "description": combined_desc,
+                "has_tirith": has_tirith,
             }
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"


### PR DESCRIPTION
Fixes #41769. Gateway approval cards showed an Always Allow button for Tirith security-scan findings, but the backend only persists Tirith approvals for the current session. This adds has_tirith to the approval data flow (tools/approval.py -> gateway/run.py -> adapters) and hides the Always Allow button on Discord and Teams when Tirith findings are present, matching the actual backend behavior.