### PR TITLE
fix: three targeted bug fixes for CLI, delegate_task schema, and title timeout

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -29,7 +29,7 @@ _TITLE_PROMPT = (
 def generate_title(
     user_message: str,
     assistant_response: str,
-    timeout: float = 30.0,
+    timeout: Optional[float] = None,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
 ) -> Optional[str]:

--- a/cli.py
+++ b/cli.py
@@ -15176,7 +15176,7 @@ class HermesCLI:
                             try:
                                 from tools.process_registry import process_registry
                                 for _evt, _synth in process_registry.drain_notifications():
-                                    self._pending_input.put(_synth)
+                                    _cprint(f"\n  {_synth}\n")
                             except Exception:
                                 pass
                         continue
@@ -15304,7 +15304,7 @@ class HermesCLI:
                         try:
                             from tools.process_registry import process_registry
                             for _evt, _synth in process_registry.drain_notifications():
-                                self._pending_input.put(_synth)
+                                _cprint(f"\n  {_synth}\n")
                         except Exception:
                             pass  # Non-fatal — don't break the main loop
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2885,7 +2885,7 @@ DELEGATE_TASK_SCHEMA = {
                 ),
             },
         },
-        "required": [],
+        "required": ["goal"],
     },
 }
 


### PR DESCRIPTION
## Summary

Three targeted bug fixes addressing open issues:

### 1. fix(cli): display process completion notifications in terminal (#41851)
- **Bug**: `notify_on_complete` injected notifications into `_pending_input` queue, making them invisible to users. The agent received them as pseudo-user messages and acted on them silently.
- **Fix**: Replace `_pending_input.put(_synth)` with `_cprint()` at both idle-path (line 15179) and post-agent-path (line 15307) so notifications render directly in the terminal.

### 2. fix(delegate_task): set `required: ["goal"]` to prevent empty calls (#41823)
- **Bug**: Top-level schema had `required: []`, formally accepting `{}` as valid. Weak models (MiMo, small LLMs) took this as permission to skip all parameters, causing ~55% failure rate.
- **Fix**: Change to `required: ["goal"]` — strong models already provide it; batch mode still works since the handler prioritizes `tasks` when present.

### 3. fix(title_generator): pass `timeout=None` to allow config.yaml override (#41812)
- **Bug**: `generate_title()` hardcoded `timeout=30.0`, always passing it explicitly to `call_llm()`. Since `call_llm()` only reads `auxiliary.title_generation.timeout` from config when timeout is `None`, the config value was dead code.
- **Fix**: Change default to `Optional[float] = None` so config is respected; falls back to 30s via `_DEFAULT_AUX_TIMEOUT` when unset.

## Test Plan
- [ ] CLI: Run a background process with `notify_on_complete=true`, verify notification appears in terminal output (not as agent input)
- [ ] delegate_task: Verify weak models generate valid calls with `goal` parameter
- [ ] title_generator: Set `auxiliary.title_generation.timeout: 60` in config.yaml, verify title generation uses 60s timeout

Fixes #41851, Fixes #41823, Fixes #41812
