### PR TITLE
fix(update): refuse unsafe hard reset with local repo state

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6785,6 +6785,68 @@ def _capture_head_sha(git_cmd, cwd) -> str | None:
         return None
 
 
+def _detect_git_operation_in_progress(project_root: Path) -> str | None:
+    """Return a human label if a merge/rebase/cherry-pick/revert/bisect is in
+    progress, or another git process holds ``index.lock`` — else ``None``.
+
+    A destructive ``git reset --hard`` while one of these is mid-flight would
+    compound the mess (and racing another git process on the same index can
+    corrupt it), so the update path must refuse rather than barge in.
+    """
+    git_dir = project_root / ".git"
+    # Worktrees and submodules use a ``.git`` *file* pointing at the real dir.
+    if git_dir.is_file():
+        try:
+            text = git_dir.read_text(encoding="utf-8", errors="replace").strip()
+        except OSError:
+            text = ""
+        if text.startswith("gitdir:"):
+            candidate = Path(text.split(":", 1)[1].strip())
+            git_dir = candidate if candidate.is_absolute() else (project_root / candidate)
+    markers = [
+        ("a merge", git_dir / "MERGE_HEAD"),
+        ("a rebase", git_dir / "rebase-merge"),
+        ("a rebase", git_dir / "rebase-apply"),
+        ("a cherry-pick", git_dir / "CHERRY_PICK_HEAD"),
+        ("a revert", git_dir / "REVERT_HEAD"),
+        ("a bisect", git_dir / "BISECT_LOG"),
+        ("another git process (index.lock present)", git_dir / "index.lock"),
+    ]
+    for label, path in markers:
+        try:
+            if path.exists():
+                return label
+        except OSError:
+            continue
+    return None
+
+
+def _count_local_ahead_commits(git_cmd, project_root: Path, branch: str) -> int | None:
+    """Commits reachable from HEAD but not from ``origin/<branch>``.
+
+    A non-zero count means a hard reset to ``origin/<branch>`` would move the
+    branch ref past — and orphan — local commits that were never pushed
+    (uncommitted work is handled separately by the autostash). Returns
+    ``None`` if the count can't be determined; callers must treat unknown as
+    unsafe.
+    """
+    try:
+        result = subprocess.run(
+            git_cmd + ["rev-list", "--count", f"origin/{branch}..HEAD"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return int(result.stdout.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
 def _validate_critical_files_syntax(root) -> tuple[bool, str | None, str | None]:
     """Compile each file in ``_UPDATE_CRITICAL_FILES`` to catch SyntaxErrors.
 
@@ -10565,8 +10627,51 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
+                # force-pushed or rebased). Uncommitted work is already stashed,
+                # but a hard reset to origin/<branch> ALSO moves the branch ref
+                # past any local commits that were never pushed, silently
+                # orphaning them (recoverable only via reflog). Fail closed:
+                # refuse to auto-reset when local commits would be lost or a git
+                # operation is mid-flight, unless the user explicitly opted into
+                # discarding local divergence (updates.non_interactive_local_changes
+                # = discard). See the auto-updater hard-reset incident, 2026-06-08.
+                op_in_progress = _detect_git_operation_in_progress(PROJECT_ROOT)
+                ahead = _count_local_ahead_commits(git_cmd, PROJECT_ROOT, branch)
+                if op_in_progress is not None:
+                    unsafe_reason = f"{op_in_progress} is in progress"
+                elif ahead is None:
+                    unsafe_reason = "the local commit state could not be determined"
+                elif ahead > 0:
+                    unsafe_reason = (
+                        f"{ahead} local commit(s) on '{branch}' are not on "
+                        f"origin/{branch} and a hard reset would discard them"
+                    )
+                else:
+                    unsafe_reason = None
+
+                if unsafe_reason is not None and not discard_local_changes:
+                    print(f"✗ Refusing to hard-reset to origin/{branch}: {unsafe_reason}.")
+                    print("  No data was discarded — local commits remain in the reflog.")
+                    print("  Resolve deliberately, then re-run `hermes update`:")
+                    print(f"    cd {PROJECT_ROOT}")
+                    print(f"    git log --oneline origin/{branch}..HEAD   # what's local-only")
+                    print(f"    git rebase origin/{branch}                # replay on top, OR")
+                    print(f"    git reset --hard origin/{branch}          # discard (only if sure)")
+                    if auto_stash_ref is not None:
+                        print(f"  Stashed local changes preserved at: {auto_stash_ref}")
+                        print("  Restore them after resolving with: git stash apply")
+                    sys.exit(1)
+
+                if unsafe_reason is not None:
+                    # discard_local_changes is True — an explicit opt-in to throw
+                    # local divergence away. Make the loss visible in the log.
+                    print(
+                        f"  ⚠ {unsafe_reason}; discarding per "
+                        f"updates.non_interactive_local_changes=discard"
+                    )
+
+                # ff-only failed — local and remote have diverged. Local commits
+                # (if any) were confirmed safe to discard above; reset to match.
                 print(
                     "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
                 )

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -473,12 +473,19 @@ def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch,
 def _make_update_side_effect(
     current_branch="main",
     commit_count="3",
+    ahead_count="0",
     ff_only_fails=False,
     reset_fails=False,
     fetch_fails=False,
     fetch_stderr="",
 ):
-    """Build a subprocess.run side_effect for cmd_update tests."""
+    """Build a subprocess.run side_effect for cmd_update tests.
+
+    ``ahead_count`` is what the hard-reset guard's ``rev-list --count
+    origin/<branch>..HEAD`` probe reports — the number of local commits a
+    hard reset would discard. Default "0" keeps the legacy reset-path tests
+    on the safe branch (no local commits → reset proceeds).
+    """
     recorded = []
 
     def side_effect(cmd, **kwargs):
@@ -493,6 +500,10 @@ def _make_update_side_effect(
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-list" in joined:
+            # ``origin/<branch>..HEAD`` → ahead probe (guard); ``HEAD..origin``
+            # → the "are there updates?" behind count.
+            if "..HEAD" in joined:
+                return SimpleNamespace(stdout=f"{ahead_count}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout=f"{commit_count}\n", stderr="", returncode=0)
         if "--ff-only" in joined:
             if ff_only_fails:
@@ -512,11 +523,12 @@ def _make_update_side_effect(
 
 
 def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path, capsys):
-    """When --ff-only fails (diverged history), update resets to origin/{branch}."""
+    """When --ff-only fails (diverged history) AND there are no local commits
+    to lose, update resets to origin/{branch}."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
-    side_effect, recorded = _make_update_side_effect(ff_only_fails=True)
+    side_effect, recorded = _make_update_side_effect(ff_only_fails=True, ahead_count="0")
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
     hermes_main.cmd_update(SimpleNamespace())
@@ -527,6 +539,80 @@ def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path
 
     out = capsys.readouterr().out
     assert "Fast-forward not possible" in out
+
+
+# ---------------------------------------------------------------------------
+# Hard-reset guard: ff-only fallback must NOT silently discard local commits
+# (auto-updater hard-reset incident, 2026-06-08). When local commits exist or
+# a git operation is mid-flight, the update refuses instead of resetting —
+# unless the user explicitly opted into discarding via
+# updates.non_interactive_local_changes=discard.
+# ---------------------------------------------------------------------------
+
+def test_cmd_update_refuses_reset_when_local_commits_would_be_lost(monkeypatch, tmp_path, capsys):
+    """ff-only fails AND local branch is ahead → refuse, do NOT reset --hard."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(ff_only_fails=True, ahead_count="2")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
+    assert reset_calls == [], "guard must not run a destructive reset"
+
+    out = capsys.readouterr().out
+    assert "Refusing to hard-reset" in out
+    assert "2 local commit(s)" in out
+    assert "remain in the reflog" in out
+
+
+def test_cmd_update_refuses_reset_when_git_operation_in_progress(monkeypatch, tmp_path, capsys):
+    """ff-only fails AND a merge is mid-flight → refuse, do NOT reset --hard."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    # Simulate an in-progress merge in the mocked .git dir.
+    (tmp_path / ".git" / "MERGE_HEAD").write_text("deadbeef\n")
+
+    # ahead_count=0, so only the op-in-progress check can trip the guard.
+    side_effect, recorded = _make_update_side_effect(ff_only_fails=True, ahead_count="0")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
+    assert reset_calls == []
+
+    out = capsys.readouterr().out
+    assert "Refusing to hard-reset" in out
+    assert "merge" in out
+
+
+def test_cmd_update_discard_mode_resets_despite_local_commits(monkeypatch, tmp_path, capsys):
+    """With updates.non_interactive_local_changes=discard, an explicit opt-in,
+    the reset proceeds even though local commits exist — but the loss is logged."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(
+        hermes_config, "load_config",
+        lambda *a, **kw: {"updates": {"non_interactive_local_changes": "discard"}},
+    )
+
+    side_effect, recorded = _make_update_side_effect(ff_only_fails=True, ahead_count="3")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    # gateway=True → non-interactive, so the discard setting is honored.
+    hermes_main.cmd_update(SimpleNamespace(gateway=True))
+
+    reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
+    assert len(reset_calls) == 1
+    assert reset_calls[0] == ["git", "reset", "--hard", "origin/main"]
+
+    out = capsys.readouterr().out
+    assert "discarding per" in out
 
 
 def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_update_hard_reset_guard.py
+++ b/tests/hermes_cli/test_update_hard_reset_guard.py
@@ -1,0 +1,125 @@
+"""Tests for the ``hermes update`` hard-reset safety guard.
+
+Background — auto-updater hard-reset incident (2026-06-08): a non-interactive
+``hermes update`` hit a diverged history (``git pull --ff-only`` failed) and
+fell back to ``git reset --hard origin/main``. Uncommitted work is autostashed,
+but a hard reset ALSO moves the branch ref past local commits that were never
+pushed — silently orphaning them (recoverable only via reflog). A local
+``main`` commit was lost this way while a human/agent worked in the same
+checkout.
+
+These tests cover the two helpers the guard relies on, exercised against REAL
+git repositories in ``tmp_path`` (no mocking of git itself), so they prove the
+guard reads actual on-disk repo state correctly. The end-to-end refusal
+behavior in ``cmd_update`` is covered in ``test_update_autostash.py``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import main as hermes_main
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git not available"
+)
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    )
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q", "-b", "main")
+    _git(path, "config", "user.email", "t@example.com")
+    _git(path, "config", "user.name", "t")
+    _git(path, "commit", "-q", "--allow-empty", "-m", "init")
+
+
+# ---------------------------------------------------------------------------
+# _detect_git_operation_in_progress
+# ---------------------------------------------------------------------------
+
+def test_detect_returns_none_on_clean_repo(tmp_path):
+    _init_repo(tmp_path)
+    assert hermes_main._detect_git_operation_in_progress(tmp_path) is None
+
+
+def test_detect_flags_merge_in_progress(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / ".git" / "MERGE_HEAD").write_text("deadbeef\n")
+    assert hermes_main._detect_git_operation_in_progress(tmp_path) == "a merge"
+
+
+def test_detect_flags_cherry_pick_in_progress(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / ".git" / "CHERRY_PICK_HEAD").write_text("deadbeef\n")
+    assert hermes_main._detect_git_operation_in_progress(tmp_path) == "a cherry-pick"
+
+
+def test_detect_flags_rebase_in_progress(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / ".git" / "rebase-merge").mkdir()
+    assert hermes_main._detect_git_operation_in_progress(tmp_path) == "a rebase"
+
+
+def test_detect_flags_index_lock(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / ".git" / "index.lock").write_text("")
+    label = hermes_main._detect_git_operation_in_progress(tmp_path)
+    assert label is not None and "index.lock" in label
+
+
+def test_detect_resolves_gitdir_file_for_worktrees(tmp_path):
+    """A linked worktree has a ``.git`` *file* pointing at the real git dir;
+    the detector must follow it rather than treat the file as a repo dir."""
+    real_git = tmp_path / "realgit"
+    real_git.mkdir()
+    (real_git / "MERGE_HEAD").write_text("deadbeef\n")
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {real_git}\n")
+    assert hermes_main._detect_git_operation_in_progress(worktree) == "a merge"
+
+
+# ---------------------------------------------------------------------------
+# _count_local_ahead_commits
+# ---------------------------------------------------------------------------
+
+def _clone_with_remote(tmp_path: Path) -> Path:
+    """Create a bare origin + working clone with main tracking origin/main."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    _git(origin, "init", "-q", "--bare", "-b", "main")
+
+    work = tmp_path / "work"
+    _init_repo(work)
+    _git(work, "remote", "add", "origin", str(origin))
+    _git(work, "push", "-q", "-u", "origin", "main")
+    return work
+
+
+def test_ahead_count_zero_when_in_sync(tmp_path):
+    work = _clone_with_remote(tmp_path)
+    assert hermes_main._count_local_ahead_commits(["git"], work, "main") == 0
+
+
+def test_ahead_count_reflects_unpushed_local_commits(tmp_path):
+    work = _clone_with_remote(tmp_path)
+    _git(work, "commit", "-q", "--allow-empty", "-m", "local 1")
+    _git(work, "commit", "-q", "--allow-empty", "-m", "local 2")
+    assert hermes_main._count_local_ahead_commits(["git"], work, "main") == 2
+
+
+def test_ahead_count_none_when_origin_ref_missing(tmp_path):
+    """No origin/<branch> ref → rev-list errors → guard treats as unknown."""
+    work = tmp_path / "noremote"
+    _init_repo(work)
+    assert hermes_main._count_local_ahead_commits(["git"], work, "main") is None


### PR DESCRIPTION
# PR draft — Refuse unsafe hard reset during `hermes update`

## Title

```text
fix(update): refuse unsafe hard reset with local repo state
```

## Branch

```text
pr/update-hard-reset-guard
```

Local status at preparation time:

```text
Branch: pr/update-hard-reset-guard
Base: origin/main
Ahead/behind: 1 / 0
Commit: 1741c0fe2 fix(update): refuse unsafe auto reset with local repo state
```

## Summary

This PR makes the `hermes update` fallback from `git pull --ff-only` to `git reset --hard origin/<branch>` fail closed when local repo state indicates that a hard reset could discard local work.

Previously, if `git pull --ff-only` failed because local and remote history diverged, the update flow unconditionally ran:

```bash
git reset --hard origin/<branch>
```

The existing autostash only protected uncommitted work. It did not protect committed-but-unpushed local commits, which could be orphaned silently and only recovered via reflog.

The new guard blocks the destructive fallback when:

- the local branch has ahead commits compared to `origin/<branch>`;
- the ahead count cannot be determined;
- a merge/rebase/cherry-pick/revert/bisect is in progress;
- `.git/index.lock` exists, indicating another git operation may be active.

If unsafe state is detected, the update exits with recovery instructions instead of resetting. Explicit discard mode remains supported via `updates.non_interactive_local_changes=discard`, but the loss is logged clearly.

## Why

A hard reset after a failed fast-forward pull is safe only when the local branch has no unique commits and no active git operation. Otherwise it can silently move the branch ref away from local commits.

This is especially risky for automated or non-interactive updates, where the user may not see the destructive fallback happen.

## What changed

Files:

```text
hermes_cli/main.py
tests/hermes_cli/test_update_autostash.py
tests/hermes_cli/test_update_hard_reset_guard.py
```

Main changes:

- Add `_detect_git_operation_in_progress(project_root)`.
- Add `_count_local_ahead_commits(git_cmd, project_root, branch)`.
- Guard the `reset --hard origin/<branch>` fallback after `git pull --ff-only` failure.
- Preserve explicit discard behavior.
- Add helper-level tests using real temporary git repositories.
- Add end-to-end update-flow tests for refusal and discard behavior.

Not changed:

- The normal `git pull --ff-only` path.
- The syntax-check rollback reset to the pre-update SHA; that rollback restores a known previous state and is not the same data-loss footgun.
- Gateway/launchd/runtime behavior.

## Test plan

Executed locally:

```bash
cd /Users/openclawmark/.hermes/hermes-agent
venv/bin/python -m py_compile hermes_cli/main.py tests/hermes_cli/test_update_hard_reset_guard.py tests/hermes_cli/test_update_autostash.py
venv/bin/python -m pytest tests/hermes_cli/test_update_hard_reset_guard.py tests/hermes_cli/test_update_autostash.py -q -o 'addopts='
```

Result:

```text
42 passed in 39.58s
```

Diff stat:

```text
hermes_cli/main.py                               | 109 +++++++++++++++++++-
tests/hermes_cli/test_update_autostash.py        |  92 ++++++++++++++++-
tests/hermes_cli/test_update_hard_reset_guard.py | 125 +++++++++++++++++++++++
3 files changed, 321 insertions(+), 5 deletions(-)
```

## Notes for maintainer

This PR intentionally chooses safety over silent recovery in ambiguous states. If update automation wants destructive behavior, it must opt into discard mode explicitly.

Potential future improvement, not included here: refuse `hermes update` from non-update branches unless explicitly requested. This PR focuses only on preventing silent loss of local commits/work during the hard-reset fallback.
