### PR TITLE
fix(process): strip tcsetattr noise from bg process notification output (#41698)

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1225,3 +1225,53 @@ class TestTerminateHostPidPosix:
         pr.ProcessRegistry._terminate_host_pid(12345)
 
         assert kill_calls == [(12345, signal.SIGTERM)]
+
+
+class TestCleanShellNoise:
+    """Tests for _clean_shell_noise() — strip shell noise from output."""
+
+    def test_strips_tcsetattr_from_beginning(self):
+        from tools.process_registry import ProcessRegistry as pr
+        text = "tcsetattr: Inappropriate ioctl for device\nsome real output"
+        result = pr._clean_shell_noise(text)
+        assert result == "some real output"
+
+    def test_strips_tcsetattr_from_end(self):
+        from tools.process_registry import ProcessRegistry as pr
+        text = "some real output\ntcsetattr: Inappropriate ioctl for device"
+        result = pr._clean_shell_noise(text)
+        assert result == "some real output"
+
+    def test_strips_multiple_noise_lines_from_end(self):
+        from tools.process_registry import ProcessRegistry as pr
+        text = "real output\nbash: no job control in this shell\ntcsetattr: Inappropriate ioctl for device"
+        result = pr._clean_shell_noise(text)
+        assert result == "real output"
+
+    def test_strips_noise_from_both_ends(self):
+        from tools.process_registry import ProcessRegistry as pr
+        text = "bash: cannot set terminal process group\nreal output\ntcsetattr: Inappropriate ioctl for device"
+        result = pr._clean_shell_noise(text)
+        assert result == "real output"
+
+    def test_passthrough_clean_output(self):
+        from tools.process_registry import ProcessRegistry as pr
+        text = "line 1\nline 2\nline 3"
+        result = pr._clean_shell_noise(text)
+        assert result == text
+
+    def test_empty_string(self):
+        from tools.process_registry import ProcessRegistry as pr
+        assert pr._clean_shell_noise("") == ""
+
+    def test_only_noise_lines(self):
+        from tools.process_registry import ProcessRegistry as pr
+        text = "tcsetattr: Inappropriate ioctl for device\nbash: no job control in this shell"
+        result = pr._clean_shell_noise(text)
+        assert result == ""
+
+    def test_noise_in_middle_preserved(self):
+        from tools.process_registry import ProcessRegistry as pr
+        text = "line 1\ntcsetattr: Inappropriate ioctl for device\nline 3"
+        result = pr._clean_shell_noise(text)
+        assert result == text

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -182,10 +182,12 @@ class ProcessRegistry:
 
     @staticmethod
     def _clean_shell_noise(text: str) -> str:
-        """Strip shell startup warnings from the beginning of output."""
+        """Strip shell startup/exit warnings from the beginning and end of output."""
         lines = text.split("\n")
         while lines and any(noise in lines[0] for noise in ProcessRegistry._SHELL_NOISE_SUBSTRINGS):
             lines.pop(0)
+        while lines and any(noise in lines[-1] for noise in ProcessRegistry._SHELL_NOISE_SUBSTRINGS):
+            lines.pop()
         return "\n".join(lines)
 
     def _check_watch_patterns(self, session: ProcessSession, new_text: str) -> None:
@@ -877,6 +879,7 @@ class ProcessRegistry:
         if was_running and session.notify_on_complete:
             from tools.ansi_strip import strip_ansi
             output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
+            output_tail = ProcessRegistry._clean_shell_noise(output_tail)
             self.completion_queue.put({
                 "type": "completion",
                 "session_id": session.id,
@@ -1505,7 +1508,7 @@ def format_process_notification(evt: dict) -> "str | None":
 
     if evt_type == "watch_match":
         _pat = evt.get("pattern", "?")
-        _out = evt.get("output", "")
+        _out = ProcessRegistry._clean_shell_noise(evt.get("output", ""))
         _sup = evt.get("suppressed", 0)
         text = (
             f"[IMPORTANT: Background process {_sid} matched "
@@ -1519,7 +1522,7 @@ def format_process_notification(evt: dict) -> "str | None":
         return text
 
     _exit = evt.get("exit_code", "?")
-    _out = evt.get("output", "")
+    _out = ProcessRegistry._clean_shell_noise(evt.get("output", ""))
     return (
         f"[IMPORTANT: Background process {_sid} completed "
         f"(exit code {_exit}).\n"


### PR DESCRIPTION
## Summary

Background process completion notifications leak `tcsetattr: Inappropriate ioctl for device` into the `[IMPORTANT: ...]` message. This happens because background processes use `bash -lic` (interactive flag), and bash's exit cleanup tries terminal I/O control on `/dev/null` stdin.

## Root Cause

`_clean_shell_noise()` already existed and listed `tcsetattr: Inappropriate ioctl for device` in `_SHELL_NOISE_SUBSTRINGS`, but only stripped noise from the **beginning** of output. The error appears at the **end** (during shell exit), so it was never caught.

## Changes

- **`tools/process_registry.py`**: Extended `_clean_shell_noise()` to also strip noise lines from the end of output. Applied it to the completion notification output in `_move_to_finished()` and in `format_process_notification()` (both completion and watch_match events).
- **`tests/tools/test_process_registry.py`**: 8 new tests for end-stripping, both-ends stripping, passthrough, empty string, noise-only, and noise-in-middle preservation.

## Validation

- 74/74 process registry tests pass (including 8 new)
- All existing tests unaffected

Fixes #41698