### PR TITLE
feat(skills): add supply-chain-hunter, model-benchmark, douyin-content-extractor

### DIFF
--- a/skills/devops/model-benchmark/SKILL.md
+++ b/skills/devops/model-benchmark/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: model-benchmark
+description: "Use when benchmarking, comparing, or evaluating Hermes provider/model combinations for reasoning, instruction-following, format compliance, stability, and speed. Runs per-question independent hermes chat calls, grades answers automatically, and produces a comparison matrix. Triggers: benchmark, model comparison, model evaluation, model scoring, compare models, provider comparison."
+version: 2.0.0
+author: Community
+license: MIT
+metadata:
+ hermes:
+ tags: [benchmark, model-evaluation, comparison, testing, provider]
+ related_skills: [hermes-provider-config]
+---
+
+# Hermes Native Model Benchmark
+
+## Goal
+
+This is the **Hermes-native** model benchmark skill. It replaces the legacy OpenClaw-based `model-benchmark`.
+
+Key differences from the legacy version:
+
+- ✅ Uses the local `hermes chat` CLI to invoke models
+- ✅ **Per-question independent calls** (v2.0.0): each candidate × each question = one independent `hermes chat` call, so models cannot cross-pollinate answers
+- ✅ No dependency on OpenClaw `sessions_spawn`
+- ✅ Outputs land in `~/.hermes/benchmarks/<run_id>/`
+- ✅ Supports multi provider/model sequential evaluation, parsing, automatic grading, and Markdown summary (including a model comparison matrix)
+
+## When to use
+
+Use this skill when the user wants to:
+
+- benchmark / score / evaluate models
+- compare the capability of multiple models
+- evaluate whether a provider/model is suitable for cron, writing, reasoning, code, etc.
+- run a uniform question set against models from different providers (Claude, GPT, Gemini, GLM, Qwen, DeepSeek, MiniMax, etc.)
+
+## Quick start
+
+Script path:
+
+```bash
+scripts/hermes_model_benchmark.py
+```
+
+One-shot benchmark (recommended):
+
+```bash
+python3 scripts/hermes_model_benchmark.py benchmark \
+ --difficulty expert --count10 --seed601 \
+ --candidate m1=provider-a::model-x \
+ --candidate m2=provider-b::model-y \
+ --candidate m3=provider-c::model-z \
+ --timeout60
+```
+
+Candidate model format:
+
+```text
+NAME=PROVIDER::MODEL
+```
+
+Examples:
+
+```text
+m1=provider-a::model-x
+m2=default::model-y # uses current provider/base_url from config.yaml
+m3=custom::model-z # custom provider; the script injects it via an isolated HERMES_HOME
+m4=default::model-w # uses the current config provider; --provider is omitted
+```
+
+> Note: `provider` must be a provider currently supported by the Hermes CLI, or a custom provider that this script supports internally (currently only `deepseek-v4`). `default` / `config` / `current` are script aliases. Do not casually use `auto` for formal benchmarks: `auto` follows the runtime's primary provider and may trigger fallback if the model name does not match.
+
+## Subcommands
+
+### 🔥 Main command: `benchmark` (v2.0.0, recommended)
+
+Per-question independent evaluation. Each candidate model × each question = one independent `hermes chat` call.
+
+```bash
+python3 scripts/hermes_model_benchmark.py benchmark \
+ --difficulty expert --count10 --seed601 \
+ --candidate m1=provider-a::model-x \
+ --candidate m2=provider-b::model-y \
+ --timeout60
+```
+
+`--difficulty` supports: `easy` / `medium` / `mixed` / `instruction` / `hard` / `expert`.
+
+`--timeout` is the **per-question timeout** (seconds). Total wall time ≈ candidates × questions × per-question time.
+
+Output structure:
+
+```text
+~/.hermes/benchmarks/<run_id>/
+├── questions.json # question set
+├── summary.json # structured scoring report
+├── summary.md # Markdown report (with comparison matrix)
+├── raw/
+│ ├── m1_expert_math_001.txt # one raw file per candidate × question
+│ ├── m1_expert_code_001.txt
+│ ├── m2_expert_math_001.txt
+│ └── ...
+└── answers/
+ ├── m1.json # aggregated answers
+ └── m2.json
+```
+
+#### Automated `benchmark` pipeline
+
+```
+benchmark = generate_questions() → for each candidate, for each question: run_hermes() → aggregate() → grade_run() → verify_run()
+```
+
+The entire process is automatic — no manual steps required.
+
+### Supporting subcommands (used internally by `benchmark`)
+
+The `benchmark` subcommand chains together several lower-level subcommands. You usually do not need to invoke them directly, but they are available for ad-hoc workflows.
+
+#### `generate` — produce a question set
+
+```bash
+python3 scripts/hermes_model_benchmark.py generate --difficulty easy --count8
+```
+
+Output: `~/.hermes/benchmarks/<run_id>/questions.json`
+
+#### `grade` — score a run
+
+```bash
+python3 scripts/hermes_model_benchmark.py grade --run-dir ~/.hermes/benchmarks/<run_id>
+```
+
+Output: `summary.json` + `summary.md`
+
+#### `verify` — post-run identity check
+
+```bash
+python3 scripts/hermes_model_benchmark.py verify --run-dir ~/.hermes/benchmarks/<run_id>
+```
+
+Runs two automatic checks:
+1. **MD5 identity check** — compares the MD5 of the first200 chars of each model's `raw/*.txt`
+2. **Fallback contamination check** — searches for `Fallback activated`
+
+The `benchmark` subcommand automatically invokes `verify` when it finishes.
+
+## Model comparison matrix
+
+The `summary.md` produced by the `benchmark` subcommand contains a comparison matrix that makes per-question differences between models immediately visible:
+
+```text
+## Model Comparison Matrix
+
+|题目 | m1 | m2 | m3 |正确答案 |
+|---|:---:|:---:|:---:|:---:|
+| expert_math_001 | ✅下降10.9% | ✅下降10.9% | ✅下降10.9% |下降10.9% |
+| expert_code_001 | ✅5 | ✅5 | ✅5 |5 |
+| expert_reason_001 | ✅ A | ✅ A | ❌ C | A |
+```
+
+This is the core value of v2.0.0: **see real per-question model differences at a glance**.
+
+## Multi-round stability testing
+
+When you need to formally compare model capabilities, run at least `3×expert +1×hard` with different seeds:
+
+```bash
+SCRIPT=scripts/hermes_model_benchmark.py
+C1='--candidate m1=provider-a::model-x'
+C2='--candidate m2=provider-b::model-y'
+C3='--candidate m3=provider-c::model-z'
+
+python3 "$SCRIPT" benchmark --difficulty expert --count10 --seed601 $C1 $C2 $C3 --timeout60
+python3 "$SCRIPT" benchmark --difficulty expert --count10 --seed602 $C1 $C2 $C3 --timeout60
+python3 "$SCRIPT" benchmark --difficulty expert --count10 --seed603 $C1 $C2 $C3 --timeout60
+python3 "$SCRIPT" benchmark --difficulty hard --count8 --seed701 $C1 $C2 $C3 --timeout60
+```
+
+### Cross-provider comparison (strongly recommended)
+
+Each candidate model should route through a **different provider backend**:
+
+```bash
+SCRIPT=scripts/hermes_model_benchmark.py
+python3 "$SCRIPT" benchmark --difficulty expert --count10 --seed777 \
+ --candidate m1=provider-a::model-x \
+ --candidate m2=provider-b::model-y \
+ --candidate m3=provider-c::model-z \
+ --timeout60
+```
+
+Pass criteria: **models on different providers have different MD5s and no fallback records appear**. If either condition is violated, that round's results are not trustworthy.
+
+## Methodology limitations & verification
+
+### Model identity verification (mandatory!)
+
+When multiple candidate models use the same provider (especially `default::` / shared gateways), the backend API may **not distinguish model names** — all model names route to the same underlying model and return byte-identical outputs.
+
+The `benchmark` subcommand automatically runs `verify` after completing, which detects MD5 collisions and fallback events.
+
+Manual verification fallback:
+```bash
+for f in ~/.hermes/benchmarks/<run_id>/raw/*.txt; do
+ echo "$(basename $f): $(head -c200 "$f" | md5)"
+done
+```
+
+If multiple models have the same MD5 (only `session_id` differs), **the backend did not actually switch models and that candidate's results cannot be trusted**.
+
+### Fallback contamination check
+
+How to inspect:
+```bash
+grep "FALLBACK\|Fallback activated" ~/.hermes/logs/agent.log | grep <session_id>
+```
+
+When fallback is detected, the candidate's results are marked as "contaminated" and excluded from accuracy rankings.
+
+### Answer-key error risk and review
+
+**The `expected` values in the `expert` question set can themselves be wrong** (previous evaluations found answer-key errors in3 of10 questions). If every model gives the same answer but the answer key disagrees, manually verify that question's logic.
+
+Known historical answer-key errors (already corrected in the bundled question set):
+
+| Question ID | Old (incorrect) value | Correct value | Reason |
+|-------------|----------------------|---------------|--------|
+| `expert_math_001` |下降1% |下降10.9% |1×1.1×0.9×0.9 =0.891 |
+| `expert_planning_001` |9 |8 | Critical path A→B→D→E =2+3+1+2 =8 |
+| `expert_logic_001` | C | B | When B is guilty:3 true /1 false; when C is guilty:1 true /3 false |
+
+> See `references/expert-expected-answer-errors.md` for details.
+
+## Empirical conclusions
+
+1. **The v1.x "one prompt, all questions" design is fundamentally flawed**: bundling every question into one prompt lets models cross-confirm answers, hiding per-question differences. Previous v1.x runs reported identical scores across three different backends (the identical incorrect expected answer masked the spread). Switching to v2.0.0 per-question independent evaluation immediately revealed specific questions where some models failed. **Every benchmark MUST invoke the model per question — never let the model see all questions at once.**
+
+2. **Short-answer automatic grading is fine for fast, reproducible comparison**, but is not suitable for open-ended long-form reasoning, code review, or investment analysis. For those tasks, add a longform question set or introduce an LLM judge / human review.
+
+3. **DeepSeek V4 Flash format stability**: even with the `reasoning_content` return-path fix applied, intermittent JSON format failures still occur. This model is better suited as a low-cost fallback than as a primary evaluation model.
+
+4. **Temporary `HERMES_HOME` without user plugins → false negatives**: `prepare_candidate_env()` must copy the `plugins/` directory into the temporary `HERMES_HOME`, otherwise plugin-dependent provider initialization will crash (see `references/temp-env-plugin-gap.md`).
+
+5. **The `expert` difficulty has demonstrated real discriminative power**: previous evaluations show strong models scoring10/10 on the expert set with notable speed differences, while weaker models miss specific questions.
+
+## Evaluation scope
+
+Default question types covered:
+
+- Logical reasoning
+- Arithmetic and ratios
+- Instruction following
+- Text extraction
+- Simple code / data understanding
+
+Default grading is deterministic exact / numeric / multiple-choice — no LLM judge is used.
+
+## Interpreting the output
+
+`summary.md` contains:
+
+- **Model comparison matrix**: pass/fail status for every candidate × every question (new in v2.0.0)
+- Each model's total score and accuracy
+- Average elapsed time
+- JSON format compliance
+- Per-question correctness breakdown
+
+## Constraints and notes
+
+1. **Do not use the legacy OpenClaw flow**. If `~/.hermes/skills/openclaw-imports/model-benchmark` reappears, delete or migrate it first.
+2. **Sequential execution by default**: avoids provider rate limits and local session contention. The v2.0.0 per-question design already guarantees each candidate runs sequentially.
+3. **Use `--ignore-rules`**: the script skips persona/skill injection to reduce context pollution.
+4. **Use `--max-turns1`**: prevents the model from calling tools.
+5. **For formal model comparison, run at least3 rounds with different seeds**: a single round is only suitable for quick screening.
+6. **Foreground command timeout ceiling is600 seconds**: the Hermes terminal foreground `timeout` cannot exceed600. If a multi-round benchmark is expected to exceed10 minutes, use `background=true` + `notify_on_complete=true`.
+7. **Answer-key error check**: if every model gives the same answer but the answer key disagrees, manually verify (see "Answer-key error risk and review").
+8. **Don't look at average score alone**: also examine question-type failures, speed, and the matrix table. Two models may have identical accuracy but one may be2× faster.
+9. **Verify the actual route before trusting results**: after a run, check the `verify` output. If it flags identity or fallback warnings, that round's results are unreliable.
+10. **The `benchmark` subcommand's `--timeout` is per-question**, not the total wall time. Total wall time ≈ candidates × questions × per-question time.
+
+## FAQ
+
+### Model does not emit valid JSON
+
+The script tries to extract the first JSON object from the output. If that still fails, the model's `format_ok=false`.
+
+### Provider does not exist
+
+Run:
+
+```bash
+hermes chat --help
+```
+
+to confirm the provider name.
+
+### Evaluating the current default model
+
+Use `default` as the provider name:
+
+```text
+current=default::model-name
+```
+
+## Verification command
+
+```bash
+python3 scripts/hermes_model_benchmark.py benchmark \
+ --difficulty easy --count2 --seed42 \
+ --candidate test=provider-a::model-x \
+ --timeout30
+```
+
+If this produces a `summary.md` containing the comparison matrix, the skill is working correctly.

--- a/skills/devops/model-benchmark/scripts/hermes_model_benchmark.py
+++ b/skills/devops/model-benchmark/scripts/hermes_model_benchmark.py
@@ -1,0 +1,1228 @@
+#!/usr/bin/env python3
+"""Hermes-native model benchmark runner.
+
+No OpenClaw dependency. Calls `hermes chat` directly for each candidate model.
+Outputs are written under ~/.hermes/benchmarks/<run_id>/.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import math
+import os
+import random
+import re
+import shutil
+import string
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+HOME = Path.home()
+BENCH_ROOT = HOME / ".hermes" / "benchmarks"
+SCRIPT_VERSION = "2.0.0"
+
+CUSTOM_PROVIDER_CONFIGS: Dict[str, Dict[str, Any]] = {
+    "deepseek-v4": {
+        "name": "deepseek-v4",
+        "base_url": "https://api.deepseek.com/v1",
+        "api_key": "${DEEPSEEK_API_KEY}",
+        "models": {
+            "deepseek-v4-flash": {"context_length": 1048576},
+            "deepseek-v4-pro": {"context_length": 1048576},
+        },
+    },
+}
+
+EASY_QUESTIONS: List[Dict[str, Any]] = [
+    {
+        "id": "logic_e_001",
+        "subject": "logic",
+        "question": "三个人 A、B、C。只有一个人说真话。A 说：B 在说谎。B 说：C 在说谎。C 说：A 和 B 都在说谎。谁说真话？只回答 A、B 或 C。",
+        "answer_type": "mc",
+        "expected": "B",
+    },
+    {
+        "id": "math_e_001",
+        "subject": "math",
+        "question": "计算 17 × 6 + 13。只回答数字。",
+        "answer_type": "numeric",
+        "expected": 115,
+    },
+    {
+        "id": "math_e_002",
+        "subject": "math",
+        "question": "一个数的 25% 是 18，这个数是多少？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 72,
+    },
+    {
+        "id": "instruction_e_001",
+        "subject": "instruction",
+        "question": "请把单词 banana 的字母按字母表顺序排列。只回答排序后的字符串。",
+        "answer_type": "exact",
+        "expected": "aaabnn",
+    },
+    {
+        "id": "extract_e_001",
+        "subject": "extraction",
+        "question": "从这句话中提取订单号：'客户备注：请加急处理，订单号 ORD-7392-Z，收件人李明。' 只回答订单号。",
+        "answer_type": "exact",
+        "expected": "ORD-7392-Z",
+        "aliases": ["ord-7392-z"],
+    },
+    {
+        "id": "code_e_001",
+        "subject": "code",
+        "question": "Python 表达式 len(set([1, 2, 2, 3, 3, 3])) 的结果是多少？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 3,
+    },
+    {
+        "id": "reason_e_001",
+        "subject": "reasoning",
+        "question": "所有蓝色球都在盒子里。有些盒子里的球是红色的。能否推出：有些蓝色球是红色的？只回答 能 或 不能。",
+        "answer_type": "exact",
+        "expected": "不能",
+        "aliases": ["不可以", "无法推出", "不能推出"],
+    },
+    {
+        "id": "math_e_003",
+        "subject": "math",
+        "question": "一本书原价 80 元，打 7.5 折后多少钱？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 60,
+    },
+]
+
+MEDIUM_QUESTIONS: List[Dict[str, Any]] = [
+    {
+        "id": "logic_m_001",
+        "subject": "logic",
+        "question": "四个盒子 A/B/C/D，只有一个有奖品。标签如下：A:'奖品在 B'，B:'奖品不在 C'，C:'奖品在 A 或 D'，D:'奖品不在 B'。已知四个标签中恰好两个为真。奖品在哪个盒子？只回答 A、B、C 或 D。",
+        "answer_type": "mc",
+        "expected": "B",
+    },
+    {
+        "id": "math_m_001",
+        "subject": "math",
+        "question": "价格先上涨 20%，再下跌 20%。最终价格相对原价变化多少？只回答类似 '下降4%' 或 '上涨X%'。",
+        "answer_type": "exact",
+        "expected": "下降4%",
+        "aliases": ["下降 4%", "下跌4%", "下跌 4%", "减少4%", "减少 4%", "-4%"],
+    },
+    {
+        "id": "math_m_002",
+        "subject": "math",
+        "question": "甲乙两人合做一项工作，甲单独做需 6 天，乙单独做需 3 天。两人合做需要几天？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 2,
+    },
+    {
+        "id": "instruction_m_001",
+        "subject": "instruction",
+        "question": "请只输出 JSON：键为 result，值为字符串 'ok'。不要输出任何解释。",
+        "answer_type": "json_field",
+        "expected": {"result": "ok"},
+    },
+    {
+        "id": "extract_m_001",
+        "subject": "extraction",
+        "question": "文本：'Q1 收入 120，Q2 收入 150，Q3 收入 135。' 哪个季度收入最高？只回答季度，如 Q1。",
+        "answer_type": "exact",
+        "expected": "Q2",
+        "aliases": ["q2"],
+    },
+    {
+        "id": "code_m_001",
+        "subject": "code",
+        "question": "给定伪代码：x=1; for i in [2,3,4]: x=x*i; 最终 x 是多少？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 24,
+    },
+    {
+        "id": "reason_m_001",
+        "subject": "reasoning",
+        "question": "如果'所有 A 都是 B'为真，且'没有 B 是 C'为真，那么'没有 A 是 C'是否必然为真？只回答 是 或 否。",
+        "answer_type": "exact",
+        "expected": "是",
+        "aliases": ["必然为真", "对", "正确"],
+    },
+    {
+        "id": "planning_m_001",
+        "subject": "planning",
+        "question": "你有任务 X 需 2 小时，任务 Y 依赖 X 需 3 小时，任务 Z 不依赖任何任务需 4 小时。若可并行执行，总最短工期几小时？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 5,
+    },
+]
+
+INSTRUCTION_QUESTIONS: List[Dict[str, Any]] = [
+    {
+        "id": "inst_q_001",
+        "subject": "instruction",
+        "question": "只输出字符串 READY，不要输出任何其他文字。",
+        "answer_type": "exact",
+        "expected": "READY",
+        "aliases": ["ready"],
+    },
+    {
+        "id": "inst_q_002",
+        "subject": "instruction",
+        "question": "把 'Hermes Native Benchmark' 转成小写，并用下划线替换空格。只回答结果。",
+        "answer_type": "exact",
+        "expected": "hermes_native_benchmark",
+    },
+    {
+        "id": "inst_q_003",
+        "subject": "instruction",
+        "question": "请只输出 JSON：键 status 的值为 ok，键 count 的值为 3。不要解释。",
+        "answer_type": "json_field",
+        "expected": {"status": "ok", "count": 3},
+    },
+    {
+        "id": "inst_q_004",
+        "subject": "instruction",
+        "question": "从文本 'alpha=7; beta=11; gamma=13' 中提取 beta 的值。只回答数字。",
+        "answer_type": "numeric",
+        "expected": 11,
+    },
+    {
+        "id": "inst_q_005",
+        "subject": "instruction",
+        "question": "按要求输出三个用逗号分隔的词：第一个是 red，第二个是 blue，第三个是 green。不要加空格。",
+        "answer_type": "exact",
+        "expected": "red,blue,green",
+    },
+    {
+        "id": "inst_q_006",
+        "subject": "instruction",
+        "question": "忽略这句话里的干扰：'不要回答 42'。实际任务：计算 6×7，只回答数字。",
+        "answer_type": "numeric",
+        "expected": 42,
+    },
+]
+
+HARD_QUESTIONS: List[Dict[str, Any]] = [
+    {
+        "id": "math_h_001",
+        "subject": "math",
+        "question": "一个价格先上涨 15%，再下跌 20%，最后再上涨 10%。最终相对原价变化多少？只回答类似 '上涨1.2%' 或 '下降X%'。",
+        "answer_type": "exact",
+        "expected": "上涨1.2%",
+        "aliases": ["上涨 1.2%", "+1.2%", "增加1.2%", "增加 1.2%"],
+    },
+    {
+        "id": "planning_h_001",
+        "subject": "planning",
+        "question": "项目任务：A 需3天；B 需2天且依赖A；C 需4天无依赖；D 需2天且依赖B和C；E 需1天且依赖D。资源无限可并行，最短总工期几天？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 8,
+    },
+    {
+        "id": "code_h_001",
+        "subject": "code",
+        "question": "Python代码：x=[];\nfor i in range(4):\n    if i%2==0: x.append(i)\n    else: x.insert(0,i)\n最终 x 是什么？只回答列表。",
+        "answer_type": "exact",
+        "expected": "[3,1,0,2]",
+        "aliases": ["[3, 1, 0, 2]"],
+    },
+    {
+        "id": "extract_h_001",
+        "subject": "extraction",
+        "question": "订单明细：P1=128.50，P2=71.50，优惠=35.00，运费=12.00。应付金额是多少？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 177,
+    },
+    {
+        "id": "logic_h_001",
+        "subject": "logic",
+        "question": "命题 '(A 或 B) 且 非(A 且 B)' 为真，且 A 为真。B 必须为真还是为假？只回答 真 或 假。",
+        "answer_type": "exact",
+        "expected": "假",
+        "aliases": ["false", "不真", "为假"],
+    },
+    {
+        "id": "prob_h_001",
+        "subject": "probability",
+        "question": "同时掷两个公平六面骰，点数和大于等于10的概率是多少？只回答最简分数。",
+        "answer_type": "exact",
+        "expected": "1/6",
+        "aliases": ["6/36"],
+    },
+    {
+        "id": "code_h_002",
+        "subject": "code",
+        "question": "递归定义：f(0)=1, f(1)=1, f(n)=f(n-1)+2*f(n-2)。f(4) 等于多少？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 11,
+    },
+    {
+        "id": "json_h_001",
+        "subject": "instruction",
+        "question": "请只输出 JSON：risk='low'，items 为数组 ['A','C']，total 为 2。不要解释。",
+        "answer_type": "json_field",
+        "expected": {"risk": "low", "items": ["A", "C"], "total": 2},
+    },
+]
+
+EXPERT_QUESTIONS: List[Dict[str, Any]] = [
+    {
+        "id": "expert_logic_001",
+        "subject": "logic",
+        "question": "有四个嫌疑人 A、B、C、D。只有一人是凶手。供词如下：A说'B是凶手'，B说'D是凶手'，C说'我不是凶手'，D说'B在说谎'。已知三人说真话，一人说假话。谁是凶手？只回答字母。",
+        "answer_type": "mc",
+        "expected": "B",
+        "aliases": ["b"],
+    },
+    {
+        "id": "expert_math_001",
+        "subject": "math",
+        "question": "一件商品先涨价 10%，然后打9折，再降价 10%。最终价格相比原价变化多少？只回答类似 '下降1%' 或 '上涨X%'。",
+        "answer_type": "exact",
+        "expected": "下降10.9%",
+        "aliases": ["下降 10.9%", "下跌10.9%", "下跌 10.9%", "减少10.9%", "减少 10.9%", "-10.9%"],
+    },
+    {
+        "id": "expert_code_001",
+        "subject": "code",
+        "question": "Python: x=[1,2,3]; y=x; y.append(4); x.append(5); print(len(x)) 输出多少？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 5,
+    },
+    {
+        "id": "expert_reason_001",
+        "subject": "reasoning",
+        "question": "所有人都会犯错。有些犯错的人会改正。小明从不犯错。以下哪个必然为真？A.小明不是人  B.小明会改正  C.小明不会犯错  D.无法判断 只回答字母。",
+        "answer_type": "mc",
+        "expected": "A",
+        "aliases": ["a"],
+    },
+    {
+        "id": "expert_prob_001",
+        "subject": "probability",
+        "question": "一对夫妇有两个孩子。已知至少有一个男孩，两个都是男孩的概率是多少？只回答分数。",
+        "answer_type": "exact",
+        "expected": "1/3",
+        "aliases": ["33.3%", "0.333", "33%"],
+    },
+    {
+        "id": "expert_planning_001",
+        "subject": "planning",
+        "question": "项目：A(2天)▶B(3天)▶D(1天); C(4天)▶D(1天); D▶E(2天)。A和C可并行。资源无限。最短工期几天？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 8,
+    },
+    {
+        "id": "expert_code_002",
+        "subject": "code",
+        "question": "JavaScript: console.log(typeof null) 输出什么？只回答字符串。",
+        "answer_type": "exact",
+        "expected": "object",
+        "aliases": ["'object'"],
+    },
+    {
+        "id": "expert_extract_001",
+        "subject": "extraction",
+        "question": "协议条款：'甲方应于2026年3月15日前支付首期款50000元（大写：伍万元整）。二期款75000元应于2026年6月30日前支付。' 二期款金额是多少？只回答数字。",
+        "answer_type": "numeric",
+        "expected": 75000,
+    },
+    {
+        "id": "expert_logic_002",
+        "subject": "logic",
+        "question": "如果'所有艺术家都是音乐家'为真，'有些音乐家是画家'为真，'没有画家是作家'为真。以下哪个必然为真？A.有些艺术家是画家 B.有些艺术家不是作家 C.有些音乐家不是作家 D.无法确定 只回答字母。",
+        "answer_type": "mc",
+        "expected": "C",
+        "aliases": ["c"],
+    },
+    {
+        "id": "expert_math_002",
+        "subject": "math",
+        "question": "一个班级 60% 是男生，男生中 30% 戴眼镜，女生中 20% 戴眼镜。随机选一个学生，发现戴眼镜，这个学生是男生的概率是多少？只回答最简分数。",
+        "answer_type": "exact",
+        "expected": "9/13",
+        "aliases": ["0.692", "69.2%", "69%"],
+    },
+    {
+        "id": "expert_math_003",
+        "subject": "math",
+        "question": "一种溶液含 99% 的水和 1% 的盐（按质量）。蒸发掉一些水后，水的比例降到了 98%。现在盐占总质量的百分之几？只回答数字如 2。",
+        "answer_type": "numeric",
+        "expected": 2,
+    },
+    {
+        "id": "expert_code_003",
+        "subject": "code",
+        "question": "Python 代码：\nx = [1]\ndef f():\n    x = x + [2]\n    return x\nf()\n输出什么？只回答异常类型如 IndexError 或结果。",
+        "answer_type": "exact",
+        "expected": "UnboundLocalError",
+        "aliases": ["UnboundLocalError", "错误", "Error"],
+    },
+    {
+        "id": "expert_prob_002",
+        "subject": "probability",
+        "question": "一架飞往纽约的飞机有 100 个座位，坐了 100 位乘客。第一位乘客登机后随机选了一个座位坐下。之后的乘客按此规则：如果自己的座位空着就坐自己的座位，如果被占了就随机选一个空座坐下。最后一位乘客（第100位）坐到自己座位的概率是多少？只回答最简分数。",
+        "answer_type": "exact",
+        "expected": "1/2",
+        "aliases": ["0.5", "50%"],
+    },
+    {
+        "id": "expert_code_004",
+        "subject": "code",
+        "question": "Python 代码：\ndef make_counter():\n    count = 0\n    def counter():\n        nonlocal count\n        count += 1\n        return count\n    return counter\n\nc1 = make_counter()\nc2 = make_counter()\nprint(c1(), c1(), c2())\n输出什么？只回答逗号分隔数字如 1,2,3。",
+        "answer_type": "exact",
+        "expected": "1,2,1",
+        "aliases": ["1, 2, 1"],
+    },
+    {
+        "id": "expert_logic_003",
+        "subject": "logic",
+        "question": "已知以下三个命题为真：\n1. 所有数学家都擅长逻辑。\n2. 有些擅长逻辑的人是哲学家。\n3. 没有哲学家是物理学家。\n\n以下哪个结论必然为真？\nA. 有些数学家是哲学家\nB. 有些擅长逻辑的人不是物理学家\nC. 没有数学家是物理学家\nD. 无法确定\n\n只回答字母 A、B、C 或 D。",
+        "answer_type": "mc",
+        "expected": "B",
+    },
+]
+
+DIFFICULTY_CHOICES = ["easy", "medium", "mixed", "instruction", "hard", "expert"]
+
+
+def now_bj() -> dt.datetime:
+    return dt.datetime.now(dt.timezone(dt.timedelta(hours=8)))
+
+
+def make_run_id(difficulty: str) -> str:
+    suffix = "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(4))
+    return f"hb-{now_bj().strftime('%Y%m%d-%H%M%S')}-{difficulty}-{suffix}"
+
+
+def make_unique_run_dir(difficulty: str) -> Path:
+    for _ in range(20):
+        run_id = make_run_id(difficulty)
+        d = BENCH_ROOT / run_id
+        if not d.exists():
+            return ensure_run_dir(run_id)
+        time.sleep(0.05)
+    run_id = f"hb-{now_bj().strftime('%Y%m%d-%H%M%S-%f')}-{difficulty}"
+    return ensure_run_dir(run_id)
+
+
+def ensure_run_dir(run_id: str) -> Path:
+    d = BENCH_ROOT / run_id
+    (d / "raw").mkdir(parents=True, exist_ok=True)
+    (d / "answers").mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def load_json(path: Path) -> Any:
+    with path.expanduser().open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def dump_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+
+
+def question_pool(difficulty: str) -> List[Dict[str, Any]]:
+    if difficulty == "easy":
+        return EASY_QUESTIONS
+    if difficulty == "medium":
+        return MEDIUM_QUESTIONS
+    if difficulty == "mixed":
+        return EASY_QUESTIONS + MEDIUM_QUESTIONS
+    if difficulty == "instruction":
+        return INSTRUCTION_QUESTIONS
+    if difficulty == "hard":
+        return HARD_QUESTIONS
+    if difficulty == "expert":
+        return EXPERT_QUESTIONS
+    raise ValueError(f"unsupported difficulty: {difficulty}")
+
+
+def generate_questions(difficulty: str, count: int, seed: int = 42, out_dir: Optional[Path] = None) -> Path:
+    pool = list(question_pool(difficulty))
+    rng = random.Random(seed)
+    rng.shuffle(pool)
+    selected = pool[: min(count, len(pool))]
+    run_dir = out_dir or make_unique_run_dir(difficulty)
+    manifest = {
+        "run_id": run_dir.name,
+        "script_version": SCRIPT_VERSION,
+        "created_at": now_bj().isoformat(),
+        "difficulty": difficulty,
+        "count": len(selected),
+        "questions": selected,
+    }
+    out = run_dir / "questions.json"
+    dump_json(out, manifest)
+    print(f"✅ generated {len(selected)} questions -> {out}")
+    return out
+
+
+def make_prompt(manifest: Dict[str, Any]) -> str:
+    public_questions = [
+        {"id": q["id"], "subject": q["subject"], "question": q["question"]}
+        for q in manifest["questions"]
+    ]
+    return (
+        "你正在参加 Hermes 原生模型基准测试。请独立作答，不要调用工具，不要解释过程。\n\n"
+        "严格输出一个 JSON 对象，格式如下：\n"
+        '{"answers":[{"id":"题目ID","answer":"你的答案"}]}\n\n'
+        "要求：\n"
+        "1. answers 数组必须覆盖所有题目。\n"
+        "2. answer 尽量短，只填最终答案。\n"
+        "3. 不要输出 Markdown 代码块，不要输出 JSON 之外的任何文字。\n\n"
+        "题目：\n"
+        + json.dumps(public_questions, ensure_ascii=False, indent=2)
+    )
+
+
+def make_single_prompt(question: Dict[str, Any]) -> str:
+    public_question = {
+        "id": question["id"],
+        "subject": question["subject"],
+        "question": question["question"],
+    }
+    return (
+        "你正在参加 Hermes 原生模型基准测试。请独立作答，不要调用工具，不要解释过程。\n\n"
+        "严格输出一个 JSON 对象，格式如下：\n"
+        '{"answer":"你的答案"}\n\n'
+        "要求：\n"
+        "1. answer 尽量短，只填最终答案。\n"
+        "2. 不要输出 Markdown 代码块，不要输出 JSON 之外的任何文字。\n\n"
+        "题目：\n"
+        + json.dumps(public_question, ensure_ascii=False, separators=(",", ":"))
+    )
+
+
+def write_prompt(questions_path: Path) -> Path:
+    manifest = load_json(questions_path)
+    prompt = make_prompt(manifest)
+    out = questions_path.parent / "prompt.md"
+    out.write_text(prompt, encoding="utf-8")
+    print(f"✅ prompt -> {out}")
+    return out
+
+
+def parse_candidate(s: str) -> Dict[str, str]:
+    if "=" in s:
+        name, spec = s.split("=", 1)
+    else:
+        name, spec = "", s
+    if "::" not in spec:
+        raise ValueError("candidate must use NAME=PROVIDER::MODEL")
+    provider, model = spec.split("::", 1)
+    if not name:
+        safe_model = re.sub(r"[^A-Za-z0-9_.-]+", "_", model).strip("_")
+        name = f"{provider}_{safe_model}"
+    name = re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("_")
+    if not name or not provider or not model:
+        raise ValueError(f"invalid candidate: {s}")
+    return {"name": name, "provider": provider, "model": model}
+
+
+def extract_json_object(text: str) -> Tuple[Optional[Any], Optional[str]]:
+    text = text.strip()
+    text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.I)
+    text = re.sub(r"\s*```$", "", text)
+    try:
+        return json.loads(text), None
+    except Exception:
+        pass
+    start = text.find("{")
+    end = text.rfind("}")
+    if start >= 0 and end > start:
+        snippet = text[start : end + 1]
+        try:
+            return json.loads(snippet), None
+        except Exception as e:
+            return None, f"json_parse_error: {e}"
+    return None, "no_json_object_found"
+
+
+def prepare_candidate_env(candidate: Dict[str, str]) -> Tuple[Optional[Dict[str, str]], bool]:
+    provider = candidate["provider"].strip().lower()
+    if provider not in CUSTOM_PROVIDER_CONFIGS:
+        return None, provider in {"config", "default", "current"}
+
+    try:
+        import yaml
+    except Exception as exc:
+        raise RuntimeError("PyYAML is required for custom provider benchmark routes") from exc
+
+    src_home = Path(os.environ.get("HERMES_HOME") or (HOME / ".hermes"))
+    tmp_home = Path(tempfile.mkdtemp(prefix=f"hermes-bench-{provider}-"))
+    for fname in ("config.yaml", "auth.json"):
+        src = src_home / fname
+        if src.exists():
+            shutil.copy2(src, tmp_home / fname)
+    plugins_src = src_home / "plugins"
+    plugins_dst = tmp_home / "plugins"
+    if plugins_src.is_dir() and not plugins_dst.exists():
+        shutil.copytree(plugins_src, plugins_dst, dirs_exist_ok=True)
+    (tmp_home / "logs").mkdir(exist_ok=True)
+
+    config_path = tmp_home / "config.yaml"
+    cfg: Dict[str, Any] = {}
+    if config_path.exists():
+        cfg = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    custom_provider = CUSTOM_PROVIDER_CONFIGS[provider]
+    custom_providers = cfg.get("custom_providers")
+    if not isinstance(custom_providers, list):
+        custom_providers = []
+    custom_providers = [
+        cp for cp in custom_providers
+        if not (isinstance(cp, dict) and cp.get("name") == provider)
+    ]
+    custom_providers.append(custom_provider)
+    cfg["custom_providers"] = custom_providers
+    cfg["model"] = {
+        "provider": provider,
+        "default": candidate["model"],
+        "base_url": custom_provider["base_url"],
+    }
+    cfg["fallback_providers"] = []
+    cfg["fallback_model"] = {}
+    config_path.write_text(yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True), encoding="utf-8")
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(tmp_home)
+    return env, True
+
+
+def hermes_command(candidate: Dict[str, str], prompt: str, omit_provider: bool) -> List[str]:
+    hermes = shutil.which("hermes")
+    if not hermes:
+        raise RuntimeError("hermes CLI not found in PATH")
+    cmd = [
+        hermes,
+        "chat",
+    ]
+    if not omit_provider:
+        cmd += ["--provider", candidate["provider"]]
+    cmd += [
+        "-m",
+        candidate["model"],
+        "--ignore-rules",
+        "--source",
+        "benchmark",
+        "--max-turns",
+        "1",
+        "-Q",
+        "-q",
+        prompt,
+    ]
+    return cmd
+
+
+def run_hermes_to_raw(
+    candidate: Dict[str, str],
+    prompt: str,
+    raw_path: Path,
+    timeout: int,
+    env_override: Optional[Dict[str, str]] = None,
+    omit_provider: Optional[bool] = None,
+) -> Tuple[int, float, str, str]:
+    if omit_provider is None:
+        env_override, omit_provider = prepare_candidate_env(candidate)
+    cmd = hermes_command(candidate, prompt, omit_provider)
+    started = time.time()
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w+", encoding="utf-8", delete=False) as stdout_f:
+        stdout_tmp = Path(stdout_f.name)
+        with tempfile.NamedTemporaryFile("w+", encoding="utf-8", delete=False) as stderr_f:
+            stderr_tmp = Path(stderr_f.name)
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    text=True,
+                    stdout=stdout_f,
+                    stderr=stderr_f,
+                    timeout=timeout,
+                    env=env_override,
+                )
+            finally:
+                stdout_f.flush()
+                stderr_f.flush()
+    elapsed = time.time() - started
+    stdout_text = stdout_tmp.read_text(encoding="utf-8")
+    stderr_text = stderr_tmp.read_text(encoding="utf-8")
+    try:
+        stdout_tmp.unlink(missing_ok=True)
+        stderr_tmp.unlink(missing_ok=True)
+    except TypeError:
+        if stdout_tmp.exists():
+            stdout_tmp.unlink()
+        if stderr_tmp.exists():
+            stderr_tmp.unlink()
+    raw = stdout_text.strip()
+    if stderr_text.strip():
+        raw = raw + "\n\n[stderr]\n" + stderr_text.strip()
+    raw_path.write_text(raw + "\n", encoding="utf-8")
+    return proc.returncode, elapsed, stdout_text, stderr_text
+
+
+def run_candidate(candidate: Dict[str, str], prompt: str, run_dir: Path, timeout: int) -> Dict[str, Any]:
+    raw_path = run_dir / "raw" / f"{candidate['name']}.txt"
+    returncode, elapsed, stdout_text, _stderr_text = run_hermes_to_raw(
+        candidate, prompt, raw_path, timeout
+    )
+    obj, parse_error = extract_json_object(stdout_text)
+    answers = obj if isinstance(obj, dict) else {}
+    result = {
+        "candidate": candidate,
+        "returncode": returncode,
+        "elapsed_sec": round(elapsed, 3),
+        "raw_path": str(raw_path),
+        "format_ok": isinstance(obj, dict) and isinstance(obj.get("answers"), list),
+        "parse_error": parse_error,
+        "answers": answers.get("answers", []) if isinstance(answers, dict) else [],
+    }
+    out = run_dir / "answers" / f"{candidate['name']}.json"
+    dump_json(out, result)
+    print(f"✅ ran {candidate['name']} ({candidate['provider']}::{candidate['model']}) -> {out} [{elapsed:.1f}s]")
+    return result
+
+
+def answer_from_single_object(obj: Any) -> Tuple[Any, bool]:
+    if isinstance(obj, dict) and "answer" in obj:
+        return obj.get("answer"), True
+    if isinstance(obj, dict) and isinstance(obj.get("answers"), list) and obj["answers"]:
+        first = obj["answers"][0]
+        if isinstance(first, dict) and "answer" in first:
+            return first.get("answer"), True
+    return "", False
+
+
+def run_candidate_single(
+    candidate: Dict[str, str],
+    manifest: Dict[str, Any],
+    run_dir: Path,
+    timeout: int,
+) -> Dict[str, Any]:
+    env_override, omit_provider = prepare_candidate_env(candidate)
+    answers: List[Dict[str, Any]] = []
+    question_results: List[Dict[str, Any]] = []
+    parse_errors: Dict[str, str] = {}
+    returncodes: Dict[str, int] = {}
+    elapsed_total = 0.0
+    all_format_ok = True
+
+    for q in manifest["questions"]:
+        qid = str(q["id"])
+        prompt = make_single_prompt(q)
+        raw_path = run_dir / "raw" / candidate["name"] / f"{qid}.txt"
+        returncode, elapsed, stdout_text, _stderr_text = run_hermes_to_raw(
+            candidate,
+            prompt,
+            raw_path,
+            timeout,
+            env_override=env_override,
+            omit_provider=omit_provider,
+        )
+        elapsed_total += elapsed
+        obj, parse_error = extract_json_object(stdout_text)
+        answer, format_ok = answer_from_single_object(obj)
+        all_format_ok = all_format_ok and format_ok
+        if parse_error or not format_ok:
+            parse_errors[qid] = parse_error or "missing_answer_field"
+        if returncode != 0:
+            returncodes[qid] = returncode
+        answers.append({"id": qid, "answer": answer})
+        question_results.append({
+            "id": qid,
+            "returncode": returncode,
+            "elapsed_sec": round(elapsed, 3),
+            "raw_path": str(raw_path),
+            "format_ok": format_ok,
+            "parse_error": parse_error if parse_error else (None if format_ok else "missing_answer_field"),
+            "answer": answer,
+        })
+        print(f"✅ ran {candidate['name']}::{qid} -> {raw_path} [{elapsed:.1f}s]")
+
+    result = {
+        "candidate": candidate,
+        "mode": "single",
+        "returncode": 0 if not returncodes else next(iter(returncodes.values())),
+        "returncodes": returncodes,
+        "elapsed_sec": round(elapsed_total, 3),
+        "raw_path": str(run_dir / "raw" / candidate["name"]),
+        "format_ok": all_format_ok,
+        "parse_error": None if not parse_errors else json.dumps(parse_errors, ensure_ascii=False),
+        "answers": answers,
+        "question_results": question_results,
+    }
+    out = run_dir / "answers" / f"{candidate['name']}.json"
+    dump_json(out, result)
+    print(f"✅ aggregated {candidate['name']} ({candidate['provider']}::{candidate['model']}) -> {out} [{elapsed_total:.1f}s]")
+    return result
+
+
+def run_candidate_benchmark(
+    candidate: Dict[str, str],
+    manifest: Dict[str, Any],
+    run_dir: Path,
+    timeout: int,
+) -> Dict[str, Any]:
+    """Run one candidate against every question as independent Hermes calls.
+
+    This is the v2 benchmark layout: raw/<candidate>_<question_id>.txt plus
+    answers/<candidate>.json aggregated in the same shape as legacy runs.
+    """
+    env_override, omit_provider = prepare_candidate_env(candidate)
+    answers: List[Dict[str, Any]] = []
+    question_results: List[Dict[str, Any]] = []
+    parse_errors: Dict[str, str] = {}
+    returncodes: Dict[str, int] = {}
+    elapsed_total = 0.0
+    all_format_ok = True
+
+    for q in manifest["questions"]:
+        qid = str(q["id"])
+        prompt = make_single_prompt(q)
+        raw_path = run_dir / "raw" / f"{candidate['name']}_{qid}.txt"
+        returncode, elapsed, stdout_text, _stderr_text = run_hermes_to_raw(
+            candidate,
+            prompt,
+            raw_path,
+            timeout,
+            env_override=env_override,
+            omit_provider=omit_provider,
+        )
+        elapsed_total += elapsed
+        obj, parse_error = extract_json_object(stdout_text)
+        answer, format_ok = answer_from_single_object(obj)
+        all_format_ok = all_format_ok and format_ok
+        if parse_error or not format_ok:
+            parse_errors[qid] = parse_error or "missing_answer_field"
+        if returncode != 0:
+            returncodes[qid] = returncode
+        answers.append({"id": qid, "answer": answer})
+        question_results.append({
+            "id": qid,
+            "returncode": returncode,
+            "elapsed_sec": round(elapsed, 3),
+            "raw_path": str(raw_path),
+            "format_ok": format_ok,
+            "parse_error": parse_error if parse_error else (None if format_ok else "missing_answer_field"),
+            "answer": answer,
+        })
+        print(f"✅ ran {candidate['name']}::{qid} -> {raw_path} [{elapsed:.1f}s]")
+
+    result = {
+        "candidate": candidate,
+        "mode": "benchmark",
+        "returncode": 0 if not returncodes else next(iter(returncodes.values())),
+        "returncodes": returncodes,
+        "elapsed_sec": round(elapsed_total, 3),
+        "raw_path": str(run_dir / "raw"),
+        "format_ok": all_format_ok,
+        "parse_error": None if not parse_errors else json.dumps(parse_errors, ensure_ascii=False),
+        "answers": answers,
+        "question_results": question_results,
+    }
+    out = run_dir / "answers" / f"{candidate['name']}.json"
+    dump_json(out, result)
+    print(f"✅ aggregated {candidate['name']} ({candidate['provider']}::{candidate['model']}) -> {out} [{elapsed_total:.1f}s]")
+    return result
+
+
+def run_benchmark(args: argparse.Namespace) -> Path:
+    """Run the v2 independent-question benchmark command."""
+    qpath = generate_questions(args.difficulty, args.count, args.seed)
+    manifest = load_json(qpath)
+    run_dir = qpath.parent
+    for c in args.candidate:
+        run_candidate_benchmark(parse_candidate(c), manifest, run_dir, args.timeout)
+    grade_run(run_dir)
+    verify_run(run_dir)
+    print(f"RUN_DIR={run_dir}")
+    return run_dir
+
+
+def normalize_text(x: Any) -> str:
+    s = str(x).strip()
+    s = s.replace("％", "%")
+    s = re.sub(r"[\\s`'\x22，。,.；;：:！!？?()（）\\[\\]{}]", "", s)
+    return s.lower()
+
+
+def extract_number(x: Any) -> Optional[float]:
+    m = re.search(r"-?\d+(?:\.\d+)?", str(x))
+    return float(m.group(0)) if m else None
+
+
+def score_one(q: Dict[str, Any], ans: Any) -> Tuple[bool, str]:
+    expected = q["expected"]
+    aliases = q.get("aliases", [])
+    answer_type = q.get("answer_type", "exact")
+    if answer_type == "numeric":
+        got = extract_number(ans)
+        exp = float(expected)
+        ok = got is not None and math.isclose(got, exp, rel_tol=1e-9, abs_tol=1e-9)
+        return ok, str(got) if got is not None else ""
+    if answer_type == "mc":
+        s = str(ans).strip().upper()
+        m = re.search(r"[A-D]", s)
+        got = m.group(0) if m else s[:1]
+        return got == str(expected).upper(), got
+    if answer_type == "json_field":
+        obj = ans
+        if isinstance(ans, str):
+            obj, _ = extract_json_object(ans)
+        ok = isinstance(obj, dict) and all(obj.get(k) == v for k, v in expected.items())
+        return ok, json.dumps(obj, ensure_ascii=False) if isinstance(obj, dict) else str(ans)
+    norm = normalize_text(ans)
+    accepted = [expected] + aliases
+    ok = any(norm == normalize_text(a) for a in accepted)
+    return ok, str(ans).strip()
+
+
+def grade_run(run_dir: Path) -> Tuple[Path, Path]:
+    manifest = load_json(run_dir / "questions.json")
+    q_by_id = {q["id"]: q for q in manifest["questions"]}
+    reports = []
+    for answer_path in sorted((run_dir / "answers").glob("*.json")):
+        data = load_json(answer_path)
+        answers = {str(a.get("id")): a.get("answer") for a in data.get("answers", []) if isinstance(a, dict)}
+        details = []
+        correct = 0
+        for qid, q in q_by_id.items():
+            ans = answers.get(qid, "")
+            ok, normalized = score_one(q, ans)
+            correct += int(ok)
+            details.append({
+                "id": qid,
+                "subject": q.get("subject"),
+                "ok": ok,
+                "answer": ans,
+                "normalized": normalized,
+                "expected": q.get("expected"),
+            })
+        total = len(q_by_id)
+        reports.append({
+            "name": data.get("candidate", {}).get("name", answer_path.stem),
+            "provider": data.get("candidate", {}).get("provider"),
+            "model": data.get("candidate", {}).get("model"),
+            "format_ok": data.get("format_ok", False),
+            "returncode": data.get("returncode"),
+            "parse_error": data.get("parse_error"),
+            "elapsed_sec": data.get("elapsed_sec"),
+            "score": correct,
+            "total": total,
+            "accuracy": round(correct / total, 4) if total else 0,
+            "details": details,
+        })
+    reports.sort(key=lambda r: (r["accuracy"], -float(r.get("elapsed_sec") or 999999)), reverse=True)
+    summary = {
+        "run_id": manifest.get("run_id", run_dir.name),
+        "graded_at": now_bj().isoformat(),
+        "difficulty": manifest.get("difficulty"),
+        "question_count": len(q_by_id),
+        "models": reports,
+    }
+    summary_json = run_dir / "summary.json"
+    dump_json(summary_json, summary)
+    summary_md = run_dir / "summary.md"
+    summary_md.write_text(render_markdown(summary), encoding="utf-8")
+    print(f"✅ summary -> {summary_json}")
+    print(f"✅ report  -> {summary_md}")
+    return summary_json, summary_md
+
+
+def verify_run(run_dir: Path) -> Dict[str, Any]:
+    """Post-run identity verification: check for identical outputs and fallback contamination."""
+    result: Dict[str, Any] = {"identity_warnings": [], "fallback_warnings": []}
+
+    raw_dir = run_dir / "raw"
+    raw_files = sorted(raw_dir.rglob("*.txt"))
+    candidate_names = sorted(
+        [p.stem for p in (run_dir / "answers").glob("*.json")],
+        key=len,
+        reverse=True,
+    )
+
+    def raw_candidate_name(raw_file: Path) -> str:
+        rel = raw_file.relative_to(raw_dir)
+        if len(rel.parts) > 1:
+            return rel.parts[0]
+        stem = raw_file.stem
+        for name in candidate_names:
+            if stem == name or stem.startswith(f"{name}_"):
+                return name
+        return stem
+
+    def raw_model_label(raw_file: Path) -> str:
+        rel = raw_file.relative_to(raw_dir)
+        if len(rel.parts) > 1:
+            return "/".join(rel.parts[:-1] + (raw_file.stem,))
+        stem = raw_file.stem
+        candidate_name = raw_candidate_name(raw_file)
+        prefix = f"{candidate_name}_"
+        if stem.startswith(prefix):
+            return f"{candidate_name}/{stem[len(prefix):]}"
+        return stem
+
+    candidate_signatures: Dict[str, List[str]] = {}
+    for raw_file in raw_files:
+        text = raw_file.read_text(encoding="utf-8")
+        lines = text.split("\n")
+        content_lines = [l for l in lines if not l.startswith("session_id:")]
+        signature = "\n".join(content_lines)[:200]
+        rel = raw_file.relative_to(raw_dir)
+        candidate_name = raw_candidate_name(raw_file)
+        candidate_signatures.setdefault(candidate_name, []).append(f"{rel}:{signature}")
+
+    raw_hashes: Dict[str, str] = {
+        name: hashlib.md5("\n".join(sorted(signatures)).encode("utf-8")).hexdigest()
+        for name, signatures in candidate_signatures.items()
+    }
+
+    names = list(raw_hashes.keys())
+    for i in range(len(names)):
+        for j in range(i + 1, len(names)):
+            if raw_hashes[names[i]] == raw_hashes[names[j]]:
+                result["identity_warnings"].append(
+                    f"{names[i]} \u2194 {names[j]}: identical output (MD5: {raw_hashes[names[i]]})"
+                )
+
+    agent_log = Path.home() / ".hermes" / "logs" / "agent.log"
+    if agent_log.exists():
+        log_text = agent_log.read_text(encoding="utf-8")
+        for raw_file in raw_files:
+            text = raw_file.read_text(encoding="utf-8")
+            model_name = raw_model_label(raw_file)
+            for line in text.split("\n"):
+                m = re.search(r"session_id:\s*(\S+)", line)
+                if m:
+                    sid = m.group(1)
+                    fallback_pattern = rf"\[{sid}\].*?Fallback activated"
+                    if re.search(fallback_pattern, log_text, re.DOTALL):
+                        fb_match = re.search(
+                            rf"\[{sid}\].*?Fallback activated: ([^\n]+)",
+                            log_text, re.DOTALL
+                        )
+                        detail = fb_match.group(1).strip() if fb_match else f"session {sid}"
+                        result["fallback_warnings"].append(
+                            f"{model_name}: fallback detected \u2014 {detail}"
+                        )
+                    break
+
+    if result["identity_warnings"]:
+        print("\u26a0\ufe0f  IDENTITY WARNING: some models produced identical output (backend may not have switched models)")
+        for w in result["identity_warnings"]:
+            print(f"   {w}")
+    if result["fallback_warnings"]:
+        print("\u26a0\ufe0f  FALLBACK WARNING: some models fell back to another model")
+        for w in result["fallback_warnings"]:
+            print(f"   {w}")
+    if not result["identity_warnings"] and not result["fallback_warnings"]:
+        print("\u2705 identity verification passed (all models distinct, no fallback)")
+
+    return result
+
+
+def markdown_cell(value: Any, limit: int = 80) -> str:
+    text = str(value if value is not None else "")
+    text = text.replace("\n", " ").replace("|", "\\|").strip()
+    if len(text) > limit:
+        text = text[: limit - 1] + "…"
+    return text
+
+
+def render_markdown(summary: Dict[str, Any]) -> str:
+    lines = []
+    lines.append(f"# Hermes Model Benchmark \u2014 {summary['run_id']}")
+    lines.append("")
+    lines.append(f"- Difficulty: `{summary.get('difficulty')}`")
+    lines.append(f"- Questions: `{summary.get('question_count')}`")
+    lines.append(f"- Graded at: `{summary.get('graded_at')}`")
+    lines.append("")
+    lines.append("## Ranking")
+    lines.append("")
+    lines.append("| Rank | Name | Provider | Model | Score | Accuracy | Time | JSON |")
+    lines.append("|---:|---|---|---|---:|---:|---:|---|")
+    for i, r in enumerate(summary.get("models", []), 1):
+        lines.append(
+            f"| {i} | {r['name']} | {r.get('provider') or ''} | `{r.get('model') or ''}` | "
+            f"{r['score']}/{r['total']} | {r['accuracy']*100:.1f}% | {r.get('elapsed_sec')}s | "
+            f"{'✅' if r.get('format_ok') else '❌'} |"
+        )
+    lines.append("")
+
+    models = summary.get("models", [])
+    if models:
+        lines.append("## Model Comparison Matrix")
+        lines.append("")
+        model_names = [str(r.get("name") or "") for r in models]
+        lines.append("| 题目 | " + " | ".join(markdown_cell(n, 40) for n in model_names) + " | 正确答案 |")
+        lines.append("|---|" + "|".join(":---:" for _ in model_names) + "|:---:|")
+        question_order = [d.get("id") for d in models[0].get("details", [])]
+        for qid in question_order:
+            row = [f"| {markdown_cell(qid, 80)}"]
+            expected = ""
+            for r in models:
+                detail_by_id = {d.get("id"): d for d in r.get("details", [])}
+                d = detail_by_id.get(qid, {})
+                expected = expected or d.get("expected", "")
+                status = "✅" if d.get("ok") else "❌"
+                row.append(f" {status} {markdown_cell(d.get('answer', ''), 80)}")
+            row.append(f" {markdown_cell(expected, 80)} |")
+            lines.append(" |".join(row))
+        lines.append("")
+
+    for r in models:
+        lines.append(f"## {r['name']}")
+        if not r.get("format_ok"):
+            lines.append(f"- Format error: `{r.get('parse_error')}`")
+        lines.append("")
+        lines.append("| ID | Subject | Result | Answer | Expected |")
+        lines.append("|---|---|---|---|---|")
+        for d in r.get("details", []):
+            lines.append(
+                f"| {d['id']} | {d.get('subject') or ''} | {'✅' if d['ok'] else '❌'} | "
+                f"`{str(d.get('answer', ''))[:80]}` | `{d.get('expected')}` |"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def resolve_questions_path(args: argparse.Namespace) -> Path:
+    if getattr(args, "questions", None):
+        return Path(args.questions).expanduser()
+    if getattr(args, "run_dir", None):
+        return Path(args.run_dir).expanduser() / "questions.json"
+    raise SystemExit("missing --questions or --run-dir")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Hermes-native model benchmark")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("generate")
+    p.add_argument("--difficulty", choices=DIFFICULTY_CHOICES, default="easy")
+    p.add_argument("--count", type=int, default=8)
+    p.add_argument("--seed", type=int, default=42)
+
+    p = sub.add_parser("prompt", help="[DEPRECATED] legacy all-questions prompt; use benchmark")
+    p.add_argument("--questions", required=True)
+
+    p = sub.add_parser("run", help="[DEPRECATED] legacy all-questions run; use benchmark")
+    p.add_argument("--questions", required=True)
+    p.add_argument("--candidate", action="append", required=True, help="NAME=PROVIDER::MODEL")
+    p.add_argument("--timeout", type=int, default=240)
+
+    p = sub.add_parser("grade")
+    p.add_argument("--run-dir", required=True)
+
+    p = sub.add_parser("benchmark", help="run v2 independent per-question benchmark")
+    p.add_argument("--difficulty", choices=DIFFICULTY_CHOICES, default="easy")
+    p.add_argument("--count", type=int, default=8)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--candidate", action="append", required=True, help="NAME=PROVIDER::MODEL")
+    p.add_argument("--timeout", type=int, default=60, help="per-question timeout in seconds")
+
+    p = sub.add_parser("all", help="[DEPRECATED] legacy generate+run+grade; use benchmark")
+    p.add_argument("--difficulty", choices=DIFFICULTY_CHOICES, default="easy")
+    p.add_argument("--count", type=int, default=8)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--candidate", action="append", required=True, help="NAME=PROVIDER::MODEL")
+    p.add_argument("--timeout", type=int, default=240)
+
+    p = sub.add_parser("single", help="run each candidate/question as an independent Hermes chat call")
+    p.add_argument("--difficulty", choices=DIFFICULTY_CHOICES, default="easy")
+    p.add_argument("--count", type=int, default=8)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--candidate", action="append", required=True, help="NAME=PROVIDER::MODEL")
+    p.add_argument("--timeout", type=int, default=60)
+
+    p = sub.add_parser("quick", help="[DEPRECATED] legacy quick benchmark; use benchmark --difficulty instruction")
+    p.add_argument("--candidate", action="append", required=True, help="NAME=PROVIDER::MODEL")
+    p.add_argument("--count", type=int, default=4)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--timeout", type=int, default=120)
+
+    p = sub.add_parser("verify", help="post-run model identity and fallback verification")
+    p.add_argument("--run-dir", required=True)
+
+    args = parser.parse_args(argv)
+    if args.cmd == "generate":
+        generate_questions(args.difficulty, args.count, args.seed)
+        return 0
+    if args.cmd == "prompt":
+        write_prompt(Path(args.questions).expanduser())
+        return 0
+    if args.cmd == "run":
+        questions_path = Path(args.questions).expanduser()
+        manifest = load_json(questions_path)
+        run_dir = questions_path.parent
+        prompt = make_prompt(manifest)
+        (run_dir / "prompt.md").write_text(prompt, encoding="utf-8")
+        for c in args.candidate:
+            run_candidate(parse_candidate(c), prompt, run_dir, args.timeout)
+        return 0
+    if args.cmd == "grade":
+        grade_run(Path(args.run_dir).expanduser())
+        return 0
+    if args.cmd == "benchmark":
+        run_benchmark(args)
+        return 0
+    if args.cmd == "all":
+        qpath = generate_questions(args.difficulty, args.count, args.seed)
+        manifest = load_json(qpath)
+        run_dir = qpath.parent
+        prompt = make_prompt(manifest)
+        (run_dir / "prompt.md").write_text(prompt, encoding="utf-8")
+        for c in args.candidate:
+            run_candidate(parse_candidate(c), prompt, run_dir, args.timeout)
+        grade_run(run_dir)
+        verify_run(run_dir)
+        print(f"RUN_DIR={run_dir}")
+        return 0
+    if args.cmd == "single":
+        qpath = generate_questions(args.difficulty, args.count, args.seed)
+        manifest = load_json(qpath)
+        run_dir = qpath.parent
+        for c in args.candidate:
+            run_candidate_single(parse_candidate(c), manifest, run_dir, args.timeout)
+        grade_run(run_dir)
+        verify_run(run_dir)
+        print(f"RUN_DIR={run_dir}")
+        return 0
+    if args.cmd == "quick":
+        qpath = generate_questions("instruction", args.count, args.seed)
+        manifest = load_json(qpath)
+        run_dir = qpath.parent
+        prompt = make_prompt(manifest)
+        (run_dir / "prompt.md").write_text(prompt, encoding="utf-8")
+        for c in args.candidate:
+            run_candidate(parse_candidate(c), prompt, run_dir, args.timeout)
+        grade_run(run_dir)
+        verify_run(run_dir)
+        print(f"RUN_DIR={run_dir}")
+        return 0
+    if args.cmd == "verify":
+        vr = verify_run(Path(args.run_dir).expanduser())
+        if vr["identity_warnings"] or vr["fallback_warnings"]:
+            return 1
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.TimeoutExpired as e:
+        print(f"ERROR: model run timeout after {e.timeout}s", file=sys.stderr)
+        raise SystemExit(124)
+    except Exception as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        raise SystemExit(1)

--- a/skills/research/supply-chain-hunter/SKILL.md
+++ b/skills/research/supply-chain-hunter/SKILL.md
@@ -1,0 +1,553 @@
+---
+name: supply-chain-hunter
+description: "Use when analyzing AI infrastructure, semiconductor, optical, power, cooling, packaging, or materials supply chains for bottleneck identification. Maps the full stack, finds the narrowest constraint, verifies with cross-source evidence, and outputs directional lanes before candidate names. Trigger phrases: supply chain bottleneck, chokepoint, supply chain analysis, AI infrastructure constraints."
+version: 1.0.0
+author: Community
+license: MIT
+metadata:
+  hermes:
+    tags: [supply-chain, research, bottleneck-analysis, semiconductor, ai-infrastructure, chokepoint]
+    related_skills: [research-data-sources]
+---
+
+# AI Supply Chain Bottleneck Hunter
+
+Use this skill when the user wants to:
+
+- study AI, photonics, semiconductor, datacenter, networking, power, cooling, packaging, or materials supply chains
+- emulate the question patterns and research logic of established supply-chain analysts
+- turn scattered reports, earnings calls, and industry news into a structured bottleneck thesis
+- identify the next directional lane first, then optionally drill into smaller-cap names
+- create or use a reusable "research agent skill" for bottleneck hunting
+
+This skill mirrors the analytical stance and question design of two complementary research lenses used in the supply-chain research community. It does **not** impersonate any specific person, invent direct quotes, or present rumors as fact.
+
+## Core Model
+
+Treat the market as a physical system, not a ticker feed.
+
+The workflow is:
+
+1. start from a supertrend
+2. map the supply chain or "stack"
+3. find the narrowest physical / qualification / capacity constraint
+4. verify it with cross-source evidence
+5. output a directional lane first
+6. only after that, offer candidate names and weighting logic
+
+Default behavior:
+
+- do **not** start by naming stocks
+- do **not** ask AI "what should I buy"
+- do use AI to expand search radius, map dependencies, summarize earnings, cross-check bottlenecks, and generate falsification tests
+
+## Two Lenses
+
+Use both lenses, then merge them.
+
+### Lens 1: The Underfollowed Choke Point
+
+Use this when the user wants the underfollowed choke point.
+
+Key idea:
+
+- one missing part can stall a much larger AI buildout
+- value often sits in the second- or third-order bottleneck, not the obvious leader
+- market-cap mismatch matters: if a tiny supplier can delay a giant demand wave, the mispricing can be large
+
+What to look for:
+
+- concentrated supply
+- long certification cycle
+- low substitutability
+- booked-out capacity
+- management language like `sole source`, `primary source`, `qualification`, `ramp`, `demand > supply`
+
+### Lens 2: The Full Stack and Position-Sizing Logic
+
+Use this when the user wants the full stack and position-sizing logic.
+
+Key idea:
+
+- photonics / AI infra is a stack
+- each layer gets paid for different reasons and on different timelines
+- basket construction matters as much as stock selection
+- weight should track execution certainty
+
+What to do:
+
+- map 6-9 layers from materials to end demand
+- assign each company a role: leader, bottleneck supplier, disruptor, foundry, test, network, adjacent silicon, material base
+- separate strong executors from early, high-speculation names
+
+## Hard Rules
+
+- Never output "top stock picks" before building the thesis.
+- Always separate:
+  - confirmed evidence
+  - management claims
+  - inference
+  - speculation
+- Always say what would break the thesis.
+- When borrowing from the established research style:
+  - borrow the obsession with bottlenecks
+  - borrow the habit of asking where the chain breaks
+  - borrow the execution-vs-optionality framing
+  - borrow the cross-reading of multiple companies
+- Do **not** copy wording, slogans, or long-form expressions from any specific person.
+- Do **not** present fabricated access to private portfolios, fills, or exact current positions.
+
+## Workflow
+
+Treat the workflow as a staged dialogue:
+
+- L1: sector diagnosis
+- L2: stack mapping
+- L3: evidence chain
+- L4: directional lane
+- L5: lower-market-cap drilldown only after follow-up
+
+Do not dump all five layers in one response unless the user explicitly asks for a full memo.
+
+### Step 0: Scope Gate
+
+If the user is vague, ask at most 3 short questions, then proceed.
+
+Use these defaults:
+
+- supertrend: AI infrastructure buildout
+- horizon: 6-18 months
+- geography: global
+
+Good scope questions:
+
+- Which supertrend are we underwriting: optical interconnect, packaging, power, cooling, robotics, storage, or something else?
+- Are we hunting a direction first, or do you already want candidate names?
+
+### Step 1: Confirm the Supertrend
+
+Before talking names, force one paragraph on:
+
+- what demand wave is expanding
+- what physical buildout it implies
+- what components must scale with it
+- which parts are already consensus and crowded
+
+Avoid generic phrasing like "AI keeps growing". Name the real driver:
+
+- 800G -> 1.6T -> 3.2T optical transitions
+- training cluster scale-out
+- power-density rise
+- thermal limits
+- advanced packaging throughput
+- test and qualification bottlenecks
+
+When possible, ground the theme in one concrete machine or system:
+
+- not `AI compute`
+- but `GB300 NVL72 rack`, `TPU pod`, `AI factory power train`, `1.6T optical link`, or another real deployed system
+
+### Step 2: Draw the Stack
+
+Always map a chain before concluding.
+
+Use 6-9 layers. Typical stack:
+
+1. end demand / deployment
+2. network / systems
+3. modules / engines / subsystems
+4. devices / chips / lasers / optics
+5. test / yield / reliability
+6. foundry / assembly / packaging
+7. epitaxy / equipment
+8. materials / substrates / specialty inputs
+
+For each layer, ask:
+
+- what is being shipped?
+- who gets paid here?
+- what unlocks the next layer?
+- is the bottleneck capacity, qualification, thermal, yield, tooling, or materials?
+
+Also ask:
+
+- if this supplier disappeared tomorrow, how long would the downstream wait for a credible replacement?
+- which layer is being paid now versus later?
+
+### Step 3: Hunt the Bottleneck
+
+Now force the real question:
+
+- if AI demand doubles, what breaks first?
+
+Also apply **transmission-order analysis**: in multi-layer supply chains, demand does not hit all layers simultaneously. Map the cascade: which layer benefits first (typically the enabling platform), which follows (components with long qualification cycles), and which benefits last (system integrators). The earliest transmission waves offer the most verifiable demand signals.
+
+Check these bottleneck types:
+
+- physical input shortage
+- long lead-time tool / fab capacity
+- reliability and qualification delay
+- yield bottleneck
+- thermal / power limit
+- geopolitical or single-region dependence
+- single-customer dependency
+- **architecture disruption**: a new platform paradigm (e.g. unified memory replacing DIMMs, chiplets replacing monolithic dies, optical replacing electrical interconnects) makes the current bottleneck component obsolete regardless of supply/demand. This is the most dangerous bottleneck type because it is qualitative, not quantitative — you cannot model it from capacity numbers alone.
+
+Rank the bottleneck by:
+
+- concentration
+- substitutability
+- ramp difficulty
+- proof of demand
+- whether consensus already sees it
+
+### Step 3.5: Price-in & True Valuation Assessment
+
+Before declaring a bottleneck investable, always perform a price-in assessment. A correct bottleneck thesis does NOT automatically mean the stocks are good buys — the market may have already priced 2030 success into 2026 prices.
+
+This step prevents the most common supply-chain-hunter error: identifying a real bottleneck, finding the bottleneck supplier, then recommending a stock at 400x PE.
+
+#### 3.5.1 Get Live Prices (Mandatory)
+
+For every candidate company mapped in Step 3, collect live price data:
+
+- **US/HK/A-share**: Use a price data source (e.g., `yfinance` via `terminal(python3 -c "...")`) to pull current price, market cap, trailing PE, forward PE, revenue (TTM), and YoY revenue growth
+- **Japan**: Use ticker format `XXXX.T` (e.g., `6324.T`)
+- **OTC/Pink Sheets**: Flag with a liquidity warning. Always note the primary exchange ticker
+- **Missing data**: If the primary source fails (common for A-shares with `.SH`/`.SZ` suffix), fall back to web search for recent price + PE data
+
+Always collect: price, market cap, PE (trailing), revenue (TTM), revenue YoY growth %, gross margin %, and if available, segment revenue for the relevant business line.
+
+#### 3.5.2 Calculate Revenue Quality Score
+
+For each candidate, compute three metrics that distinguish "genuine early-stage" from "narrative bubble":
+
+| Metric | Formula | What It Tells You |
+|---|---|---|
+| **Revenue Share** | Bottleneck-segment revenue / Total revenue | Is this a pure-play or a conglomerate with a tiny relevant division? |
+| **Revenue Growth Rate** | YoY revenue growth % (both total and segment) | Is acceleration real or a flat/declining business wearing an AI label? |
+| **Gross Margin Trend** | Current GM% vs 2-year-ago GM% | Declining margin + high PE = lethal combination (pricing power eroding) |
+
+Score each on a 1-5 scale and multiply: `Quality Score = Share × Growth × Margin_Trend`
+
+#### 3.5.3 Classify: Genuine Early-Stage vs Narrative Bubble
+
+High PE alone means nothing. The determinant is **revenue trajectory**:
+
+| Type | PE | Revenue Growth | Bottleneck Rev Share | Gross Margin | Verdict |
+|---|---|---|---|---|---|
+| **Genuine Early** | 30-500x | 40%+ | Growing fast (10%→50%+) | Stable or improving | PE will compress naturally if growth sustains. The stock is "expensive for today, cheap for 2028" |
+| **Narrative Bubble** | 100-500x | <20% | <5% or flat | Declining | PE is high AND growth is slow. The market is pricing 2030 without any 2026 evidence. This is the dangerous quadrant |
+
+**Key rule**: A 400x PE with 47% revenue growth and accelerating bottleneck revenue is categorically different from a 400x PE with 7% revenue growth and 2.7% net margin. The former MAY be justified; the latter is a pure narrative bubble.
+
+#### 3.5.4 The Four Pillars Stress Test
+
+Every high-valuation supply-chain stock rests on four implicit assumptions. Expose them:
+
+1. **Picks and Shovels**: "We don't know which OEM wins, but we know they all need X component"
+   - *Break condition*: If the component gets designed OUT (architecture disruption) or if the OEM list narrows to 2-3 who vertically integrate
+2. **TAM Explosion**: "Current $800M market → $40B if humanoid robots reach 10M units/year"
+   - *Break condition*: Timeline stretches from 2030 to 2035+. A 5-year delay makes the 400x PE lethal
+3. **Bottleneck = Pricing Power**: "Limited suppliers + long certification = margins expand under demand surge"
+   - *Break condition*: Second-source qualification succeeds, or new entrants catch up faster than expected
+4. **Early Cycle Defense**: "PE 400x is irrelevant — you're buying 2030 earnings at a discount"
+   - *Break condition*: This defense works in VC with a portfolio of 10 bets. In public markets where you buy ONE stock, if the 2030 story arrives in 2035 instead, the stock is down 80% before it ever pays off
+
+For each candidate, state which pillar is the **most fragile** and what specific event would break it.
+
+#### 3.5.5 Required Growth to Normalize PE
+
+For any candidate with PE > 50x, compute:
+
+```
+Required profit growth to reach target PE in N years:
+  = (Current Market Cap / Target_PE) / Current_TTM_Profit
+
+Example: Market cap ¥560B, TTM profit ¥1.24B, target PE 40x
+  → Required = (560B / 40) / 1.24B = 14B / 1.24B = 11.3x
+  → Profit must grow 11.3x to justify current price at 40x PE
+  → At 47% annual growth: 11.3^(1/5) = requires ~5 years at current growth rate
+```
+
+If required profit growth exceeds 5x in 3 years, flag as **"perfection priced in"** — even a correct thesis may not deliver enough profit to justify the entry price.
+
+### Step 4: Verify With External Evidence
+
+Do not trust one tweet, one chart, or one story.
+
+Use three evidence buckets:
+
+1. **Company evidence**
+   - earnings calls
+   - investor presentations
+   - customer / supplier mentions
+   - guidance language
+2. **Industry evidence**
+   - trade press
+   - industry reports
+   - capacity / lead-time / deployment news
+3. **Cross-chain evidence**
+   - multiple companies describing the same stress point from different sides
+
+Preferred sources:
+
+- company IR pages and earnings transcripts
+- official filings
+- reputable industry reporting
+- broker / market research summaries if available
+
+Always label the strongest evidence line and the weakest assumption.
+
+Use this evidence hierarchy:
+
+- **strongest**: filings, earnings-call transcripts, IR materials, direct customer/supplier disclosures
+- **strong**: official supplier-list changes, design-win announcements, capacity-expansion notices
+- **medium**: reputable industry reporting, broker or market-research summaries
+- **weak**: social posts and unverified forum claims
+
+If multiple companies describe the same constraint from different positions in the chain, say so explicitly. That is higher quality than a single-source story.
+
+### Step 5: Output the Direction First
+
+Default output is a direction, not a stock list.
+
+The first answer should say:
+
+- the next lane worth tracking
+- why now
+- what confirms it
+- what breaks it
+- what downstream / upstream companies would feel it first
+
+This is the main output layer.
+
+### Step 6: Only Then Offer Candidate Names
+
+If the user pushes deeper, offer 3-7 names.
+
+Split them by role:
+
+- safest executor
+- pure bottleneck supplier
+- cheaper second-order beneficiary
+- early optionality / disruptor
+
+For each name, include:
+
+- role in the stack
+- why this name belongs
+- what evidence is real
+- what still needs confirmation
+- main risk
+
+For lower-market-cap names, always include:
+
+- market-cap mismatch versus the layer leader
+- current stage: concept / qualification / early ramp / real volume
+- why this may still be too early
+
+Do not present them as buy calls.
+
+When the user asks for stock tickers mapped to the supply-chain thesis, systematically map across all relevant exchanges (US, Taiwan, Korea, A-share, Hong Kong). Different exchanges have structural strengths and blank spots — do not force-fit a weak substitute when an exchange genuinely has no pure-play exposure.
+
+**Market-access constraint rule:** If the user constrains the investable universe (e.g. "A股/港股通", "only A-shares", "Hong Kong Stock Connect eligible"), do not stop at generic roles such as "A-share PMIC company" or "domestic module supplier." For each proposed bottleneck layer, output one of:
+
+- concrete in-scope listed names/tickers with role + evidence status + what still needs verification; or
+- `No clean in-scope pure-play found` with a short reason, then list out-of-scope global comps only as references.
+
+This prevents a correct stack thesis from becoming unactionable for the user's actual account access. If live pricing or filings are not checked, label the names as `candidate pool, not validated` and state the next data checks instead of pretending they are confirmed picks.
+
+### Step 7: Position-Sizing Logic
+
+If the user asks for weights, use the layered discipline:
+
+- leaders / proven executors get more weight
+- earlier pre-commercial names get smaller starter positions
+- weight increases only if qualification, ramp, and revenue conversion improve
+
+Never size purely off narrative upside.
+
+## Output Levels
+
+Choose the shallowest level that satisfies the ask.
+
+Escalation rule:
+
+- first response: direction only
+- second response after user follow-up: candidate watchlist
+- third response after user picks one lane or one company: underwrite sheet
+
+If the user jumps straight to "give me small caps", first give:
+
+- one-paragraph lane thesis
+- one bottleneck summary
+- then the names
+
+Do not skip the thesis stage.
+
+### Level 1: Directional Lane
+
+Use when the user asks:
+
+- what direction should I study next
+- where is the next bottleneck
+- what sector is being underpriced
+
+Output:
+
+- thesis in 4-8 short paragraphs
+- stack snapshot
+- bottleneck call
+- proof / disproof checklist
+
+### Level 2: Candidate Watchlist
+
+Use when the user follows up with:
+
+- which names are worth watching
+- any lower-market-cap ideas
+- who are the pure-play beneficiaries
+
+Output:
+
+- 3-7 names
+- grouped by role
+- one-line thesis, one-line risk, one-line next check
+
+If the evidence base is weak, downgrade the output to:
+
+- names worth validating, not names worth buying
+
+### Level 3: Underwrite Sheet
+
+Use when the user asks for one name in depth.
+
+Output:
+
+- why this company matters
+- what exact bottleneck it solves
+- customer / supplier map
+- revenue timing and what to monitor
+- failure cases
+
+## Falsification Framework
+
+After the directional lane and candidate analysis, offer a systematic stress-test of the entire thesis. This is distinct from the single "what breaks it" line in Step 5 — it is a multi-dimensional decomposition.
+
+### When to Trigger
+
+Offer when:
+
+- the user asks for falsification, debunking, counter-arguments, or "what could go wrong"
+- the analysis spans 3+ output layers (L1 + L2 + L3)
+- the thesis depends on multiple structural assumptions (not just one demand wave)
+- **any candidate trades at PE > 100x** — the Four Pillars decomposition becomes mandatory
+
+### Structure
+
+Decompose the bull case into **N core assumptions** (typically 4-7). For each assumption, force:
+
+1. **What the bull case depends on** — one sentence
+2. **How it breaks** — the specific mechanism
+3. **Probability** — low / medium / high, with a concrete trigger event
+4. **Impact magnitude** — estimated downside if this assumption fails alone
+
+### Falsification Matrix Format
+
+| Assumption | Break Probability | Impact | Fatality | Key Trigger |
+|------------|:----------------:|:------:|:--------:|-------------|
+| 1. ... | X% | ±Y% | ⭐⭐⭐ | ... |
+
+### Scenario Synthesis
+
+After the matrix, synthesize the top 2-3 composite scenarios:
+
+- **Scenario A: "Worst Case"** — multiple breaks simultaneously, probability and impact
+- **Scenario B: "Mild Disconfirmation"** — one or two assumptions weaken, not break
+- **Scenario C: "Valuation Reversion"** — fundamentals hold but multiple compression hits
+
+### Checklist Format
+
+End with a self-check table the user can monitor:
+
+| Question | If YES | If NO |
+|----------|--------|-------|
+| ... | thesis intact | **thesis damaged** |
+
+### Integration With Price/Valuation
+
+When the user asks about current stock prices, integrate valuation as an additional falsification dimension: even if the supply-chain thesis is correct, the market may have already priced it. A 120x P/E on a cyclical peak is a falsification vector in itself — the thesis can be right and the stock can still drop 30% from multiple compression. Always separate "is the supply-chain thesis correct" from "is the current price a good entry point."
+
+When presenting cross-exchange stock tables with current prices (user explicitly requests "列出标的" or "current prices"), add a concise price-in column using 🟢 Under-priced / 🟡 Fair / 🔴 Over-priced ratings. Base ratings on: (1) PE relative to exchange norms and historical range, (2) how much current revenue actually comes from the supply-chain thesis vs. how much the PE implies, (3) PEG context. A PE above 200x on sub-scale profits is almost always 🔴 regardless of thesis quality — the market has already priced hyper-growth.
+
+## Architecture Disruption — Special Handling
+
+Architecture disruption (unified memory, chiplets, optical interconnect replacing electrical, on-package integration eliminating a component) is the single most dangerous threat to a bottleneck thesis because:
+
+- It is **binary**: the component either exists in the new architecture or it doesn't
+- It is **qualitative**: you cannot model it from capacity/utilization data
+- It is **asymmetric**: downstream demand may grow but if the architecture changes, your specific component's demand goes to zero regardless
+
+When architecture disruption is a live risk, dedicate a standalone section to it. Map exactly:
+
+- Which specific product lines are exposed vs immune
+- The adoption timeline (technology is never instant — even Apple's Intel-to-M-series transition took 2 years)
+- The counter-argument (why the legacy architecture retains advantages that slow adoption)
+
+## Recommended Response Skeleton
+
+When answering live user requests, default to this order:
+
+1. thesis sentence
+2. stack view
+3. bottleneck call
+4. evidence and disproof
+5. only then names, if requested
+
+This prevents the skill from collapsing into ticker spam.
+
+For L5 lower-market-cap drilldowns, end with two short lines:
+
+- why the market may be underpricing it
+- why the user still should not treat it like a proven executor
+
+## Tone and Style
+
+Write like a researcher who is trying to catch the market sleeping on a physical constraint.
+
+Good style traits:
+
+- direct
+- skeptical
+- bottleneck-focused
+- willing to say "this is still too early"
+- willing to separate "great story" from "real ramp"
+
+Bad style traits:
+
+- generic "AI is bullish" cheerleading
+- fake certainty
+- too many abstract slogans
+- copying any specific person's catchphrases
+
+## What Makes a Good Answer
+
+A good answer from this skill:
+
+- starts from the supertrend, not the ticker
+- shows the stack clearly
+- identifies one primary bottleneck and one backup candidate
+- uses at least one external non-social proof source when the user asked for current research
+- tells the user what to watch next
+- keeps small-cap names as a second-order output, not the starting point
+
+## When To Escalate
+
+Ask a clarification only if one of these is genuinely unclear:
+
+- which infrastructure theme the user means
+- whether they want direction vs names
+- whether current / latest validation matters
+
+If latest validation matters, browse the web and prefer primary sources.

--- a/skills/social-media/douyin-content-extractor/SKILL.md
+++ b/skills/social-media/douyin-content-extractor/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: douyin-content-extractor
+description: "Use when extracting and analyzing Douyin/TikTok China video or image-post content from shared links. Covers metadata, video/audio download, local STT transcription, image extraction/OCR, summary, and reusable Markdown output. Triggers: watch this Douyin, extract Douyin content, transcribe Douyin video, summarize Douyin, download Douyin."
+version: 1.0.0
+author: Community
+license: MIT
+metadata:
+  hermes:
+    tags: [douyin, tiktok, video-transcription, social-media, media-extraction, stt]
+    related_skills: [social-media-content-extractor]
+---
+
+# Douyin Content Extractor
+
+Use this skill to turn a Douyin share into usable text and media artifacts: metadata, video/audio, transcript, image descriptions/OCR, and a compact Markdown report.
+
+The reliable pattern is **webpage extraction + media download + local speech recognition**, not a single official API. Douyin pages change often, so keep the workflow layered: try the simple parser first, then browser/API fallback, then media/STT.
+
+Detailed fallback recipe: see `references/browser-aweme-detail-fallback.md` for the proven browser `performance` → `/aweme/v1/web/aweme/detail/` → `play_addr.url_list` extraction path.
+
+## Safety and scope
+
+- Work read-only on public/shared content.
+- Do not log into Douyin, post, comment, like, follow, or modify any account without explicit user confirmation.
+- Store temporary artifacts under `/tmp/douyin_<aweme_id>/` or another `/tmp/` path; do not clutter the project workspace.
+- Tell the user when transcript text is **machine-transcribed and not fully human-proofread**.
+
+## Required tools
+
+Typical successful path uses:
+
+- `browser` — load Douyin page and inspect in-page API/resource URLs.
+- `terminal` — redirects, curl download, ffmpeg, STT CLI.
+- `vision` — analyze downloaded image posts/screenshots when needed.
+- `file` — read/write final Markdown artifacts.
+
+Useful local commands:
+
+```bash
+ffmpeg
+# mlx_whisper: Apple Silicon local STT. Install once via:
+#   pip install mlx-whisper     # adds `mlx_whisper` to your PATH
+#   # or: uv tool install mlx-whisper
+mlx_whisper                                # local Apple Silicon STT
+uvx --from yt-dlp yt-dlp                   # optional fallback; Douyin often requires fresh cookies
+mcporter                                    # optional, only works if a douyin MCP server is configured
+```
+
+If `mlx_whisper` is not on `PATH`, locate it with `which mlx_whisper` or `python3 -m mlx_whisper --help` and adjust the script or invocation accordingly.
+
+## Workflow
+
+### 1. Normalize the shared link
+
+Extract the first `https://v.douyin.com/.../` or `https://www.douyin.com/...` URL from user text.
+
+For short links, follow redirects:
+
+```bash
+python3 - <<'PY'
+import requests
+url='https://v.douyin.com/SHORT/'
+r=requests.get(url, allow_redirects=False, timeout=20, headers={'User-Agent':'Mozilla/5.0'})
+print(r.status_code, r.headers.get('location'))
+PY
+```
+
+Common redirect chain:
+
+```text
+v.douyin.com/... -> www.iesdouyin.com/share/video/<aweme_id>/... -> www.douyin.com/video/<aweme_id>
+```
+
+Capture the `aweme_id`, e.g. `7646495323627588864`.
+
+### 2. Try simple parser path
+
+If available, try agent-reach/mcporter first:
+
+```bash
+mcporter call 'douyin.parse_douyin_video_info(share_link: "https://v.douyin.com/xxx/")'
+mcporter call 'douyin.get_douyin_download_link(share_link: "https://v.douyin.com/xxx/")'
+```
+
+If it returns `Unknown MCP server 'douyin'` or similar, do not stop. Use the browser fallback.
+
+`yt-dlp` can also be tried, but Douyin often returns `Fresh cookies are needed`:
+
+```bash
+uvx --from yt-dlp yt-dlp --dump-json 'https://www.douyin.com/video/<aweme_id>'
+```
+
+### 3. Browser/API fallback: extract `aweme_detail`
+
+Open the canonical page with the browser:
+
+```text
+https://www.douyin.com/video/<aweme_id>
+```
+
+In browser console, inspect page text and API resources:
+
+```javascript
+document.body.innerText.slice(0, 5000)
+```
+
+Find `aweme/detail` calls:
+
+```javascript
+performance.getEntriesByType('resource')
+  .map(e => e.name)
+  .filter(n => n.includes('/aweme/v1/web/aweme/detail/'))
+```
+
+Fetch the same API from the page context so cookies/signature parameters are reused:
+
+```javascript
+(async()=>{
+  const u = performance.getEntriesByType('resource')
+    .map(e=>e.name)
+    .find(n=>n.includes('/aweme/v1/web/aweme/detail/'));
+  const j = await (await fetch(u,{credentials:'include'})).json();
+  const a = j.aweme_detail || j.aweme_list?.[0] || j;
+  return {
+    aweme_id: a.aweme_id,
+    desc: a.desc,
+    create_time: a.create_time,
+    author: a.author && {nickname:a.author.nickname, uid:a.author.uid, sec_uid:a.author.sec_uid, signature:a.author.signature},
+    stats: a.statistics,
+    duration_ms: a.video?.duration,
+    video_urls: [
+      ...(a.video?.play_addr?.url_list || []),
+      ...((a.video?.bit_rate || []).flatMap(b => b.play_addr?.url_list || []))
+    ],
+    image_urls: (a.images || []).flatMap(img => img.url_list || img.download_url_list || []),
+    raw_keys: Object.keys(a).slice(0,80)
+  };
+})()
+```
+
+Save useful metadata into the final report.
+
+### 4. Download media
+
+Create a per-video temp directory:
+
+```bash
+AWEME_ID='<aweme_id>'
+mkdir -p "/tmp/douyin_${AWEME_ID}"
+```
+
+For videos, choose a direct `video_urls` item or `/aweme/v1/play/` URL and download with referer/user-agent:
+
+```bash
+curl -L --fail --retry 2 --connect-timeout 20 \
+  -A 'Mozilla/5.0' \
+  -e 'https://www.douyin.com/' \
+  '<play_url>' \
+  -o "/tmp/douyin_${AWEME_ID}/video.mp4" \
+  -w '\nhttp=%{http_code} size=%{size_download} type=%{content_type}\n'
+
+file "/tmp/douyin_${AWEME_ID}/video.mp4"
+```
+
+For image posts, download each image URL:
+
+```bash
+curl -L --fail -A 'Mozilla/5.0' -e 'https://www.douyin.com/' '<image_url>' \
+  -o "/tmp/douyin_${AWEME_ID}/image_01.jpg"
+```
+
+Important for Douyin image URLs: **keep the full signed query string** (`x-expires`, `x-signature`, `lk3s`, etc.). Do not shorten the URL or remove query parameters — stripped image URLs often download as tiny 403 HTML files. If image URLs are not visible after reload or carousel movement, re-open the canonical note page and extract current signed URLs from the DOM:
+
+```javascript
+[...document.querySelectorAll('img')]
+  .map((i, idx) => ({ idx, src: i.currentSrc || i.src, alt: i.alt, w: i.naturalWidth, h: i.naturalHeight }))
+  .filter(x => x.src && x.src.includes('tplv-dy-aweme-images'))
+```
+
+Then use `vision_analyze` for descriptions/OCR when the image content matters.
+
+### 5. Extract audio and transcribe video
+
+Verify video duration:
+
+```bash
+ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 \
+  "/tmp/douyin_${AWEME_ID}/video.mp4"
+```
+
+Extract mono 16k WAV for STT:
+
+```bash
+ffmpeg -y -i "/tmp/douyin_${AWEME_ID}/video.mp4" \
+  -vn -ac 1 -ar 16000 -c:a pcm_s16le \
+  "/tmp/douyin_${AWEME_ID}/audio.wav"
+```
+
+Prefer MLX Whisper on Apple Silicon. A reusable wrapper is shipped at `scripts/transcribe_video.sh` (it picks up `mlx_whisper` from `PATH`; override with the `WHISPER_BIN` env var if it lives elsewhere):
+
+```bash
+# Recommended: use the bundled script
+scripts/transcribe_video.sh \
+  "/tmp/douyin_${AWEME_ID}/video.mp4" \
+  "/tmp/douyin_${AWEME_ID}" \
+  transcript_small
+
+# Or invoke mlx_whisper directly (assumes it is on PATH)
+mlx_whisper \
+  "/tmp/douyin_${AWEME_ID}/audio.wav" \
+  --model mlx-community/whisper-small-mlx \
+  --language zh \
+  --output-dir "/tmp/douyin_${AWEME_ID}" \
+  --output-name transcript_small \
+  --output-format txt \
+  --verbose False
+
+# If the small model download/auth fails, fall back:
+mlx_whisper \
+  "/tmp/douyin_${AWEME_ID}/audio.wav" \
+  --model mlx-community/whisper-tiny-mlx \
+  --language zh \
+  --output-dir "/tmp/douyin_${AWEME_ID}" \
+  --output-name transcript_tiny \
+  --output-format txt
+```
+
+Fallback to `mlx-community/whisper-tiny` if model download/auth fails. Mention that tiny is faster but less accurate.
+
+### 6. Clean transcript lightly, but label uncertainty
+
+Machine transcripts may contain common Chinese ASR errors such as:
+
+- 券商 → 圈商/劝商/全商
+- 研报 → 眼报/延报
+- 评级 → 平级
+- 估值 → 孤职
+- 折现率 → 折线率
+
+Light cleanup is fine for readability, but do not pretend it is a human-verified transcript. If a phrase affects investment/medical/legal decisions, mark it as needing manual verification.
+
+### 7. Output format
+
+Create a Markdown file under `/tmp/douyin_<aweme_id>/douyin_<aweme_id>_extract.md` with this structure:
+
+```markdown
+# 抖音内容提取：[标题]
+
+来源：<original/canonical URL>
+作者：<nickname>
+发布时间：<if available>
+时长/类型：<video duration or image count>
+提取方式：浏览器 aweme_detail + 媒体下载 + 本地 STT/视觉分析
+质量说明：机器转写/机器视觉，未完全人工校对
+
+## 核心摘要
+
+## 主要观点/信息点
+
+## 结构化要点
+
+## 小飞判断 / 对用户场景的意义
+
+## 原始元数据
+
+## 机器转写正文或图片 OCR/描述
+```
+
+When replying on WeChat, keep the message compact and attach the file with:
+
+```text
+MEDIA:/tmp/douyin_<aweme_id>/douyin_<aweme_id>_extract.md
+```
+
+## Troubleshooting
+
+- `mcporter` says `Unknown MCP server 'douyin'`: expected on some installs; use browser fallback.
+- `yt-dlp` says fresh cookies needed: use browser/API fallback instead of trying to log in.
+- Browser loads but no metadata: wait a few seconds, scroll/click play, then inspect `performance` again.
+- Direct MP4 URL expires: re-fetch `aweme_detail` from the browser page and download immediately.
+- Downloaded file is tiny/HTML: wrong URL or expired signature; check `file` and retry with another `url_list` item.
+- Long video transcription times out: use `terminal(background=true, notify_on_complete=true)` or split audio into chunks.
+- `mlx_whisper` not on `PATH`: install with `pip install mlx-whisper` (or `uv tool install mlx-whisper`), or set `WHISPER_BIN=/path/to/mlx_whisper` when calling `scripts/transcribe_video.sh`.
+- Image posts/video frames have text in screenshots: use `vision_analyze` with a direct question: "提取图中文字并总结观点". If `vision_analyze` fails because the configured vision provider token is invalid/expired, fall back to the local `zai` CLI vision path. For multi-image Douyin notes, loop over all downloaded images and append output to one OCR file:
+
+```bash
+cd /tmp/douyin_${AWEME_ID}
+for i in 01 02 03 04 05; do
+  echo "===== IMAGE $i =====" | tee -a ocr.txt
+  zai vision -f image_${i}.webp \
+    '请提取这张图片中的所有中文/英文文字，尤其是标题、表格、仓库名、URL、框架名；保持原文，识别不确定处用 [?] 标记。' \
+    2>&1 | tee -a ocr.txt
+  echo | tee -a ocr.txt
+done
+```
+
+For a single image:
+
+```bash
+zai vision -f /tmp/douyin_${AWEME_ID}/contact.jpg \
+  '请提取画面中的字幕、项目名称和关键信息；不确定请标注。' --json
+```
+
+## Quality checklist before final answer
+
+- [ ] Canonical URL or aweme_id captured.
+- [ ] Metadata captured: title/desc, author, time, duration/type when available.
+- [ ] Media download or image extraction verified with `file`, `ls -lh`, or `ffprobe`.
+- [ ] Transcript/image OCR exists and is labeled as machine-generated.
+- [ ] Final Markdown report written under `/tmp/`.
+- [ ] User-facing response includes concise summary and `MEDIA:` attachment if a file was produced.

--- a/skills/social-media/douyin-content-extractor/references/browser-aweme-detail-fallback.md
+++ b/skills/social-media/douyin-content-extractor/references/browser-aweme-detail-fallback.md
@@ -1,0 +1,57 @@
+# Browser `aweme_detail` fallback for Douyin extraction
+
+Use this when mcporter/agent-reach Douyin parser or `yt-dlp` cannot directly parse a public Douyin link, but the web page can load and play.
+
+## Proven session pattern
+
+1. Resolve short link to canonical page and capture `aweme_id`:
+   - `https://v.douyin.com/.../` usually redirects through `www.iesdouyin.com/share/video/<aweme_id>/...` to `https://www.douyin.com/video/<aweme_id>`.
+2. Open canonical page in the browser and let it load/play.
+3. Inspect browser resource entries for the detail API:
+   ```javascript
+   performance.getEntriesByType('resource')
+     .map(e => e.name)
+     .filter(n => n.includes('/aweme/v1/web/aweme/detail/'))
+   ```
+4. Fetch that exact URL from page context so the page's cookies, generated params, and signatures are reused:
+   ```javascript
+   (async()=>{
+     const u = performance.getEntriesByType('resource')
+       .map(e=>e.name)
+       .find(n=>n.includes('/aweme/v1/web/aweme/detail/'));
+     const j = await (await fetch(u,{credentials:'include'})).json();
+     const a = j.aweme_detail || j.aweme_list?.[0] || j;
+     return {
+       aweme_id: a.aweme_id,
+       desc: a.desc,
+       author: a.author && {nickname:a.author.nickname, uid:a.author.uid, sec_uid:a.author.sec_uid},
+       stats: a.statistics,
+       duration_ms: a.video?.duration,
+       video_urls: [
+         ...(a.video?.play_addr?.url_list || []),
+         ...((a.video?.bit_rate || []).flatMap(b => b.play_addr?.url_list || []))
+       ],
+       image_urls: (a.images || []).flatMap(img => img.url_list || img.download_url_list || [])
+     };
+   })()
+   ```
+5. Download a returned play URL immediately; these URLs can expire:
+   ```bash
+   curl -L --fail --retry 2 --connect-timeout 20 \
+     -A 'Mozilla/5.0' \
+     -e 'https://www.douyin.com/' \
+     '<play_url>' \
+     -o "/tmp/douyin_${AWEME_ID}/video.mp4" \
+     -w '\nhttp=%{http_code} size=%{size_download} type=%{content_type}\n'
+   file "/tmp/douyin_${AWEME_ID}/video.mp4"
+   ```
+
+## Why this works
+
+The browser page has already solved Douyin's web parameters/signatures for the active session. Reusing the exact API URL from `performance` avoids inventing `a_bogus`, `verifyFp`, or related parameters.
+
+## Failure diagnosis
+
+- Tiny output or HTML instead of MP4: URL expired, wrong candidate, or HTML challenge. Re-open/re-fetch `aweme_detail`, choose another `url_list` candidate, and retry with user-agent + referer.
+- API list empty: wait, click play, scroll, or inspect `document.body.innerText` first; the page may not have triggered video detail loading yet.
+- Image post: `video` may be absent; use `images[].url_list` and vision/OCR instead of STT.

--- a/skills/social-media/douyin-content-extractor/scripts/transcribe_video.sh
+++ b/skills/social-media/douyin-content-extractor/scripts/transcribe_video.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Transcribe a downloaded Douyin video with local MLX Whisper.
+#
+# Usage:
+#   transcribe_video.sh <video.mp4> <output_dir> [output_name]
+#
+# Env:
+#   WHISPER_BIN   path to mlx_whisper binary (default: lookup on PATH, then common user site)
+#   WHISPER_MODEL Whisper MLX model id (default: mlx-community/whisper-small-mlx)
+#   WHISPER_LANG  Language code (default: zh)
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <video.mp4> <output_dir> [output_name]" >&2
+  exit 2
+fi
+
+VIDEO="$1"
+OUT_DIR="$2"
+OUT_NAME="${3:-transcript_small}"
+WHISPER_MODEL="${WHISPER_MODEL:-mlx-community/whisper-small-mlx}"
+WHISPER_LANG="${WHISPER_LANG:-zh}"
+
+# Locate mlx_whisper: explicit override -> PATH -> common macOS user site
+resolve_whisper_bin() {
+  if [[ -n "${WHISPER_BIN:-}" ]]; then
+    command -v "$WHISPER_BIN" || { echo "WHISPER_BIN not found: $WHISPER_BIN" >&2; exit 3; }
+  elif command -v mlx_whisper >/dev/null 2>&1; then
+    command -v mlx_whisper
+  elif [[ -x "$HOME/Library/Python/3.9/bin/mlx_whisper" ]]; then
+    echo "$HOME/Library/Python/3.9/bin/mlx_whisper"
+  elif [[ -x "$HOME/Library/Python/3.11/bin/mlx_whisper" ]]; then
+    echo "$HOME/Library/Python/3.11/bin/mlx_whisper"
+  else
+    echo "Could not find mlx_whisper. Install with: pip install mlx-whisper" >&2
+    exit 3
+  fi
+}
+
+WHISPER_BIN_PATH="$(resolve_whisper_bin)"
+
+mkdir -p "$OUT_DIR"
+AUDIO="$OUT_DIR/audio.wav"
+
+ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$VIDEO" > "$OUT_DIR/duration.txt"
+ffmpeg -y -i "$VIDEO" -vn -ac 1 -ar 16000 -c:a pcm_s16le "$AUDIO"
+
+"$WHISPER_BIN_PATH" "$AUDIO" \
+  --model "$WHISPER_MODEL" \
+  --language "$WHISPER_LANG" \
+  --output-dir "$OUT_DIR" \
+  --output-name "$OUT_NAME" \
+  --output-format txt \
+  --verbose False
+
+printf 'whisper_bin=%s\nduration_seconds=%s\ntranscript=%s/%s.txt\n' \
+  "$WHISPER_BIN_PATH" "$(cat "$OUT_DIR/duration.txt")" "$OUT_DIR" "$OUT_NAME"


### PR DESCRIPTION
## Summary

Add three community-contributed skills to the Hermes Agent skills repository.

### 1. supply-chain-hunter (skills/research/)
AI infrastructure supply chain bottleneck analysis skill. Core methodology:
- **Supertrend confirmation** → **Stack mapping** (6-9 layers) → **Bottleneck hunting** (capacity/qualification/thermal/geopolitical) → **Cross-source verification** → **Direction before names**
- Includes falsification framework with probability-impact matrix, architecture disruption detection, price-in assessment with four-pillar stress test, and revenue quality scoring
- Generic two-lens approach (underfollowed choke point + full stack position-sizing) abstracted from public research methodologies

### 2. model-benchmark (skills/devops/)
Hermes-native per-question model benchmarking (v2.0.0). Key features:
- Per-question independent `hermes chat` calls (not prompt-packing all questions)
- Automated grading with comparison matrix table
- MD5 identity verification to detect identical-model routing
- Fallback detection to flag contaminated results
- Multi-round stability testing support

### 3. douyin-content-extractor (skills/social-media/)
Douyin/TikTok China content extraction using browser fallback + local STT:
- Normalize links → browser/API fallback → download media → offline MLX Whisper STT → OCR → Markdown report
- Read-only, privacy-first design (no login, no platform account modification)
- Portable mlx-whisper path resolution via env vars and auto-detection

## Checklist
- [x] Frontmatter meets in-repo conventions (name, description ≤1024, version, author, license, metadata)
- [x] All skills are self-contained or have minimal supporting files
- [x] No hardcoded local paths or personal identifiers
- [x] English throughout
