### PR TITLE
fix(matrix): return SendResult instead of sending error to main room on missing file

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1491,9 +1491,8 @@ class MatrixAdapter(BasePlatformAdapter):
         """Read a local file and upload it."""
         p = Path(file_path).expanduser()
         if not p.exists():
-            return await self.send(
-                room_id, f"{caption or ''}\n(file not found: {file_path})", reply_to
-            )
+            logger.warning("Matrix: MEDIA file not found, skipping: %s", file_path)
+            return SendResult(success=False, error=f"file not found: {file_path}")
 
         fname = file_name or p.name
         ct = mimetypes.guess_type(fname)[0] or "application/octet-stream"

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2859,3 +2859,66 @@ class TestCreateMatrixSession:
                     assert session.connector is fake_connector
                 finally:
                     await session.close()
+
+
+
+# ---------------------------------------------------------------------------
+# _send_local_file: file-not-found handling
+# ---------------------------------------------------------------------------
+
+class TestSendLocalFileNotFound:
+    """Verify _send_local_file returns SendResult instead of sending to wrong room."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        # Mock send() so we can assert it is NOT called for missing files
+        self.adapter.send = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_failure(self, tmp_path):
+        """Missing file returns SendResult(success=False) without calling send()."""
+        missing = str(tmp_path / "nonexistent.png")
+        result = await self.adapter._send_local_file(
+            room_id="!room:example.org",
+            file_path=missing,
+            msgtype="m.image",
+            caption="test caption",
+            reply_to="$event123",
+            metadata={"thread_id": "$thread456"},
+        )
+        assert result.success is False
+        assert "file not found" in result.error
+        assert missing in result.error
+        # send() must NOT have been called (no message to wrong room)
+        self.adapter.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_file_does_not_leak_to_main_room(self, tmp_path):
+        """Even without metadata, missing file does not send error to any room."""
+        missing = str(tmp_path / "gone.jpg")
+        result = await self.adapter._send_local_file(
+            room_id="!room:example.org",
+            file_path=missing,
+            msgtype="m.image",
+        )
+        assert result.success is False
+        self.adapter.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_existing_file_still_uploads(self, tmp_path):
+        """Existing file still goes through upload path (regression guard)."""
+        real_file = tmp_path / "real.png"
+        real_file.write_bytes(b"\x89PNG\r\n")
+        # Mock _upload_and_send so we don't need a real Matrix connection
+        self.adapter._upload_and_send = AsyncMock(
+            return_value=MagicMock(success=True)
+        )
+        result = await self.adapter._send_local_file(
+            room_id="!room:example.org",
+            file_path=str(real_file),
+            msgtype="m.image",
+        )
+        assert result.success is True
+        self.adapter._upload_and_send.assert_called_once()
+        # send() should not be called for existing files either
+        self.adapter.send.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Fixes `_send_local_file()` in the Matrix adapter to return `SendResult(success=False)` instead of sending an error message to the main room when a file is not found. Previously, the error message bypassed thread routing (missing `metadata` parameter), causing confusing messages in the wrong room.

## Related Issue

Fixes #32503

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/matrix.py`: Replace `self.send()` call in file-not-found path with `logger.warning()` + `SendResult(success=False, error=...)`, matching Slack's pattern for missing files
- `tests/gateway/test_matrix.py`: Add `TestSendLocalFileNotFound` with 3 tests — missing file returns failure, no message leaked to any room, existing file still uploads correctly

## How to Test

1. Run `pytest tests/gateway/test_matrix.py::TestSendLocalFileNotFound -v` — all 3 tests pass
2. Configure Matrix gateway, send a message with `MEDIA:/nonexistent/path/file.png` in a thread — verify no error message appears in the main room
3. Check gateway logs for `Matrix: MEDIA file not found, skipping: /nonexistent/path/file.png` warning

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/matrix.py::_send_local_file` (callers: 4 within same adapter, flows: media delivery)
- Blast radius: LOW — single method in Matrix adapter only; Slack adapter already uses this pattern
- Related patterns: Slack returns `SendResult(success=False, error=...)` for missing files at lines 1725/1823/1848; this PR aligns Matrix with that convention
