### PR TITLE
fix(gateway): drop --replace from systemd unit templates (#37145)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2409,7 +2409,7 @@ StartLimitIntervalSec=0
 Type=simple
 User={username}
 Group={group_name}
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
 Environment="USER={username}"
@@ -2419,8 +2419,6 @@ Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
-RestartMaxDelaySec=300
-RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
@@ -2447,15 +2445,13 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
-RestartMaxDelaySec=300
-RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1772,7 +1772,12 @@ class TestProfileArg:
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
         unit = gateway_cli.generate_systemd_unit(system=False)
         assert "--profile mybot" in unit
-        assert "gateway run --replace" in unit
+        assert "gateway run" in unit
+        # Under a process supervisor (Restart=always), --replace makes each
+        # restart kill its predecessor → self-kill loop. The systemd unit must
+        # NOT use --replace; the supervisor owns the lifecycle. (--replace stays
+        # on the manual launchd fallback path — see test_launchd_plist_includes_profile.)
+        assert "--replace" not in unit
 
     def test_launchd_plist_includes_profile(self, tmp_path, monkeypatch):
         """generate_launchd_plist should include --profile in ProgramArguments for named profiles."""


### PR DESCRIPTION
## Summary
Generated systemd gateway units no longer use `--replace`, which under `Restart=always` created an infinite self-kill restart loop.

Root cause: with `--replace` in `ExecStart` and systemd's `Restart=always`, every restart reads `gateway.pid`, kills the previous process, writes its own PID, exits via the replace lifecycle, and gets relaunched — repeating until systemd's restart limit. A process supervisor owns the lifecycle; `--replace` is for manual one-shot takeovers and fights the supervisor.

## Changes
- `hermes_cli/gateway.py`: drop `--replace` from both the system-level and user-level systemd `ExecStart` templates. Also drop `RestartMaxDelaySec=300` / `RestartSteps=5` (require systemd v255+, silently ignored on older versions). The `_strip_optional_systemd_directives` normalizer stays so existing installs whose on-disk unit still carries those directives aren't perpetually flagged as outdated.
- `tests/hermes_cli/test_gateway_service.py`: `test_systemd_unit_includes_profile` now asserts `gateway run` (no `--replace`) and that `--replace` is absent from the systemd unit.

`--replace` is intentionally retained where it's correct: manual `hermes gateway run --replace`, and the macOS launchd fallback path (`_gateway_run_command`, issue #23387) — a deliberate manual takeover, not a supervised unit.

## Validation
| | Before | After |
|---|---|---|
| supervised gateway under `Restart=always` | each restart kills its predecessor → self-kill loop until restart limit | supervisor owns lifecycle, no self-kill |
| `tests/hermes_cli/test_gateway_service.py` + `test_systemd_optional_directives.py` + `test_gateway.py` | — | 190 passed |
| manual `--replace` / launchd fallback | works | unchanged (still uses `--replace`) |

## Credit
Reported and diagnosed by @Skippy-the-Magnificent-one in PR #37145. Reimplemented here under project authorship because the original commit was authored under a non-existent email (`skippy@hermes-agent.dev`) that can't be carried into git history — the engineering credit is theirs. Original PR will be closed with a pointer here.

## Infographic

![stop-the-self-kill-loop](https://v3b.fal.media/files/b/0a9d70e3/B9kdCJ4An_wSofJF1OgDZ_hsHC80si.png)
