### PR TITLE
fix(update): refuse implicit branch switch during update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10463,6 +10463,38 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # against a non-default channel.
         branch = _resolve_update_branch(args)
 
+        # Refuse to *implicitly* hop branches during an update. Historically
+        # `hermes update` silently `git checkout`ed the target (default main)
+        # whenever HEAD was on a different branch, which can disrupt a user's
+        # in-progress local work without warning. Only switch when the user
+        # opted in: either via --allow-branch-switch, or by naming the target
+        # explicitly with --branch (whose documented behavior is to switch).
+        allow_branch_switch = bool(getattr(args, "allow_branch_switch", False))
+        branch_explicit = bool((getattr(args, "branch", None) or "").strip())
+        if (
+            current_branch != branch
+            and not allow_branch_switch
+            and not branch_explicit
+        ):
+            current_label = (
+                "detached HEAD" if current_branch == "HEAD" else current_branch
+            )
+            print("✗ Refusing to switch branches during update.")
+            print(f"  Current branch: {current_label}")
+            print(f"  Update branch:  {branch}")
+            print()
+            print(
+                "  Hermes will not automatically switch branches during "
+                "`hermes update`"
+            )
+            print("  because this can disrupt local work.")
+            print(
+                f"  Switch to {branch} yourself, or rerun with "
+                "--allow-branch-switch if you"
+            )
+            print("  intentionally want Hermes to switch branches.")
+            sys.exit(1)
+
         # If user is on a different branch than the update target, switch
         # to the target. When the target is "main" this is the historical
         # "always update against main" behavior; for any other target it's

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -67,4 +67,10 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         default=False,
         help="Windows: proceed with the update even when another hermes.exe is detected. The concurrent process will likely cause WinError 32 warnings and may leave a reboot-deferred .exe replacement.",
     )
+    update_parser.add_argument(
+        "--allow-branch-switch",
+        action="store_true",
+        default=False,
+        help="Allow hermes to switch branches during the update. By default, when HEAD is on a branch other than the update target (e.g. a feature branch), the update refuses rather than implicitly switching and disrupting local work. Passing --branch explicitly also opts in.",
+    )
     update_parser.set_defaults(func=cmd_update)

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -115,13 +115,16 @@ class TestCmdUpdateBranchFallback:
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
     def test_update_falls_back_to_main_when_branch_not_on_remote(
-        self, mock_run, _mock_which, mock_args, capsys
+        self, mock_run, _mock_which, capsys
     ):
         mock_run.side_effect = _make_run_side_effect(
             branch="fix/stoicneko", verify_ok=False, commit_count="3"
         )
 
-        cmd_update(mock_args)
+        # On a feature branch the update would implicitly hop to main, which
+        # is now refused by default — pass --allow-branch-switch so this test
+        # keeps exercising the main-targeting fallback path.
+        cmd_update(SimpleNamespace(allow_branch_switch=True))
 
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -548,14 +548,14 @@ def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_cmd_update_switches_to_main_from_feature_branch(monkeypatch, tmp_path, capsys):
-    """When on a feature branch, update checks out main before pulling."""
+    """With --allow-branch-switch, update checks out main before pulling."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
     side_effect, recorded = _make_update_side_effect(current_branch="fix/something")
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    hermes_main.cmd_update(SimpleNamespace(allow_branch_switch=True))
 
     checkout_calls = [c for c in recorded if "checkout" in c and "main" in c]
     assert len(checkout_calls) == 1
@@ -566,20 +566,91 @@ def test_cmd_update_switches_to_main_from_feature_branch(monkeypatch, tmp_path, 
 
 
 def test_cmd_update_switches_to_main_from_detached_head(monkeypatch, tmp_path, capsys):
-    """When in detached HEAD state, update checks out main before pulling."""
+    """With --allow-branch-switch, update checks out main from detached HEAD."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
     side_effect, recorded = _make_update_side_effect(current_branch="HEAD")
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    hermes_main.cmd_update(SimpleNamespace(allow_branch_switch=True))
 
     checkout_calls = [c for c in recorded if "checkout" in c and "main" in c]
     assert len(checkout_calls) == 1
 
     out = capsys.readouterr().out
     assert "detached HEAD" in out
+
+
+def test_cmd_update_refuses_branch_switch_from_feature_branch(monkeypatch, tmp_path, capsys):
+    """Without an override, update on a feature branch refuses before any checkout."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(current_branch="fix/something")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.cmd_update(SimpleNamespace())
+    assert exc_info.value.code == 1
+
+    # No checkout/switch should have been attempted.
+    checkout_calls = [c for c in recorded if "checkout" in c]
+    assert checkout_calls == []
+    # And we must not have pulled anything either.
+    pull_calls = [c for c in recorded if "pull" in c]
+    assert pull_calls == []
+
+    out = capsys.readouterr().out
+    assert "Refusing to switch branches during update." in out
+    assert "Current branch: fix/something" in out
+    assert "Update branch:  main" in out
+    assert "--allow-branch-switch" in out
+
+
+def test_cmd_update_refuses_branch_switch_from_detached_head(monkeypatch, tmp_path, capsys):
+    """Detached HEAD also refuses to implicitly switch to the update branch."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(current_branch="HEAD")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.cmd_update(SimpleNamespace())
+    assert exc_info.value.code == 1
+
+    checkout_calls = [c for c in recorded if "checkout" in c]
+    assert checkout_calls == []
+
+    out = capsys.readouterr().out
+    assert "Refusing to switch branches during update." in out
+    assert "Current branch: detached HEAD" in out
+    assert "--allow-branch-switch" in out
+
+
+def test_cmd_update_discard_config_does_not_authorize_branch_switch(monkeypatch, tmp_path, capsys):
+    """updates.non_interactive_local_changes=discard governs stash handling,
+    not branch-hop: a non-interactive update on a feature branch still refuses."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(
+        hermes_config, "load_config",
+        lambda *a, **kw: {"updates": {"non_interactive_local_changes": "discard"}},
+    )
+
+    side_effect, recorded = _make_update_side_effect(current_branch="fix/something")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.cmd_update(SimpleNamespace(gateway=True))
+    assert exc_info.value.code == 1
+
+    checkout_calls = [c for c in recorded if "checkout" in c]
+    assert checkout_calls == []
+
+    out = capsys.readouterr().out
+    assert "Refusing to switch branches during update." in out
 
 
 def test_cmd_update_restores_stash_and_branch_when_already_up_to_date(monkeypatch, tmp_path, capsys):
@@ -603,7 +674,7 @@ def test_cmd_update_restores_stash_and_branch_when_already_up_to_date(monkeypatc
     )
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    hermes_main.cmd_update(SimpleNamespace(allow_branch_switch=True))
 
     # Stash should have been restored
     assert len(restore_calls) == 1

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -42,7 +42,7 @@ pip install --upgrade hermes-agent    # or: uv pip install --upgrade hermes-agen
 When you run `hermes update`, the following steps occur:
 
 1. **Pairing-data snapshot** — a lightweight pre-update state snapshot is saved (covers `~/.hermes/pairing/`, Feishu comment rules, and other state files that get modified at runtime). Recoverable via the snapshot restore flow described under [Snapshots and rollback](../user-guide/checkpoints-and-rollback.md), or by extracting the most recent quick-snapshot zip Hermes wrote next to your `~/.hermes/` directory.
-2. **Git pull** — pulls the latest code from the `main` branch and updates submodules
+2. **Branch safety + git pull** — pulls the latest code from the update branch (default: `main`) and updates submodules. If your checkout is on another branch, Hermes stops before switching branches unless you explicitly opt in with `--allow-branch-switch` or name the target with `--branch <name>`.
 3. **Post-pull syntax validation + auto-rollback** — after the pull, Hermes compiles the eight critical files every `hermes` invocation imports at startup. If any fails to parse (e.g. an orphan merge-conflict marker, an accidentally truncated file), Hermes runs `git reset --hard <pre-pull-sha>` to roll the install back so your shell stays bootable. Re-run `hermes update` once the upstream fix lands.
 4. **Dependency install** — runs `uv pip install -e ".[all]"` to pick up new or changed dependencies
 5. **Config migration** — detects new config options added since your version and prompts you to set them
@@ -57,7 +57,14 @@ hermes update --branch release-candidate
 hermes update --check --branch experimental   # preview behindness only
 ```
 
-If your local checkout is on a different branch, Hermes auto-stashes any uncommitted work, switches HEAD to the target branch, and then pulls. Branches that don't exist locally are auto-tracked from `origin/<name>` (`git checkout -B <name> origin/<name>`). Branches that don't exist anywhere fail cleanly — your stashed changes are restored before exit so you're never stranded in a weird state. The `main`-only fork-upstream sync logic is automatically skipped on non-`main` branches.
+If your local checkout is already on the requested update branch, Hermes pulls normally. If HEAD is on a different branch, Hermes refuses to switch branches by default so an update cannot unexpectedly move you away from feature work. Switch branches yourself first, or opt in explicitly:
+
+```bash
+hermes update --allow-branch-switch      # allow switching to the default update branch
+hermes update --branch release-candidate # explicit branch target; also opts in to switching
+```
+
+When branch switching is explicitly allowed, Hermes auto-stashes any uncommitted work, switches HEAD to the target branch, and then pulls. Branches that don't exist locally are auto-tracked from `origin/<name>` (`git checkout -B <name> origin/<name>`). Branches that don't exist anywhere fail cleanly — your stashed changes are restored before exit so you're never stranded in a weird state. The `main`-only fork-upstream sync logic is automatically skipped on non-`main` branches. `--yes` and `updates.non_interactive_local_changes: discard` do **not** authorize branch switching; they only answer prompts or decide what happens to stashed source edits after an explicitly allowed update path.
 
 ### Local changes on non-interactive updates
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1422,14 +1422,14 @@ hermes completion fish > ~/.config/fish/completions/hermes.fish
 ## `hermes update`
 
 ```bash
-hermes update [--gateway] [--check] [--no-backup] [--backup] [--yes]
+hermes update [--gateway] [--check] [--no-backup] [--backup] [--yes] [--branch NAME] [--allow-branch-switch]
 ```
 
 Pulls the latest `hermes-agent` code and reinstalls dependencies in your venv, then re-runs the post-install hooks (MCP servers, skills sync, completion install). Safe to run on a live install.
 
 **pip installs:** `hermes update` detects pip-based installations automatically — it queries PyPI for the latest release and runs `pip install --upgrade hermes-agent` instead of `git pull`. PyPI releases track tagged versions (major/minor releases), not every commit on `main`. Use `--check` to see if a newer PyPI release is available without installing.
 
-**git installs:** `hermes update` pulls the configured update branch (default: `main`). If your checkout is on another branch, Hermes may check out the update branch before pulling. Commit branch work before updating when you want to keep it outside the update autostash flow.
+**git installs:** `hermes update` pulls the configured update branch (default: `main`). If your checkout is on another branch, Hermes refuses to switch branches by default so an update cannot unexpectedly move you away from feature work. Switch to the update branch yourself, pass `--allow-branch-switch`, or name an explicit target with `--branch NAME`.
 
 | Option | Description |
 |--------|-------------|
@@ -1438,11 +1438,14 @@ Pulls the latest `hermes-agent` code and reinstalls dependencies in your venv, t
 | `--no-backup` | Skip the pre-update backup for this run, even if `updates.pre_update_backup` is enabled in `config.yaml`. |
 | `--backup` | Create a labeled pre-update snapshot of `HERMES_HOME` (config, auth, sessions, skills, pairing data) before pulling. Default is **off** — the previous always-backup behavior was adding minutes to every update on large homes. Flip it on permanently via `updates.pre_update_backup: true` in `config.yaml`. |
 | `--yes`, `-y` | Assume yes for interactive prompts such as config migration and stash restore. API-key entry is skipped; run `hermes config migrate` separately for those. |
+| `--branch NAME` | Update against this branch instead of the default (`main`). Naming a branch is an explicit opt-in to switching to that branch if the checkout is currently elsewhere. |
+| `--allow-branch-switch` | Allow Hermes to switch from the current branch to the update branch before pulling. Without this flag, an implicit branch switch is refused. `--yes` and `updates.non_interactive_local_changes: discard` do not imply this permission. |
 
 Additional behavior:
 
 - **Gateway restart.** After a successful update, Hermes attempts to restart all running gateway profiles automatically so they pick up the new code. Use `hermes gateway restart` when you want to restart a gateway without applying an update.
-- **Local source changes.** For git installs, dirty tracked files and untracked files are auto-stashed before branch checkout or pull (`git stash push --include-untracked`). Interactive terminal updates ask before restoring the stash. Non-interactive updates restore it by default; set `updates.non_interactive_local_changes: discard` only on managed installs where local source edits should be thrown away after a successful pull. If stash restore conflicts or the pull fails, the stash is left in place for manual recovery.
+- **Branch switching.** For git installs, Hermes refuses to leave the current branch implicitly. If you want `hermes update` to switch from a feature branch to the update branch, pass `--allow-branch-switch`, or use `--branch NAME` to choose the target explicitly.
+- **Local source changes.** For git installs, dirty tracked files and untracked files are auto-stashed before an explicitly allowed branch checkout or pull (`git stash push --include-untracked`). Interactive terminal updates ask before restoring the stash. Non-interactive updates restore it by default; set `updates.non_interactive_local_changes: discard` only on managed installs where local source edits should be thrown away after a successful pull. If stash restore conflicts or the pull fails, the stash is left in place for manual recovery.
 - **npm lockfile churn.** Before stashing or switching branches, Hermes makes a best-effort cleanup of tracked `package-lock.json` diffs produced by npm install/build steps. Commit or manually stash intentional lockfile edits before running `hermes update`.
 - **Pairing data snapshot.** Even when `--backup` is off, `hermes update` takes a lightweight snapshot of `~/.hermes/pairing/` and the Feishu comment rules before `git pull`. You can roll it back with `hermes backup restore --state pre-update` if a pull rewrites a file you were editing.
 - **Legacy `hermes.service` warning.** If Hermes detects a pre-rename `hermes.service` systemd unit (instead of the current `hermes-gateway.service`), it prints a one-time migration hint so you can avoid flap-loop issues.


### PR DESCRIPTION
## Summary

`hermes update` no longer silently hops branches. When HEAD is on a branch
other than the update target (default `main`) — e.g. a feature branch or a
detached HEAD — the update now refuses up front instead of implicitly running
`git checkout main` and pulling on top of the user's local work.

## Why

The historical behavior auto-switched to the update target whenever the current
branch differed, after auto-stashing. For someone in the middle of feature work
this meant a routine `hermes update` could quietly move them off their branch.
Non-interactive/automated update paths got no clear signal either — the switch
just happened. This makes the disruptive case explicit and opt-in.

## Changed behavior

- On the update target (default `main`, or `--branch <name>` when HEAD already
  matches it): unchanged.
- On a different branch / detached HEAD with no opt-in: refuse before any
  checkout/switch/pull, exit code 1, with a parseable message naming the current
  branch, the update branch, and the override.
- Opt-in still switches as before.

Error message:

```
✗ Refusing to switch branches during update.
  Current branch: <current>
  Update branch:  <target>

  Hermes will not automatically switch branches during `hermes update`
  because this can disrupt local work.
  Switch to <target> yourself, or rerun with --allow-branch-switch if you
  intentionally want Hermes to switch branches.
```

## Override flag

New `hermes update --allow-branch-switch` explicitly authorizes the branch
switch. Passing `--branch <name>` explicitly also opts in, since switching to the
named branch is that flag's documented behavior. `--yes` and
`updates.non_interactive_local_changes=discard` deliberately do **not** authorize
a branch hop — the former only skips confirmation prompts, the latter only
governs stash handling.

## Tests

- New: refuse from a feature branch, refuse from detached HEAD, and that
  `non_interactive_local_changes=discard` does not authorize a branch hop.
- Updated existing branch-switch tests to pass `--allow-branch-switch` so they
  keep exercising the switch/targeting paths.

Targeted suites green except one pre-existing, environment-dependent failure
(`test_update_refreshes_repo_and_tui_node_dependencies`, web-build npm step) that
also fails on unmodified `main`.
