### PR TITLE
fix(agent): resume codex app-server thread across turns to preserve session context

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -191,6 +191,27 @@ def run_codex_app_server_turn(
     """
     from agent.transports.codex_app_server_session import CodexAppServerSession
 
+    # Belt-and-suspenders for the cached-agent path: if a live session exists
+    # but the caller is asking us to resume a DIFFERENT thread than the one it
+    # is already on, retire it so the session below rebuilds on the requested
+    # thread. In normal operation these never differ — the gateway persists
+    # each turn's thread id and restores the same one, and the live session is
+    # already on it — so this does NOT rebuild on every cache-hit turn (which
+    # would respawn codex + reload the rollout needlessly); it only fires on an
+    # actual mismatch.
+    _want_resume = getattr(agent, "_codex_resume_thread_id", None)
+    _live_session = getattr(agent, "_codex_session", None)
+    if (
+        _live_session is not None
+        and _want_resume
+        and getattr(_live_session, "_thread_id", None) not in (None, _want_resume)
+    ):
+        try:
+            _live_session.close()
+        except Exception:
+            pass
+        agent._codex_session = None
+
     # Lazy session: one CodexAppServerSession per AIAgent instance.
     # Spawned on first turn, reused across turns, closed at AIAgent
     # shutdown (see _cleanup hook).
@@ -204,9 +225,16 @@ def run_codex_app_server_turn(
             approval_callback = _get_approval_callback()
         except Exception:
             approval_callback = None
+        # Resume the codex thread from a prior turn of this Hermes session, so
+        # the codex working context survives a respawn. Two sources set this:
+        #   - the gateway, which rebuilds the AIAgent per inbound message and
+        #     restores the persisted thread id onto the fresh agent;
+        #   - this runtime itself (below), so a should_retire respawn within
+        #     the same long-lived agent (e.g. the CLI) also resumes.
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            resume_thread_id=getattr(agent, "_codex_resume_thread_id", None),
         )
 
     # NOTE: the user message is ALREADY appended to messages by the
@@ -234,7 +262,21 @@ def run_codex_app_server_turn(
             "completed": False,
             "partial": True,
             "error": str(exc),
+            # Surface the last-known thread id so the gateway keeps it: the
+            # next turn will try to resume it (the rollout may have survived
+            # the crash) and fall back to a fresh thread/start if it didn't.
+            "codex_thread_id": getattr(agent, "_codex_resume_thread_id", None),
         }
+
+    # Remember the codex thread id so the NEXT turn for this Hermes session
+    # resumes it (preserving the codex working context — file reads, tool
+    # output, long-running task state) instead of starting a fresh thread.
+    # Set BEFORE the should_retire handling so a retired-then-respawned
+    # session in the same process still resumes; the gateway separately
+    # persists result["codex_thread_id"] across its per-message AIAgent
+    # rebuild (keyed by the stable session_key).
+    if turn.thread_id:
+        agent._codex_resume_thread_id = turn.thread_id
 
     # If the turn signalled the underlying client is wedged (deadline
     # blown, post-tool watchdog tripped, OAuth refresh died, subprocess

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -14,7 +14,19 @@ Lifecycle:
     # result.projected_messages  → list of {role, content, ...} for messages list
     # result.tool_iterations     → how many tool-shaped items completed (skill nudge counter)
     # result.interrupted         → True if Ctrl+C / interrupt_requested fired mid-turn
+    # result.thread_id           → the codex thread id (persist to resume next turn)
     session.close()                                       # tears down subprocess
+
+Cross-turn continuity:
+    The gateway builds a *fresh* AIAgent per inbound message, so this adapter
+    (held on ``agent._codex_session``) is re-created every turn and a naive
+    ``thread/start`` would discard the codex thread's working context (file
+    reads, tool output, long-running task state) on each turn. To preserve the
+    "one Codex thread per Hermes session" contract, the caller persists the
+    last ``thread_id`` for the session and passes it back as
+    ``resume_thread_id``; ``ensure_started()`` then issues ``thread/resume``
+    (which reloads the persisted rollout from disk) instead of starting a new
+    thread, falling back to ``thread/start`` if resume is unavailable.
 
 Threading model: the adapter is single-threaded from the caller's perspective.
 The underlying CodexAppServerClient owns its own reader threads but exposes
@@ -208,6 +220,7 @@ class CodexAppServerSession:
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
+        resume_thread_id: Optional[str] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
@@ -225,6 +238,11 @@ class CodexAppServerSession:
 
         self._client: Optional[CodexAppServerClient] = None
         self._thread_id: Optional[str] = None
+        # A prior codex thread id for this Hermes session. When set,
+        # ensure_started() resumes that thread (reloading its on-disk rollout)
+        # instead of starting a fresh one, so multi-turn context survives the
+        # fresh-AIAgent-per-message gateway lifecycle.
+        self._resume_thread_id = resume_thread_id
         self._interrupt_event = threading.Event()
         # Pending file-change items, keyed by item id. Populated on
         # item/started for fileChange items; consumed by the approval
@@ -251,6 +269,29 @@ class CodexAppServerSession:
             client_title="Hermes Agent",
             client_version=_get_hermes_version(),
         )
+        # Resume the prior codex thread for this Hermes session when we have
+        # one, so the thread's working context (file reads, tool output,
+        # multi-turn task state) survives the fresh-AIAgent-per-message gateway
+        # lifecycle. thread/resume reloads the persisted rollout from disk by
+        # id; if it's unavailable (rollout GC'd, codex too old to expose the
+        # method, id no longer on disk) we fall back to a fresh thread/start so
+        # a turn is never lost.
+        if self._resume_thread_id:
+            resumed = self._resume_thread(self._resume_thread_id)
+            if resumed is not None:
+                self._thread_id = resumed
+                logger.info(
+                    "codex app-server thread resumed: id=%s profile=%s cwd=%s",
+                    resumed[:8],
+                    self._permission_profile,
+                    self._cwd,
+                )
+                return self._thread_id
+            logger.info(
+                "codex app-server thread resume unavailable (id=%s); "
+                "starting a fresh thread",
+                self._resume_thread_id[:8],
+            )
         # Permission selection is intentionally NOT sent on thread/start.
         # Two reasons (live-tested against codex 0.130.0):
         #   1. `thread/start.permissions` is gated behind the experimentalApi
@@ -268,17 +309,7 @@ class CodexAppServerSession:
         # ~/.codex/config.toml the same way they would for any codex usage.
         params: dict[str, Any] = {"cwd": self._cwd}
         result = self._client.request("thread/start", params, timeout=15)
-        # Cross-fill thread.id/sessionId — different codex versions have
-        # serialized this under either key. Mirrors openclaw beta.8's
-        # tolerance fix so future codex drops/renames don't KeyError us
-        # at handshake time.
-        thread_obj = result.get("thread") or {}
-        thread_id = (
-            thread_obj.get("id")
-            or thread_obj.get("sessionId")
-            or result.get("sessionId")
-            or result.get("threadId")
-        )
+        thread_id = self._extract_thread_id(result)
         if not thread_id:
             raise CodexAppServerError(
                 code=-32603,
@@ -295,6 +326,47 @@ class CodexAppServerSession:
             self._cwd,
         )
         return self._thread_id
+
+    def _resume_thread(self, thread_id: str) -> Optional[str]:
+        """Resume a prior codex thread by id. Returns the resumed thread id on
+        success, or None when resume isn't possible so the caller can fall back
+        to thread/start. We send only `threadId`: codex loads the rollout from
+        disk and applies the thread's own config — the other ThreadResumeParams
+        fields are optional overrides we don't want.
+
+        Catches every failure mode the client can surface so a resume attempt
+        is never worse than not attempting it: CodexAppServerError (method
+        unsupported on this codex version, rollout no longer on disk, RPC
+        error), TimeoutError, and RuntimeError (the subprocess died / its stdin
+        pipe broke between handshake and resume). Any of these → fall back to a
+        fresh thread/start."""
+        assert self._client is not None
+        try:
+            result = self._client.request(
+                "thread/resume", {"threadId": thread_id}, timeout=15
+            )
+        except (CodexAppServerError, TimeoutError, RuntimeError) as exc:
+            logger.info(
+                "codex thread/resume rejected (id=%s): %s", thread_id[:8], exc
+            )
+            return None
+        return self._extract_thread_id(result)
+
+    @staticmethod
+    def _extract_thread_id(result: dict) -> Optional[str]:
+        """Pull the thread id out of a thread/start or thread/resume result.
+
+        Cross-fills thread.id / thread.sessionId / top-level sessionId /
+        threadId — different codex versions have serialized this under
+        different keys. Mirrors openclaw beta.8's tolerance fix so future
+        codex drops/renames don't KeyError us at handshake time."""
+        thread_obj = result.get("thread") or {}
+        return (
+            thread_obj.get("id")
+            or thread_obj.get("sessionId")
+            or result.get("sessionId")
+            or result.get("threadId")
+        )
 
     def close(self) -> None:
         if self._closed:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1242,6 +1242,8 @@ from gateway.session import (
     build_session_context_prompt,
     build_session_key,
     is_shared_multi_user_session,
+    should_preserve_codex_thread_id_after_reset,
+    should_preserve_codex_thread_id_after_expiry,
 )
 from gateway.delivery import DeliveryRouter
 from gateway.authz_mixin import GatewayAuthorizationMixin
@@ -5332,6 +5334,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Evict any cached AIAgent for this session_key so the next dispatch
         # rebuilds it against the CLI session_id (mirrors /resume / /branch).
         self._evict_cached_agent(session_key)
+        if hasattr(self, "_session_codex_threads"):
+            self._session_codex_threads.pop(session_key, None)
 
         # Cancel any in-flight running-agent state for the destination key
         # so the synthetic turn isn't queued behind a stale running flag.
@@ -5477,9 +5481,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _update_prompt_pending = getattr(self, "_update_prompt_pending", None)
                         if isinstance(_update_prompt_pending, dict):
                             _update_prompt_pending.pop(key, None)
-                        # The session is ending — drop its codex thread mapping
-                        # so a future session reusing this key starts a fresh
-                        # codex thread instead of resuming the expired one.
+                        # The Hermes transcript session is finalized, but a
+                        # thread-like platform lane may continue later. Keep the
+                        # persisted Codex thread id for those durable lanes so a
+                        # same-thread follow-up after daily/idle reset can still
+                        # resume Codex working context. Non-thread sessions keep
+                        # the older reset semantics and start fresh.
+                        if not should_preserve_codex_thread_id_after_expiry(entry):
+                            entry.codex_thread_id = None
                         self._session_codex_threads.pop(key, None)
                         # Mark as finalized and persist to disk so the flag
                         # survives gateway restarts.
@@ -8021,6 +8030,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     switched = self.session_store.switch_session(session_key, bound_session_id)
                     if switched is not None:
                         session_entry = switched
+                        if hasattr(self, "_session_codex_threads"):
+                            self._session_codex_threads.pop(session_key, None)
                 # If the stored binding pointed at a parent, rewrite it to the
                 # canonical descendant now that we've followed the chain.
                 if (
@@ -8035,11 +8046,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._record_telegram_topic_binding(source, session_entry)
                 except Exception:
                     logger.debug("Failed to record Telegram topic binding", exc_info=True)
+        _codex_thread_survived_reset = False
         if getattr(session_entry, "was_auto_reset", False):
-            # Treat auto-reset as a full conversation boundary — drop every
-            # session-scoped transient state so the fresh session does not
-            # inherit the previous conversation's model/reasoning overrides
-            # or a queued "/model switched" note.
+            _reset_reason = getattr(session_entry, "auto_reset_reason", None)
+            _codex_thread_survived_reset = bool(
+                getattr(session_entry, "codex_thread_id", None)
+                and should_preserve_codex_thread_id_after_reset(source, _reset_reason)
+            )
+            # Treat auto-reset as a Hermes transcript boundary for model and
+            # reasoning overrides, but not necessarily as a Codex thread
+            # boundary. SessionStore carries codex_thread_id across normal
+            # idle/daily resets for durable thread-like lanes; dropping this
+            # in-memory value simply forces the fresh agent to reload it from
+            # sessions.json.
             self._session_model_overrides.pop(session_key, None)
             self._set_session_reasoning_override(session_key, None)
             self._session_codex_threads.pop(session_key, None)
@@ -8087,6 +8106,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             reset_reason = getattr(session_entry, 'auto_reset_reason', None) or 'idle'
             if reset_reason == "suspended":
                 context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
+            elif _codex_thread_survived_reset:
+                context_note = (
+                    "[System note: The Hermes transcript session was automatically "
+                    "reset, but this is the same platform thread/topic and the "
+                    "Codex app-server working thread will be resumed if available. "
+                    "Use that Codex working context when relevant; do not assume "
+                    "the old Hermes transcript is present unless it appears in the "
+                    "resumed Codex context.]"
+                )
             elif reset_reason == "daily":
                 context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
             else:
@@ -8123,12 +8151,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             mins = policy.idle_minutes % 60
                             duration = f"{hours}h" if not mins else f"{hours}h {mins}m" if hours else f"{mins}m"
                             reason_text = f"inactive for {duration}"
-                        notice = (
-                            f"◐ Session automatically reset ({reason_text}). "
-                            f"Conversation history cleared.\n"
-                            f"Use /resume to browse and restore a previous session.\n"
-                            f"Adjust reset timing in config.yaml under session_reset."
-                        )
+                        if _codex_thread_survived_reset:
+                            notice = (
+                                f"◐ Hermes transcript session reset ({reason_text}). "
+                                f"Codex working context is preserved for this thread.\n"
+                                f"Use /new if you want a fully fresh Codex thread.\n"
+                                f"Adjust reset timing in config.yaml under session_reset."
+                            )
+                        else:
+                            notice = (
+                                f"◐ Session automatically reset ({reason_text}). "
+                                f"Conversation history cleared.\n"
+                                f"Use /resume to browse and restore a previous session.\n"
+                                f"Adjust reset timing in config.yaml under session_reset."
+                            )
                         try:
                             session_info = self._format_session_info()
                             if session_info:
@@ -14174,9 +14210,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # like _pending_model_notes for runners built without full __init__.
             if session_key:
                 _codex_threads = getattr(self, "_session_codex_threads", None)
-                agent._codex_resume_thread_id = (
-                    _codex_threads.get(session_key) if _codex_threads else None
+                _codex_resume_thread_id = (
+                    _codex_threads.get(session_key)
+                    if isinstance(_codex_threads, dict)
+                    else None
                 )
+                if not _codex_resume_thread_id:
+                    try:
+                        _codex_resume_thread_id = self.session_store.get_codex_thread_id(
+                            session_key
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Failed to load persisted codex thread id for %s",
+                            session_key,
+                            exc_info=True,
+                        )
+                    if _codex_resume_thread_id and isinstance(_codex_threads, dict):
+                        _codex_threads[session_key] = _codex_resume_thread_id
+                agent._codex_resume_thread_id = _codex_resume_thread_id
 
             # Credits / out-of-band notices (usage bands, depletion, restored).
             # Messaging has no persistent status bar, so each notice is a
@@ -14640,6 +14692,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _codex_tid = result.get("codex_thread_id")
                 if _codex_tid and hasattr(self, "_session_codex_threads"):
                     self._session_codex_threads[session_key] = _codex_tid
+                    try:
+                        self.session_store.set_codex_thread_id(session_key, _codex_tid)
+                    except Exception:
+                        logger.debug(
+                            "Failed to persist codex thread id for %s",
+                            session_key,
+                            exc_info=True,
+                        )
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2108,6 +2108,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Per-session reasoning effort overrides from /reasoning.
         # Key: session_key, Value: parsed reasoning config dict.
         self._session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
+        # Per-session codex app-server thread ids, so the codex_app_server
+        # runtime resumes the same Codex thread across turns instead of
+        # starting a fresh one each message (the gateway rebuilds the AIAgent
+        # per inbound message, which would otherwise discard the codex thread's
+        # working context). Key: session_key (stable across compaction's
+        # session_id rotation), Value: codex thread id string.
+        self._session_codex_threads: Dict[str, str] = {}
         self._kanban_notifier_profile = self._active_profile_name()
         # Teams meeting pipeline runtime (bound later when msgraph_webhook adapter exists).
         self._teams_pipeline_runtime = None
@@ -5470,6 +5477,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _update_prompt_pending = getattr(self, "_update_prompt_pending", None)
                         if isinstance(_update_prompt_pending, dict):
                             _update_prompt_pending.pop(key, None)
+                        # The session is ending — drop its codex thread mapping
+                        # so a future session reusing this key starts a fresh
+                        # codex thread instead of resuming the expired one.
+                        self._session_codex_threads.pop(key, None)
+                        # Mark as finalized and persist to disk so the flag
+                        # survives gateway restarts.
                         with self.session_store._lock:
                             entry.expiry_finalized = True
                             self.session_store._save()
@@ -8029,6 +8042,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # or a queued "/model switched" note.
             self._session_model_overrides.pop(session_key, None)
             self._set_session_reasoning_override(session_key, None)
+            self._session_codex_threads.pop(session_key, None)
             if hasattr(self, "_pending_model_notes"):
                 self._pending_model_notes.pop(session_key, None)
         
@@ -8853,6 +8867,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._evict_cached_agent(session_key)
                 self._session_model_overrides.pop(session_key, None)
                 self._set_session_reasoning_override(session_key, None)
+                self._session_codex_threads.pop(session_key, None)
                 if hasattr(self, "_pending_model_notes"):
                     self._pending_model_notes.pop(session_key, None)
                 if new_entry is not None:
@@ -14151,6 +14166,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
 
+            # Resume this session's codex thread on the next codex_app_server
+            # turn so its working context (file reads, tool output, long tasks)
+            # survives the per-message agent rebuild and should_retire respawns.
+            # Keyed by the stable session_key; only the codex runtime reads it,
+            # so it's a harmless no-op for every other runtime. getattr-guarded
+            # like _pending_model_notes for runners built without full __init__.
+            if session_key:
+                _codex_threads = getattr(self, "_session_codex_threads", None)
+                agent._codex_resume_thread_id = (
+                    _codex_threads.get(session_key) if _codex_threads else None
+                )
+
             # Credits / out-of-band notices (usage bands, depletion, restored).
             # Messaging has no persistent status bar, so each notice is a
             # standalone push: render to a single plaintext line and deliver via
@@ -14595,6 +14622,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pass
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
+
+            # Persist this turn's codex thread id so the next turn for the
+            # same session resumes it (see _session_codex_threads). Keyed by
+            # the stable session_key so it survives compaction's session_id
+            # rotation; cleared on session reset / expiry boundaries. Skip the
+            # write when this run is no longer current (a /new or /stop bumped
+            # the generation mid-turn) — otherwise a discarded turn's thread id
+            # would repopulate the map AFTER the reset cleared it, and the next
+            # turn would wrongly resume the pre-reset thread. Mirrors the
+            # stale-run guard used for agent promotion below.
+            _codex_run_current = (
+                run_generation is None
+                or self._is_session_run_current(session_key, run_generation)
+            )
+            if session_key and _codex_run_current and isinstance(result, dict):
+                _codex_tid = result.get("codex_thread_id")
+                if _codex_tid and hasattr(self, "_session_codex_threads"):
+                    self._session_codex_threads[session_key] = _codex_tid
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -508,6 +508,12 @@ class SessionEntry:
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
 
+    # Codex app-server thread id for this gateway lane. The gateway process may
+    # restart between Discord messages; persisting this lets the next process
+    # call thread/resume instead of starting a fresh Codex thread and losing the
+    # native Codex working context.
+    codex_thread_id: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "session_key": self.session_key,
@@ -538,6 +544,7 @@ class SessionEntry:
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
             "reset_had_activity": self.reset_had_activity,
+            "codex_thread_id": self.codex_thread_id,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -590,7 +597,47 @@ class SessionEntry:
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
             reset_had_activity=data.get("reset_had_activity", False),
+            codex_thread_id=data.get("codex_thread_id"),
         )
+
+
+_CODEX_THREAD_RESET_CARRY_REASONS = {"idle", "daily"}
+
+
+def is_thread_like_session_source(source: Optional[SessionSource]) -> bool:
+    """Return True for platform lanes that represent a durable thread/topic."""
+    if source is None:
+        return False
+    return source.chat_type == "thread" or bool(source.thread_id)
+
+
+def is_thread_like_session_entry(entry: "SessionEntry") -> bool:
+    """Return True when a persisted entry belongs to a durable thread/topic."""
+    if entry.origin is not None and is_thread_like_session_source(entry.origin):
+        return True
+    return entry.chat_type == "thread"
+
+
+def should_preserve_codex_thread_id_after_reset(
+    source: Optional[SessionSource],
+    reset_reason: Optional[str],
+) -> bool:
+    """Return whether a reset should keep the Codex app-server thread id.
+
+    Hermes idle/daily reset rotates the transcript session. For durable platform
+    lanes like Discord threads and Telegram topics, that should not necessarily
+    discard Codex's working thread. Hard reset reasons such as suspended sessions
+    still force a clean Codex slate.
+    """
+    return (
+        reset_reason in _CODEX_THREAD_RESET_CARRY_REASONS
+        and is_thread_like_session_source(source)
+    )
+
+
+def should_preserve_codex_thread_id_after_expiry(entry: "SessionEntry") -> bool:
+    """Return whether expiry finalization should keep the Codex thread id."""
+    return is_thread_like_session_entry(entry)
 
 
 def is_shared_multi_user_session(
@@ -904,6 +951,7 @@ class SessionStore:
         # All _entries / _loaded mutations are protected by self._lock.
         db_end_session_id = None
         db_create_kwargs = None
+        codex_thread_id = None
 
         with self._lock:
             self._ensure_loaded_locked()
@@ -936,9 +984,18 @@ class SessionStore:
                     self._save()
                     return entry
                 else:
-                    # Session is being auto-reset.
+                    # Session is being auto-reset. The Hermes transcript session
+                    # rotates here, but a Discord/Telegram thread is still the
+                    # same platform lane. Keep the Codex app-server thread id for
+                    # normal idle/daily resets so same-thread follow-ups resume
+                    # Codex working context instead of starting from scratch.
                     was_auto_reset = True
                     auto_reset_reason = reset_reason
+                    if should_preserve_codex_thread_id_after_reset(
+                        source,
+                        reset_reason,
+                    ):
+                        codex_thread_id = entry.codex_thread_id
                     # Track whether the expired session had any real conversation
                     reset_had_activity = entry.total_tokens > 0
                     db_end_session_id = entry.session_id
@@ -962,6 +1019,7 @@ class SessionStore:
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
+                codex_thread_id=codex_thread_id,
             )
 
             self._entries[session_key] = entry
@@ -1002,6 +1060,46 @@ class SessionStore:
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
+
+    def get_codex_thread_id(self, session_key: str) -> Optional[str]:
+        """Return the persisted Codex app-server thread id for a session key."""
+        if not session_key:
+            return None
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            return entry.codex_thread_id
+
+    def set_codex_thread_id(self, session_key: str, thread_id: str) -> bool:
+        """Persist the Codex app-server thread id for restart-safe resume."""
+        thread_id = str(thread_id or "").strip()
+        if not session_key or not thread_id:
+            return False
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return False
+            if entry.codex_thread_id == thread_id:
+                return True
+            entry.codex_thread_id = thread_id
+            self._save()
+            return True
+
+    def clear_codex_thread_id(self, session_key: str) -> bool:
+        """Clear a persisted Codex thread id at a true conversation boundary."""
+        if not session_key:
+            return False
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or not entry.codex_thread_id:
+                return False
+            entry.codex_thread_id = None
+            self._save()
+            return True
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -117,6 +117,9 @@ class GatewaySlashCommandsMixin:
         # picks up configured defaults instead of previous session switches.
         self._session_model_overrides.pop(session_key, None)
         self._set_session_reasoning_override(session_key, None)
+        # /new is a fresh conversation — drop the codex thread mapping so the
+        # next turn starts a brand-new codex thread instead of resuming the old.
+        self._session_codex_threads.pop(session_key, None)
         if hasattr(self, "_pending_model_notes"):
             self._pending_model_notes.pop(session_key, None)
 

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -53,6 +53,11 @@ class FakeClient:
         if method == "thread/start":
             return {"thread": {"id": "thread-fake-001"},
                     "activePermissionProfile": {"id": "workspace-write"}}
+        if method == "thread/resume":
+            # Resume echoes back the requested thread, like real app-server
+            # loading the rollout from disk and returning the same id.
+            return {"thread": {"id": (params or {}).get("threadId", "thread-fake-001")},
+                    "activePermissionProfile": {"id": "workspace-write"}}
         if method == "turn/start":
             return {"turn": {"id": "turn-fake-001"}}
         if method == "turn/interrupt":
@@ -963,6 +968,124 @@ class TestSessionRetirement:
         assert r.should_retire is True
         # Stderr-derived auth hint takes precedence over generic message
         assert r.error and "codex login" in r.error
+
+
+# ---- thread/resume (cross-turn continuity) ----
+
+class TestThreadResume:
+    """When a prior codex thread id is known for the Hermes session, the
+    adapter resumes it (reloading the on-disk rollout) instead of starting a
+    new thread, so multi-turn working context survives the
+    fresh-AIAgent-per-message gateway lifecycle. Resume degrades gracefully to
+    thread/start when the rollout/method is unavailable."""
+
+    def test_resume_id_issues_thread_resume_not_start(self):
+        client = FakeClient()
+        s = make_session(client, resume_thread_id="prior-thread-xyz")
+        tid = s.ensure_started()
+        assert tid == "prior-thread-xyz"
+        methods = [m for (m, _) in client.requests]
+        assert "thread/resume" in methods
+        assert "thread/start" not in methods
+        # resume carried exactly the prior thread id, nothing else
+        _, params = next(r for r in client.requests if r[0] == "thread/resume")
+        assert params == {"threadId": "prior-thread-xyz"}
+
+    def test_no_resume_id_uses_thread_start(self):
+        client = FakeClient()
+        s = make_session(client)  # no resume_thread_id
+        s.ensure_started()
+        methods = [m for (m, _) in client.requests]
+        assert "thread/start" in methods
+        assert "thread/resume" not in methods
+
+    def test_resume_failure_falls_back_to_thread_start(self):
+        """codex too old to expose thread/resume (or rollout GC'd) → -32601 →
+        fall back to a fresh thread/start so the turn is never lost."""
+        from agent.transports.codex_app_server import CodexAppServerError
+
+        client = FakeClient()
+
+        def handler(method, params):
+            if method == "thread/resume":
+                raise CodexAppServerError(
+                    code=-32601, message="Unsupported method: thread/resume"
+                )
+            if method == "thread/start":
+                return {"thread": {"id": "fresh-thread-001"},
+                        "activePermissionProfile": {"id": "x"}}
+            if method == "turn/start":
+                return {"turn": {"id": "tu1"}}
+            return {}
+
+        client._request_handler = handler
+        s = make_session(client, resume_thread_id="dead-thread")
+        tid = s.ensure_started()
+        assert tid == "fresh-thread-001"
+        methods = [m for (m, _) in client.requests]
+        assert "thread/resume" in methods  # attempted first
+        assert "thread/start" in methods   # then fell back
+
+    def test_resume_timeout_falls_back_to_thread_start(self):
+        client = FakeClient()
+
+        def handler(method, params):
+            if method == "thread/resume":
+                raise TimeoutError(
+                    "codex method 'thread/resume' timed out after 15s"
+                )
+            if method == "thread/start":
+                return {"thread": {"id": "fresh-thread-002"},
+                        "activePermissionProfile": {"id": "x"}}
+            return {}
+
+        client._request_handler = handler
+        s = make_session(client, resume_thread_id="slow-thread")
+        assert s.ensure_started() == "fresh-thread-002"
+
+    def test_resume_runtime_error_falls_back_to_thread_start(self):
+        """A dead/closed subprocess surfaces as RuntimeError from the client
+        (broken stdin pipe). Resume must still fall back to thread/start rather
+        than letting the RuntimeError escape and fail the turn."""
+        client = FakeClient()
+
+        def handler(method, params):
+            if method == "thread/resume":
+                raise RuntimeError("codex app-server stdin closed unexpectedly")
+            if method == "thread/start":
+                return {"thread": {"id": "fresh-thread-003"},
+                        "activePermissionProfile": {"id": "x"}}
+            return {}
+
+        client._request_handler = handler
+        s = make_session(client, resume_thread_id="broken-pipe-thread")
+        assert s.ensure_started() == "fresh-thread-003"
+
+    def test_resumed_thread_flows_into_turn_start_and_result(self):
+        """End-to-end: the resumed thread id is what turn/start targets and
+        what TurnResult.thread_id reports back (so the caller re-persists it)."""
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        s = make_session(client, resume_thread_id="resumed-abc")
+        r = s.run_turn("hi", turn_timeout=1.0)
+        assert r.thread_id == "resumed-abc"
+        _, params = next(rq for rq in client.requests if rq[0] == "turn/start")
+        assert params["threadId"] == "resumed-abc"
+
+    def test_resume_tolerates_session_id_alias(self):
+        """thread/resume result under the thread.sessionId alias is accepted,
+        same cross-fill tolerance as thread/start."""
+        client = FakeClient()
+        client._request_handler = lambda method, params: (
+            {"thread": {"sessionId": "alias-resumed"}}
+            if method == "thread/resume"
+            else {"turn": {"id": "tu1"}} if method == "turn/start" else {}
+        )
+        s = make_session(client, resume_thread_id="whatever")
+        assert s.ensure_started() == "alias-resumed"
 
 
 # ---- thread/start cross-fill ----

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1223,6 +1223,176 @@ class TestLastPromptTokens:
         store.update_session("k1", last_prompt_tokens=0)
         assert entry.last_prompt_tokens == 0
 
+
+class TestCodexThreadPersistence:
+    """Codex app-server thread ids must survive gateway process restarts."""
+
+    def test_session_entry_roundtrips_codex_thread_id(self):
+        from datetime import datetime
+        from gateway.session import SessionEntry
+
+        entry = SessionEntry(
+            session_key="agent:main:discord:thread:chan:thread",
+            session_id="s1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            codex_thread_id="019ea688-7067-7461-a6a6-4237815eebc2",
+        )
+
+        data = entry.to_dict()
+        assert data["codex_thread_id"] == "019ea688-7067-7461-a6a6-4237815eebc2"
+        restored = SessionEntry.from_dict(data)
+        assert restored.codex_thread_id == "019ea688-7067-7461-a6a6-4237815eebc2"
+
+    def test_old_session_data_defaults_codex_thread_id_to_none(self):
+        from gateway.session import SessionEntry
+
+        entry = SessionEntry.from_dict(
+            {
+                "session_key": "test",
+                "session_id": "s1",
+                "created_at": "2025-01-01T00:00:00",
+                "updated_at": "2025-01-01T00:00:00",
+            }
+        )
+
+        assert entry.codex_thread_id is None
+
+    def test_session_store_persists_codex_thread_id(self, tmp_path):
+        from gateway.config import GatewayConfig, Platform
+        from gateway.session import SessionSource, SessionStore, build_session_key
+
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="thread-1",
+            chat_type="thread",
+            thread_id="thread-1",
+            parent_chat_id="channel-1",
+        )
+        key = build_session_key(source)
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._db = None
+        store.get_or_create_session(source)
+        assert store.set_codex_thread_id(key, "thread-a") is True
+
+        reloaded = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        reloaded._db = None
+        assert reloaded.get_codex_thread_id(key) == "thread-a"
+        assert reloaded.clear_codex_thread_id(key) is True
+        assert reloaded.get_codex_thread_id(key) is None
+
+    def test_thread_idle_auto_reset_carries_codex_thread_id(self, tmp_path):
+        from datetime import datetime, timedelta
+        from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+        from gateway.session import SessionSource, SessionStore, build_session_key
+
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="thread-1",
+            chat_type="thread",
+            thread_id="thread-1",
+            parent_chat_id="channel-1",
+        )
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=1)
+        )
+        key = build_session_key(source)
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = None
+        first = store.get_or_create_session(source)
+        assert store.set_codex_thread_id(key, "thread-a") is True
+        first.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+
+        reset = store.get_or_create_session(source)
+
+        assert reset.was_auto_reset is True
+        assert reset.auto_reset_reason == "idle"
+        assert reset.session_id != first.session_id
+        assert reset.codex_thread_id == "thread-a"
+
+    def test_thread_daily_auto_reset_carries_codex_thread_id(self, tmp_path):
+        from datetime import datetime, timedelta
+        from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+        from gateway.session import SessionSource, SessionStore, build_session_key
+
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="thread-1",
+            chat_type="thread",
+            thread_id="thread-1",
+            parent_chat_id="channel-1",
+        )
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="daily", at_hour=4)
+        )
+        key = build_session_key(source)
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = None
+        first = store.get_or_create_session(source)
+        assert store.set_codex_thread_id(key, "thread-a") is True
+        first.updated_at = datetime.now() - timedelta(days=2)
+        store._save()
+
+        reset = store.get_or_create_session(source)
+
+        assert reset.was_auto_reset is True
+        assert reset.auto_reset_reason == "daily"
+        assert reset.session_id != first.session_id
+        assert reset.codex_thread_id == "thread-a"
+
+    def test_dm_idle_auto_reset_drops_codex_thread_id(self, tmp_path):
+        from datetime import datetime, timedelta
+        from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+        from gateway.session import SessionSource, SessionStore, build_session_key
+
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="dm-1",
+            chat_type="dm",
+            user_id="user-1",
+        )
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=1)
+        )
+        key = build_session_key(source)
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = None
+        first = store.get_or_create_session(source)
+        assert store.set_codex_thread_id(key, "thread-a") is True
+        first.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+
+        reset = store.get_or_create_session(source)
+
+        assert reset.was_auto_reset is True
+        assert reset.auto_reset_reason == "idle"
+        assert reset.codex_thread_id is None
+
+    def test_suspended_auto_reset_drops_codex_thread_id(self, tmp_path):
+        from gateway.config import GatewayConfig, Platform
+        from gateway.session import SessionSource, SessionStore, build_session_key
+
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="thread-1",
+            chat_type="thread",
+            thread_id="thread-1",
+            parent_chat_id="channel-1",
+        )
+        key = build_session_key(source)
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._db = None
+        store.get_or_create_session(source)
+        assert store.set_codex_thread_id(key, "thread-a") is True
+        assert store.suspend_session(key) is True
+
+        reset = store.get_or_create_session(source)
+
+        assert reset.was_auto_reset is True
+        assert reset.auto_reset_reason == "suspended"
+        assert reset.codex_thread_id is None
+
 class TestRewriteTranscriptPreservesReasoning:
     """rewrite_transcript must not drop reasoning fields from SQLite."""
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -283,6 +283,78 @@ class TestRunConversationCodexPath:
         assert not client_mock.chat.completions.create.called
 
 
+class TestCodexThreadResumePersistence:
+    """The codex thread id must round-trip across turns so the codex working
+    context survives a respawn: the runtime records it on the agent after each
+    turn, and passes a known prior id into a freshly-built session as
+    resume_thread_id (the gateway carries it across its per-message AIAgent
+    rebuild)."""
+
+    def test_turn_records_thread_id_on_agent_for_next_turn(self, fake_session):
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+        # run_codex_app_server_turn stashes the thread id so the next session
+        # (gateway rebuild or should_retire respawn) can resume it.
+        assert agent._codex_resume_thread_id == "thread-stub-1"
+
+    def test_prior_thread_id_is_passed_into_new_session(self, fake_session):
+        agent = _make_codex_agent()
+        # Simulate the gateway restoring a persisted thread id onto the fresh
+        # per-message agent before the turn runs.
+        agent._codex_resume_thread_id = "prior-thread-from-gateway"
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+        # The lazily-built CodexAppServerSession was constructed to resume it.
+        assert agent._codex_session is not None
+        assert agent._codex_session._resume_thread_id == "prior-thread-from-gateway"
+        # …and after the turn the agent tracks the latest thread id.
+        assert agent._codex_resume_thread_id == "thread-stub-1"
+
+    def test_no_prior_thread_id_builds_session_without_resume(self, fake_session):
+        agent = _make_codex_agent()
+        assert getattr(agent, "_codex_resume_thread_id", None) is None
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+        # First-ever turn: session built with no resume id (fresh thread/start).
+        assert agent._codex_session is not None
+        assert agent._codex_session._resume_thread_id is None
+
+    def test_cache_hit_same_thread_reuses_live_session(self, fake_session):
+        """Cache-hit path: when the live session is already on thread T and the
+        restored resume id is also T (the lockstep invariant the gateway keeps),
+        the live session is reused — NOT respawned every turn (which would
+        reload the rollout + spawn codex needlessly)."""
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("first")
+        session_after_1 = agent._codex_session
+        assert session_after_1 is not None
+        # The live session is on thread T; the gateway restores that same T.
+        agent._codex_session._thread_id = "thread-stub-1"
+        agent._codex_resume_thread_id = "thread-stub-1"
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("second")
+        assert agent._codex_session is session_after_1  # same live session reused
+
+    def test_cache_hit_mismatched_thread_rebuilds_session(self, fake_session):
+        """Defensive guard: if a live session is on thread A but the caller asks
+        to resume a DIFFERENT thread B, the live session is retired and a fresh
+        one is built to resume B (this never happens in normal operation, but
+        the guard makes the cache-hit path provably correct)."""
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("first")
+        session_after_1 = agent._codex_session
+        agent._codex_session._thread_id = "live-thread-A"
+        agent._codex_resume_thread_id = "different-thread-B"
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("second")
+        # Old session retired, fresh one built to resume the requested thread.
+        assert agent._codex_session is not session_after_1
+        assert agent._codex_session._resume_thread_id == "different-thread-B"
+
+
 class TestReviewForkApiModeDowngrade:
     """When the parent agent runs on codex_app_server, the background
     review fork must downgrade to codex_responses — otherwise the fork

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -392,9 +392,40 @@ context-compaction's session-id rotation — and replayed as the resume target.
 
 Resume degrades gracefully: if the rollout is no longer on disk, or the Codex
 build is too old to expose `thread/resume`, Hermes falls back to `thread/start`
-for that turn (a fresh thread) rather than failing. The mapping is dropped on
-explicit conversation boundaries (`/new`, auto-reset, session expiry), so a
-brand-new conversation always starts a brand-new Codex thread.
+for that turn (a fresh thread) rather than failing. Normal idle/daily Hermes
+session resets keep the mapping for durable thread/topic lanes, so a Discord
+thread or Telegram topic can continue the same Codex working context after the
+transcript session rotates. Explicit conversation boundaries such as `/new`,
+`/reset`, or a suspended stuck session still start a brand-new Codex thread.
+
+### Operational runbook: gateway restart recovery
+
+Use this when a Discord, Telegram, or other gateway thread appears to forget
+Codex working context after the Hermes gateway restarts.
+
+1. Confirm the gateway lane. The log line for the inbound message includes the
+   stable `session_key`; Discord thread lanes look like
+   `agent:main:discord:thread:<chat-or-thread-id>:<thread-id>`.
+2. Inspect the persisted mapping on the gateway host:
+
+   ```bash
+   export HERMES_SESSION_KEY='agent:main:discord:thread:<chat-or-thread-id>:<thread-id>'
+   python -c 'import json, os; p=os.path.expanduser("~/.hermes/sessions/sessions.json"); print(json.load(open(p, encoding="utf-8")).get(os.environ["HERMES_SESSION_KEY"], {}).get("codex_thread_id"))'
+   ```
+
+   A live Codex runtime session should print the Codex thread id after a
+   successful turn. `None` means the session has not completed a Codex turn yet,
+   the runtime is not `codex_app_server`, or a true conversation boundary cleared
+   the mapping.
+3. Restart the gateway, then send one follow-up in the same platform thread. The
+   next turn should load this persisted id and call `thread/resume`. If resume
+   fails because the Codex rollout was deleted or the Codex build does not
+   support resume, Hermes logs the failure at debug level and falls back to a
+   fresh `thread/start` rather than dropping the user turn.
+4. Normal idle/daily session resets should not clear the mapping for the
+   same durable thread/topic lane. Explicit boundaries (`/new`, `/reset`,
+   suspended stuck-session recovery, and lane re-binding such as a handoff or
+   topic switch) should clear it. Idle agent-cache eviction must not clear it.
 
 ## Limitations
 

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -375,6 +375,27 @@ Switch back at any time:
 
 Effective on the next session. The Codex managed block stays in `~/.codex/config.toml` so you can re-enable later without losing config — or remove it manually if you prefer.
 
+## Cross-turn thread persistence
+
+Codex keeps each thread's working context — the files it has read, command
+output, plan state, everything built up over a long task — **inside the Codex
+thread**, not in Hermes' message transcript. Hermes therefore pins **one Codex
+thread per session** and **resumes** it on every turn (`thread/resume`) so that
+context carries across messages.
+
+This matters most under the **gateway** (Discord / Telegram / etc.), which
+builds a fresh `AIAgent` per inbound message. Without resume, every message
+would call `thread/start` and hand the model an *empty* thread, so a multi-turn
+task ("do X" → "now continue" → "what did you find?") would silently lose all of
+its earlier work. The thread id is remembered per session — keyed so it survives
+context-compaction's session-id rotation — and replayed as the resume target.
+
+Resume degrades gracefully: if the rollout is no longer on disk, or the Codex
+build is too old to expose `thread/resume`, Hermes falls back to `thread/start`
+for that turn (a fresh thread) rather than failing. The mapping is dropped on
+explicit conversation boundaries (`/new`, auto-reset, session expiry), so a
+brand-new conversation always starts a brand-new Codex thread.
+
 ## Limitations
 
 This runtime is **opt-in beta**. Working as of Hermes Agent 2026.5 + Codex CLI 0.130.0:
@@ -416,7 +437,8 @@ If you find a bug, [open an issue](https://github.com/NousResearch/hermes-agent/
              ▼                                            │
         ┌──────────────────────────────────┐              │
         │  codex app-server (subprocess)    │──────────────┘
-        │   thread/start, turn/start        │
+        │   thread/start · thread/resume    │
+        │   turn/start                      │
         │   item/* notifications            │
         │   shell + apply_patch + update_plan│
         │   view_image + sandbox            │


### PR DESCRIPTION
## What does this PR do?

The `codex_app_server` runtime is documented to keep **"one Codex thread per Hermes session"** (`agent/transports/codex_app_server_session.py`), but the gateway builds a **fresh `AIAgent` per inbound message**. Before this fix, each follow-up could call a new `thread/start`, handing Codex an empty working thread even though Hermes still had the message transcript.

A Codex thread's working context — files read, command output, plan state, and long-task runtime state — lives inside the Codex thread, not in Hermes' transcript replay. Losing the thread id makes Discord/Telegram follow-ups look like the agent forgot the task.

This PR records the Codex thread id per Hermes session and resumes it with `thread/resume`. The mapping is persisted in `~/.hermes/sessions/sessions.json`, so a gateway restart does not lose the resume target. For durable thread/topic lanes, normal idle/daily Hermes transcript resets also keep the Codex working thread; explicit fresh-start boundaries still drop it.

## Related Issue

Fixes #41904

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/transports/codex_app_server_session.py`** — `CodexAppServerSession` accepts `resume_thread_id`. `ensure_started()` issues `thread/resume {threadId}` when set, falling back to `thread/start` on resume failure so the user turn is not dropped.
- **`agent/codex_runtime.py`** — `run_codex_app_server_turn()` passes the requested resume thread into the session and records the returned `codex_thread_id` on the agent after each turn.
- **`gateway/session.py`** — persists `SessionEntry.codex_thread_id` to `sessions.json` with helpers for reading/writing/clearing it. Idle/daily reset carries the id only for durable thread/topic lanes; DM/non-thread sessions and suspended stuck sessions still start fresh.
- **`gateway/run.py`** — restores the persisted thread id onto fresh per-message agents, persists successful turn ids, skips stale-generation writes after `/new` or `/stop`, keeps thread/topic ids through expiry finalization, and updates auto-reset system/user notices so transcript reset does not contradict Codex resume behavior.
- **Docs** — updates the Codex app-server runtime docs with cross-turn persistence details, architecture notes, and an operational runbook for verifying gateway restart and daily-reset recovery.

## How to Test

Validated on the rebased PR branch:

```bash
python -m py_compile gateway/run.py gateway/session.py agent/codex_runtime.py agent/transports/codex_app_server_session.py tests/gateway/test_session.py
pytest tests/agent/transports/test_codex_app_server_session.py tests/run_agent/test_codex_app_server_integration.py tests/agent/transports/test_codex_app_server_runtime.py tests/gateway/test_session.py::TestLastPromptTokens tests/gateway/test_session.py::TestCodexThreadPersistence tests/gateway/test_session_env.py tests/gateway/test_session_reset_notify.py tests/gateway/test_restart_resume_pending.py -q
```

Result: `226 passed`.

New coverage includes:

- `TestThreadResume` for `thread/resume` versus `thread/start`, resume fallback, and thread id extraction.
- `TestCodexThreadResumePersistence` for runtime round-tripping of the resume id.
- `TestCodexThreadPersistence` for `SessionEntry` JSON roundtrip, old `sessions.json` compatibility, `SessionStore` save/reload/clear behavior, thread idle/daily reset carry-over, DM reset fresh-start behavior, and suspended reset fresh-start behavior.

## Operational Notes

For a gateway lane such as a Discord thread, a successful Codex app-server turn writes `codex_thread_id` under that lane's `session_key` in `~/.hermes/sessions/sessions.json`. After a gateway restart, the next turn in the same platform thread loads that persisted id and asks Codex to `thread/resume`.

Idle/daily Hermes transcript resets rotate the Hermes session id but keep the Codex thread id for durable thread/topic lanes, so same-thread follow-ups can continue Codex working context without replaying Discord history into the prompt. `/new`, `/reset`, suspended stuck-session recovery, and explicit lane re-binding remain fresh-start boundaries.

## Platforms tested

- macOS (Apple Silicon), Python 3.11, Codex CLI app-server runtime

## Checklist

- [x] Conventional commits
- [x] Rebased onto current `origin/main`
- [x] Relevant tests pass
- [x] Documentation and runbook updated
- [x] No new config keys; resume is automatic and transparent