### PR TITLE
fix(desktop): prevent composer busy stuck on session resume

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -495,6 +495,14 @@ export function useSessionActions({
       activeSessionIdRef.current = null
       busyRef.current = true
       setBusy(true)
+      // Safety kill switch: reset busy after 30s if resume stalls or navigated away.
+      // Without this, a gateway session.resume that hangs, or an isCurrentResume()
+      // guard that blocks the finally-reset, leaves the composer send button stuck
+      // in "running" state permanently.
+      const resumeBusyTimer = setTimeout(() => {
+        busyRef.current = false
+        setBusy(false)
+      }, 30_000)
       setAwaitingResponse(false)
       clearNotifications()
       setSelectedStoredSessionId(storedSessionId)
@@ -607,6 +615,7 @@ export function useSessionActions({
         setMessages(preserveLocalAssistantErrors(toChatMessages(fallback.messages), $messages.get()))
         notifyError(err, copy.resumeFailed)
       } finally {
+        clearTimeout(resumeBusyTimer)
         if (isCurrentResume()) {
           busyRef.current = false
           setBusy(false)


### PR DESCRIPTION
## Summary

Fix a bug where the composer send button gets permanently stuck in "running" state when clicking on a historical session in the desktop app.

## Root Cause

Two interacting issues cause the stuck busy state:

1. **Race between `session.info` and `session.resume`**: When `resumeSession()` finishes, it sets `busy: false` via `updateSessionState`. But if a `session.info` event with `running: true` fires during the resume, its RAF-scheduled `flushPendingViewState()` can re-apply `busy: true` after the resume already set it to false.

2. **No safety net**: If `isCurrentResume()` returns `false` in the `finally` block (e.g. user navigated away mid-resume), `busy` is never reset.

## Fix

Added a 30-second `setTimeout` kill switch right after `setBusy(true)` in `resumeSession()`. The timer is cleared in the `finally` block on normal completion. If the resume flow hangs, errors, or the `isCurrentResume()` guard prevents cleanup, the timer resets `busy` after 30 seconds — guaranteeing the composer recovers.

## Test Plan

- [ ] Click on historical session → send button should show brief loading, then return to normal
- [x] Navigate away quickly during resume → send button should recover within 30s
- [x] Click on session that was running when app was previously closed → send button should recover after resume

## Related

- Issue: #41901
- Files: `apps/desktop/src/app/session/hooks/use-session-actions.ts`