### PR TITLE
fix(cli): stop env sanitizer from splitting secrets on embedded KEY=

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5414,7 +5414,11 @@ def _sanitize_env_lines(lines: list) -> list:
 
     Uses a known-keys set (OPTIONAL_ENV_VARS + _EXTRA_ENV_KEYS) so we only
     split on real Hermes env var names, avoiding false positives from values
-    that happen to contain uppercase text with ``=``.
+    that happen to contain uppercase text with ``=``. A known ``KEY=`` is only
+    treated as a record boundary when the preceding record's value contains no
+    ``=`` of its own — this keeps structured values (proxy/base URLs with query
+    strings, secrets embedding ``=``) intact instead of truncating them and
+    fabricating a phantom entry for an unrelated provider.
     """
     # Build the known keys set lazily from OPTIONAL_ENV_VARS + extras.
     # Done inside the function so OPTIONAL_ENV_VARS is guaranteed to be defined.
@@ -5444,13 +5448,35 @@ def _sanitize_env_lines(lines: list) -> list:
                 match_ranges.append((idx, idx + len(needle)))
                 idx = stripped.find(needle, idx + len(needle))
 
-        split_positions = sorted({
+        candidate_positions = sorted({
             s for s, e in match_ranges
             if not any(
                 s2 <= s and e2 >= e and (s2, e2) != (s, e)
                 for s2, e2 in match_ranges
             )
         })
+
+        # Only treat a known ``KEY=`` as a record boundary when the value of
+        # the preceding record does not itself contain an ``=``. Once a value
+        # is "structured" (e.g. a proxy/base URL with a query string, or any
+        # secret that embeds ``=``), a later ``KEY=`` is almost certainly part
+        # of that value rather than a new entry — splitting there would
+        # truncate the real secret and fabricate a phantom credential for an
+        # unrelated provider. A plain token value (no ``=``) followed by a
+        # known ``KEY=`` is still the missing-newline concatenation we repair.
+        split_positions: list[int] = []
+        for pos in candidate_positions:
+            if not split_positions:
+                split_positions.append(pos)
+                continue
+            prev = split_positions[-1]
+            segment = stripped[prev:pos]  # the preceding "KEY=VALUE" record
+            eq = segment.find("=")
+            value = segment[eq + 1:] if eq >= 0 else ""
+            if "=" in value:
+                # Structured value — keep the remainder glued to it.
+                continue
+            split_positions.append(pos)
 
         if len(split_positions) > 1:
             for i, pos in enumerate(split_positions):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -477,6 +477,23 @@ class TestSanitizeEnvLines:
         assert result[0].startswith("GLM_API_KEY=")
         assert result[1].startswith("LM_API_KEY=")
 
+    def test_value_with_embedded_known_key_not_split(self):
+        """A structured value embedding a known KEY= must not be split (#secret-corruption).
+
+        A proxy/base URL whose query string contains another provider's key
+        name was being truncated and a phantom credential fabricated. The real
+        value contains an ``=`` before the embedded key, so it stays intact.
+        """
+        lines = ["OPENAI_BASE_URL=https://proxy/?upstream=OPENAI_API_KEY=secret123\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == lines
+
+    def test_secret_value_with_equals_and_embedded_key_preserved(self):
+        """A secret whose value contains '=' followed by a known key is preserved whole."""
+        lines = ["FIRECRAWL_API_KEY=tok=ANTHROPIC_API_KEY=should-stay-in-value\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == lines
+
     def test_save_env_value_fixes_corruption_on_write(self, tmp_path):
         """save_env_value sanitizes corrupted lines when writing a new key."""
         env_file = tmp_path / ".env"


### PR DESCRIPTION
## What does this PR do?

`_sanitize_env_lines` in `hermes_cli/config.py` repairs `.env` files where two
`KEY=VALUE` entries got concatenated onto one line (a missing-newline
corruption). To do that it scans the whole line for any known `KEY=` substring
and uses every match as a split point.

The problem is that the scan does not distinguish a key name that starts a new
record from one that appears *inside* a value. A perfectly valid value such as a
proxy/base URL with a query string, or a secret that embeds another provider's
key name, contains `KEY=` mid-value — so the line gets split there. The real
secret is silently truncated at the embedded match and a phantom credential is
fabricated for an unrelated provider. Because this runs on every `.env` read and
write (`save_env_value`, `remove_env_value`, load-time sanitize), the corruption
is then persisted on the next config/auth save, overwriting the user's real
value with no action on their part beyond having such a value.

Example before the fix:

    OPENAI_BASE_URL=https://proxy/?upstream=OPENAI_API_KEY=secret123

was rewritten to two lines, truncating the base URL and inventing an
`OPENAI_API_KEY`.

The fix anchors the split logic: a known `KEY=` is only treated as a record
boundary when the *preceding* record's value contains no `=` of its own. Once a
value is structured (a URL with a query string, or any value embedding `=`), the
remainder stays glued to it. A plain token value with no `=` followed by a known
`KEY=` is still treated as the missing-newline concatenation we want to repair,
so the existing recovery behavior is preserved. The genuinely ambiguous case
(a bare token whose value happens to contain a literal `KNOWN_KEY=`) is
indistinguishable from a real concatenation and is intentionally left as-is —
the realistic, dangerous, distinguishable cases are the ones this targets.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: in `_sanitize_env_lines`, filter candidate split
  positions so a known `KEY=` is only a record boundary when the preceding
  record's value contains no `=`. Updated the docstring to document the
  safeguard.
- `tests/hermes_cli/test_config.py`: added two regression tests covering a base
  URL whose query string embeds a known key, and a secret value containing `=`
  followed by a known key — both must be preserved whole.

## How to Test

1. Reproduce the original bug on `main`:
   `_sanitize_env_lines(["OPENAI_BASE_URL=https://proxy/?upstream=OPENAI_API_KEY=secret123\n"])`
   returns two lines (truncated value + phantom key).
2. With this change it returns the input unchanged.
3. Run the suite: `scripts/run_tests.sh tests/hermes_cli/test_config.py tests/hermes_cli/test_env_sanitize_on_load.py`
   — 100 tests pass, including the existing concatenation-repair tests, so the
   recovery behavior is unchanged.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A