### PR TITLE
fix(mcp): honor sessions.json change in EventBridge poll guard

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -356,7 +356,8 @@ class EventBridge:
         except OSError:
             sj_mtime = 0.0
 
-        if sj_mtime != self._sessions_json_mtime:
+        sessions_changed = sj_mtime != self._sessions_json_mtime
+        if sessions_changed:
             self._sessions_json_mtime = sj_mtime
             self._cached_sessions_index = _load_sessions_index()
 
@@ -372,7 +373,17 @@ class EventBridge:
         except OSError:
             db_mtime = 0.0
 
-        if db_mtime == self._state_db_mtime and sj_mtime == self._sessions_json_mtime:
+        db_changed = db_mtime != self._state_db_mtime
+
+        # Skip only when NEITHER input changed. Use the pre-update
+        # `sessions_changed` snapshot: comparing sj_mtime against
+        # self._sessions_json_mtime here is always True (it was just stored
+        # above), which would silently disable the sessions.json signal. Under
+        # SQLite WAL mode the main state.db mtime often does not advance on small
+        # message writes (the bytes land in the -wal sidecar), so the
+        # sessions.json bump is the only signal new messages arrived — dropping
+        # it stalls event delivery until an unrelated state.db write happens.
+        if not db_changed and not sessions_changed:
             return  # Nothing changed since last poll — skip entirely
 
         self._state_db_mtime = db_mtime

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1232,6 +1232,72 @@ class TestEventBridgePollE2E:
         assert len(r2["events"]) == 1
         assert r2["events"][0]["content"] == "New reply!"
 
+    def test_poll_detects_new_session_when_only_sessions_json_changes(self, tmp_path, monkeypatch):
+        """A new session in sessions.json is picked up even when state.db mtime is unchanged.
+
+        Under SQLite WAL mode the main state.db file mtime frequently does not
+        advance on small message writes (the bytes land in the ``-wal`` sidecar),
+        so the sessions.json update is the only signal the bridge receives.
+        Regression for the dead mtime-guard clause that made a sessions.json
+        change a no-op whenever state.db looked unchanged.
+        """
+        import mcp_serve
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+
+        db_path = tmp_path / "state.db"
+        session_id = "20260329_150000_wal_session"
+        _create_test_db(db_path, session_id, [
+            {"role": "user", "content": "Hello from a fresh session",
+             "timestamp": "2026-03-29T15:00:01"},
+        ])
+
+        # Pin both file mtimes to known values so the test is deterministic and
+        # independent of filesystem timestamp granularity.
+        base_mtime = 1_000_000.0
+        os.utime(db_path, (base_mtime, base_mtime))
+        sessions_file = sessions_dir / "sessions.json"
+        sessions_file.write_text(json.dumps({}))  # no sessions yet
+        os.utime(sessions_file, (base_mtime, base_mtime))
+
+        class TestDB:
+            def get_messages(self, sid):
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                    (sid,),
+                ).fetchall()
+                conn.close()
+                return [dict(r) for r in rows]
+
+        monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: TestDB())
+
+        bridge = mcp_serve.EventBridge()
+
+        # First poll: empty index, nothing to emit. Records both mtimes.
+        bridge._poll_once(TestDB())
+        assert bridge.poll_events(after_cursor=0)["events"] == []
+
+        # The session now appears in sessions.json. Bump ONLY the sessions.json
+        # mtime; leave state.db untouched (a WAL write that did not move the
+        # main-file mtime).
+        sessions_file.write_text(json.dumps({
+            "agent:main:telegram:dm:wal": {
+                "session_key": "agent:main:telegram:dm:wal",
+                "session_id": session_id,
+                "platform": "telegram",
+                "origin": {"platform": "telegram", "chat_id": "wal"},
+            }
+        }))
+        os.utime(sessions_file, (base_mtime + 10, base_mtime + 10))
+        os.utime(db_path, (base_mtime, base_mtime))  # state.db mtime stays constant
+
+        bridge._poll_once(TestDB())
+        events = bridge.poll_events(after_cursor=0)["events"]
+        assert [e["content"] for e in events] == ["Hello from a fresh session"]
+
     def test_poll_interval_is_200ms(self):
         """Verify the poll interval constant."""
         from mcp_serve import POLL_INTERVAL


### PR DESCRIPTION
The MCP event bridge polls two files to detect new conversation activity:
sessions.json and state.db. Its skip-when-unchanged guard meant to run only
when neither file changed, but the sessions.json half of the condition was
dead. The code stored the new sessions.json mtime, then compared the same
value against itself — always equal — so the guard effectively skipped
whenever state.db's mtime looked unchanged, ignoring sessions.json entirely.

That matters under SQLite WAL mode. Small message writes land in the -wal
sidecar and frequently leave the main state.db mtime untouched, so the
sessions.json bump is the only signal the bridge gets. With that signal
dropped, events_poll/events_wait silently stall until some unrelated state.db
write moves its mtime. The existing test even works around this by manually
touching state.db.

Fix snapshots whether each file changed before updating the stored mtimes,
then skips only when neither changed.

## What does this PR do?

Fixes a dead clause in `EventBridge._poll_once` so a sessions.json change
triggers a poll even when the state.db mtime has not advanced. Without it the
MCP event bridge misses new messages whenever SQLite WAL keeps state.db's
mtime static — the common case.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `mcp_serve.py`: capture `sessions_changed`/`db_changed` snapshots before
  storing the new mtimes; skip only when neither changed. Drops the
  always-true self-comparison that disabled the sessions.json signal.
- `tests/test_mcp_serve.py`: add a regression test — a new session appears in
  sessions.json while state.db mtime stays constant; the bridge must still
  emit the message event.

## How to Test

1. Run `pytest tests/test_mcp_serve.py -q` — all pass.
2. New test `test_poll_detects_new_session_when_only_sessions_json_changes`
   fails on the old code (`[] == ['Hello from a fresh session']`) and passes
   with the fix.
3. `test_poll_skips_when_unchanged` still passes — the no-op skip when both
   files are unchanged is preserved.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A