### PR TITLE
fix(cron): allow safe resume actions from cron jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -61,17 +61,21 @@ class CronPromptInjectionBlocked(Exception):
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
-    Three protected toolsets are always disabled in cron context:
-      - ``cronjob`` — would let a cron-spawned agent schedule more cron jobs
+    Two protected toolsets are always disabled in cron context:
       - ``messaging`` — interactive, needs a live gateway session
       - ``clarify`` — interactive, blocks waiting for user input
+
+    ``cronjob`` is no longer blanket-disabled here. The tool itself now
+    enforces a cron-context action allowlist so cron-spawned agents can use
+    safe list/resume flows without being able to create, pause, mutate,
+    trigger, or delete jobs recursively.
 
     User-level ``agent.disabled_toolsets`` from config.yaml is layered on top
     so per-job ``enabled_toolsets`` cannot bypass policy that applies to
     ordinary agent runs (#25752 — LLM-supplied enabled_toolsets was widening
     past config.yaml's denylist).
     """
-    disabled = ["cronjob", "messaging", "clarify"]
+    disabled = ["messaging", "clarify"]
     agent_cfg = (cfg or {}).get("agent") or {}
     user_disabled = agent_cfg.get("disabled_toolsets") or []
     for name in user_disabled:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1065,8 +1065,8 @@ class TestRunJobSessionPersistence:
         LLM-supplied cronjob() call re-enable tools the operator had globally
         disabled. The fix: ALWAYS include agent.disabled_toolsets in the
         disabled_toolsets passed to AIAgent, on top of the cron baseline
-        (cronjob/messaging/clarify). AIAgent's disabled_toolsets takes
-        precedence over enabled_toolsets, so this stops the bypass.
+        (messaging/clarify). AIAgent's disabled_toolsets takes precedence over
+        enabled_toolsets, so this stops the bypass.
         """
         (tmp_path / "config.yaml").write_text(
             "agent:\n"
@@ -1091,8 +1091,28 @@ class TestRunJobSessionPersistence:
 
         kwargs = mock_agent_cls.call_args.kwargs
         assert set(kwargs["disabled_toolsets"]) >= {
-            "cronjob", "messaging", "clarify", "terminal", "file",
+            "messaging", "clarify", "terminal", "file",
         }
+        assert "cronjob" not in kwargs["disabled_toolsets"]
+
+    def test_run_job_cronjob_toolset_can_reach_agent_when_explicitly_enabled(self, tmp_path):
+        job = {
+            "id": "cronjob-toolset-job",
+            "name": "test",
+            "prompt": "resume the paused jobs",
+            "enabled_toolsets": ["cronjob", "file"],
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["enabled_toolsets"] == ["cronjob", "file"]
+        assert "cronjob" not in kwargs["disabled_toolsets"]
 
     def test_run_job_enabled_toolsets_resolves_from_platform_config_when_not_set(self, tmp_path):
         """When a job has no explicit enabled_toolsets, the scheduler now
@@ -1820,7 +1840,7 @@ class TestRunJobSkillBacked:
         assert final_response == "ok"
 
         kwargs = mock_agent_cls.call_args.kwargs
-        assert "cronjob" in (kwargs["disabled_toolsets"] or [])
+        assert kwargs["disabled_toolsets"] == ["messaging", "clarify"]
 
         prompt_arg = mock_agent.run_conversation.call_args.args[0]
         assert "blogwatcher" in prompt_arg

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -8,6 +8,7 @@ from tools.cronjob_tools import (
     check_cronjob_requirements,
     cronjob,
 )
+from gateway.session_context import set_session_vars, clear_session_vars
 
 
 # =========================================================================
@@ -210,6 +211,14 @@ class TestCronjobRequirements:
 
         assert check_cronjob_requirements() is True
 
+    def test_accepts_cron_session(self, monkeypatch):
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+        assert check_cronjob_requirements() is True
+
     def test_rejects_when_no_session_env(self, monkeypatch):
         """Without any session env vars, cronjob tool should not be available."""
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
@@ -297,6 +306,62 @@ class TestUnifiedCronjobTool:
         resumed = json.loads(cronjob(action="resume", job_id=job_id))
         assert resumed["success"] is True
         assert resumed["job"]["state"] == "scheduled"
+
+    def test_cron_context_blocks_recursive_job_creation(self):
+        tokens = set_session_vars(platform="cron")
+        try:
+            blocked = json.loads(
+                cronjob(action="create", prompt="Check", schedule="every 1h")
+            )
+        finally:
+            clear_session_vars(tokens)
+        assert blocked["success"] is False
+        assert "blocked inside cron-run sessions" in blocked["error"]
+
+    @pytest.mark.parametrize("action", ["pause", "update", "remove", "run"])
+    def test_cron_context_blocks_mutating_actions(self, action):
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+        job_id = created["job_id"]
+        tokens = set_session_vars(platform="cron")
+        try:
+            blocked = json.loads(cronjob(action=action, job_id=job_id, name="New Name"))
+        finally:
+            clear_session_vars(tokens)
+        assert blocked["success"] is False
+        assert "blocked inside cron-run sessions" in blocked["error"]
+
+    def test_cron_context_allows_list_resume(self):
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+        job_id = created["job_id"]
+        json.loads(cronjob(action="pause", job_id=job_id))
+        tokens = set_session_vars(platform="cron")
+        try:
+            listing = json.loads(cronjob(action="list"))
+            resumed = json.loads(cronjob(action="resume", job_id=job_id))
+        finally:
+            clear_session_vars(tokens)
+        assert listing["success"] is True
+        assert resumed["success"] is True
+
+    def test_cron_env_flag_also_blocks_mutating_actions(self, monkeypatch):
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        try:
+            blocked = json.loads(cronjob(action="remove", job_id=created["job_id"]))
+        finally:
+            monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        assert blocked["success"] is False
+        assert "blocked inside cron-run sessions" in blocked["error"]
+
+    def test_non_cron_session_overrides_process_cron_flag(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        tokens = set_session_vars(platform="discord")
+        try:
+            created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+        finally:
+            clear_session_vars(tokens)
+            monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        assert created["success"] is True
 
     def test_update_schedule_recomputes_display(self):
         created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -7,6 +7,7 @@ Compatibility wrappers remain for direct Python callers and legacy tests.
 
 import json
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -15,6 +16,8 @@ from typing import Any, Dict, List, Optional, Union
 from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
+
+_CRON_CONTEXT_ALLOWED_ACTIONS = {"list", "resume"}
 
 # Import from cron module (will be available when properly installed)
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -462,6 +465,28 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
+def _is_cron_tool_call_context() -> bool:
+    """Return True when the current cronjob() call is running inside a cron tick."""
+    try:
+        from gateway.session_context import get_session_env
+
+        session_platform = (get_session_env("HERMES_SESSION_PLATFORM", "") or "").strip().lower()
+        if session_platform:
+            return session_platform == "cron"
+    except Exception:
+        pass
+    return os.getenv("HERMES_CRON_SESSION", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _cron_context_action_error(action: str) -> str:
+    allowed = ", ".join(sorted(_CRON_CONTEXT_ALLOWED_ACTIONS))
+    return tool_error(
+        f"cronjob(action='{action}') is blocked inside cron-run sessions. "
+        f"Cron jobs may only use cronjob actions {{{allowed}}} to avoid recursive scheduling or destructive cron mutation.",
+        success=False,
+    )
+
+
 def cronjob(
     action: str,
     job_id: Optional[str] = None,
@@ -489,6 +514,8 @@ def cronjob(
 
     try:
         normalized = (action or "").strip().lower()
+        if _is_cron_tool_call_context() and normalized not in _CRON_CONTEXT_ALLOWED_ACTIONS:
+            return _cron_context_action_error(normalized)
 
         if normalized == "create":
             if not schedule:
@@ -844,9 +871,9 @@ def check_cronjob_requirements() -> bool:
     """
     Check if cronjob tools can be used.
 
-    Available in interactive CLI mode and gateway/messaging platforms.
-    The cron system is internal (JSON file-based scheduler ticked by the gateway),
-    so no external crontab executable is required.
+    Available in interactive CLI mode, gateway/messaging platforms, and cron
+    sessions. The cron system is internal (JSON file-based scheduler ticked by
+    the gateway), so no external crontab executable is required.
 
     Session env vars must hold an explicit truthy string (``1``, ``true``,
     ``yes``, ``on``) — false-like values (``0``, ``false``, ``no``, ``off``)
@@ -859,6 +886,7 @@ def check_cronjob_requirements() -> bool:
         env_var_enabled("HERMES_INTERACTIVE")
         or env_var_enabled("HERMES_GATEWAY_SESSION")
         or env_var_enabled("HERMES_EXEC_ASK")
+        or env_var_enabled("HERMES_CRON_SESSION")
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Cron-spawned agent sessions currently cannot use the `cronjob` tool at all because the scheduler always strips the `cronjob` toolset. That makes a legitimate class of jobs impossible: one-shot restore jobs that need to list or resume previously paused cron jobs.

This PR moves that policy boundary down into the tool itself. Cron sessions can now reach `cronjob`, but only for `list` and `resume`. Recursive scheduling and other destructive cron mutations (`create`, `pause`, `update`, `remove`, `run`) stay blocked in cron context. The patch also makes the tool registry available in cron sessions and adds regression tests for both the scheduler-side toolset wiring and the cron-context allowlist.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py`: stop blanket-disabling `cronjob` for cron-spawned agents; keep `messaging` and `clarify` disabled and document that cron safety now lives in the tool allowlist.
- `tools/cronjob_tools.py`: detect cron execution context, allow only `list` and `resume` there, and keep other cronjob actions blocked with a clear error.
- `tools/cronjob_tools.py`: treat `HERMES_CRON_SESSION` as a valid environment for tool registration so cron-spawned agents can actually see the tool.
- `tests/tools/test_cronjob_tools.py`: add regression coverage for cron-context action blocking, env-based cron detection, non-cron session override behavior, and cron-session tool registration.
- `tests/cron/test_scheduler.py`: add coverage that cron jobs can explicitly receive the `cronjob` toolset and update assertions for the new disabled-toolset baseline.

## How to Test

1. Run `pytest tests/tools/test_cronjob_tools.py tests/cron/test_scheduler.py -q`
2. Confirm the new cron-context tests pass: `create`, `pause`, `update`, `remove`, and `run` are blocked inside cron context, while `list` and `resume` are allowed.
3. Confirm the scheduler tests pass: an explicit `enabled_toolsets=["cronjob", ...]` reaches `AIAgent`, but `messaging` and `clarify` remain disabled.
4. Reproduce the motivating case by creating a cron job with `enabled_toolsets=["cronjob"]` that lists paused jobs and resumes a target job; verify it succeeds without permitting recursive cron creation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04 / Linux 5.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted validation run: `pytest tests/tools/test_cronjob_tools.py tests/cron/test_scheduler.py -q` → `203 passed, 1 warning`
- Independent review found and I fixed two follow-up issues before commit:
  - cron context must not allow `pause`
  - `HERMES_CRON_SESSION` fallback must not bleed into non-cron sessions with an explicit platform context
