### PR TITLE
fix(desktop): preserve streamed text when provider sends empty completion

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -463,6 +463,14 @@ export function useMessageStream({
         const dedupeReference = normalize(finalText)
 
         const replaceTextPart = (parts: ChatMessagePart[]) => {
+          // When the provider sends an empty final text (e.g. NVIDIA NIM
+          // sends finish_reason:"stop" with no content), preserve the
+          // streamed text parts that were accumulated via message.delta.
+          // Otherwise the already-rendered response vanishes on completion.
+          if (!finalText) {
+            return parts
+          }
+
           const kept = parts.filter(part => {
             if (part.type === 'text') {
               return false
@@ -477,7 +485,7 @@ export function useMessageStream({
             return !(r && (dedupeReference.startsWith(r) || r.startsWith(dedupeReference)))
           })
 
-          return finalText ? [...kept, assistantTextPart(finalText)] : kept
+          return [...kept, assistantTextPart(finalText)]
         }
 
         const completeMessage = (message: ChatMessage): ChatMessage =>
@@ -532,8 +540,18 @@ export function useMessageStream({
         const hasInlineError = nextMessages.some(m => m.role === 'assistant' && m.error && !m.hidden)
         const lastVisible = [...nextMessages].reverse().find(m => !m.hidden)
         const unresolvedUserTail = lastVisible?.role === 'user'
+        // Hydrate from stored session when we never received streamed content
+        // (no assistant payload seen) OR when the stored session may have a
+        // richer version of the final text.  Skip hydration when we already
+        // have streamed text but the provider sent an empty completion — the
+        // streamed content is authoritative and hydrating would overwrite it
+        // with a stale snapshot that predates the streamed deltas.
+        const hasStreamedText = nextMessages.some(
+          m => m.role === 'assistant' && m.parts.some(p => p.type === 'text' && p.text.trim())
+        )
         shouldHydrate =
-          !completionError && !hasInlineError && !unresolvedUserTail && (!state.sawAssistantPayload || !finalText)
+          !completionError && !hasInlineError && !unresolvedUserTail &&
+          (!state.sawAssistantPayload || (!!finalText && !hasStreamedText))
 
         return {
           ...state,


### PR DESCRIPTION
## What does this PR do?

Preserves streamed assistant text when a provider sends a `message.complete` event with empty `text`/`rendered` fields. This fixes a bug where responses from NVIDIA NIM (and any provider that sends `finish_reason: "stop"` with no content in the final chunk) would flash briefly and then disappear from the Desktop UI.

## Related Issue

Fixes #41898

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream.ts`:
  - `replaceTextPart`: early-return existing parts when `finalText` is empty, preserving streamed text accumulated via `message.delta` events
  - `shouldHydrate`: skip stored-session hydration when streamed text already exists but `finalText` is empty, preventing stale snapshot from overwriting visible response

## How to Test

1. Configure a provider that sends empty content in the final `message.complete` chunk (e.g. NVIDIA NIM with `nvidia/nemotron-3-ultra-550b-a55b`)
2. Launch Hermes Desktop App
3. Send any prompt
4. Verify the assistant response remains visible after streaming completes (no flash-and-disappear)
5. Test with a normal provider (e.g. DeepSeek) to verify no regression — responses should still appear and stay
6. Test interruption: start a response, cancel mid-stream, verify partial text is preserved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `use-message-stream.ts` → `replaceTextPart`, `completeAssistantMessage`, `shouldHydrate`
- Callers: `message.complete` event handler (line 803), streaming delta handlers
- Blast radius: LOW — scoped to Desktop app's message completion path
- Related patterns: `hydrateFromStoredSession` fallback (line 561), `completeMessage` (line 491)
