### PR TITLE
fix(gateway): hide Always Allow button for Tirith findings (#41769)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17346,6 +17346,7 @@ class GatewayRunner(GatewayKanbanWatchersMixin):
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                has_tirith = approval_data.get("has_tirith", False)
 
                 # Prefer button-based approval when the adapter supports it.
                 # Check the *class* for the method, not the instance — avoids
@@ -17358,7 +17359,8 @@ class GatewayRunner(GatewayKanbanWatchersMixin):
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata={**(_status_thread_metadata or {}),
+                                           "has_tirith": has_tirith},
                             ),
                             _loop_for_step,
                             logger=logger,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4309,6 +4309,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 session_key=session_key,
                 allowed_user_ids=self._allowed_user_ids,
                 allowed_role_ids=self._allowed_role_ids,
+                has_tirith=bool(metadata and metadata.get("has_tirith")),
             )
 
             msg = await channel.send(embed=embed, view=view)
@@ -5275,12 +5276,19 @@ def _define_discord_view_classes() -> None:
             session_key: str,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
+            has_tirith: bool = False,
         ):
             super().__init__(timeout=300)  # 5-minute timeout
             self.session_key = session_key
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
             self.resolved = False
+            self.has_tirith = has_tirith
+            # Remove the "Always Allow" button for Tirith findings — the
+            # backend only persists session-level approvals for those,
+            # so the button's "Approved permanently" label is misleading.
+            if has_tirith:
+                self.remove_item(self.allow_always)
 
         def _check_auth(self, interaction: discord.Interaction) -> bool:
             """Verify the user clicking is authorized."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1381,6 +1381,7 @@ def check_all_command_guards(command: str, env_type: str,
                 "pattern_key": primary_key,
                 "pattern_keys": all_keys,
                 "description": combined_desc,
+                "has_tirith": has_tirith,
             }
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"


### PR DESCRIPTION
Fixes #41769. Pass has_tirith flag through approval data to gateway adapters and remove the Always Allow button in Discord ExecApprovalView when Tirith findings are present, since the backend only persists session-level approvals for those.