### PR TITLE
fix(tui): log auto-resume errors instead of silently falling back (#41853)

### DIFF
--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -389,7 +389,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           scheduleStartupPrompt()
         })
       })
-      .catch(() => {
+      .catch((err) => {
+        console.warn('[TUI] auto-resume failed, falling back to new session:', err)
         patchUiState({ status: 'forging session…' })
         newSession()
         scheduleStartupPrompt()


### PR DESCRIPTION
Fixes #41853. The TUI auto-resume silently fell back to creating a new session when config/RPC errors occurred. Added console.warn logging in the catch block so errors are visible for debugging.