### PR TITLE
feat(desktop): add font size scaling option in Appearance settings

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Check, Palette } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { $fontScale, setFontScale } from '@/store/font-scale'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { useTheme } from '@/themes/context'
 import { BUILTIN_THEMES } from '@/themes/presets'
@@ -57,6 +58,7 @@ export function AppearanceSettings() {
   const { t, isSavingLocale } = useI18n()
   const { themeName, mode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
+  const fontScale = useStore($fontScale)
   const a = t.settings.appearance
 
   const modeOptions = MODE_OPTIONS.map(({ id, icon }) => ({ icon, id, label: t.settings.modeOptions[id].label }))
@@ -139,6 +141,30 @@ export function AppearanceSettings() {
             description={a.themeDesc}
             title={a.themeTitle}
             wide
+          />
+
+          <ListRow
+            action={
+              <div className="flex items-center gap-3">
+                <span className="w-12 text-right text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                  {Math.round(fontScale * 100)}%
+                </span>
+                <input
+                  className="h-1.5 w-32 cursor-pointer appearance-none rounded-full bg-(--ui-stroke-tertiary) accent-primary"
+                  max={200}
+                  min={80}
+                  onChange={e => {
+                    triggerHaptic('selection')
+                    setFontScale(Number(e.target.value) / 100)
+                  }}
+                  step={5}
+                  type="range"
+                  value={Math.round(fontScale * 100)}
+                />
+              </div>
+            }
+            description={a.fontScaleDesc}
+            title={a.fontScaleTitle}
           />
 
           <ListRow

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -292,7 +292,9 @@ export const en: Translations = {
       technical: 'Technical',
       technicalDesc: 'Include raw tool args/results and low-level details.',
       themeTitle: 'Theme',
-      themeDesc: 'Desktop palettes only. The selected mode is applied on top.'
+      themeDesc: 'Desktop palettes only. The selected mode is applied on top.',
+      fontScaleTitle: 'Font Size',
+      fontScaleDesc: 'Scale all conversation text proportionally. Default is 100%.'
     },
     fieldLabels: FIELD_LABELS,
     fieldDescriptions: FIELD_DESCRIPTIONS,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -215,7 +215,9 @@ export const ja = defineLocale({
       technical: 'テクニカル',
       technicalDesc: '生のツール引数、結果、低レベルの詳細を含めます。',
       themeTitle: 'テーマ',
-      themeDesc: 'デスクトップ専用のパレットです。選択したモードの上に適用されます。'
+      themeDesc: 'デスクトップ専用のパレットです。選択したモードの上に適用されます。',
+      fontScaleTitle: 'フォントサイズ',
+      fontScaleDesc: '会話テキスト全体を比例的にスケールします。デフォルトは 100%。'
     },
     fieldLabels: defineFieldCopy({
       model: 'デフォルトモデル',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -219,6 +219,8 @@ export interface Translations {
       technicalDesc: string
       themeTitle: string
       themeDesc: string
+      fontScaleTitle: string
+      fontScaleDesc: string
     }
     fieldLabels: Record<string, string>
     fieldDescriptions: Record<string, string>

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -209,7 +209,9 @@ export const zhHant = defineLocale({
       technical: '技術',
       technicalDesc: '包含原始工具參數、結果與底層細節。',
       themeTitle: '主題',
-      themeDesc: '僅限桌面端的調色盤。所選模式會套用在其上。'
+      themeDesc: '僅限桌面端的調色盤。所選模式會套用在其上。',
+      fontScaleTitle: '字體大小',
+      fontScaleDesc: '按比例縮放所有對話文字。預設 100%。'
     },
     fieldLabels: defineFieldCopy({
       model: '預設模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -287,7 +287,9 @@ export const zh: Translations = {
       technical: '技术',
       technicalDesc: '包含原始工具参数/结果及底层细节。',
       themeTitle: '主题',
-      themeDesc: '仅桌面端调色板。所选模式叠加其上。'
+      themeDesc: '仅桌面端调色板。所选模式叠加其上。',
+      fontScaleTitle: '字体大小',
+      fontScaleDesc: '按比例缩放所有对话文字。默认 100%。'
     },
     fieldLabels: defineFieldCopy({
       model: '默认模型',

--- a/apps/desktop/src/store/font-scale.test.ts
+++ b/apps/desktop/src/store/font-scale.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock document.documentElement before importing the module
+const mockSetProperty = vi.fn()
+const mockGetItem = vi.fn()
+const mockSetItem = vi.fn()
+
+Object.defineProperty(globalThis, 'document', {
+  value: { documentElement: { style: { setProperty: mockSetProperty } } },
+  writable: true
+})
+
+Object.defineProperty(globalThis, 'window', {
+  value: { localStorage: { getItem: mockGetItem, setItem: mockSetItem } },
+  writable: true
+})
+
+describe('font-scale store', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockSetProperty.mockClear()
+    mockGetItem.mockReset()
+    mockSetItem.mockClear()
+  })
+
+  it('defaults to 1 when no stored value', async () => {
+    mockGetItem.mockReturnValue(null)
+    const { $fontScale } = await import('./font-scale')
+    expect($fontScale.get()).toBe(1)
+  })
+
+  it('loads stored value within range', async () => {
+    mockGetItem.mockReturnValue('1.25')
+    const { $fontScale } = await import('./font-scale')
+    expect($fontScale.get()).toBe(1.25)
+  })
+
+  it('falls back to 1 for out-of-range values', async () => {
+    mockGetItem.mockReturnValue('5')
+    const { $fontScale } = await import('./font-scale')
+    expect($fontScale.get()).toBe(1)
+  })
+
+  it('falls back to 1 for non-numeric values', async () => {
+    mockGetItem.mockReturnValue('abc')
+    const { $fontScale } = await import('./font-scale')
+    expect($fontScale.get()).toBe(1)
+  })
+
+  it('setFontScale clamps to valid range', async () => {
+    mockGetItem.mockReturnValue('1')
+    const { $fontScale, setFontScale } = await import('./font-scale')
+
+    setFontScale(0.5) // below min 0.8
+    expect($fontScale.get()).toBe(0.8)
+
+    setFontScale(3) // above max 2
+    expect($fontScale.get()).toBe(2)
+
+    setFontScale(1.15)
+    expect($fontScale.get()).toBe(1.15)
+  })
+
+  it('persists to localStorage on change', async () => {
+    mockGetItem.mockReturnValue('1')
+    const { setFontScale } = await import('./font-scale')
+
+    setFontScale(1.25)
+    expect(mockSetItem).toHaveBeenCalledWith('hermes.desktop.fontScale', '1.25')
+  })
+
+  it('sets CSS variable on change', async () => {
+    mockGetItem.mockReturnValue('1')
+    const { setFontScale } = await import('./font-scale')
+
+    setFontScale(1.5)
+    expect(mockSetProperty).toHaveBeenCalledWith('--dt-font-scale', '1.5')
+  })
+
+  it('applyFontScaleBoot sets CSS variable for non-default scale', async () => {
+    mockGetItem.mockReturnValue('1.2')
+    const { applyFontScaleBoot } = await import('./font-scale')
+
+    applyFontScaleBoot()
+    expect(mockSetProperty).toHaveBeenCalledWith('--dt-font-scale', '1.2')
+  })
+
+  it('applyFontScaleBoot skips CSS variable for default scale', async () => {
+    mockGetItem.mockReturnValue('1')
+    const { applyFontScaleBoot } = await import('./font-scale')
+
+    mockSetProperty.mockClear() // Clear initial subscribe call
+    applyFontScaleBoot()
+    expect(mockSetProperty).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/font-scale.ts
+++ b/apps/desktop/src/store/font-scale.ts
@@ -1,0 +1,46 @@
+import { atom } from 'nanostores'
+
+const FONT_SCALE_KEY = 'hermes.desktop.fontScale'
+
+function loadFontScale(): number {
+  if (typeof window === 'undefined') {
+    return 1
+  }
+
+  try {
+    const raw = window.localStorage.getItem(FONT_SCALE_KEY)
+    const val = raw ? parseFloat(raw) : 1
+    return Number.isFinite(val) && val >= 0.8 && val <= 2 ? val : 1
+  } catch {
+    return 1
+  }
+}
+
+export const $fontScale = atom<number>(loadFontScale())
+
+$fontScale.subscribe(scale => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(FONT_SCALE_KEY, String(scale))
+  } catch {
+    // Ignore storage failures.
+  }
+
+  document.documentElement.style.setProperty('--dt-font-scale', String(scale))
+})
+
+export function setFontScale(scale: number) {
+  const clamped = Math.round(Math.max(80, Math.min(200, scale * 100))) / 100
+  $fontScale.set(clamped)
+}
+
+/** Apply persisted font scale on boot (before React mounts). */
+export function applyFontScaleBoot() {
+  const scale = loadFontScale()
+  if (scale !== 1 && typeof document !== 'undefined') {
+    document.documentElement.style.setProperty('--dt-font-scale', String(scale))
+  }
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -283,11 +283,11 @@
 
     --composer-shell-pad-block-end: 0.625rem;
     --message-text-indent: 0.75rem;
-    --conversation-text-font-size: 0.8125rem;
-    --conversation-tool-font-size: 0.6875rem;
-    --conversation-caption-font-size: 0.75rem;
-    --conversation-line-height: 1.125rem;
-    --conversation-caption-line-height: 1rem;
+    --conversation-text-font-size: calc(0.8125rem * var(--dt-font-scale, 1));
+    --conversation-tool-font-size: calc(0.6875rem * var(--dt-font-scale, 1));
+    --conversation-caption-font-size: calc(0.75rem * var(--dt-font-scale, 1));
+    --conversation-line-height: calc(1.125rem * var(--dt-font-scale, 1));
+    --conversation-caption-line-height: calc(1rem * var(--dt-font-scale, 1));
     --conversation-turn-gap: 0.375rem;
     /* Gap between top-level turn blocks (prose ↔ tools ↔ thinking) — enough air
        that scaffolding reads as separate from the reply, not crammed into it. */

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -209,6 +209,7 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
     '--dt-user-bubble-border': c.userBubbleBorder ?? c.border,
     '--dt-font-sans': typo.fontSans,
     '--dt-font-mono': typo.fontMono,
+    ...(typo.fontScale && typo.fontScale !== 1 ? { '--dt-font-scale': String(typo.fontScale) } : {}),
     '--noise-opacity-mul': isDark ? 'calc(0.04 / 0.21)' : 'calc(0.34 / 0.21)'
   }
 
@@ -237,6 +238,9 @@ if (typeof window !== 'undefined') {
   const mode = (window.localStorage.getItem(MODE_KEY) as ThemeMode) ?? 'light'
   const resolved = resolveMode(mode)
   applyTheme(deriveTheme(skin, resolved), resolved)
+
+  // Apply persisted font-scale preference (overrides theme-level fontScale).
+  void import('@/store/font-scale').then(m => m.applyFontScaleBoot())
 }
 
 // ─── Context ────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/themes/types.ts
+++ b/apps/desktop/src/themes/types.ts
@@ -52,6 +52,12 @@ export interface DesktopThemeTypography {
   fontMono: string
   /** Google/Bunny/self-hosted font stylesheet URL. */
   fontUrl?: string
+  /**
+   * Global font-size multiplier (1.0 = default, 1.25 = 125%, etc.).
+   * Applied via `--dt-font-scale` CSS variable so all conversation text,
+   * tool output, and caption text scale proportionally.
+   */
+  fontScale?: number
 }
 
 export interface DesktopTheme {


### PR DESCRIPTION
## Problem

The Desktop app's conversation text, tool output, and caption text are hardcoded at small sizes (13px, 11px, 12px). Users on high-DPI displays or with visual impairments have no way to scale the text without manually editing the ASAR-packed `styles.css`.

## Solution

Add a font size slider (80%–200%, default 100%) in **Settings → Appearance** that scales all conversation text proportionally via the `--dt-font-scale` CSS variable.

The approach is zero-risk: the CSS variable defaults to `1`, so all existing themes and layouts are unchanged. The slider persists to `localStorage` and applies on boot before React mounts (no flash).

## Changes

| File | Change |
|------|--------|
| `themes/types.ts` | Add `fontScale?: number` to `DesktopThemeTypography` |
| `themes/context.tsx` | Set `--dt-font-scale` CSS var when theme provides `fontScale`; apply user preference on boot |
| `store/font-scale.ts` | New nanostore: `atom<number>` with localStorage persistence, `setFontScale()` clamped to 0.8–2.0, `applyFontScaleBoot()` |
| `styles.css` | Wrap 5 conversation CSS vars with `calc(... * var(--dt-font-scale, 1))` |
| `app/settings/appearance-settings.tsx` | Range slider with percentage readout |
| `i18n/types.ts` | Add `fontScaleTitle`, `fontScaleDesc` |
| `i18n/en.ts`, `zh.ts`, `zh-hant.ts`, `ja.ts` | Localized strings |
| `store/font-scale.test.ts` | 9 tests: defaults, clamping, persistence, CSS variable, boot |

## How it works

1. The slider sets `$fontScale` nanostore → subscribes set `--dt-font-scale` on `:root`
2. `styles.css` uses `calc(0.8125rem * var(--dt-font-scale, 1))` for conversation text, tool text, and caption text
3. Line-height scales proportionally so text doesn't get cramped at larger sizes
4. Theme-level `fontScale` (in `DesktopThemeTypography`) is applied in `applyTheme()` but the user's persisted preference overrides it

## Testing

```
✓ src/store/font-scale.test.ts (9 tests) 15ms
✓ src/themes/presets.test.ts (10 tests) 3ms
```

Closes #41879
