### PR TITLE
fix(qqbot): handle WSMsgType.CLOSING to prevent CPU spin (#41872)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -699,7 +699,8 @@ class QQAdapter(BasePlatformAdapter):
                 pass
             elif msg.type == aiohttp.WSMsgType.CLOSE:
                 raise QQCloseError(msg.data, msg.extra)
-            elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
+            elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR,
+                              aiohttp.WSMsgType.CLOSING}:
                 raise RuntimeError("WebSocket closed")
 
     async def _heartbeat_loop(self) -> None:


### PR DESCRIPTION
Fixes #41872. QQ Bot adapter's _read_events loop did not handle WSMsgType.CLOSING, causing a tight receive() loop that pinned a CPU core at 100%. Added CLOSING to the CLOSED/ERROR handler to break the loop cleanly.