### PR TITLE
fix(nix): make config.yaml group-writable under addToSystemPackages

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -49,6 +49,12 @@
 
     configMergeScript = pkgs.callPackage ./configMergeScript.nix { };
 
+    # config.yaml mode: group-writable (0660) when interactive users share this
+    # HERMES_HOME via addToSystemPackages, so they can save settings through the
+    # CLI/TUI without hitting EACCES; otherwise group-read-only (0640). Secrets
+    # (.env) stay 0640 regardless — see below.
+    configYamlMode = if cfg.addToSystemPackages then "0660" else "0640";
+
     # Generate .env from non-secret environment attrset
     envFileContent = lib.concatStringsSep "\n" (
       lib.mapAttrsToList (k: v: "${k}=${v}") cfg.environment
@@ -728,7 +734,8 @@
           chmod 0750 ${cfg.stateDir}/home
 
           # Create subdirs, set setgid + group-writable, migrate existing files.
-          # Nix-managed files (config.yaml, .env, .managed) stay 0640/0644.
+          # Nix-managed .env/.managed stay 0640/0644; config.yaml uses
+          # configYamlMode (0660 under addToSystemPackages, else 0640).
           find ${cfg.stateDir}/.hermes -maxdepth 1 \
             \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
             -exec chmod g+rw {} + 2>/dev/null || true
@@ -743,12 +750,14 @@
           # Merge Nix settings into existing config.yaml.
           # Preserves user-added keys (skills, streaming, etc.); Nix keys win.
           # If configFile is user-provided (not generated), overwrite instead of merge.
+          # Mode is configYamlMode (0660 under addToSystemPackages so interactive
+          # hermes-group users can save settings via the CLI/TUI, else 0640).
           ${if cfg.configFile != null then ''
-            install -o ${cfg.user} -g ${cfg.group} -m 0640 -D ${configFile} ${cfg.stateDir}/.hermes/config.yaml
+            install -o ${cfg.user} -g ${cfg.group} -m ${configYamlMode} -D ${configFile} ${cfg.stateDir}/.hermes/config.yaml
           '' else ''
             ${configMergeScript} ${generatedConfigFile} ${cfg.stateDir}/.hermes/config.yaml
             chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/config.yaml
-            chmod 0640 ${cfg.stateDir}/.hermes/config.yaml
+            chmod ${configYamlMode} ${cfg.stateDir}/.hermes/config.yaml
           ''}
 
           # Managed mode marker (so interactive shells also detect NixOS management)


### PR DESCRIPTION
## Summary
`services.hermes-agent.addToSystemPackages = true` exists to let interactive users **share the gateway's state** — it exports `HERMES_HOME` system-wide and puts the `hermes` CLI on their `PATH`. But the activation script wrote `config.yaml` as **`0640`** (group read-only), so an interactive user (in the `hermes` group) who tried to save a setting through the CLI/TUI hit:

```
error: [Errno 13] Permission denied: '/var/lib/hermes/.hermes/config.yaml'
```

That's a direct contradiction of what the option is for: it shares state but then forbids the most basic interactive write.

## Fix
Make `config.yaml`'s mode conditional (one new `let` binding, used in both the `configFile` and generated-merge paths):

```nix
configYamlMode = if cfg.addToSystemPackages then "0660" else "0640";
```

- **`addToSystemPackages = true`** → `0660`, so `hermes`-group users can persist settings.
- **otherwise** → `0640`, exactly as before (no behavior change for pure-service deployments).
- **`.env` stays `0640`** regardless — it holds secrets, not user-facing settings.

The config merge already preserves user-added keys across rebuilds, so this just lets interactive users actually make those edits instead of failing with `EACCES`.

## Test plan
Evaluated the module's `hermes-agent-setup` activation script in a throwaway `nixosSystem` for both option values:

```
[addToSystemPackages = true]   chmod 0660 /var/lib/hermes/.hermes/config.yaml
[addToSystemPackages = false]  chmod 0640 /var/lib/hermes/.hermes/config.yaml
```

## Notes
Group membership is still the operator's responsibility (the interactive user must be in the `hermes` group, as with all shared-state access) — this only fixes the file mode that made it impossible regardless.
