### PR TITLE
fix(tui): handle Windows PTY stdin and detached WS frames

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -152,6 +152,21 @@ def test_write_json_returns_false_on_broken_pipe(monkeypatch):
     assert server.write_json({"ok": True}) is False
 
 
+def test_write_json_drops_detached_ws_frames(monkeypatch):
+    out = _ThreadUnsafeStdout()
+    monkeypatch.setattr(server, "_real_stdout", out)
+    server._sessions["detached-sid"] = {"transport": server._detached_ws_transport}
+    try:
+        assert server.write_json({
+            "jsonrpc": "2.0",
+            "method": "event",
+            "params": {"session_id": "detached-sid", "type": "message.delta"},
+        }) is False
+        assert out.parts == []
+    finally:
+        server._sessions.pop("detached-sid", None)
+
+
 def test_tui_verbose_tool_details_fail_closed_when_redaction_fails(monkeypatch):
     redact_module = types.ModuleType("agent.redact")
 
@@ -933,7 +948,7 @@ def test_ws_orphan_reap_closes_worker_when_session_stays_detached(monkeypatch):
             closed["worker"] = True
 
     server._sessions["orphan-sid"] = _session(
-        transport=server._stdio_transport,
+        transport=server._detached_ws_transport,
         slash_worker=_FakeWorker(),
         running=False,
     )
@@ -961,11 +976,15 @@ def test_ws_orphan_reap_spares_reattached_session(monkeypatch):
     assert server._ws_session_is_orphaned(reattached) is False
 
     # Mid-turn sessions are also spared even if detached.
-    mid_turn = _session(transport=server._stdio_transport, running=True)
+    mid_turn = _session(transport=server._detached_ws_transport, running=True)
     assert server._ws_session_is_orphaned(mid_turn) is False
 
     # Already finalized sessions are spared (idempotency).
-    done = _session(transport=server._stdio_transport, running=False, _finalized=True)
+    done = _session(
+        transport=server._detached_ws_transport,
+        running=False,
+        _finalized=True,
+    )
     assert server._ws_session_is_orphaned(done) is False
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -153,7 +153,7 @@ def test_write_json_returns_false_on_broken_pipe(monkeypatch):
 
 
 def test_write_json_drops_detached_ws_frames(monkeypatch):
-    out = _ThreadUnsafeStdout()
+    out = _ChunkyStdout()
     monkeypatch.setattr(server, "_real_stdout", out)
     server._sessions["detached-sid"] = {"transport": server._detached_ws_transport}
     try:

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -63,6 +63,44 @@ def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool
     return False
 
 
+def test_write_stdin_uses_str_for_windows_pty(monkeypatch, registry):
+    """pywinpty expects str input; bytes raises a PyString conversion error."""
+    written = []
+
+    class _FakePty:
+        def write(self, value):
+            written.append(value)
+
+    session = _make_session(sid="pty-win")
+    session._pty = _FakePty()
+    registry._running[session.id] = session
+    monkeypatch.setattr("tools.process_registry._IS_WINDOWS", True)
+
+    result = registry.write_stdin(session.id, "hello\n")
+
+    assert result == {"status": "ok", "bytes_written": 6}
+    assert written == ["hello\n"]
+    assert isinstance(written[0], str)
+
+
+def test_write_stdin_uses_bytes_for_posix_pty(monkeypatch, registry):
+    written = []
+
+    class _FakePty:
+        def write(self, value):
+            written.append(value)
+
+    session = _make_session(sid="pty-posix")
+    session._pty = _FakePty()
+    registry._running[session.id] = session
+    monkeypatch.setattr("tools.process_registry._IS_WINDOWS", False)
+
+    result = registry.write_stdin(session.id, "hello\n")
+
+    assert result == {"status": "ok", "bytes_written": 6}
+    assert written == [b"hello\n"]
+
+
 # =========================================================================
 # Get / Poll
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1207,10 +1207,14 @@ class ProcessRegistry:
         if session.exited:
             return {"status": "already_exited", "error": "Process has already finished"}
 
-        # PTY mode -- write through pty handle (expects bytes)
+        # PTY mode -- write through pty handle.
         if hasattr(session, '_pty') and session._pty:
             try:
-                pty_data = data.encode("utf-8") if isinstance(data, str) else data
+                # pywinpty expects str on Windows; ptyprocess expects bytes on POSIX.
+                if _IS_WINDOWS:
+                    pty_data = data.decode("utf-8") if isinstance(data, bytes) else str(data)
+                else:
+                    pty_data = data.encode("utf-8") if isinstance(data, str) else data
                 session._pty.write(pty_data)
                 return {"status": "ok", "bytes_written": len(data)}
             except Exception as e:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -202,10 +202,26 @@ atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))
 _real_stdout = sys.stdout
 sys.stdout = sys.stderr
 
+
+class _DropTransport:
+    """Detached WS sink: keep sessions resumable without writing stale frames."""
+
+    def write(self, obj: dict) -> bool:
+        return False
+
+    def close(self) -> None:
+        return None
+
+
 # Module-level stdio transport — fallback sink when no transport is bound via
 # contextvar or session. Stream resolved through a lambda so runtime monkey-
 # patches of `_real_stdout` (used extensively in tests) still land correctly.
 _stdio_transport = StdioTransport(lambda: _real_stdout, _stdout_lock)
+
+# Detached websocket sessions use a drop sink instead of stdio. Desktop embeds
+# the gateway in-process and captures stdout into logs, so stale JSON-RPC frames
+# must not fall through there while the session waits for resume or reap.
+_detached_ws_transport = _DropTransport()
 
 
 class _SlashWorker:
@@ -383,16 +399,15 @@ def _teardown_session(session: dict | None) -> None:
 def _ws_session_is_orphaned(session: dict | None) -> bool:
     """True if a WS session has no live transport and no in-flight turn.
 
-    After ``handle_ws`` detaches a disconnected client it points the session
-    at ``_stdio_transport``. In the dashboard's in-process gateway there is no
-    real stdio peer reading those frames, so a session left on the stdio
-    transport (and not mid-turn) is genuinely orphaned and safe to reap.
+    After ``handle_ws`` detaches a disconnected client it points the session at
+    ``_detached_ws_transport``. A session left on that transport (and not
+    mid-turn) is genuinely orphaned and safe to reap.
     """
     if not session or session.get("_finalized"):
         return False
     if session.get("running"):
         return False
-    return session.get("transport") is _stdio_transport
+    return session.get("transport") is _detached_ws_transport
 
 
 def _schedule_ws_orphan_reap(sid: str) -> None:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -289,17 +289,13 @@ async def handle_ws(ws: Any) -> None:
             transport.close()
 
             # Detach the transport from any sessions it owned so later emits
-            # fall back to stdio instead of crashing into a closed socket.
-            #
-            # In the dashboard's in-process gateway that stdio fallback has no
-            # real reader, so a detached session would otherwise sit forever
-            # holding its _SlashWorker subprocess open (one leaked python proc
-            # per browser refresh — #38591 fallout). Schedule a grace-delayed
-            # reap; a quick reconnect / session.resume re-binds a live
-            # transport and cancels it (see _ws_session_is_orphaned).
+            # do not crash into a closed socket or fall through to desktop
+            # stdout logs. Schedule a grace-delayed reap; a quick reconnect /
+            # session.resume re-binds a live transport and cancels it (see
+            # _ws_session_is_orphaned).
             for _sid, sess in list(server._sessions.items()):
                 if sess.get("transport") is transport:
-                    sess["transport"] = server._stdio_transport
+                    sess["transport"] = server._detached_ws_transport
                     detached_sessions += 1
                     try:
                         server._schedule_ws_orphan_reap(_sid)


### PR DESCRIPTION
## What does this PR do?

Fixes two Windows desktop regressions that can show up together during normal
desktop use:

1. Windows PTY stdin writes can fail because `pywinpty` receives `bytes`.
2. Detached desktop WebSocket sessions can dump raw JSON-RPC stream frames into
   desktop stdout, which Electron captures into `desktop.log`.

The changes are intentionally narrow. They do not touch the installer, desktop
build scripts, dependency installation, provider configuration, or model
routing.

## Background and failure path

This was investigated from a Windows desktop install under:

```text
%LOCALAPPDATA%\hermes\hermes-agent
%LOCALAPPDATA%\hermes\logs
```

The Windows logs showed a PTY stdin failure like:

```text
argument 'to_write': 'bytes' object cannot be converted to 'PyString'
```

The relevant code path is `ProcessRegistry.write_stdin()` in
`tools/process_registry.py`. Before this PR, PTY mode encoded string input to
`bytes` unconditionally before calling `session._pty.write(...)`:

```python
pty_data = data.encode("utf-8") if isinstance(data, str) else data
session._pty.write(pty_data)
```

That is correct for POSIX `ptyprocess`, but not for Windows `pywinpty`.
`pywinpty` expects `str`; passing `bytes` produces the conversion error above.

The same desktop install also showed repeated WebSocket send/write failures in
the gateway logs, followed by `desktop.log` growth containing raw JSON-RPC
frames. The relevant flow was:

1. `tui_gateway.ws.handle_ws()` accepted a desktop/dashboard WebSocket.
2. The WebSocket disconnected or failed to send.
3. The disconnect cleanup detached sessions owned by that WebSocket transport.
4. Before this PR, cleanup replaced the session transport with
   `server._stdio_transport`.
5. `server.write_json()` routes event frames with a `session_id` through the
   transport stored on that session.
6. In the desktop app, backend stdout is captured by Electron and written to
   desktop logs; it is not a JSON-RPC reader.

That made detached session events fall through to desktop stdout/logs as raw
JSON-RPC frames. It also meant a transient WebSocket failure could amplify into
large desktop log churn while the session was waiting for reconnect or orphan
reaping.

This PR does not claim that every desktop freeze was caused by these two
issues. It fixes two concrete, independently reproducible bad behaviors that
were observed in the Windows desktop path.

## Changes made

### `tools/process_registry.py`

PTY stdin writes are now platform-aware:

- Windows: pass `str` to `pywinpty`.
- POSIX: keep passing `bytes` to `ptyprocess`.

The new logic preserves the old POSIX behavior while fixing the Windows type
contract:

```python
if _IS_WINDOWS:
    pty_data = data.decode("utf-8") if isinstance(data, bytes) else str(data)
else:
    pty_data = data.encode("utf-8") if isinstance(data, str) else data
session._pty.write(pty_data)
```

### `tui_gateway/server.py`

Adds a detached-only drop transport:

```python
class _DropTransport:
    """Detached WS sink: keep sessions resumable without writing stale frames."""

    def write(self, obj: dict) -> bool:
        return False

    def close(self) -> None:
        return None
```

The module now exposes:

```python
_detached_ws_transport = _DropTransport()
```

`_ws_session_is_orphaned()` now treats sessions parked on
`_detached_ws_transport` as detached WS orphans, instead of using
`_stdio_transport` as the detached marker.

This keeps the existing orphan reaper semantics:

- detached and `running=False`: eligible for reap after the grace window
- detached and `running=True`: spared because a turn is still in flight
- `_finalized=True`: spared for idempotency
- reattached to a live transport: spared

### `tui_gateway/ws.py`

WebSocket disconnect cleanup now parks affected sessions on
`server._detached_ws_transport`:

```python
sess["transport"] = server._detached_ws_transport
```

The session remains resumable and still gets a grace-delayed orphan reap, but
stream frames produced while detached no longer fall through to desktop stdout.

### Tests

Adds focused regression coverage:

- `tests/tools/test_process_registry.py`
  - `test_write_stdin_uses_str_for_windows_pty`
  - `test_write_stdin_uses_bytes_for_posix_pty`

- `tests/test_tui_gateway_server.py`
  - `test_write_json_drops_detached_ws_frames`
  - existing WS orphan reap tests updated to use `_detached_ws_transport`

## Reproduction before the fix

### Windows PTY stdin

Before this PR, Windows PTY stdin writes encoded text input to `bytes` and sent
that to `pywinpty`:

```python
registry.write_stdin(session.id, "hello\n")
```

On Windows this could fail with:

```text
argument 'to_write': 'bytes' object cannot be converted to 'PyString'
```

After this PR, the same write path passes a `str` on Windows and preserves
`bytes` on POSIX.

### Detached desktop WebSocket frames

Before this PR, WebSocket disconnect cleanup did this:

```python
sess["transport"] = server._stdio_transport
```

Then a later event frame with the detached `session_id` would route through
`server.write_json()` to stdio:

```python
server.write_json({
    "jsonrpc": "2.0",
    "method": "event",
    "params": {
        "session_id": detached_sid,
        "type": "message.delta",
    },
})
```

In the desktop app, that stdio frame is captured as process output and written
to `desktop.log`, not consumed by a JSON-RPC client.

After this PR, the detached session transport returns `False` and writes
nothing to stdout until the session either reconnects/resumes or is reaped.

## How to test

Focused static checks:

```bash
python -m py_compile \
  tools/process_registry.py \
  tui_gateway/server.py \
  tui_gateway/ws.py
```

```bash
git diff --check -- \
  tools/process_registry.py \
  tui_gateway/server.py \
  tui_gateway/ws.py \
  tests/test_tui_gateway_server.py \
  tests/tools/test_process_registry.py
```

Focused pytest targets:

```bash
python -m pytest \
  tests/tools/test_process_registry.py \
  tests/test_tui_gateway_server.py \
  -k "write_stdin_uses_str_for_windows_pty or write_stdin_uses_bytes_for_posix_pty or write_json_drops_detached_ws_frames or ws_orphan_reap" \
  -q
```

## Local validation performed

On the Windows desktop install, the following checks passed:

```powershell
cd "$env:LOCALAPPDATA\hermes\hermes-agent"
.\venv\Scripts\python.exe -m py_compile tools\process_registry.py tui_gateway\server.py tui_gateway\ws.py
```

A Windows runtime probe also passed and verified both key behaviors:

```text
ok: drop transport and Windows PTY stdin
```

The probe verified:

- detached WS frames do not write to `_real_stdout`
- Windows PTY stdin succeeds without the `PyString` conversion error

The local Windows install venv did not include `pytest`, so pytest was not run
there. No dependencies were installed into that environment to keep this fix
scope clean.

## Risk and compatibility notes

- The PTY change is platform-gated with `_IS_WINDOWS`, so POSIX behavior stays
  on the previous `bytes` path.
- The drop transport only applies to sessions explicitly detached by the
  WebSocket disconnect cleanup.
- Normal stdio JSON-RPC behavior is unchanged.
- Normal live WebSocket transport behavior is unchanged.
- Detached sessions remain resumable during the grace window.
- Existing orphan reaping still closes genuinely orphaned, not-running sessions.

## What this PR intentionally does not do

- Does not change the Windows installer.
- Does not change desktop build configuration.
- Does not install or modify optional native npm dependencies.
- Does not change provider configuration or LLM routing.
- Does not claim to prove that all desktop freezes were caused by these bugs.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Checklist

### Code

- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I ran `pytest tests/ -q` and all tests pass
- [x] I added tests for the bug fixes
- [x] I considered cross-platform impact

### Documentation and Housekeeping

- [x] I updated relevant documentation or docstrings - N/A
- [x] I updated config examples if I added or changed config keys - N/A
- [x] I updated tool descriptions or schemas if I changed tool behavior - N/A

## Screenshots / Logs

No UI screenshots. This PR is covered by focused backend/gateway tests and the
Windows runtime probe described above.
