### PR TITLE
fix(cli): resolve config set provider/base_url shortcuts to canonical dotted paths

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6028,7 +6028,18 @@ def set_config_value(key: str, value: str):
     elif value.replace('.', '', 1).isdigit():
         value = float(value)
 
-    _set_nested(user_config, key, value)
+    # Resolve shortcut keys to their canonical dotted paths so that
+    # `hermes config set provider X` writes to `model.provider` (the key
+    # the runtime actually reads) instead of a dead top-level `provider:`.
+    # Without this mapping the shortcut silently diverges from the runtime
+    # key, creating a false sense of configuration success (issue #41943).
+    _KEY_SHORTCUTS = {
+        "provider": "model.provider",
+        "base_url": "model.base_url",
+    }
+    resolved_key = _KEY_SHORTCUTS.get(key, key)
+
+    _set_nested(user_config, resolved_key, value)
     
     # Write only user config back (not the full merged defaults)
     ensure_hermes_home()
@@ -6065,10 +6076,11 @@ def set_config_value(key: str, value: str):
         "terminal.container_disk": "TERMINAL_CONTAINER_DISK",
         "terminal.container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
     }
-    if key in _config_to_env_sync:
-        save_env_value(_config_to_env_sync[key], str(value))
+    if resolved_key in _config_to_env_sync:
+        save_env_value(_config_to_env_sync[resolved_key], str(value))
 
-    print(f"✓ Set {key} = {value} in {config_path}")
+    display_key = resolved_key if resolved_key != key else key
+    print(f"✓ Set {display_key} = {value} in {config_path}")
 
 
 # =============================================================================

--- a/tests/cli/test_config_set_shortcut.py
+++ b/tests/cli/test_config_set_shortcut.py
@@ -1,0 +1,96 @@
+"""Tests for set_config_value shortcut key aliasing (issue #41943).
+
+`hermes config set provider X` must write to `model.provider`, not a dead
+top-level `provider:` key.  Same for `base_url` → `model.base_url`.
+"""
+import textwrap
+
+import pytest
+
+
+@pytest.fixture
+def config_env(tmp_path, monkeypatch):
+    """Set up an isolated config.yaml + .env for set_config_value tests."""
+    cfg_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    cfg_path.write_text(textwrap.dedent("""\
+        model:
+          provider: alibaba
+          default: deepseek-v4-pro
+    """))
+    env_path.write_text("")
+
+    import hermes_cli.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "get_config_path", lambda: cfg_path)
+    monkeypatch.setattr(cfg_mod, "get_env_path", lambda: env_path)
+    monkeypatch.setattr(cfg_mod, "is_managed", lambda: False)
+    monkeypatch.setattr(cfg_mod, "ensure_hermes_home", lambda: None)
+
+    yield cfg_path, env_path
+
+
+def _load_yaml(path):
+    import yaml
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+class TestProviderShortcut:
+    """`hermes config set provider X` → model.provider."""
+
+    def test_provider_shortcut_writes_model_provider(self, config_env):
+        from hermes_cli.config import set_config_value
+        cfg_path, _ = config_env
+
+        set_config_value("provider", "opencode-go")
+
+        data = _load_yaml(cfg_path)
+        assert data["model"]["provider"] == "opencode-go"
+        # Dead top-level key must NOT exist
+        assert "provider" not in data, (
+            "Shortcut 'provider' wrote to dead top-level key instead of model.provider"
+        )
+
+    def test_base_url_shortcut_writes_model_base_url(self, config_env):
+        from hermes_cli.config import set_config_value
+        cfg_path, _ = config_env
+
+        set_config_value("base_url", "http://localhost:8080/v1")
+
+        data = _load_yaml(cfg_path)
+        assert data["model"]["base_url"] == "http://localhost:8080/v1"
+        assert "base_url" not in data, (
+            "Shortcut 'base_url' wrote to dead top-level key instead of model.base_url"
+        )
+
+    def test_dotted_key_not_affected_by_shortcut(self, config_env):
+        """Explicit `model.provider` still works (no double-wrapping)."""
+        from hermes_cli.config import set_config_value
+        cfg_path, _ = config_env
+
+        set_config_value("model.provider", "anthropic")
+
+        data = _load_yaml(cfg_path)
+        assert data["model"]["provider"] == "anthropic"
+
+    def test_non_shortcut_key_unchanged(self, config_env):
+        """Keys that have no shortcut pass through unchanged."""
+        from hermes_cli.config import set_config_value
+        cfg_path, _ = config_env
+
+        set_config_value("terminal.backend", "docker")
+
+        data = _load_yaml(cfg_path)
+        assert data["terminal"]["backend"] == "docker"
+
+    def test_provider_shortcut_preserves_other_model_keys(self, config_env):
+        """Setting provider via shortcut must not overwrite model.default."""
+        from hermes_cli.config import set_config_value
+        cfg_path, _ = config_env
+
+        set_config_value("provider", "opencode-go")
+
+        data = _load_yaml(cfg_path)
+        assert data["model"]["provider"] == "opencode-go"
+        # Original model.default should survive
+        assert data["model"]["default"] == "deepseek-v4-pro"


### PR DESCRIPTION
## What does this PR do?

Resolves shortcut keys `provider` and `base_url` in `hermes config set` to their canonical dotted paths (`model.provider`, `model.base_url`) so the value lands in the key the runtime actually reads instead of a dead top-level key.

## Related Issue

Fixes #41943

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: Added `_KEY_SHORTCUTS` mapping that resolves `provider` → `model.provider` and `base_url` → `model.base_url` before calling `_set_nested`. Updated the `_config_to_env_sync` lookup and the success message to use the resolved key.
- `tests/cli/test_config_set_shortcut.py`: 5 regression tests covering shortcut resolution, dotted-key passthrough, non-shortcut keys, and preservation of sibling model keys.

## How to Test

1. Run `hermes config set provider opencode-go` and verify it writes to `model.provider` in `config.yaml` (not a top-level `provider:` key)
2. Run `hermes config show` and confirm the provider reflects the new value
3. Run `pytest tests/cli/test_config_set_shortcut.py -v` — all 5 tests pass
4. Verify `hermes config set model.provider anthropic` still works (explicit dotted path unaffected)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/config.py::set_config_value()` (callers: CLI `config set` command, setup wizard)
- Blast radius: LOW — only affects `hermes config set` for the two shortcut keys; all dotted-path usage unchanged
- Related patterns: `_config_to_env_sync` already maps dotted config keys to env vars; this adds a parallel shortcut resolution layer
