### PR TITLE
fix(gateway): make shutdown diagnostics and 2 tests work on macOS

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -248,6 +249,19 @@ def spawn_async_diagnostic(
     except OSError:
         return None
 
+    # Wrap the snapshot in timeout(1) so a wedged ``ps`` still self-cleans.
+    # GNU coreutils ships ``timeout`` on Linux; stock macOS has neither
+    # ``timeout`` nor ``gtimeout`` (the latter arrives with Homebrew
+    # coreutils).  When no timeout binary exists, run bash directly — the
+    # script's own commands are individually bounded (``head``/``tail``) and
+    # we detach via ``start_new_session``, so a best-effort snapshot without
+    # the hard cap is acceptable rather than skipping diagnostics entirely.
+    timeout_bin = shutil.which("timeout") or shutil.which("gtimeout")
+    if timeout_bin:
+        argv = [timeout_bin, f"{timeout_seconds:.0f}", "bash", "-c", script]
+    else:
+        argv = ["bash", "-c", script]
+
     try:
         # Detach from our process group so the subprocess survives even
         # if systemd kills our cgroup with KillMode=control-group (which
@@ -255,7 +269,7 @@ def spawn_async_diagnostic(
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
+            argv,
             stdout=fd,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -298,7 +298,12 @@ class TestRunBackgroundTask:
         # (default mode requires the file to exist as a regular file).
         import os as _os
         import tempfile as _tempfile
-        _tmpdir = _tempfile.mkdtemp(prefix="bg_media_")
+        # realpath() so the expected paths match what the media-delivery
+        # validator returns: it resolves symlinks before the denylist check
+        # (gateway/platforms/base.py validate_media_delivery_path), and on
+        # macOS the tempdir lives under /var → /private/var. Without this the
+        # assertions below compare /var/... against the resolved /private/var/...
+        _tmpdir = _os.path.realpath(_tempfile.mkdtemp(prefix="bg_media_"))
         _ogg = _os.path.join(_tmpdir, "clip.ogg")
         _mp4 = _os.path.join(_tmpdir, "render.mp4")
         _png = _os.path.join(_tmpdir, "chart.png")

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -141,7 +141,13 @@ async def test_gateway_stop_systemd_service_restart_exits_cleanly(tmp_path, monk
     monkeypatch.setenv("INVOCATION_ID", "systemd-test")
     runner._launch_systemd_restart_shortcut = MagicMock()
 
-    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+    # Pin platform to linux so the systemd clean-exit path is exercised
+    # regardless of host OS. On macOS the code deliberately keeps a non-zero
+    # exit for launchd (see test_gateway_stop_launchd_service_restart_keeps_
+    # nonzero_exit), so without this the assertion fails on a macOS dev box.
+    with patch("gateway.run.sys.platform", "linux"), patch(
+        "gateway.status.remove_pid_file"
+    ), patch("gateway.status.write_runtime_status"):
         await runner.stop(restart=True, service_restart=True)
 
     runner._launch_systemd_restart_shortcut.assert_called_once_with()


### PR DESCRIPTION
## What does this PR do?

Makes the gateway's shutdown diagnostics work on macOS and fixes two tests that only passed on Linux. All three issues surface when running the suite on a darwin dev box; they're invisible on Linux/CI, so they had silently accumulated.

The one behavior change is real and user-facing: `spawn_async_diagnostic()` (the detached `ps`-style snapshot written when the gateway receives SIGTERM/SIGINT) hard-coded the GNU `timeout` binary. Stock macOS ships neither `timeout` nor `gtimeout` (the latter only arrives with Homebrew coreutils), so `subprocess.Popen(["timeout", ...])` raised `FileNotFoundError`, was swallowed, and the function returned `None` — meaning **macOS gateway operators got no shutdown diagnostics at all**. The fix resolves `timeout`/`gtimeout` via `shutil.which()` and falls back to running `bash` directly when neither exists. The fallback loses the hard self-clean cap, but the snapshot script's commands are already individually bounded (`head`/`tail`) and the process is detached via `start_new_session`, so a best-effort snapshot beats no diagnostics.

The other two are test-robustness fixes (no production change):
- `test_media_files_routed_by_type` compared `send_voice`/`send_video`/etc. paths against an un-resolved `mkdtemp()` path, but the media-delivery validator (`validate_media_delivery_path`) resolves symlinks before its denylist check. On macOS the tempdir lives under `/var → /private/var`, so the assertions mismatched. `realpath()`-ing the tempdir makes expected == actual on every platform.
- `test_gateway_stop_systemd_service_restart_exits_cleanly` asserted exit code `0`, but `stop()` deliberately keeps a non-zero (`EX_TEMPFAIL`) exit on darwin for launchd's `KeepAlive`. The test simulated systemd via `INVOCATION_ID` but never pinned `sys.platform`, so it failed on a macOS host. Pinning `sys.platform="linux"` mirrors the existing companion test `test_gateway_stop_launchd_service_restart_keeps_nonzero_exit`.

## Related Issue

Related: #32681

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`gateway/shutdown_forensics.py`** — `spawn_async_diagnostic()` now resolves `timeout`/`gtimeout` via `shutil.which()` and falls back to bare `bash` when neither is on PATH (stock macOS). Added `import shutil`.
- **`tests/gateway/test_background_command.py`** — `realpath()` the media tempdir in `test_media_files_routed_by_type` so expected paths match the validator's symlink-resolved output (`/var → /private/var` on macOS).
- **`tests/gateway/test_gateway_shutdown.py`** — pin `sys.platform="linux"` in `test_gateway_stop_systemd_service_restart_exits_cleanly` so the systemd clean-exit path is exercised regardless of host OS.

## How to Test

1. On macOS (or any host without GNU `timeout` on PATH):
   ```bash
   scripts/run_tests.sh tests/gateway/test_shutdown_forensics.py \
                        tests/gateway/test_background_command.py \
                        tests/gateway/test_gateway_shutdown.py
   ```
   All pass (66 tests). On `main`, three fail on macOS:
   - `test_shutdown_forensics.py::TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output` (pid `None`)
   - `test_background_command.py::TestRunBackgroundTask::test_media_files_routed_by_type` (`/var` vs `/private/var`)
   - `test_gateway_shutdown.py::test_gateway_stop_systemd_service_restart_exits_cleanly` (exit `75` vs `0`)
2. Behavior check for the code fix: with no `timeout`/`gtimeout` on PATH, `spawn_async_diagnostic(log, "SIGTERM")` now returns a real pid and writes the `=== shutdown diagnostic @ SIGTERM ===` header to the log (previously returned `None` and wrote nothing).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suites and they pass (`scripts/run_tests.sh` over the 3 files: 66 tests, all green)
- [x] I've added tests for my changes (the code fix is covered by the existing `test_spawns_subprocess_and_writes_output`, which fails on `main`/macOS and passes with this change)
- [x] I've tested on my platform: macOS (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior fix; existing docstrings still accurate)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — yes; this PR *is* the cross-platform fix (macOS), and the Windows skip path in `spawn_async_diagnostic` is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/gateway/test_shutdown_forensics.py \
                       tests/gateway/test_background_command.py \
                       tests/gateway/test_gateway_shutdown.py
=== Summary: 3 files, 66 tests passed, 0 failed (100% complete) ===
```
