### PR TITLE
fix(security): bind PR head_ref via env to block branch-name shell injection in lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,12 +46,22 @@ jobs:
 
       - name: Determine base ref
         id: base
+        env:
+          # Move context values into env so the `run:` block reads them as
+          # plain bash variables instead of templating them into the shell
+          # source.  Branch / event names are attacker-influenced on PRs;
+          # binding via env keeps any future trigger change (e.g. switching
+          # to `pull_request_target`) from turning a rename into an
+          # injection sink.  See GitHub's "Use an intermediate environment
+          # variable" guidance.
+          GH_EVENT_NAME: ${{ inputs.event_name }}
+          GH_BASE_REF: ${{ github.base_ref }}
         run: |
           # For PRs, diff against the merge base with the target branch.
           # For pushes to main, diff against the previous commit on main.
-          if [ "${{ inputs.event_name }}" = "pull_request" ]; then
-            BASE_SHA=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
-            BASE_REF="origin/${{ github.base_ref }}"
+          if [ "$GH_EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA=$(git merge-base "origin/$GH_BASE_REF" HEAD)
+            BASE_REF="origin/$GH_BASE_REF"
           else
             BASE_SHA=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
             BASE_REF="HEAD~1"
@@ -72,13 +82,15 @@ jobs:
           echo "HEAD ty:   $(wc -c < .lint-reports/head/ty.json) bytes"
 
       - name: Run ruff + ty on base (via git worktree)
+        env:
+          BASE_SHA_OUT: ${{ steps.base.outputs.sha }}
         run: |
           mkdir -p .lint-reports/base
           # Use a worktree so we don't clobber the main checkout. If the basex
           # SHA is identical to HEAD (e.g. first commit), skip and leave the
           # base reports empty — the diff script handles missing files.
           HEAD_SHA=$(git rev-parse HEAD)
-          BASE_SHA="${{ steps.base.outputs.sha }}"
+          BASE_SHA="$BASE_SHA_OUT"
           if [ "$BASE_SHA" = "$HEAD_SHA" ]; then
             echo "Base SHA == HEAD SHA, skipping base scan."
             echo '[]' > .lint-reports/base/ruff.json
@@ -98,14 +110,23 @@ jobs:
           echo "base ty:   $(wc -c < .lint-reports/base/ty.json) bytes"
 
       - name: Generate diff summary
+        env:
+          BASE_REF_OUT: ${{ steps.base.outputs.ref }}
+          # Bind the head ref through env to keep an attacker-chosen PR
+          # branch name (e.g. `";id;"` or `$(curl evil)`) from being
+          # spliced into this `run:` step's shell source.  The Python
+          # script only renders the value into a Markdown header, so
+          # passing it as an argv element is safe; the danger was solely
+          # in the YAML→shell templating layer.
+          HEAD_REF_OUT: ${{ inputs.event_name == 'pull_request' && github.head_ref || github.ref_name }}
         run: |
           python scripts/lint_diff.py \
             --base-ruff .lint-reports/base/ruff.json \
             --head-ruff .lint-reports/head/ruff.json \
             --base-ty   .lint-reports/base/ty.json \
             --head-ty   .lint-reports/head/ty.json \
-            --base-ref  "${{ steps.base.outputs.ref }}" \
-            --head-ref  "${{ inputs.event_name == 'pull_request' && github.head_ref || github.ref_name }}" \
+            --base-ref  "$BASE_REF_OUT" \
+            --head-ref  "$HEAD_REF_OUT" \
             --output    .lint-reports/summary.md
           cat .lint-reports/summary.md >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Summary

The `lint-diff` job in `.github/workflows/lint.yml` templates `github.head_ref` (the PR branch name — fully attacker-chosen on forks) and a couple of sibling `github` / `steps.outputs` context values directly into a `run:` shell block. GitHub refs allow characters that bash treats as metacharacters inside double quotes — `$()`, backticks, `${}`. A PR opened from a branch named like `";id;"` or `$(curl evil)` expands at templating time and gives the runner an attacker-controlled shell command.

This PR moves the four `${{ ... }}` interpolations in the `lint-diff` job's `run:` blocks into step-level `env:` entries and reads them as plain bash variables — the canonical "Use an intermediate environment variable" pattern from [GitHub's hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable), and the same pattern this repo already uses in `docker-publish.yml` (env blocks at L42-43 and L124-126).

## Impact

The vulnerable step is in `lint.yml`, triggered by `pull_request` (not `pull_request_target`):

* **Fork PRs:** GitHub auto-downgrades the GITHUB_TOKEN to read-only, so direct secret exfiltration via the API is limited. The runner can still poison the [Actions cache](https://github.blog/2024-01-17-actions-cache-poisoning/) and any downstream artifact (`actions/upload-artifact` step further down runs in the same job), and run arbitrary network / compute under the runner identity.
* **Same-repo PRs:** Anyone with write access can open a PR from a maliciously-named branch and inherit the workflow's full `pull-requests: write` token — enough to ghost-write or modify arbitrary PR comments via the runner.

The "Post / update PR comment" step at L124 reads from `.lint-reports/summary.md`, so an injected step that overwrites that file before it's posted can also make the bot publish arbitrary content on the PR thread.

## Location

`.github/workflows/lint.yml` — the `lint-diff` job's `Determine base ref`, `Run ruff + ty on base (via git worktree)`, and `Generate diff summary` steps.

The headline sink is at L113 in `main`:

```yaml
--head-ref  "${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
```

with sibling repo-controlled (but same-anti-pattern) interpolations at L57–59 and L86.

## Fix

For each affected step, declare a `env:` block at the step level binding the relevant context value (`github.event_name`, `github.base_ref`, `steps.base.outputs.sha`, `steps.base.outputs.ref`, and the conditional `github.head_ref` / `github.ref_name`) to a named env var, then reference it as a regular `"$VAR"` shell expansion inside the `run:` block. The YAML→shell templating layer never sees the attacker-controlled string; bash treats env vars as data, not source.

`lint_diff.py` only renders `--head-ref` into a Markdown header (`buf.append(f"# 🔎 Lint report: \`{args.head_ref}\` vs \`{args.base_ref}\`\n")`), so passing the value as an `argv` element is safe — the only injection sink was in the YAML→shell layer.

## Detected by

Aeon + semgrep
- Rule: `yaml.github-actions.security.run-shell-injection.run-shell-injection` (ERROR)
- CWE-78 (OS Command Injection)

## Verification

* `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"` — YAML still parses; the `lint-diff` step list is unchanged.
* No change to `lint_diff.py` arguments, behaviour, or the report's rendered output: env-bound `"$BASE_REF_OUT"` / `"$HEAD_REF_OUT"` reach the script as exactly the same argv they would have via the previous templating, just without the YAML→shell intermediate.

If you'd like to verify end-to-end, push a branch with a benign name like `'";echo NOT-INJECTED-HERE;"'` and observe that the `Generate diff summary` step's stdout no longer contains the `NOT-INJECTED-HERE` token (it lands in the Markdown header as literal text instead).

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
