### PR TITLE
fix(observability): NeMo Relay plugin-config teardown failure-safety + post-finalize guard (follow-up to #41551)

### DIFF
--- a/plugins/observability/nemo_relay/README.md
+++ b/plugins/observability/nemo_relay/README.md
@@ -163,7 +163,10 @@ agent_version = "local"
 
 When `HERMES_NEMO_RELAY_PLUGINS_TOML` is set and initializes successfully, NeMo
 Relay owns exporter lifecycle through that config. The direct
-`HERMES_NEMO_RELAY_ATOF_*` fallback setup is skipped.
+`HERMES_NEMO_RELAY_ATOF_*` fallback setup is skipped. If the same
+`plugins.toml` observability config enables `atif`, the direct
+`HERMES_NEMO_RELAY_ATIF_*` fallback setup is also skipped so Hermes does not
+double-export trajectories on teardown.
 
 To enable NeMo Relay managed execution intercepts for provider and tool calls,
 include an adaptive component in the same `plugins.toml`:

--- a/plugins/observability/nemo_relay/README.md
+++ b/plugins/observability/nemo_relay/README.md
@@ -166,7 +166,8 @@ Relay owns exporter lifecycle through that config. The direct
 `HERMES_NEMO_RELAY_ATOF_*` fallback setup is skipped. If the same
 `plugins.toml` observability config enables `atif`, the direct
 `HERMES_NEMO_RELAY_ATIF_*` fallback setup is also skipped so Hermes does not
-double-export trajectories on teardown.
+double-export trajectories on teardown. If `plugins.toml` initialization fails,
+Hermes keeps the direct env-var fallbacks active for that run.
 
 To enable NeMo Relay managed execution intercepts for provider and tool calls,
 include an adaptive component in the same `plugins.toml`:

--- a/plugins/observability/nemo_relay/__init__.py
+++ b/plugins/observability/nemo_relay/__init__.py
@@ -78,16 +78,21 @@ class _Runtime:
             return False
         try:
             self._ensure_plugin_config_output_dirs(self.settings.plugins_config)
-            result = initialize(self.settings.plugins_config)
-            if inspect.isawaitable(result):
-                asyncio.run(result)
+            _resolve_awaitable(initialize(self.settings.plugins_config))
             return True
-        except RuntimeError:
-            logger.debug("NeMo Relay plugins.toml init skipped inside a running event loop")
-            return False
         except Exception as exc:
             logger.debug("NeMo Relay plugins.toml init failed: %s", exc, exc_info=True)
             return False
+
+    def _clear_plugins_toml(self) -> None:
+        if not self._plugin_config_initialized:
+            return
+        plugin_mod = getattr(self.nemo_relay, "plugin", None)
+        clear = getattr(plugin_mod, "clear", None)
+        if not callable(clear):
+            return
+        _resolve_awaitable(clear())
+        self._plugin_config_initialized = False
 
     def _ensure_plugin_config_output_dirs(self, config: dict[str, Any]) -> None:
         for component in config.get("components", []):
@@ -124,6 +129,8 @@ class _Runtime:
         self.atof_exporter.register("hermes.nemo_relay.atof")
 
     def ensure_session(self, kwargs: dict[str, Any]) -> _SessionState:
+        if self.settings.plugins_config and not self._plugin_config_initialized:
+            self._plugin_config_initialized = self._configure_plugins_toml()
         session_id = _session_id(kwargs)
         state = self.sessions.get(session_id)
         if state is not None:
@@ -189,6 +196,11 @@ class _Runtime:
                 state.atif_exporter.deregister(state.atif_subscriber_name)
             except Exception:
                 logger.debug("NeMo Relay ATIF deregister failed", exc_info=True)
+        if self._plugin_config_initialized and not self.sessions:
+            try:
+                self._clear_plugins_toml()
+            except Exception:
+                logger.debug("NeMo Relay plugins.toml clear failed", exc_info=True)
 
     def mark(self, name: str, kwargs: dict[str, Any]) -> None:
         state = self.ensure_session(kwargs)
@@ -561,6 +573,12 @@ def _load_settings() -> _Settings:
     plugins_toml_path = _env("HERMES_NEMO_RELAY_PLUGINS_TOML")
     plugins_config = _load_plugins_config(plugins_toml_path)
     adaptive_config = _enabled_component_config(plugins_config, "adaptive")
+    atif_enabled = _env_bool("HERMES_NEMO_RELAY_ATIF_ENABLED")
+    if atif_enabled and _observability_exporter_enabled(plugins_config, "atif"):
+        logger.debug(
+            "NeMo Relay direct ATIF fallback disabled because plugins.toml observability.atif owns exporter lifecycle"
+        )
+        atif_enabled = False
     return _Settings(
         plugins_toml_path=plugins_toml_path,
         plugins_config=plugins_config,
@@ -570,7 +588,7 @@ def _load_settings() -> _Settings:
         atof_output_directory=_env("HERMES_NEMO_RELAY_ATOF_OUTPUT_DIRECTORY"),
         atof_filename=_env("HERMES_NEMO_RELAY_ATOF_FILENAME") or "hermes-atof.jsonl",
         atof_mode=_env("HERMES_NEMO_RELAY_ATOF_MODE") or "append",
-        atif_enabled=_env_bool("HERMES_NEMO_RELAY_ATIF_ENABLED"),
+        atif_enabled=atif_enabled,
         atif_output_directory=_env("HERMES_NEMO_RELAY_ATIF_OUTPUT_DIRECTORY"),
         atif_filename_template=_env("HERMES_NEMO_RELAY_ATIF_FILENAME_TEMPLATE") or "hermes-atif-{session_id}.json",
         atif_subagent_export_mode=_atif_subagent_export_mode(),
@@ -616,6 +634,19 @@ def _adaptive_mode(config: dict[str, Any] | None) -> str:
     if isinstance(mode, str) and mode.strip():
         return mode.strip()
     return "observe"
+
+
+def _observability_exporter_enabled(
+    plugins_config: dict[str, Any] | None,
+    exporter_name: str,
+) -> bool:
+    observability_config = _enabled_component_config(plugins_config, "observability")
+    if not isinstance(observability_config, dict):
+        return False
+    exporter_config = observability_config.get(exporter_name)
+    if not isinstance(exporter_config, dict):
+        return False
+    return exporter_config.get("enabled", True) is not False
 
 
 def _env(name: str) -> str:

--- a/plugins/observability/nemo_relay/__init__.py
+++ b/plugins/observability/nemo_relay/__init__.py
@@ -65,9 +65,11 @@ class _Runtime:
         self.sessions: dict[str, _SessionState] = {}
         self.subagent_parents: dict[str, _SubagentParent] = {}
         self.atof_exporter: Any = None
+        self._atof_subscriber_name = "hermes.nemo_relay.atof"
         self._plugin_config_initialized = self._configure_plugins_toml()
+        self._plugin_config_needs_reinit = False
         if not self._plugin_config_initialized:
-            self._configure_atof()
+            self._activate_direct_fallbacks()
 
     def _configure_plugins_toml(self) -> bool:
         if not self.settings.plugins_config:
@@ -93,6 +95,27 @@ class _Runtime:
             return
         _resolve_awaitable(clear())
         self._plugin_config_initialized = False
+        self._plugin_config_needs_reinit = bool(self.settings.plugins_config)
+
+    def _activate_direct_fallbacks(self) -> None:
+        self._plugin_config_needs_reinit = False
+        self._configure_atof()
+
+    def _maybe_reinitialize_plugins_toml(self) -> None:
+        if not self._plugin_config_needs_reinit or self._plugin_config_initialized:
+            return
+        self._plugin_config_initialized = self._configure_plugins_toml()
+        if not self._plugin_config_initialized:
+            self._activate_direct_fallbacks()
+            return
+        self._clear_atof()
+        self._plugin_config_needs_reinit = False
+
+    def _plugins_toml_owns_exporter(self, exporter_name: str) -> bool:
+        return self._plugin_config_initialized and _observability_exporter_enabled(
+            self.settings.plugins_config,
+            exporter_name,
+        )
 
     def _ensure_plugin_config_output_dirs(self, config: dict[str, Any]) -> None:
         for component in config.get("components", []):
@@ -114,7 +137,7 @@ class _Runtime:
                     Path(output_directory).mkdir(parents=True, exist_ok=True)
 
     def _configure_atof(self) -> None:
-        if not self.settings.atof_enabled:
+        if not self.settings.atof_enabled or self.atof_exporter is not None:
             return
         config = self.nemo_relay.AtofExporterConfig()
         if self.settings.atof_output_directory:
@@ -126,18 +149,28 @@ class _Runtime:
         else:
             config.mode = self.nemo_relay.AtofExporterMode.Append
         self.atof_exporter = self.nemo_relay.AtofExporter(config)
-        self.atof_exporter.register("hermes.nemo_relay.atof")
+        self.atof_exporter.register(self._atof_subscriber_name)
+
+    def _clear_atof(self) -> None:
+        if self.atof_exporter is None:
+            return
+        deregister = getattr(self.atof_exporter, "deregister", None)
+        if callable(deregister):
+            try:
+                deregister(self._atof_subscriber_name)
+            except Exception:
+                logger.debug("NeMo Relay ATOF deregister failed", exc_info=True)
+        self.atof_exporter = None
 
     def ensure_session(self, kwargs: dict[str, Any]) -> _SessionState:
-        if self.settings.plugins_config and not self._plugin_config_initialized:
-            self._plugin_config_initialized = self._configure_plugins_toml()
+        self._maybe_reinitialize_plugins_toml()
         session_id = _session_id(kwargs)
         state = self.sessions.get(session_id)
         if state is not None:
             return state
 
         state = _SessionState(session_id=session_id)
-        if self.settings.atif_enabled:
+        if self.settings.atif_enabled and not self._plugins_toml_owns_exporter("atif"):
             state.atif_exporter = self.nemo_relay.AtifExporter(
                 session_id,
                 self.settings.atif_agent_name,
@@ -201,6 +234,8 @@ class _Runtime:
                 self._clear_plugins_toml()
             except Exception:
                 logger.debug("NeMo Relay plugins.toml clear failed", exc_info=True)
+        elif self.settings.plugins_config and not self.sessions:
+            self._plugin_config_needs_reinit = True
 
     def mark(self, name: str, kwargs: dict[str, Any]) -> None:
         state = self.ensure_session(kwargs)
@@ -573,12 +608,6 @@ def _load_settings() -> _Settings:
     plugins_toml_path = _env("HERMES_NEMO_RELAY_PLUGINS_TOML")
     plugins_config = _load_plugins_config(plugins_toml_path)
     adaptive_config = _enabled_component_config(plugins_config, "adaptive")
-    atif_enabled = _env_bool("HERMES_NEMO_RELAY_ATIF_ENABLED")
-    if atif_enabled and _observability_exporter_enabled(plugins_config, "atif"):
-        logger.debug(
-            "NeMo Relay direct ATIF fallback disabled because plugins.toml observability.atif owns exporter lifecycle"
-        )
-        atif_enabled = False
     return _Settings(
         plugins_toml_path=plugins_toml_path,
         plugins_config=plugins_config,
@@ -588,7 +617,7 @@ def _load_settings() -> _Settings:
         atof_output_directory=_env("HERMES_NEMO_RELAY_ATOF_OUTPUT_DIRECTORY"),
         atof_filename=_env("HERMES_NEMO_RELAY_ATOF_FILENAME") or "hermes-atof.jsonl",
         atof_mode=_env("HERMES_NEMO_RELAY_ATOF_MODE") or "append",
-        atif_enabled=atif_enabled,
+        atif_enabled=_env_bool("HERMES_NEMO_RELAY_ATIF_ENABLED"),
         atif_output_directory=_env("HERMES_NEMO_RELAY_ATIF_OUTPUT_DIRECTORY"),
         atif_filename_template=_env("HERMES_NEMO_RELAY_ATIF_FILENAME_TEMPLATE") or "hermes-atif-{session_id}.json",
         atif_subagent_export_mode=_atif_subagent_export_mode(),

--- a/plugins/observability/nemo_relay/__init__.py
+++ b/plugins/observability/nemo_relay/__init__.py
@@ -9,6 +9,7 @@ import logging
 import os
 import threading
 import tomllib
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
@@ -64,6 +65,13 @@ class _Runtime:
         self.settings = settings
         self.sessions: dict[str, _SessionState] = {}
         self.subagent_parents: dict[str, _SubagentParent] = {}
+        # Bounded record of recently-finalized session ids. Used to stop a
+        # stray hook (anything that funnels through ensure_session after the
+        # terminal close_session for an id) from resurrecting the session:
+        # re-pushing an unpopped scope and re-arming plugins.toml that then
+        # never gets cleared. Only an explicit session start (create=True)
+        # clears the marker and allows (re)creation.
+        self._finalized_sessions: "OrderedDict[str, None]" = OrderedDict()
         self.atof_exporter: Any = None
         self._atof_subscriber_name = "hermes.nemo_relay.atof"
         self._plugin_config_initialized = self._configure_plugins_toml()
@@ -93,9 +101,17 @@ class _Runtime:
         clear = getattr(plugin_mod, "clear", None)
         if not callable(clear):
             return
-        _resolve_awaitable(clear())
-        self._plugin_config_initialized = False
-        self._plugin_config_needs_reinit = bool(self.settings.plugins_config)
+        # Treat clear as a completed state transition even if the relay's
+        # clear() raises: flip the flags in finally so a partial/failed clear
+        # still re-arms reinit (or direct fallback) on the next session start.
+        # Otherwise a raising clear() would strand the runtime at
+        # initialized=True / needs_reinit=False, and no later session would
+        # ever reinitialize plugins.toml or activate the direct fallbacks.
+        try:
+            _resolve_awaitable(clear())
+        finally:
+            self._plugin_config_initialized = False
+            self._plugin_config_needs_reinit = bool(self.settings.plugins_config)
 
     def _activate_direct_fallbacks(self) -> None:
         self._plugin_config_needs_reinit = False
@@ -162,9 +178,30 @@ class _Runtime:
                 logger.debug("NeMo Relay ATOF deregister failed", exc_info=True)
         self.atof_exporter = None
 
-    def ensure_session(self, kwargs: dict[str, Any]) -> _SessionState:
-        self._maybe_reinitialize_plugins_toml()
+    _FINALIZED_SESSIONS_MAX = 256
+
+    def _mark_finalized(self, session_id: str) -> None:
+        self._finalized_sessions[session_id] = None
+        self._finalized_sessions.move_to_end(session_id)
+        while len(self._finalized_sessions) > self._FINALIZED_SESSIONS_MAX:
+            self._finalized_sessions.popitem(last=False)
+
+    def ensure_session(self, kwargs: dict[str, Any], *, create: bool = False) -> _SessionState:
         session_id = _session_id(kwargs)
+        if create:
+            # An explicit session start clears any stale finalized marker so a
+            # legitimately restarted id is allowed to (re)create.
+            self._finalized_sessions.pop(session_id, None)
+        else:
+            existing = self.sessions.get(session_id)
+            if existing is not None:
+                return existing
+            if session_id in self._finalized_sessions:
+                # Stray hook for an already-finalized session — do NOT reinit
+                # plugins.toml or push a new scope. Return a detached, unstored
+                # state so callers stay null-safe without resurrecting it.
+                return _SessionState(session_id=session_id)
+        self._maybe_reinitialize_plugins_toml()
         state = self.sessions.get(session_id)
         if state is not None:
             return state
@@ -218,6 +255,7 @@ class _Runtime:
         state = self.sessions.pop(session_id, None)
         if state is None:
             return
+        self._mark_finalized(session_id)
         if state.handle is not None:
             try:
                 self.nemo_relay.scope.pop(state.handle, output=_jsonable(kwargs))
@@ -387,7 +425,7 @@ def register(ctx) -> None:
 def on_session_start(**kwargs: Any) -> None:
     runtime = _get_runtime()
     if runtime is not None:
-        _safe(lambda: runtime.ensure_session(kwargs))
+        _safe(lambda: runtime.ensure_session(kwargs, create=True))
 
 
 def on_session_end(**kwargs: Any) -> None:

--- a/tests/plugins/test_nemo_relay_plugin.py
+++ b/tests/plugins/test_nemo_relay_plugin.py
@@ -121,6 +121,10 @@ class _FakeAtofExporter:
     def register(self, name):
         self.events.append(("atof.register", name, self.config.output_directory, self.config.filename))
 
+    def deregister(self, name):
+        self.events.append(("atof.deregister", name, self.config.output_directory, self.config.filename))
+        return True
+
 
 class _FakeAtifExporter:
     def __init__(self, events, session_id, agent_name, agent_version, kwargs):
@@ -567,6 +571,93 @@ output_directory = "{(tmp_path / "managed-atif").as_posix()}"
     assert "plugin.clear" in event_names
     assert "atif.register" not in event_names
     assert not (tmp_path / "direct-atif" / "hermes-atif-s1.json").exists()
+
+
+def test_nemo_relay_plugin_keeps_direct_atif_when_plugins_toml_init_fails(tmp_path, monkeypatch):
+    fake = _FakeNemoRelay()
+
+    async def _failing_initialize(config):
+        fake.events.append(("plugin.initialize.failed", config))
+        raise RuntimeError("boom")
+
+    fake.plugin.initialize = _failing_initialize
+    plugin = _fresh_plugin(monkeypatch, fake)
+    plugins_toml = tmp_path / "plugins.toml"
+    plugins_toml.write_text(
+        f"""
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+
+[components.config.atif]
+enabled = true
+output_directory = "{(tmp_path / "managed-atif").as_posix()}"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
+    monkeypatch.setenv("HERMES_NEMO_RELAY_ATIF_ENABLED", "1")
+    monkeypatch.setenv("HERMES_NEMO_RELAY_ATIF_OUTPUT_DIRECTORY", str(tmp_path / "direct-atif"))
+
+    plugin.on_session_start(session_id="s1")
+    plugin.on_session_finalize(session_id="s1", reason="shutdown")
+
+    event_names = [event[0] for event in fake.events]
+    assert "plugin.initialize.failed" in event_names
+    assert "plugin.clear" not in event_names
+    assert "atif.register" in event_names
+    assert (tmp_path / "direct-atif" / "hermes-atif-s1.json").exists()
+
+
+def test_nemo_relay_plugin_retries_plugins_toml_after_fallback_only_session_and_clears_direct_atof(
+    tmp_path,
+    monkeypatch,
+):
+    fake = _FakeNemoRelay()
+    initialize_calls = 0
+
+    async def _flaky_initialize(config):
+        nonlocal initialize_calls
+        initialize_calls += 1
+        fake.events.append(("plugin.initialize.attempt", initialize_calls, config))
+        if initialize_calls == 1:
+            raise RuntimeError("boom")
+        return {"diagnostics": []}
+
+    fake.plugin.initialize = _flaky_initialize
+    plugin = _fresh_plugin(monkeypatch, fake)
+    plugins_toml = tmp_path / "plugins.toml"
+    plugins_toml.write_text(
+        f"""
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+
+[components.config.atof]
+enabled = true
+output_directory = "{(tmp_path / "managed-atof").as_posix()}"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
+    monkeypatch.setenv("HERMES_NEMO_RELAY_ATOF_ENABLED", "1")
+    monkeypatch.setenv("HERMES_NEMO_RELAY_ATOF_OUTPUT_DIRECTORY", str(tmp_path / "direct-atof"))
+
+    plugin.on_session_start(session_id="s1")
+    plugin.on_session_finalize(session_id="s1", reason="shutdown")
+    plugin.on_session_start(session_id="s2")
+
+    runtime = plugin._get_runtime()
+    assert runtime is not None
+    assert runtime._plugin_config_initialized is True
+    event_names = [event[0] for event in fake.events]
+    assert event_names.count("plugin.initialize.attempt") == 2
+    assert event_names.count("atof.register") == 1
+    assert event_names.count("atof.deregister") == 1
 
 
 def test_nemo_relay_adaptive_llm_execution_middleware_preserves_raw_response(tmp_path, monkeypatch):

--- a/tests/plugins/test_nemo_relay_plugin.py
+++ b/tests/plugins/test_nemo_relay_plugin.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import builtins
+import gc
 import importlib
 import json
 import sys
+import warnings
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -37,7 +40,7 @@ class _FakeNemoRelay:
             call_end=self._tool_call_end,
             execute=self._tool_execute,
         )
-        self.plugin = SimpleNamespace(initialize=self._plugin_initialize)
+        self.plugin = SimpleNamespace(initialize=self._plugin_initialize, clear=self._plugin_clear)
         self.LLMRequest = _FakeLLMRequest
         self.AtofExporterConfig = _FakeAtofExporterConfig
         self.AtofExporterMode = SimpleNamespace(Append="append", Overwrite="overwrite")
@@ -92,6 +95,9 @@ class _FakeNemoRelay:
     async def _plugin_initialize(self, config):
         self.events.append(("plugin.initialize", config))
         return {"diagnostics": []}
+
+    async def _plugin_clear(self):
+        self.events.append(("plugin.clear",))
 
 
 class _FakeLLMRequest:
@@ -443,6 +449,124 @@ output_directory = "{atif_dir}"
     assert not any(event[0] == "atof.register" for event in fake.events)
     assert atof_dir.is_dir()
     assert atif_dir.is_dir()
+
+
+def test_nemo_relay_plugin_clears_plugins_toml_on_final_session_finalize_and_reinitializes(tmp_path, monkeypatch):
+    fake = _FakeNemoRelay()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    plugins_toml = tmp_path / "plugins.toml"
+    plugins_toml.write_text(
+        """
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
+
+    plugin.on_session_start(session_id="s1")
+    plugin.on_session_finalize(session_id="s1", reason="shutdown")
+    plugin.on_session_start(session_id="s2")
+
+    event_names = [event[0] for event in fake.events]
+    assert event_names.count("plugin.initialize") == 2
+    assert event_names.count("plugin.clear") == 1
+
+
+def test_nemo_relay_plugin_keeps_plugins_toml_active_while_other_sessions_remain(tmp_path, monkeypatch):
+    fake = _FakeNemoRelay()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    plugins_toml = tmp_path / "plugins.toml"
+    plugins_toml.write_text(
+        """
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
+
+    plugin.on_session_start(session_id="parent")
+    plugin.on_session_start(session_id="child")
+    plugin.on_session_finalize(session_id="child", reason="shutdown")
+    plugin.on_session_finalize(session_id="parent", reason="shutdown")
+
+    event_names = [event[0] for event in fake.events]
+    assert event_names.count("plugin.initialize") == 1
+    assert event_names.count("plugin.clear") == 1
+
+
+def test_nemo_relay_plugin_reinitializes_plugins_toml_inside_active_event_loop(tmp_path, monkeypatch):
+    fake = _FakeNemoRelay()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    plugins_toml = tmp_path / "plugins.toml"
+    plugins_toml.write_text(
+        """
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
+
+    async def _drive() -> None:
+        plugin.on_session_start(session_id="s1")
+        plugin.on_session_finalize(session_id="s1", reason="shutdown")
+        plugin.on_session_start(session_id="s2")
+        await asyncio.sleep(0)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        asyncio.run(_drive())
+        gc.collect()
+
+    assert not any("was never awaited" in str(w.message) for w in caught)
+    runtime = plugin._get_runtime()
+    assert runtime is not None
+    assert runtime._plugin_config_initialized is True
+    scope_push_names = [event[1] for event in fake.events if event[0] == "scope.push"]
+    assert "hermes-session-s2" in scope_push_names
+
+
+def test_nemo_relay_plugin_disables_direct_atif_when_plugins_toml_owns_atif(tmp_path, monkeypatch):
+    fake = _FakeNemoRelay()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    plugins_toml = tmp_path / "plugins.toml"
+    plugins_toml.write_text(
+        f"""
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+
+[components.config.atif]
+enabled = true
+output_directory = "{(tmp_path / "managed-atif").as_posix()}"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
+    monkeypatch.setenv("HERMES_NEMO_RELAY_ATIF_ENABLED", "1")
+    monkeypatch.setenv("HERMES_NEMO_RELAY_ATIF_OUTPUT_DIRECTORY", str(tmp_path / "direct-atif"))
+
+    plugin.on_session_start(session_id="s1")
+    plugin.on_session_finalize(session_id="s1", reason="shutdown")
+
+    event_names = [event[0] for event in fake.events]
+    assert "plugin.initialize" in event_names
+    assert "plugin.clear" in event_names
+    assert "atif.register" not in event_names
+    assert not (tmp_path / "direct-atif" / "hermes-atif-s1.json").exists()
 
 
 def test_nemo_relay_adaptive_llm_execution_middleware_preserves_raw_response(tmp_path, monkeypatch):

--- a/tests/plugins/test_nemo_relay_plugin.py
+++ b/tests/plugins/test_nemo_relay_plugin.py
@@ -660,6 +660,104 @@ output_directory = "{(tmp_path / "managed-atof").as_posix()}"
     assert event_names.count("atof.deregister") == 1
 
 
+def _observability_only_plugins_toml(tmp_path: Path) -> Path:
+    plugins_toml = tmp_path / "plugins.toml"
+    plugins_toml.write_text(
+        """
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+""",
+        encoding="utf-8",
+    )
+    return plugins_toml
+
+
+def test_nemo_relay_plugin_recovers_when_plugins_toml_clear_raises(tmp_path, monkeypatch):
+    # Regression: a raising plugin.clear() must still transition lifecycle
+    # state (cleared + re-armed) so the next session reinitializes instead of
+    # stranding the runtime at initialized=True / needs_reinit=False forever.
+    fake = _FakeNemoRelay()
+
+    clear_calls = 0
+
+    async def _flaky_clear():
+        nonlocal clear_calls
+        clear_calls += 1
+        fake.events.append(("plugin.clear.attempt",))
+        if clear_calls == 1:
+            raise RuntimeError("clear boom")
+        fake.events.append(("plugin.clear.ok",))
+
+    fake.plugin.clear = _flaky_clear
+    plugin = _fresh_plugin(monkeypatch, fake)
+    plugins_toml = _observability_only_plugins_toml(tmp_path)
+    monkeypatch.setenv("HERMES_NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
+
+    plugin.on_session_start(session_id="s1")
+    plugin.on_session_finalize(session_id="s1", reason="shutdown")  # clear() raises here
+
+    runtime = plugin._get_runtime()
+    assert runtime is not None
+    # State transitioned despite the failure — not stranded.
+    assert runtime._plugin_config_initialized is False
+    assert runtime._plugin_config_needs_reinit is True
+
+    plugin.on_session_start(session_id="s2")  # must reinitialize
+    assert runtime._plugin_config_initialized is True
+    event_names = [event[0] for event in fake.events]
+    assert event_names.count("plugin.initialize") == 2
+
+
+def test_nemo_relay_plugin_does_not_resurrect_after_terminal_finalize(tmp_path, monkeypatch):
+    # Regression: a stray hook that funnels through ensure_session after the
+    # terminal close_session for an id must NOT re-create the session, re-push
+    # a scope, or re-arm plugins.toml. on_session_end is the named example.
+    fake = _FakeNemoRelay()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    plugins_toml = _observability_only_plugins_toml(tmp_path)
+    monkeypatch.setenv("HERMES_NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
+
+    plugin.on_session_start(session_id="s1")
+    plugin.on_session_finalize(session_id="s1", reason="shutdown")
+    plugin.on_session_end(session_id="s1")  # stray hook AFTER finalize
+
+    runtime = plugin._get_runtime()
+    assert runtime is not None
+    assert "s1" not in runtime.sessions  # no resurrection
+    event_names = [event[0] for event in fake.events]
+    # Scopes stay balanced (no leaked unpopped scope) and plugins.toml is not
+    # re-initialized a second time.
+    assert event_names.count("scope.push") == event_names.count("scope.pop")
+    assert event_names.count("plugin.initialize") == 1
+
+
+def test_nemo_relay_plugin_allows_legitimate_restart_of_finalized_session(tmp_path, monkeypatch):
+    # The finalized-session guard must not block a genuine restart: an explicit
+    # on_session_start for a previously-finalized id clears the marker and
+    # re-creates the session normally.
+    fake = _FakeNemoRelay()
+    plugin = _fresh_plugin(monkeypatch, fake)
+    plugins_toml = _observability_only_plugins_toml(tmp_path)
+    monkeypatch.setenv("HERMES_NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
+
+    plugin.on_session_start(session_id="s1")
+    plugin.on_session_finalize(session_id="s1", reason="shutdown")
+    plugin.on_session_start(session_id="s1")  # legitimate restart of same id
+
+    runtime = plugin._get_runtime()
+    assert runtime is not None
+    assert "s1" in runtime.sessions
+    assert runtime._plugin_config_initialized is True
+
+    plugin.on_session_finalize(session_id="s1", reason="shutdown")
+    event_names = [event[0] for event in fake.events]
+    # Both lifecycles fully balanced end to end.
+    assert event_names.count("scope.push") == event_names.count("scope.pop")
+
+
 def test_nemo_relay_adaptive_llm_execution_middleware_preserves_raw_response(tmp_path, monkeypatch):
     fake = _FakeNemoRelay()
     plugin = _fresh_plugin(monkeypatch, fake)


### PR DESCRIPTION
## What does this PR do?

Two follow-up hardening fixes on top of the bundled NeMo Relay observability plugin lifecycle work in #41551, found while reviewing that PR. Stacks on `#41551` (branched from its head).

### 1. `clear()`-failure no longer strands the runtime
`_clear_plugins_toml` flipped `_plugin_config_initialized` / `_plugin_config_needs_reinit` only **after** `_resolve_awaitable(clear())` returned. `close_session` catches and logs a raising `clear()`, so on failure the flags stayed `initialized=True / needs_reinit=False` — and **no later session would ever reinitialize plugins.toml or activate the direct fallbacks**. The exporter was silently dead for the rest of the process.

Fix: flip the flags in a `finally`, so a partial/failed clear still re-arms reinit (or the direct fallback) on the next session start.

### 2. `ensure_session` no longer resurrects a finalized session
Any hook that funnels through `ensure_session` after the terminal `close_session` for an id re-initialized plugins.toml and pushed a scope that was never popped — silently re-arming an exporter for an ended session (and leaking the scope). `on_session_end` is the named example.

Fix: track a bounded set of recently-finalized session ids. A stray hook for a finalized id returns a detached, unstored `_SessionState` (no reinit, no scope push). An explicit `on_session_start` (`create=True`) clears the marker, so a genuine restart of the same id still works.

> Note on severity: (2) has **no production trigger today** — the plugin `on_session_end` hook isn't invoked anywhere in `cli.py`/`gateway/`, and per-turn hooks fire during `run_conversation`, before finalize. It's defense against a future hook addition. (1) is a real latent bug that triggers whenever the relay's `clear()` raises.

## Verification

- `_resolve_awaitable` repro: drove both failure modes — clear-failure recovers (reinit fires on next start), stray post-finalize hook produces no resurrection and balanced `scope.push`/`scope.pop`.
- Added 3 regression tests; the first two **fail against the pre-fix code** (verified by reverting the prod change and re-running).
- `tests/plugins/` full suite green (1089 passed), ruff clean. Behavior-preserving for all existing paths (24 prior nemo_relay tests still pass).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Related
Follow-up to #41551 (and its parent #38232). Branched from #41551's head — merge that first, or treat these two commits as fixups to fold in.
