### PR TITLE
feat: hover tooltips on status bar items (desktop + TUI)

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -17,7 +17,7 @@ import {
   ZapFilled
 } from '@/lib/icons'
 import { useI18n } from '@/i18n'
-import { formatModelStatusLabel } from '@/lib/model-status-label'
+import { formatModelStatusLabel, reasoningEffortLabel } from '@/lib/model-status-label'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
 import { cn } from '@/lib/utils'
@@ -356,14 +356,14 @@ export function useStatusbarItems({
               menuClassName: 'w-64',
               menuContent: modelMenuContent,
               title: currentProvider
-                ? copy.modelTitle(currentProvider, currentModel || copy.modelNone)
+                ? copy.modelDetailTitle(currentProvider, currentModel || copy.modelNone, reasoningEffortLabel(currentReasoningEffort) || 'Med', currentFastMode)
                 : copy.switchModel,
               variant: 'menu' as const
             }
           : {
               onSelect: () => setModelPickerOpen(true),
               title: currentProvider
-                ? copy.providerModelTitle(currentProvider, currentModel || copy.noModel)
+                ? copy.modelDetailTitle(currentProvider, currentModel || copy.noModel, reasoningEffortLabel(currentReasoningEffort) || 'Med', currentFastMode)
                 : copy.openModelPicker,
               variant: 'action' as const
             })

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -2,6 +2,7 @@ import type { ComponentProps, ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { Tip } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
 // Shared chrome styling for interactive statusbar items (button / link / menu
@@ -94,11 +95,13 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
   if (item.variant === 'menu' && (item.menuContent || (item.menuItems && item.menuItems.length > 0))) {
     return (
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
-            {content}
-          </button>
-        </DropdownMenuTrigger>
+        <Tip label={item.title}>
+          <DropdownMenuTrigger asChild>
+            <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
+              {content}
+            </button>
+          </DropdownMenuTrigger>
+        </Tip>
         <DropdownMenuContent
           align={item.menuAlign ?? 'start'}
           className={cn('w-56', item.menuContent && 'p-0', item.menuClassName)}
@@ -147,39 +150,45 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
   if (item.variant === 'text' && !item.onSelect && !item.to && !item.href) {
     return (
-      <div
-        className={cn(
-          'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
-          item.className
-        )}
-      >
-        {content}
-      </div>
+      <Tip label={item.title}>
+        <div
+          className={cn(
+            'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
+            item.className
+          )}
+        >
+          {content}
+        </div>
+      </Tip>
     )
   }
 
   if (item.href || item.variant === 'link') {
     return (
-      <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
-        {content}
-      </a>
+      <Tip label={item.title}>
+        <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
+          {content}
+        </a>
+      </Tip>
     )
   }
 
   return (
-    <button
-      className={cn(STATUSBAR_ACTION_CLASS, item.className)}
-      disabled={item.disabled}
-      onClick={() => {
-        if (item.to) {
-          navigate(item.to)
-        }
+    <Tip label={item.title}>
+      <button
+        className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+        disabled={item.disabled}
+        onClick={() => {
+          if (item.to) {
+            navigate(item.to)
+          }
 
-        item.onSelect?.()
-      }}
-      type="button"
-    >
-      {content}
-    </button>
+          item.onSelect?.()
+        }}
+        type="button"
+      >
+        {content}
+      </button>
+    </Tip>
   )
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1470,7 +1470,9 @@ export const en: Translations = {
       switchModel: 'Switch model',
       openModelPicker: 'Open model picker',
       modelTitle: (provider, model) => `Model · ${provider}: ${model}`,
-      providerModelTitle: (provider, model) => `${provider} · ${model}`
+      providerModelTitle: (provider, model) => `${provider} · ${model}`,
+      modelDetailTitle: (provider, model, effort, fastMode) =>
+        [provider, model, effort, fastMode ? 'Fast mode on' : ''].filter(Boolean).join(' · ')
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1143,6 +1143,7 @@ export interface Translations {
       openModelPicker: string
       modelTitle: (provider: string, model: string) => string
       providerModelTitle: (provider: string, model: string) => string
+      modelDetailTitle: (provider: string, model: string, effort: string, fastMode: boolean) => string
     }
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1574,7 +1574,9 @@ export const zhHant = defineLocale({
       switchModel: '切換模型',
       openModelPicker: '開啟模型選擇器',
       modelTitle: (provider, model) => `模型 · ${provider}：${model}`,
-      providerModelTitle: (provider, model) => `${provider} · ${model}`
+      providerModelTitle: (provider, model) => `${provider} · ${model}`,
+      modelDetailTitle: (provider, model, effort, fastMode) =>
+        [provider, model, effort, fastMode ? '快速模式已開啟' : ''].filter(Boolean).join(' · ')
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1651,7 +1651,9 @@ export const zh: Translations = {
       switchModel: '切换模型',
       openModelPicker: '打开模型选择器',
       modelTitle: (provider, model) => `模型 · ${provider}: ${model}`,
-      providerModelTitle: (provider, model) => `${provider} · ${model}`
+      providerModelTitle: (provider, model) => `${provider} · ${model}`,
+      modelDetailTitle: (provider, model, effort, fastMode) =>
+        [provider, model, effort, fastMode ? '快速模式已开启' : ''].filter(Boolean).join(' · ')
     }
   },
 

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -397,11 +397,54 @@ class TestSanePathIncludesHomebrew:
         assert "/opt/homebrew/bin" in result["PATH"]
         assert "/opt/homebrew/sbin" in result["PATH"]
 
-    def test_make_run_env_does_not_duplicate_on_full_path(self):
-        """When PATH already has /usr/bin, _make_run_env should not append."""
-        from tools.environments.local import _make_run_env
-        full_env = {"PATH": "/usr/bin:/bin"}
-        with patch.dict(os.environ, full_env, clear=True):
+    def test_make_run_env_fills_missing_homebrew_when_usr_bin_present(self):
+        """Regression: a PATH containing /usr/bin must STILL get the missing
+        standard dirs appended (covers the macOS launchd / GUI-launch case).
+
+        When Hermes is launched from a .app bundle the inherited PATH is the
+        bare launchd PATH ("/usr/bin:/bin:/usr/sbin:/sbin" or similar).  The
+        old all-or-nothing guard saw /usr/bin and skipped injection entirely,
+        leaving Homebrew and other standard dirs missing.  Core file tools
+        (read_file -> `sed -n ...`) and any binary living only in /usr/sbin,
+        /sbin, or Homebrew then silently failed with "command not found".
+        """
+        from tools.environments.local import _make_run_env, _SANE_PATH
+        launchd_env = {"PATH": "/usr/local/bin:/usr/bin:/bin"}
+        with patch.dict(os.environ, launchd_env, clear=True):
             result = _make_run_env({})
-        # Should keep existing PATH unchanged
-        assert result["PATH"] == "/usr/bin:/bin"
+        path_entries = result["PATH"].split(":")
+        assert "/opt/homebrew/bin" in path_entries
+        assert "/opt/homebrew/sbin" in path_entries
+        # Pre-existing entries must keep their original order at the front.
+        assert path_entries[0] == "/usr/local/bin"
+        assert path_entries[1] == "/usr/bin"
+        assert path_entries[2] == "/bin"
+
+    def test_make_run_env_does_not_duplicate_existing_sane_entries(self):
+        """Already-present sane entries must not be duplicated."""
+        from tools.environments.local import _make_run_env, _SANE_PATH
+        full_path = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        with patch.dict(os.environ, {"PATH": full_path}, clear=True):
+            result = _make_run_env({})
+        path_entries = result["PATH"].split(":")
+        assert path_entries.count("/opt/homebrew/bin") == 1
+        assert path_entries.count("/usr/local/bin") == 1
+        assert path_entries.count("/usr/bin") == 1
+
+    def test_make_run_env_preserves_user_path_precedence(self):
+        """A user/rc-provided dir must keep priority over injected fallbacks."""
+        from tools.environments.local import _make_run_env
+        with patch.dict(os.environ, {"PATH": "/Users/me/.local/bin:/usr/bin:/bin"}, clear=True):
+            result = _make_run_env({})
+        parts = result["PATH"].split(":")
+        assert parts[0] == "/Users/me/.local/bin"
+        assert len(parts) == len(set(parts))
+
+    def test_make_run_env_idempotent(self):
+        """Running the result back through _make_run_env changes nothing."""
+        from tools.environments.local import _make_run_env
+        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin:/usr/sbin:/sbin"}, clear=True):
+            first = _make_run_env({})["PATH"]
+        with patch.dict(os.environ, {"PATH": first}, clear=True):
+            second = _make_run_env({})["PATH"]
+        assert first == second

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -300,6 +300,46 @@ _SANE_PATH = (
 )
 
 
+def _append_missing_sane_path_entries(existing_path: str) -> str:
+    """Return PATH with each missing POSIX sane entry appended once.
+
+    Idempotent: already-present entries are never duplicated.  Existing
+    entries keep their original order and precedence — missing standard
+    dirs are appended at the tail so a user/rc-provided tool of the same
+    name still wins.
+
+    Windows: short-circuits immediately (caller guards with _path_env_key).
+    """
+    sane_entries = [entry for entry in _SANE_PATH.split(":") if entry]
+    if not existing_path:
+        return ":".join(sane_entries)
+
+    existing_entries = existing_path.split(":")
+    existing_set = {entry for entry in existing_entries if entry}
+    missing_entries = [entry for entry in sane_entries if entry not in existing_set]
+    if not missing_entries:
+        return existing_path
+    return f"{existing_path}:{':'.join(missing_entries)}"
+
+
+def _path_env_key(run_env: dict) -> str | None:
+    """Return the PATH env key present in run_env without altering Windows casing.
+
+    On POSIX PATH is always uppercase.  On Windows the key can be ``Path``,
+    ``PATH``, or any other capitalisation depending on how it was inherited
+    from the parent process.  We must update the key that is actually there
+    rather than always writing ``PATH``, otherwise Windows ends up with two
+    independent entries (``Path`` from the original env *and* a new ``PATH``
+    we injected) and the shell only sees one of them.
+    """
+    if not _IS_WINDOWS:
+        return "PATH"
+    for key in run_env:
+        if key.upper() == "PATH":
+            return key
+    return None
+
+
 def _make_run_env(env: dict) -> dict:
     """Build a run environment with a sane PATH and provider-var stripping."""
     try:
@@ -315,17 +355,9 @@ def _make_run_env(env: dict) -> dict:
             run_env[real_key] = v
         elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
             run_env[k] = v
-    existing_path = run_env.get("PATH", "")
-    # The "/usr/bin not already present → inject sane POSIX path" heuristic
-    # only makes sense on POSIX.  On Windows the PATH separator is ";"
-    # (the split(":") above turns a full Windows PATH into a single
-    # unrecognisable chunk, which then triggers prepending POSIX paths
-    # to a Windows PATH — completely wrong).  Skip the injection entirely
-    # on Windows; the native PATH already points at whatever shell
-    # Hermes is driving via _find_bash (Git Bash), and Git Bash itself
-    # prepends its MSYS2 /usr/bin equivalent via the shell-init files.
-    if not _IS_WINDOWS and "/usr/bin" not in existing_path.split(":"):
-        run_env["PATH"] = f"{existing_path}:{_SANE_PATH}" if existing_path else _SANE_PATH
+    path_key = _path_env_key(run_env)
+    if path_key is not None:
+        run_env[path_key] = _append_missing_sane_path_entries(run_env.get(path_key, ""))
 
     _inject_context_hermes_home(run_env)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1829,6 +1829,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         yolo = False
     info: dict = {
         "model": getattr(agent, "model", ""),
+        "provider": getattr(agent, "provider", None) or "",
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -96,6 +96,7 @@ export interface OverlayState {
   secret: null | SecretReq
   sessions: boolean
   skillsHub: boolean
+  statusTooltip: null | { lines: string[] }
   sudo: null | SudoReq
 }
 

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -13,6 +13,7 @@ const buildOverlayState = (): OverlayState => ({
   secret: null,
   sessions: false,
   skillsHub: false,
+  statusTooltip: null,
   sudo: null
 })
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -5,6 +5,7 @@ import unicodeSpinners from 'unicode-animations'
 
 import { $delegationState } from '../app/delegationStore.js'
 import type { IndicatorStyle, Notice } from '../app/interfaces.js'
+import { patchOverlayState } from '../app/overlayStore.js'
 import { useTurnSelector } from '../app/turnStore.js'
 import { DEV_CREDITS_MODE } from '../config/env.js'
 import { FACES } from '../content/faces.js'
@@ -362,6 +363,17 @@ const shortModelLabel = (model: string) =>
 const modelLabel = (model: string, effort?: string, fast?: boolean) =>
   [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
 
+function buildModelTooltip(model: string, effort?: string, fast?: boolean, provider?: string): string[] {
+  const lines: string[] = []
+  lines.push(`model: ${model}`)
+  if (provider) lines.push(`provider: ${provider}`)
+  if (effort && effort !== 'medium' && effort !== 'normal' && effort !== 'default') {
+    lines.push(`reasoning: ${effort}`)
+  }
+  if (fast) lines.push('fast mode: on  (priority / low-latency tier)')
+  return lines
+}
+
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
   const [color, setColor] = useState(t.color.accent)
@@ -396,6 +408,7 @@ export function StatusRule({
   model,
   modelFast,
   modelReasoningEffort,
+  provider,
   indicatorStyle = 'kaomoji',
   notice,
   usage,
@@ -538,7 +551,16 @@ export function StatusRule({
           </Box>
         ) : null}
         {/* Pinned essentials — model + context never shrink, always visible. */}
-        <Box flexDirection="row" flexShrink={0}>
+        <Box
+          flexDirection="row"
+          flexShrink={0}
+          onMouseEnter={() =>
+            patchOverlayState({
+              statusTooltip: { lines: buildModelTooltip(model, modelReasoningEffort, modelFast, provider) }
+            })
+          }
+          onMouseLeave={() => patchOverlayState({ statusTooltip: null })}
+        >
           {DEV_CREDITS_MODE ? (
             <Text color={t.color.warn} wrap="truncate-end">
               {' (dev credits)'}
@@ -732,6 +754,7 @@ interface StatusRuleProps {
   model: string
   modelFast?: boolean
   modelReasoningEffort?: string
+  provider?: string
   indicatorStyle?: IndicatorStyle
   notice?: Notice | null
   sessionStartedAt?: null | number

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -372,6 +372,7 @@ const StatusRulePane = memo(function StatusRulePane({
         modelReasoningEffort={ui.info?.reasoning_effort}
         notice={ui.notice}
         onSessionCountClick={() => patchOverlayState({ sessions: true })}
+        provider={ui.info?.provider}
         sessionStartedAt={status.sessionStartedAt}
         showCost={ui.showCost}
         status={ui.status}

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -125,6 +125,7 @@ export function FloatingOverlays({
     overlay.pager ||
     overlay.sessions ||
     overlay.skillsHub ||
+    overlay.statusTooltip ||
     completions.length
 
   if (!hasAny) {
@@ -140,6 +141,16 @@ export function FloatingOverlays({
 
   return (
     <Box alignItems="flex-start" bottom="100%" flexDirection="column" left={0} position="absolute" right={0}>
+      {overlay.statusTooltip && (
+        <FloatBox color={theme.color.border}>
+          {overlay.statusTooltip.lines.map((line, i) => (
+            <Text color={theme.color.muted} key={i}>
+              {line}
+            </Text>
+          ))}
+        </FloatBox>
+      )}
+
       {overlay.sessions && (
         <FloatBox color={theme.color.border}>
           <ActiveSessionSwitcher

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -150,6 +150,7 @@ export interface SessionInfo {
   mcp_servers?: McpServerStatus[]
   model: string
   profile_name?: string
+  provider?: string
   reasoning_effort?: string
   release_date?: string
   service_tier?: string


### PR DESCRIPTION
## Summary

Adds informative hover tooltips to the status bar items in both the Hermes Desktop app and the Ink TUI (`hermes --tui`).

### Problem

The status bar shows a compact model label like `Sonnet 4.6 · Med` with no way to see the full model ID, active provider, or whether fast mode is on without opening the model picker. The `⚡`/Zap yolo indicator similarly had no hover context in the desktop. In the TUI, the `title` field on `StatusbarItem` was populated but never forwarded to the DOM.

### Changes

#### Hermes Desktop (`apps/desktop/`)

- **`statusbar-controls.tsx`**: import `Tip` (the codebase's established drop-in for `title=`, self-contained Radix tooltip) and wrap every rendered variant — menu trigger, text div, link anchor, action button — with `<Tip label={item.title}>`. This activates tooltips for all statusbar items uniformly, including the existing `yolo`, `version`, `gateway-health` items which already had good `title` copy.
- **`use-statusbar-items.tsx`**: replace the sparse `providerModelTitle` / `modelTitle` strings on `model-summary` with the new `modelDetailTitle` key that includes the active reasoning effort and fast mode state.
- **`i18n/types.ts`**, **`en.ts`**, **`zh.ts`**, **`zh-hant.ts`**: add `modelDetailTitle(provider, model, effort, fastMode)` to the statusbar copy section in all three locales.

**Tooltip content on the model chip:**
```
openrouter · anthropic/claude-sonnet-4-6 · Med · Fast mode on
```
(effort and fast mode are omitted when not active/non-default)

#### Ink TUI (`ui-tui/`)

- **`tui_gateway/server.py`**: add `provider` to the `session.info` payload so the frontend knows which provider is active.
- **`types.ts`**: `SessionInfo.provider?: string`
- **`interfaces.ts`**: add `statusTooltip: null | { lines: string[] }` to `OverlayState` (excluded from `$isBlocked` — informational only)
- **`overlayStore.ts`**: initialise `statusTooltip: null`, cleared by `resetFlowOverlays()`
- **`appChrome.tsx`**: `buildModelTooltip()` helper + `provider` prop on `StatusRule` + `onMouseEnter`/`onMouseLeave` on the pinned model+ctx Box fires `patchOverlayState`
- **`appLayout.tsx`**: thread `provider={ui.info?.provider}` to `StatusRule`
- **`appOverlays.tsx`**: render `FloatBox` when `overlay.statusTooltip` is set

### Testing

- Desktop: built with `npm run build` in `apps/desktop/`, no new type errors in changed files
- TUI: built with `npm run build` in `ui-tui/`, `tsc --noEmit` clean in changed files
- Pre-existing type errors in `packages/hermes-ink/execFileNoThrow.ts` and uninstalled optional deps (`@assistant-ui`, `@dnd-kit`, etc.) are unchanged