### PR TITLE
Preserve context_length when switching desktop models

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -713,8 +713,10 @@ def _apply_main_model_assignment(
     The runtime resolver reads ``model.base_url`` from config (it ignores
     ``OPENAI_BASE_URL``) and only honors it when the configured provider matches
     and the pool entry is on the registry default, so preserving it here is what
-    lets the override actually route. The hardcoded ``context_length`` override
-    is always dropped since the new model may have a different context window.
+    lets the override actually route. ``model.context_length`` is treated as an
+    explicit user override and must survive model switches; local/OpenAI-
+    compatible setups often need a pinned context window regardless of which
+    model name is selected in the UI.
 
     Returns the same dict (coerced to a fresh dict if the input wasn't one) so
     callers can assign it straight back onto the model config.
@@ -732,7 +734,6 @@ def _apply_main_model_assignment(
         # it so the new provider's default endpoint is used. Same-provider
         # re-assignment keeps the user's configured base_url intact.
         model_cfg["base_url"] = ""
-    model_cfg.pop("context_length", None)
     return model_cfg
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1962,6 +1962,34 @@ class TestConfigRoundTrip:
         assert set(after["model"].keys()) >= original_keys, \
             f"Lost model subkeys: {original_keys - set(after['model'].keys())}"
 
+    def test_set_model_assignment_preserves_context_length_override(self):
+        """Switching the main model should keep an explicit context_length override."""
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "model": {
+                "default": "qwen3.5:14b",
+                "provider": "ollama",
+                "base_url": "http://127.0.0.1:11434/v1",
+                "context_length": 131072,
+            }
+        })
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": "ollama",
+                "model": "qwen3.5:32b",
+            },
+        )
+
+        assert resp.status_code == 200
+        after = load_config()
+        assert after["model"]["provider"] == "ollama"
+        assert after["model"]["default"] == "qwen3.5:32b"
+        assert after["model"]["context_length"] == 131072
+
     def test_edit_model_name_preserved(self):
         """Changing the model string should update model.default on disk."""
         from hermes_cli.config import load_config


### PR DESCRIPTION
## Summary
- preserve an explicit  override when the desktop model picker switches the main model
- keep the existing provider/base_url reconciliation logic unchanged
- add a regression test covering a fresh Ollama session with a custom context length

## Testing
- uv run --frozen --extra dev pytest tests/hermes_cli/test_web_server.py -k set_model_assignment_preserves_context_length_override
- uv run --frozen ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py
- git diff --check

Closes #41944