### PR TITLE
feat(desktop): hover tooltips on status bar items

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -17,7 +17,7 @@ import {
   Zap,
   ZapFilled
 } from '@/lib/icons'
-import { formatModelStatusLabel } from '@/lib/model-status-label'
+import { formatModelStatusLabel, reasoningEffortLabel } from '@/lib/model-status-label'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
 import { cn } from '@/lib/utils'
@@ -373,14 +373,14 @@ export function useStatusbarItems({
               menuClassName: 'w-64',
               menuContent: modelMenuContent,
               title: currentProvider
-                ? copy.modelTitle(currentProvider, currentModel || copy.modelNone)
+                ? copy.modelDetailTitle(currentProvider, currentModel || copy.modelNone, reasoningEffortLabel(currentReasoningEffort) || 'Med', currentFastMode)
                 : copy.switchModel,
               variant: 'menu' as const
             }
           : {
               onSelect: () => setModelPickerOpen(true),
               title: currentProvider
-                ? copy.providerModelTitle(currentProvider, currentModel || copy.noModel)
+                ? copy.modelDetailTitle(currentProvider, currentModel || copy.noModel, reasoningEffortLabel(currentReasoningEffort) || 'Med', currentFastMode)
                 : copy.openModelPicker,
               variant: 'action' as const
             })

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -2,6 +2,7 @@ import type { ComponentProps, ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { Tip } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
 // Shared chrome styling for interactive statusbar items (button / link / menu
@@ -98,11 +99,13 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
   if (item.variant === 'menu' && (item.menuContent || (item.menuItems && item.menuItems.length > 0))) {
     return (
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
-            {content}
-          </button>
-        </DropdownMenuTrigger>
+        <Tip label={item.title}>
+          <DropdownMenuTrigger asChild>
+            <button className={cn(STATUSBAR_ACTION_CLASS, item.className)} disabled={item.disabled} type="button">
+              {content}
+            </button>
+          </DropdownMenuTrigger>
+        </Tip>
         <DropdownMenuContent
           align={item.menuAlign ?? 'start'}
           className={cn('w-56', item.menuContent && 'p-0', item.menuClassName)}
@@ -151,39 +154,45 @@ function StatusbarItemView({ item, navigate }: { item: StatusbarItem; navigate: 
 
   if (item.variant === 'text' && !item.onSelect && !item.to && !item.href) {
     return (
-      <div
-        className={cn(
-          'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
-          item.className
-        )}
-      >
-        {content}
-      </div>
+      <Tip label={item.title}>
+        <div
+          className={cn(
+            'inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
+            item.className
+          )}
+        >
+          {content}
+        </div>
+      </Tip>
     )
   }
 
   if (item.href || item.variant === 'link') {
     return (
-      <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
-        {content}
-      </a>
+      <Tip label={item.title}>
+        <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
+          {content}
+        </a>
+      </Tip>
     )
   }
 
   return (
-    <button
-      className={cn(STATUSBAR_ACTION_CLASS, item.className)}
-      disabled={item.disabled}
-      onClick={event => {
-        if (item.to) {
-          navigate(item.to)
-        }
+    <Tip label={item.title}>
+      <button
+        className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+        disabled={item.disabled}
+        onClick={event => {
+          if (item.to) {
+            navigate(item.to)
+          }
 
-        item.onSelect?.({ shiftKey: event.shiftKey })
-      }}
-      type="button"
-    >
-      {content}
-    </button>
+          item.onSelect?.({ shiftKey: event.shiftKey })
+        }}
+        type="button"
+      >
+        {content}
+      </button>
+    </Tip>
   )
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1470,7 +1470,9 @@ export const en: Translations = {
       switchModel: 'Switch model',
       openModelPicker: 'Open model picker',
       modelTitle: (provider, model) => `Model · ${provider}: ${model}`,
-      providerModelTitle: (provider, model) => `${provider} · ${model}`
+      providerModelTitle: (provider, model) => `${provider} · ${model}`,
+      modelDetailTitle: (provider, model, effort, fastMode) =>
+        [provider, model, effort, fastMode ? 'Fast mode on' : ''].filter(Boolean).join(' · ')
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1143,6 +1143,7 @@ export interface Translations {
       openModelPicker: string
       modelTitle: (provider: string, model: string) => string
       providerModelTitle: (provider: string, model: string) => string
+      modelDetailTitle: (provider: string, model: string, effort: string, fastMode: boolean) => string
     }
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1574,7 +1574,9 @@ export const zhHant = defineLocale({
       switchModel: '切換模型',
       openModelPicker: '開啟模型選擇器',
       modelTitle: (provider, model) => `模型 · ${provider}：${model}`,
-      providerModelTitle: (provider, model) => `${provider} · ${model}`
+      providerModelTitle: (provider, model) => `${provider} · ${model}`,
+      modelDetailTitle: (provider, model, effort, fastMode) =>
+        [provider, model, effort, fastMode ? '快速模式已開啟' : ''].filter(Boolean).join(' · ')
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1651,7 +1651,9 @@ export const zh: Translations = {
       switchModel: '切换模型',
       openModelPicker: '打开模型选择器',
       modelTitle: (provider, model) => `模型 · ${provider}: ${model}`,
-      providerModelTitle: (provider, model) => `${provider} · ${model}`
+      providerModelTitle: (provider, model) => `${provider} · ${model}`,
+      modelDetailTitle: (provider, model, effort, fastMode) =>
+        [provider, model, effort, fastMode ? '快速模式已开启' : ''].filter(Boolean).join(' · ')
     }
   },
 


### PR DESCRIPTION
## Summary
All status bar items now show a Radix tooltip on hover. The `title` field on `StatusbarItem` was populated in i18n copy but never forwarded to the DOM — items had no hover feedback.

The model chip tooltip is also enriched to include provider, reasoning effort, and fast-mode state so users can inspect the active configuration without opening the model picker.

## Changes
- `statusbar-controls.tsx`: import `Tip` (the codebase's established drop-in for `title=`) and wrap every rendered variant — menu trigger, text div, link, action button — with `<Tip label={item.title}>`
- `use-statusbar-items.tsx`: replace `providerModelTitle`/`modelTitle` on `model-summary` with new `modelDetailTitle` key that includes effort and fast mode; import `reasoningEffortLabel`
- `i18n/types.ts`, `en.ts`, `zh.ts`, `zh-hant.ts`: add `modelDetailTitle(provider, model, effort, fastMode)` to the statusbar copy section

## Validation
| | Before | After |
|---|---|---|
| Statusbar item hover | no feedback | Radix tooltip via `Tip` |
| Model chip tooltip | `openrouter · claude-sonnet-4-6` | `openrouter · claude-sonnet-4-6 · Med` (fast mode appended when active) |
| `tsc` in changed files | clean | clean |
| `npm run build` + `electron .` | ✓ | ✓ tested live — tooltip appears on hover over model chip in status bar |