### PR TITLE
feat(tui): hover tooltip on status bar model segment

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1829,6 +1829,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         yolo = False
     info: dict = {
         "model": getattr(agent, "model", ""),
+        "provider": getattr(agent, "provider", None) or "",
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -96,6 +96,7 @@ export interface OverlayState {
   secret: null | SecretReq
   sessions: boolean
   skillsHub: boolean
+  statusTooltip: null | { lines: string[] }
   sudo: null | SudoReq
 }
 

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -13,6 +13,7 @@ const buildOverlayState = (): OverlayState => ({
   secret: null,
   sessions: false,
   skillsHub: false,
+  statusTooltip: null,
   sudo: null
 })
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -5,6 +5,7 @@ import unicodeSpinners from 'unicode-animations'
 
 import { $delegationState } from '../app/delegationStore.js'
 import type { IndicatorStyle, Notice } from '../app/interfaces.js'
+import { patchOverlayState } from '../app/overlayStore.js'
 import { useTurnSelector } from '../app/turnStore.js'
 import { DEV_CREDITS_MODE } from '../config/env.js'
 import { FACES } from '../content/faces.js'
@@ -362,6 +363,17 @@ const shortModelLabel = (model: string) =>
 const modelLabel = (model: string, effort?: string, fast?: boolean) =>
   [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
 
+function buildModelTooltip(model: string, effort?: string, fast?: boolean, provider?: string): string[] {
+  const lines: string[] = []
+  lines.push(`model: ${model}`)
+  if (provider) lines.push(`provider: ${provider}`)
+  if (effort && effort !== 'medium' && effort !== 'normal' && effort !== 'default') {
+    lines.push(`reasoning: ${effort}`)
+  }
+  if (fast) lines.push('fast mode: on  (priority / low-latency tier)')
+  return lines
+}
+
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
   const [color, setColor] = useState(t.color.accent)
@@ -396,6 +408,7 @@ export function StatusRule({
   model,
   modelFast,
   modelReasoningEffort,
+  provider,
   indicatorStyle = 'kaomoji',
   notice,
   usage,
@@ -538,7 +551,16 @@ export function StatusRule({
           </Box>
         ) : null}
         {/* Pinned essentials — model + context never shrink, always visible. */}
-        <Box flexDirection="row" flexShrink={0}>
+        <Box
+          flexDirection="row"
+          flexShrink={0}
+          onMouseEnter={() =>
+            patchOverlayState({
+              statusTooltip: { lines: buildModelTooltip(model, modelReasoningEffort, modelFast, provider) }
+            })
+          }
+          onMouseLeave={() => patchOverlayState({ statusTooltip: null })}
+        >
           {DEV_CREDITS_MODE ? (
             <Text color={t.color.warn} wrap="truncate-end">
               {' (dev credits)'}
@@ -732,6 +754,7 @@ interface StatusRuleProps {
   model: string
   modelFast?: boolean
   modelReasoningEffort?: string
+  provider?: string
   indicatorStyle?: IndicatorStyle
   notice?: Notice | null
   sessionStartedAt?: null | number

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -372,6 +372,7 @@ const StatusRulePane = memo(function StatusRulePane({
         modelReasoningEffort={ui.info?.reasoning_effort}
         notice={ui.notice}
         onSessionCountClick={() => patchOverlayState({ sessions: true })}
+        provider={ui.info?.provider}
         sessionStartedAt={status.sessionStartedAt}
         showCost={ui.showCost}
         status={ui.status}

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -125,6 +125,7 @@ export function FloatingOverlays({
     overlay.pager ||
     overlay.sessions ||
     overlay.skillsHub ||
+    overlay.statusTooltip ||
     completions.length
 
   if (!hasAny) {
@@ -140,6 +141,16 @@ export function FloatingOverlays({
 
   return (
     <Box alignItems="flex-start" bottom="100%" flexDirection="column" left={0} position="absolute" right={0}>
+      {overlay.statusTooltip && (
+        <FloatBox color={theme.color.border}>
+          {overlay.statusTooltip.lines.map((line, i) => (
+            <Text color={theme.color.muted} key={i}>
+              {line}
+            </Text>
+          ))}
+        </FloatBox>
+      )}
+
       {overlay.sessions && (
         <FloatBox color={theme.color.border}>
           <ActiveSessionSwitcher

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -150,6 +150,7 @@ export interface SessionInfo {
   mcp_servers?: McpServerStatus[]
   model: string
   profile_name?: string
+  provider?: string
   reasoning_effort?: string
   release_date?: string
   service_tier?: string


### PR DESCRIPTION
## Summary
Hovering over the model+context segment in the Ink TUI status bar shows a `FloatBox` tooltip with the full model ID, provider, reasoning effort (when non-default), and fast-mode state.

## Changes
- `tui_gateway/server.py`: add `provider` to `_session_info()` payload
- `ui-tui/src/types.ts`: `SessionInfo.provider?: string`
- `ui-tui/src/app/interfaces.ts`: add `statusTooltip: null | { lines: string[] }` to `OverlayState` (excluded from `$isBlocked` — informational only)
- `ui-tui/src/app/overlayStore.ts`: initialise `statusTooltip: null`; cleared by `resetFlowOverlays()`
- `ui-tui/src/components/appChrome.tsx`: `buildModelTooltip()` helper; `provider` prop on `StatusRule`; `onMouseEnter`/`onMouseLeave` on the pinned model+ctx `Box` fires `patchOverlayState`
- `ui-tui/src/components/appLayout.tsx`: pass `provider={ui.info?.provider}` to `StatusRule`
- `ui-tui/src/components/appOverlays.tsx`: render `FloatBox` when `overlay.statusTooltip` is set

## Validation
| | Before | After |
|---|---|---|
| Model segment hover | no feedback | FloatBox: `model: …` / `provider: …` / `reasoning: …` / `fast mode: on` |
| `statusTooltip` blocks input | — | no (`$isBlocked` unchanged) |
| `tsc --noEmit` in changed files | clean | clean |
| `npm run build` (ui-tui) | ✓ | ✓ |