### PR TITLE
fix(cron): close session row for no_agent script-mode jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1383,6 +1383,23 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             logger.error("Job '%s': %s", job_id, err)
             return False, "", "", err
 
+        # Create a session row so no_agent jobs are visible in
+        # session_search and properly closed (ended_at set) when the
+        # script finishes.  Without this, every no_agent tick inserts a
+        # row via the delivery / mark_job_run path but never calls
+        # end_session, accumulating zombie sessions in state.db.
+        _no_agent_sdb = None
+        _no_agent_sid = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+        try:
+            from hermes_state import SessionDB as _NASDB
+            _no_agent_sdb = _NASDB()
+            _no_agent_sdb.create_session(_no_agent_sid, source="cron")
+        except Exception as _na_e:
+            logger.debug(
+                "Job '%s': session store unavailable for no_agent: %s",
+                job.get("id", "?"), _na_e,
+            )
+
         # Apply workdir if configured — lets scripts use predictable relative
         # paths. For no_agent jobs this is just the subprocess cwd (not an
         # agent TERMINAL_CWD bridge).
@@ -1402,6 +1419,18 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 try:
                     os.chdir(_prior_cwd)
                 except OSError:
+                    pass
+            # Close the session row so it doesn't linger as a zombie.
+            if _no_agent_sdb is not None:
+                try:
+                    _no_agent_sdb.end_session(
+                        _no_agent_sid, "cron_complete"
+                    )
+                except Exception:
+                    pass
+                try:
+                    _no_agent_sdb.close()
+                except Exception:
                     pass
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -280,6 +280,88 @@ def test_run_job_no_agent_never_invokes_aiagent(hermes_env):
     ai_mock.assert_not_called()
 
 
+def test_run_job_no_agent_closes_session_on_success(hermes_env):
+    """no_agent jobs must end their session row, not leave zombies (issue #41935)."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+    from hermes_state import SessionDB
+
+    script_path = hermes_env / "scripts" / "ok.sh"
+    script_path.write_text("#!/bin/bash\necho 'hello'\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="ok.sh",
+        no_agent=True, deliver="local",
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is True
+
+    # Verify the session row was created and closed.
+    sdb = SessionDB()
+    open_rows = sdb._conn.execute(
+        "SELECT id, ended_at, end_reason FROM sessions WHERE source = 'cron'"
+    ).fetchall()
+    assert len(open_rows) >= 1, "no_agent job should create at least one session row"
+    row = open_rows[-1]
+    assert row["ended_at"] is not None, "session should be ended (ended_at set)"
+    assert row["end_reason"] == "cron_complete"
+    sdb.close()
+
+
+def test_run_job_no_agent_closes_session_on_failure(hermes_env):
+    """no_agent session must be closed even when the script fails."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+    from hermes_state import SessionDB
+
+    script_path = hermes_env / "scripts" / "fail.sh"
+    script_path.write_text("#!/bin/bash\nexit 1\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="fail.sh",
+        no_agent=True, deliver="local",
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is False
+
+    sdb = SessionDB()
+    open_rows = sdb._conn.execute(
+        "SELECT id, ended_at, end_reason FROM sessions WHERE source = 'cron'"
+    ).fetchall()
+    assert len(open_rows) >= 1, "no_agent job should create a session even on failure"
+    row = open_rows[-1]
+    assert row["ended_at"] is not None, "session should be ended even on script failure"
+    assert row["end_reason"] == "cron_complete"
+    sdb.close()
+
+
+def test_run_job_no_agent_no_zombie_sessions(hermes_env):
+    """Repeated no_agent runs should not accumulate sessions with ended_at=NULL."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+    from hermes_state import SessionDB
+
+    script_path = hermes_env / "scripts" / "tick.sh"
+    script_path.write_text("#!/bin/bash\necho 'tick'\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="tick.sh",
+        no_agent=True, deliver="local",
+    )
+
+    # Run the same job 3 times (simulating 3 cron ticks).
+    for _ in range(3):
+        run_job(job)
+
+    sdb = SessionDB()
+    # The critical assertion: no zombie sessions left open.
+    zombie_count = sdb._conn.execute(
+        "SELECT COUNT(*) FROM sessions WHERE source = 'cron' AND ended_at IS NULL"
+    ).fetchone()[0]
+    assert zombie_count == 0, f"found {zombie_count} zombie sessions with ended_at=NULL"
+    sdb.close()
+
+
 # ---------------------------------------------------------------------------
 # _run_job_script: shell-script support
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `no_agent=True` (script-mode) cron jobs never close their session rows in `state.db`. The `ended_at` column stays NULL indefinitely, accumulating zombie sessions that inflate `/sessions` counts and break dashboards.

The fix adds session lifecycle management to the `no_agent` code path: create a `SessionDB` instance and session row before running the script, then call `end_session` and `close` in the existing `finally` block.

## Related Issue

Fixes #41935

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Added `SessionDB` creation, `create_session`, and `end_session`/`close` cleanup to the `no_agent` branch of `_run_job_impl`.
- `tests/cron/test_cron_no_agent.py`: Added 3 regression tests — session closed on success, session closed on script failure, no zombie sessions after repeated runs.

## How to Test

1. Create a `no_agent` cron job: `hermes cron add --script /tmp/test.sh --no-agent --schedule "*/5 * * * *"`
2. Let it run a few times
3. Query: `sqlite3 ~/.hermes/state.db "SELECT COUNT(*) FROM sessions WHERE source='cron' AND ended_at IS NULL"`
4. **Expected**: 0 (all sessions are properly closed)
5. **Before fix**: count grows with each tick

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_run_job_impl` in `cron/scheduler.py` (session lifecycle in `no_agent` vs LLM path)
- Blast radius: LOW — changes are scoped to the `no_agent` short-circuit path; LLM cron path is unaffected
- Related patterns: mirrors the existing `SessionDB` init/cleanup pattern from the LLM path (lines 1474-1479, 1989)
