### PR TITLE
fix(config): map `provider` shortcut to `model.provider` for hermes config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6028,6 +6028,20 @@ def set_config_value(key: str, value: str):
     elif value.replace('.', '', 1).isdigit():
         value = float(value)
 
+    # Map user-friendly key shortcuts to canonical nested config paths.
+    # This lets users write \`hermes config set provider X\` instead of
+    # having to remember \`hermes config set model.provider X\`.
+    _CONFIG_KEY_ALIASES = {
+        "provider": "model.provider",
+    }
+    if key in _CONFIG_KEY_ALIASES:
+        canonical = _CONFIG_KEY_ALIASES[key]
+        print(f"'{key}' is a shortcut for '{canonical}'; redirecting")
+        # Clean up any legacy bare key that might linger from a previous write
+        if key in user_config:
+            del user_config[key]
+        key = canonical
+
     _set_nested(user_config, key, value)
     
     # Write only user config back (not the full merged defaults)


### PR DESCRIPTION
## What does this PR do?

`hermes config set provider X` writes to a top-level `provider:` key in `config.yaml`, but the runtime reads the effective provider from `model.provider` — a nested key. The two keys silently diverge, so a user who runs `hermes config set provider openai` and later checks `hermes config show` sees the value, but the agent never actually uses it.

Add a `CONFIG_KEY_ALIASES` registry inside `set_config_value()` that transparently maps the user-friendly shortcut `provider` to the canonical dotted path `model.provider`, and cleans up any legacy bare key left by previous writes.

## Related Issue

Fixes #41943

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: Added `_CONFIG_KEY_ALIASES` mapping that resolves `provider` → `model.provider` before calling `_set_nested`. Also cleans up any lingering bare `provider:` key from previous writes.

## How to Test

1. Run `hermes config set provider opencode-go` and verify it writes to `model.provider` in `config.yaml` (not a top-level `provider:` key)
2. Run `hermes config show` and confirm the provider reflects the new value
3. Verify `hermes config set model.provider anthropic` still works (explicit dotted path unaffected)

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [ ] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I have tested on my platform: Docker/Linux

### Documentation & Housekeeping

- [ ] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I have updated tool descriptions/schemas if I changed tool behavior — or N/A