### PR TITLE
test(gateway): de-flake concurrent-compression lock test with a barrier

### DIFF
--- a/tests/gateway/test_compression_concurrent_sessions.py
+++ b/tests/gateway/test_compression_concurrent_sessions.py
@@ -146,6 +146,30 @@ def test_concurrent_compressions_same_session_serialize(tmp_path: Path) -> None:
     agent_a = _build_agent_with_db(db, shared_sid)
     agent_b = _build_agent_with_db(db, shared_sid)
 
+    # Force genuine simultaneous lock contention instead of relying on a
+    # ``time.sleep`` inside the compressor stub to make the threads overlap.
+    # Under CI CPU starvation that sleep is not enough: one thread could
+    # acquire → compress → rotate → RELEASE the lock before the other even
+    # reaches ``try_acquire``, so both would acquire on the shared id and
+    # both would compress (the historical "got 2" flake). A two-party
+    # barrier in front of the real acquire guarantees both threads are
+    # contending for the lock at the same instant, which is exactly the
+    # condition this test means to assert — with zero timing dependency.
+    barrier = threading.Barrier(2, timeout=15)
+    _real_acquire = db.try_acquire_compression_lock
+
+    def _barriered_acquire(*args, **kwargs):
+        # Rendezvous both callers, then let the real (atomic) acquire decide
+        # the single winner. Tolerate a broken barrier so a test-side timeout
+        # never masquerades as a lock-logic failure.
+        try:
+            barrier.wait()
+        except threading.BrokenBarrierError:
+            pass
+        return _real_acquire(*args, **kwargs)
+
+    db.try_acquire_compression_lock = _barriered_acquire
+
     results: dict[str, list | None] = {"a": None, "b": None}
     errors: list[Exception] = []
 
@@ -162,6 +186,10 @@ def test_concurrent_compressions_same_session_serialize(tmp_path: Path) -> None:
     t_b.start()
     t_a.join(timeout=15)
     t_b.join(timeout=15)
+
+    # Restore the real method so the post-join lock-leak assertion below
+    # (and any future call) hits the unwrapped implementation.
+    db.try_acquire_compression_lock = _real_acquire
 
     assert not errors, f"Compression raised exceptions: {errors}"
 


### PR DESCRIPTION
## Summary
`tests/gateway/test_compression_concurrent_sessions.py::test_concurrent_compressions_same_session_serialize` no longer flakes under CI load. It was failing on shard `test (1)` with *"Expected exactly one agent to compress, got 2"* — including on `main` HEAD, independent of any feature PR.

**Root cause (test-only, not a lock bug):** the test relied on a `time.sleep(0.25)` inside the stubbed compressor to make the two threads overlap inside the per-session lock window. Under CI CPU starvation that sleep is insufficient — one thread can acquire → compress → rotate → **release** the lock before the other thread even reaches `try_acquire`. Both then acquire on the shared `session_id` and both compress. The real per-session lock (#34351) is correct; the test's overlap was a timing accident.

## Changes
- `tests/gateway/test_compression_concurrent_sessions.py`: wrap the shared db's `try_acquire_compression_lock` in a `threading.Barrier(2)` so both threads rendezvous immediately before the real atomic acquire — guaranteeing genuine simultaneous contention regardless of scheduling. The real lock logic is untouched; it still picks exactly one winner. The wrapper is restored after `join()` so the post-join lock-leak assertion hits the unwrapped method.

## Validation
| | Old (sleep-overlap) | New (barrier) |
|---|---|---|
| 20× plain runs | flaked in CI | 20/20 pass |
| 15× under all-core CPU stress (load avg ~4.6) | reproduced the race | 15/15 pass |
| sibling test (5-session aliasing) | pass | pass |
| canonical isolated runner | 2/2 | 2/2 |

CPU-stress reproduction is the key check: the old version's failure mode (one thread finishing before the other starts) is now structurally impossible.

## Infographic
![de-flaked concurrent compression test](https://v3b.fal.media/files/b/0a9d7426/f3iyw5v8rMToqCjnP3xcR_bgbS5KMW.png)
