### PR TITLE
Repair cron ownership on container restart

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -262,6 +262,14 @@ if [ -d "$HERMES_HOME/profiles" ]; then
     chown -R hermes:hermes "$HERMES_HOME/profiles" 2>/dev/null || true
 fi
 
+# Always reset ownership of $HERMES_HOME/cron on every boot for the same
+# docker-exec/root-write reason as profiles/. The cron scheduler state
+# (jobs.json) must stay readable by the unprivileged hermes runtime even
+# after root-context maintenance commands or scheduler writes.
+if [ -d "$HERMES_HOME/cron" ]; then
+    chown -R hermes:hermes "$HERMES_HOME/cron" 2>/dev/null || true
+fi
+
 # Reset ownership of hermes-owned top-level state files on every boot.
 # The targeted data-volume chown above only covers hermes-owned
 # *subdirectories*; loose state files living directly under $HERMES_HOME

--- a/tests/test_docker_home_override_scripts.py
+++ b/tests/test_docker_home_override_scripts.py
@@ -6,6 +6,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DASHBOARD_RUN = REPO_ROOT / "docker" / "s6-rc.d" / "dashboard" / "run"
 MAIN_WRAPPER = REPO_ROOT / "docker" / "main-wrapper.sh"
+STAGE2_HOOK = REPO_ROOT / "docker" / "stage2-hook.sh"
 
 
 def test_main_wrapper_preserves_docker_workdir() -> None:
@@ -77,3 +78,14 @@ def test_dashboard_run_does_not_derive_insecure_from_bind_host() -> None:
         assert truthy in text, (
             f"HERMES_DASHBOARD_INSECURE should accept truthy value {truthy!r}"
         )
+
+
+def test_stage2_hook_repairs_profiles_and_cron_ownership_on_every_boot() -> None:
+    """profiles/ and cron/ must both be reclaimed after root-context writes."""
+    text = STAGE2_HOOK.read_text(encoding="utf-8")
+
+    assert 'if [ -d "$HERMES_HOME/profiles" ]; then' in text
+    assert 'chown -R hermes:hermes "$HERMES_HOME/profiles" 2>/dev/null || true' in text
+
+    assert 'if [ -d "$HERMES_HOME/cron" ]; then' in text
+    assert 'chown -R hermes:hermes "$HERMES_HOME/cron" 2>/dev/null || true' in text


### PR DESCRIPTION
## Summary
- always repair `$HERMES_HOME/cron` ownership on container boot, matching the existing profiles repair path
- keep cron state readable after root-context `docker exec` writes or scheduler writes
- add a regression test that locks in the unconditional ownership repairs for both `profiles/` and `cron/`

## Testing
- bash -n docker/stage2-hook.sh
- uv run --frozen --extra dev pytest tests/test_docker_home_override_scripts.py -q
- uv run --frozen ruff check tests/test_docker_home_override_scripts.py
- git diff --check

Closes #41966
