### PR TITLE
fix: surface kanban dispatch claim races

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1018,15 +1018,21 @@ class GatewayKanbanWatchersMixin:
                 results = await asyncio.to_thread(_tick_once)
                 any_spawned = False
                 for slug, res in (results or []):
-                    if res is not None and getattr(res, "spawned", None):
+                    if res is None:
+                        continue
+                    spawned = getattr(res, "spawned", None) or []
+                    concurrent_claimed = getattr(res, "concurrent_claimed", None) or []
+                    if spawned or concurrent_claimed:
                         any_spawned = True
                         # Quiet by default — only log when something actually
                         # happened, so an idle gateway stays silent.
                         logger.info(
-                            "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
+                            "kanban dispatcher [%s]: spawned=%d concurrent_claimed=%d "
+                            "reclaimed=%d crashed=%d timed_out=%d promoted=%d "
+                            "auto_blocked=%d",
                             slug,
-                            len(res.spawned),
+                            len(spawned),
+                            len(concurrent_claimed),
                             res.reclaimed,
                             len(res.crashed) if hasattr(res.crashed, "__len__") else 0,
                             len(res.timed_out) if hasattr(res.timed_out, "__len__") else 0,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2159,6 +2159,15 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 {"task_id": tid, "assignee": who, "workspace": ws}
                 for (tid, who, ws) in res.spawned
             ],
+            "concurrent_claimed": [
+                {
+                    "task_id": tid,
+                    "assignee": who,
+                    "status": status,
+                    "worker_pid": pid,
+                }
+                for (tid, who, status, pid) in res.concurrent_claimed
+            ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
             "skipped_per_profile_capped": [
@@ -2186,6 +2195,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     for tid, who, ws in res.spawned:
         tag = " (dry)" if args.dry_run else ""
         print(f"  - {tid}  ->  {who}  @ {ws or '-'}{tag}")
+    if res.concurrent_claimed:
+        print(f"Claimed elsewhere: {len(res.concurrent_claimed)}")
+        for tid, who, status, pid in res.concurrent_claimed:
+            pid_s = f" pid={pid}" if pid is not None else ""
+            print(f"  - {tid}  ->  {who or '-'}  status={status}{pid_s}")
     if res.auto_assigned_default:
         print(
             f"Auto-assigned to kanban.default_assignee={default_assignee!r}: "
@@ -2276,7 +2290,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
 
     def _on_tick(res):
         ready_pending = bool(res.skipped_unassigned) or _ready_queue_nonempty()
-        spawned_any = bool(res.spawned)
+        spawned_any = bool(res.spawned or res.concurrent_claimed)
         if ready_pending and not spawned_any:
             health_state["bad_ticks"] += 1
         else:
@@ -2302,7 +2316,8 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             return
         did_work = (
             res.reclaimed or res.crashed or res.timed_out or res.promoted
-            or res.spawned or res.auto_blocked or res.stale
+            or res.spawned or res.concurrent_claimed
+            or res.auto_blocked or res.stale
         )
         if did_work:
             print(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4868,6 +4868,17 @@ class DispatchResult:
     promoted: int = 0
     spawned: list[tuple[str, str, str]] = field(default_factory=list)
     """List of ``(task_id, assignee, workspace_path)`` triples."""
+    concurrent_claimed: list[tuple[str, str, str, Optional[int]]] = field(
+        default_factory=list
+    )
+    """Tasks that were ready/review when this tick scanned the queue but were
+    already claimed by another dispatcher before our CAS could win.
+
+    Entries are ``(task_id, assignee, status, worker_pid)``. This bucket keeps
+    cockpit JSON honest in multi-dispatcher races: ``spawned=[]`` no longer
+    implies no progress happened when a gateway tick claimed the same task a
+    moment earlier.
+    """
     skipped_unassigned: list[str] = field(default_factory=list)
     """Ready task ids skipped because they have no assignee at all.
     Operator-actionable — usually a misfiled task waiting for routing."""
@@ -6022,6 +6033,35 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     return False
 
 
+def _concurrent_claim_snapshot(
+    conn: sqlite3.Connection, task_id: str,
+) -> Optional[tuple[str, str, str, Optional[int]]]:
+    """Return a compact snapshot when a dispatcher lost the claim CAS.
+
+    ``dispatch_once`` reads ready/review rows, then atomically claims each row.
+    Another dispatcher can win the CAS in that small window. Previously we
+    silently continued, so JSON output looked idle even though the task moved to
+    ``running`` and may already have a worker pid. Surface that race explicitly
+    without pretending this dispatcher spawned the worker.
+    """
+    row = conn.execute(
+        "SELECT id, assignee, status, worker_pid FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    status = row["status"] or ""
+    if status not in {"running", "review", "done", "blocked"}:
+        return None
+    pid = row["worker_pid"]
+    return (
+        row["id"],
+        row["assignee"] or "",
+        status,
+        int(pid) if pid is not None else None,
+    )
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -6281,6 +6321,8 @@ def dispatch_once(
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            if snapshot := _concurrent_claim_snapshot(conn, row["id"]):
+                result.concurrent_claimed.append(snapshot)
             continue
         try:
             workspace = resolve_workspace(claimed, board=board)
@@ -6367,6 +6409,8 @@ def dispatch_once(
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            if snapshot := _concurrent_claim_snapshot(conn, row["id"]):
+                result.concurrent_claimed.append(snapshot)
             continue
         try:
             workspace = resolve_workspace(claimed, board=board)

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -8,6 +8,7 @@ operator footgun that only manifests in long-running setups.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 import tempfile
@@ -92,6 +93,37 @@ def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypat
     assert captured.get("max_spawn") == 2, (
         f"CLI --max=2 must override config kanban.max_spawn=10; got {captured.get('max_spawn')!r}"
     )
+
+
+def test_cli_dispatch_json_reports_concurrent_claims(
+    isolated_kanban_home, monkeypatch, capsys
+):
+    """`dispatch --json` must surface tasks claimed by another dispatcher.
+
+    Otherwise an operator can see `spawned: []` while `kanban show` proves the
+    task was claimed/spawned by a racing gateway tick.
+    """
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"kanban": {}})
+    result = kanban_db.DispatchResult()
+    result.concurrent_claimed.append(("t_race", "worker-a", "running", 12345))
+    monkeypatch.setattr(kanban_db, "dispatch_once", lambda conn, **kw: result)
+
+    args = argparse.Namespace(dry_run=False, max=1, failure_limit=2, json=True)
+
+    assert kb_cli._cmd_dispatch(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["spawned"] == []
+    assert payload["concurrent_claimed"] == [
+        {
+            "task_id": "t_race",
+            "assignee": "worker-a",
+            "status": "running",
+            "worker_pid": 12345,
+        }
+    ]
 
 
 def test_cli_invalid_max_in_progress_silently_disables(isolated_kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1547,6 +1547,44 @@ def test_dispatch_promotes_ready_and_spawns(kanban_home, all_assignees_spawnable
         assert kb.get_task(conn, c).status == "running"
 
 
+def test_dispatch_surfaces_ready_claim_race(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    """If another dispatcher claims a ready row between SELECT and CAS,
+    the current tick must expose that race instead of looking idle.
+
+    This is the cockpit failure seen in the golden-loop canary: one
+    dispatcher reported ``spawned=[]`` while another dispatcher had already
+    claimed and spawned the task. Operators need a deterministic "claimed
+    elsewhere" bucket so JSON output does not imply no progress happened.
+    """
+    original_claim_task = kb.claim_task
+    spawns = []
+
+    def racing_claim(conn, task_id, **kwargs):
+        claimed = original_claim_task(conn, task_id, **kwargs)
+        assert claimed is not None
+        kb._set_worker_pid(conn, task_id, 12345)
+        return None
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    monkeypatch.setattr(kb, "claim_task", racing_claim)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="racy", assignee="alice")
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        task = kb.get_task(conn, task_id)
+
+    assert spawns == []
+    assert res.spawned == []
+    assert res.concurrent_claimed == [(task_id, "alice", "running", 12345)]
+    assert task is not None
+    assert task.status == "running"
+    assert task.worker_pid == 12345
+
+
 def test_dispatch_spawn_failure_releases_claim(kanban_home, all_assignees_spawnable):
     def boom(task, workspace):
         raise RuntimeError("spawn failed")


### PR DESCRIPTION
## Summary
- surface dispatcher claim races in `DispatchResult.concurrent_claimed`
- include concurrent claims in `hermes kanban dispatch --json` and human output
- treat concurrent claims as dispatcher activity for gateway/daemon stuck-health telemetry

## Why
A manual or CLI dispatch tick can report `spawned: []` when another dispatcher has already claimed the same ready/review task between the queue scan and the compare-and-swap claim. That makes the operator surface look idle even though useful progress happened elsewhere.

This change makes that race explicit by reporting the task in `concurrent_claimed` instead of silently continuing and implying no progress occurred.

## Validation
- `./venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py::test_dispatch_surfaces_ready_claim_race tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py::test_cli_dispatch_json_reports_concurrent_claims -q` → 2 passed
- `./venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py -q` → 220 passed
- `./venv/bin/python -m ruff check gateway/kanban_watchers.py hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py` → All checks passed
- `git diff --check origin/main..HEAD` → passed
