### PR TITLE
fix(cron): close no_agent session rows to prevent zombie accumulation in state.db (#41935)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1348,6 +1348,27 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         return _run_job_impl(job)
 
 
+def _end_no_agent_session(
+    session_db: object, session_id: str | None, end_reason: str
+) -> None:
+    """Close a no_agent cron session row in state.db.
+
+    Safe to call with *session_db*=``None`` or *session_id*=``None``
+    (e.g. when SessionDB failed to initialise).  All exceptions are
+    swallowed and logged — this is cleanup, not business logic.
+    """
+    if session_db is None or session_id is None:
+        return
+    try:
+        session_db.end_session(session_id, end_reason)
+    except Exception as e:
+        logger.debug("no_agent session %s: end_session failed: %s", session_id, e)
+    try:
+        session_db.close()
+    except Exception as e:
+        logger.debug("no_agent session %s: close failed: %s", session_id, e)
+
+
 def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -1383,6 +1404,37 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             logger.error("Job '%s': %s", job_id, err)
             return False, "", "", err
 
+        # Initialize SQLite session store for no_agent jobs so the session
+        # row is properly closed when the script finishes.  Without this, the
+        # outer finally block's end_session is never reached because the
+        # no_agent path returns early, and zombie rows accumulate in state.db.
+        # (issue #41935)
+        _session_db = None
+        _cron_session_id = None
+        try:
+            from hermes_state import SessionDB
+            _session_db = SessionDB()
+        except Exception as e:
+            logger.debug(
+                "Job '%s': SQLite session store not available: %s", job_id, e
+            )
+
+        if _session_db is not None:
+            _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+            try:
+                _session_db.create_session(
+                    _cron_session_id,
+                    platform="cron",
+                    source="cron",
+                    model="no_agent",
+                    provider="script",
+                )
+            except Exception as e:
+                logger.debug(
+                    "Job '%s': failed to create session: %s", job_id, e
+                )
+                _cron_session_id = None
+
         # Apply workdir if configured — lets scripts use predictable relative
         # paths. For no_agent jobs this is just the subprocess cwd (not an
         # agent TERMINAL_CWD bridge).
@@ -1406,10 +1458,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
 
+        # Determine the end_reason for the session row.
         if not ok:
-            # Script crashed / timed out / exited non-zero.  Deliver the
-            # error so the user knows the watchdog itself broke — silent
-            # failure for an alerting job is the worst-case outcome.
+            end_reason = "cron_script_failed"
             alert = (
                 f"⚠ Cron watchdog '{job_name}' script failed\n\n"
                 f"{output}\n\n"
@@ -1423,14 +1474,14 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Status:** script failed\n\n"
                 f"{output}\n"
             )
+            _end_no_agent_session(_session_db, _cron_session_id, end_reason)
             return False, doc, alert, output
 
-        # Honour the wakeAgent gate as a silent signal — `wakeAgent: false`
-        # means "nothing to report this tick", same as empty stdout.
         if not _parse_wake_gate(output):
             logger.info(
                 "Job '%s' (no_agent): wakeAgent=false gate — silent run", job_id
             )
+            end_reason = "cron_silent_wake"
             silent_doc = (
                 f"# Cron Job: {job_name}\n\n"
                 f"**Job ID:** {job_id}\n"
@@ -1438,10 +1489,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (wakeAgent=false)\n"
             )
+            _end_no_agent_session(_session_db, _cron_session_id, end_reason)
             return True, silent_doc, SILENT_MARKER, None
 
         if not output.strip():
             logger.info("Job '%s' (no_agent): empty stdout — silent run", job_id)
+            end_reason = "cron_silent_empty"
             silent_doc = (
                 f"# Cron Job: {job_name}\n\n"
                 f"**Job ID:** {job_id}\n"
@@ -1449,8 +1502,10 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (empty output)\n"
             )
+            _end_no_agent_session(_session_db, _cron_session_id, end_reason)
             return True, silent_doc, SILENT_MARKER, None
 
+        end_reason = "cron_complete"
         doc = (
             f"# Cron Job: {job_name}\n\n"
             f"**Job ID:** {job_id}\n"
@@ -1459,6 +1514,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             f"---\n\n"
             f"{output}\n"
         )
+        _end_no_agent_session(_session_db, _cron_session_id, end_reason)
         return True, doc, output, None
 
     # ---------------------------------------------------------------

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -329,3 +329,215 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+# ---------------------------------------------------------------------------
+# no_agent session lifecycle (issue #41935)
+# ---------------------------------------------------------------------------
+
+
+def test_no_agent_success_closes_session(hermes_env, monkeypatch):
+    """A successful no_agent run must call end_session on the session row."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "ok.sh"
+    script_path.write_text("#!/bin/bash\necho hello\n")
+
+    calls = []
+
+    class FakeSessionDB:
+        def create_session(self, *a, **kw):
+            calls.append(("create", a, kw))
+
+        def end_session(self, sid, reason):
+            calls.append(("end", sid, reason))
+
+        def close(self):
+            calls.append(("close",))
+
+    monkeypatch.setattr(
+        "hermes_state.SessionDB", lambda: FakeSessionDB(), raising=False
+    )
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="ok.sh", no_agent=True, deliver="local"
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is True
+
+    end_calls = [c for c in calls if c[0] == "end"]
+    assert len(end_calls) == 1
+    assert end_calls[0][2] == "cron_complete"
+
+
+def test_no_agent_script_failure_closes_session(hermes_env, monkeypatch):
+    """A failed no_agent script must still call end_session."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "fail.sh"
+    script_path.write_text("#!/bin/bash\necho boom >&2\nexit 1\n")
+
+    calls = []
+
+    class FakeSessionDB:
+        def create_session(self, *a, **kw):
+            calls.append(("create", a, kw))
+
+        def end_session(self, sid, reason):
+            calls.append(("end", sid, reason))
+
+        def close(self):
+            calls.append(("close",))
+
+    monkeypatch.setattr(
+        "hermes_state.SessionDB", lambda: FakeSessionDB(), raising=False
+    )
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="fail.sh", no_agent=True, deliver="local"
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is False
+
+    end_calls = [c for c in calls if c[0] == "end"]
+    assert len(end_calls) == 1
+    assert end_calls[0][2] == "cron_script_failed"
+
+
+def test_no_agent_wake_gate_closes_session(hermes_env, monkeypatch):
+    """wakeAgent=false silent run must still call end_session."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job, SILENT_MARKER
+
+    script_path = hermes_env / "scripts" / "gate.sh"
+    script_path.write_text('#!/bin/bash\necho \'{"wakeAgent": false}\'\n')
+
+    calls = []
+
+    class FakeSessionDB:
+        def create_session(self, *a, **kw):
+            calls.append(("create", a, kw))
+
+        def end_session(self, sid, reason):
+            calls.append(("end", sid, reason))
+
+        def close(self):
+            calls.append(("close",))
+
+    monkeypatch.setattr(
+        "hermes_state.SessionDB", lambda: FakeSessionDB(), raising=False
+    )
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="gate.sh", no_agent=True, deliver="local"
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is True
+    assert final_response == SILENT_MARKER
+
+    end_calls = [c for c in calls if c[0] == "end"]
+    assert len(end_calls) == 1
+    assert end_calls[0][2] == "cron_silent_wake"
+
+
+def test_no_agent_empty_output_closes_session(hermes_env, monkeypatch):
+    """Empty stdout silent run must still call end_session."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job, SILENT_MARKER
+
+    script_path = hermes_env / "scripts" / "empty.sh"
+    script_path.write_text("#!/bin/bash\n# silent\n")
+
+    calls = []
+
+    class FakeSessionDB:
+        def create_session(self, *a, **kw):
+            calls.append(("create", a, kw))
+
+        def end_session(self, sid, reason):
+            calls.append(("end", sid, reason))
+
+        def close(self):
+            calls.append(("close",))
+
+    monkeypatch.setattr(
+        "hermes_state.SessionDB", lambda: FakeSessionDB(), raising=False
+    )
+
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="empty.sh",
+        no_agent=True,
+        deliver="local",
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is True
+    assert final_response == SILENT_MARKER
+
+    end_calls = [c for c in calls if c[0] == "end"]
+    assert len(end_calls) == 1
+    assert end_calls[0][2] == "cron_silent_empty"
+
+
+def test_no_agent_multiple_runs_no_zombie_sessions(hermes_env, monkeypatch):
+    """Running a no_agent job N times must call end_session N times."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "tick.sh"
+    script_path.write_text("#!/bin/bash\necho tick\n")
+
+    calls = []
+
+    class FakeSessionDB:
+        def create_session(self, *a, **kw):
+            calls.append(("create", a, kw))
+
+        def end_session(self, sid, reason):
+            calls.append(("end", sid, reason))
+
+        def close(self):
+            calls.append(("close",))
+
+    monkeypatch.setattr(
+        "hermes_state.SessionDB", lambda: FakeSessionDB(), raising=False
+    )
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="tick.sh", no_agent=True, deliver="local"
+    )
+    for _ in range(5):
+        success, _, _, _ = run_job(job)
+        assert success is True
+
+    end_calls = [c for c in calls if c[0] == "end"]
+    assert len(end_calls) == 5
+    for c in end_calls:
+        assert c[2] == "cron_complete"
+
+
+def test_end_no_agent_session_handles_none_db():
+    """_end_no_agent_session must be safe when SessionDB is None."""
+    from cron.scheduler import _end_no_agent_session
+
+    # Should not raise.
+    _end_no_agent_session(None, None, "cron_complete")
+    _end_no_agent_session(None, "some_id", "cron_complete")
+
+
+def test_end_no_agent_session_handles_none_session_id():
+    """_end_no_agent_session must be safe when session_id is None."""
+    from cron.scheduler import _end_no_agent_session
+
+    class FakeDB:
+        def end_session(self, *a, **kw):
+            raise RuntimeError("should not be called")
+
+        def close(self):
+            raise RuntimeError("should not be called")
+
+    # Should not raise even though session_id is None.
+    _end_no_agent_session(FakeDB(), None, "cron_complete")


### PR DESCRIPTION
## Problem

When `no_agent=True` (script-mode) cron jobs run, the early return in `_run_job_impl` bypasses the outer `finally` block that calls `end_session`. This leaves session rows with `ended_at=NULL` indefinitely, causing `state.db` to accumulate zombie sessions that appear 'active' to every tool that reads session state.

## Root Cause

`cron/scheduler.py::_run_job_impl` (line ~1400) has a `no_agent` short-circuit that runs the script via `_run_job_script` and **returns early** — before the outer `_run_job` `finally` block (lines ~1962-2014) gets a chance to call `end_session`.

## Fix

- Initialize a `SessionDB` and create a session row at the start of the `no_agent` branch
- Call `end_session` with an appropriate `end_reason` at every return point:
  - `cron_complete` — script succeeded with output
  - `cron_script_failed` — script exited non-zero
  - `cron_silent_wake` — wakeAgent=false gate
  - `cron_silent_empty` — empty stdout
- Added `_end_no_agent_session()` helper that safely handles `None` db/session_id

## Tests

7 new tests in `tests/cron/test_cron_no_agent.py`:
- Session closed on success, failure, wake gate, empty output
- Multiple runs produce correct number of closed rows (no zombies)
- `_end_no_agent_session` handles `None` db and `None` session_id gracefully

All 25 tests in the file pass. Ruff clean.