### PR TITLE
fix(gateway): widen agent-cache memory-leak fixes to all eviction paths (#18438)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12390,7 +12390,17 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
         _lock = getattr(self, "_agent_cache_lock", None)
         if _lock:
             with _lock:
-                self._agent_cache.pop(session_key, None)
+                entry = self._agent_cache.pop(session_key, None)
+            # Release clients on a daemon thread, same as _enforce_agent_cache_cap.
+            if entry is not None:
+                agent = entry[0] if isinstance(entry, tuple) and entry else None
+                if agent is not None:
+                    threading.Thread(
+                        target=self._release_evicted_agent_soft,
+                        args=(agent,),
+                        daemon=True,
+                        name=f"agent-cache-cmd-evict-{session_key[:24]}",
+                    ).start()
 
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
@@ -12432,6 +12442,10 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                 self._cleanup_agent_resources(agent)
         except Exception:
             pass
+        # Free conversation history memory — can be tens of MB with tool
+        # outputs (file reads, terminal output, search results).
+        if hasattr(agent, '_session_messages'):
+            agent._session_messages = []
 
     def _enforce_agent_cache_cap(self) -> None:
         """Evict oldest cached agents when cache exceeds _AGENT_CACHE_MAX_SIZE.
@@ -12556,6 +12570,22 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                 daemon=True,
                 name=f"agent-cache-idle-{key[:24]}",
             ).start()
+        # Prune stale entries from per-session dicts for keys no longer in
+        # the agent cache.  This prevents unbounded growth over long uptimes.
+        if to_evict:
+            evicted_keys = {key for key, _ in to_evict}
+            with _lock:
+                live_keys = set(_cache.keys())
+            stale_keys = evicted_keys - live_keys
+            for d in (
+                getattr(self, "_session_model_overrides", None),
+                getattr(self, "_session_reasoning_overrides", None),
+                getattr(self, "_pending_approvals", None),
+                getattr(self, "_update_prompt_pending", None),
+            ):
+                if d is not None:
+                    for sk in stale_keys:
+                        d.pop(sk, None)
         return len(to_evict)
 
     # ------------------------------------------------------------------

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12402,6 +12402,45 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                         name=f"agent-cache-cmd-evict-{session_key[:24]}",
                     ).start()
 
+    def _prune_stale_session_dicts(self, evicted_keys: set, *, lock_held: bool = False) -> None:
+        """Drop per-session dict entries for keys no longer in the agent cache.
+
+        Per-session override/approval dicts grow one entry per session and are
+        never cleaned when the backing agent leaves _agent_cache, so over long
+        uptimes they accumulate unboundedly (issue #18438).  Called from every
+        eviction path (idle sweep AND cap enforcement) so no path leaks.
+
+        We re-check live cache membership before pruning: a key that was
+        evicted but immediately re-inserted by a new turn must keep its
+        overrides.  ``lock_held=True`` MUST be passed by callers that already
+        hold ``_agent_cache_lock`` (e.g. _enforce_agent_cache_cap) — the lock
+        is a plain ``threading.Lock`` (non-reentrant), so re-acquiring it here
+        would deadlock.
+        """
+        if not evicted_keys:
+            return
+        _lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        if _cache is None:
+            live_keys = set()
+        elif lock_held or _lock is None:
+            live_keys = set(_cache.keys())
+        else:
+            with _lock:
+                live_keys = set(_cache.keys())
+        stale_keys = evicted_keys - live_keys
+        if not stale_keys:
+            return
+        for d in (
+            getattr(self, "_session_model_overrides", None),
+            getattr(self, "_session_reasoning_overrides", None),
+            getattr(self, "_pending_approvals", None),
+            getattr(self, "_update_prompt_pending", None),
+        ):
+            if d is not None:
+                for sk in stale_keys:
+                    d.pop(sk, None)
+
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
         """Reset per-turn state on a cached agent before a new turn starts.
@@ -12522,6 +12561,15 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                     daemon=True,
                     name=f"agent-cache-evict-{key[:24]}",
                 ).start()
+        # Prune stale per-session dict entries for evicted keys (issue #18438).
+        # Sibling of the idle-sweep pruning — cap enforcement evicts agents too,
+        # so the same override/approval dicts would otherwise leak here.
+        # lock_held=True: this method runs with _agent_cache_lock already held
+        # (see docstring), and the lock is non-reentrant.
+        if evict_plan:
+            self._prune_stale_session_dicts(
+                {key for key, _ in evict_plan}, lock_held=True
+            )
 
     def _sweep_idle_cached_agents(self) -> int:
         """Evict cached agents whose AIAgent has been idle > _AGENT_CACHE_IDLE_TTL_SECS.
@@ -12570,22 +12618,9 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                 daemon=True,
                 name=f"agent-cache-idle-{key[:24]}",
             ).start()
-        # Prune stale entries from per-session dicts for keys no longer in
-        # the agent cache.  This prevents unbounded growth over long uptimes.
+        # Prune stale per-session dict entries for evicted keys (issue #18438).
         if to_evict:
-            evicted_keys = {key for key, _ in to_evict}
-            with _lock:
-                live_keys = set(_cache.keys())
-            stale_keys = evicted_keys - live_keys
-            for d in (
-                getattr(self, "_session_model_overrides", None),
-                getattr(self, "_session_reasoning_overrides", None),
-                getattr(self, "_pending_approvals", None),
-                getattr(self, "_update_prompt_pending", None),
-            ):
-                if d is not None:
-                    for sk in stale_keys:
-                        d.pop(sk, None)
+            self._prune_stale_session_dicts({key for key, _ in to_evict})
         return len(to_evict)
 
     # ------------------------------------------------------------------

--- a/model_tools.py
+++ b/model_tools.py
@@ -330,7 +330,7 @@ def get_tool_definitions(
         # (DeepSeek, Xiaomi MiMo, Moonshot Kimi) reject the request with
         # HTTP 400. Mirrors the cache-hit path above. (issue #17335)
         if len(_tool_defs_cache) >= 8:
-            _tool_defs_cache.clear()
+            _tool_defs_cache.pop(next(iter(_tool_defs_cache)))  # evict oldest
         _tool_defs_cache[cache_key] = result
         return list(result)
     return result

--- a/model_tools.py
+++ b/model_tools.py
@@ -329,6 +329,8 @@ def get_tool_definitions(
         # agent inits and providers that enforce unique tool names
         # (DeepSeek, Xiaomi MiMo, Moonshot Kimi) reject the request with
         # HTTP 400. Mirrors the cache-hit path above. (issue #17335)
+        if len(_tool_defs_cache) >= 8:
+            _tool_defs_cache.clear()
         _tool_defs_cache[cache_key] = result
         return list(result)
     return result

--- a/run_agent.py
+++ b/run_agent.py
@@ -3087,6 +3087,17 @@ class AIAgent:
         except Exception:
             pass
 
+        # 6. Free conversation history memory.  Mirrors the soft-eviction
+        # path (_release_evicted_agent_soft clears _session_messages) — the
+        # hard teardown must do the same, otherwise a held reference to this
+        # agent (e.g. a still-draining background task) pins tens of MB of
+        # tool outputs (file reads, terminal output, search results) for the
+        # process lifetime.  Safe here: close() is a true session boundary.
+        try:
+            self._session_messages = []
+        except Exception:
+            pass
+
     def _hydrate_todo_store(self, history: List[Dict[str, Any]]) -> None:
         """
         Recover todo state from conversation history.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -65,6 +65,7 @@ AUTHOR_MAP = {
     "129007007+HeLLGURD@users.noreply.github.com": "HeLLGURD",
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "jeanclawdai@proton.me": "mssteuer",
     "adityamalik2833@gmail.com": "alarcritty",
     "islam666@users.noreply.github.com": "islam666",
     "25539605+lsaether@users.noreply.github.com": "lsaether",

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -1514,3 +1514,74 @@ class TestAgentConfigSignatureUserId:
             user_id=None, user_id_alt=None,
         )
         assert sig_implicit == sig_explicit_none
+
+
+class TestSiblingEvictionLeakFixes:
+    """Widening of #18438: every eviction path frees per-session state.
+
+    The contributor's PR fixed _evict_cached_agent + the idle-sweep path.
+    These tests cover the sibling sites: cap-enforcement pruning and the
+    re-entrant-lock safety of the shared _prune_stale_session_dicts helper.
+    """
+
+    def _runner_with_session_dicts(self):
+        from gateway.run import GatewayRunner
+        from collections import OrderedDict
+
+        r = GatewayRunner.__new__(GatewayRunner)
+        r._agent_cache = OrderedDict()
+        r._agent_cache_lock = threading.Lock()
+        r._running_agents = {}
+        r._session_model_overrides = {}
+        r._session_reasoning_overrides = {}
+        r._pending_approvals = {}
+        r._update_prompt_pending = {}
+        return r
+
+    def test_prune_removes_stale_but_keeps_live(self):
+        """A key still in the cache keeps its overrides; a stale key loses them."""
+        r = self._runner_with_session_dicts()
+        r._agent_cache["live"] = (MagicMock(), "sys")
+        r._session_model_overrides["live"] = "opus"
+        r._session_model_overrides["stale"] = "sonnet"
+        r._pending_approvals["stale"] = object()
+        r._prune_stale_session_dicts({"live", "stale"})
+        assert "live" in r._session_model_overrides
+        assert "stale" not in r._session_model_overrides
+        assert "stale" not in r._pending_approvals
+
+    def test_prune_does_not_deadlock_when_lock_held(self):
+        """lock_held=True must not re-acquire the non-reentrant cache lock."""
+        r = self._runner_with_session_dicts()
+        r._session_model_overrides["gone"] = "x"
+        # Simulate the cap-enforcement caller, which holds the lock.
+        completed = []
+        with r._agent_cache_lock:
+            r._prune_stale_session_dicts({"gone"}, lock_held=True)
+            completed.append(True)
+        assert completed == [True]
+        assert "gone" not in r._session_model_overrides
+
+    def test_cap_enforcement_prunes_evicted_session_dicts(self):
+        """_enforce_agent_cache_cap evicts AND prunes per-session dicts."""
+        import gateway.run as gr
+
+        r = self._runner_with_session_dicts()
+        old_max = gr._AGENT_CACHE_MAX_SIZE
+        gr._AGENT_CACHE_MAX_SIZE = 1
+        try:
+            old_agent = MagicMock()
+            old_agent.release_clients = MagicMock()
+            r._agent_cache["old"] = (old_agent, "sys")
+            r._session_model_overrides["old"] = "opus"
+            r._session_reasoning_overrides["old"] = "high"
+            # Push over cap.
+            r._agent_cache["new"] = (MagicMock(), "sys")
+            with r._agent_cache_lock:
+                r._enforce_agent_cache_cap()
+            assert "old" not in r._agent_cache
+            assert "old" not in r._session_model_overrides
+            assert "old" not in r._session_reasoning_overrides
+        finally:
+            gr._AGENT_CACHE_MAX_SIZE = old_max
+

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -87,6 +87,25 @@ class TestQuietModeCacheIsolation:
             f"baseline={baseline}, final={len(final)}."
         )
 
+    def test_cache_bounded_by_lru_eviction(self):
+        """The cache evicts the oldest entry when it reaches 8 entries,
+        keeping 7 warm entries instead of clearing everything."""
+        # Fill cache with 8 distinct keys by varying enabled_toolsets
+        toolset_names = [f"fake_toolset_{i}" for i in range(8)]
+        for name in toolset_names:
+            model_tools.get_tool_definitions(
+                enabled_toolsets=[name], quiet_mode=True,
+            )
+        assert len(model_tools._tool_defs_cache) == 8
+
+        # Adding a 9th should evict the oldest, not clear all
+        model_tools.get_tool_definitions(
+            enabled_toolsets=["fake_toolset_overflow"], quiet_mode=True,
+        )
+        assert len(model_tools._tool_defs_cache) == 8, (
+            "LRU eviction should keep the cache at 8 entries, not clear it"
+        )
+
     def test_non_quiet_mode_does_not_use_cache(self):
         """Sanity: quiet_mode=False (TUI path) skips the cache entirely \u2014
         explains why the bug only hit Gateway."""


### PR DESCRIPTION
## Summary
Closes the gateway memory leak that drives OOM kills, on every eviction path — not just the two the original PR touched.

Salvage of @mssteuer's #25318 (4 eviction-path leak fixes) onto current main, widened so no eviction path leaks per-session state.

## What was leaking
On current main, `_evict_cached_agent()` (called on `/new`, `/model`, compression-driven session rotation) only did `_agent_cache.pop()` — it never released the agent's OpenAI client, httpx transport, SSL context, or conversation history. Under the active-session churn in #18438 (2 Discord sessions, 30–60 api_calls/turn, compression rotating session_id repeatedly), orphaned agents + per-session override dicts accumulated until OOM.

## Changes
- `gateway/run.py` (@mssteuer):
  - `_evict_cached_agent()` now releases clients via the same daemon-thread path as cap/idle eviction.
  - `_release_evicted_agent_soft()` clears `_session_messages` (tens of MB of tool outputs).
  - idle-sweep prunes stale per-session dicts (`_session_model_overrides`, `_session_reasoning_overrides`, `_pending_approvals`, `_update_prompt_pending`).
- `model_tools.py` (@mssteuer): `_tool_defs_cache` LRU-bounded to 8 (evict oldest, keep 7 warm).
- `gateway/run.py` (widening, ours):
  - `_enforce_agent_cache_cap()` now prunes the same per-session dicts — the original PR only fixed the idle-sweep path, but cap enforcement is the path that fires under sustained active load.
  - `AIAgent.close()` clears `_session_messages`, mirroring the soft-evict path so hard teardown can't pin history either.
  - Extracted pruning into `_prune_stale_session_dicts(lock_held=)` so both paths share one impl; the kwarg avoids a re-entrant deadlock on the non-reentrant cache lock (caught by E2E).

## Validation
| Path | Before | After |
|---|---|---|
| `_evict_cached_agent` (/new, /model) | client + history leaked | released + history cleared |
| idle-TTL sweep | per-session dicts leaked | dicts pruned |
| cap enforcement | per-session dicts leaked | dicts pruned (new) |
| `AIAgent.close()` | history pinned | history freed (new) |

- E2E: built a real `GatewayRunner`, exercised all four paths + the re-insert race guard — all pass. The deadlock in the cap-enforcement path (re-acquiring a held non-reentrant lock) was caught here, not by unit tests.
- Targeted suite: `tests/gateway/test_agent_cache.py` + 5 sibling eviction/cache test files + the tool-defs cache test → 90 passed. Added 3 tests for the widening.

## Attribution
- `7b14303b9` — Michael Steuer (@mssteuer)
- `2d25e387d` — Jean Clawd / @mssteuer (self-declared alt identity; AUTHOR_MAP updated)
- `3a112bccd` — widening + tests (ours)

Salvages and supersedes #25318. Addresses #18438 (and the eviction-churn shape of #25315). Rebase-merge to preserve contributor per-commit authorship.

## Infographic

![gateway-memory-leak-patched](https://v3b.fal.media/files/b/0a9d7478/nyifyCpwWf3nC7CntchEX_8r00aINX.png)
