### PR TITLE
fix(utils): preserve env_bool defaults for unset vars

### DIFF
--- a/tests/test_utils_truthy_values.py
+++ b/tests/test_utils_truthy_values.py
@@ -1,6 +1,6 @@
 """Tests for shared truthy-value helpers."""
 
-from utils import env_var_enabled, is_truthy_value
+from utils import env_bool, env_var_enabled, is_truthy_value
 
 
 def test_is_truthy_value_accepts_common_truthy_strings():
@@ -27,3 +27,10 @@ def test_env_var_enabled_uses_shared_truthy_rules(monkeypatch):
 
     monkeypatch.setenv("HERMES_TEST_BOOL", "no")
     assert env_var_enabled("HERMES_TEST_BOOL") is False
+
+
+def test_env_bool_respects_default_when_variable_is_unset(monkeypatch):
+    monkeypatch.delenv("HERMES_TEST_BOOL", raising=False)
+
+    assert env_bool("HERMES_TEST_BOOL", default=True) is True
+    assert env_bool("HERMES_TEST_BOOL", default=False) is False

--- a/utils.py
+++ b/utils.py
@@ -299,7 +299,7 @@ def env_int(key: str, default: int = 0) -> int:
 
 def env_bool(key: str, default: bool = False) -> bool:
     """Read an environment variable as a boolean."""
-    return is_truthy_value(os.getenv(key, ""), default=default)
+    return is_truthy_value(os.getenv(key), default=default)
 
 
 # ─── Proxy Helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- preserve `env_bool()` defaults when an environment variable is unset
- pass `None` through to `is_truthy_value()` instead of forcing an empty string
- add a regression test covering `default=True` and `default=False`

## Testing
- `uv run --frozen --extra dev python -m pytest tests/test_utils_truthy_values.py -q`
- `uv run --frozen ruff check utils.py tests/test_utils_truthy_values.py`
- `git diff HEAD^ HEAD --check`

Closes #41902