### PR TITLE
[verified] fix: honor env defaults for missing variables

### DIFF
--- a/tests/test_utils_truthy_values.py
+++ b/tests/test_utils_truthy_values.py
@@ -1,6 +1,6 @@
 """Tests for shared truthy-value helpers."""
 
-from utils import env_var_enabled, is_truthy_value
+from utils import env_bool, env_var_enabled, is_truthy_value
 
 
 def test_is_truthy_value_accepts_common_truthy_strings():
@@ -27,3 +27,15 @@ def test_env_var_enabled_uses_shared_truthy_rules(monkeypatch):
 
     monkeypatch.setenv("HERMES_TEST_BOOL", "no")
     assert env_var_enabled("HERMES_TEST_BOOL") is False
+
+
+def test_env_var_enabled_uses_default_when_unset(monkeypatch):
+    monkeypatch.delenv("HERMES_TEST_BOOL", raising=False)
+    assert env_var_enabled("HERMES_TEST_BOOL", default=False) is False
+    assert env_var_enabled("HERMES_TEST_BOOL", default=True) is True
+
+
+def test_env_bool_uses_default_when_unset(monkeypatch):
+    monkeypatch.delenv("HERMES_BOOL_ALT", raising=False)
+    assert env_bool("HERMES_BOOL_ALT", default=False) is False
+    assert env_bool("HERMES_BOOL_ALT", default=True) is True

--- a/utils.py
+++ b/utils.py
@@ -28,9 +28,9 @@ def is_truthy_value(value: Any, default: bool = False) -> bool:
     return bool(value)
 
 
-def env_var_enabled(name: str, default: str = "") -> bool:
+def env_var_enabled(name: str, default: bool = False) -> bool:
     """Return True when an environment variable is set to a truthy value."""
-    return is_truthy_value(os.getenv(name, default), default=False)
+    return is_truthy_value(os.getenv(name), default=default)
 
 
 def _preserve_file_mode(path: Path) -> "int | None":
@@ -299,7 +299,7 @@ def env_int(key: str, default: int = 0) -> int:
 
 def env_bool(key: str, default: bool = False) -> bool:
     """Read an environment variable as a boolean."""
-    return is_truthy_value(os.getenv(key, ""), default=default)
+    return is_truthy_value(os.getenv(key), default=default)
 
 
 # ─── Proxy Helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix `env_var_enabled` and `env_bool` so missing environment variables correctly respect the provided default value.
- Avoid forcing an empty-string fallback for missing env vars, which previously bypassed the helper default.
- Add regression tests for unset-variable behavior.

## Testing
- `python3 -m py_compile utils.py tests/test_utils_truthy_values.py`
- `python3 -m pytest -o addopts='' -q tests/test_utils_truthy_values.py`
- `ruff check utils.py tests/test_utils_truthy_values.py`

Closes #41902
