### PR TITLE
feat: add native delegation profiles

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -714,13 +714,23 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         except Exception:
             pass
 
-    # Qwen session metadata
+    # Qwen session metadata.  Native Qwen Portal uses sessionId/promptId;
+    # qwen-local / Qwen-web relays also need a stable conversation_id so the
+    # relay can keep one upstream Qwen chat per Hermes session.
     _qwen_meta = None
     if _is_qwen:
         _qwen_meta = {
             "sessionId": agent.session_id or "hermes",
             "promptId": str(uuid.uuid4()),
         }
+    else:
+        try:
+            from agent.qwen_session_state import build_qwen_session_metadata
+            _qwen_meta = build_qwen_session_metadata(agent)
+            if _qwen_meta is not None:
+                _qwen_meta["promptId"] = str(uuid.uuid4())
+        except Exception:
+            _qwen_meta = None
 
     # ── Provider profile path (registered providers) ───────────────────
     # Profiles handle per-provider quirks via hooks. When a profile is

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -975,6 +975,16 @@ def run_conversation(
                         agent.thinking_callback("")
 
                 _use_streaming = True
+                # Qwen-web relays return upstream chatId/parentId only on the
+                # non-streaming response body. Use non-streaming so Hermes can
+                # persist those ids and resume the real Qwen chat after relay
+                # restarts.
+                try:
+                    from agent.qwen_session_state import is_qwen_session_provider
+                    if is_qwen_session_provider(agent):
+                        _use_streaming = False
+                except Exception:
+                    pass
                 # Provider signaled "stream not supported" on a previous
                 # attempt — switch to non-streaming for the rest of this
                 # session instead of re-failing every retry.
@@ -1274,6 +1284,12 @@ def run_conversation(
                                 f"{int(sleep_end - time.time())}s remaining"
                             )
                     continue  # Retry the API call
+
+                try:
+                    from agent.qwen_session_state import maybe_update_qwen_session_from_response
+                    maybe_update_qwen_session_from_response(agent, response)
+                except Exception:
+                    pass
 
                 # Check finish_reason before proceeding
                 if agent.api_mode == "codex_responses":

--- a/agent/qwen_session_state.py
+++ b/agent/qwen_session_state.py
@@ -1,0 +1,197 @@
+"""Persistent Qwen-web session hints for OpenAI-compatible relays.
+
+Some Qwen web relays expose an OpenAI-compatible ``/chat/completions``
+endpoint but keep the real upstream conversation as ``chatId``/``parentId``.
+Hermes normally treats OpenAI-compatible providers as stateless, so a relay can
+create a fresh Qwen chat every turn unless we give it a stable conversation key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from utils import base_url_host_matches
+
+
+_STATE_VERSION = 1
+_STATE_FILE = "qwen_sessions.json"
+
+
+def is_qwen_session_provider(agent: Any) -> bool:
+    """Return True for custom/user Qwen-web relays that need session hints.
+
+    The built-in Qwen OAuth/Portal provider already has its own metadata
+    contract (``sessionId``/``promptId``) and should not receive chatId/parentId
+    fields intended for local web relays.
+    """
+
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    if not provider:
+        return False
+
+    base_url = str(getattr(agent, "base_url", "") or "")
+    if base_url_host_matches(base_url, "portal.qwen.ai"):
+        return False
+
+    # User-defined providers from config.yaml keep their own slug (for example
+    # ``qwen-local``). Legacy custom providers use ``custom:<name>``.
+    return "qwen" in provider
+
+
+def _state_path() -> Path:
+    return get_hermes_home() / "state" / _STATE_FILE
+
+
+def _read_state() -> dict[str, Any]:
+    path = _state_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {"version": _STATE_VERSION, "sessions": {}}
+    except Exception:
+        return {"version": _STATE_VERSION, "sessions": {}}
+
+    if not isinstance(data, dict):
+        return {"version": _STATE_VERSION, "sessions": {}}
+    sessions = data.get("sessions")
+    if not isinstance(sessions, dict):
+        data["sessions"] = {}
+    data["version"] = _STATE_VERSION
+    return data
+
+
+def _write_state(data: dict[str, Any]) -> None:
+    path = _state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{_STATE_FILE}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        except OSError:
+            pass
+
+
+def _stable_session_source(agent: Any) -> str:
+    gateway_key = str(getattr(agent, "_gateway_session_key", "") or "").strip()
+    if gateway_key:
+        return gateway_key
+
+    parts = [
+        str(getattr(agent, "platform", "") or ""),
+        str(getattr(agent, "_chat_id", "") or ""),
+        str(getattr(agent, "_thread_id", "") or ""),
+        str(getattr(agent, "session_id", "") or ""),
+    ]
+    source = ":".join(p for p in parts if p)
+    return source or "hermes"
+
+
+def _conversation_id(agent: Any) -> str:
+    provider = str(getattr(agent, "provider", "") or "")
+    base_url = str(getattr(agent, "base_url", "") or "").rstrip("/")
+    source = _stable_session_source(agent)
+    digest = hashlib.sha256(f"{provider}\n{base_url}\n{source}".encode("utf-8")).hexdigest()
+    return f"hermes_{digest[:32]}"
+
+
+def load_qwen_session(agent: Any) -> dict[str, Any] | None:
+    if not is_qwen_session_provider(agent):
+        return None
+    conversation_id = _conversation_id(agent)
+    data = _read_state()
+    session = data.get("sessions", {}).get(conversation_id)
+    if isinstance(session, dict):
+        return dict(session)
+    return {"conversation_id": conversation_id}
+
+
+def build_qwen_session_metadata(agent: Any) -> dict[str, Any] | None:
+    """Build top-level OpenAI ``metadata`` for Qwen-web relays.
+
+    ``conversation_id`` gives the relay a stable scoped key. If Hermes has seen
+    upstream ``chatId``/``parentId`` before, include them so the relay can resume
+    even after its in-memory map was lost.
+    """
+
+    session = load_qwen_session(agent)
+    if session is None:
+        return None
+
+    conversation_id = str(session.get("conversation_id") or _conversation_id(agent))
+    metadata: dict[str, Any] = {
+        "conversation_id": conversation_id,
+        "sessionId": conversation_id,
+    }
+
+    chat_id = session.get("chatId") or session.get("chat_id")
+    parent_id = session.get("parentId") or session.get("parent_id")
+    if chat_id:
+        metadata["chatId"] = chat_id
+    if parent_id:
+        metadata["parentId"] = parent_id
+    return metadata
+
+
+def _get_response_value(response: Any, *names: str) -> Any:
+    if response is None:
+        return None
+    if isinstance(response, dict):
+        for name in names:
+            if response.get(name):
+                return response.get(name)
+    for name in names:
+        value = getattr(response, name, None)
+        if value:
+            return value
+    extra = getattr(response, "model_extra", None)
+    if isinstance(extra, dict):
+        for name in names:
+            if extra.get(name):
+                return extra.get(name)
+    return None
+
+
+def maybe_update_qwen_session_from_response(agent: Any, response: Any) -> None:
+    """Persist upstream Qwen chat identifiers from a successful response."""
+
+    if not is_qwen_session_provider(agent):
+        return
+
+    chat_id = _get_response_value(response, "chatId", "chat_id")
+    parent_id = _get_response_value(response, "parentId", "parent_id", "response_id")
+    if not chat_id and not parent_id:
+        return
+
+    conversation_id = _conversation_id(agent)
+    data = _read_state()
+    sessions = data.setdefault("sessions", {})
+    previous = sessions.get(conversation_id) if isinstance(sessions.get(conversation_id), dict) else {}
+    entry = {
+        "conversation_id": conversation_id,
+        "provider": str(getattr(agent, "provider", "") or ""),
+        "base_url": str(getattr(agent, "base_url", "") or "").rstrip("/"),
+        "session_source": _stable_session_source(agent),
+        "updated_at": int(time.time()),
+    }
+    if previous:
+        entry.update(previous)
+    if chat_id:
+        entry["chatId"] = chat_id
+    if parent_id:
+        entry["parentId"] = parent_id
+    entry["updated_at"] = int(time.time())
+    sessions[conversation_id] = entry
+    _write_state(data)

--- a/agent/qwen_session_state.py
+++ b/agent/qwen_session_state.py
@@ -24,6 +24,68 @@ _STATE_VERSION = 1
 _STATE_FILE = "qwen_sessions.json"
 
 
+def _normalized_base_url(value: Any) -> str:
+    return str(value or "").strip().rstrip("/")
+
+
+def _custom_provider_entry_matches_model(agent: Any, entry: dict[str, Any]) -> bool:
+    model = str(getattr(agent, "model", "") or "").strip()
+    entry_model = str(entry.get("model", "") or "").strip()
+    if entry_model:
+        return not model or entry_model == model
+
+    models = entry.get("models")
+    if isinstance(models, dict) and models:
+        return not model or model in models
+    return True
+
+
+def _qwen_provider_identity(agent: Any) -> str:
+    """Return the stable Qwen-web provider identity, or ``""``.
+
+    Runtime resolution can turn a user-defined provider such as ``qwen-local``
+    into the generic provider name ``custom`` while preserving its base URL and
+    a normalized entry in ``agent._custom_providers``.  The session bridge must
+    still recognize that endpoint as Qwen and must use the original provider
+    key for the conversation digest, otherwise CLI/runtime-resolved and
+    gateway-switched sessions get different conversation IDs.
+    """
+
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    if not provider:
+        return ""
+
+    base_url = str(getattr(agent, "base_url", "") or "")
+    if base_url_host_matches(base_url, "portal.qwen.ai"):
+        return ""
+
+    if "qwen" in provider:
+        return provider
+
+    if provider != "custom":
+        return ""
+
+    target_url = _normalized_base_url(base_url)
+    if not target_url:
+        return ""
+
+    for entry in getattr(agent, "_custom_providers", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        if _normalized_base_url(entry.get("base_url")) != target_url:
+            continue
+        if not _custom_provider_entry_matches_model(agent, entry):
+            continue
+
+        provider_key = str(entry.get("provider_key", "") or "").strip()
+        name = str(entry.get("name", "") or "").strip()
+        haystack = f"{provider_key} {name}".lower()
+        if "qwen" in haystack:
+            return (provider_key or name).lower()
+
+    return ""
+
+
 def is_qwen_session_provider(agent: Any) -> bool:
     """Return True for custom/user Qwen-web relays that need session hints.
 
@@ -32,17 +94,7 @@ def is_qwen_session_provider(agent: Any) -> bool:
     fields intended for local web relays.
     """
 
-    provider = str(getattr(agent, "provider", "") or "").strip().lower()
-    if not provider:
-        return False
-
-    base_url = str(getattr(agent, "base_url", "") or "")
-    if base_url_host_matches(base_url, "portal.qwen.ai"):
-        return False
-
-    # User-defined providers from config.yaml keep their own slug (for example
-    # ``qwen-local``). Legacy custom providers use ``custom:<name>``.
-    return "qwen" in provider
+    return bool(_qwen_provider_identity(agent))
 
 
 def _state_path() -> Path:
@@ -100,8 +152,8 @@ def _stable_session_source(agent: Any) -> str:
 
 
 def _conversation_id(agent: Any) -> str:
-    provider = str(getattr(agent, "provider", "") or "")
-    base_url = str(getattr(agent, "base_url", "") or "").rstrip("/")
+    provider = _qwen_provider_identity(agent) or str(getattr(agent, "provider", "") or "")
+    base_url = _normalized_base_url(getattr(agent, "base_url", ""))
     source = _stable_session_source(agent)
     digest = hashlib.sha256(f"{provider}\n{base_url}\n{source}".encode("utf-8")).hexdigest()
     return f"hermes_{digest[:32]}"
@@ -181,8 +233,8 @@ def maybe_update_qwen_session_from_response(agent: Any, response: Any) -> None:
     previous = sessions.get(conversation_id) if isinstance(sessions.get(conversation_id), dict) else {}
     entry = {
         "conversation_id": conversation_id,
-        "provider": str(getattr(agent, "provider", "") or ""),
-        "base_url": str(getattr(agent, "base_url", "") or "").rstrip("/"),
+        "provider": _qwen_provider_identity(agent) or str(getattr(agent, "provider", "") or ""),
+        "base_url": _normalized_base_url(getattr(agent, "base_url", "")),
         "session_source": _stable_session_source(agent),
         "updated_at": int(time.time()),
     }

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -54,6 +54,12 @@ def _is_ancestor_or_same(a: Path, b: Path) -> bool:
     except ValueError:
         return False
 
+
+def _logical_abspath(path: Path) -> Path:
+    """Absolute path normalization without resolving symlink targets."""
+    return Path(os.path.abspath(os.fspath(path)))
+
+
 class SubdirectoryHintTracker:
     """Track which directories the agent visits and load hints on first access.
 
@@ -68,10 +74,20 @@ class SubdirectoryHintTracker:
     """
 
     def __init__(self, working_dir: Optional[str] = None):
-        self.working_dir = Path(working_dir or os.getcwd()).resolve()
+        raw_working_dir = Path(working_dir or os.getcwd()).expanduser()
+        if not raw_working_dir.is_absolute():
+            raw_working_dir = Path.cwd() / raw_working_dir
+        # Keep both the logical path the user/agent sees and the resolved path.
+        # Some workspaces intentionally live under a symlink inside the active
+        # tree (for example ~/projects/foo -> /var/tmp/foo).  Using only
+        # resolve() makes those project files look "outside" the workspace and
+        # suppresses their AGENTS.md/CLAUDE.md hints.
+        self.working_dir_logical = _logical_abspath(raw_working_dir)
+        self.working_dir = self.working_dir_logical.resolve()
         self._loaded_dirs: Set[Path] = set()
         # Pre-mark the working dir as loaded (startup context handles it)
         self._loaded_dirs.add(self.working_dir)
+        self._loaded_dirs.add(self.working_dir_logical)
 
     def check_tool_call(
         self,
@@ -129,8 +145,12 @@ class SubdirectoryHintTracker:
         try:
             p = Path(raw_path).expanduser()
             if not p.is_absolute():
-                p = self.working_dir / p
-            p = p.resolve()
+                p = self.working_dir_logical / p
+            # Deliberately do not resolve symlinks here: the logical path is
+            # what determines whether the user is working inside the active
+            # workspace.  _is_valid_subdir() still allows already-resolved paths
+            # when they are physically inside the workspace.
+            p = _logical_abspath(p)
             # Use parent if it's a file path (has extension or doesn't exist as dir)
             if p.suffix or (p.exists() and p.is_file()):
                 p = p.parent
@@ -146,6 +166,29 @@ class SubdirectoryHintTracker:
                 p = parent
         except (OSError, ValueError):
             pass
+
+    def _is_within_working_dir(self, path: Path) -> bool:
+        """Return True when *path* is inside the logical or resolved workspace."""
+        logical = _logical_abspath(path)
+        try:
+            if logical.is_relative_to(self.working_dir_logical):
+                return True
+        except (OSError, ValueError):
+            if _is_ancestor_or_same(self.working_dir_logical, logical):
+                return True
+
+        try:
+            resolved = logical.resolve()
+            if resolved.is_relative_to(self.working_dir):
+                return True
+        except (OSError, ValueError):
+            try:
+                if _is_ancestor_or_same(self.working_dir, logical.resolve()):
+                    return True
+            except (OSError, ValueError):
+                pass
+
+        return False
 
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):
         """Extract path-like tokens from a shell command string."""
@@ -181,18 +224,10 @@ class SubdirectoryHintTracker:
             return False
         if path in self._loaded_dirs:
             return False
-        # Reject paths outside the working directory tree.
-        # path.resolve() may differ from working_dir.resolve() due to symlinks,
-        # but path.is_relative_to(working_dir) handles both absolute and
-        # symlinked paths correctly on Python 3.9+.
-        try:
-            if not path.is_relative_to(self.working_dir):
-                return False
-        except (OSError, ValueError):
-            # Older Python or path resolution error — fall back to parent
-            # check as a best-effort safeguard.
-            if not _is_ancestor_or_same(self.working_dir, path):
-                return False
+        # Reject paths outside the active workspace, but preserve logical
+        # symlinked paths that sit under the workspace root.
+        if not self._is_within_working_dir(path):
+            return False
         return True
 
     def _load_hints_for_directory(self, directory: Path) -> Optional[str]:
@@ -201,22 +236,18 @@ class SubdirectoryHintTracker:
         Only loads hints from directories within the working directory tree.
         """
         self._loaded_dirs.add(directory)
-
-        # Reject paths outside the working directory tree.
         try:
-            if not directory.is_relative_to(self.working_dir):
-                logger.debug(
-                    "Skipping hint files in %s — outside working_dir %s",
-                    directory, self.working_dir,
-                )
-                return None
+            self._loaded_dirs.add(directory.resolve())
         except (OSError, ValueError):
-            if not _is_ancestor_or_same(self.working_dir, directory):
-                logger.debug(
-                    "Skipping hint files in %s — outside working_dir %s",
-                    directory, self.working_dir,
-                )
-                return None
+            pass
+
+        # Reject paths outside the active workspace.
+        if not self._is_within_working_dir(directory):
+            logger.debug(
+                "Skipping hint files in %s — outside working_dir %s",
+                directory, self.working_dir_logical,
+            )
+            return None
 
         found_hints = []
         for filename in _HINT_FILENAMES:
@@ -240,13 +271,16 @@ class SubdirectoryHintTracker:
                 # Best-effort relative path for display
                 rel_path = str(hint_path)
                 try:
-                    rel_path = str(hint_path.relative_to(self.working_dir))
+                    rel_path = str(hint_path.relative_to(self.working_dir_logical))
                 except ValueError:
                     try:
-                        rel_path = str(hint_path.relative_to(Path.home()))
-                        rel_path = "~/" + rel_path
-                    except ValueError:
-                        pass  # keep absolute
+                        rel_path = str(hint_path.resolve().relative_to(self.working_dir))
+                    except (OSError, ValueError):
+                        try:
+                            rel_path = str(hint_path.relative_to(Path.home()))
+                            rel_path = "~/" + rel_path
+                        except ValueError:
+                            pass  # keep absolute
                 found_hints.append((rel_path, content))
                 # First match wins per directory (like startup loading)
                 break

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -375,6 +375,11 @@ class ChatCompletionsTransport(ProviderTransport):
             if _lm_effort is not None:
                 api_kwargs["reasoning_effort"] = _lm_effort
 
+        # Qwen-web relays use top-level metadata for conversation hints.
+        qwen_session_metadata = params.get("qwen_session_metadata")
+        if qwen_session_metadata:
+            api_kwargs["metadata"] = qwen_session_metadata
+
         # extra_body assembly
         extra_body: dict[str, Any] = {}
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1738,6 +1738,23 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+        # Named first-class delegation profiles. A profile can route one
+        # delegate_task call (or one task in a batch) to another provider/model
+        # and constrain the child's tools without changing global delegation
+        # defaults. Select with delegate_task(..., delegation_profile="name").
+        "profiles": {
+            # Cheap read-only scout profile for DeepSeek and similar aux models.
+            # Requires DEEPSEEK_API_KEY when selected. It deliberately cannot
+            # write files, run terminal commands, send messages, or delegate.
+            "deepseek_aux": {
+                "provider": "deepseek",
+                "model": "deepseek-v4-pro",
+                "toolsets": ["file_readonly", "web", "session_search"],
+                "allowed_toolsets": ["file_readonly", "web", "session_search"],
+                "max_iterations": 30,
+                "reasoning_effort": "low",
+            },
+        },
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/run_agent.py
+++ b/run_agent.py
@@ -5040,6 +5040,7 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+            delegation_profile=function_args.get("delegation_profile"),
             parent_agent=self,
         )
 

--- a/tests/agent/test_qwen_session_state.py
+++ b/tests/agent/test_qwen_session_state.py
@@ -12,6 +12,7 @@ def _agent(**overrides):
     values = {
         "provider": "qwen-local",
         "base_url": "http://127.0.0.1:3264/api",
+        "model": "qwen3.7-max",
         "session_id": "session-1",
         "platform": "telegram",
         "_chat_id": "330137562",
@@ -59,6 +60,49 @@ def test_qwen_portal_provider_keeps_native_metadata_contract(monkeypatch, tmp_pa
 def test_non_qwen_provider_does_not_emit_qwen_metadata(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     agent = _agent(provider="openrouter", base_url="https://openrouter.ai/api/v1")
+
+    assert not is_qwen_session_provider(agent)
+    assert build_qwen_session_metadata(agent) is None
+
+
+def test_resolved_custom_qwen_provider_uses_original_provider_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    direct = _agent(provider="qwen-local")
+    resolved_custom = _agent(
+        provider="custom",
+        _custom_providers=[
+            {
+                "provider_key": "qwen-local",
+                "name": "Qwen Local",
+                "base_url": "http://127.0.0.1:3264/api",
+                "model": "qwen3.7-max",
+            }
+        ],
+    )
+
+    direct_metadata = build_qwen_session_metadata(direct)
+    custom_metadata = build_qwen_session_metadata(resolved_custom)
+
+    assert direct_metadata is not None
+    assert is_qwen_session_provider(resolved_custom)
+    assert custom_metadata is not None
+    assert custom_metadata["conversation_id"] == direct_metadata["conversation_id"]
+
+
+def test_plain_custom_provider_with_qwen_model_is_not_assumed_qwen(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    agent = _agent(
+        provider="custom",
+        base_url="http://127.0.0.1:1234/v1",
+        _custom_providers=[
+            {
+                "provider_key": "local-openai",
+                "name": "Local OpenAI",
+                "base_url": "http://127.0.0.1:1234/v1",
+                "model": "qwen3.7-max",
+            }
+        ],
+    )
 
     assert not is_qwen_session_provider(agent)
     assert build_qwen_session_metadata(agent) is None

--- a/tests/agent/test_qwen_session_state.py
+++ b/tests/agent/test_qwen_session_state.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+from agent.qwen_session_state import (
+    build_qwen_session_metadata,
+    is_qwen_session_provider,
+    maybe_update_qwen_session_from_response,
+)
+from agent.transports.chat_completions import ChatCompletionsTransport
+
+
+def _agent(**overrides):
+    values = {
+        "provider": "qwen-local",
+        "base_url": "http://127.0.0.1:3264/api",
+        "session_id": "session-1",
+        "platform": "telegram",
+        "_chat_id": "330137562",
+        "_thread_id": "201820",
+        "_gateway_session_key": "agent:main:telegram:dm:330137562:201820",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_qwen_local_metadata_uses_stable_conversation_id(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    agent = _agent()
+
+    metadata = build_qwen_session_metadata(agent)
+
+    assert metadata is not None
+    assert metadata["conversation_id"].startswith("hermes_")
+    assert metadata["sessionId"] == metadata["conversation_id"]
+    assert "chatId" not in metadata
+    assert build_qwen_session_metadata(agent)["conversation_id"] == metadata["conversation_id"]
+
+
+def test_qwen_local_response_updates_persistent_chat_ids(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    agent = _agent()
+    response = SimpleNamespace(chatId="qwen-chat-1", parentId="qwen-parent-1")
+
+    maybe_update_qwen_session_from_response(agent, response)
+    metadata = build_qwen_session_metadata(_agent())
+
+    assert metadata is not None
+    assert metadata["chatId"] == "qwen-chat-1"
+    assert metadata["parentId"] == "qwen-parent-1"
+
+
+def test_qwen_portal_provider_keeps_native_metadata_contract(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    agent = _agent(provider="qwen", base_url="https://portal.qwen.ai/v1")
+
+    assert not is_qwen_session_provider(agent)
+    assert build_qwen_session_metadata(agent) is None
+
+
+def test_non_qwen_provider_does_not_emit_qwen_metadata(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    agent = _agent(provider="openrouter", base_url="https://openrouter.ai/api/v1")
+
+    assert not is_qwen_session_provider(agent)
+    assert build_qwen_session_metadata(agent) is None
+
+
+def test_legacy_chat_completions_puts_qwen_metadata_top_level():
+    transport = ChatCompletionsTransport()
+    kwargs = transport.build_kwargs(
+        model="qwen3.7-max",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        qwen_session_metadata={"conversation_id": "hermes_test"},
+    )
+
+    assert kwargs["metadata"] == {"conversation_id": "hermes_test"}
+    assert "metadata" not in kwargs.get("extra_body", {})

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -121,6 +121,50 @@ class TestSubdirectoryHintTracker:
         assert result is not None
         assert "Frontend rules" in result
 
+    def test_symlinked_project_under_working_dir_loads_hints(self, tmp_path):
+        """Logical project paths under working_dir should load hints even when symlinked elsewhere."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        real_project = tmp_path / "real-project"
+        real_project.mkdir()
+        (real_project / "AGENTS.md").write_text("Symlinked project instructions")
+        (real_project / "src").mkdir()
+        (real_project / "src" / "main.py").write_text("print('hi')")
+        link = workspace / "project-link"
+        link.symlink_to(real_project, target_is_directory=True)
+
+        tracker = SubdirectoryHintTracker(working_dir=str(workspace))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(link / "src" / "main.py")}
+        )
+
+        assert result is not None
+        assert "Symlinked project instructions" in result
+
+        direct_target_tracker = SubdirectoryHintTracker(working_dir=str(workspace))
+        direct_target_result = direct_target_tracker.check_tool_call(
+            "read_file", {"path": str(real_project / "src" / "main.py")}
+        )
+        assert direct_target_result is None
+
+    def test_parent_traversal_outside_working_dir_rejected(self, tmp_path):
+        """Paths that normalize outside working_dir must not load outside hints."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "AGENTS.md").write_text("Outside project instructions")
+        (outside / "file.py").write_text("print('outside')")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(workspace))
+
+        for path in [
+            "../outside/file.py",
+            str(workspace / ".." / "outside" / "file.py"),
+        ]:
+            result = tracker.check_tool_call("read_file", {"path": path})
+            assert result is None
+
     def test_outside_working_dir_rejected(self, tmp_path, project):
         """Paths outside working_dir are rejected — no hints from outside workspace.
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -55,6 +55,12 @@ class TestResolveToolset:
         tools = resolve_toolset("web")
         assert set(tools) == {"web_search", "web_extract"}
 
+    def test_file_readonly_toolset_excludes_write_tools(self):
+        tools = resolve_toolset("file_readonly")
+        assert set(tools) == {"read_file", "search_files"}
+        assert "write_file" not in tools
+        assert "patch" not in tools
+
     def test_composite_toolset(self):
         tools = resolve_toolset("debugging")
         assert "terminal" in tools

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2412,6 +2412,59 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 class TestDispatchDelegateTask(unittest.TestCase):
     """Tests for the _dispatch_delegate_task helper and full param forwarding."""
 
+    def test_dispatch_helper_forwards_top_level_delegation_profile(self):
+        """Agent-loop dispatch must not drop the top-level profile selector."""
+        from run_agent import AIAgent
+
+        parent = _make_mock_parent(depth=0)
+        args = {
+            "goal": "repo scan",
+            "context": "read only",
+            "toolsets": ["file_readonly"],
+            "delegation_profile": "deepseek_aux",
+            "role": "leaf",
+        }
+
+        with patch("tools.delegate_tool.delegate_task", return_value='{"results": []}') as mock_delegate:
+            result = AIAgent._dispatch_delegate_task(parent, args)
+
+        self.assertEqual(result, '{"results": []}')
+        mock_delegate.assert_called_once_with(
+            goal="repo scan",
+            context="read only",
+            toolsets=["file_readonly"],
+            tasks=None,
+            max_iterations=None,
+            acp_command=None,
+            acp_args=None,
+            role="leaf",
+            delegation_profile="deepseek_aux",
+            parent_agent=parent,
+        )
+
+    def test_delegate_task_positional_parent_agent_back_compat(self):
+        """Adding delegation_profile must not steal positional parent_agent."""
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True,
+                "api_calls": 1, "messages": [],
+            }
+            mock_child._delegate_saved_tool_names = []
+            mock_child._credential_pool = None
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.model = "test"
+            mock_build.return_value = mock_child
+
+            result = json.loads(
+                delegate_task("test", None, None, None, None, None, None, None, parent)
+            )
+
+        self.assertIn("results", result)
+        self.assertEqual(result["results"][0]["status"], "completed")
+
     @patch("tools.delegate_tool._load_config", return_value={})
     @patch("tools.delegate_tool._resolve_delegation_credentials")
     def test_acp_args_forwarded(self, mock_creds, mock_cfg):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -30,8 +30,11 @@ from tools.delegate_tool import (
     _build_child_system_prompt,
     _extract_output_tail,
     _strip_blocked_tools,
+    _cap_toolsets_to_allowed,
+    _normalize_toolset_list,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _resolve_delegation_profile_config,
 )
 
 
@@ -69,6 +72,7 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("delegation_profile", props)
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -1162,6 +1166,78 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["provider"])
 
 
+class TestDelegationProfileConfig(unittest.TestCase):
+    def test_named_profile_merges_over_base_delegation_config(self):
+        base = {
+            "model": "",
+            "provider": "",
+            "max_iterations": 50,
+            "child_timeout_seconds": 600,
+            "toolsets": ["terminal", "file"],
+            "allowed_toolsets": [],
+            "profiles": {
+                "deepseek_aux": {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "toolsets": ["file_readonly", "web"],
+                    "allowed_toolsets": ["file_readonly", "web"],
+                    "max_iterations": 20,
+                }
+            },
+        }
+
+        cfg = _resolve_delegation_profile_config(base, "deepseek_aux")
+
+        self.assertEqual(cfg["provider"], "deepseek")
+        self.assertEqual(cfg["model"], "deepseek-v4-pro")
+        self.assertEqual(cfg["toolsets"], ["file_readonly", "web"])
+        self.assertEqual(cfg["allowed_toolsets"], ["file_readonly", "web"])
+        self.assertEqual(cfg["max_iterations"], 20)
+        self.assertEqual(cfg["child_timeout_seconds"], 600)
+        self.assertNotIn("profiles", cfg)
+
+    def test_profile_provider_does_not_inherit_global_direct_endpoint(self):
+        base = {
+            "provider": "custom",
+            "model": "local-model",
+            "base_url": "http://127.0.0.1:1234/v1",
+            "api_key": "local-key",
+            "api_mode": "anthropic_messages",
+            "profiles": {
+                "deepseek_aux": {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "toolsets": ["file_readonly"],
+                    "allowed_toolsets": ["file_readonly"],
+                }
+            },
+        }
+
+        cfg = _resolve_delegation_profile_config(base, "deepseek_aux")
+
+        self.assertEqual(cfg["provider"], "deepseek")
+        self.assertEqual(cfg["model"], "deepseek-v4-pro")
+        self.assertNotIn("base_url", cfg)
+        self.assertNotIn("api_key", cfg)
+        self.assertNotIn("api_mode", cfg)
+
+    def test_missing_profile_is_user_facing_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_delegation_profile_config({"profiles": {}}, "missing")
+
+        self.assertIn("Unknown delegation profile 'missing'", str(ctx.exception))
+
+    def test_hard_cap_rejects_composite_toolset_with_disallowed_includes(self):
+        result = _cap_toolsets_to_allowed(["debugging"], ["terminal", "file"])
+
+        self.assertEqual(result, [])
+
+    def test_invalid_toolset_list_fails_closed(self):
+        result = _normalize_toolset_list({"terminal": True})
+
+        self.assertEqual(result, [])
+
+
 class TestDelegationProviderIntegration(unittest.TestCase):
     """Integration tests: delegation config → _run_single_child → AIAgent construction."""
 
@@ -1198,6 +1274,338 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             self.assertEqual(kwargs["base_url"], "https://openrouter.ai/api/v1")
             self.assertEqual(kwargs["api_key"], "sk-or-delegation-key")
             self.assertEqual(kwargs["api_mode"], "chat_completions")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_named_profile_routes_model_and_caps_toolsets(self, mock_runtime, mock_cfg):
+        """delegation_profile selects a named provider/model/tool policy without scripts."""
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "profiles": {
+                "deepseek_aux": {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "toolsets": ["file_readonly", "web"],
+                    "allowed_toolsets": ["file_readonly", "web"],
+                    "max_iterations": 20,
+                }
+            },
+        }
+        mock_runtime.return_value = {
+            "model": "deepseek-v4-pro",
+            "provider": "deepseek",
+            "base_url": "https://api.deepseek.com/v1",
+            "api_key": "deepseek-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["hermes-cli"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="Read-only repo scout",
+                delegation_profile="deepseek_aux",
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "deepseek-v4-pro")
+            self.assertEqual(kwargs["provider"], "deepseek")
+            self.assertEqual(kwargs["base_url"], "https://api.deepseek.com/v1")
+            self.assertEqual(kwargs["api_key"], "deepseek-key")
+            self.assertEqual(kwargs["api_mode"], "chat_completions")
+            self.assertEqual(kwargs["max_iterations"], 20)
+            self.assertEqual(kwargs["enabled_toolsets"], ["file_readonly", "web"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_profile_allowed_toolsets_are_a_hard_cap(self, mock_runtime, mock_cfg):
+        """A read-only profile cannot be widened by a caller requesting file/terminal."""
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "profiles": {
+                "deepseek_aux": {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "toolsets": ["file_readonly"],
+                    "allowed_toolsets": ["file_readonly"],
+                }
+            },
+        }
+        mock_runtime.return_value = {
+            "model": "deepseek-v4-pro",
+            "provider": "deepseek",
+            "base_url": "https://api.deepseek.com/v1",
+            "api_key": "deepseek-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["hermes-cli"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="Read-only repo scout",
+                delegation_profile="deepseek_aux",
+                toolsets=["terminal", "file", "file_readonly"],
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["enabled_toolsets"], ["file_readonly"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_profile_cap_disables_kanban_auto_add(self, mock_runtime, mock_cfg):
+        """Hard-capped profiles must not be widened by HERMES_KANBAN_TASK auto-tools."""
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "profiles": {
+                "deepseek_aux": {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "toolsets": ["file_readonly"],
+                    "allowed_toolsets": ["file_readonly"],
+                }
+            },
+        }
+        mock_runtime.return_value = {
+            "model": "deepseek-v4-pro",
+            "provider": "deepseek",
+            "base_url": "https://api.deepseek.com/v1",
+            "api_key": "deepseek-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["hermes-cli"]
+
+        with patch.dict(os.environ, {"HERMES_KANBAN_TASK": "task-1"}, clear=False):
+            with patch("run_agent.AIAgent") as MockAgent:
+                mock_child = MagicMock()
+                mock_child.run_conversation.return_value = {
+                    "final_response": "done",
+                    "completed": True,
+                    "api_calls": 1,
+                }
+                MockAgent.return_value = mock_child
+
+                delegate_task(
+                    goal="Read-only repo scout",
+                    delegation_profile="deepseek_aux",
+                    parent_agent=parent,
+                )
+
+                _, kwargs = MockAgent.call_args
+                self.assertEqual(kwargs["enabled_toolsets"], ["file_readonly"])
+                self.assertEqual(kwargs["disabled_toolsets"], ["kanban"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_batch_ignores_top_level_toolsets(self, mock_run, mock_cfg):
+        """In batch mode, top-level toolsets must not leak into task children."""
+        mock_cfg.return_value = {"max_iterations": 50}
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "done",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["hermes-cli"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            delegate_task(
+                goal="Ignored top-level goal",
+                tasks=[{"goal": "Actual task"}],
+                toolsets=["terminal"],
+                parent_agent=parent,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["enabled_toolsets"], ["hermes-cli"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_batch_profile_error_cleans_up_already_built_children(self, mock_runtime, mock_cfg):
+        """A later batch profile error must not leave earlier child agents active."""
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "profiles": {
+                "deepseek_aux": {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "toolsets": ["file_readonly"],
+                    "allowed_toolsets": ["file_readonly"],
+                }
+            },
+        }
+        mock_runtime.return_value = {
+            "model": "deepseek-v4-pro",
+            "provider": "deepseek",
+            "base_url": "https://api.deepseek.com/v1",
+            "api_key": "deepseek-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["hermes-cli"]
+        first_child = MagicMock()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = first_child
+            result = json.loads(
+                delegate_task(
+                    tasks=[
+                        {"goal": "A", "delegation_profile": "deepseek_aux"},
+                        {"goal": "B", "delegation_profile": "missing"},
+                    ],
+                    parent_agent=parent,
+                )
+            )
+
+        self.assertIn("Unknown delegation profile 'missing'", result["error"])
+        self.assertEqual(parent._active_children, [])
+        first_child.close.assert_called_once()
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_per_task_profile_overrides_top_level_profile(self, mock_runtime, mock_run, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "profiles": {
+                "deepseek_aux": {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "toolsets": ["file_readonly"],
+                    "allowed_toolsets": ["file_readonly"],
+                },
+                "gemini_aux": {
+                    "provider": "openrouter",
+                    "model": "google/gemini-3-flash-preview",
+                    "toolsets": ["web"],
+                    "allowed_toolsets": ["web"],
+                },
+            },
+        }
+
+        def _runtime(requested, target_model):
+            return {
+                "provider": requested,
+                "model": target_model,
+                "base_url": f"https://{requested}.example/v1",
+                "api_key": f"{requested}-key",
+                "api_mode": "chat_completions",
+            }
+
+        mock_runtime.side_effect = _runtime
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "done",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["hermes-cli"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            delegate_task(
+                tasks=[
+                    {"goal": "A"},
+                    {"goal": "B", "delegation_profile": "gemini_aux"},
+                ],
+                delegation_profile="deepseek_aux",
+                parent_agent=parent,
+            )
+
+        first_kwargs = MockAgent.call_args_list[0].kwargs
+        second_kwargs = MockAgent.call_args_list[1].kwargs
+        self.assertEqual(first_kwargs["provider"], "deepseek")
+        self.assertEqual(first_kwargs["model"], "deepseek-v4-pro")
+        self.assertEqual(first_kwargs["enabled_toolsets"], ["file_readonly"])
+        self.assertEqual(second_kwargs["provider"], "openrouter")
+        self.assertEqual(second_kwargs["model"], "google/gemini-3-flash-preview")
+        self.assertEqual(second_kwargs["enabled_toolsets"], ["web"])
+
+    @patch("tools.delegate_tool._load_config")
+    def test_unknown_profile_returns_json_error(self, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 50, "profiles": {}}
+        parent = _make_mock_parent(depth=0)
+
+        result = json.loads(
+            delegate_task(
+                goal="No such profile",
+                delegation_profile="missing",
+                parent_agent=parent,
+            )
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("Unknown delegation profile 'missing'", result["error"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_profile_readonly_cap_degrades_orchestrator_to_leaf(self, mock_runtime, mock_cfg):
+        mock_cfg.return_value = {
+            "max_spawn_depth": 2,
+            "orchestrator_enabled": True,
+            "max_iterations": 50,
+            "profiles": {
+                "deepseek_aux": {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "toolsets": ["file_readonly"],
+                    "allowed_toolsets": ["file_readonly"],
+                }
+            },
+        }
+        mock_runtime.return_value = {
+            "model": "deepseek-v4-pro",
+            "provider": "deepseek",
+            "base_url": "https://api.deepseek.com/v1",
+            "api_key": "deepseek-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["hermes-cli"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="Read-only repo scout",
+                role="orchestrator",
+                delegation_profile="deepseek_aux",
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["enabled_toolsets"], ["file_readonly"])
+            self.assertEqual(mock_child._delegate_role, "leaf")
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tests/tools/test_delegate_config_reload.py
+++ b/tests/tools/test_delegate_config_reload.py
@@ -1,0 +1,78 @@
+"""Regression tests for delegate_task runtime config reload.
+
+A long-running gateway can have cli.CLI_CONFIG from process startup while
+~/.hermes/config.yaml has since changed. delegate_task runtime knobs must read
+fresh persistent config first so updates like delegation.child_timeout_seconds
+are honored without relying on stale CLI_CONFIG values.
+"""
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+
+def test_load_config_prefers_fresh_persistent_config_over_stale_cli_config(monkeypatch):
+    from tools import delegate_tool
+    import hermes_cli.config as config_mod
+
+    fake_cli = ModuleType("cli")
+    setattr(
+        fake_cli,
+        "CLI_CONFIG",
+        {
+            "delegation": {
+                "child_timeout_seconds": 300,
+                "max_concurrent_children": 2,
+            }
+        },
+    )
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {
+            "delegation": {
+                "child_timeout_seconds": 900,
+                "max_concurrent_children": 5,
+            }
+        },
+    )
+
+    cfg = delegate_tool._load_config()
+
+    assert cfg["child_timeout_seconds"] == 900
+    assert delegate_tool._get_child_timeout() == 900.0
+    assert delegate_tool._get_max_concurrent_children() == 5
+
+
+def test_load_config_does_not_use_stale_cli_when_persistent_config_load_succeeds(monkeypatch):
+    from tools import delegate_tool
+    import hermes_cli.config as config_mod
+
+    monkeypatch.delenv("DELEGATION_CHILD_TIMEOUT_SECONDS", raising=False)
+    fake_cli = ModuleType("cli")
+    setattr(fake_cli, "CLI_CONFIG", {"delegation": {"child_timeout_seconds": 300}})
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+
+    assert delegate_tool._load_config() == {}
+    assert delegate_tool._get_child_timeout() == float(delegate_tool.DEFAULT_CHILD_TIMEOUT)
+
+
+def test_load_config_falls_back_to_cli_config_when_persistent_config_unavailable(monkeypatch):
+    from tools import delegate_tool
+    import hermes_cli.config as config_mod
+
+    fake_cli = ModuleType("cli")
+    setattr(fake_cli, "CLI_CONFIG", {"delegation": {"child_timeout_seconds": 300}})
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    def _raise_load_config():
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr(config_mod, "load_config", _raise_load_config)
+
+    cfg = delegate_tool._load_config()
+
+    assert cfg["child_timeout_seconds"] == 300
+    assert delegate_tool._get_child_timeout() == 300.0

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2140,8 +2140,8 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
-    delegation_profile: Optional[str] = None,
     parent_agent=None,
+    delegation_profile: Optional[str] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -30,7 +30,7 @@ from concurrent.futures import (
 )
 from typing import Any, Dict, List, Optional
 
-from toolsets import TOOLSETS
+from toolsets import TOOLSETS, resolve_toolset
 
 # Sentinel value used by the runtime provider system for providers that are
 # not natively known (named custom providers, third-party aggregators, etc.).
@@ -359,6 +359,105 @@ def _normalize_role(r: Optional[str]) -> str:
     return "leaf"
 
 
+def _normalize_toolset_list(value: Any) -> Optional[List[str]]:
+    """Return a clean list of toolset names, preserving order and uniqueness.
+
+    Accepts YAML lists/tuples/sets and comma-separated strings. ``None`` means
+    "not configured"; an explicit empty list/string stays empty so profiles can
+    intentionally provide no tools. Unsupported types fail closed to an empty
+    list instead of widening child tools by falling back to inherited defaults.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        raw_items = value.replace("\n", ",").split(",")
+    elif isinstance(value, (list, tuple, set)):
+        raw_items = list(value)
+    else:
+        logger.warning("Invalid toolset list value %r; using empty list", value)
+        return []
+
+    result: List[str] = []
+    seen = set()
+    for item in raw_items:
+        text = str(item).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _resolve_delegation_profile_config(cfg: dict, profile_name: Optional[str]) -> dict:
+    """Merge a named delegation profile over the base delegation config.
+
+    ``delegation.provider/model/base_url/...`` remains the backward-compatible
+    global default. ``delegation.profiles.<name>`` can override any of those
+    fields plus policy fields such as ``toolsets``, ``allowed_toolsets``, and
+    ``max_iterations`` for one delegate_task call. The returned dict excludes
+    the nested ``profiles`` map so downstream credential resolution sees a
+    normal delegation config.
+    """
+    if not isinstance(cfg, dict):
+        cfg = {}
+
+    base = dict(cfg)
+    profiles = base.pop("profiles", {})
+    name = str(profile_name or "").strip()
+    if not name:
+        return base
+
+    if not isinstance(profiles, dict) or name not in profiles:
+        available = sorted(str(k) for k in profiles.keys()) if isinstance(profiles, dict) else []
+        suffix = f" Available profiles: {', '.join(available)}." if available else " No profiles are configured."
+        raise ValueError(f"Unknown delegation profile '{name}'.{suffix}")
+
+    profile_cfg = profiles.get(name)
+    if not isinstance(profile_cfg, dict):
+        raise ValueError(f"Delegation profile '{name}' must be a mapping/object.")
+
+    merged = dict(base)
+    profile_provider = str(profile_cfg.get("provider") or "").strip()
+    profile_base_url = str(profile_cfg.get("base_url") or "").strip()
+    if profile_provider and not profile_base_url:
+        # A named provider profile should route through the runtime provider
+        # resolver. Do not let global direct-endpoint settings silently win
+        # over profile.provider just because base_url has higher precedence in
+        # _resolve_delegation_credentials(). Profiles that want a direct
+        # endpoint must set base_url themselves.
+        for direct_key in ("base_url", "api_key", "api_mode", "acp_command", "acp_args"):
+            if direct_key not in profile_cfg or not profile_cfg.get(direct_key):
+                merged.pop(direct_key, None)
+    for key, value in profile_cfg.items():
+        if key == "profiles":
+            continue
+        if value is not None:
+            merged[key] = value
+    return merged
+
+
+def _cap_toolsets_to_allowed(
+    child_toolsets: List[str], allowed_toolsets: Optional[List[str]]
+) -> List[str]:
+    """Apply a profile hard-cap to child toolsets.
+
+    ``allowed_toolsets`` is intentionally stricter than normal parent
+    inheritance: if set, the child cannot regain terminal/file/delegation tools
+    by asking for them or by using role='orchestrator'. Composite caps such as
+    ``hermes-cli`` are expanded to the toolset names they contain.
+    """
+    if allowed_toolsets is None:
+        return child_toolsets
+    allowed = _expand_parent_toolsets(set(allowed_toolsets))
+    return [t for t in child_toolsets if t in allowed]
+
+
+def _toolset_cap_allows(toolset_name: str, allowed_toolsets: Optional[List[str]]) -> bool:
+    if allowed_toolsets is None:
+        return True
+    return toolset_name in _expand_parent_toolsets(set(allowed_toolsets))
+
+
 def _get_max_concurrent_children() -> int:
     """Read delegation.max_concurrent_children from config, falling back to
     DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (3).
@@ -509,24 +608,24 @@ def _expand_parent_toolsets(parent_toolsets: set) -> set:
     or ``terminal``.  A simple name-based intersection would reject them
     because ``"web" != "hermes-cli"``.
 
-    This helper collects the tool names from each parent toolset, then adds
-    the names of any individual toolsets whose tools are a *subset* of the
-    parent's available tools.  The original parent toolset names are preserved.
+    This helper collects the fully resolved tool names from each parent toolset
+    (including nested ``includes``), then adds the names of any individual
+    toolsets whose fully resolved tools are a *subset* of the parent's
+    available tools.  The original parent toolset names are preserved.
     """
     parent_tool_names: set = set()
     for ts_name in parent_toolsets:
-        ts_def = TOOLSETS.get(ts_name)
-        if ts_def:
-            parent_tool_names.update(ts_def.get("tools", []))
+        if TOOLSETS.get(ts_name):
+            parent_tool_names.update(resolve_toolset(ts_name))
 
     if not parent_tool_names:
         return set(parent_toolsets)
 
     expanded = set(parent_toolsets)
-    for ts_name, ts_def in TOOLSETS.items():
+    for ts_name in TOOLSETS:
         if ts_name in expanded:
             continue
-        ts_tools = ts_def.get("tools", [])
+        ts_tools = resolve_toolset(ts_name)
         if ts_tools and set(ts_tools).issubset(parent_tool_names):
             expanded.add(ts_name)
     return expanded
@@ -922,6 +1021,12 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Optional hard cap from delegation profile policy. When set, the child
+    # cannot gain toolsets outside this list even if requested explicitly or
+    # via role='orchestrator'.
+    allowed_toolsets: Optional[List[str]] = None,
+    override_reasoning_effort: Optional[str] = None,
+    child_timeout_seconds: Optional[float] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -944,7 +1049,12 @@ def _build_child_agent(
     child_depth = getattr(parent_agent, "_delegate_depth", 0) + 1
     max_spawn = _get_max_spawn_depth()
     orchestrator_ok = _get_orchestrator_enabled() and child_depth < max_spawn
+    allowed_toolsets = _normalize_toolset_list(allowed_toolsets)
     effective_role = role if (role == "orchestrator" and orchestrator_ok) else "leaf"
+    if effective_role == "orchestrator" and not _toolset_cap_allows(
+        "delegation", allowed_toolsets
+    ):
+        effective_role = "leaf"
 
     # ── Subagent identity (stable across events, 0-indexed for TUI) ─────
     # subagent_id is generated here so the progress callback, the
@@ -976,12 +1086,13 @@ def _build_child_agent(
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
-    if toolsets:
+    requested_toolsets = _normalize_toolset_list(toolsets)
+    if requested_toolsets is not None:
         # Intersect with parent — subagent must not gain tools the parent lacks.
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
+        child_toolsets = [t for t in requested_toolsets if t in expanded_parent]
         if _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
@@ -1000,6 +1111,13 @@ def _build_child_agent(
     # test_intersection_preserves_delegation_bound test for the design rationale.
     if effective_role == "orchestrator" and "delegation" not in child_toolsets:
         child_toolsets.append("delegation")
+    child_toolsets = _cap_toolsets_to_allowed(child_toolsets, allowed_toolsets)
+    child_disabled_toolsets: List[str] = []
+    if allowed_toolsets is not None and not _toolset_cap_allows("kanban", allowed_toolsets):
+        # model_tools auto-adds kanban in HERMES_KANBAN_TASK contexts after
+        # enabled_toolsets filtering. A profile hard-cap must also block that
+        # post-filter widening unless kanban is explicitly allowed.
+        child_disabled_toolsets = ["kanban"]
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
     child_prompt = _build_child_system_prompt(
@@ -1095,7 +1213,10 @@ def _build_child_agent(
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
     try:
-        delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
+        if override_reasoning_effort is not None:
+            delegation_effort = str(override_reasoning_effort or "").strip()
+        else:
+            delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
         if delegation_effort:
             from hermes_constants import parse_reasoning_effort
 
@@ -1151,6 +1272,7 @@ def _build_child_agent(
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         fallback_model=parent_fallback,
         enabled_toolsets=child_toolsets,
+        disabled_toolsets=child_disabled_toolsets,
         quiet_mode=True,
         ephemeral_system_prompt=child_prompt,
         log_prefix=f"[subagent-{task_index}]",
@@ -1180,6 +1302,8 @@ def _build_child_agent(
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
+    if child_timeout_seconds is not None:
+        setattr(child, "_delegate_child_timeout_seconds", child_timeout_seconds)
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
 
     # Share a credential pool with the child when possible so subagents can
@@ -1540,7 +1664,14 @@ def _run_single_child(
 
         # Run child with a hard timeout to prevent indefinite blocking
         # when the child's API call or tool-level HTTP request hangs.
-        child_timeout = _get_child_timeout()
+        timeout_override = getattr(child, "_delegate_child_timeout_seconds", None)
+        if timeout_override is not None:
+            try:
+                child_timeout = max(30.0, float(timeout_override))
+            except (TypeError, ValueError):
+                child_timeout = _get_child_timeout()
+        else:
+            child_timeout = _get_child_timeout()
         _timeout_executor = ThreadPoolExecutor(
             max_workers=1,
             # Install a non-interactive approval callback in the worker thread
@@ -1967,6 +2098,39 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+def _cleanup_unstarted_children(
+    children: List[tuple[int, Dict[str, Any], Any]], parent_agent: Any
+) -> None:
+    """Close child agents that were built but will never be submitted.
+
+    _build_child_agent() registers each child in parent_agent._active_children
+    immediately so interrupts can reach queued workers. If a later batch task
+    fails validation before workers reach _run_single_child(), that runner's
+    finally block never executes; clean the already-built children here.
+    """
+    for _, _, child in reversed(children):
+        if hasattr(parent_agent, "_active_children"):
+            try:
+                lock = getattr(parent_agent, "_active_children_lock", None)
+                if lock:
+                    with lock:
+                        parent_agent._active_children.remove(child)
+                else:
+                    parent_agent._active_children.remove(child)
+            except ValueError:
+                pass
+            except Exception as exc:
+                logger.debug(
+                    "Could not remove unstarted child from active_children: %s", exc
+                )
+
+        try:
+            if hasattr(child, "close"):
+                child.close()
+        except Exception:
+            logger.debug("Failed to close unstarted child agent", exc_info=True)
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -1976,6 +2140,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    delegation_profile: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2024,31 +2189,18 @@ def delegate_task(
             }
         )
 
-    # Load config
+    # Load base delegation config. Named profiles are resolved per task below so
+    # a batch can mix providers/tool policies while preserving the top-level
+    # profile as the default.
     cfg = _load_config()
-    default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
-    # Model-supplied max_iterations is ignored — the config value is authoritative
-    # so users get predictable budgets. The kwarg is retained for internal callers
-    # and tests; a model-emitted value here would only shrink the budget and
-    # surprise the user mid-run. Log and drop it if one slips through from a
-    # cached tool schema or a stale provider.
-    if max_iterations is not None and max_iterations != default_max_iter:
+    if max_iterations is not None:
         logger.debug(
             "delegate_task: ignoring caller-supplied max_iterations=%s; "
-            "using delegation.max_iterations=%s from config",
-            max_iterations, default_max_iter,
+            "delegation.max_iterations or profile.max_iterations is authoritative",
+            max_iterations,
         )
-    effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
+    top_profile = str(delegation_profile or "").strip() or None
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -2070,7 +2222,13 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "role": top_role,
+                "delegation_profile": top_profile,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2107,7 +2265,42 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            task_profile = str(t.get("delegation_profile") or top_profile or "").strip() or None
+            try:
+                task_cfg = _resolve_delegation_profile_config(cfg, task_profile)
+                creds = _resolve_delegation_credentials(task_cfg, parent_agent)
+            except ValueError as exc:
+                _cleanup_unstarted_children(children, parent_agent)
+                return tool_error(str(exc))
+
+            configured_max_iter = task_cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
+            try:
+                effective_max_iter = max(1, int(configured_max_iter))
+            except (TypeError, ValueError):
+                logger.warning(
+                    "delegation.max_iterations/profile.max_iterations=%r is not a valid integer; using default %d",
+                    configured_max_iter,
+                    DEFAULT_MAX_ITERATIONS,
+                )
+                effective_max_iter = DEFAULT_MAX_ITERATIONS
+
+            configured_timeout = task_cfg.get("child_timeout_seconds")
+            child_timeout_seconds = None
+            if configured_timeout is not None:
+                try:
+                    child_timeout_seconds = max(30.0, float(configured_timeout))
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "delegation.child_timeout_seconds/profile.child_timeout_seconds=%r is not a valid number; using runtime default",
+                        configured_timeout,
+                    )
+
             task_acp_args = t.get("acp_args") if "acp_args" in t else None
+            task_toolsets = t.get("toolsets") if "toolsets" in t else None
+            if task_toolsets is None:
+                task_toolsets = task_cfg.get("toolsets")
+            allowed_toolsets = _normalize_toolset_list(task_cfg.get("allowed_toolsets"))
+
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
@@ -2115,7 +2308,7 @@ def delegate_task(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets,
+                toolsets=task_toolsets,
                 model=creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
@@ -2126,13 +2319,21 @@ def delegate_task(
                 override_api_mode=creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
+                or task_cfg.get("acp_command")
                 or creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (
+                        acp_args
+                        if acp_args is not None
+                        else task_cfg.get("acp_args", creds.get("args"))
+                    )
                 ),
                 role=effective_role,
+                allowed_toolsets=allowed_toolsets,
+                override_reasoning_effort=task_cfg.get("reasoning_effort"),
+                child_timeout_seconds=child_timeout_seconds,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -2548,7 +2749,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "
             f"Check that the provider is configured (API key set, valid provider name), "
             f"or set delegation.base_url/delegation.api_key for a direct endpoint. "
-            f"Available providers: openrouter, nous, zai, kimi-coding, minimax."
+            f"Available providers include: openrouter, nous, anthropic, openai, deepseek, "
+            f"google, xai, zai, kimi-coding, minimax, and custom:<name>."
         ) from exc
 
     api_key = runtime.get("api_key", "")
@@ -2821,6 +3023,15 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "delegation_profile": {
+                "type": "string",
+                "description": (
+                    "Optional named profile from config.yaml delegation.profiles. "
+                    "Profiles can set provider/model/toolsets/allowed_toolsets "
+                    "for first-class aux workers (for example 'deepseek_aux'). "
+                    "Per-task delegation_profile overrides the top-level value."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -2835,6 +3046,10 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                        },
+                        "delegation_profile": {
+                            "type": "string",
+                            "description": "Per-task named delegation profile. Overrides the top-level delegation_profile.",
                         },
                         "acp_command": {
                             "type": "string",
@@ -2911,6 +3126,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        delegation_profile=args.get("delegation_profile"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2570,28 +2570,33 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config from the persistent config first.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    ``cli.CLI_CONFIG`` is a startup snapshot. In long-lived gateway processes it
+    can be stale after ``hermes config set ...`` edits, so runtime delegation
+    knobs (timeouts, concurrency, provider overrides) must consult
+    ``hermes_cli.config.load_config()`` first. Fall back to ``CLI_CONFIG`` only
+    if the persistent config cannot be loaded.
     """
-    try:
-        from cli import CLI_CONFIG
-
-        cfg = CLI_CONFIG.get("delegation") or {}
-        if cfg:
-            return cfg
-    except Exception:
-        pass
     try:
         from hermes_cli.config import load_config
 
         full = load_config()
-        return full.get("delegation") or {}
+        cfg = full.get("delegation") if isinstance(full, dict) else None
+        return cfg if isinstance(cfg, dict) else {}
     except Exception:
-        return {}
+        pass
+
+    try:
+        from cli import CLI_CONFIG
+
+        cfg = CLI_CONFIG.get("delegation") or {}
+        if isinstance(cfg, dict):
+            return cfg
+    except Exception:
+        pass
+
+    return {}
 
 
 # ---------------------------------------------------------------------------

--- a/toolsets.py
+++ b/toolsets.py
@@ -200,6 +200,12 @@ TOOLSETS = {
         "tools": ["read_file", "write_file", "patch", "search_files"],
         "includes": []
     },
+
+    "file_readonly": {
+        "description": "Read-only file inspection tools: read files and search file names/content; no writes or patches",
+        "tools": ["read_file", "search_files"],
+        "includes": []
+    },
     
     "tts": {
         "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, OpenAI, or xAI",

--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -162,7 +162,7 @@ Hermes supports a configured fallback provider chain — a list of `(provider, m
 
 ### How it works internally
 
-1. **Storage**: `AIAgent.__init__` stores the `fallback_model` dict and sets `_fallback_activated = False`.
+1. **Storage**: `AIAgent.__init__` normalizes `fallback_model` into `_fallback_chain` and sets `_fallback_activated = False`.
 
 2. **Trigger points**: `_try_activate_fallback()` is called from three places in the main retry loop in `run_agent.py`:
    - After max retries on invalid API responses (None choices, missing content)
@@ -184,12 +184,12 @@ Hermes supports a configured fallback provider chain — a list of `(provider, m
    - Gateway: `gateway/run.py._load_fallback_model()` reads `config.yaml` → passes to `AIAgent`
    - Validation: both `provider` and `model` keys must be non-empty, or fallback is disabled
 
-### What does NOT support fallback
+### Other execution paths
 
-- **Subagent delegation** (`tools/delegate_tool.py`): subagents inherit the parent's provider but not the fallback config
-- **Auxiliary tasks**: use their own independent provider auto-detection chain (see Auxiliary model routing above)
+- **Subagent delegation** (`tools/delegate_tool.py`): subagents inherit the parent's fallback provider chain by default, so delegated work can recover from the same rate-limit or credential failures as the parent.
+- **Auxiliary tasks**: use their own independent provider auto-detection chain (see Auxiliary model routing above).
 
-Cron jobs **do** support fallback: `run_job()` reads `fallback_providers` (or legacy `fallback_model`) from `config.yaml` and passes it to `AIAgent(fallback_model=...)`, matching the gateway's `_load_fallback_model()` pattern. See [Cron Internals](./cron-internals.md).
+Cron jobs also support fallback: `run_job()` reads `fallback_providers` (or legacy `fallback_model`) from `config.yaml` and passes it to `AIAgent(fallback_model=...)`, matching the gateway's `_load_fallback_model()` pattern. See [Cron Internals](./cron-internals.md).
 
 ### Test coverage
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -142,6 +142,25 @@ delegation:
 
 If omitted, subagents use the same model as the parent.
 
+## Named Delegation Profiles
+
+For recurring aux-worker policies, define free-form named profiles under `delegation.profiles` and select them with `delegate_task(..., delegation_profile="name")` or per task in a batch. Profiles can set provider/model, iteration and timeout limits, and tool policy without changing global delegation defaults:
+
+```yaml
+# In ~/.hermes/config.yaml
+delegation:
+  profiles:
+    deepseek_aux:
+      provider: deepseek
+      model: deepseek-v4-pro
+      toolsets: [file_readonly, web]
+      allowed_toolsets: [file_readonly, web]
+      max_iterations: 25
+      child_timeout_seconds: 600
+```
+
+`allowed_toolsets` is a hard cap: callers cannot widen that child back to `terminal`, `file`, `delegation`, or other toolsets outside the profile. In batch mode, top-level `delegation_profile` acts as the default, and `tasks[].delegation_profile` overrides it for that one child. Profile names are configuration keys, not built-in roles; the only delegation roles remain `leaf` and `orchestrator`.
+
 ## Toolset Selection Tips
 
 The `toolsets` parameter controls what tools the subagent has access to. Choose based on the task:
@@ -151,7 +170,8 @@ The `toolsets` parameter controls what tools the subagent has access to. Choose 
 | `["terminal", "file"]` | Code work, debugging, file editing, builds |
 | `["web"]` | Research, fact-checking, documentation lookup |
 | `["terminal", "file", "web"]` | Full-stack tasks (default) |
-| `["file"]` | Read-only analysis, code review without execution |
+| `["file_readonly"]` | Read-only analysis and code review without execution or file writes |
+| `["file"]` | File editing/review tasks that may need read/write/patch access |
 | `["terminal"]` | System administration, process management |
 
 Certain toolsets are blocked for subagents regardless of what you specify:
@@ -163,15 +183,19 @@ Certain toolsets are blocked for subagents regardless of what you specify:
 
 ## Max Iterations
 
-Each subagent has an iteration limit (default: 50) that controls how many tool-calling turns it can take:
+Each subagent has an iteration limit (default: 50) that controls how many tool-calling turns it can take. This is configured in `config.yaml`, either globally for all delegated children or inside a named profile:
 
-```python
-delegate_task(
-    goal="Quick file check",
-    context="Check if /etc/nginx/nginx.conf exists and print its first 10 lines",
-    max_iterations=10  # Simple task, don't need many turns
-)
+```yaml
+delegation:
+  max_iterations: 50
+  profiles:
+    quick_scout:
+      toolsets: [file_readonly]
+      allowed_toolsets: [file_readonly]
+      max_iterations: 10
 ```
+
+The model-facing `delegate_task` schema does not expose per-call `max_iterations`; configuration and named profiles are the authoritative path.
 
 ## Child Timeout
 


### PR DESCRIPTION
## Summary

Refreshes PR #41998 onto current `main` and keeps the branch clean for the existing native delegation profiles proposal.

Adds first-class delegation profiles under `delegation.profiles` so `delegate_task` can route child agents to a named provider/model/tool policy without shell wrappers or separate spawned Hermes processes.

Key behavior:
- Adds top-level and per-task `delegation_profile` support.
- Merges named profile config over base `delegation` config.
- Resolves profile provider/model/base_url/api_key/api_mode via runtime provider resolution.
- Supports `toolsets` defaults and `allowed_toolsets` hard caps per profile.
- Ensures hard-capped profiles cannot be widened by requested toolsets, orchestrator role, composite toolsets, or Kanban auto-add.
- Reloads persisted delegation config before resolving child config so gateway/CLI snapshots do not keep stale delegation settings.
- Preserves `delegate_task(..., parent_agent)` positional compatibility while adding `delegation_profile`.
- Adds `file_readonly` as a read-only subagent toolset option and documents the difference from writable `file`.
- Documents named delegation profiles and subagent fallback-chain inheritance.

Also preserves the existing Qwen local-relay session identity fixes already on this PR branch:
- Stable Qwen custom/local relay session metadata.
- No impact on native Qwen Portal routing.
- Regression coverage for preserving chat/parent session IDs.

## Tests

- `uv run --frozen --with pytest --with pytest-timeout python -m pytest tests/tools/test_delegate.py tests/tools/test_delegate_config_reload.py tests/agent/test_qwen_session_state.py tests/test_toolsets.py -q`
  - 193 passed
- `python3 -m compileall -q agent tools hermes_cli run_agent.py toolsets.py`
- `uv run --frozen ruff check agent/chat_completion_helpers.py agent/conversation_loop.py agent/qwen_session_state.py agent/transports/chat_completions.py hermes_cli/config.py run_agent.py tools/delegate_tool.py toolsets.py tests/agent/test_qwen_session_state.py tests/test_toolsets.py tests/tools/test_delegate.py tests/tools/test_delegate_config_reload.py`
  - All checks passed
- `git diff --check origin/main...HEAD`
- Static scan of added lines for obvious hardcoded secrets / shell execution / eval / pickle / SQL string formatting
  - clean
- PR diff artifact check
  - no `.omx/ultragoal` files in the submitted diff

## Review

Local review passes found and fixed issues before this refresh:
- `run_agent.AIAgent._dispatch_delegate_task()` initially did not forward top-level `delegation_profile`; fixed and covered by regression test.
- `delegate_task` signature initially inserted `delegation_profile` before `parent_agent`; fixed by keeping `parent_agent` in its previous positional slot and adding a back-compat regression test.
- Documentation initially described writable `file` as read-only; fixed to document `file_readonly` separately.

Latest independent pre-push review: APPROVE, 8/10, no blockers.

## Notes / residual risks

- `delegation.profiles.<name>.allowed_toolsets` is intentionally fail-closed and exact-name based after known composite expansion.
- If a selected profile targets a provider without credentials, delegation returns a clear provider/key error instead of silently falling back.
- Batch mode intentionally does not let top-level `toolsets` leak into each task; use per-task toolsets or profile defaults.
- Long-lived gateway sessions may need a fresh session/restart to expose newly added tool schema fields, matching existing Hermes tool-schema behavior.
