### PR TITLE
fix(plugins): nested category plugin discovery + alias-normalized enable/disable (#41066)

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -654,24 +654,26 @@ def cmd_enable(name: str) -> None:
     from rich.console import Console
 
     console = Console()
-    # Discover the plugin — check installed (user) AND bundled.
-    if not _plugin_exists(name):
+    plugin_ref = _resolve_plugin_reference(name)
+    if plugin_ref is None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
+    canonical_name, aliases = plugin_ref
 
-    if name in enabled and name not in disabled:
-        console.print(f"[dim]Plugin '{name}' is already enabled.[/dim]")
+    if aliases & enabled and not aliases & disabled:
+        console.print(f"[dim]Plugin '{canonical_name}' is already enabled.[/dim]")
         return
 
-    enabled.add(name)
-    disabled.discard(name)
+    enabled.difference_update(aliases)
+    disabled.difference_update(aliases)
+    enabled.add(canonical_name)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
     console.print(
-        f"[green]✓[/green] Plugin [bold]{name}[/bold] enabled. "
+        f"[green]✓[/green] Plugin [bold]{canonical_name}[/bold] enabled. "
         "Takes effect on next session."
     )
 
@@ -681,111 +683,148 @@ def cmd_disable(name: str) -> None:
     from rich.console import Console
 
     console = Console()
-    if not _plugin_exists(name):
+    plugin_ref = _resolve_plugin_reference(name)
+    if plugin_ref is None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
+    canonical_name, aliases = plugin_ref
 
-    if name not in enabled and name in disabled:
-        console.print(f"[dim]Plugin '{name}' is already disabled.[/dim]")
+    if not aliases & enabled and aliases & disabled:
+        console.print(f"[dim]Plugin '{canonical_name}' is already disabled.[/dim]")
         return
 
-    enabled.discard(name)
-    disabled.add(name)
+    enabled.difference_update(aliases)
+    disabled.difference_update(aliases)
+    disabled.add(canonical_name)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
     console.print(
-        f"[yellow]\u2298[/yellow] Plugin [bold]{name}[/bold] disabled. "
+        f"[yellow]\u2298[/yellow] Plugin [bold]{canonical_name}[/bold] disabled. "
         "Takes effect on next session."
     )
 
 
 def _plugin_exists(name: str) -> bool:
-    """Return True if a plugin with *name* is installed (user) or bundled."""
-    # Installed: directory name or manifest name match in user plugins dir
-    user_dir = _plugins_dir()
-    if user_dir.is_dir():
-        if (user_dir / name).is_dir():
-            return True
-        for child in user_dir.iterdir():
-            if not child.is_dir():
-                continue
-            manifest = _read_manifest(child)
-            if manifest.get("name") == name:
-                return True
-    # Bundled: <repo>/plugins/<name>/ (or HERMES_BUNDLED_PLUGINS on Nix).
-    from hermes_cli.plugins import get_bundled_plugins_dir
-    repo_plugins = get_bundled_plugins_dir()
-    if repo_plugins.is_dir():
-        candidate = repo_plugins / name
-        if candidate.is_dir() and (
-            (candidate / "plugin.yaml").exists()
-            or (candidate / "plugin.yml").exists()
-        ):
-            return True
-    return False
+    """Return True if *name* matches a discovered plugin key or legacy alias."""
+    return _resolve_plugin_reference(name) is not None
+
+
+def _resolve_plugin_entry(name: str) -> tuple[str, str, str, str, str, Path | None] | None:
+    """Resolve *name* to the discovered plugin entry."""
+    for entry in _discover_all_plugins():
+        key, legacy_name, _version, _description, _source, _dir = entry
+        aliases = {key}
+        if legacy_name:
+            aliases.add(legacy_name)
+        if name in aliases:
+            return entry
+    return None
+
+
+def _resolve_plugin_reference(name: str) -> tuple[str, set[str]] | None:
+    """Resolve *name* to a canonical plugin key and all supported aliases."""
+    entry = _resolve_plugin_entry(name)
+    if entry is None:
+        return None
+    key, legacy_name, _version, _description, _source, _dir = entry
+    aliases = {key}
+    if legacy_name:
+        aliases.add(legacy_name)
+    return key, aliases
+
+
+def _normalize_plugin_selection(
+    plugin_refs: list[tuple[str, set[str]]],
+    chosen: set[int],
+    disabled: set[str],
+) -> tuple[set[str], set[str]]:
+    """Return canonical enabled/disabled sets for a composite plugin selection."""
+    new_enabled: set[str] = set()
+    new_disabled: set[str] = set(disabled)
+    for i, (canonical_name, aliases) in enumerate(plugin_refs):
+        new_disabled.difference_update(aliases)
+        if i in chosen:
+            new_enabled.add(canonical_name)
+        else:
+            new_disabled.add(canonical_name)
+    return new_enabled, new_disabled
 
 
 def _discover_all_plugins() -> list:
-    """Return a list of (name, version, description, source, dir_path) for
-    every plugin the loader can see — user + bundled + project.
+    """Return a list of ``(key, legacy_name, version, description, source, dir_path)`` for
+    every plugin the loader can see.
 
     Matches the ordering/dedup of ``PluginManager.discover_and_load``:
-    bundled first, then user, then project; user overrides bundled on
-    name collision.
+    bundled first, then user, then project, then entry points; later sources
+    override earlier ones on registry-key collision.
     """
-    try:
-        import yaml
-    except ImportError:
-        yaml = None
+    from hermes_cli.plugins import (
+        PluginManager,
+        get_bundled_plugins_dir,
+    )
 
-    seen: dict = {}  # name -> (name, version, description, source, path)
+    manager = PluginManager()
+    seen: dict[str, tuple[str, str, str, str, str, Path | None]] = {}
 
-    # Bundled (<repo>/plugins/<name>/), excluding memory/ and context_engine/
-    from hermes_cli.plugins import get_bundled_plugins_dir
     repo_plugins = get_bundled_plugins_dir()
-    for base, source in ((repo_plugins, "bundled"), (_plugins_dir(), "user")):
-        if not base.is_dir():
-            continue
-        for d in sorted(base.iterdir()):
-            if not d.is_dir():
-                continue
-            if source == "bundled" and d.name in {"memory", "context_engine"}:
-                continue
-            manifest_file = d / "plugin.yaml"
-            if not manifest_file.exists():
-                manifest_file = d / "plugin.yml"
-            if not manifest_file.exists():
-                continue
-            name = d.name
-            version = ""
-            description = ""
-            if yaml:
-                try:
-                    with open(manifest_file, encoding="utf-8") as f:
-                        manifest = yaml.safe_load(f) or {}
-                    name = manifest.get("name", d.name)
-                    version = manifest.get("version", "")
-                    description = manifest.get("description", "")
-                except Exception:
-                    pass
-            # User plugins override bundled on name collision.
-            if name in seen and source == "bundled":
-                continue
-            src_label = source
-            if source == "user" and (d / ".git").exists():
-                src_label = "git"
-            seen[name] = (name, version, description, src_label, d)
+    manifests = manager._scan_directory(  # noqa: SLF001 - keep list discovery aligned with runtime scanning
+        repo_plugins,
+        source="bundled",
+        skip_names={"memory", "context_engine", "platforms", "model-providers"},
+    )
+    manifests.extend(
+        manager._scan_directory(  # noqa: SLF001 - keep list discovery aligned with runtime scanning
+            repo_plugins / "platforms",
+            source="bundled",
+        )
+    )
+    manifests.extend(
+        manager._scan_directory(  # noqa: SLF001 - keep list discovery aligned with runtime scanning
+            _plugins_dir(),
+            source="user",
+        )
+    )
+    if os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS", "").strip().lower() in {"1", "true", "yes", "on"}:
+        manifests.extend(
+            manager._scan_directory(  # noqa: SLF001 - keep list discovery aligned with runtime scanning
+                Path.cwd() / ".hermes" / "plugins",
+                source="project",
+            )
+        )
+    manifests.extend(manager._scan_entry_points())  # noqa: SLF001 - keep list discovery aligned with runtime scanning
+
+    for manifest in manifests:
+        key = manifest.key or manifest.name
+        src_label = manifest.source
+        manifest_path = Path(manifest.path) if manifest.path else None
+        if manifest.source == "user" and manifest_path is not None and (manifest_path / ".git").exists():
+            src_label = "git"
+        seen[key] = (
+            key,
+            manifest.name,
+            manifest.version,
+            manifest.description,
+            src_label,
+            manifest_path,
+        )
     return list(seen.values())
 
 
-def _plugin_status(name: str, enabled: set, disabled: set) -> str:
-    """Return the user-facing activation state for a plugin name."""
-    if name in disabled:
+def _plugin_status(name: str, enabled: set, disabled: set, legacy_name: str | None = None) -> str:
+    """Return the user-facing activation state for a plugin name.
+
+    Mirrors runtime loader back-compat: both the path-derived key and the
+    legacy bare manifest name count for explicit enable/disable state.
+    """
+    aliases = {name}
+    if legacy_name:
+        aliases.add(legacy_name)
+    if aliases & disabled:
         return "disabled"
-    if name in enabled:
+    if aliases & enabled:
         return "enabled"
     return "not enabled"
 
@@ -794,11 +833,11 @@ def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set
     """Apply ``hermes plugins list`` CLI filters."""
     filtered = entries
     if getattr(args, "no_bundled", False) or getattr(args, "user", False):
-        filtered = [entry for entry in filtered if entry[3] != "bundled"]
+        filtered = [entry for entry in filtered if entry[4] != "bundled"]
     if getattr(args, "enabled", False):
         filtered = [
             entry for entry in filtered
-            if _plugin_status(entry[0], enabled, disabled) == "enabled"
+            if _plugin_status(entry[0], enabled, disabled, entry[1]) == "enabled"
         ]
     return filtered
 
@@ -823,19 +862,19 @@ def cmd_list(args: Any | None = None) -> None:
         payload = [
             {
                 "name": name,
-                "status": _plugin_status(name, enabled, disabled),
+                "status": _plugin_status(name, enabled, disabled, legacy_name),
                 "version": str(version),
                 "description": description,
                 "source": source,
             }
-            for name, version, description, source, _dir in entries
+            for name, legacy_name, version, description, source, _dir in entries
         ]
         print(json.dumps(payload, indent=2))
         return
 
     if getattr(args, "plain", False):
-        for name, version, _description, source, _dir in entries:
-            status = _plugin_status(name, enabled, disabled)
+        for name, legacy_name, version, _description, source, _dir in entries:
+            status = _plugin_status(name, enabled, disabled, legacy_name)
             print(f"{status:12} {source:8} {str(version):8} {name}")
         return
 
@@ -850,8 +889,8 @@ def cmd_list(args: Any | None = None) -> None:
     table.add_column("Description")
     table.add_column("Source", style="dim")
 
-    for name, version, description, source, _dir in entries:
-        status_name = _plugin_status(name, enabled, disabled)
+    for name, legacy_name, version, description, source, _dir in entries:
+        status_name = _plugin_status(name, enabled, disabled, legacy_name)
         if status_name == "disabled":
             status = "[red]disabled[/red]"
         elif status_name == "enabled":
@@ -1049,16 +1088,17 @@ def cmd_toggle() -> None:
 
     plugin_names = []
     plugin_labels = []
+    plugin_refs = []
     plugin_selected = set()
 
-    for i, (name, _version, description, source, _d) in enumerate(entries):
+    for i, (name, legacy_name, _version, description, source, _d) in enumerate(entries):
         label = f"{name} \u2014 {description}" if description else name
         if source == "bundled":
             label = f"{label} [bundled]"
         plugin_names.append(name)
         plugin_labels.append(label)
-        # Selected (enabled) when in enabled-set AND not in disabled-set
-        if name in enabled_set and name not in disabled_set:
+        plugin_refs.append((name, {name, legacy_name} if legacy_name else {name}))
+        if _plugin_status(name, enabled_set, disabled_set, legacy_name) == "enabled":
             plugin_selected.add(i)
 
     # -- Provider categories --
@@ -1086,14 +1126,14 @@ def cmd_toggle() -> None:
     try:
         import curses
         _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
-                          disabled_set, categories, console)
+                          plugin_refs, disabled_set, categories, console)
     except ImportError:
         _run_composite_fallback(plugin_names, plugin_labels, plugin_selected,
-                                disabled_set, categories, console)
+                                plugin_refs, disabled_set, categories, console)
 
 
 def _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
-                      disabled, categories, console):
+                      plugin_refs, disabled, categories, console):
     """Custom curses screen with checkboxes + category action rows."""
     from hermes_cli.curses_ui import flush_stdin
 
@@ -1317,14 +1357,7 @@ def _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
     # plugin names that were checked; anything not checked is explicitly
     # disabled (written to disabled-list) so it remains off even if the
     # plugin code does something clever like auto-enable in the future.
-    new_enabled: set = set()
-    new_disabled: set = set(disabled)  # preserve existing disabled state for unseen plugins
-    for i, name in enumerate(plugin_names):
-        if i in chosen:
-            new_enabled.add(name)
-            new_disabled.discard(name)
-        else:
-            new_disabled.add(name)
+    new_enabled, new_disabled = _normalize_plugin_selection(plugin_refs, chosen, disabled)
 
     prev_enabled = _get_enabled_set()
     enabled_changed = new_enabled != prev_enabled
@@ -1354,7 +1387,7 @@ def _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
 
 
 def _run_composite_fallback(plugin_names, plugin_labels, plugin_selected,
-                            disabled, categories, console):
+                            plugin_refs, disabled, categories, console):
     """Text-based fallback for the composite plugins UI."""
     from hermes_cli.colors import Colors, color
 
@@ -1382,14 +1415,7 @@ def _run_composite_fallback(plugin_names, plugin_labels, plugin_selected,
                 return
             print()
 
-        new_enabled: set = set()
-        new_disabled: set = set(disabled)
-        for i, name in enumerate(plugin_names):
-            if i in chosen:
-                new_enabled.add(name)
-                new_disabled.discard(name)
-            else:
-                new_disabled.add(name)
+        new_enabled, new_disabled = _normalize_plugin_selection(plugin_refs, chosen, disabled)
         prev_enabled = _get_enabled_set()
         if new_enabled != prev_enabled or new_disabled != disabled:
             _save_enabled_set(new_enabled)
@@ -1552,31 +1578,35 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     For plugins that provide tools (toolsets), also toggles the toolset in
     ``platform_toolsets`` so the agent actually sees the tools in sessions.
     """
-    if not _plugin_exists(name):
+    plugin_ref = _resolve_plugin_reference(name)
+    if plugin_ref is None:
         return {"ok": False, "error": f"Plugin '{name}' is not installed or bundled."}
 
     en = _get_enabled_set()
     dis = _get_disabled_set()
+    canonical_name, aliases = plugin_ref
 
     if enabled:
-        if name in en and name not in dis:
-            return {"ok": True, "name": name, "unchanged": True}
-        en.add(name)
-        dis.discard(name)
+        if aliases & en and not aliases & dis:
+            return {"ok": True, "name": canonical_name, "unchanged": True}
+        en.difference_update(aliases)
+        dis.difference_update(aliases)
+        en.add(canonical_name)
         _save_enabled_set(en)
         _save_disabled_set(dis)
-        _toggle_plugin_toolset(name, enable=True)
-        return {"ok": True, "name": name, "unchanged": False}
+        _toggle_plugin_toolset(canonical_name, enable=True)
+        return {"ok": True, "name": canonical_name, "unchanged": False}
 
-    if name not in en and name in dis:
-        return {"ok": True, "name": name, "unchanged": True}
+    if not aliases & en and aliases & dis:
+        return {"ok": True, "name": canonical_name, "unchanged": True}
 
-    en.discard(name)
-    dis.add(name)
+    en.difference_update(aliases)
+    dis.difference_update(aliases)
+    dis.add(canonical_name)
     _save_enabled_set(en)
     _save_disabled_set(dis)
-    _toggle_plugin_toolset(name, enable=False)
-    return {"ok": True, "name": name, "unchanged": False}
+    _toggle_plugin_toolset(canonical_name, enable=False)
+    return {"ok": True, "name": canonical_name, "unchanged": False}
 
 
 def _user_installed_plugin_dir(name: str) -> Optional[Path]:
@@ -1641,9 +1671,12 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
 def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
     """Delete a plugin tree under ``~/.hermes/plugins/`` only."""
     plugins_dir = _plugins_dir()
-    for n, _ver, _d, src, _path in _discover_all_plugins():
-        if n == name and src == "bundled":
+    entry = _resolve_plugin_entry(name)
+    if entry is not None:
+        canonical_name, _legacy_name, _ver, _d, src, _path = entry
+        if src == "bundled":
             return {"ok": False, "error": "Bundled plugins cannot be removed from the dashboard."}
+        name = canonical_name
 
     target = _user_installed_plugin_dir(name)
     if target is None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9575,16 +9575,24 @@ def _merged_plugins_hub() -> Dict[str, Any]:
     plugins_root_resolved = (get_hermes_home() / "plugins").resolve()
     rows: List[Dict[str, Any]] = []
 
-    for name, version, description, source, dir_str in _discover_all_plugins():
-        if name in disabled_set:
+    for key, legacy_name, version, description, source, dir_str in _discover_all_plugins():
+        # `key` is the canonical registry identity (path-derived for nested
+        # category plugins, e.g. "observability/nemo_relay"); `legacy_name` is
+        # the bare manifest name. Both count for enabled/disabled state to
+        # match the runtime loader's back-compat lookup.
+        name = key
+        aliases = {key}
+        if legacy_name:
+            aliases.add(legacy_name)
+        if aliases & disabled_set:
             runtime_status = "disabled"
-        elif name in enabled_set:
+        elif aliases & enabled_set:
             runtime_status = "enabled"
         else:
             runtime_status = "inactive"
 
         dir_path = Path(dir_str)
-        dm = dash_by_name.get(name)
+        dm = dash_by_name.get(name) or (dash_by_name.get(legacy_name) if legacy_name else None)
         has_dash_manifest = dm is not None or (dir_path / "dashboard" / "manifest.json").exists()
 
         under_user_tree = False

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -1,5 +1,7 @@
 import argparse
 import json
+from pathlib import Path
+from types import SimpleNamespace
 
 from hermes_cli import plugins_cmd
 
@@ -18,9 +20,9 @@ def _args(**kwargs):
 
 def test_filter_plugin_entries_enabled_only():
     entries = [
-        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None),
-        ("web-search-plus", "2.2.0", "Search", "git", None),
-        ("old-plugin", "1.0.0", "Old", "user", None),
+        ("disk-cleanup", "disk-cleanup", "2.0.0", "Bundled", "bundled", None),
+        ("web-search-plus", "web-search-plus", "2.2.0", "Search", "git", None),
+        ("old-plugin", "old-plugin", "1.0.0", "Old", "user", None),
     ]
 
     filtered = plugins_cmd._filter_plugin_entries(
@@ -35,9 +37,9 @@ def test_filter_plugin_entries_enabled_only():
 
 def test_filter_plugin_entries_no_bundled():
     entries = [
-        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None),
-        ("drawthings-grpc", "0.3.0", "Draw Things", "user", None),
-        ("web-search-plus", "2.2.0", "Search", "git", None),
+        ("disk-cleanup", "disk-cleanup", "2.0.0", "Bundled", "bundled", None),
+        ("drawthings-grpc", "drawthings-grpc", "0.3.0", "Draw Things", "user", None),
+        ("web-search-plus", "web-search-plus", "2.2.0", "Search", "git", None),
     ]
 
     filtered = plugins_cmd._filter_plugin_entries(
@@ -52,8 +54,8 @@ def test_filter_plugin_entries_no_bundled():
 
 def test_cmd_list_plain_compact_output(monkeypatch, capsys):
     entries = [
-        ("disk-cleanup", "2.0.0", "Bundled", "bundled", None),
-        ("web-search-plus", "2.2.0", "Search", "git", None),
+        ("disk-cleanup", "disk-cleanup", "2.0.0", "Bundled", "bundled", None),
+        ("web-search-plus", "web-search-plus", "2.2.0", "Search", "git", None),
     ]
     monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"web-search-plus"})
@@ -69,7 +71,7 @@ def test_cmd_list_plain_compact_output(monkeypatch, capsys):
 
 
 def test_cmd_list_json_output(monkeypatch, capsys):
-    entries = [("web-search-plus", "2.2.0", "Search", "git", None)]
+    entries = [("web-search-plus", "web-search-plus", "2.2.0", "Search", "git", None)]
     monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
     monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"web-search-plus"})
     monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
@@ -86,3 +88,367 @@ def test_cmd_list_json_output(monkeypatch, capsys):
             "source": "git",
         }
     ]
+
+
+def test_cmd_list_json_output_marks_nested_plugin_enabled_via_legacy_name(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"nemo_relay"})
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+
+    plugins_cmd.cmd_list(_args(json=True, enabled=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == [
+        {
+            "name": "observability/nemo_relay",
+            "status": "enabled",
+            "version": "0.1.0",
+            "description": "Relay observability",
+            "source": "bundled",
+        }
+    ]
+
+
+def test_plugin_exists_accepts_legacy_nested_name(monkeypatch):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+
+    assert plugins_cmd._plugin_exists("nemo_relay") is True
+    assert plugins_cmd._plugin_exists("observability/nemo_relay") is True
+
+
+def test_cmd_enable_accepts_legacy_nested_name(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = set()
+    disabled = set()
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+
+    plugins_cmd.cmd_enable("nemo_relay")
+
+    assert enabled == {"observability/nemo_relay"}
+    assert disabled == set()
+    assert "enabled" in capsys.readouterr().out
+
+
+def test_cmd_disable_accepts_legacy_nested_name(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = {"nemo_relay"}
+    disabled = set()
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+
+    plugins_cmd.cmd_disable("nemo_relay")
+
+    assert enabled == set()
+    assert disabled == {"observability/nemo_relay"}
+    assert "disabled" in capsys.readouterr().out
+
+
+def test_cmd_enable_clears_mixed_nested_alias_disable_state(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = set()
+    disabled = {"observability/nemo_relay"}
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+
+    plugins_cmd.cmd_enable("nemo_relay")
+
+    assert enabled == {"observability/nemo_relay"}
+    assert disabled == set()
+    assert "enabled" in capsys.readouterr().out
+
+
+def test_cmd_enable_resolves_split_nested_alias_state(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = {"observability/nemo_relay"}
+    disabled = {"nemo_relay"}
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+
+    plugins_cmd.cmd_enable("observability/nemo_relay")
+
+    assert enabled == {"observability/nemo_relay"}
+    assert disabled == set()
+    assert "enabled" in capsys.readouterr().out
+
+
+def test_cmd_disable_resolves_split_nested_alias_state(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = {"nemo_relay"}
+    disabled = {"observability/nemo_relay"}
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+
+    plugins_cmd.cmd_disable("observability/nemo_relay")
+
+    assert enabled == set()
+    assert disabled == {"observability/nemo_relay"}
+    assert "disabled" in capsys.readouterr().out
+
+
+def test_dashboard_enable_resolves_split_nested_alias_state(monkeypatch):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = {"observability/nemo_relay"}
+    disabled = {"nemo_relay"}
+    toggled: list[tuple[str, bool]] = []
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_toggle_plugin_toolset", lambda name, enable: toggled.append((name, enable)))
+
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled("observability/nemo_relay", enabled=True)
+
+    assert result == {"ok": True, "name": "observability/nemo_relay", "unchanged": False}
+    assert enabled == {"observability/nemo_relay"}
+    assert disabled == set()
+    assert toggled == [("observability/nemo_relay", True)]
+
+
+def test_dashboard_disable_resolves_split_nested_alias_state(monkeypatch):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    enabled = {"nemo_relay"}
+    disabled = {"observability/nemo_relay"}
+    toggled: list[tuple[str, bool]] = []
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: enabled.clear() or enabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: disabled.clear() or disabled.update(value))
+    monkeypatch.setattr(plugins_cmd, "_toggle_plugin_toolset", lambda name, enable: toggled.append((name, enable)))
+
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled("nemo_relay", enabled=False)
+
+    assert result == {"ok": True, "name": "observability/nemo_relay", "unchanged": False}
+    assert enabled == set()
+    assert disabled == {"observability/nemo_relay"}
+    assert toggled == [("observability/nemo_relay", False)]
+
+
+def test_cmd_toggle_does_not_crash_on_nested_plugin_entry_shape(monkeypatch, capsys):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd.sys, "stdin", SimpleNamespace(isatty=lambda: False))
+
+    plugins_cmd.cmd_toggle()
+
+    assert "Interactive mode requires a terminal." in capsys.readouterr().out
+
+
+def test_cmd_toggle_marks_nested_plugin_selected_via_legacy_alias(monkeypatch):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"nemo_relay"})
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd.sys, "stdin", SimpleNamespace(isatty=lambda: True))
+
+    def _fake_ui(_curses, plugin_names, _plugin_labels, plugin_selected, plugin_refs, disabled, _categories, _console):
+        captured["plugin_names"] = plugin_names
+        captured["plugin_selected"] = plugin_selected
+        captured["plugin_refs"] = plugin_refs
+        captured["disabled"] = disabled
+
+    monkeypatch.setattr(plugins_cmd, "_run_composite_ui", _fake_ui)
+
+    plugins_cmd.cmd_toggle()
+
+    assert captured["plugin_names"] == ["observability/nemo_relay"]
+    assert captured["plugin_selected"] == {0}
+    assert captured["plugin_refs"] == [("observability/nemo_relay", {"observability/nemo_relay", "nemo_relay"})]
+    assert captured["disabled"] == set()
+
+
+def test_normalize_plugin_selection_cleans_mixed_nested_alias_state():
+    plugin_refs = [("observability/nemo_relay", {"observability/nemo_relay", "nemo_relay"})]
+
+    new_enabled, new_disabled = plugins_cmd._normalize_plugin_selection(
+        plugin_refs,
+        {0},
+        {"nemo_relay"},
+    )
+
+    assert new_enabled == {"observability/nemo_relay"}
+    assert new_disabled == set()
+
+
+def test_dashboard_remove_user_plugin_rejects_bundled_nested_alias_without_crash(monkeypatch, tmp_path: Path):
+    entries = [
+        (
+            "observability/nemo_relay",
+            "nemo_relay",
+            "0.1.0",
+            "Relay observability",
+            "bundled",
+            None,
+        )
+    ]
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: tmp_path)
+
+    result = plugins_cmd.dashboard_remove_user_plugin("nemo_relay")
+
+    assert result == {"ok": False, "error": "Bundled plugins cannot be removed from the dashboard."}
+
+
+def test_discover_all_plugins_includes_nested_bundled_keys(monkeypatch, tmp_path: Path):
+    bundled_dir = tmp_path / "bundled"
+    nested_plugin_dir = bundled_dir / "observability" / "nemo_relay"
+    nested_plugin_dir.mkdir(parents=True)
+    (nested_plugin_dir / "plugin.yaml").write_text(
+        "\n".join(
+            [
+                "name: nemo_relay",
+                "version: '0.1.0'",
+                "description: nested bundled plugin",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+
+    monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: user_dir)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_bundled_plugins_dir",
+        lambda: bundled_dir,
+    )
+
+    entries = plugins_cmd._discover_all_plugins()
+
+    assert (
+        "observability/nemo_relay",
+        "nemo_relay",
+        "0.1.0",
+        "nested bundled plugin",
+        "bundled",
+        nested_plugin_dir,
+    ) in entries


### PR DESCRIPTION
## What does this PR do?

Salvage that merges two complementary community PRs into one coherent fix for nested category plugin handling, **superseding both**:

- **#41076** (@islam666) — made `hermes plugins list` discover nested category plugins (`observability/nemo_relay`, `image_gen/openai`, …).
- **#41613** (@mnajafian-nv) — the superset: nested discovery aligned with the runtime loader, **plus** the enable/disable mutation side that #41076 left flat. (@mnajafian-nv had closed this in favor of #41076; it turned out to be the more complete approach.)

### The gap this closes
#41076 fixed discovery/listing but the **mutation path stayed flat**, so nested bundled plugins were untoggleable:

```
$ hermes plugins enable nemo_relay
Plugin 'nemo_relay' is not installed or bundled.   # exit 1  (before)
```

### How
- `_discover_all_plugins()` now reuses the runtime `PluginManager._scan_directory` / `_scan_entry_points`, so the list view can't drift from what actually loads (covers bundled categories, platforms, user, project, entry points). Returns 6-tuples `(key, legacy_name, version, description, source, dir_path)`.
- A single normalization point, `_resolve_plugin_reference()`, resolves a bare manifest/leaf name **or** a full `category/name` key to the canonical key the loader gates on, with the full alias set.
- `cmd_enable` / `cmd_disable` / `cmd_toggle`, the dashboard helpers, and `_plugin_status` are all key+legacy-name aware; enable/disable persist the canonical key and clear stale bare-name aliases so the two can't drift.
- All `cmd_list` / `_filter_plugin_entries` call sites and the `test_plugins_cmd_list.py` fixtures updated to the 6-tuple shape (this also fixes the 5-tuple→6-tuple `ValueError` those tests would otherwise hit).

## Verification
- Verified e2e against the real bundled plugins dir: **23 nested plugins discovered**, and `_resolve_plugin_reference("nemo_relay")` resolves to `observability/nemo_relay` (with both aliases) — the original bug is fixed.
- `tests/hermes_cli/test_plugins_cmd_list.py` + `test_plugins_cmd.py`: **83 passed**, ruff clean.
- One unrelated pre-existing failure (`test_plugins.py::...test_discover_project_plugins_skipped_by_default`) reproduces on clean `origin/main` — environmental (dev-box project plugins), not introduced here.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Related
Closes #41066. Supersedes #41076 (@islam666) and #41613 (@mnajafian-nv) — both credited as co-authors. Surfaced while reviewing #41551 (the nested `observability/nemo_relay` plugin is what exposed the mutation gap).
