### PR TITLE
fix: harden system prompt cache persistence

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -536,6 +536,7 @@ def compress_context(
                 source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                 model=agent.model,
                 model_config=agent._session_init_model_config,
+                system_prompt=new_system_prompt,
                 parent_session_id=old_session_id,
             )
             agent._session_db_created = True
@@ -546,7 +547,14 @@ def compress_context(
                     agent._session_db.set_session_title(agent.session_id, new_title)
                 except (ValueError, Exception) as e:
                     logger.debug("Could not propagate title on compression: %s", e)
-            agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+            persisted = agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+            if persisted is False:
+                logger.warning(
+                    "Session DB compression split did not persist system prompt "
+                    "for new session %s; continuation may rebuild and miss the "
+                    "prefix cache.",
+                    agent.session_id,
+                )
             # Reset flush cursor — new session starts with no messages written
             agent._last_flushed_db_idx = 0
         except Exception as e:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -327,7 +327,25 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # subsequent turn).
     if agent._session_db:
         try:
-            agent._session_db.update_system_prompt(agent.session_id, agent._cached_system_prompt)
+            persisted = agent._session_db.update_system_prompt(
+                agent.session_id,
+                agent._cached_system_prompt,
+            )
+            if persisted is False:
+                ensure_db_session = getattr(agent, "_ensure_db_session", None)
+                if callable(ensure_db_session):
+                    ensure_db_session()
+                    persisted = agent._session_db.update_system_prompt(
+                        agent.session_id,
+                        agent._cached_system_prompt,
+                    )
+            if persisted is False:
+                logger.warning(
+                    "Session DB update_system_prompt did not persist for "
+                    "session %s after session-row repair. Subsequent turns "
+                    "will rebuild the system prompt and miss the prefix cache.",
+                    agent.session_id,
+                )
         except Exception as exc:
             logger.warning(
                 "Session DB update_system_prompt failed for session %s: "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1154,14 +1154,28 @@ class SessionDB:
             )
         self._execute_write(_do)
 
-    def update_system_prompt(self, session_id: str, system_prompt: str) -> None:
-        """Store the full assembled system prompt snapshot."""
+    def update_system_prompt(self, session_id: str, system_prompt: str) -> bool:
+        """Store the full assembled system prompt snapshot.
+
+        Returns ``True`` when an existing session row was updated and
+        ``False`` when no row matched.  Missing rows are deliberately not
+        inserted here: callers with access to full agent/session metadata
+        should create the session row, then retry persistence.  This keeps
+        the cache-persistence repair from creating partial stub sessions.
+        """
+        if not session_id:
+            return False
+        if not system_prompt or not system_prompt.strip():
+            raise ValueError("Refusing to persist empty system_prompt")
+
         def _do(conn):
-            conn.execute(
+            cursor = conn.execute(
                 "UPDATE sessions SET system_prompt = ? WHERE id = ?",
                 (system_prompt, session_id),
             )
-        self._execute_write(_do)
+            return cursor.rowcount > 0
+
+        return bool(self._execute_write(_do))
 
     def update_session_model(self, session_id: str, model: str) -> None:
         """Update the model for a session after a mid-session switch.

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -171,6 +171,46 @@ class TestSilentFailureWarnings:
             for m in warnings
         ), f"Expected write-failure warning, got: {warnings}"
 
+    def test_missing_session_row_is_created_with_prompt_then_persisted(self, caplog):
+        """A missing DB row should be repaired through the agent lifecycle.
+
+        ``update_system_prompt`` deliberately does not create stub rows; it
+        returns False so the caller can create a proper session row with the
+        agent's metadata, then retry prompt persistence once.
+        """
+        db = MagicMock()
+        db.get_session.return_value = None
+        db.update_system_prompt.side_effect = [False, True]
+        agent = _make_agent(session_db=db)
+        agent._ensure_db_session = MagicMock()
+
+        with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(agent, None, [])
+
+        agent._build_system_prompt.assert_called_once()
+        agent._ensure_db_session.assert_called_once_with()
+        assert db.update_system_prompt.call_count == 2
+        db.update_system_prompt.assert_any_call(agent.session_id, "BUILT_PROMPT")
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_missing_session_row_retry_failure_warns_loudly(self, caplog):
+        db = MagicMock()
+        db.get_session.return_value = None
+        db.update_system_prompt.side_effect = [False, False]
+        agent = _make_agent(session_db=db)
+        agent._ensure_db_session = MagicMock()
+
+        with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(agent, None, [])
+
+        agent._ensure_db_session.assert_called_once_with()
+        warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any(
+            "update_system_prompt did not persist" in m
+            and "Subsequent turns will rebuild" in m
+            for m in warnings
+        ), f"Expected retry-failure warning, got: {warnings}"
+
     def test_no_history_with_null_row_does_not_warn(self, caplog):
         """First turn (no history) hitting a null row is not surprising — no warn."""
         db = MagicMock()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -123,10 +123,35 @@ class TestSessionLifecycle:
 
     def test_update_system_prompt(self, db):
         db.create_session(session_id="s1", source="cli")
-        db.update_system_prompt("s1", "You are a helpful assistant.")
+        result = db.update_system_prompt("s1", "You are a helpful assistant.")
 
         session = db.get_session("s1")
+        assert result is True
         assert session["system_prompt"] == "You are a helpful assistant."
+
+    def test_update_system_prompt_repairs_null_existing_row(self, db):
+        """A pre-created row with NULL system_prompt must be repairable."""
+        db.create_session(session_id="s1", source="telegram", system_prompt=None)
+
+        result = db.update_system_prompt("s1", "stable prompt")
+
+        assert result is True
+        assert db.get_session("s1")["system_prompt"] == "stable prompt"
+
+    def test_update_system_prompt_reports_missing_row_without_stub_insert(self, db):
+        """Missing rows return False so callers can create a full metadata row."""
+        result = db.update_system_prompt("missing-session", "stable prompt")
+
+        assert result is False
+        assert db.get_session("missing-session") is None
+
+    def test_update_system_prompt_rejects_empty_prompts(self, db):
+        db.create_session(session_id="s1", source="cli")
+
+        with pytest.raises(ValueError, match="empty system_prompt"):
+            db.update_system_prompt("s1", "  \n\t")
+
+        assert db.get_session("s1")["system_prompt"] is None
 
     def test_update_token_counts(self, db):
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
## Summary
- make `SessionDB.update_system_prompt()` guarded and observable instead of silently best-effort
- repair missing session rows through the agent lifecycle before retrying prompt persistence
- persist compression continuation prompts at row creation and warn on failed prompt persistence

## Test Plan
- `python -m py_compile hermes_state.py agent/conversation_loop.py agent/conversation_compression.py`
- `pytest -q tests/agent/test_system_prompt_restore.py tests/test_hermes_state.py tests/cli/test_manual_compress.py tests/cli/test_compress_here.py tests/cli/test_compress_focus.py tests/gateway/test_compress_plugin_engine.py`
