### PR TITLE
fix: include --profile default in systemd service to prevent active_profile hijacking

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1447,7 +1447,7 @@ def _profile_arg(hermes_home: str | None = None) -> str:
     home = Path(hermes_home or str(get_hermes_home())).resolve()
     default = get_default_hermes_root().resolve()
     if home == default:
-        return ""
+        return "--profile default"
     profiles_root = (default / "profiles").resolve()
     try:
         rel = home.relative_to(profiles_root)


### PR DESCRIPTION
## Problem

When running multiple Hermes profiles (e.g. `default` + `mishu`) with separate systemd services, the **default gateway crashes on startup** with:

```
Gateway already running (PID XXXXX).
```

The PID actually belongs to the *other* profile's gateway.

### Root Cause

`_profile_arg()` returns `""` (empty) for the default profile (`~/.hermes`). This means the systemd service `ExecStart` has **no `--profile` flag**.

When the gateway starts, `_apply_profile_override()` in `hermes_cli/main.py` reads `~/.hermes/active_profile` (set by `hermes profile use <name>`). If it contains a named profile (e.g. `mishu`), `HERMES_HOME` gets overridden to that profile's directory. The default gateway then detects the other gateway's PID file and exits with "Gateway already running".

### Fix

Return `"--profile default"` from `_profile_arg()` when `HERMES_HOME` is the default root. This makes the systemd service explicitly declare its profile identity, so `_apply_profile_override()` skips the `active_profile` check (the code has `if name and name != "default"` guard).

```python
# Before
if home == default:
    return ""

# After
if home == default:
    return "--profile default"
```

### Testing

Verified with two gateways running simultaneously:
- `hermes-gateway.service` → `--profile default gateway run` → PID isolation at `~/.hermes/gateway.pid`
- `hermes-gateway-mishu.service` → `--profile mishu gateway run` → PID isolation at `~/.hermes/profiles/mishu/gateway.pid`

Both gateways start cleanly, connect to their respective Feishu/WeChat apps, and process messages independently.

### Note

The `--replace` flag in systemd service templates was already removed in a prior commit. This PR only addresses the `active_profile` hijacking issue for the default profile.