### PR TITLE
fix(tools): coerce null SDK exit codes in _ThreadedProcessHandle

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -84,6 +84,7 @@ AUTHOR_MAP = {
     "16943149+nepenth@users.noreply.github.com": "nepenth",
     "ben.bartholomew@vectorize.io": "benfrank241",
     "74339271+SaguaroDev@users.noreply.github.com": "SaguaroDev",
+    "290877012+itswane@users.noreply.github.com": "itswane",
     "subw3@mail2.sysu.edu.cn": "Subway2023",
     "trevin@trevinchow.com": "tmchow",
     "zhipengli@thebrainly.ai": "a1245582339",

--- a/tests/tools/test_threaded_process_handle.py
+++ b/tests/tools/test_threaded_process_handle.py
@@ -74,6 +74,44 @@ class TestPolling:
         assert handle.poll() == 0
 
 
+class TestNoneExitCode:
+    """A finished command with a null exit code must not look 'still running'.
+
+    Daytona/Modal SDKs can hand back ``None`` for ``exit_code`` even though the
+    command completed.  If that None reached _returncode verbatim, poll() —
+    ``self._returncode if self._done.is_set() else None`` — would return None
+    for a finished command, and _wait_for_process's ``while poll() is None``
+    loop would spin until its deadline and report a bogus timeout.
+    """
+
+    def test_none_exit_code_coerced_to_int(self):
+        def exec_fn():
+            return ("finished", None)
+
+        handle = _ThreadedProcessHandle(exec_fn)
+        handle.wait(timeout=5)
+
+        assert handle.returncode == 0
+        output = handle.stdout.read()
+        assert "finished" in output
+
+    def test_poll_reports_completion_with_none_exit_code(self):
+        # The regression guard: once the worker is done, poll() must return a
+        # concrete int so the wait loop can detect completion.
+        done = threading.Event()
+
+        def exec_fn():
+            done.wait(timeout=5)
+            return ("late", None)
+
+        handle = _ThreadedProcessHandle(exec_fn)
+        assert handle.poll() is None  # genuinely still running
+
+        done.set()
+        handle.wait(timeout=5)
+        assert handle.poll() == 0  # finished — never None
+
+
 class TestCancelFn:
     def test_cancel_fn_called_on_kill(self):
         called = threading.Event()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -229,7 +229,17 @@ class _ThreadedProcessHandle:
         def _worker():
             try:
                 output, exit_code = exec_fn()
-                self._returncode = exit_code
+                # Some SDK backends (Daytona, Modal) can report a null exit
+                # code for a command that actually finished.  Storing that None
+                # straight into _returncode is dangerous: poll() returns
+                # ``self._returncode if self._done.is_set() else None``, so a
+                # finished-but-None command is indistinguishable from a still
+                # running one.  _wait_for_process loops ``while poll() is None``
+                # and would spin until its deadline, killing the process and
+                # reporting a bogus timeout (returncode 124) for a command that
+                # already completed.  Coerce to a concrete int so completion is
+                # signalled solely by _done, never by the value of the code.
+                self._returncode = exit_code if isinstance(exit_code, int) else 0
                 # Write output into the pipe so drain thread picks it up.
                 try:
                     os.write(self._write_fd, output.encode("utf-8", errors="replace"))


### PR DESCRIPTION
## What does this PR do?

Fixes a hang in the Modal/Daytona terminal backends. `_ThreadedProcessHandle`
wraps a blocking `exec_fn() -> (output, exit_code)` and exposes a
`subprocess`-style interface. Its `poll()` returns
`self._returncode if self._done.is_set() else None`, which overloads `None`
to mean two different things: "still running" and "finished, but the SDK
reported no exit code".

The Daytona backend assigns `response.exit_code` straight into `_returncode`
(`tools/environments/daytona.py:240`), and the Modal backend does the same via
`process.wait.aio()` (`tools/environments/modal.py:436`); neither normalizes a
`None`. When an SDK reports a null exit code for a command that actually
finished, the worker sets `_done` but leaves `_returncode` as `None`, so
`poll()` keeps returning `None`. `_wait_for_process` loops
`while proc.poll() is None`, never observes completion, spins until its
deadline, kills the (already finished) process, and reports a bogus timeout
(returncode 124) while discarding the real result.

The fix makes completion depend solely on the `_done` event, never on the
value of the exit code: the worker coerces a non-int exit code to `0` at the
`_ThreadedProcessHandle` boundary, so `poll()` always returns a concrete int
once the command is done.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/base.py`: in `_ThreadedProcessHandle._worker`, coerce a
  non-int `exit_code` (e.g. `None`) to `0` before storing it in `_returncode`,
  so a finished command is never mistaken for a running one by `poll()`.
- `tests/tools/test_threaded_process_handle.py`: add `TestNoneExitCode`
  covering both the coercion and the `poll()` completion-detection regression.
- `scripts/release.py`: add the contributor email to `AUTHOR_MAP` so the
  contributor check passes.

## How to Test

1. Run the focused suite: `scripts/run_tests.sh tests/tools/test_threaded_process_handle.py`.
2. Confirm `TestNoneExitCode::test_poll_reports_completion_with_none_exit_code`
   passes — with the fix removed it fails (`poll()` returns `None` for a
   finished command, so the assertion `poll() == 0` does not hold).
3. Regression check the neighbours:
   `scripts/run_tests.sh tests/tools/test_base_environment.py tests/tools/test_daytona_environment.py`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A