### PR TITLE
fix(state): keep telegram topic migration inside its write transaction

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3687,7 +3687,19 @@ class SessionDB:
                automatically clears bindings.
         """
         def _do(conn):
-            conn.executescript(
+            # NOTE: every statement below is issued via conn.execute() — never
+            # conn.executescript().  executescript() implicitly COMMITs any
+            # pending transaction before it runs and then executes its
+            # statements in autocommit mode, which would silently break out of
+            # the BEGIN IMMEDIATE transaction _execute_write() has opened for
+            # us.  That matters here because the v1→v2 rebuild below does a
+            # destructive DROP TABLE + RENAME: under executescript() those run
+            # outside any transaction, so a crash between them would lose the
+            # bindings table with no rollback, and a lock-driven retry of _do()
+            # would re-run a half-finished rebuild.  Keeping plain execute()
+            # calls inside the outer transaction makes the whole migration
+            # atomic and safe to retry.
+            conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS telegram_dm_topic_mode (
                     chat_id TEXT PRIMARY KEY,
@@ -3700,8 +3712,11 @@ class SessionDB:
                     capability_checked_at REAL,
                     intro_message_id TEXT,
                     pinned_message_id TEXT
-                );
-
+                )
+                """
+            )
+            conn.execute(
+                """
                 CREATE TABLE IF NOT EXISTS telegram_dm_topic_bindings (
                     chat_id TEXT NOT NULL,
                     thread_id TEXT NOT NULL,
@@ -3712,14 +3727,16 @@ class SessionDB:
                     linked_at REAL NOT NULL,
                     updated_at REAL NOT NULL,
                     PRIMARY KEY (chat_id, thread_id)
-                );
-
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_session
-                ON telegram_dm_topic_bindings(session_id);
-
-                CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user
-                ON telegram_dm_topic_bindings(user_id, chat_id);
+                )
                 """
+            )
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_session "
+                "ON telegram_dm_topic_bindings(session_id)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user "
+                "ON telegram_dm_topic_bindings(user_id, chat_id)"
             )
 
             # v1 → v2: rebuild telegram_dm_topic_bindings if its session_id FK
@@ -3739,7 +3756,11 @@ class SessionDB:
                     for row in fk_rows
                 )
                 if needs_rebuild:
-                    conn.executescript(
+                    # Drop any scratch table left behind by an interrupted
+                    # earlier attempt so the CREATE below can't trip over a
+                    # stale leftover (the original CREATE had no IF NOT EXISTS).
+                    conn.execute("DROP TABLE IF EXISTS telegram_dm_topic_bindings_new")
+                    conn.execute(
                         """
                         CREATE TABLE telegram_dm_topic_bindings_new (
                             chat_id TEXT NOT NULL,
@@ -3751,19 +3772,29 @@ class SessionDB:
                             linked_at REAL NOT NULL,
                             updated_at REAL NOT NULL,
                             PRIMARY KEY (chat_id, thread_id)
-                        );
+                        )
+                        """
+                    )
+                    conn.execute(
+                        """
                         INSERT INTO telegram_dm_topic_bindings_new
                             SELECT chat_id, thread_id, user_id, session_key,
                                    session_id, managed_mode, linked_at, updated_at
-                            FROM telegram_dm_topic_bindings;
-                        DROP TABLE telegram_dm_topic_bindings;
-                        ALTER TABLE telegram_dm_topic_bindings_new
-                            RENAME TO telegram_dm_topic_bindings;
-                        CREATE UNIQUE INDEX idx_telegram_dm_topic_bindings_session
-                            ON telegram_dm_topic_bindings(session_id);
-                        CREATE INDEX idx_telegram_dm_topic_bindings_user
-                            ON telegram_dm_topic_bindings(user_id, chat_id);
+                            FROM telegram_dm_topic_bindings
                         """
+                    )
+                    conn.execute("DROP TABLE telegram_dm_topic_bindings")
+                    conn.execute(
+                        "ALTER TABLE telegram_dm_topic_bindings_new "
+                        "RENAME TO telegram_dm_topic_bindings"
+                    )
+                    conn.execute(
+                        "CREATE UNIQUE INDEX idx_telegram_dm_topic_bindings_session "
+                        "ON telegram_dm_topic_bindings(session_id)"
+                    )
+                    conn.execute(
+                        "CREATE INDEX idx_telegram_dm_topic_bindings_user "
+                        "ON telegram_dm_topic_bindings(user_id, chat_id)"
                     )
 
             conn.execute(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2223,6 +2223,145 @@ class TestSchemaInit:
         assert sessions[0]["preview"] == "first prompt"
         db.close()
 
+    @staticmethod
+    def _make_v1_topic_db(db_path):
+        """Open a SessionDB that already holds the *v1* topic-bindings table.
+
+        v1 differs from v2 only in that ``session_id`` references
+        ``sessions(id)`` WITHOUT ``ON DELETE CASCADE`` — the exact shape that
+        ``apply_telegram_topic_migration`` must rebuild.  Returns the open
+        SessionDB with one session and one pre-existing binding row.
+        """
+        db = SessionDB(db_path=db_path)
+        db.create_session(session_id="topic-session", source="telegram", user_id="u1")
+        # Hand-build the v1 bindings table (no CASCADE) plus the mode table so
+        # the migration's IF NOT EXISTS create is a no-op and only the v1→v2
+        # rebuild path fires.
+        def _seed(conn):
+            conn.execute(
+                """
+                CREATE TABLE telegram_dm_topic_bindings (
+                    chat_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    user_id TEXT NOT NULL,
+                    session_key TEXT NOT NULL,
+                    session_id TEXT NOT NULL REFERENCES sessions(id),
+                    managed_mode TEXT NOT NULL DEFAULT 'auto',
+                    linked_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY (chat_id, thread_id)
+                )
+                """
+            )
+            conn.execute(
+                "INSERT INTO telegram_dm_topic_bindings "
+                "(chat_id, thread_id, user_id, session_key, session_id, "
+                " managed_mode, linked_at, updated_at) "
+                "VALUES ('c1', 't1', 'u1', 'k1', 'topic-session', 'auto', 1.0, 1.0)"
+            )
+        db._execute_write(_seed)
+        return db
+
+    @staticmethod
+    def _binding_fk_is_cascade(db):
+        rows = db._conn.execute(
+            "PRAGMA foreign_key_list('telegram_dm_topic_bindings')"
+        ).fetchall()
+        return any(row[2] == "sessions" and (row[6] or "") == "CASCADE" for row in rows)
+
+    def test_telegram_topic_v1_to_v2_rebuild_preserves_rows_and_adds_cascade(self, tmp_path):
+        """The v1→v2 rebuild upgrades the FK to CASCADE without losing bindings."""
+        db = self._make_v1_topic_db(tmp_path / "state.db")
+        assert not self._binding_fk_is_cascade(db)  # precondition: genuine v1
+
+        db.apply_telegram_topic_migration()
+
+        assert self._binding_fk_is_cascade(db)
+        assert db.get_meta("telegram_dm_topic_schema_version") == "2"
+        rows = db._conn.execute(
+            "SELECT chat_id, thread_id, session_id FROM telegram_dm_topic_bindings"
+        ).fetchall()
+        assert [tuple(r) for r in rows] == [("c1", "t1", "topic-session")]
+        # The scratch table used during the swap must be gone.
+        tables = {
+            r[0]
+            for r in db._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "telegram_dm_topic_bindings_new" not in tables
+        db.close()
+
+    def test_telegram_topic_migration_is_atomic_on_failure(self, tmp_path):
+        """A failure mid-rebuild rolls back, leaving the v1 table intact.
+
+        Because the rebuild runs inside ``_execute_write``'s BEGIN IMMEDIATE
+        transaction (no ``executescript``, which would implicitly COMMIT), an
+        error after the destructive DROP/RENAME must undo the whole migration
+        rather than leave the bindings table half-rebuilt or missing.
+        """
+        db = self._make_v1_topic_db(tmp_path / "state.db")
+
+        # sqlite3.Connection.execute is read-only, so inject the fault through a
+        # thin delegating proxy that raises right after the destructive swap —
+        # while the BEGIN IMMEDIATE transaction is still open.
+        class _FailOnRename:
+            def __init__(self, real):
+                self._real = real
+
+            def execute(self, sql, *args, **kwargs):
+                if isinstance(sql, str) and "RENAME TO telegram_dm_topic_bindings" in sql:
+                    self._real.execute(sql, *args, **kwargs)
+                    raise sqlite3.OperationalError("injected failure mid-rebuild")
+                return self._real.execute(sql, *args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+        real_conn = db._conn
+        db._conn = _FailOnRename(real_conn)
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="injected failure"):
+                db.apply_telegram_topic_migration()
+        finally:
+            db._conn = real_conn
+
+        # Rollback restored the original v1 table, its row, and left the
+        # schema-version marker unset (migration never committed).
+        rows = db._conn.execute(
+            "SELECT chat_id, thread_id, session_id FROM telegram_dm_topic_bindings"
+        ).fetchall()
+        assert [tuple(r) for r in rows] == [("c1", "t1", "topic-session")]
+        assert not self._binding_fk_is_cascade(db)
+        assert db.get_meta("telegram_dm_topic_schema_version") is None
+        db.close()
+
+    def test_telegram_topic_rebuild_survives_leftover_scratch_table(self, tmp_path):
+        """A leftover ``_new`` table from an interrupted attempt is reclaimed.
+
+        The rebuild's CREATE has no IF NOT EXISTS, so without an upfront
+        DROP it would raise ``table already exists`` and abort the /topic
+        opt-in.  The migration must instead clear the stale scratch table and
+        complete the rebuild.
+        """
+        db = self._make_v1_topic_db(tmp_path / "state.db")
+
+        def _seed_leftover(conn):
+            conn.execute(
+                "CREATE TABLE telegram_dm_topic_bindings_new (chat_id TEXT, junk TEXT)"
+            )
+        db._execute_write(_seed_leftover)
+
+        db.apply_telegram_topic_migration()
+
+        assert self._binding_fk_is_cascade(db)
+        assert db.get_meta("telegram_dm_topic_schema_version") == "2"
+        rows = db._conn.execute(
+            "SELECT chat_id, thread_id, session_id FROM telegram_dm_topic_bindings"
+        ).fetchall()
+        assert [tuple(r) for r in rows] == [("c1", "t1", "topic-session")]
+        db.close()
+
     def test_migration_from_v2(self, tmp_path):
         """Simulate a v2 database and verify migration adds title column."""
         import sqlite3


### PR DESCRIPTION
## What does this PR do?

`SessionDB.apply_telegram_topic_migration()` runs its DDL through a `_do`
callback that `_execute_write()` wraps in a `BEGIN IMMEDIATE` transaction and
relies on `commit()`/`rollback()` to keep atomic. The body used
`conn.executescript()` for both the initial table creation and the v1->v2
rebuild. Python's `sqlite3.executescript()` issues an implicit `COMMIT` of any
pending transaction before it runs and then executes its statements in
autocommit mode, so the work silently escaped the surrounding transaction.

That is harmless for the idempotent `CREATE TABLE IF NOT EXISTS` block, but the
v1->v2 rebuild performs a destructive `DROP TABLE` + `RENAME` to add
`ON DELETE CASCADE` to the `session_id` foreign key. Because those statements
ran outside any transaction, a crash between the `DROP` and the `RENAME` would
leave the `telegram_dm_topic_bindings` table gone with nothing to roll back to,
and the `rollback()` in `_execute_write()`'s error path was a no-op against the
already-committed DDL. The same escape also defeated the lock-retry logic: if
the writer hit `database is locked` after the rebuild had already committed its
non-idempotent `CREATE TABLE telegram_dm_topic_bindings_new`, the retry re-ran
that statement and raised `table already exists`, aborting the user's `/topic`
opt-in.

This replaces both `executescript()` calls with individual `conn.execute()`
statements so the whole migration stays inside the one `BEGIN IMMEDIATE`
transaction. The destructive swap now commits atomically (crash-safe) and a
lock-driven retry re-runs the migration from a clean, rolled-back state. A
`DROP TABLE IF EXISTS telegram_dm_topic_bindings_new` is added in front of the
rebuild so a scratch table left over from an interrupted earlier attempt cannot
make the retry fail.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: rewrote `apply_telegram_topic_migration._do()` to issue
  every DDL statement via `conn.execute()` instead of two
  `conn.executescript()` calls, keeping them inside the transaction opened by
  `_execute_write()`; added an upfront `DROP TABLE IF EXISTS
  telegram_dm_topic_bindings_new` so the rebuild is safe to retry; documented
  the executescript-implicit-commit pitfall in a comment.
- `tests/test_hermes_state.py`: added three `TestSchemaInit` cases covering the
  v1->v2 rebuild path (previously untested) — that the rebuild preserves
  bindings and upgrades the FK to `CASCADE`, that a failure mid-rebuild rolls
  back and leaves the original table and version marker untouched, and that a
  leftover scratch table from an interrupted attempt is reclaimed instead of
  aborting the migration.

## How to Test

1. Run the migration tests against this subsystem:
   `scripts/run_tests.sh tests/test_hermes_state.py -- -k "telegram_topic or apply_telegram"`
   — all pass.
2. Confirm the new regression coverage fails on the previous code: temporarily
   revert `hermes_state.py` and rerun `test_telegram_topic_migration_is_atomic_on_failure`
   and `test_telegram_topic_rebuild_survives_leftover_scratch_table`; both fail
   (the rollback never restores the table / the rebuild raises `table already
   exists`).
3. Run the full file plus the gateway topic suite for regressions:
   `scripts/run_tests.sh tests/test_hermes_state.py tests/gateway/test_telegram_topic_mode.py`
   — 265 + 44 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A