### PR TITLE
fix: sync chat sidebar model badge with resumed sessions

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -72,9 +72,14 @@ const STATE_TONE: Record<
 interface ChatSidebarProps {
   channel: string;
   className?: string;
+  resumeSessionId?: string | null;
 }
 
-export function ChatSidebar({ channel, className }: ChatSidebarProps) {
+export function ChatSidebar({
+  channel,
+  className,
+  resumeSessionId = null,
+}: ChatSidebarProps) {
   // `version` bumps on reconnect; gw is derived so we never call setState
   // for it inside an effect (React 19's set-state-in-effect rule). The
   // counter is the dependency on purpose — it's not read in the memo body,
@@ -112,21 +117,33 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
       }
     });
 
-    // Adopt whichever session the gateway hands us. session.create on the
-    // sidecar is independent of the PTY pane's session by design — we
-    // only need a sid to drive the model picker's slash.exec calls.
+    // Mirror the active PTY session when resuming a historical chat so the
+    // sidebar model badge / picker reflect the current conversation rather
+    // than a detached helper session's defaults.
     gw.connect()
       .then(() => {
         if (cancelled) {
           return;
         }
-        return gw.request<{ session_id: string }>("session.create", {});
+        if (resumeSessionId) {
+          return gw.request<{ info?: SessionInfo; session_id: string }>(
+            "session.resume",
+            { session_id: resumeSessionId },
+          );
+        }
+        return gw.request<{ info?: SessionInfo; session_id: string }>(
+          "session.create",
+          {},
+        );
       })
-      .then((created) => {
-        if (cancelled || !created?.session_id) {
+      .then((session) => {
+        if (cancelled || !session?.session_id) {
           return;
         }
-        setSessionId(created.session_id);
+        if (session.info) {
+          setInfo(session.info);
+        }
+        setSessionId(session.session_id);
       })
       .catch((e: Error) => {
         if (!cancelled) {
@@ -141,7 +158,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
       offError();
       gw.close();
     };
-  }, [gw]);
+  }, [gw, resumeSessionId]);
 
   // Event subscriber WebSocket — receives the rebroadcast of every
   // dispatcher emit from the PTY child's gateway.  See /api/pub +

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -851,7 +851,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               "border-t border-current/10",
             )}
           >
-            <ChatSidebar channel={channel} />
+            <ChatSidebar
+              key={channel}
+              channel={channel}
+              resumeSessionId={resumeParam}
+            />
           </div>
         </div>
       </>,
@@ -919,7 +923,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             className="flex min-h-0 shrink-0 flex-col overflow-hidden lg:h-full lg:w-80"
           >
             <div className="min-h-0 flex-1 overflow-hidden">
-              <ChatSidebar channel={channel} />
+              <ChatSidebar
+                key={channel}
+                channel={channel}
+                resumeSessionId={resumeParam}
+              />
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- make `ChatSidebar` resume the active chat session when `resumeParam` is present instead of always creating a detached helper session
- hydrate sidebar `session.info` from the resumed session so the model badge and picker reflect the current conversation immediately
- remount the sidebar on channel changes so switching conversations does not leave stale session state behind

Closes #41987.

## Verification
- `git diff --check`
- `eslint src/components/ChatSidebar.tsx src/pages/ChatPage.tsx`

## Baseline note
- `tsc -b` and `vite build` still fail on latest `origin/main` because untouched `web/src/pages/ChannelsPage.tsx` imports missing `qrcode`; recorded as `preexisting_unrelated`
