### PR TITLE
fix(gateway): add bootout before bootstrap in launchd_restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3548,10 +3548,15 @@ def launchd_restart():
                 _launchd_fallback_to_detached(f"launchctl kickstart exit {e.returncode}")
                 return
             raise
-        # Job not loaded — bootstrap and start fresh
+        # Job not loaded — bootout any stale registration, then bootstrap fresh
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
         try:
+            subprocess.run(
+                ["launchctl", "bootout", target],
+                check=False,
+                timeout=30,
+            )
             subprocess.run(
                 ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
                 check=True,

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -825,6 +825,44 @@ class TestLaunchdServiceRecovery:
 
         assert "stopped" in capsys.readouterr().out.lower()
 
+    def test_launchd_restart_bootouts_stale_job_before_bootstrap(self, monkeypatch, capsys):
+        """When kickstart fails with 'unloaded', bootout stale registration before bootstrap."""
+        calls = []
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        plist_path = gateway_cli.get_launchd_plist_path()
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        def fake_run_with_kickstart_fail(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", "-k", target]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    3, cmd, stderr="No such process"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run_with_kickstart_fail)
+
+        gateway_cli.launchd_restart()
+
+        # bootout must happen before bootstrap
+        assert ["launchctl", "bootout", target] in calls
+        bootout_idx = calls.index(["launchctl", "bootout", target])
+        bootstrap_cmd = ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)]
+        assert bootstrap_cmd in calls
+        bootstrap_idx = calls.index(bootstrap_cmd)
+        assert bootout_idx < bootstrap_idx, "bootout must precede bootstrap"
+        out = capsys.readouterr().out
+        assert "Service restarted" in out
+
     def test_launchd_fallback_exits_when_spawn_fails(self, monkeypatch, capsys):
         """If the detached spawn fails, surface the manual workaround and exit 1."""
         monkeypatch.setattr(gateway_cli, "_spawn_detached_gateway", lambda: False)


### PR DESCRIPTION
## What does this PR do?

Fixes `launchd_restart()` to call `launchctl bootout` on any stale registration before `launchctl bootstrap`, preventing error 5 ("Input/output error") after `hermes update` on macOS.

## Related Issue

Fixes #42006

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: Added `launchctl bootout` call before `launchctl bootstrap` in the "job not loaded" recovery path of `launchd_restart()`. This matches the existing pattern in `refresh_launchd_plist_if_needed()` (line 3303).
- `tests/hermes_cli/test_gateway_service.py`: Added `test_launchd_restart_bootouts_stale_job_before_bootstrap` — verifies that when `kickstart -k` fails with an "unloaded" exit code (3), the bootout call happens before bootstrap and the restart completes successfully.

## How to Test

1. Mock `subprocess.run` to make `kickstart -k` fail with exit code 3 (job not loaded)
2. Call `launchd_restart()` 
3. Verify `launchctl bootout <target>` is called before `launchctl bootstrap <domain> <plist>`
4. Run: `pytest tests/hermes_cli/test_gateway_service.py -k "launchd_restart" -xvs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `launchd_restart()` in `hermes_cli/gateway.py` (callers: `_handle_gateway_restart()`, `launchd_restart_after_update()`)
- Blast radius: LOW — only affects macOS launchd restart path when kickstart fails with unloaded code
- Related patterns: `refresh_launchd_plist_if_needed()` already uses the same bootout+bootstrap sequence at line 3303
