### PR TITLE
feat(desktop): resolve Obsidian wikilinks and relative .md links in preview pane

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5457,6 +5457,49 @@ ipcMain.handle('hermes:fs:gitRoot', async (_event, startPath) => {
   }
 })
 
+const VAULT_SCAN_EXCLUDED_DIRS = new Set(['.git', '.obsidian', 'node_modules', '.trash', '.stversions'])
+const VAULT_SCAN_MAX_FILES = 50000
+
+ipcMain.handle('hermes:fs:scanVaultMd', async (_event, vaultRoot) => {
+  const resolved = path.resolve(String(vaultRoot || ''))
+
+  if (!resolved || !directoryExists(resolved)) {
+    return { files: [], error: 'invalid-path' }
+  }
+
+  const files = []
+
+  async function walk(dir) {
+    if (files.length >= VAULT_SCAN_MAX_FILES) return
+
+    let dirents
+    try {
+      dirents = await fs.promises.readdir(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+
+    for (const d of dirents) {
+      if (files.length >= VAULT_SCAN_MAX_FILES) return
+
+      if (d.isDirectory()) {
+        if (!VAULT_SCAN_EXCLUDED_DIRS.has(d.name)) {
+          await walk(path.join(dir, d.name))
+        }
+      } else if (d.name.endsWith('.md')) {
+        files.push(path.join(dir, d.name))
+      }
+    }
+  }
+
+  try {
+    await walk(resolved)
+    return { files }
+  } catch (error) {
+    return { files, error: error?.code || 'scan-error' }
+  }
+})
+
 ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
   if (!nodePty) {
     throw new Error('PTY support is unavailable. Reinstall desktop dependencies and restart Hermes.')

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -50,6 +50,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getRecentLogs: () => ipcRenderer.invoke('hermes:logs:recent'),
   readDir: dirPath => ipcRenderer.invoke('hermes:fs:readDir', dirPath),
   gitRoot: startPath => ipcRenderer.invoke('hermes:fs:gitRoot', startPath),
+  scanVaultMd: vaultRoot => ipcRenderer.invoke('hermes:fs:scanVaultMd', vaultRoot),
   terminal: {
     dispose: id => ipcRenderer.invoke('hermes:terminal:dispose', id),
     resize: (id, size) => ipcRenderer.invoke('hermes:terminal:resize', id, size),

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -14,6 +14,7 @@ import { HERMES_PATHS_MIME } from '@/app/chat/hooks/use-composer-actions'
 import { PageLoader } from '@/components/page-loader'
 import { translateNow, useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
+import { getStoredVaultRoot, getVaultIndex, resolveObsidianLinks, type VaultIndex } from '@/lib/wikilink-resolver'
 import type { PreviewTarget } from '@/store/preview'
 
 const SHIKI_THEME = { dark: 'github-dark-default', light: 'github-light-default' } as const
@@ -286,11 +287,13 @@ const MARKDOWN_COMPONENTS = {
   code: MarkdownCode
 }
 
-function MarkdownPreview({ text }: { text: string }) {
+function MarkdownPreview({ text, filePath, vaultIndex }: { text: string; filePath: string; vaultIndex: VaultIndex | null }) {
+  const processed = useMemo(() => resolveObsidianLinks(text, filePath, vaultIndex), [text, filePath, vaultIndex])
+
   return (
     <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground">
       <Streamdown components={MARKDOWN_COMPONENTS} controls={false} mode="static" parseIncompleteMarkdown={false}>
-        {text}
+        {processed}
       </Streamdown>
     </div>
   )
@@ -416,6 +419,7 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
   const [state, setState] = useState<LocalPreviewState>({ loading: true })
   const [forcePreview, setForcePreview] = useState(false)
   const [renderMarkdownAsSource, setRenderMarkdownAsSource] = useState(false)
+  const [vaultIndex, setVaultIndex] = useState<VaultIndex | null>(null)
   const filePath = filePathForTarget(target)
   const isImage = target.previewKind === 'image'
 
@@ -423,6 +427,29 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
   // the same path as plain text files. `previewKind === 'binary'` arrives
   // when the file is forcibly previewed past the binary refusal screen.
   const isText = target.previewKind === 'text' || target.previewKind === 'binary' || target.previewKind === 'html'
+  const isMarkdown = isText && (state.language || target.language) === 'markdown'
+
+  // Load vault index when previewing a markdown file in an Obsidian vault
+  useEffect(() => {
+    if (!isMarkdown || !filePath) {
+      setVaultIndex(null)
+      return
+    }
+
+    let active = true
+    const vaultRoot = getStoredVaultRoot()
+
+    if (!vaultRoot) {
+      setVaultIndex(null)
+      return
+    }
+
+    void getVaultIndex(vaultRoot).then(index => {
+      if (active) setVaultIndex(index)
+    })
+
+    return () => { active = false }
+  }, [filePath, isMarkdown])
 
   const blockedByTarget = !isImage && !forcePreview && (target.binary || target.large)
 
@@ -530,7 +557,6 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
   }
 
   if (isText && state.text !== undefined) {
-    const isMarkdown = (state.language || target.language) === 'markdown'
     const showRendered = isMarkdown && !renderMarkdownAsSource
 
     return (
@@ -542,7 +568,7 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
         )}
         {isMarkdown && <PreviewToggle asSource={!showRendered} onToggle={() => setRenderMarkdownAsSource(s => !s)} />}
         {showRendered ? (
-          <MarkdownPreview text={state.text} />
+          <MarkdownPreview filePath={filePath} text={state.text} vaultIndex={vaultIndex} />
         ) : (
           <SourceView filePath={filePath} language={state.language || 'text'} text={state.text} />
         )}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -60,6 +60,7 @@ declare global {
       getRecentLogs: () => Promise<{ path: string; lines: string[] }>
       readDir: (path: string) => Promise<HermesReadDirResult>
       gitRoot?: (path: string) => Promise<string | null>
+      scanVaultMd?: (vaultRoot: string) => Promise<HermesScanVaultMdResult>
       terminal: {
         dispose: (id: string) => Promise<boolean>
         onData: (id: string, callback: (payload: string) => void) => () => void
@@ -406,6 +407,11 @@ export interface HermesReadDirEntry {
 
 export interface HermesReadDirResult {
   entries: HermesReadDirEntry[]
+  error?: string
+}
+
+export interface HermesScanVaultMdResult {
+  files: string[]
   error?: string
 }
 

--- a/apps/desktop/src/lib/wikilink-resolver.test.ts
+++ b/apps/desktop/src/lib/wikilink-resolver.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  basename,
+  buildVaultIndex,
+  dirname,
+  resolveObsidianLinks,
+  resolveRelativeMdLinks,
+  resolveWikilinks
+} from './wikilink-resolver'
+
+describe('wikilink-resolver', () => {
+  describe('dirname', () => {
+    it('returns parent directory for Unix paths', () => {
+      expect(dirname('/Users/test/vault/note.md')).toBe('/Users/test/vault')
+    })
+
+    it('returns parent directory for nested paths', () => {
+      expect(dirname('/a/b/c/d.md')).toBe('/a/b/c')
+    })
+
+    it('handles root path', () => {
+      expect(dirname('/note.md')).toBe('/note.md')
+    })
+  })
+
+  describe('basename', () => {
+    it('extracts filename without extension', () => {
+      expect(basename('/Users/test/note.md', '.md')).toBe('note')
+    })
+
+    it('extracts filename with spaces', () => {
+      expect(basename('/vault/My Note.md', '.md')).toBe('My Note')
+    })
+
+    it('extracts full filename without ext arg', () => {
+      expect(basename('/vault/note.md')).toBe('note.md')
+    })
+  })
+
+  describe('buildVaultIndex', () => {
+    it('maps basenames to full paths (lowercase)', () => {
+      const index = buildVaultIndex(['/vault/Notes/My Note.md', '/vault/ideas.md'])
+      expect(index.byBasename.get('my note')).toBe('/vault/Notes/My Note.md')
+      expect(index.byBasename.get('ideas')).toBe('/vault/ideas.md')
+    })
+
+    it('first match wins for duplicate basenames', () => {
+      const index = buildVaultIndex(['/vault/a/note.md', '/vault/b/note.md'])
+      expect(index.byBasename.get('note')).toBe('/vault/a/note.md')
+    })
+  })
+
+  describe('resolveWikilinks', () => {
+    const index = buildVaultIndex(['/vault/My Note.md', '/vault/ideas.md'])
+
+    it('resolves [[Note]] to preview link', () => {
+      const result = resolveWikilinks('See [[My Note]] for details.', index)
+      expect(result).toContain('[My Note]')
+      expect(result).toContain('#preview/')
+      expect(result).toContain('My%20Note')
+    })
+
+    it('resolves [[Note|alias]] with alias text', () => {
+      const result = resolveWikilinks('See [[ideas|my ideas]] here.', index)
+      expect(result).toContain('[my ideas]')
+      expect(result).toContain('#preview/')
+      expect(result).toContain('ideas')
+    })
+
+    it('resolves [[Note#Heading]] with heading', () => {
+      const result = resolveWikilinks('Jump to [[My Note#Introduction]].', index)
+      expect(result).toContain('[My Note > Introduction]')
+      expect(result).toContain('#preview/')
+    })
+
+    it('unresolved wikilinks become inline code', () => {
+      const result = resolveWikilinks('See [[Unknown Note]].', index)
+      expect(result).toBe('See `Unknown Note`.')
+    })
+
+    it('returns inline code when index is null', () => {
+      const result = resolveWikilinks('See [[My Note]].', null)
+      expect(result).toBe('See `My Note`.')
+    })
+  })
+
+  describe('resolveRelativeMdLinks', () => {
+    it('resolves relative .md links', () => {
+      const result = resolveRelativeMdLinks(
+        '[other](other.md)',
+        '/vault/notes'
+      )
+      expect(result).toContain('[other]')
+      expect(result).toContain('#preview/')
+      expect(result).toContain('other.md')
+    })
+
+    it('resolves ../ relative paths', () => {
+      const result = resolveRelativeMdLinks(
+        '[readme](../README.md)',
+        '/vault/notes'
+      )
+      expect(result).toContain('#preview/')
+      expect(result).toContain('README.md')
+    })
+
+    it('resolves relative links with heading anchor', () => {
+      const result = resolveRelativeMdLinks(
+        '[section](other.md#intro)',
+        '/vault/notes'
+      )
+      expect(result).toContain('#intro')
+    })
+
+    it('skips absolute URLs', () => {
+      const input = '[link](https://example.com)'
+      expect(resolveRelativeMdLinks(input, '/vault')).toBe(input)
+    })
+
+    it('skips file:// URLs', () => {
+      const input = '[link](file:///something.md)'
+      expect(resolveRelativeMdLinks(input, '/vault')).toBe(input)
+    })
+
+    it('skips anchor-only links', () => {
+      const input = '[link](#heading)'
+      expect(resolveRelativeMdLinks(input, '/vault')).toBe(input)
+    })
+
+    it('skips non-.md links', () => {
+      const input = '[link](image.png)'
+      expect(resolveRelativeMdLinks(input, '/vault')).toBe(input)
+    })
+
+    it('skips image links (prefixed with !)', () => {
+      const input = '![image](screenshot.png)'
+      expect(resolveRelativeMdLinks(input, '/vault')).toBe(input)
+    })
+  })
+
+  describe('resolveObsidianLinks', () => {
+    const index = buildVaultIndex(['/vault/My Note.md', '/vault/ideas.md'])
+
+    it('resolves both wikilinks and relative .md links', () => {
+      const result = resolveObsidianLinks(
+        'See [[My Note]] and [other](other.md).',
+        '/vault/index.md',
+        index
+      )
+      expect(result).toContain('[My Note]')
+      expect(result).toContain('#preview/')
+      expect(result).toContain('[other]')
+    })
+
+    it('handles mixed resolved and unresolved', () => {
+      const result = resolveObsidianLinks(
+        '[[My Note]] and [[Unknown]] and [relative](../other.md).',
+        '/vault/index.md',
+        index
+      )
+      // My Note is resolved
+      expect(result).toContain('[My Note]')
+      // Unknown is unresolved → inline code
+      expect(result).toContain('`Unknown`')
+      // relative link is resolved
+      expect(result).toContain('[relative]')
+    })
+  })
+})

--- a/apps/desktop/src/lib/wikilink-resolver.ts
+++ b/apps/desktop/src/lib/wikilink-resolver.ts
@@ -1,0 +1,179 @@
+/**
+ * Obsidian wikilink + relative .md link resolver for Desktop preview pane.
+ *
+ * Transforms `[[Note Name]]`, `[[Note|alias]]`, `[[Note#Heading]]`, and
+ * `[text](relative.md)` into `#preview/file:///abs/path` links that the
+ * existing preview routing system already understands.
+ */
+
+interface VaultIndex {
+  byBasename: Map<string, string>
+}
+
+const WIKILINK_RE = /\[\[([^\]|#]+?)(?:#([^\]|]+?))?(?:\|([^\]]+?))?\]\]/g
+const RELATIVE_MD_LINK_RE = /(?<!!)\[([^\]]*)\]\(([^)]+?\.md(?:#[^)]*)?)\)/gi
+const VAULT_ROOT_CACHE_KEY = 'hermes.desktop.obsidianVaultRoot.v1'
+const VAULT_INDEX_TTL_MS = 5 * 60 * 1000
+
+let cachedIndex: VaultIndex | null = null
+let cachedIndexAt = 0
+let cachedIndexVaultRoot = ''
+
+export function dirname(filePath: string): string {
+  const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'))
+  return lastSep > 0 ? filePath.slice(0, lastSep) : filePath
+}
+
+export function basename(filePath: string, ext?: string): string {
+  const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'))
+  const name = filePath.slice(lastSep + 1)
+  if (ext && name.endsWith(ext)) return name.slice(0, -ext.length)
+  return name
+}
+
+function resolveRelative(base: string, rel: string): string {
+  if (/^(?:\/|[a-zA-Z]:)/i.test(rel)) return rel
+
+  const isAbsolute = base.startsWith('/')
+  const parts = base.split(/[/\\]/).filter(Boolean)
+  const relParts = rel.split(/[/\\]/)
+
+  for (const part of relParts) {
+    if (part === '..') parts.pop()
+    else if (part !== '.') parts.push(part)
+  }
+
+  return (isAbsolute ? '/' : '') + parts.join('/')
+}
+
+/**
+ * Get the stored Obsidian vault root override from localStorage.
+ */
+export function getStoredVaultRoot(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage.getItem(VAULT_ROOT_CACHE_KEY) || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Store an Obsidian vault root override in localStorage.
+ */
+export function setStoredVaultRoot(vaultRoot: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(VAULT_ROOT_CACHE_KEY, vaultRoot)
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+/**
+ * Build a vault index from a list of absolute .md file paths.
+ * Maps basename (without extension, lowercase) to the first matching full path.
+ */
+export function buildVaultIndex(files: string[]): VaultIndex {
+  const byBasename = new Map<string, string>()
+
+  for (const filePath of files) {
+    const name = basename(filePath, '.md').toLowerCase()
+    if (!byBasename.has(name)) {
+      byBasename.set(name, filePath)
+    }
+  }
+
+  return { byBasename }
+}
+
+/**
+ * Get or build the vault index, using cache if available and fresh.
+ */
+export async function getVaultIndex(vaultRoot: string): Promise<VaultIndex | null> {
+  const now = Date.now()
+
+  if (cachedIndex && cachedIndexVaultRoot === vaultRoot && now - cachedIndexAt < VAULT_INDEX_TTL_MS) {
+    return cachedIndex
+  }
+
+  const desktop = window.hermesDesktop
+  if (!desktop?.scanVaultMd) return null
+
+  try {
+    const result = await desktop.scanVaultMd(vaultRoot)
+    if (result.error || !result.files.length) return null
+
+    cachedIndex = buildVaultIndex(result.files)
+    cachedIndexAt = now
+    cachedIndexVaultRoot = vaultRoot
+
+    return cachedIndex
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Invalidate the cached vault index (e.g., on window focus).
+ */
+export function invalidateVaultIndex(): void {
+  cachedIndex = null
+  cachedIndexAt = 0
+}
+
+function previewFileHref(absPath: string, heading?: string): string {
+  const fileUrl = `file://${absPath}`
+  const encoded = encodeURIComponent(fileUrl)
+  const suffix = heading ? `#${heading.toLowerCase().replace(/\s+/g, '-')}` : ''
+  return `#preview/${encoded}${suffix}`
+}
+
+/**
+ * Resolve Obsidian wikilinks in markdown text.
+ * Unresolved wikilinks become inline code (won't break markdown).
+ */
+export function resolveWikilinks(text: string, index: VaultIndex | null): string {
+  return text.replace(WIKILINK_RE, (_match, name: string, heading?: string, alias?: string) => {
+    const target = name.trim()
+    const display = alias?.trim() || (heading ? `${target} > ${heading.trim()}` : target)
+
+    if (!index) return `\`${display}\``
+
+    const filePath = index.byBasename.get(target.toLowerCase())
+    if (!filePath) return `\`${display}\``
+
+    return `[${display}](${previewFileHref(filePath, heading)})`
+  })
+}
+
+/**
+ * Resolve relative .md links in markdown text.
+ */
+export function resolveRelativeMdLinks(text: string, currentDir: string): string {
+  return text.replace(RELATIVE_MD_LINK_RE, (_match, linkText: string, href: string) => {
+    if (/^(?:https?:|file:|mailto:|tel:|#)/i.test(href)) return _match
+
+    const [relPath, heading] = href.split('#', 2)
+    const absPath = resolveRelative(currentDir, relPath)
+
+    if (!absPath.toLowerCase().endsWith('.md')) return _match
+
+    return `[${linkText}](${previewFileHref(absPath, heading)})`
+  })
+}
+
+/**
+ * Main preprocessing function: resolve all Obsidian-style links in markdown text.
+ * Call this before passing text to the markdown renderer.
+ */
+export function resolveObsidianLinks(
+  text: string,
+  currentFilePath: string,
+  index: VaultIndex | null
+): string {
+  const currentDir = dirname(currentFilePath)
+  let result = resolveWikilinks(text, index)
+  result = resolveRelativeMdLinks(result, currentDir)
+  return result
+}


### PR DESCRIPTION
## Problem

When opening a `.md` file in Hermes Desktop's right-rail preview pane, the following links are all broken (issue #41930):

- `[[Note Name]]` (Obsidian wikilink) — does nothing on click
- `[[Note|alias]]` / `[[Note#Heading]]` — same
- `[text](../foo/bar.md)` (standard markdown relative link) — Electron treats `file://` as an external link and pops the "Open external link?" dialog

## Solution

Add a wikilink + relative-md resolver to the markdown preprocess pipeline that rewrites links into the existing `#preview/file:///abs` plumbing the right-rail preview pane already understands.

### Architecture

1. **`hermes:fs:scanVaultMd` IPC** — recursive `.md` file scanner (caps at 50,000 files, excludes `.git`, `.obsidian`, `node_modules`, `.trash`, `.stversions`). Called from renderer via `window.hermesDesktop.scanVaultMd()`.

2. **`wikilink-resolver.ts`** — pure utility with three functions:
   - `buildVaultIndex(files[])` → `Map<basename, absPath>` (first match wins, consistent with Obsidian behavior)
   - `resolveWikilinks(text, index)` → transforms `[[Note]]` → `[Note](#preview/file:///abs/path)`, unresolved → inline code
   - `resolveRelativeMdLinks(text, currentDir)` → transforms `[text](relative.md)` → `[text](#preview/file:///abs/path)`

3. **`MarkdownPreview`** in `preview-file.tsx` — accepts `filePath` + `vaultIndex` props, preprocesses text via `useMemo(resolveObsidianLinks(...))`

4. **Vault root** — configured via `localStorage.hermes.desktop.obsidianVaultRoot.v1` (manual override). Index cached for 5 min.

### Resolution table

| Input | Output |
|---|---|
| `[[Note]]` | `[Note](#preview/file:///abs/path)` |
| `[[Note\|alias]]` | `[alias](#preview/file:///abs/path)` |
| `[[Note#Heading]]` | `[Note > Heading](#preview/file:///abs/path#heading)` |
| `[text](relative.md)` | `[text](#preview/file:///abs/path)` |
| `[text](relative.md#section)` | `[text](#preview/file:///abs/path#section)` |
| `[[Unresolved]]` | `` `Unresolved` `` (inline code, won't break markdown) |

## Files changed

- `apps/desktop/electron/main.cjs` — add `hermes:fs:scanVaultMd` IPC handler
- `apps/desktop/electron/preload.cjs` — expose `scanVaultMd` bridge method
- `apps/desktop/src/global.d.ts` — add `HermesScanVaultMdResult` type + `scanVaultMd` method
- `apps/desktop/src/lib/wikilink-resolver.ts` — new: vault index builder + link resolver (179 lines)
- `apps/desktop/src/lib/wikilink-resolver.test.ts` — new: 23 unit tests
- `apps/desktop/src/app/chat/right-rail/preview-file.tsx` — integrate resolver into `MarkdownPreview`

## Testing

```
✓ src/lib/wikilink-resolver.test.ts (23 tests) 3ms
  Test Files  1 passed (1)
       Tests  23 passed (23)
```

Closes #41930
