### PR TITLE
fix(gateway): show webhook in setup wizard

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4284,6 +4284,12 @@ _PLATFORMS = [
     # discovered dynamically via the platform registry entries registered by
     # plugins/platforms/{email,sms}/adapter.py::register(). #41112.
     {
+        "key": "webhook",
+        "label": "Webhook",
+        "emoji": "🔗",
+        "token_var": "WEBHOOK_ENABLED",
+    },
+    {
         "key": "weixin",
         "label": "Weixin / WeChat",
         "emoji": "💬",
@@ -5274,6 +5280,7 @@ def _builtin_setup_fn(key: str):
         # plugins/platforms/mattermost/adapter.py::register() and dispatched
         # via the plugin path in _configure_platform().
         "bluebubbles": _s._setup_bluebubbles,
+        "webhook": _s._setup_webhooks,
         "webhooks": _s._setup_webhooks,
         "signal": _setup_signal,
         # whatsapp + dingtalk moved into plugins: setup_fn registered by

--- a/tests/hermes_cli/test_gateway_platform_gating.py
+++ b/tests/hermes_cli/test_gateway_platform_gating.py
@@ -58,3 +58,23 @@ class TestMatrixHiddenOnWindows:
                 f"{must_have} disappeared from Windows picker — gate is "
                 "over-filtering"
             )
+
+
+class TestWebhookGatewaySetup:
+    def test_webhook_present_in_all_platforms(self, monkeypatch):
+        import hermes_cli.gateway as gateway_mod
+
+        monkeypatch.setattr(gateway_mod.sys, "platform", "darwin")
+        platforms = gateway_mod._all_platforms()
+        keys = {p["key"] for p in platforms}
+        assert "webhook" in keys
+
+    def test_builtin_setup_fn_accepts_webhook_key(self):
+        import hermes_cli.gateway as gateway_mod
+
+        assert gateway_mod._builtin_setup_fn("webhook") is not None
+
+    def test_builtin_setup_fn_keeps_webhooks_alias(self):
+        import hermes_cli.gateway as gateway_mod
+
+        assert gateway_mod._builtin_setup_fn("webhooks") is not None


### PR DESCRIPTION
## What does this PR do?

This fixes `hermes gateway setup` so the built-in platform picker actually surfaces the existing webhook setup flow described in the docs. The gateway runtime and `hermes_cli.setup._setup_webhooks()` already support webhook configuration, but the picker omitted `webhook` entirely and the built-in dispatch table only matched the plural `webhooks` key.

## Related Issue

Fixes #24911

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`: added the missing built-in `webhook` platform entry so it appears in `hermes gateway setup`.
- `hermes_cli/gateway.py`: mapped both `webhook` and the existing `webhooks` alias to `_setup_webhooks()` so the picker and any legacy callers resolve the same flow.
- `tests/hermes_cli/test_gateway_platform_gating.py`: added regression coverage for webhook visibility in `_all_platforms()` and builtin setup dispatch for both singular and plural keys.

## How to Test

1. Run `hermes gateway setup`.
2. Verify the platform picker now includes `Webhook`.
3. Select `Webhook` and confirm the existing webhook setup flow prompts for port/secret and enables `WEBHOOK_ENABLED`.
4. Run `pytest -q tests/hermes_cli/test_gateway_platform_gating.py tests/hermes_cli/test_setup.py tests/hermes_cli/test_setup_irc.py`.

## What platforms tested on

- macOS 15 on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `pytest -q tests/hermes_cli/test_gateway_platform_gating.py tests/hermes_cli/test_setup.py tests/hermes_cli/test_setup_irc.py` passed locally (`32 passed`).
- `python scripts/check-windows-footguns.py --diff HEAD` passed locally.
- `git diff --check` passed locally.
- The bounded full-suite command stopped early on a pre-existing local environment import error: `tests/hermes_cli/test_dashboard_auth_401_reauth.py` could not import `fastapi`.
- A broader mechanically-derived CLI/gateway subset completed, but its failures were outside this change (`tests/hermes_cli/test_gateway_service.py`, `tests/hermes_cli/test_gateway_wsl.py`, `tests/hermes_cli/test_service_manager.py`).

<!-- autocontrib:worker-id=issue-new-9b741a58 kind=pr-open -->