### PR TITLE
fix(web): keep configured web_search callable when backend setup is missing

### DIFF
--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -206,6 +206,38 @@ class TestDDGSBackendWiring:
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
         assert web_tools.check_web_api_key() is True
 
+    def test_web_search_schema_stays_visible_when_ddgs_package_missing(self, monkeypatch):
+        from model_tools import _clear_tool_defs_cache, get_tool_definitions
+        from tools import web_tools
+        from tools.registry import invalidate_check_fn_cache
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "ddgs"})
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+
+        invalidate_check_fn_cache()
+        _clear_tool_defs_cache()
+
+        tool_names = {
+            tool_def["function"]["name"]
+            for tool_def in get_tool_definitions(
+                enabled_toolsets=["web"],
+                quiet_mode=True,
+            )
+        }
+
+        assert "web_search" in tool_names
+
+    def test_web_search_tool_returns_structured_error_when_ddgs_package_missing(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "ddgs"})
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+
+        result = json.loads(web_tools.web_search_tool("hello world", limit=3))
+
+        assert result["success"] is False
+        assert "ddgs package is not installed" in result["error"]
+
 
 # ---------------------------------------------------------------------------
 # ddgs is search-only: web_extract returns a clear error

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1190,6 +1190,26 @@ def check_web_api_key() -> bool:
     )
 
 
+def check_web_search_api_key() -> bool:
+    """Check whether ``web_search`` should be exposed to the model.
+
+    When the user explicitly configures a search backend, keep the tool
+    visible even if that backend is currently unavailable. That lets the
+    dispatcher return the provider's structured "missing package / missing
+    API key" error instead of hiding the schema and causing raw tool-call
+    text to leak back to the user.
+    """
+    configured = _load_web_config()
+    explicit = (
+        configured.get("search_backend")
+        or configured.get("backend")
+        or ""
+    ).lower().strip()
+    if explicit in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
+        return True
+    return check_web_api_key()
+
+
 def check_auxiliary_model() -> bool:
     """Check if an auxiliary text model is available for LLM content processing."""
     client, _, _ = _resolve_web_extract_auxiliary()
@@ -1355,7 +1375,7 @@ registry.register(
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
     handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
-    check_fn=check_web_api_key,
+    check_fn=check_web_search_api_key,
     requires_env=_web_requires_env(),
     emoji="🔍",
     max_result_size_chars=100_000,


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where `web_search` disappears from the model tool catalog when the user explicitly configures a search backend but its local setup is missing. In the `ddgs` case from #42011, that meant the model no longer had a callable `web_search` schema and would fall back to echoing raw tool-call text instead of receiving the provider's structured setup error.

This keeps `web_search` visible when `web.search_backend` or `web.backend` is explicitly configured, then lets provider dispatch surface the real error such as `ddgs package is not installed`.

## Related Issue

Fixes #42011

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a `check_web_search_api_key()` gate in [tools/web_tools.py](/Users/idah/.hermes/hermes-agent-3/tools/web_tools.py:1193) so `web_search` remains exposed when a search backend is explicitly configured, even if the backend package or credential is currently missing.
- Kept the fix scoped to `web_search` instead of relaxing the whole `web` toolset gate, so `web_extract` behavior stays unchanged.
- Added regression tests in [tests/tools/test_web_providers_ddgs.py](/Users/idah/.hermes/hermes-agent-3/tests/tools/test_web_providers_ddgs.py:209) covering both schema visibility and the structured missing-package error path.

## How to Test

1. Configure `web.backend: ddgs` (or `web.search_backend: ddgs`) and ensure the `ddgs` package is not installed in the Hermes venv.
2. Run `web_search` and confirm the tool returns a structured error instead of raw echoed tool-call text.
3. Run:
   `pytest -q tests/tools/test_web_providers_ddgs.py -k "schema_stays_visible or structured_error_when_ddgs_package_missing"`
4. Run:
   `pytest -q tests/tools/test_web_providers_ddgs.py tests/tools/test_web_providers.py tests/tools/test_web_tools_config.py -k "ddgs or web_search_tool_runs_discovery_before_registry_lookup or search_error_response_does_not_expose_diagnostics or configured_backend_must_match_available_provider"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Regression before fix:

- `get_tool_definitions(enabled_toolsets=['web'])` returned no `web_search` schema when `backend=ddgs` and the package was unavailable.

After fix:

- `get_tool_definitions(enabled_toolsets=['web'])` includes `web_search`.
- `handle_function_call('web_search', {'query': 'hello', 'limit': 3})` returns:
  `{"success": false, "error": "ddgs package is not installed — run \`pip install ddgs\`"}`
