### PR TITLE
fix: surface gateway sessions in desktop

### DIFF
--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { coerceThinkingText } from './chat-runtime'
+import { coerceThinkingText, sessionTitle } from './chat-runtime'
 
 describe('coerceThinkingText', () => {
   it('strips streaming status prefixes from thinking deltas', () => {
@@ -14,5 +14,19 @@ describe('coerceThinkingText', () => {
         "◉_◉ processing... I don't see any current rewritten thinking or next thinking to process. Could you provide the thinking content you'd like me to rewrite?"
       )
     ).toBe('')
+  })
+})
+
+describe('sessionTitle', () => {
+  it('keeps stored titles for local sessions', () => {
+    expect(sessionTitle({ source: 'tui', title: 'Old local title', preview: 'newer local preview' } as any)).toBe(
+      'Old local title'
+    )
+  })
+
+  it('prefers previews for gateway sessions so long-lived chats do not hide under stale titles', () => {
+    expect(sessionTitle({ source: 'whatsapp', title: 'Hostname check', preview: 'Karpathy LLM wiki follow-up' } as any)).toBe(
+      'Karpathy LLM wiki follow-up'
+    )
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -51,8 +51,35 @@ export function createClientSessionState(
   }
 }
 
+const GATEWAY_SESSION_SOURCES = new Set([
+  'whatsapp',
+  'telegram',
+  'discord',
+  'slack',
+  'signal',
+  'matrix',
+  'email',
+  'sms',
+  'bluebubbles',
+  'weixin',
+  'wecom',
+  'feishu',
+  'dingtalk'
+])
+
 export function sessionTitle(session: SessionInfo): string {
-  return session.title?.trim() || session.preview?.trim() || 'Untitled session'
+  const title = session.title?.trim()
+  const preview = session.preview?.trim()
+
+  // Gateway chats often reuse one long session per external conversation, so a
+  // generated title from the first turn ("Hostname…") quickly becomes stale.
+  // Prefer the live preview for messaging sessions so WhatsApp/Telegram rows
+  // describe the current thread instead of hiding under an old title.
+  if (session.source && GATEWAY_SESSION_SOURCES.has(session.source) && preview) {
+    return preview
+  }
+
+  return title || preview || 'Untitled session'
 }
 
 export function coerceGatewayText(value: unknown): string {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -238,9 +238,12 @@ export const ALL_PROFILES = '__all__'
 
 const SHOW_ALL_PROFILES_STORAGE_KEY = 'hermes.desktop.showAllProfiles'
 
-// Opt-in unified view. When false, scope follows the live gateway profile, so
-// single-profile users (who never see the switcher) are completely unaffected.
-export const $showAllProfiles = atom<boolean>(storedBoolean(SHOW_ALL_PROFILES_STORAGE_KEY, false))
+// Unified view is the safe default for multi-profile Desktop installs: gateway
+// chats may arrive under a non-default profile (e.g. WhatsApp under `desktop`)
+// while the embedded dashboard initially connects to `default`. Showing all
+// profiles prevents those externally-created sessions from looking "missing".
+// Users can still switch to a concrete profile from the rail.
+export const $showAllProfiles = atom<boolean>(storedBoolean(SHOW_ALL_PROFILES_STORAGE_KEY, true))
 
 $showAllProfiles.subscribe(value => persistBoolean(SHOW_ALL_PROFILES_STORAGE_KEY, value))
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -237,13 +237,32 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
 export const ALL_PROFILES = '__all__'
 
 const SHOW_ALL_PROFILES_STORAGE_KEY = 'hermes.desktop.showAllProfiles'
+const SHOW_ALL_PROFILES_MIGRATION_KEY = 'hermes.desktop.showAllProfiles.migratedGatewayDefault.v1'
+
+function initialShowAllProfiles(): boolean {
+  try {
+    // One-shot migration for existing Desktop installs. A previous persisted
+    // `false` keeps gateway sessions (WhatsApp, Telegram, etc.) hidden when
+    // they are saved under a non-active profile. Flip existing installs to the
+    // safer unified view once; after that, the user's explicit rail choice wins.
+    if (window.localStorage.getItem(SHOW_ALL_PROFILES_MIGRATION_KEY) !== 'true') {
+      window.localStorage.setItem(SHOW_ALL_PROFILES_STORAGE_KEY, 'true')
+      window.localStorage.setItem(SHOW_ALL_PROFILES_MIGRATION_KEY, 'true')
+      return true
+    }
+  } catch {
+    // Fall through to the normal storage helper.
+  }
+
+  return storedBoolean(SHOW_ALL_PROFILES_STORAGE_KEY, true)
+}
 
 // Unified view is the safe default for multi-profile Desktop installs: gateway
 // chats may arrive under a non-default profile (e.g. WhatsApp under `desktop`)
 // while the embedded dashboard initially connects to `default`. Showing all
 // profiles prevents those externally-created sessions from looking "missing".
 // Users can still switch to a concrete profile from the rail.
-export const $showAllProfiles = atom<boolean>(storedBoolean(SHOW_ALL_PROFILES_STORAGE_KEY, true))
+export const $showAllProfiles = atom<boolean>(initialShowAllProfiles())
 
 $showAllProfiles.subscribe(value => persistBoolean(SHOW_ALL_PROFILES_STORAGE_KEY, value))
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1753,10 +1753,18 @@ class SessionDB:
                 )
                 SELECT s.*,
                     COALESCE(
-                        (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
-                         FROM messages m
-                         WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                         ORDER BY m.timestamp, m.id LIMIT 1),
+                        CASE
+                            WHEN s.source IN ('whatsapp', 'telegram', 'discord', 'slack', 'signal', 'matrix', 'email', 'sms', 'bluebubbles', 'weixin', 'wecom', 'feishu', 'dingtalk') THEN
+                                (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                                 FROM messages m
+                                 WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                                 ORDER BY m.timestamp DESC, m.id DESC LIMIT 1)
+                            ELSE
+                                (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                                 FROM messages m
+                                 WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                                 ORDER BY m.timestamp, m.id LIMIT 1)
+                        END,
                         ''
                     ) AS _preview_raw,
                     COALESCE(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2652,6 +2652,24 @@ class TestListSessionsRich:
             s["id"] for s in db.list_sessions_rich(limit=5, order_by_last_active=True)
         ] == ["old", "new"]
 
+    def test_order_by_last_active_uses_latest_user_preview_for_gateway_sessions(self, db):
+        db.create_session("wa", "whatsapp")
+        db.append_message("wa", "user", "Whats the hostname")
+        db.append_message("wa", "assistant", "DESKTOP")
+        db.append_message("wa", "user", "Why my WhatsApp conversations dont appear")
+
+        sessions = db.list_sessions_rich(order_by_last_active=True)
+        assert sessions[0]["preview"] == "Why my WhatsApp conversations dont appear"
+
+    def test_order_by_last_active_keeps_first_user_preview_for_local_sessions(self, db):
+        db.create_session("cli", "tui")
+        db.append_message("cli", "user", "Initial local task")
+        db.append_message("cli", "assistant", "Working")
+        db.append_message("cli", "user", "Later local follow-up")
+
+        sessions = db.list_sessions_rich(order_by_last_active=True)
+        assert sessions[0]["preview"] == "Initial local task"
+
     def test_order_by_last_active_uses_compression_tip_activity(self, db):
         """A compression root whose tip was touched recently must rank above
         a newer uncompressed session, even when that tip activity lives in a


### PR DESCRIPTION
## Summary
- default Desktop sidebar to a unified all-profiles view so gateway sessions saved under non-active profiles do not look missing
- prefer current previews for gateway/messaging session rows instead of stale first-turn titles
- use the latest user message as the preview for gateway sessions while keeping local sessions stable
- add a one-shot localStorage migration for existing Desktop installs that previously persisted profile-scoped sidebar mode

## Test Plan
- npm --prefix apps/desktop run test:ui -- src/lib/chat-runtime.test.ts
- python -m pytest tests/test_hermes_state.py::TestListSessionsRich::test_order_by_last_active_uses_latest_user_preview_for_gateway_sessions tests/test_hermes_state.py::TestListSessionsRich::test_order_by_last_active_keeps_first_user_preview_for_local_sessions -q -o 'addopts='\n- npm --prefix apps/desktop run type-check\n- python -m py_compile hermes_state.py\n- git diff --check\n\n## Runtime Verification\n- verified a live WhatsApp session in the desktop profile database appears with the latest user preview after rebuild/relaunch\n