### PR TITLE
fix(dashboard): avoid chat resume param update loop

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -187,7 +187,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           return;
         }
 
-        const next = new URLSearchParams(searchParams);
+        const next = new URLSearchParams(window.location.search);
+        if (next.get("resume") !== resumeParam) {
+          return;
+        }
         next.set("resume", res.session_id);
         setSearchParams(next, { replace: true });
       })
@@ -198,7 +201,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     return () => {
       cancelled = true;
     };
-  }, [resumeParam, searchParams, setSearchParams]);
+  }, [resumeParam, setSearchParams]);
 
   useEffect(() => {
     const mql = window.matchMedia("(max-width: 1023px)");


### PR DESCRIPTION
## Summary
- avoid re-running the dashboard Chat resume normalization effect from its own query-param write
- preserve the latest query string when replacing stale `resume` ids
- skip the replacement if the user has already navigated to a different resume target

Fixes #41808
Fixes #41739

## Tests
- `npm.cmd ci --workspace web --ignore-scripts`
- `npm.cmd --prefix web run build`
- `npm.cmd --prefix web run lint` *(fails on existing React Compiler / refresh lint errors in unrelated files such as `web/src/App.tsx`, `LanguageSwitcher.tsx`, `OAuthProvidersCard.tsx`; no new lint errors from this change)*