### PR TITLE
fix(cli): skip invalid project file completions

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1422,7 +1422,9 @@ class SlashCommandCompleter(Completer):
                     raw = proc.stdout.strip().split("\n")
                     # Store relative paths
                     for p in raw[:5000]:
-                        rel = os.path.relpath(p, cwd) if os.path.isabs(p) else p
+                        rel = self._project_relative_path(p, cwd)
+                        if rel is None:
+                            continue
                         files.append(rel)
                     break
             except (subprocess.TimeoutExpired, OSError):
@@ -1432,6 +1434,18 @@ class SlashCommandCompleter(Completer):
         self._file_cache_time = now
         self._file_cache_cwd = cwd
         return files
+
+    @staticmethod
+    def _project_relative_path(path: str, cwd: str) -> str | None:
+        """Return a project-relative path, or None for invalid tool output."""
+        if not path:
+            return None
+        if not os.path.isabs(path):
+            return path
+        try:
+            return os.path.relpath(path, cwd)
+        except (OSError, ValueError):
+            return None
 
     @staticmethod
     def _score_path(filepath: str, query: str) -> int:

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1,5 +1,7 @@
 """Tests for the central command registry and autocomplete."""
 
+import subprocess
+
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 
@@ -603,6 +605,34 @@ class TestSlashCommandCompleter:
         completions = _completions(completer, "/no-desc")
         assert len(completions) == 1
         assert "Skill command" in completions[0].display_meta_text
+
+    def test_project_file_cache_skips_relpath_errors(self, monkeypatch, tmp_path):
+        """Windows device paths can make relpath raise; autocomplete should continue."""
+        completer = SlashCommandCompleter()
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("hermes_cli.commands.shutil.which", lambda _tool: "rg")
+
+        def fake_run(*_args, **_kwargs):
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="\\\\.\\nul\nC:\\repo\\ok.py\nrelative.md\n",
+                stderr="",
+            )
+
+        def fake_isabs(path):
+            return path.startswith("\\\\") or path.startswith("C:")
+
+        def fake_relpath(path, _cwd):
+            if path.startswith("\\\\.\\"):
+                raise ValueError("path is on mount '\\\\.\\nul', start on mount 'C:'")
+            return "ok.py"
+
+        monkeypatch.setattr("hermes_cli.commands.subprocess.run", fake_run)
+        monkeypatch.setattr("hermes_cli.commands.os.path.isabs", fake_isabs)
+        monkeypatch.setattr("hermes_cli.commands.os.path.relpath", fake_relpath)
+
+        assert completer._get_project_files() == ["ok.py", "relative.md"]
 
 
 # ── SUBCOMMANDS extraction ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- guard project-wide `@` file completion against invalid absolute paths returned by file discovery tools
- skip entries whose project-relative conversion raises `OSError` or `ValueError`, including Windows device/cross-mount paths like `\\.\nul`
- add a regression test that simulates the Windows `relpath` failure while keeping normal paths in the cache

Fixes #42016

## Tests
- `D:\agent\hermes\venv\Scripts\python.exe -m pytest -o addopts= -p no:timeout tests/hermes_cli/test_commands.py::TestSlashCommandCompleter::test_project_file_cache_skips_relpath_errors tests/hermes_cli/test_commands.py::TestSlashCommandCompleter -q`