### PR TITLE
fix(web): add runtime availability check in web_search_tool handler

### DIFF
--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -292,7 +292,7 @@ class TestUnconfiguredErrorEnvelopeParity:
             monkeypatch.delenv(k, raising=False)
 
     def test_unconfigured_search_emits_top_level_error(self, monkeypatch):
-        """``web_search_tool`` with no creds returns ``{"error": "Error searching web: ..."}``
+        """``web_search_tool`` with no creds returns ``{"error": "..."}``
         — matching main's ``tool_error()`` envelope, not a per-result shape.
         """
         from tools import web_tools
@@ -305,9 +305,10 @@ class TestUnconfiguredErrorEnvelopeParity:
 
         result = json.loads(web_tools.web_search_tool("hello world", limit=3))
         assert "error" in result, f"expected top-level 'error' key, got {result}"
-        # ``Error searching web:`` prefix comes from web_tools' top-level except handler
-        assert "Error searching web:" in result["error"]
-        assert "FIRECRAWL_API_KEY" in result["error"]
+        # Runtime availability guard returns a clear error when the configured
+        # backend is unavailable (issue #42011).
+        assert "not available" in result["error"]
+        assert "hermes tools" in result["error"]
         # No per-result burying
         assert "results" not in result
 

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -499,6 +499,7 @@ class TestWebSearchSchema:
         fake_provider.name = "parallel"
 
         with patch("tools.web_tools._get_search_backend", return_value="parallel"), \
+             patch("tools.web_tools._is_backend_available", return_value=True), \
              patch("agent.web_search_registry.get_provider", return_value=fake_provider), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
              patch.object(tools.web_tools._debug, "log_call"), \
@@ -527,6 +528,7 @@ class TestWebSearchErrorHandling:
         fake_provider.name = "firecrawl"
 
         with patch("tools.web_tools._get_search_backend", return_value="firecrawl"), \
+             patch("tools.web_tools._is_backend_available", return_value=True), \
              patch("agent.web_search_registry.get_provider", return_value=fake_provider), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
              patch.object(tools.web_tools._debug, "log_call") as mock_log_call, \
@@ -543,6 +545,60 @@ class TestWebSearchErrorHandling:
         assert "exception_type" not in result
         assert "exception_chain" not in result
         assert "traceback" not in result
+
+    def test_web_search_returns_clear_error_when_backend_unavailable(self):
+        """When the configured backend is unavailable at invocation time,
+        web_search_tool returns a structured error instead of silently
+        falling through (issue #42011)."""
+        import tools.web_tools
+
+        with patch("tools.web_tools._get_search_backend", return_value="ddgs"), \
+             patch("tools.web_tools._is_backend_available", return_value=False), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test", limit=5))
+
+        assert result["success"] is False
+        assert "ddgs" in result["error"]
+        assert "pip install ddgs" in result["error"]
+
+    def test_web_search_returns_clear_error_for_unavailable_api_backend(self):
+        """For non-ddgs backends, the error mentions API keys and hermes tools."""
+        import tools.web_tools
+
+        with patch("tools.web_tools._get_search_backend", return_value="tavily"), \
+             patch("tools.web_tools._is_backend_available", return_value=False), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test", limit=5))
+
+        assert result["success"] is False
+        assert "tavily" in result["error"]
+        assert "hermes tools" in result["error"]
+
+    def test_web_search_skips_availability_check_when_no_backend_configured(self):
+        """When _get_search_backend returns empty, the guard must not trigger."""
+        import tools.web_tools
+
+        fake_provider = MagicMock(
+            supports_search=MagicMock(return_value=True),
+        )
+        fake_provider.search.return_value = {"success": True, "data": {"web": []}}
+        fake_provider.name = "brave-free"
+
+        with patch("tools.web_tools._get_search_backend", return_value=""), \
+             patch("tools.web_tools._is_backend_available", return_value=False), \
+             patch("agent.web_search_registry.get_provider", return_value=None), \
+             patch("agent.web_search_registry.get_active_search_provider",
+                   return_value=fake_provider), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test", limit=5))
+
+        assert result["success"] is True
 
 
 class TestCheckWebApiKey:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -848,6 +848,32 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         )
 
         backend = _get_search_backend()
+
+        # Runtime availability guard: when the configured backend is
+        # explicitly set but its package / credentials are missing, fail
+        # early with an actionable error instead of silently falling
+        # through.  check_fn filters the tool from the LLM's schema list
+        # at get_definitions() time, but the handler can still be reached
+        # via the tool_call bridge or a stale context — issue #42011.
+        if backend and not _is_backend_available(backend):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"The configured web search backend '{backend}' "
+                        "is not available. "
+                        + (
+                            "Install the package with: pip install ddgs"
+                            if backend == "ddgs"
+                            else "Check that the required API key or "
+                            "environment variable is set. "
+                            "Run `hermes tools` to reconfigure."
+                        )
+                    ),
+                },
+                ensure_ascii=False,
+            )
+
         provider = _wsp_get_provider(backend) if backend else None
         if provider is None or not provider.supports_search():
             # Fall back to availability-walked active provider when the

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -860,7 +860,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 {
                     "success": False,
                     "error": (
-                        f"The configured web search backend '{backend}' "
+                        f"Error: configured web search backend '{backend}' "
                         "is not available. "
                         + (
                             "Install the package with: pip install ddgs"


### PR DESCRIPTION
## What does this PR do?

Adds a runtime availability check at the beginning of `web_search_tool()` so that when the configured web search backend (e.g. `ddgs`) is unavailable at invocation time, the tool returns a clear, actionable error instead of silently falling through to provider-internal error handling.

## Related Issue

Fixes #42011

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/web_tools.py`: Added `_is_backend_available(backend)` guard after `_get_search_backend()` in `web_search_tool()`. When the configured backend is not available, returns `{"success": false, "error": "..."}` with backend-specific installation instructions before the provider dispatch path is entered.
- `tests/tools/test_web_tools_config.py`: Added 3 new tests — unavailable ddgs backend, unavailable API-key backend, and empty-backend passthrough. Updated 2 existing tests to mock `_is_backend_available`.
- `tests/tools/test_web_providers.py`: Updated `test_unconfigured_search_emits_top_level_error` to match the new error message format.

## How to Test

1. Set `web.backend: ddgs` in `~/.hermes/config.yaml`
2. Ensure the `ddgs` package is NOT installed: `pip uninstall ddgs`
3. Call `web_search` tool — should return `{"success": false, "error": "The configured web search backend 'ddgs' is not available. Install the package with: pip install ddgs"}`
4. Run `pytest tests/tools/test_web_tools_config.py tests/tools/test_web_providers.py tests/tools/test_web_providers_ddgs.py -v` — all tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/web_tools.py::web_search_tool` (callers: 1 via registry handler lambda)
- Blast radius: LOW — additive guard at handler entry; existing provider-internal error handling unchanged
- Related patterns: `check_web_api_key()` at `get_definitions()` time, `_is_backend_available()` shared with `_get_capability_backend()`
