### PR TITLE
fix(cli): stop .env sanitizer from corrupting valid secret values

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5404,17 +5404,78 @@ def invalidate_env_cache() -> None:
     _env_cache = None
 
 
+def _split_concatenated_env_pairs(stripped: str, known_keys: set) -> Optional[list]:
+    """Split a line that is a concatenation of >=2 known ``KEY=VALUE`` pairs.
+
+    Returns the list of ``"KEY=VALUE"`` segments, or ``None`` when the line is
+    not *safely* splittable so the caller can leave it untouched.
+
+    Splitting on a known ``KEY=`` found at an arbitrary position corrupts
+    perfectly valid single-value lines: a secret whose value legitimately
+    embeds a known key name (URL query strings, passwords) was being
+    truncated and a phantom entry fabricated. Two rules keep that from
+    happening:
+
+    * **Anchor the first segment to position 0.** The line must START with a
+      known ``KEY=``; otherwise it is not a recognizable concatenation and we
+      return ``None`` (the caller emits it verbatim). This also stops the old
+      behaviour of silently dropping any text before the first match.
+    * **Never split inside a URL value.** A following known ``KEY=`` is only
+      accepted as a boundary when the value accumulated so far is not URL-like
+      (does not contain ``"://"``). URL query strings embed ``name=value``
+      pairs whose names may collide with Hermes key names, and splitting there
+      would mangle the URL.
+
+    Overlapping suffix collisions are handled by dropping matches fully
+    contained inside a longer needle (e.g. ``LM_API_KEY=`` inside
+    ``GLM_API_KEY=``).
+    """
+    match_ranges: list[tuple[int, int]] = []
+    for key_name in known_keys:
+        needle = key_name + "="
+        idx = stripped.find(needle)
+        while idx >= 0:
+            match_ranges.append((idx, idx + len(needle)))
+            idx = stripped.find(needle, idx + len(needle))
+
+    starts = sorted({
+        s for s, e in match_ranges
+        if not any(
+            s2 <= s and e2 >= e and (s2, e2) != (s, e)
+            for s2, e2 in match_ranges
+        )
+    })
+
+    # The line must begin with a known key for us to treat it as concatenated
+    # pairs. Anything else is left verbatim.
+    if not starts or starts[0] != 0:
+        return None
+
+    segments: list[str] = []
+    seg_start = 0
+    for nxt in starts[1:]:
+        # Don't break a URL value (its query string can embed key-like names).
+        if "://" in stripped[seg_start:nxt]:
+            continue
+        segments.append(stripped[seg_start:nxt])
+        seg_start = nxt
+    segments.append(stripped[seg_start:])
+
+    cleaned = [seg.strip() for seg in segments if seg.strip()]
+    return cleaned if len(cleaned) >= 2 else None
+
+
 def _sanitize_env_lines(lines: list) -> list:
     """Fix corrupted .env lines before reading or writing.
 
-    Handles two known corruption patterns:
-    1. Concatenated KEY=VALUE pairs on a single line (missing newline between
-       entries, e.g. ``ANTHROPIC_API_KEY=sk-...OPENAI_BASE_URL=https://...``).
-    2. Stale ``KEY=***`` placeholder entries left by incomplete setup runs.
+    Handles the known corruption pattern of concatenated KEY=VALUE pairs on a
+    single line (missing newline between entries, e.g.
+    ``ANTHROPIC_API_KEY=sk-...OPENAI_BASE_URL=https://...``).
 
     Uses a known-keys set (OPTIONAL_ENV_VARS + _EXTRA_ENV_KEYS) so we only
-    split on real Hermes env var names, avoiding false positives from values
-    that happen to contain uppercase text with ``=``.
+    split on real Hermes env var names, and only when the line is safely
+    recognizable as a concatenation (see :func:`_split_concatenated_env_pairs`)
+    — valid single-value lines are never altered.
     """
     # Build the known keys set lazily from OPTIONAL_ENV_VARS + extras.
     # Done inside the function so OPTIONAL_ENV_VARS is guaranteed to be defined.
@@ -5430,36 +5491,12 @@ def _sanitize_env_lines(lines: list) -> list:
             sanitized.append(raw + "\n")
             continue
 
-        # Detect concatenated KEY=VALUE pairs on one line.
-        # Search for known KEY= patterns at any position in the line.
-        # We collect full needle ranges so we can drop matches that are
-        # fully contained within a longer overlapping needle. Without this,
-        # suffix collisions corrupt the file: e.g. LM_API_KEY= inside
-        # GLM_API_KEY= would otherwise split the line into "G\nLM_API_KEY=...".
-        match_ranges: list[tuple[int, int]] = []
-        for key_name in known_keys:
-            needle = key_name + "="
-            idx = stripped.find(needle)
-            while idx >= 0:
-                match_ranges.append((idx, idx + len(needle)))
-                idx = stripped.find(needle, idx + len(needle))
-
-        split_positions = sorted({
-            s for s, e in match_ranges
-            if not any(
-                s2 <= s and e2 >= e and (s2, e2) != (s, e)
-                for s2, e2 in match_ranges
-            )
-        })
-
-        if len(split_positions) > 1:
-            for i, pos in enumerate(split_positions):
-                end = split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
-                part = stripped[pos:end].strip()
-                if part:
-                    sanitized.append(part + "\n")
-        else:
+        segments = _split_concatenated_env_pairs(stripped, known_keys)
+        if segments is None:
             sanitized.append(stripped + "\n")
+        else:
+            for part in segments:
+                sanitized.append(part + "\n")
 
     return sanitized
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1488,6 +1488,7 @@ AUTHOR_MAP = {
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
     "42903577+ohMyJason@users.noreply.github.com": "ohMyJason",  # PR #29810 (discover_models in custom_providers section 4)
     "singhsanidhya741@gmail.com": "sanidhyasin",  # PR #40403 salvage (model.default_headers for custom OpenAI-compatible providers, #40033)
+    "214165399+kernel-t1@users.noreply.github.com": "kernel-t1",  # .env sanitizer no longer splits inside URL/value-embedded keys
 }
 
 

--- a/tests/hermes_cli/test_env_sanitize_on_load.py
+++ b/tests/hermes_cli/test_env_sanitize_on_load.py
@@ -63,6 +63,55 @@ def test_load_env_normal_file_unchanged():
         env_path.unlink(missing_ok=True)
 
 
+def test_load_env_preserves_url_value_with_embedded_key():
+    """A valid single value whose URL embeds a known KEY= must not be split.
+
+    Regression: ``_sanitize_env_lines`` used to scan for any known ``KEY=``
+    at any position, so a URL query string like
+    ``...?TELEGRAM_HOME_CHANNEL=123`` was treated as a concatenation boundary.
+    The URL got truncated and a phantom ``TELEGRAM_HOME_CHANNEL`` entry was
+    fabricated.
+    """
+    from hermes_cli.config import load_env
+
+    url = "http://localhost:8080/v1/send?TELEGRAM_HOME_CHANNEL=123"
+    content = f"SIGNAL_HTTP_URL={url}\n"
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".env", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(content)
+        env_path = Path(f.name)
+
+    try:
+        with patch("hermes_cli.config.get_env_path", return_value=env_path):
+            result = load_env()
+        assert result.get("SIGNAL_HTTP_URL") == url, (
+            f"URL should round-trip intact, got {result.get('SIGNAL_HTTP_URL')!r}"
+        )
+        # The embedded query parameter must NOT become its own env var.
+        assert "TELEGRAM_HOME_CHANNEL" not in result
+    finally:
+        env_path.unlink(missing_ok=True)
+
+
+def test_sanitize_does_not_drop_leading_text():
+    """Text before the first known key must never be silently dropped.
+
+    Regression: when a line contained two or more known keys but did not
+    start with one (e.g. an ``export `` prefix), the splitter began at the
+    first match position and discarded everything before it.
+    """
+    from hermes_cli.config import _sanitize_env_lines
+
+    line = "export OPENAI_API_KEY=sk-aOPENAI_BASE_URL=https://example.test\n"
+    out = _sanitize_env_lines([line])
+
+    assert out == [line.rstrip("\r\n") + "\n"], (
+        f"Line not starting with a known key must be left verbatim, got {out!r}"
+    )
+
+
 def test_env_loader_sanitizes_before_dotenv():
     """Verify env_loader._sanitize_env_file_if_needed fixes corrupted files."""
     from hermes_cli.env_loader import _sanitize_env_file_if_needed


### PR DESCRIPTION
## What does this PR do?

Some users hit gateway/CLI auth that suddenly failed with no error, after a
`.env` value that had been working got silently mangled. The cause is the
`.env` sanitizer: `_sanitize_env_lines()` scanned every line for any known
`KEY=` substring *at any position* and split there. When a perfectly valid
value legitimately contained a known key name — most often a URL whose query
string carries `?TELEGRAM_HOME_CHANNEL=...`, or a password — the line was cut
in two: the real value got truncated and a phantom env var was fabricated.
Because this runs on every `load_env()` cache miss and `save_env_value()`
later writes the split lines back, the damage became permanent on disk. A
related defect dropped any text before the first match (e.g. an `export `
prefix), losing part of the line.

The fix makes the sanitizer conservative: it only treats a line as
concatenated `KEY=VALUE` pairs when the line actually *starts* with a known
key, and it never breaks inside a URL value. Genuinely concatenated lines (a
missing newline between two real entries) are still repaired; valid
single-value lines are now left untouched.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: extracted the splitting logic into a new
  `_split_concatenated_env_pairs()` helper that (a) requires the first known
  `KEY=` to sit at position 0, otherwise the line is emitted verbatim so
  leading text is never dropped, and (b) refuses to split at a following key
  when the value accumulated so far is URL-like (contains `://`), so query
  strings are preserved. `_sanitize_env_lines()` now delegates to it. The
  existing suffix-collision handling (`LM_API_KEY` inside `GLM_API_KEY`) is
  retained.
- `tests/hermes_cli/test_env_sanitize_on_load.py`: added regression tests for
  a URL value with an embedded key name and for the dropped-leading-text case.
- `scripts/release.py`: added author email to `AUTHOR_MAP`.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_env_sanitize_on_load.py` — all
   pass, including the two new regression tests.
2. Reproduce the corruption: put
   `SIGNAL_HTTP_URL=http://localhost:8080/v1/send?TELEGRAM_HOME_CHANNEL=123`
   in `~/.hermes/.env`, then run
   `python -c "from hermes_cli.config import load_env; print(load_env())"`.
   Before this change the URL is truncated and a bogus `TELEGRAM_HOME_CHANNEL`
   key appears; after, the URL round-trips intact and no phantom key is added.
3. Confirm legitimate concatenation still repairs:
   `TELEGRAM_BOT_TOKEN=xxxANTHROPIC_API_KEY=sk-...` is still split into two
   separate entries.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant env/config tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings updated) — or N/A
- [x] N/A — no config keys added/changed, so `cli-config.yaml.example` is untouched
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (logic is pure string handling) — or N/A
- [x] N/A — no tool description/schema change