### PR TITLE
fix(agent): lazily resolve steer prompt note

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -36,7 +36,6 @@ from agent.prompt_builder import (
     PLATFORM_HINTS,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
-    STEER_CHANNEL_NOTE,
     TASK_COMPLETION_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
@@ -135,6 +134,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Steering only lands inside tool results, so it's only reachable when the
     # agent has tools. Static text → byte-stable prompt (no cache hit).
     if agent.valid_tool_names:
+        from agent.prompt_builder import STEER_CHANNEL_NOTE
         stable_parts.append(STEER_CHANNEL_NOTE)
 
     # Computer-use (macOS) — goes in as its own block rather than being

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -55,3 +55,17 @@ class TestContextFileCwd:
     def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
+
+    def test_steer_note_is_resolved_when_prompt_is_built(self):
+        agent = _make_agent(valid_tool_names=["terminal"])
+
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+            patch("agent.prompt_builder.STEER_CHANNEL_NOTE", "LAZY_STEER_NOTE"),
+        ):
+            parts = build_system_prompt_parts(agent)
+
+        assert "LAZY_STEER_NOTE" in parts["stable"]


### PR DESCRIPTION
## Summary
- remove the top-level `STEER_CHANNEL_NOTE` binding from `agent.system_prompt`
- resolve the steer note lazily when building the system prompt, matching the existing lazy pattern for other prompt-builder guidance blocks
- add a regression test that proves the note is read at prompt-build time while preserving the existing steer marker contract

Fixes #41986

## Tests
- `D:\agent\hermes\venv\Scripts\python.exe -m pytest -o addopts= -p no:timeout tests/agent/test_system_prompt.py tests/run_agent/test_steer.py::TestSteerMarkerContract -q`