### PR TITLE
fix(config): stop version migrations from freezing defaults into config.yaml

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4289,7 +4289,10 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     
     # ── Version 3 → 4: migrate tool progress from .env to config.yaml ──
     if current_ver < 4:
-        config = load_config()
+        # Read the user's raw config, not the defaults-merged view: save_config()
+        # persists exactly what it's given, so starting from load_config() would
+        # freeze the entire DEFAULT_CONFIG tree into the user's config.yaml.
+        config = read_raw_config()
         display = config.get("display", {})
         if not isinstance(display, dict):
             display = {}
@@ -4312,7 +4315,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     
     # ── Version 4 → 5: add timezone field ──
     if current_ver < 5:
-        config = load_config()
+        config = read_raw_config()
         if "timezone" not in config:
             old_tz = os.getenv("HERMES_TIMEZONE", "")
             if old_tz and old_tz.strip():
@@ -4340,7 +4343,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
 
     # ── Version 11 → 12: migrate custom_providers list → providers dict ──
     if current_ver < 12:
-        config = load_config()
+        config = read_raw_config()
         custom_list = config.get("custom_providers")
         if isinstance(custom_list, list) and custom_list:
             providers_dict = config.get("providers", {})
@@ -4808,8 +4811,12 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         config["_config_version"] = latest_ver
         save_config(config)
     elif current_ver < latest_ver:
-        # Just update version
-        config = load_config()
+        # Just update version. Read the raw on-disk config rather than the
+        # defaults-merged view so we don't rewrite the user's minimal
+        # config.yaml into the full DEFAULT_CONFIG tree — this branch fires on
+        # every version bump, so load_config() here would freeze defaults for
+        # everyone who upgrades and stop future default changes from reaching them.
+        config = read_raw_config()
         config["_config_version"] = latest_ver
         save_config(config)
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -918,7 +918,12 @@ class TestDiscordChannelPromptsConfig:
     def test_default_config_includes_discord_channel_prompts(self):
         assert DEFAULT_CONFIG["discord"]["channel_prompts"] == {}
 
-    def test_migrate_adds_discord_channel_prompts_default(self, tmp_path):
+    def test_migrate_does_not_freeze_channel_prompts_default(self, tmp_path):
+        # No migration block writes ``discord.channel_prompts`` — it is a pure
+        # DEFAULT_CONFIG value supplied at read time by ``load_config()``'s
+        # deep-merge. Migrating an upgrading user must not freeze that default
+        # into their raw config.yaml; their file should keep only the keys they
+        # actually set (plus the bumped version).
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
             yaml.safe_dump({"_config_version": 17, "discord": {"auto_thread": True}}),
@@ -928,11 +933,57 @@ class TestDiscordChannelPromptsConfig:
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            # The default is still available to the running agent via deep-merge.
+            assert load_config()["discord"]["channel_prompts"] == {}
 
         from hermes_cli.config import DEFAULT_CONFIG
         assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
         assert raw["discord"]["auto_thread"] is True
-        assert raw["discord"]["channel_prompts"] == {}
+        assert "channel_prompts" not in raw["discord"]
+
+
+class TestMigrationDoesNotFreezeDefaults:
+    """A config-version bump must preserve the user's minimal config.yaml
+    instead of rewriting the full DEFAULT_CONFIG tree into it.
+
+    Regression: the version-bump path used ``load_config()`` (defaults merged)
+    and handed the result straight to ``save_config()`` (which persists exactly
+    what it's given), freezing every default into the user's file on every
+    upgrade — so later DEFAULT_CONFIG changes silently stopped reaching them.
+    """
+
+    def test_version_bump_keeps_config_minimal(self, tmp_path):
+        latest = DEFAULT_CONFIG["_config_version"]
+        # ``latest - 1`` triggers no version-specific migration block, so only
+        # the generic version-bump path runs — isolating the behavior under test.
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": latest - 1,
+                    "model": {"default": "openai/gpt-5.4", "provider": "openrouter"},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        # Version bumped and the user's own keys are preserved.
+        assert raw["_config_version"] == latest
+        assert raw["model"] == {"default": "openai/gpt-5.4", "provider": "openrouter"}
+
+        # The full DEFAULT_CONFIG tree must NOT be frozen into the file. Only
+        # the keys the user set survive (``agent.max_turns`` is a benign save
+        # normalization). Representative default-only sections the user never
+        # touched stay out of config.yaml so future default changes reach them.
+        for section in ("compression", "terminal", "display", "discord", "toolsets"):
+            assert section not in raw, (
+                f"default-only section {section!r} was frozen into config.yaml"
+            )
+        assert set(raw.keys()) <= {"_config_version", "model", "agent"}
 
 
 class TestUserMessagePreviewConfig:


### PR DESCRIPTION
## What does this PR do?

`migrate_config()` rewrote each upgrading user's minimal config.yaml into the
full DEFAULT_CONFIG tree. The version-bump path and the v3→4/v4→5/v11→12 blocks
read through `load_config()` (defaults deep-merged) and passed the result to
`save_config()`, which persists exactly what it's given. The version-bump fires
on every upgrade, so all defaults got frozen on disk — later DEFAULT_CONFIG
changes then stopped reaching that user. These paths now use `read_raw_config()`,
matching every v14+ block.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: `migrate_config()` reads `read_raw_config()` instead of
  `load_config()` in the v3→4, v4→5, v11→12 blocks and the version-bump path, so
  only the user's own keys (plus the bumped version) are written.
- `tests/hermes_cli/test_config.py`: added `TestMigrationDoesNotFreezeDefaults`;
  fixed the discord test that asserted the old churn behavior.

## How to Test

1. Write a minimal config.yaml at `_config_version: latest-1` with one `model` key.
2. Run `migrate_config(interactive=False, quiet=True)`.
3. Saved config.yaml keeps only the user's keys + bumped version — no default-only sections.
4. `pytest tests/hermes_cli/test_config.py -q` → 96 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A