### PR TITLE
fix(gateway): send background process notifications as DMs, not synthetic agent messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12048,23 +12048,17 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                             break
                     if adapter and source.chat_id:
                         try:
-                            synth_event = MessageEvent(
-                                text=synth_text,
-                                message_type=MessageType.TEXT,
-                                source=source,
-                                internal=True,
-                                message_id=message_id,
-                            )
+                            send_meta = {"thread_id": source.thread_id} if source.thread_id else None
                             logger.info(
-                                "Process %s finished — injecting agent notification for session %s chat=%s thread=%s",
+                                "Process %s finished — notifying user via %s chat=%s thread=%s",
                                 session_id,
-                                session_key,
+                                source.platform.value if source.platform else "?",
                                 source.chat_id,
                                 source.thread_id,
                             )
-                            await adapter.handle_message(synth_event)
+                            await adapter.send(source.chat_id, synth_text, metadata=send_meta)
                         except Exception as e:
-                            logger.error("Agent notify injection error: %s", e)
+                            logger.error("Agent notify delivery error: %s", e)
                     break
 
                 # --- Normal text-only notification ---


### PR DESCRIPTION
## What does this PR do?

Background processes started with `notify_on_complete=true` on gateway platforms (Telegram, Discord, etc.) were creating a synthetic `MessageEvent` and calling `adapter.handle_message()`. This routed the completion notification back through the gateway message handler as a new inbound message, causing the agent to treat each process completion as a user message and respond to it — producing duplicate/spurious responses.

The fix uses `adapter.send()` instead, which delivers a DM to the user's chat without re-entering the agent loop.

This is the gateway counterpart of PR #41878, which fixed the same class of bug in the CLI path.

## Related Issue

Related: #41878 (CLI-side fix: notify_on_complete notifications injected into _pending_input as pseudo-user messages)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: In `_run_process_watcher`, replace `MessageEvent(...)` + `adapter.handle_message(synth_event)` with `adapter.send(chat_id, text, metadata=send_meta)`. Completion notifications are now delivered directly to the user chat instead of injected into the agent session.

## How to Test

1. Start a background process from a gateway platform (e.g. Telegram) with `notify_on_complete=true`
2. Let the process finish
3. **Before**: The agent responds again as if the user sent a new message asking about the process completion
4. **After**: A DM appears in the chat with the completion info, but no new agent turn is triggered

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've considered cross-platform impact — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before** (gateway.log):
```
Process proc_095a828b4e48 finished — injecting agent notification for session agent:main:telegram:dm:8726716690 chat=8726716690 thread=None
inbound message: platform=telegram user=Argon chat=8726716690 msg='[IMPORTANT: Background process proc_095a828b4e48 completed ...'
```

**After**: Message is sent via `adapter.send()` — no synthetic inbound message, no agent loop re-entry.
