### PR TITLE
fix(vision): match DeepSeek single-quote image-rejection error and gu…

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1961,9 +1961,12 @@ def run_conversation(
                     "image_url'. expected",
                     # DeepSeek's OpenAI-compatible API reports text-only
                     # request-body variants as:
-                    # "unknown variant `image_url`, expected `text`".
+                    # "unknown variant `image_url`, expected `text`"
+                    # or "unknown variant 'image_url', expected 'text'".
                     "unknown variant `image_url`, expected `text`",
+                    "unknown variant 'image_url', expected 'text'",
                     "unknown variant image_url, expected text",
+                    "unknown variant 'image_url'",
                 )
                 _err_lower = _err_body.lower()
                 _looks_like_image_rejection = any(

--- a/run_agent.py
+++ b/run_agent.py
@@ -4402,8 +4402,26 @@ class AIAgent:
         not receive those image parts, because a rejected tool result becomes
         part of the canonical history and can make the next user turn fail before
         the agent has a chance to recover.
+
+        Non-_multimodal results may still carry image parts as list-type
+        content (e.g. MCP tools that return image_url blocks).  When the
+        active model is text-only, proactively strip those images.
         """
         if not _is_multimodal_tool_result(result):
+            if isinstance(result, list) and self._content_has_image_parts(result):
+                if not self._model_supports_vision():
+                    text_parts = []
+                    for p in result:
+                        if isinstance(p, dict) and p.get("type") == "text":
+                            text_parts.append(str(p.get("text", "")))
+                        elif isinstance(p, dict) and p.get("type") in {"image_url", "input_image", "image"}:
+                            text_parts.append("[screenshot]")
+                    logger.warning(
+                        "Tool %s returned non-_multimodal image content for "
+                        "non-vision model %s/%s; falling back to text summary",
+                        tool_name, self.provider, self.model,
+                    )
+                    return "\n".join(text_parts) if text_parts else "[image content removed]"
             return result
 
         content = result.get("content") or []


### PR DESCRIPTION
## Problem

When using DeepSeek (text-only model) with computer_use or MCP cua-driver tools, image content blocks (screenshots) cause HTTP 400 errors:

```
unknown variant 'image_url', expected 'text'
```

Two root causes:

### 1. Image rejection detection misses DeepSeek's actual error format

DeepSeek returns errors with **single quotes** (`'image_url'`), but `_IMAGE_REJECTION_PHRASES` only matched backtick and quoteless variants. The reactive image-stripping recovery never triggered.

### 2. Non-`_multimodal` list-type tool content bypasses proactive guard

`_tool_result_content_for_active_model` only stripped images from `_multimodal` envelopes. Tool results from MCP tools (or other sources) returning plain list-type content with `image_url` parts passed through unmodified to text-only models, causing HTTP 400.

## What does this PR do?

Fixes two gaps in vision/image routing for text-only models:

- **Reactive recovery**: Adds single-quote DeepSeek error variants to the image-rejection phrase list so the session-level stripping fallback triggers on DeepSeek's actual error format
- **Proactive guard**: Extends `_tool_result_content_for_active_model` to inspect non-`_multimodal` list-type tool results for image parts, stripping them before they reach a text-only model

## Changes Made

- **`agent/conversation_loop.py`** (+2 phrases): Added `"unknown variant 'image_url', expected 'text'"` and `"unknown variant 'image_url'"` to `_IMAGE_REJECTION_PHRASES`
- **`run_agent.py`** (+18 lines): Added image-stripping logic for list-type content without `_multimodal` wrapper in `_tool_result_content_for_active_model`

## How to Test

1. Configure DeepSeek as primary model with `auxiliary.vision` pointing to a vision-capable endpoint (e.g. doubao on volcano engine)
2. Run computer_use on macOS — captured screenshots should route through aux vision (existing #24015 fix) or be proactively stripped
3. Verify no HTTP 400 `unknown variant 'image_url'` errors appear
4. Run existing tests: `pytest tests/run_agent/test_multimodal_tool_content_recovery.py tests/run_agent/test_image_rejection_fallback.py tests/tools/test_computer_use_vision_routing.py`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run relevant tests and all pass
- [x] I've tested on macOS 15.7.5

### Documentation & Housekeeping

- [x] N/A — no docs changes needed (internal error-handling fix)
- [x] N/A — no config key changes
- [x] N/A — no architecture changes
- [x] N/A — platform-agnostic (provider-level image routing)
- [x] N/A — no tool behavior changes
