### PR TITLE
fix(desktop): read icon as buffer to support asar packaging

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3070,7 +3070,16 @@ function registerPowerResumeListeners() {
 }
 
 function getAppIconPath() {
-  return APP_ICON_PATHS.find(fileExists)
+  const found = APP_ICON_PATHS.find(fileExists)
+  if (!found) return null
+  // nativeImage.createFromPath() cannot read from inside asar archives,
+  // so read the file as a buffer (fs works transparently through asar)
+  // and create the NativeImage from the buffer instead.
+  try {
+    return nativeImage.createFromBuffer(fs.readFileSync(found))
+  } catch {
+    return null
+  }
 }
 
 function sendOpenUpdatesRequested() {


### PR DESCRIPTION
**Problem:** `getAppIconPath()` returns a file path string, but callers expect a `NativeImage`. `nativeImage.createFromPath()` fails when the path points inside an asar archive.

**Fix:** Read the file as a buffer first (`fs.readFileSync` works transparently through asar) and create the `NativeImage` from the buffer instead. Falls back to `null` if the file is missing or unreadable.

Closes: # (no issue filed)