### PR TITLE
fix(title): generate session titles in the conversation's language

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -22,6 +22,8 @@ TitleCallback = Callable[[str], None]
 _TITLE_PROMPT = (
     "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
     "following exchange. The title should capture the main topic or intent. "
+    "Write the title in the SAME LANGUAGE as the conversation (e.g. a Chinese conversation "
+    "gets a Chinese title, an English conversation gets an English title). "
     "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
 )
 


### PR DESCRIPTION
## Problem

Session titles are auto-generated by `agent/title_generator.py` using a single English-only system prompt (`_TITLE_PROMPT`). The prompt contains no instruction about output language, so the auxiliary LLM defaults to English **even when the conversation itself is in another language**.

As a result, a fully Chinese (or Japanese, Spanish, etc.) conversation gets an English title, which is jarring and inconsistent with the conversation content.

## Fix

Add one explicit instruction to the title prompt: write the title in the **same language as the conversation**. This makes titles language-adaptive — a Chinese conversation gets a Chinese title, an English conversation gets an English title — without forcing any particular language.

```diff
 _TITLE_PROMPT = (
     "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
     "following exchange. The title should capture the main topic or intent. "
+    "Write the title in the SAME LANGUAGE as the conversation (e.g. a Chinese conversation "
+    "gets a Chinese title, an English conversation gets an English title). "
     "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
 )
```

## Notes

- Minimal, low-risk change: only affects the language of newly generated titles.
- No behavior change for English conversations.
- No new dependencies, no API/schema change.
