### PR TITLE
fix(cron): centralize Telegram private topic delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -430,6 +430,33 @@ def _get_home_target_thread_id(platform_name: str) -> Optional[str]:
     return value or None
 
 
+def _parse_telegram_named_private_topic_target(rest: str) -> Optional[tuple[str, str]]:
+    """Parse ``<private_chat_id>:<topic name>`` cron targets.
+
+    ``tools.send_message_tool._parse_target_ref`` intentionally only accepts
+    numeric Telegram thread IDs. Cron must preserve named private-chat topics
+    so the gateway delivery layer can resolve/create the current
+    ``message_thread_id`` through ``TelegramAdapter.ensure_dm_topic()``.
+    """
+
+    if ":" not in str(rest):
+        return None
+    chat_id, topic_name = str(rest).split(":", 1)
+    chat_id = chat_id.strip()
+    topic_name = topic_name.strip()
+    if not chat_id or not topic_name:
+        return None
+
+    try:
+        from gateway.delivery import is_named_telegram_private_topic_target
+    except Exception:
+        return None
+
+    if not is_named_telegram_private_topic_target("telegram", chat_id, topic_name):
+        return None
+    return chat_id, topic_name
+
+
 def _iter_home_target_platforms():
     """Iterate built-in + plugin platform names that expose a home channel.
 
@@ -524,6 +551,17 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
     if ":" in deliver_value:
         platform_name, rest = deliver_value.split(":", 1)
         platform_key = platform_name.lower()
+
+        named_telegram_private_topic = None
+        if platform_key == "telegram":
+            named_telegram_private_topic = _parse_telegram_named_private_topic_target(rest)
+        if named_telegram_private_topic:
+            chat_id, topic_name = named_telegram_private_topic
+            return {
+                "platform": platform_name,
+                "chat_id": chat_id,
+                "thread_id": topic_name,
+            }
 
         from tools.send_message_tool import _parse_target_ref
 
@@ -673,52 +711,97 @@ def _send_media_via_adapter(
     loop,
     job: dict,
     platform=None,
-) -> None:
+    *,
+    named_telegram_private_topic: bool = False,
+    delivery_target=None,
+    prepared_send=None,
+) -> Optional[str]:
     """Send extracted MEDIA files as native platform attachments via a live adapter.
 
     Routes each file to the appropriate adapter method (send_voice, send_image_file,
     send_video, send_document) based on file extension — mirroring the routing logic
     in ``BasePlatformAdapter._process_message_background``.
+
+    Returns an error string only for fail-closed delivery paths. Existing
+    non-critical media behavior is preserved for other targets: failed
+    attachments are logged, while the text delivery can still count as delivered.
     """
     from pathlib import Path
 
+    from agent.async_utils import safe_schedule_threadsafe
+    from gateway.delivery import (
+        is_thread_not_found_delivery_error,
+        refresh_named_telegram_private_topic_metadata,
+        send_result_error,
+        send_result_failed,
+    )
     from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
-
-    for media_path, _is_voice in media_files:
+    def wait_for_media_coro(coro, timeout: int = 30):
+        future = safe_schedule_threadsafe(coro, loop)
+        if future is None:
+            raise RuntimeError("gateway loop unavailable")
         try:
-            ext = Path(media_path).suffix.lower()
-            route_platform = platform if platform is not None else getattr(adapter, "platform", None)
-            if should_send_media_as_audio(route_platform, ext, is_voice=_is_voice):
-                coro = adapter.send_voice(chat_id=chat_id, audio_path=media_path, metadata=metadata)
-            elif ext in _VIDEO_EXTS:
-                coro = adapter.send_video(chat_id=chat_id, video_path=media_path, metadata=metadata)
-            elif ext in _IMAGE_EXTS:
-                coro = adapter.send_image_file(chat_id=chat_id, image_path=media_path, metadata=metadata)
-            else:
-                coro = adapter.send_document(chat_id=chat_id, file_path=media_path, metadata=metadata)
+            return future.result(timeout=timeout)
+        except TimeoutError:
+            future.cancel()
+            raise
 
-            from agent.async_utils import safe_schedule_threadsafe
-            future = safe_schedule_threadsafe(coro, loop)
-            if future is None:
-                logger.warning(
-                    "Job '%s': cannot send media %s, gateway loop unavailable",
-                    job.get("id", "?"), media_path,
-                )
-                return
-            try:
-                result = future.result(timeout=30)
-            except TimeoutError:
-                future.cancel()
-                raise
-            if result and not getattr(result, "success", True):
-                logger.warning(
-                    "Job '%s': media send failed for %s: %s",
-                    job.get("id", "?"), media_path, getattr(result, "error", "unknown"),
-                )
+    def build_media_coro(media_path: str, is_voice: bool, send_metadata: dict | None):
+        ext = Path(media_path).suffix.lower()
+        route_platform = platform if platform is not None else getattr(adapter, "platform", None)
+        if should_send_media_as_audio(route_platform, ext, is_voice=is_voice):
+            return adapter.send_voice(chat_id=chat_id, audio_path=media_path, metadata=send_metadata)
+        if ext in _VIDEO_EXTS:
+            return adapter.send_video(chat_id=chat_id, video_path=media_path, metadata=send_metadata)
+        if ext in _IMAGE_EXTS:
+            return adapter.send_image_file(chat_id=chat_id, image_path=media_path, metadata=send_metadata)
+        return adapter.send_document(chat_id=chat_id, file_path=media_path, metadata=send_metadata)
+
+    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    send_metadata = metadata
+
+    for media_path, is_voice in media_files:
+        try:
+            result = wait_for_media_coro(
+                build_media_coro(str(media_path), is_voice, send_metadata),
+            )
+            if result and send_result_failed(result):
+                if (
+                    named_telegram_private_topic
+                    and prepared_send is not None
+                    and delivery_target is not None
+                    and is_thread_not_found_delivery_error(result)
+                ):
+                    prepared_send = wait_for_media_coro(
+                        refresh_named_telegram_private_topic_metadata(
+                            adapter,
+                            delivery_target,
+                            prepared_send,
+                        ),
+                        timeout=60,
+                    )
+                    send_metadata = prepared_send.metadata
+                    result = wait_for_media_coro(
+                        build_media_coro(str(media_path), is_voice, send_metadata),
+                    )
+
+                if result and send_result_failed(result):
+                    err = send_result_error(result) or "unknown"
+                    logger.warning(
+                        "Job '%s': media send failed for %s: %s",
+                        job.get("id", "?"), media_path, err,
+                    )
+                    if named_telegram_private_topic:
+                        topic_name = getattr(prepared_send, "named_telegram_private_topic_name", None) or "?"
+                        return f"Telegram named private DM topic '{topic_name}' media delivery failed: {err}"
         except Exception as e:
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
+            if named_telegram_private_topic:
+                topic_name = getattr(prepared_send, "named_telegram_private_topic_name", None) or "?"
+                return f"Telegram named private DM topic '{topic_name}' media delivery failed: {e}"
+
+    return None
 
 
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
@@ -820,51 +903,135 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)
+        live_loop_running = runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)()
+
+        from gateway.delivery import (
+            DeliveryTarget,
+            is_named_telegram_private_topic_target,
+            is_telegram_private_topic_target,
+            is_thread_not_found_delivery_error,
+            prepare_platform_send_metadata,
+            refresh_named_telegram_private_topic_metadata,
+            send_result_error,
+            send_result_failed,
+        )
+
+        delivery_target = DeliveryTarget(
+            platform=platform,
+            chat_id=str(chat_id),
+            thread_id=str(thread_id) if thread_id is not None else None,
+            is_explicit=True,
+        )
+        named_telegram_private_topic = is_named_telegram_private_topic_target(
+            platform,
+            str(chat_id),
+            str(thread_id) if thread_id is not None else None,
+        )
+        telegram_private_topic = is_telegram_private_topic_target(
+            platform,
+            str(chat_id),
+            str(thread_id) if thread_id is not None else None,
+        )
+        if telegram_private_topic and not named_telegram_private_topic:
+            msg = (
+                f"Telegram private DM topic thread_id '{thread_id}' for chat {chat_id} "
+                "requires a reply anchor; use a named Telegram topic target"
+            )
+            logger.error("Job '%s': %s", job["id"], msg)
+            delivery_errors.append(msg)
+            continue
+        if named_telegram_private_topic and not live_loop_running:
+            msg = (
+                f"Telegram named private DM topic '{thread_id}' for chat {chat_id} "
+                "requires a live Telegram adapter"
+            )
+            logger.error("Job '%s': %s", job["id"], msg)
+            delivery_errors.append(msg)
+            continue
+
         delivered = False
-        if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
+        if live_loop_running:
+            assert runtime_adapter is not None
+            send_metadata = None
             try:
+                from agent.async_utils import safe_schedule_threadsafe
+
+                def wait_for_adapter_coro(coro, timeout: int = 60):
+                    future = safe_schedule_threadsafe(coro, loop)
+                    if future is None:
+                        raise RuntimeError("gateway loop unavailable")
+                    try:
+                        return future.result(timeout=timeout)
+                    except TimeoutError:
+                        future.cancel()
+                        raise
+
+                prepared_send = None
+                if thread_id:
+                    if named_telegram_private_topic:
+                        prepared_send = wait_for_adapter_coro(
+                            prepare_platform_send_metadata(runtime_adapter, delivery_target),
+                        )
+                        send_metadata = prepared_send.metadata
+                    else:
+                        send_metadata = {"thread_id": thread_id}
+
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
                 if text_to_send:
-                    from agent.async_utils import safe_schedule_threadsafe
-                    future = safe_schedule_threadsafe(
+                    send_result = wait_for_adapter_coro(
                         runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
-                        loop,
                     )
-                    if future is None:
-                        adapter_ok = False
-                    else:
-                        try:
-                            send_result = future.result(timeout=60)
-                        except TimeoutError:
-                            future.cancel()
-                            raise
-                        if send_result and not getattr(send_result, "success", True):
-                            err = getattr(send_result, "error", "unknown")
+                    raw_response = None
+                    if send_result and send_result_failed(send_result):
+                        if (
+                            named_telegram_private_topic
+                            and prepared_send is not None
+                            and is_thread_not_found_delivery_error(send_result)
+                        ):
+                            prepared_send = wait_for_adapter_coro(
+                                refresh_named_telegram_private_topic_metadata(
+                                    runtime_adapter,
+                                    delivery_target,
+                                    prepared_send,
+                                ),
+                            )
+                            send_metadata = prepared_send.metadata
+                            send_result = wait_for_adapter_coro(
+                                runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
+                            )
+
+                        if send_result and send_result_failed(send_result):
+                            err = send_result_error(send_result) or "unknown"
+                            if named_telegram_private_topic:
+                                msg = f"Telegram named private DM topic '{thread_id}' delivery failed: {err}"
+                                logger.error("Job '%s': %s", job["id"], msg)
+                                delivery_errors.append(msg)
+                                continue
                             logger.warning(
                                 "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",
                                 job["id"], platform_name, chat_id, err,
                             )
                             adapter_ok = False  # fall through to standalone path
-                        elif (
-                            send_result
-                            and thread_id
-                            and getattr(send_result, "raw_response", None)
-                            and send_result.raw_response.get("thread_fallback")
-                        ):
-                            requested_thread_id = send_result.raw_response.get("requested_thread_id") or thread_id
-                            msg = (
-                                f"configured thread_id {requested_thread_id} for "
-                                f"{platform_name}:{chat_id} was not found; delivered without thread_id"
-                            )
-                            logger.warning("Job '%s': %s", job["id"], msg)
-                            delivery_errors.append(msg)
+                    raw_response = getattr(send_result, "raw_response", None)
+                    if (
+                        send_result
+                        and thread_id
+                        and isinstance(raw_response, dict)
+                        and raw_response.get("thread_fallback")
+                    ):
+                        requested_thread_id = raw_response.get("requested_thread_id") or thread_id
+                        msg = (
+                            f"configured thread_id {requested_thread_id} for "
+                            f"{platform_name}:{chat_id} was not found; delivered without thread_id"
+                        )
+                        logger.warning("Job '%s': %s", job["id"], msg)
+                        delivery_errors.append(msg)
 
                 # Send extracted media files as native attachments via the live adapter
                 if adapter_ok and media_files:
-                    _send_media_via_adapter(
+                    media_error = _send_media_via_adapter(
                         runtime_adapter,
                         chat_id,
                         media_files,
@@ -872,12 +1039,23 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         loop,
                         job,
                         platform=platform,
+                        named_telegram_private_topic=named_telegram_private_topic,
+                        delivery_target=delivery_target,
+                        prepared_send=prepared_send,
                     )
+                    if media_error:
+                        delivery_errors.append(media_error)
+                        continue
 
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
             except Exception as e:
+                if named_telegram_private_topic:
+                    msg = f"Telegram named private DM topic '{thread_id}' delivery failed: {e}"
+                    logger.error("Job '%s': %s", job["id"], msg)
+                    delivery_errors.append(msg)
+                    continue
                 logger.warning(
                     "Job '%s': live adapter delivery to %s:%s failed (%s), falling back to standalone",
                     job["id"], platform_name, chat_id, e,

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -14,7 +14,7 @@ import re
 from pathlib import Path
 from datetime import datetime
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Union
 
 from hermes_cli.config import get_hermes_home
 
@@ -72,13 +72,17 @@ def _looks_like_int(value: Optional[str]) -> bool:
         return False
 
 
-def _send_result_failed(result: Any) -> bool:
+def send_result_failed(result: Any) -> bool:
     if isinstance(result, dict):
         return result.get("success") is False
     return getattr(result, "success", True) is False
 
 
-def _send_result_error(result: Any) -> Optional[str]:
+# Backward-compatible private alias for existing internal call sites.
+_send_result_failed = send_result_failed
+
+
+def send_result_error(result: Any) -> Optional[str]:
     if isinstance(result, dict):
         error = result.get("error")
     else:
@@ -86,9 +90,175 @@ def _send_result_error(result: Any) -> Optional[str]:
     return str(error) if error else None
 
 
-def _is_thread_not_found_delivery_error(result: Any) -> bool:
-    error = _send_result_error(result)
+# Backward-compatible private alias for existing internal call sites.
+_send_result_error = send_result_error
+
+
+def is_thread_not_found_delivery_error(result: Any) -> bool:
+    error = send_result_error(result)
     return bool(error and "thread not found" in error.lower())
+
+
+# Backward-compatible private alias for existing internal call sites.
+_is_thread_not_found_delivery_error = is_thread_not_found_delivery_error
+
+
+def _has_explicit_telegram_direct_topic(send_metadata: Dict[str, Any]) -> bool:
+    return (
+        "direct_messages_topic_id" in send_metadata
+        or "telegram_direct_messages_topic_id" in send_metadata
+    )
+
+
+def _platform_value(platform: Union["Platform", str]) -> str:
+    return getattr(platform, "value", str(platform)).lower()
+
+
+def is_telegram_private_topic_target(
+    platform: Union["Platform", str],
+    chat_id: Optional[str],
+    thread_id: Optional[str],
+    metadata: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Return True when a target addresses a Telegram private-chat topic lane."""
+
+    if not thread_id:
+        return False
+    send_metadata = dict(metadata or {})
+    return (
+        _platform_value(platform) == Platform.TELEGRAM.value
+        and _looks_like_telegram_private_chat_id(str(chat_id) if chat_id is not None else None)
+        and "thread_id" not in send_metadata
+        and "message_thread_id" not in send_metadata
+        and not _has_explicit_telegram_direct_topic(send_metadata)
+    )
+
+
+def is_named_telegram_private_topic_target(
+    platform: Union["Platform", str],
+    chat_id: Optional[str],
+    thread_id: Optional[str],
+    metadata: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Return True for a Telegram private-chat topic addressed by stable name.
+
+    Named private topics must be resolved through ``TelegramAdapter.ensure_dm_topic()``
+    before sending; a raw Bot API standalone send cannot safely create, refresh,
+    or fail closed for these lanes.
+    """
+
+    if not thread_id:
+        return False
+    return (
+        is_telegram_private_topic_target(platform, chat_id, thread_id, metadata)
+        and not _looks_like_int(str(thread_id))
+    )
+
+
+@dataclass
+class PreparedPlatformSend:
+    metadata: Optional[Dict[str, Any]]
+    named_telegram_private_topic_name: Optional[str] = None
+
+
+async def prepare_platform_send_metadata(
+    adapter: Any,
+    target: "DeliveryTarget",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> PreparedPlatformSend:
+    """Build adapter metadata for a delivery target.
+
+    This is the central place for Telegram private DM-topic semantics.  Both
+    ``DeliveryRouter`` and cron's live-adapter path use it so named topics are
+    always resolved/created through ``ensure_dm_topic()`` and numeric private
+    lanes remain fail-closed unless they have a reply anchor or explicit true
+    Direct Messages-topic metadata.
+    """
+
+    send_metadata = dict(metadata or {})
+    named_topic_name: Optional[str] = None
+
+    if target.thread_id:
+        target_thread_id = target.thread_id
+        has_explicit_direct_topic = _has_explicit_telegram_direct_topic(send_metadata)
+        if is_named_telegram_private_topic_target(
+            target.platform,
+            target.chat_id,
+            target_thread_id,
+            send_metadata,
+        ):
+            named_topic_name = target_thread_id
+            ensure_dm_topic = getattr(adapter, "ensure_dm_topic", None)
+            if ensure_dm_topic is None:
+                raise RuntimeError(
+                    "Telegram adapter cannot create named private DM topics"
+                )
+            created_thread_id = await ensure_dm_topic(target.chat_id, target_thread_id)
+            if not created_thread_id:
+                raise RuntimeError(
+                    f"Failed to create Telegram private DM topic '{target_thread_id}'"
+                )
+            send_metadata["thread_id"] = str(created_thread_id)
+            send_metadata["telegram_dm_topic_created_for_send"] = True
+        elif (
+            target.platform == Platform.TELEGRAM
+            and _looks_like_telegram_private_chat_id(target.chat_id)
+            and "thread_id" not in send_metadata
+            and "message_thread_id" not in send_metadata
+            and not has_explicit_direct_topic
+        ):
+            # Legacy private topic/thread ids that were not created by this
+            # send path may still need a reply anchor to stay visible in the
+            # requested lane. Named targets are created above via
+            # createForumTopic and can use message_thread_id directly.
+            reply_anchor = send_metadata.get("telegram_reply_to_message_id")
+            if reply_anchor is None:
+                raise RuntimeError(
+                    "Telegram private DM topic delivery requires telegram_reply_to_message_id; "
+                    "send to the bare chat or provide a reply anchor"
+                )
+            send_metadata["thread_id"] = target_thread_id
+            send_metadata["telegram_dm_topic_reply_fallback"] = True
+        elif (
+            "thread_id" not in send_metadata
+            and "message_thread_id" not in send_metadata
+            and not has_explicit_direct_topic
+        ):
+            send_metadata["thread_id"] = target_thread_id
+
+    return PreparedPlatformSend(
+        metadata=send_metadata or None,
+        named_telegram_private_topic_name=named_topic_name,
+    )
+
+
+async def refresh_named_telegram_private_topic_metadata(
+    adapter: Any,
+    target: "DeliveryTarget",
+    prepared: PreparedPlatformSend,
+) -> PreparedPlatformSend:
+    """Force-create a replacement Telegram private topic and update metadata."""
+
+    topic_name = prepared.named_telegram_private_topic_name
+    if not topic_name:
+        return prepared
+    ensure_dm_topic = getattr(adapter, "ensure_dm_topic", None)
+    if ensure_dm_topic is None:
+        raise RuntimeError("Telegram adapter cannot refresh named private DM topics")
+    refreshed_thread_id = await ensure_dm_topic(
+        target.chat_id,
+        topic_name,
+        force_create=True,
+    )
+    if not refreshed_thread_id:
+        raise RuntimeError(f"Failed to refresh Telegram private DM topic '{topic_name}'")
+    send_metadata = dict(prepared.metadata or {})
+    send_metadata["thread_id"] = str(refreshed_thread_id)
+    send_metadata["telegram_dm_topic_created_for_send"] = True
+    return PreparedPlatformSend(
+        metadata=send_metadata,
+        named_telegram_private_topic_name=topic_name,
+    )
 
 
 @dataclass
@@ -347,83 +517,19 @@ class DeliveryRouter:
                 "delivered": False,
             }
 
-        send_metadata = dict(metadata or {})
-        is_named_telegram_private_topic = False
-        named_telegram_private_topic_name: Optional[str] = None
-        if target.thread_id:
-            has_explicit_direct_topic = (
-                "direct_messages_topic_id" in send_metadata
-                or "telegram_direct_messages_topic_id" in send_metadata
-            )
-            target_thread_id = target.thread_id
-            is_named_telegram_private_topic = (
-                target.platform == Platform.TELEGRAM
-                and _looks_like_telegram_private_chat_id(target.chat_id)
-                and not _looks_like_int(target_thread_id)
-                and "thread_id" not in send_metadata
-                and "message_thread_id" not in send_metadata
-                and not has_explicit_direct_topic
-            )
-            if is_named_telegram_private_topic:
-                named_telegram_private_topic_name = target_thread_id
-                ensure_dm_topic = getattr(adapter, "ensure_dm_topic", None)
-                if ensure_dm_topic is None:
-                    raise RuntimeError(
-                        "Telegram adapter cannot create named private DM topics"
-                    )
-                created_thread_id = await ensure_dm_topic(target.chat_id, target_thread_id)
-                if not created_thread_id:
-                    raise RuntimeError(
-                        f"Failed to create Telegram private DM topic '{target_thread_id}'"
-                    )
-                target_thread_id = str(created_thread_id)
-                send_metadata["thread_id"] = target_thread_id
-                send_metadata["telegram_dm_topic_created_for_send"] = True
-            elif (
-                target.platform == Platform.TELEGRAM
-                and _looks_like_telegram_private_chat_id(target.chat_id)
-                and "thread_id" not in send_metadata
-                and "message_thread_id" not in send_metadata
-                and not has_explicit_direct_topic
-            ):
-                # Legacy private topic/thread ids that were not created by this
-                # send path may still need a reply anchor to stay visible in the
-                # requested lane. Named targets are created above via
-                # createForumTopic and can use message_thread_id directly.
-                reply_anchor = send_metadata.get("telegram_reply_to_message_id")
-                if reply_anchor is None:
-                    raise RuntimeError(
-                        "Telegram private DM topic delivery requires telegram_reply_to_message_id; "
-                        "send to the bare chat or provide a reply anchor"
-                    )
-                send_metadata["thread_id"] = target_thread_id
-                send_metadata["telegram_dm_topic_reply_fallback"] = True
-            elif "thread_id" not in send_metadata and "message_thread_id" not in send_metadata and not has_explicit_direct_topic:
-                send_metadata["thread_id"] = target_thread_id
-        result = await adapter.send(target.chat_id, content, metadata=send_metadata or None)
+        prepared = await prepare_platform_send_metadata(adapter, target, metadata)
+        result = await adapter.send(target.chat_id, content, metadata=prepared.metadata)
         if _send_result_failed(result):
             if (
-                is_named_telegram_private_topic
-                and named_telegram_private_topic_name
-                and _is_thread_not_found_delivery_error(result)
+                prepared.named_telegram_private_topic_name
+                and is_thread_not_found_delivery_error(result)
             ):
-                ensure_dm_topic = getattr(adapter, "ensure_dm_topic", None)
-                if ensure_dm_topic is None:
-                    raise RuntimeError(
-                        "Telegram adapter cannot refresh named private DM topics"
-                    )
-                refreshed_thread_id = await ensure_dm_topic(
-                    target.chat_id,
-                    named_telegram_private_topic_name,
-                    force_create=True,
+                prepared = await refresh_named_telegram_private_topic_metadata(
+                    adapter,
+                    target,
+                    prepared,
                 )
-                if not refreshed_thread_id:
-                    raise RuntimeError(
-                        f"Failed to refresh Telegram private DM topic '{named_telegram_private_topic_name}'"
-                    )
-                send_metadata["thread_id"] = str(refreshed_thread_id)
-                send_metadata["telegram_dm_topic_created_for_send"] = True
-                result = await adapter.send(target.chat_id, content, metadata=send_metadata or None)
+                result = await adapter.send(target.chat_id, content, metadata=prepared.metadata)
             if _send_result_failed(result):
                 raise RuntimeError(_send_result_error(result) or f"{target.platform.value} delivery failed")
         return result

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -209,6 +209,27 @@ class TestResolveDeliveryTarget:
             "thread_id": "17",
         }
 
+    def test_explicit_telegram_named_private_topic_target(self):
+        """deliver: 'telegram:private_chat_id:topic name' preserves the topic name."""
+        job = {
+            "deliver": "telegram:722341991:Debug",
+        }
+        assert _resolve_delivery_target(job) == {
+            "platform": "telegram",
+            "chat_id": "722341991",
+            "thread_id": "Debug",
+        }
+
+    def test_explicit_telegram_named_private_topic_allows_colons_in_name(self):
+        job = {
+            "deliver": "telegram:722341991:Ops: Debug",
+        }
+        assert _resolve_delivery_target(job) == {
+            "platform": "telegram",
+            "chat_id": "722341991",
+            "thread_id": "Ops: Debug",
+        }
+
     def test_explicit_telegram_topic_thread_survives_bare_directory_match(self):
         """Exact channel-directory matches must not erase an explicit topic id."""
         job = {
@@ -787,6 +808,264 @@ class TestDeliverResultWrapping:
         text_sent = adapter.send.call_args[0][1]
         assert "MEDIA:" not in text_sent
         assert "Report" in text_sent
+
+    def test_live_adapter_resolves_named_telegram_private_topic(self):
+        """Named Telegram PM-topic cron targets resolve before live adapter send."""
+        import asyncio
+        from concurrent.futures import Future
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        adapter.ensure_dm_topic.return_value = "38132"
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {
+            "dm_topics": [
+                {
+                    "chat_id": 722341991,
+                    "topics": [{"name": "Debug", "thread_id": 38132}],
+                }
+            ]
+        }
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        def run_scheduled(coro, _loop):
+            future = Future()
+            future.set_result(asyncio.run(coro))
+            return future
+
+        job = {
+            "id": "named-topic-job",
+            "deliver": "telegram:722341991:Debug",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as standalone_send, \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=run_scheduled):
+            result = _deliver_result(
+                job,
+                "Debug report",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        adapter.ensure_dm_topic.assert_called_once_with("722341991", "Debug")
+        adapter.send.assert_called_once()
+        assert adapter.send.call_args.args[:2] == ("722341991", "Debug report")
+        assert adapter.send.call_args.kwargs["metadata"] == {
+            "thread_id": "38132",
+            "telegram_dm_topic_created_for_send": True,
+        }
+        standalone_send.assert_not_called()
+
+    def test_named_telegram_private_topic_refreshes_stale_thread_before_fallback(self):
+        """Cron should use DeliveryRouter's stale-topic refresh instead of standalone fallback."""
+        import asyncio
+        from concurrent.futures import Future
+        from unittest.mock import call
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+        adapter = AsyncMock()
+        adapter.ensure_dm_topic.side_effect = ["32343", "38132"]
+        adapter.send.side_effect = [
+            SendResult(success=False, error="Bad Request: message thread not found"),
+            SendResult(success=True, message_id="fresh-message"),
+        ]
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {
+            "dm_topics": [
+                {
+                    "chat_id": 722341991,
+                    "topics": [{"name": "Debug", "thread_id": 32343}],
+                }
+            ]
+        }
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def run_scheduled(coro, _loop):
+            future = Future()
+            future.set_result(asyncio.run(coro))
+            return future
+
+        job = {"id": "stale-topic-job", "deliver": "telegram:722341991:Debug"}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as standalone_send, \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=run_scheduled):
+            result = _deliver_result(
+                job,
+                "Debug report",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        assert adapter.ensure_dm_topic.call_args_list == [
+            call("722341991", "Debug"),
+            call("722341991", "Debug", force_create=True),
+        ]
+        assert [call.kwargs["metadata"]["thread_id"] for call in adapter.send.call_args_list] == [
+            "32343",
+            "38132",
+        ]
+        standalone_send.assert_not_called()
+
+    def test_named_telegram_private_topic_media_only_refreshes_stale_thread(self, tmp_path, monkeypatch):
+        """Media-only named-topic cron sends should refresh stale Telegram thread ids."""
+        import asyncio
+        from concurrent.futures import Future
+        from unittest.mock import call
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "chart.png")
+        adapter = AsyncMock()
+        adapter.ensure_dm_topic.side_effect = ["32343", "38132"]
+        adapter.send_image_file.side_effect = [
+            SendResult(success=False, error="Bad Request: message thread not found"),
+            SendResult(success=True, message_id="fresh-media"),
+        ]
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def run_scheduled(coro, _loop):
+            future = Future()
+            future.set_result(asyncio.run(coro))
+            return future
+
+        job = {"id": "media-only-topic-job", "deliver": "telegram:722341991:Debug"}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as standalone_send, \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=run_scheduled):
+            result = _deliver_result(
+                job,
+                f"MEDIA:{media_path}",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        adapter.send.assert_not_called()
+        assert adapter.ensure_dm_topic.call_args_list == [
+            call("722341991", "Debug"),
+            call("722341991", "Debug", force_create=True),
+        ]
+        assert [call.kwargs["metadata"]["thread_id"] for call in adapter.send_image_file.call_args_list] == [
+            "32343",
+            "38132",
+        ]
+        standalone_send.assert_not_called()
+
+    def test_named_telegram_private_topic_without_live_adapter_fails_closed(self):
+        """Named private DM topics need a live adapter; standalone cannot safely create/refresh them."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {
+            "dm_topics": [
+                {
+                    "chat_id": 722341991,
+                    "topics": [{"name": "Debug", "thread_id": 32343}],
+                }
+            ]
+        }
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        job = {"id": "no-live-topic-job", "deliver": "telegram:722341991:Debug"}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as standalone_send:
+            result = _deliver_result(job, "Debug report", adapters={}, loop=None)
+
+        assert result is not None
+        assert "requires a live Telegram adapter" in result
+        standalone_send.assert_not_called()
+
+    def test_numeric_telegram_private_topic_without_anchor_fails_closed(self):
+        """Bare numeric private DM-topic ids cannot safely fall back to standalone sends."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        job = {"id": "numeric-private-topic-job", "deliver": "telegram:722341991:32343"}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as standalone_send:
+            result = _deliver_result(job, "Debug report", adapters={}, loop=None)
+
+        assert result is not None
+        assert "use a named Telegram topic target" in result
+        standalone_send.assert_not_called()
+
+    def test_named_telegram_private_topic_live_failure_does_not_fallback_to_standalone(self):
+        """Non-refreshable named-topic send failures should surface instead of escaping to standalone."""
+        import asyncio
+        from concurrent.futures import Future
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+
+        adapter = AsyncMock()
+        adapter.ensure_dm_topic.return_value = "38132"
+        adapter.send.return_value = SendResult(success=False, error="Forbidden: bot was blocked")
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def run_scheduled(coro, _loop):
+            future = Future()
+            future.set_result(asyncio.run(coro))
+            return future
+
+        job = {"id": "failed-topic-job", "deliver": "telegram:722341991:Debug"}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as standalone_send, \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=run_scheduled):
+            result = _deliver_result(
+                job,
+                "Debug report",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is not None
+        assert "Forbidden: bot was blocked" in result
+        standalone_send.assert_not_called()
 
     def test_no_mirror_to_session_call(self):
         """Cron deliveries should NOT mirror into the gateway session."""
@@ -2569,7 +2848,7 @@ class TestDeliverResultTimeoutCancelsFuture:
 
         job = {
             "id": "thread-fallback-job",
-            "deliver": "telegram:226252250:7072",
+            "deliver": "telegram:-100226252250:7072",
         }
 
         completed_future = Future()
@@ -2590,11 +2869,11 @@ class TestDeliverResultTimeoutCancelsFuture:
             )
 
         assert result == (
-            "configured thread_id 7072 for telegram:226252250 was not found; "
+            "configured thread_id 7072 for telegram:-100226252250 was not found; "
             "delivered without thread_id"
         )
         adapter.send.assert_called_once_with(
-            "226252250",
+            "-100226252250",
             "Hello world",
             metadata={"thread_id": "7072"},
         )

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -210,15 +210,8 @@ class TestSendMessageTool:
         config, _telegram_cfg = _make_config()
         config.get_home_channel = lambda _platform: home
 
-        with patch.dict(
-            os.environ,
-            {
-                "HERMES_CRON_AUTO_DELIVER_PLATFORM": "telegram",
-                "HERMES_CRON_AUTO_DELIVER_CHAT_ID": "-1001",
-            },
-            clear=False,
-        ), \
-             patch("gateway.config.load_gateway_config", return_value=config), \
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.send_message_tool._get_cron_auto_delivery_target", return_value={"platform": "telegram", "chat_id": "-1001", "thread_id": None}), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
              patch("model_tools._run_async", side_effect=_run_async_immediately), \
              patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
@@ -454,6 +447,54 @@ class TestSendMessageTool:
             media_files=[],
             force_document=False,
         )
+
+    def test_telegram_private_numeric_thread_target_fails_closed_before_send(self):
+        _config, telegram_cfg = _make_config()
+
+        with patch("tools.send_message_tool._send_telegram", new=AsyncMock(return_value={"success": True})) as send_mock:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.TELEGRAM,
+                    telegram_cfg,
+                    "722341991",
+                    "hello",
+                    thread_id="32343",
+                )
+            )
+
+        assert "error" in result
+        assert "use a named Telegram topic target" in result["error"]
+        send_mock.assert_not_awaited()
+
+    def test_telegram_group_numeric_thread_target_still_sends(self):
+        _config, telegram_cfg = _make_config()
+
+        with patch("tools.send_message_tool._send_telegram", new=AsyncMock(return_value={"success": True})) as send_mock:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.TELEGRAM,
+                    telegram_cfg,
+                    "-100722341991",
+                    "hello",
+                    thread_id="32343",
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once()
+        assert send_mock.await_args is not None
+        assert send_mock.await_args.kwargs["thread_id"] == "32343"
+
+    def test_send_telegram_private_numeric_thread_target_fails_before_bot_send(self, monkeypatch):
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(_send_telegram("tok", "722341991", "hello", thread_id="32343"))
+
+        assert "error" in result
+        assert "use a named Telegram topic target" in result["error"]
+        bot.send_message.assert_not_awaited()
 
     def test_top_level_send_failure_redacts_query_token(self):
         config, _telegram_cfg = _make_config()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -80,6 +80,21 @@ def _error(message: str) -> dict:
     return {"error": _sanitize_error_text(message)}
 
 
+def _telegram_private_topic_standalone_error(chat_id, thread_id) -> dict | None:
+    """Fail closed for Telegram private DM-topic sends without router metadata."""
+
+    try:
+        from gateway.delivery import is_telegram_private_topic_target
+    except Exception:
+        return None
+    if not is_telegram_private_topic_target("telegram", str(chat_id), str(thread_id) if thread_id is not None else None):
+        return None
+    return _error(
+        f"Telegram private DM topic thread_id '{thread_id}' for chat {chat_id} "
+        "requires a reply anchor; use a named Telegram topic target routed through the gateway"
+    )
+
+
 def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
     retry_after = getattr(exc, "retry_after", None)
     if retry_after is not None:
@@ -653,6 +668,10 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     # --- Telegram: special handling for media attachments ---
     if platform == Platform.TELEGRAM:
+        private_topic_error = _telegram_private_topic_standalone_error(chat_id, thread_id)
+        if private_topic_error is not None:
+            return private_topic_error
+
         last_result = None
         disable_link_previews = bool(getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews"))
         for i, chunk in enumerate(chunks):
@@ -845,6 +864,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
     already contains HTML tags, it is sent with ``parse_mode='HTML'``
     instead, bypassing MarkdownV2 conversion.
     """
+    private_topic_error = _telegram_private_topic_standalone_error(chat_id, thread_id)
+    if private_topic_error is not None:
+        return private_topic_error
+
     try:
         from telegram import Bot
         from telegram.constants import ParseMode


### PR DESCRIPTION
## What does this PR do?

Fixes Telegram private DM-topic cron delivery by moving the Telegram-specific private-topic routing semantics into the shared gateway delivery layer instead of keeping them in cron or the standalone `send_message` path.

Cron still preserves the user's delivery target shape, but it now delegates named Telegram private-topic metadata preparation and stale-topic recovery to shared helpers in `gateway/delivery.py`. This avoids silently falling back to the root DM when a private-topic send is stale or unsafe.

The important behavior changes are:

- named Telegram private DM-topic targets are detected centrally
- named-topic metadata is prepared centrally before text and media delivery
- stale named topics are refreshed with `ensure_dm_topic(..., force_create=True)` instead of falling back to standalone/root-chat delivery
- named private-topic cron sends fail closed when no live Telegram adapter is available
- standalone positive private-chat numeric thread sends fail closed without router metadata, while negative group/forum thread IDs remain allowed

This is related to the narrower open cron fix PR #23249, but takes a shared delivery-router approach instead of adding only a `send_message_tool.py` retry branch.

## Related Issue

Fixes #22773.

Related to #23249, #33375, #35739, and #31501 as adjacent Telegram DM-topic routing failures.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/delivery.py`
  - add shared helpers for Telegram private-topic target detection and metadata preparation
  - add named private-topic stale refresh through the live Telegram adapter
  - normalize named-topic refresh around `ensure_dm_topic(..., force_create=True)`
- `cron/scheduler.py`
  - preserve named Telegram target shape while delegating private-topic routing semantics to the delivery layer
  - fail closed for named Telegram private-topic deliveries when a live adapter is required but unavailable
  - use the same refreshed metadata path for text and media delivery
- `tools/send_message_tool.py`
  - fail closed for standalone positive Telegram private-chat `chat_id:thread_id` sends without router metadata
  - keep negative group/forum thread IDs working normally
- `tests/cron/test_scheduler.py`
  - add regression coverage for named private-topic refresh, no-live-adapter fail-closed behavior, and media delivery
- `tests/tools/test_send_message_tool.py`
  - add regression coverage for unsafe private-topic standalone sends and allowed group/forum numeric threads

## How to Test

Reproduction before the fix:

1. Configure a cron delivery target for a named Telegram private DM topic.
2. Delete or stale the underlying Telegram topic/thread so the persisted thread ID is no longer valid.
3. Run the cron job.
4. Observe that delivery can fall back to standalone/root DM behavior instead of refreshing the named topic or failing safely.

Proof after the fix:

1. Named private-topic cron delivery refreshes stale metadata through the live Telegram adapter.
2. If no live adapter is available for a named private-topic delivery, cron returns a delivery failure instead of falling back to root chat.
3. Media-only delivery follows the same refreshed named-topic metadata path as text delivery.
4. Standalone `send_message` rejects ambiguous positive private-chat thread sends before trying Telegram, while supergroup/forum thread targets still send.

Automated verification run on this branch:

```text
scripts/run_tests.sh tests/gateway/test_delivery.py tests/cron/test_scheduler.py tests/tools/test_send_message_tool.py tests/tools/test_send_message_telegram_proxy.py
# 302 passed, 0 failed

python -m py_compile cron/scheduler.py gateway/delivery.py tools/send_message_tool.py tests/cron/test_scheduler.py tests/gateway/test_delivery.py tests/tools/test_send_message_tool.py tests/tools/test_send_message_telegram_proxy.py
# passed

ruff check cron/scheduler.py gateway/delivery.py tools/send_message_tool.py tests/cron/test_scheduler.py tests/gateway/test_delivery.py tests/tools/test_send_message_tool.py tests/tools/test_send_message_telegram_proxy.py
# All checks passed

git diff --cached --check
# passed

python scripts/check-windows-footguns.py cron/scheduler.py gateway/delivery.py tools/send_message_tool.py tests/cron/test_scheduler.py tests/tools/test_send_message_tool.py
# No Windows footguns found (5 files scanned)
```

Full `pytest tests/ -q` was not run for this PR; the verification above covers the touched gateway, cron, and send-message paths.

Tested platform: Linux 6.8.0-117-generic, Python 3.11.15.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused suite run above instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8.0-117-generic, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; internal delivery behavior only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no schema or target syntax changed

## Screenshots / Logs

Focused test output:

```text
=== Summary: 4 files, 302 tests passed, 0 failed (100% complete) in 7.5s (8 workers) ===
```