### PR TITLE
fix: sort live sessions newest-first

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4411,7 +4411,7 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
 # ── active live TUI sessions ─────────────────────────────────────────
 
 
-def test_session_active_list_reports_live_sessions(monkeypatch):
+def test_session_active_list_reports_live_sessions_newest_first(monkeypatch):
     class _DB:
         def get_session_title(self, key):
             return {"key-a": "Research", "key-b": "Implement"}.get(key, "")
@@ -4439,7 +4439,7 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
             {
                 "id": "1",
                 "method": "session.active_list",
-                "params": {"current_session_id": "sid-b"},
+                "params": {"current_session_id": "sid-a"},
             }
         )
     finally:
@@ -4447,11 +4447,11 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         server._sessions.update(previous_sessions)
 
     session_rows = resp["result"]["sessions"]
-    assert [row["id"] for row in session_rows] == ["sid-a", "sid-b"]
+    assert [row["id"] for row in session_rows] == ["sid-b", "sid-a"]
 
     rows = {row["id"]: row for row in session_rows}
     assert rows["sid-a"] == {
-        "current": False,
+        "current": True,
         "id": "sid-a",
         "last_active": 20.0,
         "message_count": 1,
@@ -4462,7 +4462,7 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         "status": "idle",
         "title": "Research",
     }
-    assert rows["sid-b"]["current"] is True
+    assert rows["sid-b"]["current"] is False
     assert rows["sid-b"]["status"] == "working"
     assert rows["sid-b"]["title"] == "Implement"
     assert rows["sid-b"]["preview"] == "writing code"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3563,9 +3563,11 @@ def _(rid, params: dict) -> dict:
     except Exception as e:
         return _err(rid, 5036, f"could not enumerate active sessions: {e}")
 
-    # Keep the natural creation/insertion order from ``_sessions``.  The
-    # frontend marks the focused session with ``current``; it should not jump to
-    # the top just because the user switched to it.
+    # Show the newest live sessions first so newly created conversations do not
+    # disappear to the bottom of the switcher. Keep this keyed to creation time
+    # rather than current focus so activating an older session does not reorder
+    # the whole list underneath the user.
+    snapshot.sort(key=lambda item: (float(item[1].get("created_at") or 0.0), item[0]), reverse=True)
     rows = [_session_live_item(sid, session, current) for sid, session in snapshot]
     return _ok(rid, {"sessions": rows})
 


### PR DESCRIPTION
## Summary
- sort live TUI sessions by creation time descending so newly created sessions appear at the top of the switcher
- keep the current-session marker independent from ordering so focusing an older session does not reshuffle the whole list
- cover the regression with a targeted `session.active_list` test

## Test Plan
- `uv run --frozen pytest tests/test_tui_gateway_server.py::test_session_active_list_reports_live_sessions_newest_first -q -o addopts=`
- `uv run --frozen ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check`

Closes #42029
