### PR TITLE
feat(hindsight): make prefetch join timeout configurable

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -595,6 +595,12 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_prompt_preamble = ""
         self._recall_max_input_chars = 800
 
+        # Prefetch join timeout (seconds). How long prefetch() waits for the
+        # background recall thread to complete before returning empty.
+        # Configurable via config.json "prefetch_join_timeout" or
+        # HINDSIGHT_PREFETCH_JOIN_TIMEOUT env var. Default: 5.0s.
+        self._prefetch_join_timeout = 5.0
+
         # Bank
         self._bank_mission = ""
         self._bank_retain_mission: str | None = None
@@ -877,6 +883,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
+            {"key": "prefetch_join_timeout", "description": "Seconds to wait for background prefetch recall before returning empty (0 disables prefetch)", "default": 5.0},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
@@ -1215,6 +1222,10 @@ class HindsightMemoryProvider(MemoryProvider):
             self._recall_types = list(configured_types) or ["observation"]
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+        self._prefetch_join_timeout = float(self._config.get(
+            "prefetch_join_timeout",
+            os.environ.get("HINDSIGHT_PREFETCH_JOIN_TIMEOUT", 5.0)
+        ))
         self._retain_async = self._config.get("retain_async", True)
 
         _client_version = "unknown"
@@ -1306,7 +1317,7 @@ class HindsightMemoryProvider(MemoryProvider):
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             logger.debug("Prefetch: waiting for background thread to complete")
-            self._prefetch_thread.join(timeout=3.0)
+            self._prefetch_thread.join(timeout=self._prefetch_join_timeout)
         with self._prefetch_lock:
             result = self._prefetch_result
             self._prefetch_result = ""
@@ -1716,7 +1727,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # 2. Drain any in-flight prefetch from the old session and drop
         # its cached result so the new session doesn't see stale recall.
         if self._prefetch_thread and self._prefetch_thread.is_alive():
-            self._prefetch_thread.join(timeout=3.0)
+            self._prefetch_thread.join(timeout=self._prefetch_join_timeout)
         with self._prefetch_lock:
             self._prefetch_result = ""
 


### PR DESCRIPTION
## Problem

The `prefetch()` method in the Hindsight memory plugin has a hardcoded 3.0s join timeout for the background recall thread. On slower Hindsight instances (local deployments, resource-constrained servers), recall can take 2-5 seconds, causing prefetch to consistently return empty results.

This means auto-injected memory context is always empty, forcing users to manually call `hindsight_recall` to search for relevant memories.

## Solution

Make the prefetch join timeout configurable via:

- **config.json**: `"prefetch_join_timeout": 6.0`
- **Environment variable**: `HINDSIGHT_PREFETCH_JOIN_TIMEOUT=6.0`
- **Default**: 5.0s (increased from 3.0s)

The timeout is applied in both `prefetch()` and `on_session_switch()` where the same join pattern exists.

## Testing

Tested with different timeout values:

| Timeout | Result |
|---------|--------|
| 0.5s | Always timeouts (as expected) |
| 5.0s | Works for most recalls |
| 6.0s | Works for all recalls |

## Configuration

Add to `~/.hermes/hindsight/config.json`:
```json
{
  "prefetch_join_timeout": 6.0
}
```

Or set environment variable:
```bash
export HINDSIGHT_PREFETCH_JOIN_TIMEOUT=6.0
```

## Related Issues

This fixes the issue where auto-injected memory context was always empty because the background recall thread hadn't finished by the time `prefetch()` returned.

## Changes

- Added `_prefetch_join_timeout` config variable (default: 5.0s)
- Updated `prefetch()` to use configurable timeout
- Updated `on_session_switch()` to use configurable timeout
- Added config schema entry for discoverability

---
**Note**: This is a clean PR containing only the prefetch timeout fix. The previous PR #42054 was closed because it contained unrelated changes from the fork.