### PR TITLE
fix(cli): discover category-layout plugins in hermes plugins list

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -734,7 +734,9 @@ def _discover_all_plugins() -> list:
 
     Matches the ordering/dedup of ``PluginManager.discover_and_load``:
     bundled first, then user, then project; user overrides bundled on
-    name collision.
+    name collision.  Supports both flat (``<root>/<name>/plugin.yaml``)
+    and category (``<root>/<category>/<name>/plugin.yaml``) layouts,
+    consistent with :meth:`PluginManager._scan_directory`.
     """
     try:
         import yaml
@@ -743,41 +745,62 @@ def _discover_all_plugins() -> list:
 
     seen: dict = {}  # name -> (name, version, description, source, path)
 
+    def _read_manifest_info(manifest_path: Path):
+        """Return (name, version, description) from a plugin.yaml."""
+        name = version = description = ""
+        if yaml:
+            try:
+                with open(manifest_path, encoding="utf-8") as mf:
+                    manifest = yaml.safe_load(mf) or {}
+                name = manifest.get("name", "")
+                version = manifest.get("version", "")
+                description = manifest.get("description", "")
+            except Exception:
+                pass
+        return name, version, description
+
+    def _is_git_plugin(plugin_dir: Path) -> bool:
+        return (plugin_dir / ".git").exists()
+
+    def _scan_level(
+        base: Path, source: str, *, prefix: str = "", depth: int = 0
+    ) -> None:
+        """Recursively scan *base* for plugin manifests (max depth 2)."""
+        if depth > 1 or not base.is_dir():
+            return
+        for child in sorted(base.iterdir()):
+            if not child.is_dir():
+                continue
+            if depth == 0 and source == "bundled" and child.name in {
+                "memory", "context_engine"
+            }:
+                continue
+            manifest_file = child / "plugin.yaml"
+            if not manifest_file.exists():
+                manifest_file = child / "plugin.yml"
+            if manifest_file.exists():
+                p_name, p_version, p_desc = _read_manifest_info(manifest_file)
+                if not p_name:
+                    p_name = child.name
+                key = f"{prefix}{child.name}" if prefix else p_name
+                # User plugins override bundled on name collision.
+                if key in seen and source == "bundled":
+                    continue
+                src_label = source
+                if source == "user" and _is_git_plugin(child):
+                    src_label = "git"
+                seen[key] = (key, p_version, p_desc, src_label, child)
+            else:
+                # Category directory — recurse one level.
+                _scan_level(
+                    child, source, prefix=f"{child.name}/", depth=depth + 1
+                )
+
     # Bundled (<repo>/plugins/<name>/), excluding memory/ and context_engine/
     from hermes_cli.plugins import get_bundled_plugins_dir
     repo_plugins = get_bundled_plugins_dir()
     for base, source in ((repo_plugins, "bundled"), (_plugins_dir(), "user")):
-        if not base.is_dir():
-            continue
-        for d in sorted(base.iterdir()):
-            if not d.is_dir():
-                continue
-            if source == "bundled" and d.name in {"memory", "context_engine"}:
-                continue
-            manifest_file = d / "plugin.yaml"
-            if not manifest_file.exists():
-                manifest_file = d / "plugin.yml"
-            if not manifest_file.exists():
-                continue
-            name = d.name
-            version = ""
-            description = ""
-            if yaml:
-                try:
-                    with open(manifest_file, encoding="utf-8") as f:
-                        manifest = yaml.safe_load(f) or {}
-                    name = manifest.get("name", d.name)
-                    version = manifest.get("version", "")
-                    description = manifest.get("description", "")
-                except Exception:
-                    pass
-            # User plugins override bundled on name collision.
-            if name in seen and source == "bundled":
-                continue
-            src_label = source
-            if source == "user" and (d / ".git").exists():
-                src_label = "git"
-            seen[name] = (name, version, description, src_label, d)
+        _scan_level(base, source)
     return list(seen.values())
 
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -698,3 +698,153 @@ class TestNoAutoActivation:
         # The old code had: "Even with default config, check if a plugin registered one"
         # The fix removes this. Verify it's gone.
         assert "Even with default config, check if a plugin registered one" not in source
+
+
+# ── Category layout discovery tests (regression for #42033) ─────────────────
+
+class TestDiscoverAllPluginsCategoryLayout:
+    """Verify _discover_all_plugins handles both flat and category layouts."""
+
+    @staticmethod
+    def _make_plugin_yaml(plugin_dir: Path, name: str, version: str = "1.0.0") -> None:
+        """Write a minimal plugin.yaml into *plugin_dir*."""
+        import textwrap
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            textwrap.dedent(f"""\
+                name: {name}
+                version: "{version}"
+                description: "Test plugin {name}"
+            """),
+            encoding="utf-8",
+        )
+
+    def test_category_layout_discovered(self, tmp_path):
+        """Plugins under <category>/<name>/plugin.yaml must be found."""
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+
+        self._make_plugin_yaml(
+            tmp_path / "observability" / "langfuse", "langfuse"
+        )
+        self._make_plugin_yaml(tmp_path / "disk-cleanup", "disk-cleanup")
+
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=tmp_path,
+        ), patch(
+            "hermes_cli.plugins_cmd._plugins_dir",
+            return_value=MagicMock(is_dir=lambda: False),
+        ):
+            plugins = _discover_all_plugins()
+
+        names = {p[0] for p in plugins}
+        assert "observability/langfuse" in names
+        assert "disk-cleanup" in names
+
+    def test_category_key_uses_directory_name(self, tmp_path):
+        """The plugin key must use the directory name, not the manifest name."""
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+        import textwrap
+
+        cat_dir = tmp_path / "browser" / "browser_use"
+        cat_dir.mkdir(parents=True, exist_ok=True)
+        (cat_dir / "plugin.yaml").write_text(
+            textwrap.dedent("""\
+                name: browser-browser-use
+                version: "1.0.0"
+                description: "Browser Use plugin"
+            """),
+            encoding="utf-8",
+        )
+
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=tmp_path,
+        ), patch(
+            "hermes_cli.plugins_cmd._plugins_dir",
+            return_value=MagicMock(is_dir=lambda: False),
+        ):
+            plugins = _discover_all_plugins()
+
+        names = {p[0] for p in plugins}
+        assert "browser/browser_use" in names
+
+    def test_user_plugins_override_bundled_category(self, tmp_path):
+        """User category plugin overrides bundled with same key."""
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+
+        bundled_dir = tmp_path / "bundled"
+        user_dir = tmp_path / "user"
+
+        self._make_plugin_yaml(
+            bundled_dir / "observability" / "langfuse", "langfuse", "1.0.0"
+        )
+        self._make_plugin_yaml(
+            user_dir / "observability" / "langfuse", "langfuse", "2.0.0"
+        )
+
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=bundled_dir,
+        ), patch(
+            "hermes_cli.plugins_cmd._plugins_dir",
+            return_value=user_dir,
+        ):
+            plugins = _discover_all_plugins()
+
+        langfuse = [p for p in plugins if p[0] == "observability/langfuse"]
+        assert len(langfuse) == 1
+        assert langfuse[0][1] == "2.0.0"
+        assert langfuse[0][3] == "user"
+
+    def test_memory_context_engine_excluded_for_bundled(self, tmp_path):
+        """memory/ and context_engine/ categories excluded for bundled."""
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+
+        self._make_plugin_yaml(tmp_path / "memory" / "honcho", "honcho")
+        self._make_plugin_yaml(
+            tmp_path / "context_engine" / "test-engine", "test-engine"
+        )
+        self._make_plugin_yaml(
+            tmp_path / "observability" / "langfuse", "langfuse"
+        )
+
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=tmp_path,
+        ), patch(
+            "hermes_cli.plugins_cmd._plugins_dir",
+            return_value=MagicMock(is_dir=lambda: False),
+        ):
+            plugins = _discover_all_plugins()
+
+        names = {p[0] for p in plugins}
+        assert "memory/honcho" not in names
+        assert "context_engine/test-engine" not in names
+        assert "observability/langfuse" in names
+
+    def test_deeply_nested_ignored(self, tmp_path):
+        """Plugins nested >2 levels deep must be ignored."""
+        from hermes_cli.plugins_cmd import _discover_all_plugins
+        import textwrap
+
+        deep_dir = tmp_path / "a" / "b" / "c"
+        deep_dir.mkdir(parents=True, exist_ok=True)
+        (deep_dir / "plugin.yaml").write_text(
+            'name: deep\nversion: "1.0.0"\ndescription: deep\n',
+            encoding="utf-8",
+        )
+        self._make_plugin_yaml(tmp_path / "a" / "d", "d-plugin")
+
+        with patch(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            return_value=tmp_path,
+        ), patch(
+            "hermes_cli.plugins_cmd._plugins_dir",
+            return_value=MagicMock(is_dir=lambda: False),
+        ):
+            plugins = _discover_all_plugins()
+
+        names = {p[0] for p in plugins}
+        assert "a/b/c" not in names
+        assert "a/d" in names


### PR DESCRIPTION
## What does this PR do?

Fixes `_discover_all_plugins()` in `hermes_cli/plugins_cmd.py` to correctly discover plugins in category directories (e.g., `observability/langfuse/`, `model-providers/anthropic/`). Previously, only flat-layout plugins (`disk-cleanup/`, `google_meet/`) appeared in `hermes plugins list --plain` — all category-layout plugins were invisible despite being correctly loaded at runtime by `PluginManager`.

## Related Issue

Fixes #42033

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins_cmd.py`: Replaced flat-only iteration with recursive `_scan_level()` helper that mirrors `PluginManager._scan_directory()` behavior — flat layout at depth 0, category layout at depth 1, max 2 levels. Plugin keys use directory names (not manifest names) to match `_plugin_exists()` and enable/disable commands.
- `tests/hermes_cli/test_plugins_cmd.py`: Added 5 regression tests covering category discovery, directory-name keys, user-overrides-bundled, memory/context_engine exclusion, and depth cap.

## How to Test

1. Run the new tests: `pytest tests/hermes_cli/test_plugins_cmd.py -v --timeout=30`
2. Verify `hermes plugins list --plain` now shows category-layout plugins like `observability/langfuse`
3. Verify `hermes plugins list` (Rich table) shows all 65+ bundled plugins including category ones

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_discover_all_plugins()` ↔ `PluginManager._scan_directory()` (callers: `cmd_list()`, `cmd_enable()`)
- Blast radius: LOW — only affects `hermes plugins list` display; runtime plugin loading unaffected
- Related patterns: Category layout (`<root>/<category>/<name>/plugin.yaml`) used by 60+ of 65 bundled plugins
