### PR TITLE
fix: avoid CDP probes during browser tool checks

### DIFF
--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -116,3 +116,23 @@ class TestGetCdpOverride:
 
         assert resolved == WS_URL
         mock_get.assert_called_once_with(VERSION_URL, timeout=10)
+
+
+class TestCdpAvailabilityChecks:
+    def test_check_browser_requirements_uses_raw_cdp_override_without_network_probe(self, monkeypatch):
+        import tools.browser_tool as browser_tool
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+        with patch("hermes_cli.config.read_raw_config", return_value={"browser": {"cdp_url": HTTP_URL}}), \
+             patch("tools.browser_tool.requests.get", side_effect=AssertionError("unexpected CDP probe")):
+            assert browser_tool.check_browser_requirements() is True
+
+    def test_browser_cdp_check_uses_raw_cdp_override_without_network_probe(self, monkeypatch):
+        from tools import browser_cdp_tool
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+        with patch("hermes_cli.config.read_raw_config", return_value={"browser": {"cdp_url": HTTP_URL}}), \
+             patch("tools.browser_tool.requests.get", side_effect=AssertionError("unexpected CDP probe")):
+            assert browser_cdp_tool._browser_cdp_check() is True

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -525,9 +525,9 @@ BROWSER_CDP_SCHEMA: Dict[str, Any] = {
 def _browser_cdp_check() -> bool:
     """Availability check for browser_cdp.
 
-    The tool is only offered when the Python side can actually reach a CDP
-    endpoint right now — meaning a static URL is set via ``/browser connect``
-    (``BROWSER_CDP_URL``) or ``browser.cdp_url`` in ``config.yaml``.
+    The tool is only offered when a static CDP override is configured via
+    ``/browser connect`` (``BROWSER_CDP_URL``) or ``browser.cdp_url`` in
+    ``config.yaml``.
 
     Backends that do *not* currently expose CDP to us — Camofox (REST-only),
     the default local agent-browser mode (Playwright hides its internal CDP
@@ -541,7 +541,7 @@ def _browser_cdp_check() -> bool:
     """
     try:
         from tools.browser_tool import (  # type: ignore[import-not-found]
-            _get_cdp_override,
+            _get_raw_cdp_override,
             check_browser_requirements,
         )
     except ImportError as exc:  # pragma: no cover — defensive
@@ -549,7 +549,7 @@ def _browser_cdp_check() -> bool:
         return False
     if not check_browser_requirements():
         return False
-    return bool(_get_cdp_override())
+    return bool(_get_raw_cdp_override())
 
 
 registry.register(

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -281,6 +281,31 @@ def _resolve_cdp_override(cdp_url: str) -> str:
     return raw
 
 
+def _get_raw_cdp_override() -> str:
+    """Return the configured CDP override without network I/O.
+
+    Mirrors the env/config precedence of ``_get_cdp_override`` but leaves
+    discovery-style URLs untouched. Availability checks must stay side-effect
+    free so an unreachable or stale ``browser.cdp_url`` does not trigger CDP
+    probing during ordinary Hermes startup/tool selection.
+    """
+    env_override = os.environ.get("BROWSER_CDP_URL", "").strip()
+    if env_override:
+        return env_override
+
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {})
+        if isinstance(browser_cfg, dict):
+            return str(browser_cfg.get("cdp_url", "") or "").strip()
+    except Exception as e:
+        logger.debug("Could not read browser.cdp_url from config: %s", e)
+
+    return ""
+
+
 def _get_cdp_override() -> str:
     """Return a normalized CDP URL override, or empty string.
 
@@ -292,21 +317,10 @@ def _get_cdp_override() -> str:
     launcher and connect directly to the supplied Chrome DevTools Protocol
     endpoint.
     """
-    env_override = os.environ.get("BROWSER_CDP_URL", "").strip()
-    if env_override:
-        return _resolve_cdp_override(env_override)
-
-    try:
-        from hermes_cli.config import read_raw_config
-
-        cfg = read_raw_config()
-        browser_cfg = cfg.get("browser", {})
-        if isinstance(browser_cfg, dict):
-            return _resolve_cdp_override(str(browser_cfg.get("cdp_url", "") or ""))
-    except Exception as e:
-        logger.debug("Could not read browser.cdp_url from config: %s", e)
-
-    return ""
+    raw_override = _get_raw_cdp_override()
+    if not raw_override:
+        return ""
+    return _resolve_cdp_override(raw_override)
 
 
 def _get_dialog_policy_config() -> Tuple[str, float]:
@@ -3670,9 +3684,11 @@ def check_browser_requirements() -> bool:
     if _is_camofox_mode():
         return True
 
-    # CDP override mode can connect to an existing remote/local browser endpoint
-    # without requiring the local agent-browser binary on PATH.
-    if _get_cdp_override():
+    # A configured CDP override is enough to advertise the browser toolset.
+    # Do not resolve discovery endpoints here: tool availability checks run
+    # during ordinary startup/tool selection and must not trigger network I/O
+    # against stale browser.cdp_url values.
+    if _get_raw_cdp_override():
         return True
 
     # The agent-browser CLI is required for local launch and cloud-provider flows.


### PR DESCRIPTION
## Summary
- separate raw CDP override detection from websocket resolution so browser tool availability checks stay side-effect free
- keep `/json/version` probing on real browser connect/tool-use paths instead of ordinary startup/tool selection
- cover the regression with targeted tests for `check_browser_requirements` and `browser_cdp` availability

## Test Plan
- `uv run --frozen pytest tests/tools/test_browser_cdp_override.py -q -o addopts=`
- `uv run --frozen ruff check tools/browser_tool.py tools/browser_cdp_tool.py tests/tools/test_browser_cdp_override.py`
- `git diff --check`

Closes #42040
