### PR TITLE
fix(plugins): trigger discovery in get_plugin_toolsets

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1906,8 +1906,14 @@ def get_plugin_toolsets() -> List[tuple]:
 
     Used by the ``hermes tools`` TUI so plugin-provided toolsets appear
     alongside the built-in ones and can be toggled on/off per platform.
+
+    Triggers idempotent plugin discovery so callers can read the registry
+    before any explicit ``discover_plugins()`` call — matching the other
+    ``get_plugin_*`` accessors. Without it, calling this before discovery
+    has run reads an empty ``_plugin_tool_names`` and silently returns ``[]``,
+    hiding every plugin toolset from the picker.
     """
-    manager = get_plugin_manager()
+    manager = _ensure_plugins_discovered()
     if not manager._plugin_tool_names:
         return []
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1759,3 +1759,43 @@ class TestPluginDebugLogging:
             plugins_mod._PLUGINS_DEBUG = original_debug
             plugins_mod.logger.setLevel(original_level)
             plugins_mod.logger.handlers = original_handlers
+
+
+class TestGetPluginToolsetsDiscovery:
+    """get_plugin_toolsets() must trigger plugin discovery like its siblings."""
+
+    def test_get_plugin_toolsets_triggers_discovery(self, monkeypatch):
+        """Regression: reading plugin toolsets must run discovery first.
+
+        ``get_plugin_toolsets()`` reads ``manager._plugin_tool_names`` to build
+        the ``hermes tools`` picker. The other ``get_plugin_*`` accessors route
+        through ``_ensure_plugins_discovered()`` so they work before any
+        explicit ``discover_plugins()`` call; this one used the bare
+        ``get_plugin_manager()`` and silently returned ``[]`` when invoked
+        before discovery had run, hiding every plugin toolset.
+        """
+        from hermes_cli import plugins as plugins_mod
+
+        fresh = PluginManager()
+        fresh._discovered = False
+
+        discover_calls = []
+
+        def _spy_discover(*args, **kwargs):
+            discover_calls.append((args, kwargs))
+            fresh._discovered = True
+
+        monkeypatch.setattr(fresh, "discover_and_load", _spy_discover)
+        monkeypatch.setattr(plugins_mod, "_PLUGIN_MANAGER", fresh, raising=False)
+        monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: fresh)
+
+        result = plugins_mod.get_plugin_toolsets()
+
+        # Discovery must have been triggered before the registry was read.
+        assert discover_calls, (
+            "get_plugin_toolsets() must trigger plugin discovery before "
+            "reading the tool registry"
+        )
+        # No plugin tools registered on the fresh manager → empty list, but the
+        # important part is that discovery ran rather than short-circuiting.
+        assert result == []


### PR DESCRIPTION
## What does this PR do?

This change fixes a latent bug in the plugin toolset accessor. The
`get_plugin_toolsets()` helper builds the list of plugin-provided toolsets
shown in the `hermes tools` picker by reading `manager._plugin_tool_names`.
Unlike its sibling accessors (`get_plugin_commands`,
`get_plugin_command_handler`, `get_plugin_auxiliary_tasks`,
`get_plugin_context_engine`), it called the bare `get_plugin_manager()`
rather than `_ensure_plugins_discovered()`. The bare accessor returns the
singleton manager without running plugin discovery, so when the function was
invoked before discovery had been triggered, `_plugin_tool_names` was empty
and the function returned an empty list, silently hiding every plugin toolset
from the picker. Routing the accessor through `_ensure_plugins_discovered()`
makes it consistent with the rest of the `get_plugin_*` family and guarantees
discovery has run before the registry is read. Discovery is idempotent, so
this is safe for callers that already trigger it themselves.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py`: `get_plugin_toolsets()` now calls
  `_ensure_plugins_discovered()` instead of `get_plugin_manager()`, ensuring
  idempotent plugin discovery runs before the tool registry is read. The
  docstring documents this behaviour to match the sibling accessors.
- `tests/hermes_cli/test_plugins.py`: added
  `TestGetPluginToolsetsDiscovery::test_get_plugin_toolsets_triggers_discovery`,
  a regression test that asserts `get_plugin_toolsets()` triggers discovery
  before reading the registry.

## How to Test

1. Check out the branch and run
   `scripts/run_tests.sh tests/hermes_cli/test_plugins.py`; all tests pass.
2. Run the regression test in isolation:
   `pytest tests/hermes_cli/test_plugins.py::TestGetPluginToolsetsDiscovery -q`.
3. To confirm it guards the fix, temporarily revert the accessor to
   `get_plugin_manager()` and re-run the test; it fails because discovery is
   never triggered and the function short-circuits to an empty list.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A