### PR TITLE
fix(skills): prevent skill_manage create from wiping an existing category dir

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1488,6 +1488,7 @@ AUTHOR_MAP = {
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
     "42903577+ohMyJason@users.noreply.github.com": "ohMyJason",  # PR #29810 (discover_models in custom_providers section 4)
     "singhsanidhya741@gmail.com": "sanidhyasin",  # PR #40403 salvage (model.default_headers for custom OpenAI-compatible providers, #40033)
+    "290858493+sasquatch9818@users.noreply.github.com": "sasquatch9818",  # skill_manage create guard against rmtree of an existing category dir
 }
 
 

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -259,6 +259,41 @@ class TestCreateSkill:
         assert f"Invalid category '{outside}'" in result["error"]
         assert not (outside / "my-skill" / "SKILL.md").exists()
 
+    def test_create_into_existing_category_dir_is_refused(self, tmp_path):
+        # `name` collides with a category folder (e.g. `devops/`) whose
+        # SKILL.md files live one level deeper. `_find_skill` doesn't catch
+        # this, so the create must refuse rather than write into the live
+        # category — and, critically, must NOT rmtree it on rollback.
+        with _skill_dir(tmp_path):
+            _create_skill("kanban", VALID_SKILL_CONTENT, category="devops")
+            assert (tmp_path / "devops" / "kanban" / "SKILL.md").exists()
+
+            result = _create_skill("devops", VALID_SKILL_CONTENT)
+
+        assert result["success"] is False
+        assert "already exists" in result["error"]
+        # The sibling skill inside the category survives untouched.
+        assert (tmp_path / "devops" / "kanban" / "SKILL.md").exists()
+
+    def test_create_rollback_preserves_preexisting_dir(self, tmp_path):
+        # An empty directory already on disk at the target path must survive
+        # a scan-block rollback: only the freshly written SKILL.md is removed.
+        target = tmp_path / "my-skill"
+        target.mkdir()
+
+        with _skill_dir(tmp_path), \
+             patch(
+                 "tools.skill_manager_tool._security_scan_skill",
+                 return_value="Security scan blocked this skill (test).",
+             ):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT)
+
+        assert result["success"] is False
+        assert "Security scan blocked" in result["error"]
+        # Directory pre-existed, so it is kept; only our SKILL.md is gone.
+        assert target.exists()
+        assert not (target / "SKILL.md").exists()
+
 
 class TestEditSkill:
     def test_edit_existing_skill(self, tmp_path):

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -512,16 +512,36 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
 
     # Create the skill directory
     skill_dir = _resolve_skill_dir(name, category)
+
+    # Refuse to write into a directory that already exists with contents.
+    # `_find_skill` above only catches dirs that *directly* contain a
+    # SKILL.md, so a category folder (e.g. `devops/`, whose SKILL.md files
+    # live one level deeper) slips through the collision check. Without this
+    # guard the SKILL.md would be dropped straight into the live category and
+    # the scan-block rollback below would `rmtree` it — wiping every sibling
+    # skill inside.
+    if skill_dir.exists() and any(skill_dir.iterdir()):
+        return {
+            "success": False,
+            "error": f"Cannot create skill '{name}': {skill_dir} already exists and is not empty.",
+        }
+
+    dir_pre_existed = skill_dir.exists()
     skill_dir.mkdir(parents=True, exist_ok=True)
 
     # Write SKILL.md atomically
     skill_md = skill_dir / "SKILL.md"
     _atomic_write_text(skill_md, content)
 
-    # Security scan — roll back on block
+    # Security scan — roll back on block. Only remove what we created:
+    # rmtree the directory when we made it, otherwise just drop the SKILL.md
+    # we wrote so a pre-existing (empty) directory is never destroyed.
     scan_error = _security_scan_skill(skill_dir)
     if scan_error:
-        shutil.rmtree(skill_dir, ignore_errors=True)
+        if dir_pre_existed:
+            skill_md.unlink(missing_ok=True)
+        else:
+            shutil.rmtree(skill_dir, ignore_errors=True)
         return {"success": False, "error": scan_error}
 
     result = {


### PR DESCRIPTION
skill_manage(action='create') could delete an entire skills category and
every skill inside it. The collision check `_find_skill(name)` only matches
directories whose immediate child is a SKILL.md named `name`. A category
folder like `devops/` keeps its SKILL.md files one level deeper, so
`_find_skill('devops')` returns None and the name passes validation.

`_resolve_skill_dir` then points at the live `devops/` directory.
`mkdir(exist_ok=True)` silently reuses it, SKILL.md is written into the
category, and the post-write security scan recurses the whole tree — sibling
skills' scripts trip threat patterns and the scan blocks. The rollback then
runs `shutil.rmtree(skill_dir)` on the category, taking out every sibling
skill. Even with the guard off, the stray SKILL.md corrupts the layout.

Refuse to create when the target dir already exists and is non-empty, and on
rollback only rmtree when we actually created the directory — otherwise just
remove the SKILL.md we wrote. A pre-existing dir is never destroyed.

## What does this PR do?

Stops `skill_manage(action='create')` from clobbering a pre-existing
directory. When the requested name collides with a category folder (or any
non-skill directory already on disk), the create now refuses instead of
writing into it, and the scan-block rollback no longer `rmtree`s a directory
it did not create. This closes a data-loss path that could delete a whole
category of skills.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_manager_tool.py` — `_create_skill`: refuse when the resolved
  target directory exists and is non-empty; track whether the directory
  pre-existed and, on scan-block rollback, only `rmtree` directories we
  created (otherwise unlink just the written SKILL.md).
- `tests/tools/test_skill_manager_tool.py` — add regression tests: creating
  over a populated category is refused and siblings survive; rollback keeps a
  pre-existing directory and removes only the new SKILL.md.
- `scripts/release.py` — add author email to `AUTHOR_MAP`.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py`
2. The two new tests fail on `main` and pass with this change.
3. Repro: create `devops/kanban`, then `skill_manage(action='create',
   name='devops')`. Before: the `devops` category is deleted. After: the
   create is refused and `devops/kanban` is intact.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A