### PR TITLE
feat(agent): add active_context tool for session-scoped task tracking

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1080,6 +1080,10 @@ def init_agent(
     from tools.todo_tool import TodoStore
     agent._todo_store = TodoStore()
     
+    # Active context store for session-scoped task tracking (one per agent/session)
+    from tools.active_context_tool import ActiveContextStore
+    agent._active_context_store = ActiveContextStore()
+    
     # Load config once for memory, skills, and compression sections
     try:
         from hermes_cli.config import load_config as _load_agent_config

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -494,6 +494,13 @@ def compress_context(
     if todo_snapshot:
         compressed.append({"role": "user", "content": todo_snapshot})
 
+    # Preserve active context through compression
+    active_ctx = getattr(agent, "_active_context_store", None)
+    if active_ctx is not None:
+        active_ctx_prompt = active_ctx.format_for_prompt()
+        if active_ctx_prompt:
+            compressed.append({"role": "user", "content": active_ctx_prompt})
+
     agent._invalidate_system_prompt()
     new_system_prompt = agent._build_system_prompt(system_message)
     agent._cached_system_prompt = new_system_prompt

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -326,6 +326,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             pass
 
+    # Active context (session-scoped task tracking)
+    _active_ctx_store = getattr(agent, "_active_context_store", None)
+    if _active_ctx_store is not None:
+        _active_ctx_prompt = _active_ctx_store.format_for_prompt()
+        if _active_ctx_prompt:
+            volatile_parts.append(_active_ctx_prompt)
+
     from hermes_time import now as _hermes_now
     now = _hermes_now()
     # Date-only (not minute-precision) so the system prompt is byte-stable

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -980,6 +980,25 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
+        elif function_name == "active_context":
+            def _execute(next_args: dict) -> Any:
+                from tools.active_context_tool import active_context_tool as _active_context_fn
+                return _active_context_fn(
+                    action=next_args.get("action", "get"),
+                    task=next_args.get("task"),
+                    store=agent._active_context_store,
+                )
+            function_result, function_args = _run_agent_tool_execution_middleware(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                execute=_execute,
+            )
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('active_context', function_args, tool_duration, result=function_result)}")
         elif function_name == "session_search":
             def _execute(next_args: dict) -> Any:
                 session_db = agent._get_session_db_for_recall()

--- a/run_agent.py
+++ b/run_agent.py
@@ -638,6 +638,10 @@ class AIAgent:
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
 
+        # Clear active context on session reset (auto-reset, /new)
+        if hasattr(self, "_active_context_store") and self._active_context_store is not None:
+            self._active_context_store.reset()
+
         # Context engine reset/transition (works for built-in compressor and plugins)
         self._transition_context_engine_session(
             old_session_id=old_session_id,

--- a/tests/test_active_context_tool.py
+++ b/tests/test_active_context_tool.py
@@ -1,0 +1,161 @@
+"""Tests for active_context tool — session-scoped task tracking."""
+
+import json
+import time
+import unittest
+
+from tools.active_context_tool import (
+    ActiveContextStore,
+    active_context_tool,
+)
+
+
+class TestActiveContextStore(unittest.TestCase):
+    """Unit tests for the in-memory ActiveContextStore."""
+
+    def test_set_and_get(self):
+        store = ActiveContextStore()
+        result = json.loads(store.set("debugging Memory OS update script"))
+        self.assertEqual(result["status"], "set")
+        self.assertEqual(result["task"], "debugging Memory OS update script")
+
+        result = json.loads(store.get())
+        self.assertEqual(result["status"], "active")
+        self.assertEqual(result["task"], "debugging Memory OS update script")
+
+    def test_get_empty(self):
+        store = ActiveContextStore()
+        result = json.loads(store.get())
+        self.assertEqual(result["status"], "empty")
+        self.assertIsNone(result["task"])
+
+    def test_clear(self):
+        store = ActiveContextStore()
+        store.set("some task")
+        result = json.loads(store.clear())
+        self.assertEqual(result["status"], "cleared")
+        self.assertEqual(result["task"], "some task")
+
+        result = json.loads(store.get())
+        self.assertEqual(result["status"], "empty")
+
+    def test_clear_empty(self):
+        store = ActiveContextStore()
+        result = json.loads(store.clear())
+        self.assertEqual(result["status"], "empty")
+
+    def test_overwrite(self):
+        store = ActiveContextStore()
+        store.set("task A")
+        store.set("task B")
+        result = json.loads(store.get())
+        self.assertEqual(result["task"], "task B")
+
+    def test_set_empty_string_clears(self):
+        store = ActiveContextStore()
+        store.set("task A")
+        result = json.loads(store.set(""))
+        self.assertEqual(result["status"], "cleared")
+        result = json.loads(store.get())
+        self.assertEqual(result["status"], "empty")
+
+    def test_truncation(self):
+        store = ActiveContextStore()
+        long_task = "x" * 1000
+        store.set(long_task)
+        result = json.loads(store.get())
+        self.assertEqual(len(result["task"]), 500)
+
+    def test_ttl_expiry(self):
+        store = ActiveContextStore(ttl_seconds=1)
+        store.set("expiring task")
+        result = json.loads(store.get())
+        self.assertEqual(result["status"], "active")
+
+        time.sleep(1.1)
+        result = json.loads(store.get())
+        self.assertEqual(result["status"], "expired")
+
+    def test_format_for_prompt_active(self):
+        store = ActiveContextStore()
+        store.set("fixing browser bug")
+        prompt = store.format_for_prompt()
+        self.assertIn("fixing browser bug", prompt)
+        self.assertIn("[Active context:", prompt)
+
+    def test_format_for_prompt_empty(self):
+        store = ActiveContextStore()
+        prompt = store.format_for_prompt()
+        self.assertIsNone(prompt)
+
+    def test_format_for_prompt_expired(self):
+        store = ActiveContextStore(ttl_seconds=1)
+        store.set("expiring task")
+        time.sleep(1.1)
+        prompt = store.format_for_prompt()
+        self.assertIsNone(prompt)
+
+    def test_reset(self):
+        store = ActiveContextStore()
+        store.set("task A")
+        store.reset()
+        result = json.loads(store.get())
+        self.assertEqual(result["status"], "empty")
+
+    def test_set_strips_whitespace(self):
+        store = ActiveContextStore()
+        store.set("  hello world  ")
+        result = json.loads(store.get())
+        self.assertEqual(result["task"], "hello world")
+
+
+class TestActiveContextTool(unittest.TestCase):
+    """Tests for the tool handler function."""
+
+    def test_set_action(self):
+        store = ActiveContextStore()
+        result = json.loads(
+            active_context_tool(action="set", task="my task", store=store)
+        )
+        self.assertEqual(result["status"], "set")
+        self.assertEqual(result["task"], "my task")
+
+    def test_get_action(self):
+        store = ActiveContextStore()
+        store.set("existing task")
+        result = json.loads(
+            active_context_tool(action="get", store=store)
+        )
+        self.assertEqual(result["status"], "active")
+
+    def test_clear_action(self):
+        store = ActiveContextStore()
+        store.set("task")
+        result = json.loads(
+            active_context_tool(action="clear", store=store)
+        )
+        self.assertEqual(result["status"], "cleared")
+
+    def test_set_without_task_returns_error(self):
+        store = ActiveContextStore()
+        result = json.loads(
+            active_context_tool(action="set", task=None, store=store)
+        )
+        self.assertIn("error", result)
+
+    def test_invalid_action(self):
+        store = ActiveContextStore()
+        result = json.loads(
+            active_context_tool(action="invalid", store=store)
+        )
+        self.assertIn("error", result)
+
+    def test_no_store(self):
+        result = json.loads(
+            active_context_tool(action="get", store=None)
+        )
+        self.assertIn("error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/active_context_tool.py
+++ b/tools/active_context_tool.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Active Context Tool — short-lived session task tracking.
+
+Maintains exactly one "currently working on" string per session.
+Auto-clears on session reset (/new, auto-reset). Prominently
+surfaced in the system prompt so the agent always knows what
+it was doing before a context compression or reset.
+
+Difference from durable memory:
+  - Auto-clears on session boundaries
+  - Shorter TTL — hours, not forever
+  - One field only — swapped atomically
+  - Token-efficient — no scanning, just a structured string
+"""
+
+import json
+import time
+from typing import Optional
+
+# Maximum length for the task description
+_MAX_TASK_CHARS = 500
+
+# Default TTL in seconds (4 hours)
+_DEFAULT_TTL_SECONDS = 4 * 60 * 60
+
+
+class ActiveContextStore:
+    """In-memory store for the active task context. One per session."""
+
+    def __init__(self, ttl_seconds: int = _DEFAULT_TTL_SECONDS):
+        self._task: Optional[str] = None
+        self._set_at: Optional[float] = None
+        self._ttl = ttl_seconds
+
+    def set(self, task: str) -> str:
+        """Record the current task. Returns confirmation."""
+        task = task.strip()[:_MAX_TASK_CHARS]
+        if not task:
+            return self.clear()
+        self._task = task
+        self._set_at = time.time()
+        return json.dumps({"status": "set", "task": task})
+
+    def get(self) -> str:
+        """Return the current task, or empty if expired/cleared."""
+        if self._task is None:
+            return json.dumps({"status": "empty", "task": None})
+        if self._set_at is not None and (time.time() - self._set_at) > self._ttl:
+            expired = self._task
+            self._task = None
+            self._set_at = None
+            return json.dumps({"status": "expired", "task": expired})
+        return json.dumps({"status": "active", "task": self._task})
+
+    def clear(self) -> str:
+        """Clear the active context."""
+        old = self._task
+        self._task = None
+        self._set_at = None
+        if old:
+            return json.dumps({"status": "cleared", "task": old})
+        return json.dumps({"status": "empty", "task": None})
+
+    def format_for_prompt(self) -> Optional[str]:
+        """Return a prompt-injectable string, or None if no active task."""
+        if self._task is None:
+            return None
+        if self._set_at is not None and (time.time() - self._set_at) > self._ttl:
+            self._task = None
+            self._set_at = None
+            return None
+        return f"[Active context: {self._task}]"
+
+    def reset(self):
+        """Clear on session reset."""
+        self._task = None
+        self._set_at = None
+
+
+def active_context_tool(
+    action: str = "get",
+    task: Optional[str] = None,
+    store: Optional[ActiveContextStore] = None,
+) -> str:
+    """Handle active_context tool calls.
+
+    Args:
+        action: 'set', 'get', or 'clear'
+        task: The task description (required when action='set')
+        store: The ActiveContextStore instance from the AIAgent.
+    """
+    if store is None:
+        return json.dumps({"error": "ActiveContextStore not initialized"})
+
+    if action == "set":
+        if not task or not task.strip():
+            return json.dumps({"error": "task is required when action='set'"})
+        return store.set(task)
+    elif action == "get":
+        return store.get()
+    elif action == "clear":
+        return store.clear()
+    else:
+        return json.dumps({"error": f"Unknown action: {action}. Use 'set', 'get', or 'clear'."})
+
+
+def check_active_context_requirements() -> bool:
+    """No external requirements."""
+    return True
+
+
+# =============================================================================
+# OpenAI Function-Calling Schema
+# =============================================================================
+
+ACTIVE_CONTEXT_SCHEMA = {
+    "name": "active_context",
+    "description": (
+        "Track what you are currently working on in this session. "
+        "Use this when switching between tasks or starting a complex multi-step "
+        "task so you can recover context after auto-resets or /new.\n\n"
+        "Actions:\n"
+        "- set: record your current task (1-2 short sentences)\n"
+        "- get: read the current task\n"
+        "- clear: remove the current task\n\n"
+        "The active context is automatically injected into your system prompt "
+        "and auto-clears on session boundaries. Unlike durable memory, this is "
+        "ephemeral and session-scoped."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["set", "get", "clear"],
+                "description": (
+                    "set: record current task. get: read current task. "
+                    "clear: remove current task."
+                ),
+            },
+            "task": {
+                "type": "string",
+                "description": (
+                    "Short task description (1-2 sentences). "
+                    "Required when action='set', ignored otherwise."
+                ),
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+# --- Registry ---
+from tools.registry import registry
+
+registry.register(
+    name="active_context",
+    toolset="memory",
+    schema=ACTIVE_CONTEXT_SCHEMA,
+    handler=lambda args, **kw: active_context_tool(
+        action=args.get("action", "get"),
+        task=args.get("task"),
+        store=kw.get("store"),
+    ),
+    check_fn=check_active_context_requirements,
+    emoji="🎯",
+)


### PR DESCRIPTION
## Problem

When Hermes auto-resets between turns (or resumes after a /new), it loses knowledge of what the user and agent were actively working on. This creates ambiguity with follow-ups like "run it now" or "check it again" — especially when the user has multiple recent tasks.

Durable memory is not the right solution: it's permanent, token-heavy, and designed for stable facts — not ephemeral "what are we doing right now" state.

## Solution

Add a lightweight `active_context` tool that maintains short-lived session context across resets:

- **Set** — agent records "currently working on: X" (1-2 token-efficient sentences)
- **Get** — returns the current task string or empty
- **Clear** — removes the current task

Key design decisions (per the issue's requirements):

| Aspect | Behavior |
|--------|----------|
| Auto-clear | On session boundaries (auto-reset, /new) |
| TTL | 4 hours default, then auto-expires |
| One field | Always exactly one active task, swapped atomically |
| Prompt injection | Volatile tier (above memory, below timestamp) |
| Compression | Preserved through context compression via format_for_prompt |
| Token-efficient | No scanning/searching, just a structured string |

## Implementation

Follows the `TodoStore` pattern established in the codebase:

1. **`tools/active_context_tool.py`** — `ActiveContextStore` (in-memory, per-session) + handler + OpenAI schema + registry registration
2. **`agent/agent_init.py`** — Initialize `agent._active_context_store`
3. **`agent/tool_executor.py`** — Direct dispatch with store (same pattern as todo)
4. **`agent/system_prompt.py`** — Inject in volatile tier
5. **`agent/conversation_compression.py`** — Preserve through compression
6. **`run_agent.py`** — Auto-clear on `reset_session_state`

## Testing

19 unit tests covering:
- Set/get/clear lifecycle
- Overwrite behavior
- Empty string → clear
- Long task truncation (500 char cap)
- TTL expiry (1-second test)
- `format_for_prompt` for active/empty/expired states
- `reset()` for session boundary clearing
- Whitespace stripping
- Tool handler: all actions, missing task error, invalid action error, no-store error

## Files Changed

| File | Change |
|------|--------|
| `tools/active_context_tool.py` | New — store + handler + schema |
| `agent/agent_init.py` | +4 lines — initialize store |
| `agent/tool_executor.py` | +19 lines — dispatch with store |
| `agent/system_prompt.py` | +7 lines — volatile tier injection |
| `agent/conversation_compression.py` | +7 lines — compression preservation |
| `run_agent.py` | +4 lines — auto-clear on reset |
| `tests/test_active_context_tool.py` | New — 19 tests |

Closes #41993
