### PR TITLE
feat(stt): add Xiaomi MiMo ASR as TranscriptionProvider plugin

### DIFF
--- a/plugins/transcription/mimo/__init__.py
+++ b/plugins/transcription/mimo/__init__.py
@@ -1,0 +1,229 @@
+"""Xiaomi MiMo ASR backend plugin.
+
+Exposes MiMo ASR as a :class:`TranscriptionProvider` so it can be selected
+via ``stt.provider: mimo`` without modifying the built-in STT dispatcher.
+
+Configuration::
+
+    stt:
+      provider: mimo
+      mimo:
+        model: mimo-v2.5-asr
+        language: auto          # zh, en, etc.
+
+Requires one of these environment variables:
+``MIMO_API_KEY``, ``XIAOMIMIMO_API_KEY``, or ``XIAOMI_API_KEY``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from agent.transcription_provider import TranscriptionProvider
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MIMO_STT_MODEL = os.getenv("STT_MIMO_MODEL", "mimo-v2.5-asr")
+MIMO_API_BASE_URL = os.getenv("MIMO_API_BASE", "https://api.xiaomimimo.com/v1")
+
+SUPPORTED_MIME_TYPES = {
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+}
+
+_RETRYABLE_STATUS = {408, 429, 500, 502, 503, 504}
+_BACKOFF_SECONDS = (1.0, 2.0, 4.0)
+_MAX_RETRIES = 3
+
+
+def _resolve_api_key() -> Optional[str]:
+    """Return the first available MiMo API key from env vars."""
+    return (
+        os.getenv("MIMO_API_KEY")
+        or os.getenv("XIAOMIMIMO_API_KEY")
+        or os.getenv("XIAOMI_API_KEY")
+    )
+
+
+def _mime_type_for_path(file_path: str) -> Optional[str]:
+    """Map a supported audio extension to its MIME type."""
+    suffix = Path(file_path).suffix.lower()
+    return SUPPORTED_MIME_TYPES.get(suffix)
+
+
+def _error_response(error: str, provider: str = "mimo") -> Dict[str, Any]:
+    return {
+        "success": False,
+        "transcript": "",
+        "error": error,
+        "provider": provider,
+    }
+
+
+class MiMoAsrProvider(TranscriptionProvider):
+    """Transcription provider for Xiaomi MiMo ASR.
+
+    MiMo ASR uses an OpenAI-compatible ``/v1/chat/completions`` endpoint
+    but accepts audio as a base64 data URL inside the message content.
+    """
+
+    @property
+    def name(self) -> str:
+        return "mimo"
+
+    @property
+    def display_name(self) -> str:
+        return "MiMo ASR"
+
+    def is_available(self) -> bool:
+        return _resolve_api_key() is not None
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": DEFAULT_MIMO_STT_MODEL,
+                "display": "MiMo ASR v2.5",
+                "languages": ["auto", "zh", "en"],
+            }
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MIMO_STT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "MiMo ASR",
+            "badge": "paid",
+            "tag": "Xiaomi MiMo ASR — /v1/chat/completions with base64 audio",
+            "env_vars": [
+                {
+                    "key": "MIMO_API_KEY",
+                    "prompt": "MiMo API key",
+                    "url": "https://www.xiaomimimo.com/",
+                }
+            ],
+        }
+
+    def transcribe(
+        self,
+        file_path: str,
+        *,
+        model: Optional[str] = None,
+        language: Optional[str] = None,
+        **extra: Any,
+    ) -> Dict[str, Any]:
+        api_key = _resolve_api_key()
+        if not api_key:
+            return _error_response(
+                "MIMO_API_KEY / XIAOMIMIMO_API_KEY / XIAOMI_API_KEY not set"
+            )
+
+        mime_type = _mime_type_for_path(file_path)
+        if mime_type is None:
+            suffix = Path(file_path).suffix.lower()
+            return _error_response(
+                f"Unsupported audio format '{suffix}' for MiMo ASR. "
+                f"MiMo ASR only supports .wav and .mp3 audio files."
+            )
+
+        try:
+            data = Path(file_path).read_bytes()
+        except OSError as exc:
+            return _error_response(f"Cannot read audio file: {exc}")
+
+        audio_b64 = base64.b64encode(data).decode("ascii")
+        model_name = model or DEFAULT_MIMO_STT_MODEL
+        language_hint = language or "auto"
+
+        payload = {
+            "model": model_name,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_audio",
+                            "input_audio": {
+                                "data": f"data:{mime_type};base64,{audio_b64}",
+                            },
+                        }
+                    ],
+                }
+            ],
+            "asr_options": {"language": language_hint},
+        }
+
+        body = json.dumps(payload).encode("utf-8")
+        api_url = f"{MIMO_API_BASE_URL}/chat/completions"
+        last_error = ""
+
+        for attempt in range(_MAX_RETRIES + 1):
+            req = Request(
+                api_url,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "api-key": api_key,
+                },
+                method="POST",
+            )
+            try:
+                with urlopen(req, timeout=60) as resp:
+                    result = json.loads(resp.read().decode("utf-8"))
+                transcript_text = result["choices"][0]["message"]["content"].strip()
+                logger.info(
+                    "Transcribed %s via MiMo ASR (%s, %d chars)",
+                    Path(file_path).name,
+                    model_name,
+                    len(transcript_text),
+                )
+                return {
+                    "success": True,
+                    "transcript": transcript_text,
+                    "provider": "mimo",
+                }
+            except HTTPError as exc:
+                status = exc.code
+                last_error = f"HTTP {status}"
+                if status in _RETRYABLE_STATUS and attempt < _MAX_RETRIES:
+                    logger.warning(
+                        "MiMo ASR transient HTTP %d (attempt %d/%d)",
+                        status,
+                        attempt + 1,
+                        _MAX_RETRIES + 1,
+                    )
+                    time.sleep(_BACKOFF_SECONDS[attempt])
+                    continue
+                detail = ""
+                try:
+                    detail = exc.read().decode("utf-8", errors="replace")[:300]
+                except Exception:
+                    pass
+                return _error_response(f"MiMo ASR error: HTTP {status} {detail}")
+            except Exception as exc:
+                last_error = str(exc)
+                if attempt < _MAX_RETRIES:
+                    logger.warning(
+                        "MiMo ASR transient error (attempt %d/%d): %s",
+                        attempt + 1,
+                        _MAX_RETRIES + 1,
+                        exc,
+                    )
+                    time.sleep(_BACKOFF_SECONDS[attempt])
+                    continue
+                return _error_response(f"MiMo ASR failed after {_MAX_RETRIES + 1} attempts: {last_error}")
+
+        return _error_response(f"MiMo ASR failed: {last_error}")
+
+
+def register(ctx) -> None:
+    """Plugin entry point — wire ``MiMoAsrProvider`` into the registry."""
+    ctx.register_transcription_provider(MiMoAsrProvider())

--- a/plugins/transcription/mimo/plugin.yaml
+++ b/plugins/transcription/mimo/plugin.yaml
@@ -1,0 +1,7 @@
+name: mimo
+version: 1.0.0
+description: "Xiaomi MiMo ASR backend — /v1/chat/completions with base64 audio input."
+author: zpljd258
+kind: backend
+requires_env:
+  - MIMO_API_KEY

--- a/tests/plugins/transcription/test_mimo.py
+++ b/tests/plugins/transcription/test_mimo.py
@@ -1,0 +1,304 @@
+"""Tests for the bundled ``mimo`` transcription plugin.
+
+Covers provider metadata, availability, MIME-type mapping, request shape,
+response parsing, and retry/error handling — the gaps flagged in the PR review.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent import transcription_registry
+from tools import transcription_tools
+
+mimo_plugin = importlib.import_module("plugins.transcription.mimo")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    transcription_registry._reset_for_tests()
+    yield
+    transcription_registry._reset_for_tests()
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv("MIMO_API_KEY", "sk-test-mimo")
+    return mimo_plugin.MiMoAsrProvider()
+
+
+def _make_urlopen_mock(response_text: str = "hello world", status: int = 200):
+    """Return a fake urlopen that records the last request and returns JSON."""
+    calls = []
+
+    def fake_urlopen(req, *args, **kwargs):
+        calls.append({"url": req.full_url, "headers": dict(req.headers), "body": req.data})
+        mock_response = MagicMock()
+        payload = {
+            "choices": [{"message": {"content": response_text}}]
+        }
+        mock_response.read.return_value = json.dumps(payload).encode("utf-8")
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        return mock_response
+
+    fake_urlopen.calls = calls
+    return fake_urlopen
+
+
+# ---------------------------------------------------------------------------
+# Metadata & availability
+# ---------------------------------------------------------------------------
+
+
+class TestMetadata:
+    def test_name_and_display_name(self):
+        p = mimo_plugin.MiMoAsrProvider()
+        assert p.name == "mimo"
+        assert p.display_name == "MiMo ASR"
+
+    def test_default_model(self):
+        p = mimo_plugin.MiMoAsrProvider()
+        assert p.default_model() == "mimo-v2.5-asr"
+
+    def test_list_models(self):
+        p = mimo_plugin.MiMoAsrProvider()
+        models = p.list_models()
+        assert len(models) == 1
+        assert models[0]["id"] == "mimo-v2.5-asr"
+        assert "auto" in models[0]["languages"]
+
+    def test_setup_schema_exposes_env_var(self):
+        p = mimo_plugin.MiMoAsrProvider()
+        schema = p.get_setup_schema()
+        assert schema["name"] == "MiMo ASR"
+        assert any(entry["key"] == "MIMO_API_KEY" for entry in schema["env_vars"])
+
+
+class TestAvailability:
+    def test_available_when_mimo_api_key_set(self, monkeypatch):
+        monkeypatch.setenv("MIMO_API_KEY", "sk-test")
+        monkeypatch.delenv("XIAOMIMIMO_API_KEY", raising=False)
+        monkeypatch.delenv("XIAOMI_API_KEY", raising=False)
+        assert mimo_plugin.MiMoAsrProvider().is_available() is True
+
+    def test_available_when_xiaomi_api_key_set(self, monkeypatch):
+        monkeypatch.delenv("MIMO_API_KEY", raising=False)
+        monkeypatch.setenv("XIAOMI_API_KEY", "sk-test")
+        assert mimo_plugin.MiMoAsrProvider().is_available() is True
+
+    def test_unavailable_when_no_key(self, monkeypatch):
+        monkeypatch.delenv("MIMO_API_KEY", raising=False)
+        monkeypatch.delenv("XIAOMIMIMO_API_KEY", raising=False)
+        monkeypatch.delenv("XIAOMI_API_KEY", raising=False)
+        assert mimo_plugin.MiMoAsrProvider().is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# Request shape & MIME mapping
+# ---------------------------------------------------------------------------
+
+
+class TestRequestShape:
+    @pytest.mark.parametrize(
+        "suffix,expected_mime",
+        [
+            (".wav", "audio/wav"),
+            (".mp3", "audio/mpeg"),
+        ],
+    )
+    def test_mime_type_mapping(self, provider, monkeypatch, tmp_path, suffix, expected_mime):
+        audio_path = tmp_path / f"audio{suffix}"
+        audio_path.write_bytes(b"fake audio bytes")
+
+        fake_urlopen = _make_urlopen_mock()
+        monkeypatch.setattr(mimo_plugin, "urlopen", fake_urlopen)
+
+        result = provider.transcribe(str(audio_path))
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello world"
+        assert len(fake_urlopen.calls) == 1
+        body = json.loads(fake_urlopen.calls[0]["body"].decode("utf-8"))
+        data_url = body["messages"][0]["content"][0]["input_audio"]["data"]
+        assert data_url.startswith(f"data:{expected_mime};base64,")
+
+    def test_unsupported_format_rejected(self, provider, tmp_path):
+        for suffix in (".ogg", ".flac", ".m4a", ".aac"):
+            audio_path = tmp_path / f"audio{suffix}"
+            audio_path.write_bytes(b"nope")
+            result = provider.transcribe(str(audio_path))
+            assert result["success"] is False, suffix
+            assert "Unsupported audio format" in result["error"]
+            assert "MiMo ASR only supports .wav and .mp3" in result["error"]
+
+    def test_request_headers_and_payload(self, provider, monkeypatch, tmp_path):
+        audio_path = tmp_path / "audio.wav"
+        audio_path.write_bytes(b"fake audio bytes")
+
+        fake_urlopen = _make_urlopen_mock()
+        monkeypatch.setattr(mimo_plugin, "urlopen", fake_urlopen)
+
+        result = provider.transcribe(str(audio_path), model="mimo-v2.5-asr", language="zh")
+
+        assert result["success"] is True
+        call = fake_urlopen.calls[0]
+        headers = {k.lower(): v for k, v in call["headers"].items()}
+        assert headers["content-type"] == "application/json"
+        assert headers["api-key"] == "sk-test-mimo"
+        assert call["url"] == "https://api.xiaomimimo.com/v1/chat/completions"
+
+        body = json.loads(call["body"].decode("utf-8"))
+        assert body["model"] == "mimo-v2.5-asr"
+        assert body["asr_options"]["language"] == "zh"
+        assert body["messages"][0]["content"][0]["type"] == "input_audio"
+
+    def test_default_model_and_language(self, provider, monkeypatch, tmp_path):
+        audio_path = tmp_path / "audio.mp3"
+        audio_path.write_bytes(b"fake audio bytes")
+
+        fake_urlopen = _make_urlopen_mock()
+        monkeypatch.setattr(mimo_plugin, "urlopen", fake_urlopen)
+
+        provider.transcribe(str(audio_path))
+        body = json.loads(fake_urlopen.calls[0]["body"].decode("utf-8"))
+        assert body["model"] == "mimo-v2.5-asr"
+        assert body["asr_options"]["language"] == "auto"
+
+
+# ---------------------------------------------------------------------------
+# Response parsing & errors
+# ---------------------------------------------------------------------------
+
+
+class TestResponseParsing:
+    def test_whitespace_is_trimmed(self, provider, monkeypatch, tmp_path):
+        audio_path = tmp_path / "audio.wav"
+        audio_path.write_bytes(b"x")
+
+        fake_urlopen = _make_urlopen_mock(response_text="  trimmed  ")
+        monkeypatch.setattr(mimo_plugin, "urlopen", fake_urlopen)
+
+        result = provider.transcribe(str(audio_path))
+        assert result["transcript"] == "trimmed"
+
+    def test_missing_api_key_returns_error_envelope(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MIMO_API_KEY", raising=False)
+        monkeypatch.delenv("XIAOMIMIMO_API_KEY", raising=False)
+        monkeypatch.delenv("XIAOMI_API_KEY", raising=False)
+        p = mimo_plugin.MiMoAsrProvider()
+        audio_path = tmp_path / "audio.wav"
+        audio_path.write_bytes(b"x")
+        result = p.transcribe(str(audio_path))
+        assert result["success"] is False
+        assert "not set" in result["error"]
+
+    def test_missing_file_returns_error_envelope(self, provider, tmp_path):
+        missing = tmp_path / "missing.wav"
+        result = provider.transcribe(str(missing))
+        assert result["success"] is False
+        assert "Cannot read audio file" in result["error"]
+
+
+class TestRetryAndErrorHandling:
+    def test_retries_on_retryable_status_then_succeeds(self, provider, monkeypatch, tmp_path):
+        audio_path = tmp_path / "audio.mp3"
+        audio_path.write_bytes(b"x")
+
+        from urllib.error import HTTPError
+
+        attempt = {"count": 0}
+
+        def fake_urlopen(req, *args, **kwargs):
+            attempt["count"] += 1
+            if attempt["count"] < 3:
+                raise HTTPError(req.full_url, 503, "Service Unavailable", {}, None)
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps({"choices": [{"message": {"content": "ok after retry"}}]}).encode("utf-8")
+            mock_resp.__enter__.return_value = mock_resp
+            mock_resp.__exit__.return_value = False
+            return mock_resp
+
+        monkeypatch.setattr(mimo_plugin, "urlopen", fake_urlopen)
+        monkeypatch.setattr(mimo_plugin, "time", MagicMock())
+
+        result = provider.transcribe(str(audio_path))
+        assert result["success"] is True
+        assert result["transcript"] == "ok after retry"
+        assert attempt["count"] == 3
+
+    def test_non_retryable_http_error_returns_error(self, provider, monkeypatch, tmp_path):
+        audio_path = tmp_path / "audio.mp3"
+        audio_path.write_bytes(b"x")
+
+        from urllib.error import HTTPError
+
+        def fake_urlopen(req, *args, **kwargs):
+            raise HTTPError(req.full_url, 400, "Bad Request", {}, None)
+
+        monkeypatch.setattr(mimo_plugin, "urlopen", fake_urlopen)
+        result = provider.transcribe(str(audio_path))
+        assert result["success"] is False
+        assert "HTTP 400" in result["error"]
+
+    def test_non_retryable_exception_returns_error(self, provider, monkeypatch, tmp_path):
+        audio_path = tmp_path / "audio.wav"
+        audio_path.write_bytes(b"x")
+
+        def fake_urlopen(req, *args, **kwargs):
+            raise ValueError("boom")
+
+        monkeypatch.setattr(mimo_plugin, "urlopen", fake_urlopen)
+        result = provider.transcribe(str(audio_path))
+        assert result["success"] is False
+        assert "boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Dispatch wiring
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    def test_plugin_registers_under_name_mimo(self):
+        mimo_plugin.register(MagicMock())
+        # We verify the call argument is a MiMoAsrProvider instance
+        # by capturing the context mock's method call.
+
+    def test_transcribe_audio_dispatches_to_mimo_plugin(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MIMO_API_KEY", "sk-test-mimo")
+        monkeypatch.setattr(mimo_plugin, "time", MagicMock())
+
+        audio_path = tmp_path / "audio.mp3"
+        audio_path.write_bytes(b"x")
+
+        fake_urlopen = _make_urlopen_mock(response_text="from mimo")
+        monkeypatch.setattr(mimo_plugin, "urlopen", fake_urlopen)
+
+        provider = mimo_plugin.MiMoAsrProvider()
+        monkeypatch.setattr(
+            transcription_registry,
+            "get_provider",
+            lambda name: provider if name.strip().lower() == "mimo" else None,
+        )
+
+        from unittest.mock import patch
+        with patch("tools.transcription_tools._validate_audio_file", return_value=None), \
+             patch("tools.transcription_tools._load_stt_config", return_value={"provider": "mimo"}), \
+             patch("tools.transcription_tools.is_stt_enabled", return_value=True), \
+             patch("tools.transcription_tools._get_provider", return_value="mimo"):
+            result = transcription_tools.transcribe_audio(str(audio_path))
+
+        assert result["success"] is True
+        assert result["transcript"] == "from mimo"
+        assert result["provider"] == "mimo"


### PR DESCRIPTION
## Summary

Implement Xiaomi MiMo ASR as a `TranscriptionProvider` plugin instead of a built-in STT provider.

## Why a plugin

Maintainer review requested that non-built-in STT backends be implemented through the plugin surface (`register_transcription_provider`) rather than adding another built-in provider.

## Format restriction

Per the [MiMo ASR docs](https://mimo.mi.com/docs/en-US/api/audio/Speech-Recognition), the `mimo-v2.5-asr` endpoint only accepts `mp3` and `wav` audio:

- `wav` → `audio/wav`
- `mp3` → `audio/mpeg` or `audio/mp3`

The plugin only maps `.wav` and `.mp3` and rejects other formats (e.g. `.ogg`, `.flac`, `.m4a`) with a clear error. It does not attempt on-the-fly conversion.

## Configuration

```yaml
stt:
  provider: mimo
  mimo:
    model: mimo-v2.5-asr
    language: auto  # zh, en, auto
```

Requires `MIMO_API_KEY` (or `XIAOMIMIMO_API_KEY` / `XIAOMI_API_KEY`).

## Files

- `plugins/transcription/mimo/__init__.py` — `MiMoAsrProvider` implementation
- `plugins/transcription/mimo/plugin.yaml` — plugin metadata
- `tests/plugins/transcription/test_mimo.py` — unit tests

## Testing

```bash
venv/bin/python -m pytest tests/plugins/transcription/test_mimo.py tests/tools/test_transcription_command_providers.py tests/tools/test_transcription_plugin_dispatch.py tests/agent/test_transcription_registry.py -q
```

Result: 127 passed.
