### PR TITLE
fix(secrets): fallback to stale BWS disk cache on network failure (#41925)

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -494,7 +494,21 @@ def fetch_bitwarden_secrets(
             "`hermes secrets bitwarden setup`."
         )
 
-    secrets, warnings = _run_bws_list(bws, access_token, project_id, server_url)
+    try:
+        secrets, warnings = _run_bws_list(bws, access_token, project_id, server_url)
+    except RuntimeError:
+        # Live BWS call failed (DNS, transient network outage, etc.).
+        # Fall back to a stale disk cache if one exists — better to start
+        # with slightly old secrets than no secrets at all.  Pass
+        # ``float("inf")`` as TTL so any cached entry counts as fresh.
+        stale = _read_disk_cache(cache_key, float("inf"), home_path)
+        if stale is not None:
+            _CACHE[cache_key] = stale
+            return stale.secrets, [
+                "warning: BWS network call failed; using stale disk cache"
+            ]
+        raise  # No stale cache available — propagate the original error.
+
     entry = _CachedFetch(secrets=secrets, fetched_at=time.time())
     _CACHE[cache_key] = entry
     if use_cache:


### PR DESCRIPTION
Fixes #41925. When the BWS network call fails at gateway startup (DNS resolution failure, transient network outage), the gateway continued running without any injected secrets. This adds a fallback to the stale disk cache when the live BWS call fails, providing valid secrets from previous successful fetches instead of an empty credential pool.