### PR TITLE
fix(model): anchor custom-endpoint context-length matching to id boundaries

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -798,6 +798,27 @@ def fetch_endpoint_model_metadata(
     return {}
 
 
+def _model_ids_boundary_match(a: str, b: str) -> bool:
+    """Return True if model ids *a* and *b* line up on a separator boundary.
+
+    The shorter id must be a prefix of the longer one and stop on a
+    separator (``-`` ``:`` ``.`` ``/``), or the two must be identical. This is
+    stricter than a bare substring test: it lets ``"llama-3.3-70b-instruct"``
+    match ``"llama-3.3-70b-instruct-fp8"`` while refusing to let ``"gpt-4"``
+    latch onto an unrelated ``"gpt-4o"`` (whose next char ``o`` is not a
+    boundary).
+    """
+    a, b = a.strip().lower(), b.strip().lower()
+    if not a or not b:
+        return False
+    short, long = (a, b) if len(a) <= len(b) else (b, a)
+    if short == long:
+        return True
+    if not long.startswith(short):
+        return False
+    return long[len(short)] in "-:./"
+
+
 def _resolve_endpoint_context_length(
     model: str,
     base_url: str,
@@ -810,10 +831,22 @@ def _resolve_endpoint_context_length(
         if len(endpoint_metadata) == 1:
             matched = next(iter(endpoint_metadata.values()))
         else:
-            for key, entry in endpoint_metadata.items():
-                if model in key or key in model:
-                    matched = entry
-                    break
+            # No exact hit. A bare first-match substring scan
+            # (`model in key or key in model`) is order-dependent and can
+            # latch onto an unrelated model — e.g. configured "gpt-4" matching
+            # "gpt-4o" and reporting its (larger) window, which then overflows
+            # the real model's context. Require a separator-boundary match
+            # instead, and pick the most specific (longest) endpoint id so the
+            # closest match wins deterministically regardless of the order
+            # /models returns its catalog.
+            best_key: Optional[str] = None
+            for key in endpoint_metadata:
+                bare_key = key.split("/", 1)[1] if "/" in key else key
+                if _model_ids_boundary_match(model, key) or _model_ids_boundary_match(model, bare_key):
+                    if best_key is None or len(key) > len(best_key):
+                        best_key = key
+            if best_key is not None:
+                matched = endpoint_metadata[best_key]
     if matched:
         context_length = matched.get("context_length")
         if isinstance(context_length, int):

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -65,6 +65,7 @@ AUTHOR_MAP = {
     "harjoth.khara@gmail.com": "harjothkhara",
     "129007007+HeLLGURD@users.noreply.github.com": "HeLLGURD",
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
+    "290880780+vondelomlo@users.noreply.github.com": "vondelomlo",
     "dirtyren@users.noreply.github.com": "dirtyren",
     "adityamalik2833@gmail.com": "alarcritty",
     "islam666@users.noreply.github.com": "islam666",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -829,6 +829,54 @@ class TestGetModelContextLength:
         assert result == 131072
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_custom_endpoint_fuzzy_match_rejects_boundary_collision(
+        self, mock_endpoint_fetch, mock_fetch
+    ):
+        """A short configured name must not latch onto an unrelated longer model.
+
+        "gpt-4" overlaps both "gpt-4o" (a different model with a larger window)
+        and "gpt-4-base". The old first-substring scan returned whichever the
+        endpoint listed first — picking "gpt-4o"'s 1M window for an 8K model
+        overflows context on the next turn. Matching must be anchored on a
+        separator boundary, so "gpt-4o" is rejected and "gpt-4-base" wins
+        regardless of catalog order.
+        """
+        mock_fetch.return_value = {}
+        mock_endpoint_fetch.return_value = {
+            "gpt-4o": {"context_length": 1_000_000},
+            "gpt-4-base": {"context_length": 8192},
+        }
+
+        result = get_model_context_length(
+            "gpt-4",
+            base_url="http://myserver.example.com:8080/v1",
+            api_key="test-key",
+        )
+
+        assert result == 8192
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_custom_endpoint_fuzzy_match_is_order_independent(
+        self, mock_endpoint_fetch, mock_fetch
+    ):
+        """The chosen match is the most specific id, not the first one listed."""
+        mock_fetch.return_value = {}
+        mock_endpoint_fetch.return_value = {
+            "gpt-4-base": {"context_length": 8192},
+            "gpt-4o": {"context_length": 1_000_000},
+        }
+
+        result = get_model_context_length(
+            "gpt-4",
+            base_url="http://myserver.example.com:8080/v1",
+            api_key="test-key",
+        )
+
+        assert result == 8192
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     def test_config_context_length_overrides_all(self, mock_fetch):
         """Explicit config_context_length takes priority over everything."""
         mock_fetch.return_value = {


### PR DESCRIPTION
## What does this PR do?

Stops `_resolve_endpoint_context_length` from reporting an unrelated model's
context window for custom OpenAI-compatible endpoints.

When the configured model has no exact match in the endpoint's `/models`
catalog, the old fallback scanned with a bare `model in key or key in model`
substring test and took the *first* hit in dict order. A short configured name
like `gpt-4` would latch onto `gpt-4o`, inherit its (much larger) window, and
overflow the real model's context on the next turn — order-dependent and
silently wrong. Matching is now anchored on a separator boundary and picks the
most specific (longest) id deterministically, so `gpt-4o` is rejected and the
real `gpt-4-*` entry wins regardless of catalog order. A missed match now
degrades safely to the catalog/default path instead of returning a wrong number.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: add `_model_ids_boundary_match` helper (prefix match
  that must stop on a `-`/`:`/`.`/`/` boundary) and rewrite the no-exact-match
  fallback in `_resolve_endpoint_context_length` to select the most specific
  boundary-anchored id instead of the first loose substring hit.
- `tests/agent/test_model_metadata.py`: add two regression tests — boundary
  collision rejection (`gpt-4` ≠ `gpt-4o`) and order-independence of the pick.
- `scripts/release.py`: add author email to `AUTHOR_MAP`.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_model_metadata.py` — 102 pass.
2. New tests fail on the pre-fix `model in key or key in model` scan: with
   `{"gpt-4o": 1_000_000, "gpt-4-base": 8192}` and model `gpt-4`, the old code
   returns `1_000_000` (first hit); the fix returns `8192` for both catalog
   orderings.
3. Existing `test_custom_endpoint_fuzzy_substring_match` and
   `test_custom_endpoint_single_model_fallback` still pass unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
tests/agent/test_model_metadata.py ... 102 passed in 3.6s
ruff check: All checks passed!
check-windows-footguns.py --all: ✓ No Windows footguns found
```