### PR TITLE
fix(gateway): honor --start-now/--start-on-login flags and support non-TTY headless installs

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6235,8 +6235,24 @@ def _gateway_command_inner(args):
                     "  Or use tmux/screen for persistence: tmux new -s hermes 'hermes gateway run'"
                 )
                 print()
-            start_now = prompt_yes_no("Start the gateway now after installing the service?", True)
-            start_on_login = prompt_yes_no("Start the gateway automatically on login/boot with systemd?", True)
+            # Honor CLI flags (--start-now / --no-start-now, --start-on-login /
+            # --no-start-on-login).  When not provided, prompt interactively or
+            # fall back to True for non-TTY / headless contexts (SSH, CI, pipes).
+            _sn = getattr(args, "start_now", None)
+            if _sn is not None:
+                start_now = _sn
+            elif sys.stdin.isatty():
+                start_now = prompt_yes_no("Start the gateway now after installing the service?", True)
+            else:
+                start_now = True
+
+            _sol = getattr(args, "start_on_login", None)
+            if _sol is not None:
+                start_on_login = _sol
+            elif sys.stdin.isatty():
+                start_on_login = prompt_yes_no("Start the gateway automatically on login/boot with systemd?", True)
+            else:
+                start_on_login = True
             systemd_install(
                 force=force,
                 system=system,

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -139,26 +139,26 @@ def build_gateway_parser(subparsers, *, cmd_gateway: Callable, cmd_proxy: Callab
         dest="start_now",
         action="store_true",
         default=None,
-        help=argparse.SUPPRESS,
+        help="Start the gateway service immediately after installing",
     )
     gateway_install.add_argument(
         "--no-start-now",
         dest="start_now",
         action="store_false",
-        help=argparse.SUPPRESS,
+        help="Do not start the gateway service after installing",
     )
     gateway_install.add_argument(
         "--start-on-login",
         dest="start_on_login",
         action="store_true",
         default=None,
-        help=argparse.SUPPRESS,
+        help="Enable the service to start automatically on login/boot",
     )
     gateway_install.add_argument(
         "--no-start-on-login",
         dest="start_on_login",
         action="store_false",
-        help=argparse.SUPPRESS,
+        help="Do not enable the service to start on login/boot",
     )
     gateway_install.add_argument(
         "--elevated-handoff",

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -234,6 +234,7 @@ def test_gateway_install_in_container_with_operational_systemd_uses_systemd(monk
     monkeypatch.setattr(gateway, "is_wsl", lambda: False)
     monkeypatch.setattr(gateway, "is_macos", lambda: False)
     monkeypatch.setattr(gateway, "is_managed", lambda: False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
     calls = []
     monkeypatch.setattr(gateway, "prompt_yes_no", lambda question, default=True: calls.append(("prompt", question, default)) or True)
@@ -530,6 +531,7 @@ def test_gateway_install_can_decline_start_now_and_startup(monkeypatch):
     monkeypatch.setattr(gateway, "is_wsl", lambda: False)
     monkeypatch.setattr(gateway, "is_macos", lambda: False)
     monkeypatch.setattr(gateway, "is_managed", lambda: False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
     answers = iter([False, False])
     calls = []
@@ -549,6 +551,87 @@ def test_gateway_install_can_decline_start_now_and_startup(monkeypatch):
         ("prompt", "Start the gateway automatically on login/boot with systemd?", True),
         ("install", True, False, None, False),
     ]
+
+
+def test_gateway_install_systemd_honors_start_now_flag(monkeypatch):
+    """--start-now / --no-start-now should bypass the interactive prompt."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "is_managed", lambda: False)
+
+    calls = []
+    monkeypatch.setattr(gateway, "prompt_yes_no", lambda question, default=True: calls.append(("prompt", question)))
+    monkeypatch.setattr(
+        gateway,
+        "systemd_install",
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append(("install", enable_on_startup)),
+    )
+    monkeypatch.setattr(gateway, "systemd_start", lambda system=False: calls.append(("start",)))
+
+    args = SimpleNamespace(
+        gateway_command="install", force=False, system=False,
+        run_as_user=None, start_now=True, start_on_login=False,
+    )
+    gateway.gateway_command(args)
+
+    assert ("prompt", "Start the gateway now after installing the service?") not in calls
+    assert ("start",) in calls
+    assert ("install", False) in calls
+
+
+def test_gateway_install_systemd_non_tty_uses_defaults(monkeypatch):
+    """Non-TTY stdin (headless/CI) should use True defaults without prompting."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "is_managed", lambda: False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    calls = []
+    monkeypatch.setattr(gateway, "prompt_yes_no", lambda question, default=True: calls.append(("prompt", question)))
+    monkeypatch.setattr(
+        gateway,
+        "systemd_install",
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append(("install", enable_on_startup)),
+    )
+    monkeypatch.setattr(gateway, "systemd_start", lambda system=False: calls.append(("start",)))
+
+    args = SimpleNamespace(gateway_command="install", force=False, system=False, run_as_user=None)
+    gateway.gateway_command(args)
+
+    # No prompts — defaults used (start_now=True, start_on_login=True)
+    assert all(c[0] != "prompt" for c in calls)
+    assert ("install", True) in calls
+    assert ("start",) in calls
+
+
+def test_gateway_install_systemd_no_start_now_flag_non_tty(monkeypatch):
+    """--no-start-now in non-TTY should skip starting the service."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "is_managed", lambda: False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    calls = []
+    monkeypatch.setattr(gateway, "prompt_yes_no", lambda question, default=True: calls.append(("prompt", question)))
+    monkeypatch.setattr(
+        gateway,
+        "systemd_install",
+        lambda force=False, system=False, run_as_user=None, enable_on_startup=True: calls.append(("install", enable_on_startup)),
+    )
+    monkeypatch.setattr(gateway, "systemd_start", lambda system=False: calls.append(("start",)))
+
+    args = SimpleNamespace(
+        gateway_command="install", force=False, system=False,
+        run_as_user=None, start_now=False, start_on_login=True,
+    )
+    gateway.gateway_command(args)
+
+    assert all(c[0] != "prompt" for c in calls)
+    assert ("install", True) in calls
+    assert ("start",) not in calls
 
 
 def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a regression in `hermes gateway install` on Linux/systemd where the command unconditionally prompts with two interactive yes/no questions, making it impossible to use in headless/CI/SSH contexts. The fix honors the existing `--start-now` / `--start-on-login` CLI flags (previously only respected by the Windows branch) and falls back to sensible defaults when stdin is not a TTY.

## Related Issue

Fixes #42065

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: The systemd install branch now reads `args.start_now` and `args.start_on_login` first (mirroring the Windows path). Only prompts interactively when flags are not provided AND stdin is a TTY. Falls back to True defaults for non-TTY/headless contexts.
- `hermes_cli/subcommands/gateway.py`: Promoted `--start-now` / `--no-start-now` / `--start-on-login` / `--no-start-on-login` help strings from `argparse.SUPPRESS` to visible help text, making the flags discoverable via `--help`.
- `tests/hermes_cli/test_gateway.py`: Added 3 new tests covering flag-based bypass, non-TTY defaults, and `--no-start-now` in non-TTY. Updated 2 existing tests to mock `sys.stdin.isatty` for correct interactive flow.

## How to Test

1. On a Linux system with systemd, run `hermes gateway install </dev/null` — should no longer hang or abort; installs and starts with defaults
2. Run `hermes gateway install --no-start-now` — should skip starting the service without prompting
3. Run `hermes gateway install --no-start-on-login` — should install without enabling auto-start
4. Run `hermes gateway install` interactively — should still prompt as before
5. Run `python -m pytest tests/hermes_cli/test_gateway.py -v -k "install"` — all 11 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway_command()` systemd install branch (callers: `cli.py` → `_gateway_command_inner`, `hermes_cli/setup.py` → `gateway_command`)
- Blast radius: LOW — only affects `hermes gateway install` on Linux/systemd; Windows and macOS paths unchanged
- Related patterns: mirrors `gateway_windows.install()` flag-respecting pattern at line 6251-6258
