### PR TITLE
fix(security): block subshell/brace-group wrappers in hardline command floor

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1488,6 +1488,7 @@ AUTHOR_MAP = {
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
     "42903577+ohMyJason@users.noreply.github.com": "ohMyJason",  # PR #29810 (discover_models in custom_providers section 4)
     "singhsanidhya741@gmail.com": "sanidhyasin",  # PR #40403 salvage (model.default_headers for custom OpenAI-compatible providers, #40033)
+    "290871358+Vesna-9@users.noreply.github.com": "Vesna-9",  # subshell/brace-group hardline command-position anchor fix
 }
 
 

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -85,6 +85,16 @@ _HARDLINE_BLOCK = [
     "exec shutdown",
     "nohup reboot",
     "setsid poweroff",
+    # Bare subshell `(...)` and brace-group `{ ...; }` openers are ordinary
+    # command-start positions too. They were missing from the command-position
+    # anchor, so the hardline floor silently let them through.
+    "(reboot)",
+    "( reboot )",
+    "(shutdown -h now)",
+    "{ reboot; }",
+    "{ poweroff; }",
+    "(systemctl reboot)",
+    "(init 0)",
 ]
 
 
@@ -197,6 +207,25 @@ def test_yolo_env_var_cannot_bypass_hardline(clean_session, monkeypatch):
         r2 = check_all_command_guards(cmd, "local")
         assert r2["approved"] is False, f"yolo leaked hardline on {cmd!r} (check_all_command_guards)"
         assert r2.get("hardline") is True
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    ["(reboot)", "{ shutdown -h now; }", "(poweroff)", "{ systemctl reboot; }"],
+)
+def test_subshell_and_brace_group_cannot_bypass_hardline(cmd):
+    """A bare `(...)` subshell or `{ ...; }` brace group is a command-start
+    position. Wrapping a shutdown/reboot in one must NOT escape the hardline
+    floor — previously the command-position anchor only recognized `;`, `&`,
+    `|`, newline, backtick and `$(`, so `(reboot)` slipped through entirely.
+    """
+    is_hl, desc = detect_hardline_command(cmd)
+    assert is_hl, f"expected hardline to match {cmd!r}"
+    assert desc
+
+    result = check_all_command_guards(cmd, "local")
+    assert result["approved"] is False
+    assert result.get("hardline") is True
 
 
 def test_session_yolo_cannot_bypass_hardline(clean_session):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -235,10 +235,16 @@ _COMMAND_TAIL = r'(?:\s*(?:&&|\|\||;).*)?$'
 # a shell would begin parsing a new command).  Used by shutdown/reboot
 # patterns so they don't fire on "echo reboot" or "grep 'shutdown' log".
 # Matches: start of string, after command separators (; && || | newline),
-# after subshell openers ( `$(` or backtick ), optionally consuming
-# leading wrapper commands (sudo, env VAR=VAL, exec, nohup, setsid).
+# after subshell openers ( `$(`, a bare `(` subshell, or backtick ), after a
+# `{ ...; }` brace-group opener, optionally consuming leading wrapper
+# commands (sudo, env VAR=VAL, exec, nohup, setsid).
+#
+# The `(` and `{` openers matter: `(reboot)` and `{ reboot; }` are ordinary
+# shell command-start positions, but without them in the class the hardline
+# floor never fired — so `(reboot)` / `{ shutdown -h now; }` slipped past the
+# unconditional block that is supposed to stop host shutdown even under --yolo.
 _CMDPOS = (
-    r'(?:^|[;&|\n`]|\$\()'         # start position
+    r'(?:^|[;&|\n`({]|\$\()'       # start position
     r'\s*'                          # optional whitespace
     r'(?:sudo\s+(?:-[^\s]+\s+)*)?'  # optional sudo with flags
     r'(?:env\s+(?:\w+=\S*\s+)*)?'   # optional env with VAR=VAL pairs


### PR DESCRIPTION
## What does this PR do?

The hardline blocklist in `tools/approval.py` is the unconditional floor that
stops catastrophic commands (shutdown, reboot, halt, poweroff, init 0/6,
systemctl poweroff) even under `--yolo`, gateway `/yolo`, `approvals.mode=off`,
or cron approve mode. Those patterns are anchored to a command-start position
via the shared `_CMDPOS` fragment so they fire on `reboot` but not on prose
like `echo reboot` or `grep 'shutdown' log`.

The command-position character class only recognized `;`, `&`, `|`, newline,
backtick, and `$(` as command-start markers. It omitted two equally ordinary
ones: the bare subshell opener `(` and the brace-group opener `{`. As a result,
wrapping a catastrophic command in a subshell or brace group walked straight
past the floor:

- Before: `detect_hardline_command("(reboot)")` -> `(False, None)`, and
  `check_all_command_guards("(reboot)", "local")` returned `approved=True` even
  with `HERMES_YOLO_MODE=1`. Same for `{ shutdown -h now; }`, `(poweroff)`,
  `(systemctl reboot)`, etc. `$(reboot)` and `` `shutdown now` `` were already
  caught, so the gap was specific to the bare `(` / `{` forms.
- After: those forms are detected and blocked unconditionally, matching the
  existing `$(...)` / backtick coverage. Negative cases are unaffected —
  `echo reboot`, `cat rebooting.log`, `python3 -c 'print("shutdown")'`,
  `find . -name '*reboot*'` still pass through, because the trigger word is not
  at a command-start position in any of them.

The fix is a single character-class extension (`[;&|\n`]` -> `[;&|\n`({]`) in
`_CMDPOS`, which every shutdown/reboot hardline pattern already shares.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py`: added `(` and `{` to the `_CMDPOS` command-start
  character class so subshell and brace-group openers count as command
  positions; updated the explanatory comment to spell out why.
- `tests/tools/test_hardline_blocklist.py`: extended the "Compound / subshell
  variants" block with `(reboot)`, `( reboot )`, `(shutdown -h now)`,
  `{ reboot; }`, `{ poweroff; }`, `(systemctl reboot)`, `(init 0)`; added a
  parametrized regression test asserting these are blocked through
  `check_all_command_guards`.
- `scripts/release.py`: registered my author email in `AUTHOR_MAP` for the
  release gate.

## How to Test

1. Reproduce the bypass on `main`:
   `python3 -c "from tools.approval import detect_hardline_command as h; print(h('(reboot)'))"`
   prints `(False, None)` (command would run), while `h('reboot')` prints
   `(True, 'system shutdown/reboot')`.
2. Apply this change and rerun: `h('(reboot)')` and `h('{ shutdown -h now; }')`
   now return `(True, 'system shutdown/reboot')`.
3. Run the suite:
   `scripts/run_tests.sh tests/tools/test_hardline_blocklist.py` — all pass,
   including the new subshell/brace-group cases and the must-not-block prose
   cases.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests (hardline blocklist + approval + gateway approve/deny suites) and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the change is a pure-regex edit with no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A