### PR TITLE
fix(research): resume batch runs by index so duplicate prompts aren't dropped

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import time
+from collections import Counter
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Tuple
 from datetime import datetime
@@ -729,67 +730,101 @@ class BatchRunner:
         else:
             atomic_json_write(self.checkpoint_file, checkpoint_data)
     
-    def _scan_completed_prompts_by_content(self) -> set:
+    def _scan_completed_work(self) -> Tuple[set, Counter]:
         """
-        Scan all batch files and extract completed prompts by their actual content.
-        
-        This provides a more robust resume mechanism that matches on prompt text
-        rather than indices, allowing recovery even if indices don't match.
-        
+        Scan all batch files to determine which dataset entries are done.
+
+        Each saved trajectory carries the ``prompt_index`` of the dataset entry
+        it was generated from. Resuming by that index is robust even when a
+        dataset intentionally contains duplicate ``prompt`` strings (the same
+        task sampled multiple times at different temperatures / toolset
+        distributions for RL/MoA data) — every copy keeps its own index.
+
+        For legacy batch files written before ``prompt_index`` was recorded we
+        fall back to matching on the prompt text, but as a *multiset* so that N
+        completed copies skip exactly N dataset entries rather than every entry
+        that shares the text.
+
         Returns:
-            set: Set of prompt texts that have been successfully processed
+            Tuple of (completed_indices, completed_text_counts):
+              - completed_indices: set of ``prompt_index`` values already saved.
+              - completed_text_counts: multiset of prompt texts for legacy
+                entries that lack a ``prompt_index``.
         """
-        completed_prompts = set()
+        completed_indices: set = set()
+        completed_text_counts: Counter = Counter()
         batch_files = sorted(self.output_dir.glob("batch_*.jsonl"))
-        
+
         if not batch_files:
-            return completed_prompts
-        
+            return completed_indices, completed_text_counts
+
         print(f"📂 Scanning {len(batch_files)} batch files for completed prompts...")
-        
+
         for batch_file in batch_files:
             try:
                 with open(batch_file, 'r', encoding='utf-8') as f:
                     for line in f:
                         try:
                             entry = json.loads(line.strip())
-                            
-                            # Skip failed entries - we want to retry these
-                            if entry.get("failed", False):
-                                continue
-                            
-                            # Extract the human/user prompt from conversations
-                            conversations = entry.get("conversations", [])
-                            for msg in conversations:
-                                if msg.get("from") == "human":
-                                    prompt_text = msg.get("value", "").strip()
-                                    if prompt_text:
-                                        completed_prompts.add(prompt_text)
-                                    break  # Only need the first human message
                         except json.JSONDecodeError:
                             continue
+
+                        # Skip failed entries - we want to retry these
+                        if entry.get("failed", False):
+                            continue
+
+                        # Prefer the recorded index: unique per dataset entry,
+                        # so duplicate prompts resume correctly.
+                        idx = entry.get("prompt_index")
+                        if isinstance(idx, int):
+                            completed_indices.add(idx)
+                            continue
+
+                        # Legacy fallback: match on the first human message.
+                        conversations = entry.get("conversations", [])
+                        for msg in conversations:
+                            if msg.get("from") == "human":
+                                prompt_text = msg.get("value", "").strip()
+                                if prompt_text:
+                                    completed_text_counts[prompt_text] += 1
+                                break  # Only need the first human message
             except Exception as e:
                 print(f"  ⚠️  Warning: Error reading {batch_file.name}: {e}")
-        
-        return completed_prompts
-    
-    def _filter_dataset_by_completed(self, completed_prompts: set) -> Tuple[List[Dict], List[int]]:
+
+        return completed_indices, completed_text_counts
+
+    def _filter_dataset_by_completed(
+        self, completed_indices: set, completed_text_counts: Counter
+    ) -> Tuple[List[Dict], List[int]]:
         """
-        Filter the dataset to exclude prompts that have already been completed.
-        
+        Filter the dataset to exclude entries that have already been completed.
+
+        Entries are skipped by index first; the text multiset is only consulted
+        for legacy batch files that lack a ``prompt_index``. Consuming the
+        multiset (decrementing as matches are found) ensures that a dataset with
+        duplicate prompts only skips as many copies as were actually completed,
+        instead of dropping every remaining copy.
+
         Args:
-            completed_prompts: Set of prompt texts that have been completed
-            
+            completed_indices: set of completed ``prompt_index`` values.
+            completed_text_counts: multiset of completed prompt texts (legacy).
+
         Returns:
             Tuple of (filtered_dataset, skipped_indices)
         """
+        # Copy so we can decrement as legacy matches are consumed.
+        remaining_text_counts = Counter(completed_text_counts)
         filtered_dataset = []
         skipped_indices = []
-        
+
         for idx, entry in enumerate(self.dataset):
+            if idx in completed_indices:
+                skipped_indices.append(idx)
+                continue
+
             # Extract prompt from the dataset entry
             prompt_text = entry.get("prompt", "").strip()
-            
+
             # Also check conversations format
             if not prompt_text:
                 conversations = entry.get("conversations", [])
@@ -798,13 +833,16 @@ class BatchRunner:
                     if role in {"user", "human"}:
                         prompt_text = (msg.get("content") or msg.get("value", "")).strip()
                         break
-            
-            if prompt_text in completed_prompts:
+
+            # Legacy text fallback: skip at most as many entries as were
+            # completed for this prompt text.
+            if prompt_text and remaining_text_counts.get(prompt_text, 0) > 0:
+                remaining_text_counts[prompt_text] -= 1
                 skipped_indices.append(idx)
             else:
                 # Keep original index for tracking
                 filtered_dataset.append((idx, entry))
-        
+
         return filtered_dataset, skipped_indices
     
     def run(self, resume: bool = False):
@@ -818,16 +856,22 @@ class BatchRunner:
         print("🚀 Starting Batch Processing")
         print("=" * 70)
         
-        # Smart resume: scan batch files by content to find completed prompts
-        completed_prompt_texts = set()
+        # Smart resume: scan batch files to find completed prompts. Resume by
+        # the recorded prompt_index (with a legacy text fallback) so datasets
+        # that intentionally repeat prompts don't drop their unprocessed copies.
+        completed_indices: set = set()
+        completed_text_counts: Counter = Counter()
         if resume:
-            completed_prompt_texts = self._scan_completed_prompts_by_content()
-            if completed_prompt_texts:
-                print(f"   Found {len(completed_prompt_texts)} already-completed prompts by content matching")
-        
+            completed_indices, completed_text_counts = self._scan_completed_work()
+            completed_total = len(completed_indices) + sum(completed_text_counts.values())
+            if completed_total:
+                print(f"   Found {completed_total} already-completed prompts")
+
         # Filter dataset to only include unprocessed prompts
-        if resume and completed_prompt_texts:
-            filtered_entries, skipped_indices = self._filter_dataset_by_completed(completed_prompt_texts)
+        if resume and (completed_indices or completed_text_counts):
+            filtered_entries, skipped_indices = self._filter_dataset_by_completed(
+                completed_indices, completed_text_counts
+            )
             
             if not filtered_entries:
                 print("\n✅ All prompts have already been processed!")

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -1,6 +1,7 @@
 """Tests for batch_runner checkpoint behavior — incremental writes, resume, atomicity."""
 
 import json
+from collections import Counter
 from pathlib import Path
 from threading import Lock
 
@@ -248,3 +249,89 @@ class TestFinalCheckpointNoDuplicates:
             buggy.extend(br.get("completed_prompts", []))
         # Every index appears twice
         assert len(buggy) == 2 * len(set(buggy))
+
+
+def _resume_runner(tmp_path, dataset):
+    """Build a BatchRunner wired for resume scans (output_dir + dataset only)."""
+    r = BatchRunner.__new__(BatchRunner)
+    r.run_name = "test_run"
+    r.output_dir = tmp_path
+    r.batch_size = 4
+    r.dataset = dataset
+    return r
+
+
+def _write_batch_file(tmp_path, entries):
+    """Write saved trajectory entries to a batch_*.jsonl file."""
+    batch_file = tmp_path / "batch_0.jsonl"
+    with open(batch_file, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+    return batch_file
+
+
+class TestResumeWithDuplicatePrompts:
+    """Regression: resuming a run whose dataset intentionally repeats prompts
+    must only skip the copies that were actually completed, not every copy that
+    shares the prompt text.
+
+    Such datasets are normal here — the same task is sampled several times at
+    different temperatures / toolset distributions for RL/MoA training data.
+    Before this fix, resume matched on prompt *text* as a plain set, so a single
+    completed copy removed all remaining copies from the run, silently dropping
+    those trajectories from the output.
+    """
+
+    def test_only_completed_index_is_skipped(self, tmp_path):
+        # Three copies of the same prompt; index 1 was completed before a crash.
+        dataset = [{"prompt": "same task"} for _ in range(3)]
+        _write_batch_file(tmp_path, [
+            {"prompt_index": 1, "conversations": [{"from": "human", "value": "same task"}]},
+        ])
+        runner = _resume_runner(tmp_path, dataset)
+
+        completed_indices, completed_text_counts = runner._scan_completed_work()
+        assert completed_indices == {1}
+
+        filtered, skipped = runner._filter_dataset_by_completed(
+            completed_indices, completed_text_counts
+        )
+        # Only the completed copy is skipped; the other two are rescheduled.
+        assert skipped == [1]
+        assert [idx for idx, _ in filtered] == [0, 2]
+
+    def test_legacy_text_fallback_is_multiset_aware(self, tmp_path):
+        # Legacy batch files predate prompt_index: match by text, but as a
+        # multiset so N completed copies skip exactly N dataset entries.
+        dataset = [{"prompt": "dup"}, {"prompt": "dup"}, {"prompt": "dup"}, {"prompt": "other"}]
+        _write_batch_file(tmp_path, [
+            {"conversations": [{"from": "human", "value": "dup"}]},
+            {"conversations": [{"from": "human", "value": "dup"}]},
+        ])
+        runner = _resume_runner(tmp_path, dataset)
+
+        completed_indices, completed_text_counts = runner._scan_completed_work()
+        assert completed_indices == set()
+        assert completed_text_counts == Counter({"dup": 2})
+
+        filtered, skipped = runner._filter_dataset_by_completed(
+            completed_indices, completed_text_counts
+        )
+        # Two "dup" copies were completed -> skip two, keep the third + "other".
+        assert len(skipped) == 2
+        remaining_prompts = [entry["prompt"] for _, entry in filtered]
+        assert remaining_prompts == ["dup", "other"]
+
+    def test_failed_entries_are_not_treated_as_completed(self, tmp_path):
+        dataset = [{"prompt": "task a"}, {"prompt": "task b"}]
+        _write_batch_file(tmp_path, [
+            {"prompt_index": 0, "failed": True,
+             "conversations": [{"from": "human", "value": "task a"}]},
+            {"prompt_index": 1,
+             "conversations": [{"from": "human", "value": "task b"}]},
+        ])
+        runner = _resume_runner(tmp_path, dataset)
+
+        completed_indices, _ = runner._scan_completed_work()
+        # The failed index 0 must remain schedulable for retry.
+        assert completed_indices == {1}


### PR DESCRIPTION
## What does this PR do?

Fixes a training-data loss bug in the batch runner's resume path. When a run
is resumed, `run()` scanned the saved batch files and collected completed work
into a *set of prompt texts*, then dropped every dataset entry whose prompt
text appeared in that set. Datasets in this subsystem routinely contain
identical `prompt` values on purpose — the same task sampled multiple times at
different temperatures or toolset distributions for RL/MoA data. So if even one
copy of a prompt had completed before a crash, resume treated *all* remaining
copies as already done and silently removed them from the run. Those
trajectories never got generated, and the resume summary over-reported
completion.

Each saved trajectory already records the `prompt_index` it came from, and
those indices are unique per dataset entry, so resuming by index handles
duplicates correctly and lines up with the index-based filter the workers
already apply. I kept a text-based fallback for older batch files written
before `prompt_index` existed, but made it a multiset: N completed copies skip
exactly N dataset entries instead of every entry sharing the text. Driving the
content scan by index rather than text also keeps it consistent with the
secondary checkpoint filter, which avoids a double-skip when the two sources
disagree on which specific duplicate was completed.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `batch_runner.py`: replaced `_scan_completed_prompts_by_content()` with
  `_scan_completed_work()`, which returns the set of completed `prompt_index`
  values plus a `Counter` multiset of prompt texts for legacy entries lacking
  an index.
- `batch_runner.py`: reworked `_filter_dataset_by_completed()` to skip by index
  first and consume the text multiset for legacy fallback, so duplicate prompts
  only skip as many copies as were actually completed.
- `batch_runner.py`: updated the resume block in `run()` to use the new
  index/multiset return values and report the combined completed count.
- `tests/test_batch_runner_checkpoint.py`: added `TestResumeWithDuplicatePrompts`
  covering index-based skip with duplicates, the multiset legacy fallback, and
  that failed entries stay schedulable for retry.

## How to Test

1. Build a dataset with three identical `prompt` values and write a batch file
   marking only `prompt_index: 1` complete.
2. Run the resume scan: `_scan_completed_work()` returns `{1}` and an empty
   text counter; `_filter_dataset_by_completed()` reschedules indices 0 and 2.
3. Run the suite: `pytest tests/test_batch_runner_checkpoint.py -q` — all 19
   tests pass (16 existing + 3 new).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A