### PR TITLE
feat(minimax): use adaptive thinking for MiniMax-M3

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -208,8 +208,8 @@ def _resolve_anthropic_messages_max_tokens(
 
 
 def _supports_adaptive_thinking(model: str) -> bool:
-    """Return True for Claude 4.6+ models that support adaptive thinking."""
-    return any(v in model for v in _ADAPTIVE_THINKING_SUBSTRINGS)
+    """Return True for Claude 4.6+ and MiniMax-M3 models (adaptive thinking)."""
+    return any(v in model for v in _ADAPTIVE_THINKING_SUBSTRINGS) or "minimax-m3" in model.lower()
 
 
 def _supports_xhigh_effort(model: str) -> bool:

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -128,6 +128,22 @@ class TestMinimaxThinkingSupport:
         assert "thinking" in kwargs
         assert kwargs["thinking"]["type"] == "enabled"
 
+    def test_minimax_m3_gets_adaptive_thinking(self):
+        # Unlike M2.x, MiniMax-M3 is Anthropic-compatible and supports the
+        # adaptive thinking format (type=adaptive + output_config.effort),
+        # so it should self-scale reasoning rather than use a fixed budget.
+        from agent.anthropic_adapter import build_anthropic_kwargs
+        kwargs = build_anthropic_kwargs(
+            model="MiniMax-M3",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert kwargs["output_config"] == {"effort": "medium"}
+        assert "budget_tokens" not in kwargs["thinking"]
+
     def test_thinking_still_works_for_claude(self):
         from agent.anthropic_adapter import build_anthropic_kwargs
         kwargs = build_anthropic_kwargs(


### PR DESCRIPTION
## Summary

`MiniMax-M3` is an Anthropic Messages–compatible model that accepts the **adaptive thinking** request format (`thinking={"type":"adaptive"}` + `output_config.effort`) — the same shape Hermes already emits for Claude 4.6+/4.7+/4.8.

Currently M3 isn't recognized by `_supports_adaptive_thinking()`, so it falls through to manual budget-based thinking (`{"type":"enabled","budget_tokens":N}`) and ends up reasoning even on trivial prompts. This routes M3 onto the existing adaptive path so it self-scales how much it thinks.

## Changes

- `agent/anthropic_adapter.py` — `_supports_adaptive_thinking()` now also recognizes `MiniMax-M3` (matched case-insensitively to catch `minimax/minimax-m3` surfaces). Legacy MiniMax **M2.x stays on manual thinking** — its Anthropic-compat stream leaks `reasoning_content` and still needs the budget shim.
- `tests/agent/test_minimax_provider.py` — add a test asserting M3 emits `{"type":"adaptive","display":"summarized"}` + `output_config:{effort}` and no `budget_tokens`. Existing M2.5/M2.7 manual-thinking tests are unchanged.

## Verification

- `pytest tests/agent/test_minimax_provider.py` — 48 passed (incl. the new M3 test and the unchanged M2.x manual-thinking guards).
- Live-checked against the M3 endpoint: the adaptive format is accepted, thinking self-scales by prompt difficulty, and all five effort levels (low/medium/high/xhigh/max) are honored.

Note: xhigh→max downgrade for M3 is left as-is (conservative); this PR is scoped to defaulting M3 to adaptive, not effort-range tuning.
