### PR TITLE
fix(agent): honor auxiliary.title_generation.enabled to disable auto titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -9,6 +9,7 @@ import threading
 from typing import Callable, Optional
 
 from agent.auxiliary_client import call_llm
+from hermes_cli.config import load_config
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,26 @@ def _title_language() -> str:
         ).strip()
     except Exception:
         return ""
+
+
+def _auto_title_enabled() -> bool:
+    """Whether automatic session-title generation is enabled in config.
+
+    Reads ``auxiliary.title_generation.enabled`` (canonical) and also honors
+    the ``auxiliary.title.enabled`` alias for convenience. Defaults to ``True``
+    when the key is unset or the config can't be read, preserving the historical
+    always-on behavior. Only the *automatic* path consults this flag — manual
+    ``/title`` titling stays available even when auto-titles are disabled.
+    """
+    try:
+        auxiliary = (load_config() or {}).get("auxiliary", {}) or {}
+    except Exception:
+        return True
+    for key in ("title_generation", "title"):
+        section = auxiliary.get(key)
+        if isinstance(section, dict) and "enabled" in section:
+            return bool(section["enabled"])
+    return True
 
 
 def generate_title(
@@ -188,6 +209,13 @@ def maybe_auto_title(
     # (or 2 counting system). Be generous: generate on first 2 exchanges.
     user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
     if user_msg_count > 2:
+        return
+
+    # Respect the opt-out: auxiliary.title_generation.enabled=false disables
+    # automatic titling entirely (issue #41744). Checked after the cheap
+    # first-exchange guard above so the config read only happens when we are
+    # actually about to title, not on every turn of a long conversation.
+    if not _auto_title_enabled():
         return
 
     thread = threading.Thread(

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -518,6 +518,13 @@ prompt_caching:
 #                           # extra_body:
 #                           #   chat_template_kwargs:
 #                           #     enable_thinking: false
+#
+#   # Automatic session titles — names a session from its first exchange
+#   title_generation:
+#     enabled: true         # set false to turn off automatic titling entirely
+#                           # (manual /title still works)
+#     provider: "auto"
+#     model: ""
 
 # =============================================================================
 # Persistent Memory

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1539,6 +1539,7 @@ DEFAULT_CONFIG = {
             "extra_body": {},
         },
         "title_generation": {
+            "enabled": True,       # set false to disable automatic session titles
             "provider": "auto",
             "model": "",
             "base_url": "",

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -335,3 +335,51 @@ class TestMaybeAutoTitle:
 
     def test_skips_if_no_session_db(self):
         maybe_auto_title(None, "sess-1", "hello", "response", [])  # no db
+
+
+class TestAutoTitleEnabledConfig:
+    """auxiliary.title_generation.enabled must gate the automatic path (issue #41744)."""
+
+    _HISTORY = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+    ]
+
+    def _run(self, config):
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        with patch("agent.title_generator.load_config", return_value=config), \
+                patch("agent.title_generator.auto_title_session") as mock_auto:
+            maybe_auto_title(db, "sess-1", "hello", "hi there", self._HISTORY)
+            import time
+            time.sleep(0.2)
+            return mock_auto
+
+    def test_disabled_skips_generation(self):
+        mock_auto = self._run({"auxiliary": {"title_generation": {"enabled": False}}})
+        mock_auto.assert_not_called()
+
+    def test_enabled_fires_generation(self):
+        mock_auto = self._run({"auxiliary": {"title_generation": {"enabled": True}}})
+        mock_auto.assert_called_once()
+
+    def test_title_alias_disables_generation(self):
+        """The ``auxiliary.title.enabled`` alias is honored too."""
+        mock_auto = self._run({"auxiliary": {"title": {"enabled": False}}})
+        mock_auto.assert_not_called()
+
+    def test_default_enabled_when_key_absent(self):
+        """Omitting the flag preserves the historical always-on behavior."""
+        mock_auto = self._run({"auxiliary": {"title_generation": {}}})
+        mock_auto.assert_called_once()
+
+    def test_enabled_when_config_unreadable(self):
+        """A config-load failure must not silently suppress titles."""
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        with patch("agent.title_generator.load_config", side_effect=RuntimeError("boom")), \
+                patch("agent.title_generator.auto_title_session") as mock_auto:
+            maybe_auto_title(db, "sess-1", "hello", "hi there", self._HISTORY)
+            import time
+            time.sleep(0.2)
+            mock_auto.assert_called_once()


### PR DESCRIPTION
## What & why

`auxiliary.title_generation.enabled: false` had no effect — automatic session
titles were generated regardless. `maybe_auto_title()` fired a title request
after the first exchange without consulting any enabled flag, so there was no
supported way to turn the feature off. Closes #41744.

## Changes

- **`hermes_cli/config.py`** — add `enabled: True` to the
  `auxiliary.title_generation` default block (new key in an existing section, so
  the deep-merge picks it up automatically — no `_config_version` bump needed).
- **`agent/title_generator.py`** — add `_auto_title_enabled()` and gate the
  automatic path inside `maybe_auto_title()`.
- **`cli-config.yaml.example`** — document the flag so the opt-out is
  discoverable (the missing docs were part of why users couldn't find a way to
  disable it).

### Why gate inside `maybe_auto_title()` rather than at each call site

`maybe_auto_title()` has **four** callers — CLI (`cli.py`), gateway
(`gateway/run.py`), TUI gateway (`tui_gateway/server.py`), and ACP
(`acp_adapter/server.py`). Checking the flag at the call sites would have to be
duplicated four times and is easy to miss (the two desktop/ACP paths are the
ones that silently keep titling). Gating at the single choke point covers all of
them with one change.

The flag check runs **after** the cheap in-memory first-exchange guard, so the
config read only happens on the first ~2 exchanges when we're actually about to
title — not on every turn for the life of a long conversation.

Notes:
- **Default is `True`** → behavior is unchanged unless a user opts out.
- **Manual `/title` is unaffected** — it calls `set_session_title()` directly and
  never routes through `maybe_auto_title()`, so you can still title a session by
  hand while auto-titles are off.
- The **`auxiliary.title.enabled` alias** is also honored (the issue notes users
  reaching for both spellings).
- A config-load failure falls back to **enabled**, so titles are never silently
  suppressed by an unrelated error.

## How to test

```yaml
# ~/.hermes/config.yaml
auxiliary:
  title_generation:
    enabled: false
```

Start a fresh session and complete one exchange — no title is generated. Flip it
back to `true` (or remove it) and a title is generated as before. Manual `/title`
works in both cases.

Automated:

```bash
scripts/run_tests.sh tests/agent/test_title_generator.py
```

Adds `TestAutoTitleEnabledConfig` covering disabled / enabled / alias / default /
config-unreadable. Full file: 24 passed.

## Platforms

Logic-only change in shared Python; exercised via the CI-parity test runner on
macOS. No platform-specific code paths touched.