### PR TITLE
fix(computer_use): recover from a never-started cua-driver backend

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -35,6 +35,121 @@ def noop_backend():
 
 
 # ---------------------------------------------------------------------------
+# Backend caching / lifecycle (regression: broken-session never recovers)
+# ---------------------------------------------------------------------------
+
+class TestBackendCaching:
+    """Regression coverage for `_get_backend()` caching a never-started backend.
+
+    Bug: if `backend.start()` raised (e.g. cua-driver MCP session failed to
+    come up), `_backend` was left assigned but unstarted. Every later call
+    short-circuited on `_backend is not None`, skipped `start()`, and failed
+    forever with "cua-driver session not started" until the process restarted.
+    """
+
+    def test_start_failure_is_not_cached(self):
+        """A backend whose start() raises must not be cached for reuse."""
+        import tools.computer_use.tool as cu_tool
+
+        cu_tool.reset_backend_for_tests()
+
+        class _FailingBackend:
+            def __init__(self):
+                self.stopped = False
+
+            def start(self):
+                raise RuntimeError("session failed to start")
+
+            def stop(self):
+                self.stopped = True
+
+        created = []
+
+        def _factory():
+            b = _FailingBackend()
+            created.append(b)
+            return b
+
+        with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "cua"}, clear=False), \
+                patch("tools.computer_use.cua_backend.CuaDriverBackend", _factory):
+            with pytest.raises(RuntimeError, match="session failed to start"):
+                cu_tool._get_backend()
+            # First instance was torn down, not cached.
+            assert cu_tool._backend is None
+            assert created[0].stopped is True
+
+            # A second call retries cleanly with a fresh instance.
+            with pytest.raises(RuntimeError, match="session failed to start"):
+                cu_tool._get_backend()
+            assert len(created) == 2
+
+        cu_tool.reset_backend_for_tests()
+
+    def test_unstarted_cached_backend_is_recreated(self):
+        """A cached backend whose session is not started gets rebuilt on next call."""
+        import tools.computer_use.tool as cu_tool
+
+        cu_tool.reset_backend_for_tests()
+
+        class _Session:
+            def __init__(self, started):
+                self._started = started
+
+        class _Backend:
+            def __init__(self, started):
+                self._session = _Session(started)
+                self.stopped = False
+                self.start_calls = 0
+
+            def start(self):
+                self.start_calls += 1
+                self._session._started = True
+
+            def stop(self):
+                self.stopped = True
+
+        # Seed a stale backend whose session never started.
+        stale = _Backend(started=False)
+        cu_tool._backend = stale
+
+        fresh = _Backend(started=False)
+        with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "cua"}, clear=False), \
+                patch("tools.computer_use.cua_backend.CuaDriverBackend", lambda: fresh):
+            result = cu_tool._get_backend()
+
+        assert stale.stopped is True
+        assert result is fresh
+        assert fresh.start_calls == 1
+        assert fresh._session._started is True
+
+        cu_tool.reset_backend_for_tests()
+
+    def test_started_cached_backend_is_reused(self):
+        """A healthy started backend must be reused without rebuilding."""
+        import tools.computer_use.tool as cu_tool
+
+        cu_tool.reset_backend_for_tests()
+
+        class _Session:
+            _started = True
+
+        class _Backend:
+            _session = _Session()
+
+        cached = _Backend()
+        cu_tool._backend = cached
+
+        # Factory must NOT be called — if it is, this returns the wrong object.
+        with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "cua"}, clear=False), \
+                patch("tools.computer_use.cua_backend.CuaDriverBackend",
+                      lambda: pytest.fail("should not rebuild a healthy backend")):
+            result = cu_tool._get_backend()
+
+        assert result is cached
+        cu_tool.reset_backend_for_tests()
+
+
+# ---------------------------------------------------------------------------
 # Schema & registration
 # ---------------------------------------------------------------------------
 

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -129,6 +129,17 @@ _always_allow: set = set()  # action names the user unlocked for the session
 def _get_backend() -> ComputerUseBackend:
     global _backend
     with _backend_lock:
+        # If a backend exists but its session was never started (e.g. start()
+        # failed in a previous turn), tear it down and recreate it so the
+        # next call gets a fresh attempt rather than a permanent broken state.
+        if _backend is not None:
+            session = getattr(_backend, "_session", None)
+            if session is not None and not getattr(session, "_started", True):
+                try:
+                    _backend.stop()
+                except Exception:
+                    pass
+                _backend = None
         if _backend is None:
             backend_name = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "cua").lower()
             if backend_name in {"cua", "cua-driver", ""}:
@@ -138,7 +149,19 @@ def _get_backend() -> ComputerUseBackend:
                 _backend = _NoopBackend()
             else:
                 raise RuntimeError(f"Unknown HERMES_COMPUTER_USE_BACKEND={backend_name!r}")
-            _backend.start()
+            try:
+                _backend.start()
+            except Exception:
+                # Don't cache a backend whose session never came up — otherwise
+                # every subsequent call short-circuits on `_backend is not None`
+                # and fails with "session not started" forever. Drop it so the
+                # next call retries cleanly.
+                try:
+                    _backend.stop()
+                except Exception:
+                    pass
+                _backend = None
+                raise
         return _backend
 
 


### PR DESCRIPTION
## Problem

On macOS, `computer_use` calls can get permanently stuck with:

```
{"error": "capture failed: cua-driver session not started"}
```

`tools/computer_use/tool.py::_get_backend()` caches the backend in a module-level `_backend`. If `backend.start()` ever raises — a transient MCP/stdio session failure, a daemon relaunch race, a briefly-missing dep — the old code left `_backend` **assigned but unstarted**. Every subsequent call then short-circuited on `if _backend is None` being `False`, skipped `start()`, and hit `_require_started()` → "session not started".

Because `_backend` is a module global, this persists for the life of the process. A `/new` session does **not** clear it (same process). Only a full Hermes restart recovered — even though the underlying cua-driver binary, daemon, and permissions were all healthy and a fresh process could `start()` + `capture()` fine.

## Fix

Two guards in `_get_backend()`:

1. **Don't cache a never-started backend.** If `start()` raises, `stop()` it and reset `_backend = None` before re-raising, so the next call retries from scratch.
2. **Rebuild a stale cached backend.** Before reuse, if a cached backend's session reports not-started, tear it down and recreate it.

Either guard alone fixes the loop; together they cover both the same-turn failure path and any pre-existing stale instance.

## Tests

Adds `TestBackendCaching` in `tests/tools/test_computer_use.py`:
- `test_start_failure_is_not_cached` — start() raising leaves no cached instance; next call retries.
- `test_unstarted_cached_backend_is_recreated` — a stale unstarted backend is stopped and rebuilt.
- `test_started_cached_backend_is_reused` — a healthy backend is reused without rebuilding.

```
venv/bin/python -m pytest tests/tools/test_computer_use.py -o 'addopts=' -q
81 passed
```

macOS only (cua-driver backend); no behavior change on other platforms.