### PR TITLE
feat(cli): register /interrupt as top-level slash command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7979,6 +7979,8 @@ class HermesCLI(CLICommandsMixin):
             self._handle_voice_command(cmd_original)
         elif canonical == "busy":
             self._handle_busy_command(cmd_original)
+        elif canonical == "interrupt":
+            self._handle_interrupt_command()
         else:
             # Check for user-defined quick commands (bypass agent loop, no LLM call)
             base_cmd = cmd_lower.split()[0]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7300,6 +7300,9 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
         if canonical == "stop":
             return await self._handle_stop_command(event)
         
+        if canonical == "interrupt":
+            return await self._handle_interrupt_command(event)
+
         if canonical == "reasoning":
             return await self._handle_reasoning_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -595,6 +595,23 @@ class GatewaySlashCommandsMixin:
 
         return t("gateway.stop.no_active")
 
+    async def _handle_interrupt_command(self, event: MessageEvent) -> str:
+        """Handle /interrupt — interrupt the current agent run without clearing the session."""
+        source = event.source
+        session_entry = self.session_store.get_or_create_session(source)
+        session_key = session_entry.session_key
+
+        agent = self._running_agents.get(session_key)
+        if agent is _AGENT_PENDING_SENTINEL or not agent:
+            return "No active run to interrupt."
+
+        try:
+            agent.interrupt("user /interrupt command")
+            return "⚡ Interrupted the current run."
+        except Exception as e:
+            logger.debug("Failed to interrupt agent for session %s: %s", session_key, e)
+            return f"Failed to interrupt: {e}"
+
     async def _handle_platform_command(self, event: MessageEvent) -> str:
         """Handle ``/platform list|pause|resume [name]`` — surface and
         manually control failed/paused gateway adapters.

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2046,6 +2046,16 @@ class CLICommandsMixin:
         else:
             _cprint(f"  {_ACCENT}✓ Busy input mode set to '{arg}' (session only){_RST}")
 
+    def _handle_interrupt_command(self):
+        """Handle /interrupt — interrupt the current agent run."""
+        from cli import _ACCENT, _DIM, _RST, _cprint
+        agent = getattr(self, "agent", None)
+        if agent and hasattr(agent, "interrupt"):
+            agent.interrupt()
+            _cprint(f"  {_ACCENT}⚡ Interrupted the current run.{_RST}")
+        else:
+            _cprint(f"  {_DIM}No active run to interrupt.{_RST}")
+
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode)."""
         from cli import _ACCENT, _DIM, _RST, _cprint, save_config_value

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -159,6 +159,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
                cli_only=True, args_hint="[queue|steer|interrupt|status]",
                subcommands=("queue", "steer", "interrupt", "status")),
+    CommandDef("interrupt", "Interrupt the current agent run", "Session",
+               aliases=("i",)),
 
     # Tools & Skills
     CommandDef("tools", "Manage tools: /tools [list|disable|enable] [name...]", "Tools & Skills",

--- a/tests/cli/test_interrupt_command.py
+++ b/tests/cli/test_interrupt_command.py
@@ -1,0 +1,98 @@
+"""Tests for the /interrupt CLI command."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _import_cli():
+    import hermes_cli.config as config_mod
+
+    if not hasattr(config_mod, "save_env_value_secure"):
+        config_mod.save_env_value_secure = lambda key, value: {
+            "success": True,
+            "stored_as": key,
+            "validated": False,
+        }
+
+    import cli as cli_mod
+
+    return cli_mod
+
+
+class TestInterruptCommandRegistry(unittest.TestCase):
+    def test_interrupt_in_registry(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+
+        names = [c.name for c in COMMAND_REGISTRY]
+        assert "interrupt" in names
+
+    def test_interrupt_not_cli_only(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+
+        cmd = next(c for c in COMMAND_REGISTRY if c.name == "interrupt")
+        assert not cmd.cli_only
+
+    def test_interrupt_alias_i(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+
+        cmd = next(c for c in COMMAND_REGISTRY if c.name == "interrupt")
+        assert "i" in cmd.aliases
+
+    def test_interrupt_in_gateway_known_commands(self):
+        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+
+        assert "interrupt" in GATEWAY_KNOWN_COMMANDS
+        assert "i" in GATEWAY_KNOWN_COMMANDS
+
+
+class TestHandleInterruptCommand(unittest.TestCase):
+    def test_interrupt_with_active_agent(self):
+        cli_mod = _import_cli()
+        mock_agent = MagicMock()
+        stub = SimpleNamespace(agent=mock_agent)
+
+        with patch.object(cli_mod, "_cprint") as mock_cprint:
+            cli_mod.HermesCLI._handle_interrupt_command(stub)
+
+        mock_agent.interrupt.assert_called_once()
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        assert "Interrupted" in printed
+
+    def test_interrupt_with_no_agent(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(agent=None)
+
+        with patch.object(cli_mod, "_cprint") as mock_cprint:
+            cli_mod.HermesCLI._handle_interrupt_command(stub)
+
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        assert "No active run" in printed
+
+    def test_interrupt_with_agent_without_interrupt_method(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(agent=SimpleNamespace())  # no interrupt method
+
+        with patch.object(cli_mod, "_cprint") as mock_cprint:
+            cli_mod.HermesCLI._handle_interrupt_command(stub)
+
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        assert "No active run" in printed
+
+
+class TestResolveInterruptAlias(unittest.TestCase):
+    def test_resolve_i_to_interrupt(self):
+        from hermes_cli.commands import resolve_command
+
+        cmd = resolve_command("/i")
+        assert cmd.name == "interrupt"
+
+    def test_resolve_interrupt(self):
+        from hermes_cli.commands import resolve_command
+
+        cmd = resolve_command("/interrupt")
+        assert cmd.name == "interrupt"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

When a session is busy (agent is running), several slash commands return an error message telling the user to run `/interrupt` first:

```
session busy — /interrupt the current turn before /undo
session busy — /interrupt the current turn before /compress
session busy — /interrupt the current turn before /retry
session busy — /interrupt the current turn before switching models
```

However, `/interrupt` is **not a registered slash command**. Running it returns `unknown command: /interrupt`, creating a dead-end for users.

**Affected locations**: 8 occurrences in `tui_gateway/server.py` + 1 in `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`.

## Solution

Register `/interrupt` (alias: `/i`) as a top-level slash command that sends an interrupt signal to the running agent.

### Changes

| File | Change |
|------|--------|
| `hermes_cli/commands.py` | Add `CommandDef("interrupt", ...)` with alias `"i"` — not `cli_only`, so it's available in CLI and gateway |
| `hermes_cli/cli_commands_mixin.py` | Add `_handle_interrupt_command()` — calls `agent.interrupt()` |
| `cli.py` | Add dispatch for `canonical == "interrupt"` |
| `gateway/run.py` | Add dispatch for `canonical == "interrupt"` |
| `gateway/slash_commands.py` | Add `_handle_interrupt_command()` — interrupts running agent without clearing the session (lighter than `/stop`) |
| `tests/cli/test_interrupt_command.py` | 9 tests: registry, alias, gateway availability, handler behavior |

### Design decisions

- **Not `cli_only`**: The error messages are in the TUI gateway and Desktop, so `/interrupt` must work everywhere
- **Lighter than `/stop`**: `/interrupt` only sends an interrupt signal; `/stop` also clears session locks and kills background processes
- **Alias `/i`**: Quick access for the most common interrupt scenario

Fixes #42093
