### PR TITLE
fix(terminal): normalize Windows cwd for Git Bash bootstrap

### DIFF
--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -839,6 +839,23 @@ class TestLocalEnvironmentWindowsTempDir:
         assert "get_hermes_home" in source
         assert 'cache_dir = get_hermes_home() / "cache" / "terminal"' in source
 
+    def test_windows_cwd_is_normalized_for_bash_cd(self, monkeypatch):
+        import tools.environments.local as local_mod
+        from tools.environments.local import LocalEnvironment
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(LocalEnvironment, "init_session", lambda self: None)
+            env = LocalEnvironment(cwd=r"C:\Users\Some Name\project", timeout=10, env={})
+
+        assert env._quote_cwd_for_cd(env.cwd) == "'/c/Users/Some Name/project'"
+
+    def test_windows_unc_cwd_is_normalized_for_bash_cd(self, monkeypatch):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert local_mod._windows_to_msys_path(r"\\server\share\folder") == "//server/share/folder"
+
 
 class TestLocalEnvironmentPathInjectionGated:
     """The /usr/bin PATH injection in _make_run_env must be POSIX-only."""
@@ -886,6 +903,13 @@ class TestGitBashPathNormalization:
         # returns this form; it's valid for both bash and Python, so we
         # don't need to translate).
         assert cli_mod._normalize_git_bash_path("C:/Users/foo") == "C:/Users/foo"
+
+
+class TestBaseEnvironmentCwdQuoting:
+    def test_source_routes_bootstrap_cwd_through_quote_helper(self):
+        root = Path(__file__).resolve().parents[2]
+        source = (root / "tools" / "environments" / "base.py").read_text(encoding="utf-8")
+        assert "_quoted_cwd = self._quote_cwd_for_cd(self.cwd)" in source
 
 
 class TestWorktreeSymlinkFallback:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -359,7 +359,7 @@ class BaseEnvironment(ABC):
         # Restore configured cwd after login shell profile scripts, which may
         # change the working directory (e.g. bashrc `cd ~`).  Without this,
         # pwd -P captures the profile's directory, not terminal.cwd.
-        _quoted_cwd = shlex.quote(self.cwd)
+        _quoted_cwd = self._quote_cwd_for_cd(self.cwd)
         # Quote the snapshot / cwd-file paths so Git Bash on Windows handles
         # ``C:/Users/...``-shaped paths without glob-splitting the colon or
         # tripping on drive letters.  On POSIX this is a no-op (no colons /
@@ -403,9 +403,12 @@ class BaseEnvironment(ABC):
     # Command wrapping
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _quote_cwd_for_cd(cwd: str) -> str:
+    def _normalize_cwd_for_cd(self, cwd: str) -> str:
+        return cwd
+
+    def _quote_cwd_for_cd(self, cwd: str) -> str:
         """Quote a ``cd`` target while preserving ``~`` expansion."""
+        cwd = self._normalize_cwd_for_cd(cwd)
         if cwd == "~":
             return cwd
         if cwd == "~/":

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -39,6 +39,25 @@ def _msys_to_windows_path(cwd: str) -> str:
     return f"{drive}:{tail or chr(92)}"  # chr(92) = backslash, avoid raw-string escape
 
 
+def _windows_to_msys_path(cwd: str) -> str:
+    """Translate a native Windows path (``C:\\Users\\x``) to Git Bash / MSYS-style
+    POSIX form (``/c/Users/x``) so ``builtin cd`` inside bash can resolve it.
+
+    No-ops on non-Windows hosts or for paths that aren't in Windows form.
+    Returns the input unchanged when no translation applies. This is
+    idempotent — calling it on an already-MSYS path returns it as-is.
+    """
+    if not _IS_WINDOWS or not cwd:
+        return cwd
+    if len(cwd) >= 3 and cwd[1] == ":" and cwd[2] in "\\/":
+        drive = cwd[0].lower()
+        tail = cwd[3:].replace("\\", "/")
+        return f"/{drive}" + (f"/{tail}" if tail else "")
+    if cwd.startswith("\\\\") or cwd.startswith("//"):
+        return "//" + cwd.lstrip("\\/").replace("\\", "/")
+    return cwd
+
+
 def _resolve_safe_cwd(cwd: str) -> str:
     """Return ``cwd`` if it exists as a directory, else the nearest existing
     ancestor.  Falls back to ``tempfile.gettempdir()`` only if walking up the
@@ -495,6 +514,9 @@ class LocalEnvironment(BaseEnvironment):
             return candidate.rstrip("/") or "/"
 
         return "/tmp"
+
+    def _normalize_cwd_for_cd(self, cwd: str) -> str:
+        return _windows_to_msys_path(cwd)
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows terminal bootstrap bug where Hermes stores native cwd values like `C:\Users\Kingshuk` and injects them directly into Git Bash `cd` commands. Git Bash expects MSYS-style paths like `/c/Users/Kingshuk`, so session bootstrap and wrapped commands can fail before the terminal is usable.

This keeps `self.cwd` in native OS format for Python-side filesystem handling and converts only at the bash boundary. `LocalEnvironment` normalizes Windows and UNC paths for `cd`, and `BaseEnvironment.init_session()` now routes bootstrap cwd handling through the same quoting and normalization helper used for wrapped commands.

This complements #23866, which focuses on MSYS-to-Windows normalization for paths coming back from bash. This PR fixes the opposite direction: native Windows cwd values going into bash.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Route `BaseEnvironment.init_session()` cwd handling through `_quote_cwd_for_cd`
- Add overridable `_normalize_cwd_for_cd()` in `tools/environments/base.py`
- Add `_windows_to_msys_path()` and `LocalEnvironment._normalize_cwd_for_cd()` in `tools/environments/local.py`
- Add Windows regression coverage in `tests/tools/test_windows_native_support.py`

## How to Test

1. On Windows with Git Bash, set the terminal cwd to a native Windows path like `C:\Users\Kingshuk`.
2. Trigger Hermes terminal session bootstrap and run a simple command like `pwd`.
3. Confirm the session initializes successfully and no longer fails with `cd: C:\Users\Kingshuk: No such file or directory`.
4. Confirm wrapped commands still preserve native cwd values for Python-side path handling.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested targeted behavior on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) — the normalization hook is overridden only in `LocalEnvironment` and preserves existing behavior elsewhere
- [x] No config, schema, or workflow docs changes were needed

## Screenshots / Logs

- Targeted local validation confirmed:
  - `C:\Users\Some Name\project` -> `'/c/Users/Some Name/project'`
  - `\\server\share\folder` -> `//server/share/folder`
- Full `pytest` was not available in the system Python used for this local checkout