### PR TITLE
fix(cron): don't log "agent returned [SILENT]" when the agent was never invoked

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -289,6 +289,15 @@ def _is_cron_silence_response(text: str) -> bool:
         return True
     return False
 
+
+# Sentinel: the tick was short-circuited before the agent was ever invoked —
+# a ``wakeAgent=false`` gate, empty no_agent script output, or a prompt that
+# resolved to nothing.  Like SILENT_MARKER it suppresses delivery, but it lets
+# the delivery loop log "agent not invoked" instead of the misleading "agent
+# returned [SILENT]" (issue #41923).  Kept distinct from SILENT_MARKER so the
+# genuine agent-returned-[SILENT] path keeps its own accurate log line.
+AGENT_NOT_INVOKED_MARKER = "[SILENT:agent-not-invoked]"
+
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
 # The tick function submits jobs here and returns immediately so the ticker
@@ -2650,7 +2659,7 @@ def run_job(
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (wakeAgent=false)\n"
             )
-            return True, silent_doc, SILENT_MARKER, None
+            return True, silent_doc, AGENT_NOT_INVOKED_MARKER, None
 
         if not output.strip():
             logger.info("Job '%s' (no_agent): empty stdout — silent run", job_id)
@@ -2661,7 +2670,7 @@ def run_job(
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (empty output)\n"
             )
-            return True, silent_doc, SILENT_MARKER, None
+            return True, silent_doc, AGENT_NOT_INVOKED_MARKER, None
 
         doc = (
             f"# Cron Job: {job_name}\n\n"
@@ -2768,7 +2777,7 @@ def run_job(
                 f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
                 "Script gate returned `wakeAgent=false` — agent skipped.\n"
             )
-            return True, silent_doc, SILENT_MARKER, None
+            return True, silent_doc, AGENT_NOT_INVOKED_MARKER, None
 
     try:
         prompt = _build_job_prompt(job, prerun_script=prerun_script)
@@ -2797,7 +2806,7 @@ def run_job(
         return False, blocked_doc, "", str(block_exc)
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
-        return True, "", SILENT_MARKER, None
+        return True, "", AGENT_NOT_INVOKED_MARKER, None
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 
@@ -3622,13 +3631,23 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
             should_deliver = bool(deliver_content.strip())
+            # Short-circuited before the agent ran (wakeAgent=false gate, empty
+            # no_agent script output, or a prompt that resolved to nothing). The
+            # specific cause was already logged in run_job; suppress delivery but
+            # don't claim the agent replied [SILENT] — it was never invoked
+            # (#41923). Checked before _is_cron_silence_response because the
+            # ``[SILENT:agent-not-invoked]`` sentinel is intentionally not one of
+            # the recognized cron silence tokens.
+            if should_deliver and success and deliver_content.strip() == AGENT_NOT_INVOKED_MARKER:
+                logger.info("Job '%s': agent not invoked — skipping delivery", job["id"])
+                should_deliver = False
             # Cron silence suppression — see _is_cron_silence_response.  Replaces the
             # old `SILENT_MARKER in ...upper()` substring check, which both leaked
             # bracketless near-markers ("SILENT" / "NO_REPLY") and wrongly swallowed
             # a real report that merely quoted "[SILENT]" mid-sentence (#51438,
             # #46917).  Keeps the intentional bracketed-prefix / trailing-line
             # tolerance the cron contract relies on.
-            if should_deliver and success and _is_cron_silence_response(deliver_content):
+            elif should_deliver and success and _is_cron_silence_response(deliver_content):
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -211,9 +211,9 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
 
 
 def test_run_job_no_agent_empty_output_is_silent(hermes_env):
-    """Empty stdout → SILENT_MARKER, which suppresses delivery downstream."""
+    """Empty stdout → AGENT_NOT_INVOKED_MARKER, which suppresses delivery downstream."""
     from cron.jobs import create_job
-    from cron.scheduler import run_job, SILENT_MARKER
+    from cron.scheduler import run_job, AGENT_NOT_INVOKED_MARKER
 
     script_path = hermes_env / "scripts" / "quiet.sh"
     script_path.write_text("#!/bin/bash\n# nothing to say\n")
@@ -224,13 +224,13 @@ def test_run_job_no_agent_empty_output_is_silent(hermes_env):
     success, doc, final_response, error = run_job(job)
     assert success is True
     assert error is None
-    assert final_response == SILENT_MARKER
+    assert final_response == AGENT_NOT_INVOKED_MARKER
 
 
 def test_run_job_no_agent_wake_gate_is_silent(hermes_env):
-    """wakeAgent=false gate in stdout triggers a silent run."""
+    """wakeAgent=false gate in stdout triggers a silent run (agent not invoked)."""
     from cron.jobs import create_job
-    from cron.scheduler import run_job, SILENT_MARKER
+    from cron.scheduler import run_job, AGENT_NOT_INVOKED_MARKER
 
     script_path = hermes_env / "scripts" / "gated.sh"
     script_path.write_text('#!/bin/bash\necho \'{"wakeAgent": false}\'\n')
@@ -240,7 +240,7 @@ def test_run_job_no_agent_wake_gate_is_silent(hermes_env):
     )
     success, doc, final_response, error = run_job(job)
     assert success is True
-    assert final_response == SILENT_MARKER
+    assert final_response == AGENT_NOT_INVOKED_MARKER
 
 
 def test_run_job_no_agent_script_failure_delivers_error(hermes_env):

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -78,6 +78,26 @@ def test_run_one_job_silent_skips_delivery(monkeypatch):
     assert "deliver" not in kinds
 
 
+def test_run_one_job_agent_not_invoked_skips_delivery_with_distinct_log(monkeypatch, caplog):
+    """A tick short-circuited before the agent ran (wakeAgent=false gate, empty
+    no_agent output, or no prompt) returns AGENT_NOT_INVOKED_MARKER. Delivery is
+    suppressed like [SILENT], but the log must say 'agent not invoked' — not
+    'agent returned [SILENT]', which would falsely imply the model replied
+    (#41923). Covers the external-provider path (run_one_job called directly)."""
+    import logging
+
+    calls = _patch_pipeline(monkeypatch, silent_marker_in=s.AGENT_NOT_INVOKED_MARKER)
+
+    with caplog.at_level(logging.INFO, logger="cron.scheduler"):
+        s.run_one_job({"id": "j3b", "name": "t"})
+
+    kinds = [c[0] for c in calls]
+    assert "run_job" in kinds and "save" in kinds and "mark" in kinds
+    assert "deliver" not in kinds  # suppressed, agent never ran
+    assert any("agent not invoked" in r.message for r in caplog.records)
+    assert not any("agent returned" in r.message for r in caplog.records)
+
+
 def test_run_one_job_empty_response_is_soft_failure(monkeypatch):
     """An empty final response marks the run as NOT ok (issue #8585)."""
     calls = _patch_pipeline(monkeypatch, final="   ")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2528,6 +2528,23 @@ class TestSilentDelivery:
         deliver_mock.assert_not_called()
         assert any(SILENT_MARKER in r.message for r in caplog.records)
 
+    def test_agent_not_invoked_marker_logs_distinct_message(self, caplog):
+        """A skipped tick (wakeAgent=false / no prompt) suppresses delivery but
+        must NOT be logged as 'agent returned [SILENT]' — the agent never ran
+        (issue #41923)."""
+        from cron.scheduler import AGENT_NOT_INVOKED_MARKER
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", AGENT_NOT_INVOKED_MARKER, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            with caplog.at_level(logging.INFO, logger="cron.scheduler"):
+                tick(verbose=False)
+        deliver_mock.assert_not_called()
+        assert any("agent not invoked" in r.message for r in caplog.records)
+        assert not any("agent returned" in r.message for r in caplog.records)
+
     def test_silent_with_note_suppresses_delivery(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
@@ -2823,9 +2840,9 @@ class TestRunJobWakeGate:
 
     def test_wake_false_skips_agent_and_returns_silent(self, caplog):
         """When _run_job_script output ends with {wakeAgent: false}, the agent
-        is not invoked and run_job returns the SILENT marker so delivery is
-        suppressed."""
-        from cron.scheduler import SILENT_MARKER
+        is not invoked and run_job returns the agent-not-invoked marker so
+        delivery is suppressed."""
+        from cron.scheduler import AGENT_NOT_INVOKED_MARKER
         import cron.scheduler as scheduler
 
         with patch.object(scheduler, "_run_job_script",
@@ -2835,7 +2852,7 @@ class TestRunJobWakeGate:
 
         assert success is True
         assert err is None
-        assert final == SILENT_MARKER
+        assert final == AGENT_NOT_INVOKED_MARKER
         assert "Script gate returned `wakeAgent=false`" in doc
         agent_cls.assert_not_called()
 


### PR DESCRIPTION
## What & why

Closes #41923.

When a cron tick is short-circuited **before the LLM is ever invoked**, the scheduler logs a misleading line claiming the agent ran:

```
INFO cron.scheduler: Job '…': wakeAgent=false, skipping agent run
INFO cron.scheduler: Job '…': agent returned [SILENT] — skipping delivery   ← wrong, agent never ran
```

The root cause: four pre-agent skip paths in `run_job` all returned the same `SILENT_MARKER` that a genuine agent-produced `[SILENT]` reply uses, so the delivery loop in `_process_job` couldn't tell the two apart and always logged `agent returned [SILENT]`.

The skip paths are:
- `wakeAgent=false` script gate (LLM path) — the case in the issue
- `wakeAgent=false` gate on a `no_agent` job
- empty `no_agent` script stdout
- a prompt that resolves to nothing (script produced no output)

In all four the agent is never invoked.

## Change

- Add a distinct `AGENT_NOT_INVOKED_MARKER` sentinel returned by those four skip paths. It suppresses delivery exactly like `SILENT_MARKER` (output is still saved for audit, the run still counts as a success), but lets the delivery loop log:

  ```
  INFO cron.scheduler: Job '…': agent not invoked — skipping delivery
  ```

- The genuine "agent ran and replied `[SILENT]`" path is untouched and keeps its existing `agent returned [SILENT] — skipping delivery` log line. The two markers are mutually exclusive (`[SILENT]` is not a substring of `[SILENT:agent-not-invoked]`), so the substring `[SILENT]` detection for real agent replies still works.

This keeps the per-cause line already emitted inside `run_job` (`wakeAgent=false, skipping agent run`, `empty stdout — silent run`, etc.) as the authoritative reason, and stops the second line from contradicting it.

## How to test

Repro from the issue: a cron job whose pre-run script emits `{"wakeAgent": false}`. Before this change the scheduler logged `agent returned [SILENT] — skipping delivery`; now it logs `agent not invoked — skipping delivery`.

Automated:

```
pytest tests/cron/ -q
```

- Updated `test_run_job_no_agent_empty_output_is_silent`, `test_run_job_no_agent_wake_gate_is_silent`, and `test_wake_false_skips_agent_and_returns_silent` to assert the new sentinel.
- Added `test_agent_not_invoked_marker_logs_distinct_message` asserting the skip path logs `agent not invoked` and **not** `agent returned`, while still suppressing delivery.

All 404 tests in `tests/cron/` pass.

## Platforms

Logic-only change in `cron/scheduler.py`; no platform-specific code touched. Tested on macOS.