### PR TITLE
fix(auth): propagate credential label to pool entries on re-auth

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1567,7 +1567,7 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
     for key, value in payload.items():
         if key in {"id", "priority"} or value is None:
             continue
-        if key == "label" and existing.label:
+        if key == "label" and existing.label and value == existing.label:
             continue
         if key in _field_names:
             if getattr(existing, key) != value:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3340,6 +3340,7 @@ def _sync_codex_pool_entries(
     auth_store: Dict[str, Any],
     tokens: Dict[str, str],
     last_refresh: Optional[str],
+    label: Optional[str] = None,
 ) -> None:
     """Mirror a fresh Codex re-auth into the credential_pool OAuth entries.
 
@@ -3405,6 +3406,8 @@ def _sync_codex_pool_entries(
         entry["last_error_reason"] = None
         entry["last_error_message"] = None
         entry["last_error_reset_at"] = None
+        if label:
+            entry["label"] = label
 
 
 def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
@@ -3420,7 +3423,7 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
         if label and str(label).strip():
             state["label"] = str(label).strip()
         _save_provider_state(auth_store, "openai-codex", state)
-        _sync_codex_pool_entries(auth_store, tokens, last_refresh)
+        _sync_codex_pool_entries(auth_store, tokens, last_refresh, label=label)
         _save_auth_store(auth_store)
 
 

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -658,3 +658,140 @@ def test_login_openai_codex_force_new_login_skips_existing_reuse_prompt(monkeypa
 
     assert called["device_login"] == 1
     assert called["tokens"]["access_token"] == "fresh-at"
+
+
+def test_save_codex_tokens_syncs_label_to_pool(tmp_path, monkeypatch):
+    """Re-auth with --label must update the label on pool entries.
+
+    Regression for #42102: ``hermes auth add openai-codex --label foo``
+    saved the label to providers state but _sync_codex_pool_entries did not
+    propagate it to credential_pool entries, so the pool entry kept its
+    stale label.
+    """
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {"access_token": "old-at", "refresh_token": "old-rt"},
+                "last_refresh": "2026-01-01T00:00:00Z",
+                "auth_mode": "chatgpt",
+                "label": "openai-codex-oauth-1",
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "abc123",
+                    "source": "device_code",
+                    "auth_type": "oauth",
+                    "access_token": "old-at",
+                    "refresh_token": "old-rt",
+                    "label": "openai-codex-oauth-1",
+                },
+            ],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_codex_tokens(
+        {"access_token": "new-at", "refresh_token": "new-rt"},
+        last_refresh="2026-06-08T00:00:00Z",
+        label="openai-codex-oauth-2",
+    )
+
+    auth = json.loads((hermes_home / "auth.json").read_text())
+    pool = auth["credential_pool"]["openai-codex"]
+    entry = next(e for e in pool if e["source"] == "device_code")
+    assert entry["label"] == "openai-codex-oauth-2"
+    assert entry["access_token"] == "new-at"
+
+    # Provider state also has the new label.
+    assert auth["providers"]["openai-codex"]["label"] == "openai-codex-oauth-2"
+
+
+def test_save_codex_tokens_syncs_custom_label(tmp_path, monkeypatch):
+    """Custom --label is propagated to pool entries on re-auth."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {"access_token": "old-at", "refresh_token": "old-rt"},
+                "auth_mode": "chatgpt",
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "abc123",
+                    "source": "device_code",
+                    "auth_type": "oauth",
+                    "access_token": "old-at",
+                    "refresh_token": "old-rt",
+                    "label": "device_code",
+                },
+            ],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_codex_tokens(
+        {"access_token": "new-at", "refresh_token": "new-rt"},
+        label="my-custom-label",
+    )
+
+    auth = json.loads((hermes_home / "auth.json").read_text())
+    pool = auth["credential_pool"]["openai-codex"]
+    entry = next(e for e in pool if e["source"] == "device_code")
+    assert entry["label"] == "my-custom-label"
+
+
+def test_upsert_entry_updates_label_when_different():
+    """_upsert_entry must update the label when the new value differs."""
+    from agent.credential_pool import _upsert_entry, PooledCredential
+
+    existing = PooledCredential(
+        provider="openai-codex",
+        id="abc123",
+        label="openai-codex-oauth-1",
+        auth_type="oauth",
+        priority=0,
+        source="device_code",
+        access_token="old-at",
+    )
+    entries = [existing]
+    changed = _upsert_entry(
+        entries, "openai-codex", "device_code",
+        {"source": "device_code", "auth_type": "oauth",
+         "access_token": "new-at", "label": "openai-codex-oauth-2"},
+    )
+    assert changed is True
+    assert entries[0].label == "openai-codex-oauth-2"
+    assert entries[0].access_token == "new-at"
+
+
+def test_upsert_entry_preserves_label_when_same():
+    """_upsert_entry is a no-op when the label hasn't changed."""
+    from agent.credential_pool import _upsert_entry, PooledCredential
+
+    existing = PooledCredential(
+        provider="openai-codex",
+        id="abc123",
+        label="openai-codex-oauth-1",
+        auth_type="oauth",
+        priority=0,
+        source="device_code",
+        access_token="same-at",
+    )
+    entries = [existing]
+    changed = _upsert_entry(
+        entries, "openai-codex", "device_code",
+        {"source": "device_code", "auth_type": "oauth",
+         "access_token": "same-at", "label": "openai-codex-oauth-1"},
+    )
+    # Only the label+token are same → no change
+    assert changed is False
+    assert entries[0].label == "openai-codex-oauth-1"


### PR DESCRIPTION
## What does this PR do?

Fixes credential label not updating on re-auth for `hermes auth add openai-codex` (and other OAuth providers). When a user re-authenticates, the computed label (e.g., `openai-codex-oauth-2`) was saved to auth.json but never propagated to the credential pool, so the entry kept its stale label (e.g., `openai-codex-oauth-1`). The `--label` flag was similarly ignored for existing entries.

## Related Issue

Fixes #42102

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/credential_pool.py`: In `_upsert_entry()`, changed label skip logic from "skip if existing has any label" to "skip only if new label equals existing label". This allows label updates when re-authentication produces a different label.
- `hermes_cli/auth.py`: Added `label` parameter to `_sync_codex_pool_entries()` and propagated it to pool entries alongside token updates. Updated `_save_codex_tokens()` to pass the label through.
- `tests/hermes_cli/test_auth_codex_provider.py`: Added 4 regression tests covering label sync to pool, custom `--label` propagation, label update on difference, and label preservation when unchanged.

## How to Test

1. Run `pytest tests/hermes_cli/test_auth_codex_provider.py -v` — all 28 tests pass (24 existing + 4 new)
2. Run `pytest tests/agent/test_credential_pool.py -v` — all 78 tests pass (no regression from `_upsert_entry` change)
3. Run `pytest tests/hermes_cli/test_auth_commands.py -v` — all 49 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/credential_pool.py::_upsert_entry` (callers: ~15 via `_seed_from_singletons`, `_seed_from_env`)
- Analyzed: `hermes_cli/auth.py::_sync_codex_pool_entries` (callers: 1 — `_save_codex_tokens`)
- Blast radius: LOW — label field is metadata only, change is additive (allows updates that were previously skipped)
- Related patterns: `_upsert_entry` is used by all pool seeding paths (anthropic, nous, xai, env-seeded). The label change is safe because re-authentication always produces a valid label.
