### PR TITLE
feat(desktop): add macOS launcher install support

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -60,6 +60,7 @@ const {
   resolveReadableFileForIpc,
   resolveTimeoutMs
 } = require('./hardening.cjs')
+const { installSingleInstanceGuard } = require('./single-instance.cjs')
 
 let nodePty = null
 
@@ -507,6 +508,13 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
+installSingleInstanceGuard({
+  app,
+  createWindow,
+  getMainWindow: () => mainWindow,
+  lockDir: path.join(HERMES_HOME, 'desktop-single-instance.lock'),
+  log: message => console.log(message)
+})
 let hermesProcess = null
 let connectionPromise = null
 // Additional per-profile backends, keyed by profile name. The PRIMARY backend

--- a/apps/desktop/electron/single-instance.cjs
+++ b/apps/desktop/electron/single-instance.cjs
@@ -1,0 +1,210 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { spawn } = require('node:child_process')
+
+function focusPrimaryWindow(window) {
+  if (!window || (typeof window.isDestroyed === 'function' && window.isDestroyed())) {
+    return false
+  }
+
+  if (typeof window.isMinimized === 'function' && window.isMinimized()) {
+    window.restore()
+  }
+
+  if (typeof window.isVisible === 'function' && !window.isVisible()) {
+    window.show()
+  }
+
+  if (typeof window.focus === 'function') {
+    window.focus()
+  }
+
+  return true
+}
+
+function resolveMacAppBundle(executablePath) {
+  const parts = String(executablePath || '').split(path.sep)
+  const appIndex = parts.findIndex(part => part.endsWith('.app'))
+
+  if (appIndex === -1) {
+    return null
+  }
+
+  return parts.slice(0, appIndex + 1).join(path.sep) || path.sep
+}
+
+function focusRunningAppBundle({ executablePath = process.execPath, platform = process.platform, spawnProcess = spawn } = {}) {
+  if (platform !== 'darwin') {
+    return false
+  }
+
+  const appBundle = resolveMacAppBundle(executablePath)
+  if (!appBundle) {
+    return false
+  }
+
+  const child = spawnProcess('open', [appBundle], {
+    detached: true,
+    stdio: 'ignore'
+  })
+  child.unref?.()
+  return true
+}
+
+function isProcessAlive(pid, processApi = process) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false
+  }
+
+  try {
+    processApi.kill(pid, 0)
+    return true
+  } catch (error) {
+    return error?.code === 'EPERM'
+  }
+}
+
+function readLockPid(lockDir, fsApi = fs) {
+  try {
+    const raw = fsApi.readFileSync(path.join(lockDir, 'owner.json'), 'utf8')
+    const parsed = JSON.parse(raw)
+    return Number.isInteger(parsed?.pid) ? parsed.pid : null
+  } catch {
+    return null
+  }
+}
+
+function writeLockOwner(lockDir, processApi = process, fsApi = fs) {
+  fsApi.writeFileSync(
+    path.join(lockDir, 'owner.json'),
+    JSON.stringify(
+      {
+        executable: processApi.execPath,
+        pid: processApi.pid,
+        startedAt: new Date().toISOString()
+      },
+      null,
+      2
+    )
+  )
+}
+
+function acquireDirectoryLock(lockDir, { fsApi = fs, processApi = process } = {}) {
+  const tryAcquire = () => {
+    fsApi.mkdirSync(lockDir, { mode: 0o700 })
+    writeLockOwner(lockDir, processApi, fsApi)
+    return true
+  }
+
+  try {
+    tryAcquire()
+  } catch (error) {
+    if (error?.code !== 'EEXIST') {
+      throw error
+    }
+
+    const ownerPid = readLockPid(lockDir, fsApi)
+    if (isProcessAlive(ownerPid, processApi)) {
+      return {
+        acquired: false,
+        ownerPid,
+        release: () => {}
+      }
+    }
+
+    fsApi.rmSync(lockDir, { force: true, recursive: true })
+    try {
+      tryAcquire()
+    } catch (retryError) {
+      if (retryError?.code !== 'EEXIST') {
+        throw retryError
+      }
+
+      return {
+        acquired: false,
+        ownerPid: readLockPid(lockDir, fsApi),
+        release: () => {}
+      }
+    }
+  }
+
+  let released = false
+  return {
+    acquired: true,
+    ownerPid: processApi.pid,
+    release: () => {
+      if (released) return
+      released = true
+      fsApi.rmSync(lockDir, { force: true, recursive: true })
+    }
+  }
+}
+
+function exitDuplicateApp(app) {
+  if (typeof app.exit === 'function') {
+    app.exit(0)
+    return
+  }
+
+  app.quit()
+}
+
+function installSingleInstanceGuard({
+  app,
+  createWindow,
+  getMainWindow,
+  lockDir,
+  log = () => {},
+  processApi = process,
+  spawnProcess = spawn
+}) {
+  const resolvedLockDir = lockDir || path.join(app.getPath('userData'), 'hermes-desktop-single-instance.lock')
+  const osLock = acquireDirectoryLock(resolvedLockDir, { processApi })
+
+  if (!osLock.acquired) {
+    log(`[hermes] another Hermes Desktop instance is already running (pid ${osLock.ownerPid || 'unknown'}); exiting duplicate launch`)
+    focusRunningAppBundle({ executablePath: processApi.execPath, platform: processApi.platform, spawnProcess })
+    exitDuplicateApp(app)
+    return false
+  }
+
+  const releaseOsLock = () => osLock.release()
+  processApi.once?.('exit', releaseOsLock)
+
+  const hasElectronLock = app.requestSingleInstanceLock()
+
+  if (!hasElectronLock) {
+    log('[hermes] another Hermes Desktop instance is already running; exiting duplicate launch')
+    osLock.release()
+    focusRunningAppBundle({ executablePath: processApi.execPath, platform: processApi.platform, spawnProcess })
+    exitDuplicateApp(app)
+    return false
+  }
+
+  app.on('second-instance', () => {
+    log('[hermes] duplicate Hermes Desktop launch detected; focusing the running window')
+
+    const focusOrCreateWindow = () => {
+      if (!focusPrimaryWindow(getMainWindow())) {
+        createWindow()
+      }
+    }
+
+    if (typeof app.isReady === 'function' && !app.isReady()) {
+      app.once('ready', focusOrCreateWindow)
+      return
+    }
+
+    focusOrCreateWindow()
+  })
+
+  return true
+}
+
+module.exports = {
+  acquireDirectoryLock,
+  focusPrimaryWindow,
+  focusRunningAppBundle,
+  isProcessAlive,
+  installSingleInstanceGuard
+}

--- a/apps/desktop/electron/single-instance.test.cjs
+++ b/apps/desktop/electron/single-instance.test.cjs
@@ -1,0 +1,287 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const {
+  acquireDirectoryLock,
+  focusPrimaryWindow,
+  focusRunningAppBundle,
+  installSingleInstanceGuard
+} = require('./single-instance.cjs')
+
+function tempLockPath(t) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-single-instance-test-'))
+  t.after(() => fs.rmSync(tempDir, { force: true, recursive: true }))
+  return path.join(tempDir, 'desktop.lock')
+}
+
+function makeApp({ hasLock = true, ready = true, userData = os.tmpdir() } = {}) {
+  const listeners = new Map()
+  const onceListeners = new Map()
+  const app = {
+    exitCalls: [],
+    quitCalls: 0,
+    requestSingleInstanceLock: () => hasLock,
+    quit: () => {
+      app.quitCalls += 1
+    },
+    exit: code => {
+      app.exitCalls.push(code)
+    },
+    getPath: name => {
+      assert.equal(name, 'userData')
+      return userData
+    },
+    isReady: () => ready,
+    on: (event, handler) => {
+      listeners.set(event, handler)
+    },
+    once: (event, handler) => {
+      onceListeners.set(event, handler)
+    },
+    emit: event => {
+      listeners.get(event)?.()
+    },
+    emitOnce: event => {
+      onceListeners.get(event)?.()
+    },
+    hasListener: event => listeners.has(event),
+    hasOnceListener: event => onceListeners.has(event)
+  }
+
+  return app
+}
+
+function makeWindow({ destroyed = false, minimized = false, visible = true } = {}) {
+  return {
+    focusCalls: 0,
+    restoreCalls: 0,
+    showCalls: 0,
+    isDestroyed: () => destroyed,
+    isMinimized: () => minimized,
+    isVisible: () => visible,
+    restore() {
+      this.restoreCalls += 1
+      minimized = false
+    },
+    show() {
+      this.showCalls += 1
+      visible = true
+    },
+    focus() {
+      this.focusCalls += 1
+    }
+  }
+}
+
+function makeProcess({ alivePids = new Set(), pid = 1000, platform = 'darwin' } = {}) {
+  return {
+    execPath: '/Applications/Hermes.app/Contents/MacOS/Hermes',
+    pid,
+    platform,
+    kill: targetPid => {
+      if (!alivePids.has(targetPid)) {
+        const error = new Error('No such process')
+        error.code = 'ESRCH'
+        throw error
+      }
+    },
+    once: () => {}
+  }
+}
+
+test('focusPrimaryWindow restores shows and focuses an existing window', () => {
+  const window = makeWindow({ minimized: true, visible: false })
+
+  assert.equal(focusPrimaryWindow(window), true)
+  assert.equal(window.restoreCalls, 1)
+  assert.equal(window.showCalls, 1)
+  assert.equal(window.focusCalls, 1)
+})
+
+test('focusPrimaryWindow rejects missing or destroyed windows', () => {
+  assert.equal(focusPrimaryWindow(null), false)
+  assert.equal(focusPrimaryWindow(makeWindow({ destroyed: true })), false)
+})
+
+test('focusRunningAppBundle opens the containing macOS .app bundle', () => {
+  const calls = []
+
+  const focused = focusRunningAppBundle({
+    executablePath: '/Applications/Hermes.app/Contents/MacOS/Hermes',
+    platform: 'darwin',
+    spawnProcess: (command, args, options) => {
+      calls.push({ args, command, options })
+      return { unref: () => {} }
+    }
+  })
+
+  assert.equal(focused, true)
+  assert.equal(calls[0].command, 'open')
+  assert.deepEqual(calls[0].args, ['/Applications/Hermes.app'])
+  assert.equal(calls[0].options.detached, true)
+})
+
+test('focusRunningAppBundle ignores non-macOS processes', () => {
+  assert.equal(
+    focusRunningAppBundle({
+      executablePath: '/opt/Hermes/Hermes',
+      platform: 'linux',
+      spawnProcess: () => {
+        throw new Error('spawn should not be called')
+      }
+    }),
+    false
+  )
+})
+
+test('acquireDirectoryLock creates and releases the owner lock', t => {
+  const lockDir = tempLockPath(t)
+  const processApi = makeProcess({ pid: 42 })
+
+  const lock = acquireDirectoryLock(lockDir, { processApi })
+
+  assert.equal(lock.acquired, true)
+  assert.equal(JSON.parse(fs.readFileSync(path.join(lockDir, 'owner.json'), 'utf8')).pid, 42)
+
+  lock.release()
+  assert.equal(fs.existsSync(lockDir), false)
+})
+
+test('acquireDirectoryLock rejects a live owner process', t => {
+  const lockDir = tempLockPath(t)
+  fs.mkdirSync(lockDir)
+  fs.writeFileSync(path.join(lockDir, 'owner.json'), JSON.stringify({ pid: 123 }))
+
+  const lock = acquireDirectoryLock(lockDir, {
+    processApi: makeProcess({ alivePids: new Set([123]), pid: 456 })
+  })
+
+  assert.equal(lock.acquired, false)
+  assert.equal(lock.ownerPid, 123)
+})
+
+test('acquireDirectoryLock replaces a stale owner process', t => {
+  const lockDir = tempLockPath(t)
+  fs.mkdirSync(lockDir)
+  fs.writeFileSync(path.join(lockDir, 'owner.json'), JSON.stringify({ pid: 123 }))
+
+  const lock = acquireDirectoryLock(lockDir, {
+    processApi: makeProcess({ alivePids: new Set(), pid: 456 })
+  })
+
+  assert.equal(lock.acquired, true)
+  assert.equal(JSON.parse(fs.readFileSync(path.join(lockDir, 'owner.json'), 'utf8')).pid, 456)
+})
+
+test('installSingleInstanceGuard exits duplicate process when OS lock has a live owner', t => {
+  const app = makeApp()
+  const logs = []
+  const lockDir = tempLockPath(t)
+  const spawned = []
+  let created = 0
+  fs.mkdirSync(lockDir)
+  fs.writeFileSync(path.join(lockDir, 'owner.json'), JSON.stringify({ pid: 123 }))
+
+  const installed = installSingleInstanceGuard({
+    app,
+    createWindow: () => {
+      created += 1
+    },
+    getMainWindow: () => null,
+    lockDir,
+    log: message => logs.push(message),
+    processApi: makeProcess({ alivePids: new Set([123]), pid: 456 }),
+    spawnProcess: (command, args) => {
+      spawned.push({ args, command })
+      return { unref: () => {} }
+    }
+  })
+
+  assert.equal(installed, false)
+  assert.deepEqual(app.exitCalls, [0])
+  assert.equal(created, 0)
+  assert.equal(app.hasListener('second-instance'), false)
+  assert.match(logs.join('\n'), /already running/)
+  assert.deepEqual(spawned, [{ args: ['/Applications/Hermes.app'], command: 'open' }])
+})
+
+test('installSingleInstanceGuard exits duplicate process when Electron lock is unavailable', t => {
+  const app = makeApp({ hasLock: false })
+  const lockDir = tempLockPath(t)
+
+  const installed = installSingleInstanceGuard({
+    app,
+    createWindow: () => {},
+    getMainWindow: () => null,
+    lockDir,
+    processApi: makeProcess()
+  })
+
+  assert.equal(installed, false)
+  assert.deepEqual(app.exitCalls, [0])
+  assert.equal(fs.existsSync(lockDir), false)
+})
+
+test('installSingleInstanceGuard focuses existing window on a second launch', t => {
+  const app = makeApp()
+  const window = makeWindow()
+  const lockDir = tempLockPath(t)
+  let created = 0
+
+  const installed = installSingleInstanceGuard({
+    app,
+    createWindow: () => {
+      created += 1
+    },
+    getMainWindow: () => window,
+    lockDir
+  })
+
+  assert.equal(installed, true)
+  app.emit('second-instance')
+  assert.equal(window.focusCalls, 1)
+  assert.equal(created, 0)
+})
+
+test('installSingleInstanceGuard creates a window when second launch finds none', t => {
+  const app = makeApp()
+  const lockDir = tempLockPath(t)
+  let created = 0
+
+  installSingleInstanceGuard({
+    app,
+    createWindow: () => {
+      created += 1
+    },
+    getMainWindow: () => null,
+    lockDir
+  })
+
+  app.emit('second-instance')
+  assert.equal(created, 1)
+})
+
+test('installSingleInstanceGuard waits for app readiness before creating a missing window', t => {
+  const app = makeApp({ ready: false })
+  const lockDir = tempLockPath(t)
+  let created = 0
+
+  installSingleInstanceGuard({
+    app,
+    createWindow: () => {
+      created += 1
+    },
+    getMainWindow: () => null,
+    lockDir
+  })
+
+  app.emit('second-instance')
+  assert.equal(created, 0)
+  assert.equal(app.hasOnceListener('ready'), true)
+
+  app.emitOnce('ready')
+  assert.equal(created, 1)
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/single-instance.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -255,9 +255,11 @@ if _try_termux_ultrafast_version():
 import argparse
 import hashlib
 import json
+import plistlib
 import shutil
 import stat
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -7567,6 +7569,200 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
 
 
+def _desktop_macos_app_bundle_for_executable(packaged_executable: Path) -> Path | None:
+    """Return the containing macOS ``.app`` bundle for an Electron executable."""
+    if sys.platform != "darwin":
+        return None
+
+    for parent in packaged_executable.parents:
+        if parent.name.endswith(".app") and parent.is_dir():
+            return parent
+
+    return None
+
+
+def _desktop_running_pids(packaged_executable: Path) -> list[int]:
+    """Return running Hermes Desktop PIDs for this packaged executable path."""
+    executable = str(packaged_executable)
+    self_pid = os.getpid()
+    proc: subprocess.Popen[str] | None = None
+    try:
+        proc = subprocess.Popen(
+            ["ps", "-axo", "pid=,command="],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        stdout, _ = proc.communicate(timeout=5)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        if proc is not None:
+            proc.kill()
+        return []
+
+    if proc.returncode != 0:
+        return []
+
+    pids: list[int] = []
+    for line in (stdout or "").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        pid_text, _, command = stripped.partition(" ")
+        try:
+            pid = int(pid_text)
+        except ValueError:
+            continue
+        if pid == self_pid:
+            continue
+        if executable in command:
+            pids.append(pid)
+
+    return pids
+
+
+def _desktop_focus_running_macos_app(packaged_executable: Path) -> bool:
+    """Focus an already-running macOS Hermes Desktop app bundle."""
+    app_bundle = _desktop_macos_app_bundle_for_executable(packaged_executable)
+    if app_bundle is None:
+        return False
+
+    try:
+        result = subprocess.run(["open", str(app_bundle)], check=False)
+    except (FileNotFoundError, OSError):
+        return False
+
+    return result.returncode == 0
+
+
+def _desktop_shell_single_quoted(value: str) -> str:
+    """Return a POSIX single-quoted shell literal."""
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def _desktop_launcher_script(launch_cwd: Path, *, background: bool) -> str:
+    """Return the shell script used by macOS Hermes Desktop launchers."""
+    default_cwd = _desktop_shell_single_quoted(str(launch_cwd))
+    launch_line = (
+        'nohup hermes desktop --skip-build --cwd "$LAUNCH_CWD" '
+        '>/tmp/hermes-desktop-launcher.log 2>&1 &\nexit 0'
+        if background
+        else 'exec hermes desktop --skip-build --cwd "$LAUNCH_CWD"'
+    )
+
+    return f"""#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+DEFAULT_LAUNCH_CWD={default_cwd}
+LAUNCH_CWD="${{HERMES_DESKTOP_CWD:-$DEFAULT_LAUNCH_CWD}}"
+HERMES_AGENT_DIR="${{HERMES_AGENT_DIR:-$HOME/.hermes/hermes-agent}}"
+
+APP_BUNDLE=""
+for candidate in "$HERMES_AGENT_DIR"/apps/desktop/release/mac-*/Hermes.app; do
+  if [[ -d "$candidate" ]]; then
+    APP_BUNDLE="$candidate"
+    break
+  fi
+done
+
+if [[ -n "$APP_BUNDLE" ]]; then
+  APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/Hermes"
+  if pgrep -f "$APP_EXECUTABLE" >/dev/null 2>&1; then
+    echo "Hermes Desktop is already running; not launching another instance."
+    exit 0
+  fi
+fi
+
+{launch_line}
+"""
+
+
+def _desktop_apply_custom_icon(target: Path, icon_path: Path) -> None:
+    """Attach a Finder custom icon to a launcher file when macOS tools exist."""
+    rez = shutil.which("Rez")
+    setfile = shutil.which("SetFile")
+    if sys.platform != "darwin" or not rez or not setfile or not icon_path.is_file():
+        return
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="hermes-desktop-icon-") as tmp:
+            tmp_dir = Path(tmp)
+            tmp_icon = tmp_dir / "icon.icns"
+            tmp_resource = tmp_dir / "icon.r"
+            shutil.copy2(icon_path, tmp_icon)
+            tmp_resource.write_text("read 'icns' (-16455) \"icon.icns\";\n", encoding="utf-8")
+            subprocess.run([rez, "-append", str(tmp_resource), "-o", str(target)], cwd=tmp_dir, check=False)
+            subprocess.run([setfile, "-a", "C", str(target)], check=False)
+            target.touch()
+    except OSError as exc:
+        print(f"  (warning: could not apply launcher icon: {exc})")
+
+
+def _desktop_install_macos_launchers(
+    packaged_executable: Path,
+    launch_cwd: Path,
+    *,
+    name: str = "Hermes Desktop",
+) -> tuple[Path, Path]:
+    """Install macOS Desktop and Spotlight launchers for Hermes Desktop."""
+    if sys.platform != "darwin":
+        raise RuntimeError("Desktop launchers are currently macOS-only.")
+
+    app_bundle = _desktop_macos_app_bundle_for_executable(packaged_executable)
+    if app_bundle is None:
+        raise RuntimeError(f"Could not resolve .app bundle for {packaged_executable}")
+
+    desktop_dir = Path.home() / "Desktop"
+    if not desktop_dir.is_dir():
+        raise RuntimeError(f"Desktop folder not found: {desktop_dir}")
+
+    user_app_dir = Path.home() / "Applications"
+    user_app_dir.mkdir(parents=True, exist_ok=True)
+
+    command_path = desktop_dir / f"{name}.command"
+    spotlight_app = user_app_dir / f"{name}.app"
+    executable_name = name
+    app_executable = spotlight_app / "Contents" / "MacOS" / executable_name
+    resources_dir = spotlight_app / "Contents" / "Resources"
+    icon_path = app_bundle / "Contents" / "Resources" / "icon.icns"
+
+    command_path.write_text(_desktop_launcher_script(launch_cwd, background=False), encoding="utf-8")
+    command_path.chmod(0o755)
+
+    if spotlight_app.exists():
+        shutil.rmtree(spotlight_app)
+    app_executable.parent.mkdir(parents=True, exist_ok=True)
+    resources_dir.mkdir(parents=True, exist_ok=True)
+
+    if icon_path.is_file():
+        shutil.copy2(icon_path, resources_dir / "icon.icns")
+
+    plist = {
+        "CFBundleDisplayName": name,
+        "CFBundleExecutable": executable_name,
+        "CFBundleIconFile": "icon",
+        "CFBundleIdentifier": "com.nousresearch.hermes.desktop.launcher",
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "CFBundleName": name,
+        "CFBundlePackageType": "APPL",
+        "CFBundleShortVersionString": "1.0.0",
+        "CFBundleVersion": "1.0.0",
+    }
+    with (spotlight_app / "Contents" / "Info.plist").open("wb") as handle:
+        plistlib.dump(plist, handle)
+    (spotlight_app / "Contents" / "PkgInfo").write_text("APPL????", encoding="ascii")
+    app_executable.write_text(_desktop_launcher_script(launch_cwd, background=True), encoding="utf-8")
+    app_executable.chmod(0o755)
+
+    _desktop_apply_custom_icon(command_path, icon_path)
+    mdimport = shutil.which("mdimport")
+    if mdimport:
+        subprocess.run([mdimport, str(spotlight_app)], check=False)
+
+    return command_path, spotlight_app
+
+
 def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
     """Configure Electron's Linux SUID sandbox helper when required."""
     if sys.platform != "linux":
@@ -7721,6 +7917,35 @@ def cmd_gui(args: argparse.Namespace):
             # Build succeeded — write the stamp so next run can skip
             _write_desktop_build_stamp(PROJECT_ROOT, source_mode=source_mode)
 
+    if getattr(args, "install_launcher", False):
+        if sys.platform != "darwin":
+            print("✗ --install-launcher is currently macOS-only.")
+            sys.exit(1)
+        if source_mode:
+            print("✗ --install-launcher requires the packaged desktop app, not --source.")
+            sys.exit(1)
+        if packaged_executable is None:
+            print(f"✗ No launchable packaged desktop app was found at: {desktop_dir / 'release'}")
+            sys.exit(1)
+
+        launch_cwd = Path(getattr(args, "cwd", None) or Path.cwd()).expanduser().resolve()
+        launcher_name = getattr(args, "launcher_name", None) or "Hermes Desktop"
+        try:
+            command_path, app_path = _desktop_install_macos_launchers(
+                packaged_executable,
+                launch_cwd,
+                name=launcher_name,
+            )
+        except RuntimeError as exc:
+            print(f"✗ {exc}")
+            sys.exit(1)
+
+        print("✓ Installed Hermes Desktop launchers:")
+        print(f"  {command_path}")
+        print(f"  {app_path}")
+        print(f"  Launch folder: {launch_cwd}")
+        return
+
     # --build-only: produce the artifact but do NOT launch. The installer's
     # --update flow drives the rebuild headlessly and then launches the desktop
     # itself (detached, after the old exe has exited), so the launch must NOT
@@ -7753,6 +7978,12 @@ def cmd_gui(args: argparse.Namespace):
 
     if not _desktop_linux_sandbox_fixup(packaged_executable):
         sys.exit(1)
+
+    if sys.platform == "darwin":
+        running_pids = _desktop_running_pids(packaged_executable)
+        if running_pids:
+            print(f"→ Hermes Desktop is already running (pid {running_pids[0]}); not launching another instance.")
+            sys.exit(0)
 
     print(f"→ Launching packaged Hermes Desktop: {packaged_executable}")
     launch_result = subprocess.run([str(packaged_executable)], cwd=desktop_dir, env=env, check=False)

--- a/hermes_cli/subcommands/gui.py
+++ b/hermes_cli/subcommands/gui.py
@@ -60,4 +60,14 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
         action="store_true",
         help="Force a full rebuild even if the content stamp matches",
     )
+    gui_parser.add_argument(
+        "--install-launcher",
+        action="store_true",
+        help="Install macOS Desktop and Spotlight launchers, then exit",
+    )
+    gui_parser.add_argument(
+        "--launcher-name",
+        default="Hermes Desktop",
+        help="Launcher name for --install-launcher (default: Hermes Desktop)",
+    )
     gui_parser.set_defaults(func=cmd_gui)

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import plistlib
 import subprocess
 import sys
 from pathlib import Path
@@ -23,6 +24,8 @@ def _ns(**kw):
         ignore_existing=False,
         hermes_root=None,
         cwd=None,
+        install_launcher=False,
+        launcher_name="Hermes Desktop",
     )
     defaults.update(kw)
     return argparse.Namespace(**defaults)
@@ -151,6 +154,123 @@ def test_gui_skip_build_launches_existing_packaged_app_without_npm(tmp_path, mon
     mock_install.assert_not_called()
     mock_run.assert_called_once()
     assert mock_run.call_args.args[0] == [str(packaged_exe)]
+
+
+def test_gui_skip_build_exits_when_macos_app_is_already_running(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+
+    with patch("hermes_cli.main.shutil.which", return_value=None), \
+         patch("hermes_cli.main._desktop_running_pids", return_value=[12345]), \
+         patch("hermes_cli.main._desktop_focus_running_macos_app", return_value=True) as mock_focus, \
+         patch("hermes_cli.main.subprocess.run") as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    mock_focus.assert_not_called()
+    mock_run.assert_not_called()
+
+
+def test_desktop_macos_app_bundle_for_executable_finds_containing_bundle(tmp_path, monkeypatch):
+    packaged_exe = _make_packaged_executable(_make_desktop_tree(tmp_path), monkeypatch)
+
+    assert cli_main._desktop_macos_app_bundle_for_executable(packaged_exe) == packaged_exe.parents[2]
+
+
+def test_desktop_running_pids_matches_packaged_executable_and_ignores_self(monkeypatch):
+    monkeypatch.setattr(cli_main.os, "getpid", lambda: 11)
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    packaged_exe = Path("/Applications/Hermes.app/Contents/MacOS/Hermes")
+    output = "\n".join(
+        [
+            "11 /Applications/Hermes.app/Contents/MacOS/Hermes",
+            "22 /Applications/Hermes.app/Contents/MacOS/Hermes",
+            "33 /Applications/Other.app/Contents/MacOS/Other",
+        ]
+    )
+
+    class FakePopen:
+        returncode = 0
+
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def communicate(self, timeout):
+            assert timeout == 5
+            return output, ""
+
+    with patch("hermes_cli.main.subprocess.Popen", FakePopen):
+        assert cli_main._desktop_running_pids(packaged_exe) == [22]
+
+
+def test_desktop_launcher_script_uses_cwd_and_skips_duplicate_launch():
+    script = cli_main._desktop_launcher_script(Path("/Users/me/My Project"), background=False)
+
+    assert "DEFAULT_LAUNCH_CWD='/Users/me/My Project'" in script
+    assert 'pgrep -f "$APP_EXECUTABLE"' in script
+    assert 'exec hermes desktop --skip-build --cwd "$LAUNCH_CWD"' in script
+
+
+def test_install_macos_launchers_writes_command_and_spotlight_app(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    icon = packaged_exe.parents[2] / "Contents" / "Resources" / "icon.icns"
+    icon.parent.mkdir(parents=True)
+    icon.write_bytes(b"icns")
+    home = tmp_path / "home"
+    desktop = home / "Desktop"
+    desktop.mkdir(parents=True)
+    launch_cwd = tmp_path / "project"
+    launch_cwd.mkdir()
+    monkeypatch.setattr(cli_main.Path, "home", lambda: home)
+
+    with patch("hermes_cli.main._desktop_apply_custom_icon") as mock_icon, \
+         patch("hermes_cli.main.shutil.which", return_value=None):
+        command_path, app_path = cli_main._desktop_install_macos_launchers(
+            packaged_exe,
+            launch_cwd,
+            name="Hermes Desktop",
+        )
+
+    assert command_path == desktop / "Hermes Desktop.command"
+    assert app_path == home / "Applications" / "Hermes Desktop.app"
+    assert command_path.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash")
+    assert (app_path / "Contents" / "MacOS" / "Hermes Desktop").exists()
+    assert (app_path / "Contents" / "Resources" / "icon.icns").read_bytes() == b"icns"
+    with (app_path / "Contents" / "Info.plist").open("rb") as handle:
+        plist = plistlib.load(handle)
+    assert plist["CFBundleDisplayName"] == "Hermes Desktop"
+    assert plist["CFBundlePackageType"] == "APPL"
+    mock_icon.assert_called_once_with(command_path, icon)
+
+
+def test_gui_install_launcher_builds_and_exits_without_launch(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    launch_cwd = tmp_path / "project"
+    launch_cwd.mkdir()
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    ok = subprocess.CompletedProcess([], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=ok), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._desktop_install_macos_launchers", return_value=(Path("/d/Hermes.command"), Path("/a/Hermes.app"))) as mock_install, \
+         patch("hermes_cli.main.subprocess.run", return_value=ok) as mock_run:
+        cli_main.cmd_gui(_ns(
+            cwd=str(launch_cwd),
+            install_launcher=True,
+            launcher_name="Hermes Desktop",
+        ))
+
+    mock_install.assert_called_once_with(packaged_exe, launch_cwd, name="Hermes Desktop")
+    # Build only; no final packaged executable launch.
+    assert mock_run.call_args.args[0] == ["/usr/bin/npm", "run", "pack"]
 
 
 def test_gui_linux_configures_sandbox_before_launch(tmp_path, monkeypatch):

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -32,6 +32,14 @@ hermes desktop
 
 That uses your current config, keys, sessions, and skills.
 
+On macOS, you can also install launchers for Spotlight and the Desktop:
+
+```bash
+hermes desktop --install-launcher --cwd ~/Projects/my-project
+```
+
+This creates `~/Applications/Hermes Desktop.app` for Command-Space search and `~/Desktop/Hermes Desktop.command` for users who prefer a Desktop icon.
+
 ## What's in the app
 
 The desktop app is organized as a chat-first window with a left sidebar for navigation. It's built to allow managing multiple simultaneous agent conversations, configuring messaging providers, creating artifacts, browsing projects' folder structures, and working on multiple projects at once.
@@ -131,6 +139,8 @@ To launch via the CLI, simply run `hermes desktop`. By default it installs works
 | `--build-only`       | Build the desktop app but do not launch it (used by `hermes update`)                      |
 | `--source`           | Launch via `electron .` against `apps/desktop/dist` instead of the packaged app           |
 | `--cwd PATH`         | Initial project directory for desktop chat sessions (sets `HERMES_DESKTOP_CWD`)           |
+| `--install-launcher` | Install macOS Spotlight/Desktop launchers, then exit                                      |
+| `--launcher-name`    | Override the macOS launcher name used with `--install-launcher`                           |
 | `--hermes-root PATH` | Override the Hermes source root the app uses (sets `HERMES_DESKTOP_HERMES_ROOT`)          |
 | `--ignore-existing`  | Force the app to ignore any `hermes` CLI already on `PATH` during backend resolution      |
 | `--fake-boot`        | Enable deterministic boot delays for validating the startup UI                            |


### PR DESCRIPTION
## Summary

- Add `hermes desktop --install-launcher` for macOS to install a Spotlight-searchable `~/Applications/Hermes Desktop.app` wrapper and a `~/Desktop/Hermes Desktop.command` launcher.
- Add macOS duplicate-launch guards in both the CLI launcher path and the Electron main process so repeated Desktop/Spotlight/CLI launches do not spawn duplicate Hermes Desktop instances.
- Document the new launcher flow in the Desktop user guide.

Closes #42106.

## Test plan

- `/Users/aaronrenecarvajal/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_gui_command.py -q`
- `cd apps/desktop && npm run test:desktop:platforms`

## Security notes

- The launcher installer only writes local launcher metadata/scripts and app-wrapper files.
- It does not copy Hermes config, provider credentials, sessions, tokens, API keys, or local user data.
- The Linux sandbox fixup path continues to reject symlinks before ownership/mode checks.