### PR TITLE
fix(tools): unify proxy support across all internal tool HTTP calls

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -92,8 +92,13 @@ import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
+from utils import get_httpx_proxies
 
 logger = logging.getLogger(__name__)
+
+
+# Module-level proxy configuration for HTTP-transport MCP servers
+_httpx_proxies: dict | None = get_httpx_proxies()
 
 
 # ---------------------------------------------------------------------------
@@ -1517,6 +1522,7 @@ class MCPServerTask:
             "verify": ssl_verify,
             "follow_redirects": True,
             "timeout": _httpx.Timeout(timeout),
+            "proxies": _httpx_proxies,
         }
         if client_cert is not None:
             client_kwargs["cert"] = client_cert
@@ -1692,6 +1698,7 @@ class MCPServerTask:
                 "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
                 "verify": ssl_verify,
                 "event_hooks": {"response": [_strip_auth_on_cross_origin_redirect]},
+                "proxies": _httpx_proxies,
             }
             if headers:
                 client_kwargs["headers"] = headers

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -38,8 +38,35 @@ from tools.skills_guard import (
 )
 from tools.url_safety import is_safe_url
 from tools.website_policy import check_website_access
+from utils import get_httpx_proxies
 
 logger = logging.getLogger(__name__)
+
+
+# ─── Proxy-aware fetch helpers ──────────────────────────────────────────
+
+
+_HTTPX_PROXIES: dict | None = get_httpx_proxies()
+
+
+def _proxy_get(url: str, **kwargs: Any) -> httpx.Response:
+    """Wrapper around ``httpx.get`` that passes the configured proxy.
+
+    Falls back to bare ``httpx.get`` when no proxy is configured so that
+    mock patches on ``tools.skills_hub.httpx.get`` still work in tests.
+    """
+    if _HTTPX_PROXIES:
+        with httpx.Client(proxies=_HTTPX_PROXIES) as client:
+            return client.get(url, **kwargs)
+    return httpx.get(url, **kwargs)  # bare call — keeps wrapper non-recursive
+
+
+def _proxy_post(url: str, **kwargs: Any) -> httpx.Response:
+    """Wrapper around ``httpx.post`` that passes the configured proxy."""
+    if _HTTPX_PROXIES:
+        with httpx.Client(proxies=_HTTPX_PROXIES) as client:
+            return client.post(url, **kwargs)
+    return httpx.post(url, **kwargs)  # bare call — keeps wrapper non-recursive
 
 
 # ---------------------------------------------------------------------------
@@ -208,7 +235,7 @@ def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response
             return None
 
         try:
-            resp = httpx.get(current_url, timeout=timeout, follow_redirects=False)
+            resp = _proxy_get(current_url, timeout=timeout, follow_redirects=False)
         except httpx.HTTPError as exc:
             logger.debug("Skills Hub fetch failed for %s: %s", current_url, exc)
             return None
@@ -337,7 +364,7 @@ class GitHubAuth:
             }
             encoded_jwt = jwt.encode(payload, private_key, algorithm="RS256")
 
-            resp = httpx.post(
+            resp = _proxy_post(
                 f"https://api.github.com/app/installations/{installation_id}/access_tokens",
                 headers={
                     "Authorization": f"Bearer {encoded_jwt}",
@@ -551,7 +578,7 @@ class GitHubSource(SkillSource):
 
         url = f"https://api.github.com/repos/{repo}/contents/{path.rstrip('/')}"
         try:
-            resp = httpx.get(url, headers=self.auth.get_headers(), timeout=15, follow_redirects=True)
+            resp = _proxy_get(url, headers=self.auth.get_headers(), timeout=15, follow_redirects=True)
             if resp.status_code != 200:
                 return []
         except httpx.HTTPError:
@@ -605,7 +632,7 @@ class GitHubSource(SkillSource):
 
         # Resolve default branch
         try:
-            resp = httpx.get(
+            resp = _proxy_get(
                 f"https://api.github.com/repos/{repo}",
                 headers=headers, timeout=15, follow_redirects=True,
             )
@@ -618,7 +645,7 @@ class GitHubSource(SkillSource):
 
         # Fetch recursive tree
         try:
-            resp = httpx.get(
+            resp = _proxy_get(
                 f"https://api.github.com/repos/{repo}/git/trees/{default_branch}",
                 params={"recursive": "1"},
                 headers=headers, timeout=30, follow_redirects=True,
@@ -709,7 +736,7 @@ class GitHubSource(SkillSource):
         """Recursively download via Contents API (fallback)."""
         url = f"https://api.github.com/repos/{repo}/contents/{path.rstrip('/')}"
         try:
-            resp = httpx.get(url, headers=self.auth.get_headers(), timeout=15, follow_redirects=True)
+            resp = _proxy_get(url, headers=self.auth.get_headers(), timeout=15, follow_redirects=True)
             if resp.status_code != 200:
                 logger.debug("Contents API returned %d for %s/%s", resp.status_code, repo, path)
                 return {}
@@ -769,7 +796,7 @@ class GitHubSource(SkillSource):
         """Fetch a single file's content from GitHub."""
         url = f"https://api.github.com/repos/{repo}/contents/{path}"
         try:
-            resp = httpx.get(
+            resp = _proxy_get(
                 url,
                 headers={**self.auth.get_headers(), "Accept": "application/vnd.github.v3.raw"},
                 timeout=15, follow_redirects=True,
@@ -1340,7 +1367,7 @@ class SkillsShSource(SkillSource):
             return [SkillMeta(**item) for item in cached][:limit]
 
         try:
-            resp = httpx.get(
+            resp = _proxy_get(
                 self.SEARCH_URL,
                 params={"q": query, "limit": limit},
                 timeout=20,
@@ -1417,7 +1444,7 @@ class SkillsShSource(SkillSource):
         # Step 1: fetch the sitemap index → list of skill-sitemap URLs.
         skill_sitemap_urls: List[str] = []
         try:
-            resp = httpx.get(
+            resp = _proxy_get(
                 self.SITEMAP_INDEX_URL,
                 timeout=20,
                 follow_redirects=True,
@@ -1441,7 +1468,7 @@ class SkillsShSource(SkillSource):
         results: List[SkillMeta] = []
         for sitemap_url in skill_sitemap_urls:
             try:
-                resp = httpx.get(
+                resp = _proxy_get(
                     sitemap_url,
                     timeout=30,
                     follow_redirects=True,
@@ -1491,7 +1518,7 @@ class SkillsShSource(SkillSource):
             return [SkillMeta(**item) for item in cached][:limit]
 
         try:
-            resp = httpx.get(self.BASE_URL, timeout=20)
+            resp = _proxy_get(self.BASE_URL, timeout=20)
             if resp.status_code != 200:
                 return []
         except httpx.HTTPError:
@@ -1567,7 +1594,7 @@ class SkillsShSource(SkillSource):
             return cached
 
         try:
-            resp = httpx.get(f"{self.BASE_URL}/{identifier}", timeout=20)
+            resp = _proxy_get(f"{self.BASE_URL}/{identifier}", timeout=20)
             if resp.status_code != 200:
                 return None
         except httpx.HTTPError:
@@ -1653,7 +1680,7 @@ class SkillsShSource(SkillSource):
         # Fallback: scan repo root for directories that might contain skills
         try:
             root_url = f"https://api.github.com/repos/{repo}/contents/"
-            resp = httpx.get(root_url, headers=self.github.auth.get_headers(),
+            resp = _proxy_get(root_url, headers=self.github.auth.get_headers(),
                              timeout=15, follow_redirects=True)
             if resp.status_code == 200:
                 entries = resp.json()
@@ -2058,7 +2085,7 @@ class ClawHubSource(SkillSource):
             )
 
         try:
-            resp = httpx.get(
+            resp = _proxy_get(
                 f"{self.BASE_URL}/skills",
                 params={"search": query, "limit": limit},
                 timeout=15,
@@ -2189,7 +2216,7 @@ class ClawHubSource(SkillSource):
                 params["cursor"] = cursor
 
             try:
-                resp = httpx.get(f"{self.BASE_URL}/skills", params=params, timeout=30)
+                resp = _proxy_get(f"{self.BASE_URL}/skills", params=params, timeout=30)
                 if resp.status_code != 200:
                     break
                 data = resp.json()
@@ -2226,7 +2253,7 @@ class ClawHubSource(SkillSource):
 
     def _get_json(self, url: str, timeout: int = 20) -> Optional[Any]:
         try:
-            resp = httpx.get(url, timeout=timeout)
+            resp = _proxy_get(url, timeout=timeout)
             if resp.status_code != 200:
                 return None
             return resp.json()
@@ -2295,7 +2322,7 @@ class ClawHubSource(SkillSource):
         max_retries = 3
         for attempt in range(max_retries):
             try:
-                resp = httpx.get(
+                resp = _proxy_get(
                     f"{self.BASE_URL}/download",
                     params={"slug": slug, "version": version},
                     timeout=30,
@@ -2438,7 +2465,7 @@ class ClaudeMarketplaceSource(SkillSource):
 
         url = f"https://api.github.com/repos/{repo}/contents/.claude-plugin/marketplace.json"
         try:
-            resp = httpx.get(
+            resp = _proxy_get(
                 url,
                 headers={**self.auth.get_headers(), "Accept": "application/vnd.github.v3.raw"},
                 timeout=15,
@@ -2556,7 +2583,7 @@ class LobeHubSource(SkillSource):
             return cached
 
         try:
-            resp = httpx.get(self.INDEX_URL, timeout=30)
+            resp = _proxy_get(self.INDEX_URL, timeout=30)
             if resp.status_code != 200:
                 return None
             data = resp.json()
@@ -2570,7 +2597,7 @@ class LobeHubSource(SkillSource):
         """Fetch a single agent's JSON file."""
         url = f"https://chat-agents.lobehub.com/{agent_id}.json"
         try:
-            resp = httpx.get(url, timeout=15)
+            resp = _proxy_get(url, timeout=15)
             if resp.status_code == 200:
                 return resp.json()
         except (httpx.HTTPError, json.JSONDecodeError) as e:
@@ -2645,7 +2672,7 @@ class BrowseShSource(SkillSource):
         if cached is not None:
             return cached
         try:
-            resp = httpx.get(self.CATALOG_URL, timeout=20)
+            resp = _proxy_get(self.CATALOG_URL, timeout=20)
             if resp.status_code != 200:
                 return []
             data = resp.json()
@@ -2731,7 +2758,7 @@ class BrowseShSource(SkillSource):
         if not md_url:
             return None
         try:
-            resp = httpx.get(md_url, timeout=20, follow_redirects=True)
+            resp = _proxy_get(md_url, timeout=20, follow_redirects=True)
             if resp.status_code != 200:
                 return None
             content = resp.text
@@ -2762,7 +2789,7 @@ class BrowseShSource(SkillSource):
         ``sourceUrl`` (some entries may), use it directly.
         """
         try:
-            detail = httpx.get(
+            detail = _proxy_get(
                 self.SKILL_DETAIL_URL.format(slug=slug),
                 timeout=20,
                 follow_redirects=True,
@@ -3415,7 +3442,7 @@ def _load_hermes_index() -> Optional[dict]:
 
     # Fetch from docs site
     try:
-        resp = httpx.get(HERMES_INDEX_URL, timeout=15, follow_redirects=True)
+        resp = _proxy_get(HERMES_INDEX_URL, timeout=15, follow_redirects=True)
         if resp.status_code != 200:
             logger.debug("Hermes index fetch returned %d", resp.status_code)
             return _load_stale_index_cache()

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -37,7 +37,7 @@ from pathlib import Path
 from typing import Optional, Dict, Any
 from urllib.parse import urljoin
 
-from utils import is_truthy_value
+from utils import is_truthy_value, get_requests_proxies
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import (
     managed_nous_tools_enabled,
@@ -1486,6 +1486,7 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
                 },
                 data=data,
                 timeout=120,
+                proxies=get_requests_proxies(),
             )
 
         if response.status_code != 200:
@@ -1568,6 +1569,7 @@ def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
                 files={"file": (Path(file_path).name, audio_file)},
                 data=data,
                 timeout=120,
+                proxies=get_requests_proxies(),
             )
 
         if response.status_code != 200:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -53,6 +53,7 @@ from typing import Callable, Dict, Any, Optional
 from urllib.parse import urljoin
 
 from hermes_constants import display_hermes_home
+from utils import get_requests_proxies
 
 logger = logging.getLogger(__name__)
 def get_env_value(name, default=None):
@@ -1165,6 +1166,7 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         },
         json=payload,
         timeout=60,
+        proxies=get_requests_proxies(),
     )
     response.raise_for_status()
 
@@ -1257,7 +1259,8 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
             "voice_id": voice_id,
         }
 
-    response = requests.post(base_url, json=payload, headers=headers, timeout=60)
+    response = requests.post(base_url, json=payload, headers=headers, timeout=60,
+                             proxies=get_requests_proxies())
 
     if is_t2a_v2:
         # t2a_v2 returns JSON with hex-encoded audio
@@ -1445,6 +1448,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         headers={"Content-Type": "application/json"},
         json=payload,
         timeout=60,
+        proxies=get_requests_proxies(),
     )
     if response.status_code != 200:
         # Surface the API error message when present

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -41,6 +41,7 @@ from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
 from hermes_constants import get_hermes_dir
 from tools.debug_helpers import DebugSession
 from tools.website_policy import check_website_access
+from utils import get_httpx_proxies
 import sys
 
 logger = logging.getLogger(__name__)
@@ -202,6 +203,7 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
                 timeout=_VISION_DOWNLOAD_TIMEOUT,
                 follow_redirects=True,
                 event_hooks={"response": [_ssrf_redirect_guard]},
+                proxies=get_httpx_proxies(),
             ) as client:
                 response = await client.get(
                     image_url,

--- a/utils.py
+++ b/utils.py
@@ -317,12 +317,18 @@ def normalize_proxy_url(proxy_url: str | None) -> str | None:
     WSL/Clash-style environments often export SOCKS proxies as
     ``socks://127.0.0.1:PORT``. httpx rejects that alias and expects the
     explicit ``socks5://`` scheme instead.
+
+    Also normalises ``socks5h://`` to ``socks5://`` because:
+    * httpx/requests do not support the ``socks5h`` scheme at all.
+    * Chromium-based tools reject ``socks5h://`` with
+      ``ERR_NO_SUPPORTED_PROXIES``; only plain ``socks5://`` works.
     """
     candidate = str(proxy_url or "").strip()
     if not candidate:
         return None
-    if candidate.lower().startswith("socks://"):
-        return f"socks5://{candidate[len('socks://'):]}"
+    lowered = candidate.lower()
+    if lowered.startswith("socks://") or lowered.startswith("socks5h://"):
+        return f"socks5://{candidate.split('://', 1)[1]}"
     return candidate
 
 
@@ -374,3 +380,54 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     if not domain:
         return False
     return hostname == domain or hostname.endswith("." + domain)
+
+
+# ─── Proxy helpers for internal tool HTTP calls ─────────────────────────
+
+
+def get_httpx_proxies() -> dict | None:
+    """Return a proxy URL string for ``httpx.AsyncClient(proxies=...)``.
+
+    Reads ``HTTPS_PROXY``, ``HTTP_PROXY``, ``ALL_PROXY`` (and lowercase
+    variants) from the environment and returns the first non-empty value.
+
+    Returns ``None`` when no proxy is configured so callers can pass the
+    result directly to ``httpx.AsyncClient(proxies=proxies)`` — ``httpx``
+    treats ``None`` the same as omitting the parameter.
+    """
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        value = os.environ.get(key, "").strip()
+        if value:
+            return normalize_proxy_url(value)
+    return None
+
+
+def get_requests_proxies() -> dict[str, str] | None:
+    """Return a ``proxies`` dict suitable for ``requests.post(proxies=...)``.
+
+    ``requests`` expects a ``{"http": ..., "https": ...}`` dict or
+    ``{"all": ...}``.  This helper builds one from environment variables so
+    that ``requests``-based tools honour the same proxy config as
+    ``httpx``-based tools and the model API client.
+
+    Returns ``None`` (not ``{}``) when no proxy is configured so callers
+    can simply pass the result to ``requests.post(proxies=proxies)``.
+    """
+    https = os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy") or ""
+    http = os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy") or ""
+    all_ = os.environ.get("ALL_PROXY") or os.environ.get("all_proxy") or ""
+
+    if not https and not http and not all_:
+        return None
+
+    proxies: dict[str, str] = {}
+    if https := https.strip():
+        proxies["https"] = normalize_proxy_url(https)
+    if http := http.strip():
+        proxies["http"] = normalize_proxy_url(http)
+    # ``all`` is a requests-specific catch-all key.
+    if all_ := all_.strip():
+        proxies["all"] = normalize_proxy_url(all_)
+
+    return proxies or None


### PR DESCRIPTION
## What changed and why

Internal tools (vision, web search, skills hub, MCP HTTP transport, TTS, STT) made direct `httpx`/`requests` calls that ignored proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`), causing silent failures in proxied/corporate environments.

Additionally, Chromium-based browser tools reject `socks5h://` with `ERR_NO_SUPPORTED_PROXIES` — only plain `socks5://` works. The existing `normalize_proxy_url` only handled `socks://` → `socks5://`, not `socks5h://`.

### Changes

| File | Change |
|------|--------|
| **utils.py** | Added `get_httpx_proxies()` and `get_requests_proxies()` helpers that read env vars and return normalized proxy config. Updated `normalize_proxy_url` to also normalize `socks5h://` → `socks5://`. |
| **tools/vision_tools.py** | Pass `proxies=get_httpx_proxies()` to `httpx.AsyncClient` for image downloads |
| **tools/skills_hub.py** | Route all `httpx.get`/`httpx.post` calls (24 sites) through proxy-aware `_proxy_get`/`_proxy_post` wrappers |
| **tools/mcp_tool.py** | Pass `proxies=_httpx_proxies` to both `httpx.AsyncClient` instances (probe + main MCP HTTP transport) |
| **tools/tts_tool.py** | Pass `proxies=get_requests_proxies()` to all 3 `requests.post` calls |
| **tools/transcription_tools.py** | Pass `proxies=get_requests_proxies()` to both `requests.post` calls |

All helpers return `None` when no proxy env vars are set, so non-proxied environments are completely unaffected. Test patches via `mock.patch` continue to work because the `skills_hub` wrappers fall back to bare `httpx.get`/`httpx.post` when no proxy is configured.

## How to test

1. Set a proxy env var: `export HTTPS_PROXY=http://proxy:8080`
2. Call any internal tool that makes HTTP requests (e.g. `web_search`, `vision_analyze`, skills hub operations, TTS)
3. Verify the requests go through the proxy
4. Unset the proxy env var
5. Verify everything still works without proxy

## Platforms tested

- Linux (code review + static analysis)
- MacOS (code review)
- Windows WSL2 (code review)

Closes #17978