### PR TITLE
fix(auxiliary): forward explicit_base_url/explicit_api_key in fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3119,8 +3119,8 @@ def _resolve_single_provider(
     client, resolved_model = resolve_provider_client(
         provider=provider,
         model=model,
-        base_url=base_url,
-        api_key=api_key,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
     )
     return client
 


### PR DESCRIPTION
## What does this PR do?

`_resolve_single_provider()` calls `resolve_provider_client()` with `base_url` and `api_key` keyword arguments, but `resolve_provider_client` expects `explicit_base_url` and `explicit_api_key`. Because Python does not recognize the unexpected kwargs, the call raises a `TypeError` that is caught silently by the fallback chain's `except Exception:` guard — causing custom provider base URLs and API keys in fallback entries to be silently ignored.

The fix renames the two kwargs to match the actual parameter names.

## Related Issue

Fixes #42082

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Changed `base_url=base_url` → `explicit_base_url=base_url` and `api_key=api_key` → `explicit_api_key=api_key` in `_resolve_single_provider()`.

## How to Test

1. Configure a custom provider with an explicit `base_url` and `api_key` in a `fallback_chain` entry
2. Trigger a fallback scenario (e.g., by exhausting the primary provider's credits)
3. Before the fix: the custom provider's base URL is ignored and fallback falls through to auto-detection
4. After the fix: the custom provider's base URL and API key are properly forwarded to `resolve_provider_client`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: Docker/Linux

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
