### PR TITLE
fix(auxiliary): pass explicit_base_url/explicit_api_key in _resolve_single_provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3119,8 +3119,8 @@ def _resolve_single_provider(
     client, resolved_model = resolve_provider_client(
         provider=provider,
         model=model,
-        base_url=base_url,
-        api_key=api_key,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
     )
     return client
 


### PR DESCRIPTION
## Fixes #42082

`_resolve_single_provider()` passed `base_url`/`api_key` as kwargs to `resolve_provider_client()`, but that function expects `explicit_base_url`/`explicit_api_key`. The parameter name mismatch caused a TypeError on invocation, making the `fallback_chain` config path completely broken.

### Changes
- `base_url=base_url` → `explicit_base_url=base_url`
- `api_key=api_key` → `explicit_api_key=api_key`