### PR TITLE
fix(vision): support gemini-2.5 and gemini-2.0 in _supports_media_in_tool_results

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -50,8 +50,11 @@ class TestSupportsMediaInToolResults:
     def test_gemini_3_yes(self):
         assert _supports_media_in_tool_results("google", "gemini-3-flash-preview") is True
 
-    def test_gemini_2_no(self):
-        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is False
+    def test_gemini_2_5_yes(self):
+        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is True
+
+    def test_gemini_2_0_yes(self):
+        assert _supports_media_in_tool_results("google", "gemini-2.0-flash") is True
 
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -574,12 +574,14 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         return True
 
     # Gemini — gate on model name; older Gemini variants did not support
-    # multimodal functionResponse. Gemini 3.x does.
+    # multimodal functionResponse.  Gemini 2.0+ and 3.x do.
     if p in {"google", "gemini", "google-gemini", "google-vertex-gemini"}:
         if not isinstance(model, str):
             return False
         m = model.strip().lower()
         if "gemini-3" in m or "gemini-pro-3" in m or "gemini-flash-3" in m:
+            return True
+        if "gemini-2.5" in m or "gemini-2.0" in m:
             return True
         return False
 


### PR DESCRIPTION
## Fixes #42086

The Gemini multimodal tool-result gate only matched `gemini-3.x` model strings. Gemini 2.5 Pro and 2.0 Flash also support multimodal `functionResponse` but were incorrectly falling back to the legacy aux-LLM text path.

### Changes
- Added `gemini-2.5` and `gemini-2.0` pattern matching in `_supports_media_in_tool_results()`
- Updated test: `test_gemini_2_no` → `test_gemini_2_5_yes` + `test_gemini_2_0_yes`

### Testing
```
10 passed in 0.44s
```