### PR TITLE
fix(desktop): stop macOS Update & Restart loop by always updating in-app

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1561,16 +1561,27 @@ async function applyUpdates(opts = {}) {
   updateInFlight = true
 
   try {
-    const updater = resolveUpdaterBinary()
-    if (!updater && !IS_WINDOWS) {
-      // macOS/Linux drag-install: no staged Tauri hermes-setup. Unlike Windows
-      // (where a venv-shim file lock forces the quit→hand-off→rebuild dance),
-      // there's no mandatory file locking here, so the desktop can drive the
-      // whole update itself: `hermes update` (backend) + `hermes desktop
-      // --build-only` (OS-aware GUI rebuild), then swap the running .app bundle
-      // with the freshly built one and relaunch.
+    // macOS/Linux: the desktop drives the whole update in-app — `hermes update`
+    // (backend) + `hermes desktop --build-only` (OS-aware GUI rebuild), then an
+    // atomic swap of the running .app bundle and a relaunch. There's no
+    // mandatory file lock on a running binary here (releaseBackendLock is a
+    // no-op off Windows), so we never need an external process to take over.
+    //
+    // Only Windows uses the staged hermes-setup hand-off below, because a
+    // running hermes.exe keeps the venv shim mandatory-locked and `hermes
+    // update` refuses until the desktop fully exits.
+    //
+    // Previously any macOS/Linux install that happened to have a staged
+    // hermes-setup (e.g. a .dmg / installer user) was routed through the
+    // Windows-style hand-off: the desktop fire-and-forget spawned the updater
+    // and quit, but the version never advanced and the flow kept re-handing-off
+    // — the "Update & Restart" loop. Keep every non-Windows install on the
+    // robust in-app path regardless of whether a staged updater exists.
+    if (!IS_WINDOWS) {
       return await applyUpdatesPosixInApp(opts)
     }
+
+    const updater = resolveUpdaterBinary()
     if (!updater) {
       // No staged updater binary — this is a CLI-installed user (they ran
       // `hermes desktop`, never the Tauri installer that self-copies


### PR DESCRIPTION
## What does this PR do?

Stops the macOS "Update & Restart" infinite loop where the desktop app installs an update, relaunches, but the version never advances — so the update prompt keeps reappearing.

Root cause is in the desktop's `applyUpdates()` routing. The desktop has two update mechanisms:

- **In-app (POSIX):** `applyUpdatesPosixInApp()` — the desktop drives the whole update itself: `hermes update`, `hermes desktop --build-only`, an atomic swap of the running `.app` bundle, then a relaunch.
- **External hand-off:** spawns the staged `hermes-setup` binary with `--update` and quits, so the updater can run while the desktop is gone.

The hand-off exists **only** because of Windows: a running `hermes.exe` keeps the venv shim mandatory-locked, so `hermes update` refuses until the desktop fully exits. macOS/Linux have no such lock — `releaseBackendLock()` is literally a no-op off Windows.

The bug: `applyUpdates()` only used the in-app path when **no** staged updater existed. A macOS user who installed via the `.dmg`/installer **has** a staged `hermes-setup`, so they were routed through the Windows-style hand-off. The hand-off is fire-and-forget (`detached`, `stdio: 'ignore'`, no `error`/`exit` listener): the desktop logs "exiting desktop to release venv shim", spawns the updater, and quits — but the version never advances and the flow keeps re-handing-off. That is the loop in the report.

The fix gates the hand-off to **Windows only**. Every non-Windows install now uses the robust in-app path regardless of whether a staged updater binary happens to exist — the same path that drag-install users already update through successfully.

## Related Issue

Fixes #39339

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.cjs` — in `applyUpdates()`, route all non-Windows platforms to `applyUpdatesPosixInApp()` before considering the staged-updater hand-off. The external `hermes-setup` hand-off (and the manual-command fallback for a missing updater) is now reached only on Windows.

## How to Test

Evidence from the user's debug log (macOS) shows the loop and confirms the diagnosis:

- Repeated `[updates] restart: Handing off to the Hermes updater…` / `launched updater: …/hermes-setup --update --branch main --target-app /Applications/Hermes.app; exiting desktop to release venv shim`, interleaved with backend `[boot]` cycles.
- `State snapshot created: …-pre-update` (i.e. `hermes update` actually running) appears **once**, while the hand-off fires many times → later hand-offs never run a real update.
- The renderer loads the same `app.asar/.../index-*.js` bundle throughout → the version never changes.

Verification steps:

1. On macOS installed via the `.dmg`/installer (so `~/.hermes/hermes-setup` exists), with the checkout behind upstream.
2. Click the version indicator → "New update available" → Install.
3. Before: app closes/relaunches on the same version; prompt reappears (loop).
4. After: the desktop runs the in-app update (`hermes update` + `hermes desktop --build-only`), swaps `/Applications/Hermes.app`, relaunches on the new version, and the prompt clears.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've considered cross-platform impact — Windows hand-off path is unchanged; only the macOS/Linux routing is corrected

### Notes

- `main.cjs` is the Electron main process and has no unit-test harness in-tree; the change is a small routing conditional verified with `node --check`. I don't have a macOS packaged build to exercise the full relaunch end-to-end, so a maintainer sanity-check on a `.dmg` install is appreciated.
- The repeated `Cannot have two HTML5 backends at the same time` renderer error in the same log is a **separate** (react-dnd) bug, not the update loop, and is intentionally out of scope here.
