### PR TITLE
fix(agent): clear _session_messages in AIAgent.close()

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3087,6 +3087,17 @@ class AIAgent:
         except Exception:
             pass
 
+        # 6. Free conversation history.  Mirrors _release_evicted_agent_soft's
+        # soft-eviction clear — close() is the hard teardown for true session
+        # boundaries (/new, /reset, session expiry), so the message list won't
+        # be reused.  Drops the reference proactively rather than waiting for
+        # the agent object itself to be collected, which matters when a caller
+        # still holds the closed agent (e.g. a draining background task).
+        try:
+            self._session_messages = []
+        except Exception:
+            pass
+
     def _hydrate_todo_store(self, history: List[Dict[str, Any]]) -> None:
         """
         Recover todo state from conversation history.


### PR DESCRIPTION
## Summary
`AIAgent.close()` now clears `_session_messages`, so the conversation-history list is freed at hard teardown instead of waiting for the agent object itself to be garbage-collected.

## Why
`close()` is the hard teardown for true session boundaries (`/new`, `/reset`, session expiry). It already kills background procs, terminal sandboxes, browser daemons, child agents, and the OpenAI client — but left the message list intact. The soft-eviction path (`_release_evicted_agent_soft`, fixed in `3d029a53e`) already clears `_session_messages`; this closes the matching gap on the hard path. Matters when a caller still holds a reference to the closed agent (e.g. a draining background task), which would otherwise pin tens of MB of tool outputs.

## Changes
- `run_agent.py`: clear `self._session_messages` as step 6 of `close()`, guarded.

## Validation
- `py_compile` clean. One added block, no behavior change beyond freeing the list at a point where the session is already over.

Follow-up to `3d029a53e` / #18438.

## Infographic

![aiagent-close-free-history](https://v3b.fal.media/files/b/0a9d7a2d/xaKgeLqZTKE-Nfq8HZ2yL_WejxpCBP.png)
