### PR TITLE
feat(cli): persist last-used model/provider across restarts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -181,6 +181,54 @@ _project_env = Path(__file__).parent / '.env'
 load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
 
 
+# ── Persist last-used model/provider (#42111) ─────────────────────────
+_LAST_MODEL_FILE = _hermes_home / "last_model.json"
+
+
+def _load_persisted_model() -> dict:
+    """Load the last-used model/provider from ``last_model.json``.
+
+    Returns ``{"model": str, "provider": str}`` or empty dict if file
+    missing / unreadable / stale (>30 days).
+    """
+    try:
+        import json as _json
+        from datetime import datetime, timezone, timedelta
+
+        if not _LAST_MODEL_FILE.exists():
+            return {}
+        data = _json.loads(_LAST_MODEL_FILE.read_text())
+        ts = data.get("timestamp")
+        if ts:
+            age = datetime.now(timezone.utc) - datetime.fromisoformat(ts)
+            if age > timedelta(days=30):
+                return {}
+        result: dict = {}
+        if data.get("model"):
+            result["model"] = data["model"]
+        if data.get("provider"):
+            result["provider"] = data["provider"]
+        return result
+    except Exception:
+        return {}
+
+
+def _save_persisted_model(model: str = "", provider: str = "") -> None:
+    """Save the current model/provider to ``last_model.json``."""
+    try:
+        import json as _json
+        from datetime import datetime, timezone
+
+        data = {
+            "model": model or "",
+            "provider": provider or "",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        _LAST_MODEL_FILE.write_text(_json.dumps(data, indent=2) + "\n")
+    except Exception:
+        pass  # best-effort; never block session on persist failure
+
+
 _REASONING_TAGS = (
     "REASONING_SCRATCHPAD",
     "think",
@@ -13785,6 +13833,23 @@ def main(
     
     parsed_skills = _parse_skills_argument(skills)
 
+    # ── Persist last-used model/provider (#42111) ─────────────────────
+    # If persist_last is enabled and user didn't pass explicit --model or
+    # --provider, load the last-used values from last_model.json.
+    _persist_last = False
+    try:
+        _model_cfg = CLI_CONFIG.get("model", {})
+        _persist_last = bool(
+            isinstance(_model_cfg, dict) and _model_cfg.get("persist_last")
+        )
+    except Exception:
+        pass
+    if _persist_last and not model and not provider:
+        _persisted = _load_persisted_model()
+        if _persisted:
+            model = _persisted.get("model") or model
+            provider = _persisted.get("provider") or provider
+
     # Create CLI instance
     cli = HermesCLI(
         model=model,
@@ -14127,10 +14192,22 @@ def main(
             cli._show_security_advisories()
             cli.chat(query, images=single_query_images or None)
             cli._print_exit_summary()
+        # Persist model/provider on successful single-query completion
+        if _persist_last:
+            _save_persisted_model(
+                model=getattr(cli, "model", ""),
+                provider=getattr(cli, "provider", ""),
+            )
         return
-    
+
     # Run interactive mode
     cli.run()
+    # Persist model/provider on successful interactive session completion
+    if _persist_last:
+        _save_persisted_model(
+            model=getattr(cli, "model", ""),
+            provider=getattr(cli, "provider", ""),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_persist_last_model.py
+++ b/tests/cli/test_persist_last_model.py
@@ -1,0 +1,157 @@
+"""Tests for persist-last-model feature (#42111).
+
+Verifies that ``model.persist_last`` config option saves and restores
+the last-used model/provider across CLI restarts.
+"""
+
+import json
+import tempfile
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+def _make_cli_module():
+    """Import cli module functions without triggering full CLI init."""
+    import importlib
+    import cli as _cli
+    importlib.reload(_cli)
+    return _cli
+
+
+# ── _save_persisted_model ──────────────────────────────────────────────
+
+class TestSavePersistedModel:
+    """Tests for _save_persisted_model()."""
+
+    def test_creates_file_with_model_and_provider(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "last_model.json"
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            cli._save_persisted_model(model="gpt-4", provider="openai")
+        data = json.loads(target.read_text())
+        assert data["model"] == "gpt-4"
+        assert data["provider"] == "openai"
+        assert "timestamp" in data
+
+    def test_creates_file_with_empty_values(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "last_model.json"
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            cli._save_persisted_model()
+        data = json.loads(target.read_text())
+        assert data["model"] == ""
+        assert data["provider"] == ""
+
+    def test_overwrites_existing_file(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "last_model.json"
+        target.write_text('{"model": "old", "provider": "old", "timestamp": "x"}')
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            cli._save_persisted_model(model="new-model", provider="new-provider")
+        data = json.loads(target.read_text())
+        assert data["model"] == "new-model"
+        assert data["provider"] == "new-provider"
+
+    def test_no_exception_on_write_failure(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "nonexistent_dir" / "last_model.json"
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            # Should not raise
+            cli._save_persisted_model(model="x", provider="y")
+
+
+# ── _load_persisted_model ──────────────────────────────────────────────
+
+class TestLoadPersistedModel:
+    """Tests for _load_persisted_model()."""
+
+    def test_returns_empty_when_no_file(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "last_model.json"
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            result = cli._load_persisted_model()
+        assert result == {}
+
+    def test_returns_model_and_provider(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "last_model.json"
+        target.write_text(json.dumps({
+            "model": "claude-sonnet-4-20250514",
+            "provider": "anthropic",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }))
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            result = cli._load_persisted_model()
+        assert result["model"] == "claude-sonnet-4-20250514"
+        assert result["provider"] == "anthropic"
+
+    def test_skips_empty_model_and_provider(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "last_model.json"
+        target.write_text(json.dumps({
+            "model": "",
+            "provider": "",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }))
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            result = cli._load_persisted_model()
+        assert result == {}
+
+    def test_skips_stale_data_older_than_30_days(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "last_model.json"
+        stale_ts = (datetime.now(timezone.utc) - timedelta(days=31)).isoformat()
+        target.write_text(json.dumps({
+            "model": "gpt-4",
+            "provider": "openai",
+            "timestamp": stale_ts,
+        }))
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            result = cli._load_persisted_model()
+        assert result == {}
+
+    def test_accepts_data_within_30_days(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "last_model.json"
+        recent_ts = (datetime.now(timezone.utc) - timedelta(days=29)).isoformat()
+        target.write_text(json.dumps({
+            "model": "gpt-4",
+            "provider": "openai",
+            "timestamp": recent_ts,
+        }))
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            result = cli._load_persisted_model()
+        assert result["model"] == "gpt-4"
+        assert result["provider"] == "openai"
+
+    def test_handles_corrupt_json(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "last_model.json"
+        target.write_text("not valid json {{{")
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            result = cli._load_persisted_model()
+        assert result == {}
+
+    def test_handles_missing_timestamp(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "last_model.json"
+        target.write_text(json.dumps({"model": "gpt-4", "provider": "openai"}))
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            result = cli._load_persisted_model()
+        # No timestamp → no staleness check → should return data
+        assert result["model"] == "gpt-4"
+        assert result["provider"] == "openai"
+
+    def test_roundtrip_save_then_load(self, tmp_path):
+        cli = _make_cli_module()
+        target = tmp_path / "last_model.json"
+        with patch.object(cli, "_LAST_MODEL_FILE", target):
+            cli._save_persisted_model(model="gemini-2.5-pro", provider="gemini")
+            result = cli._load_persisted_model()
+        assert result["model"] == "gemini-2.5-pro"
+        assert result["provider"] == "gemini"


### PR DESCRIPTION
## Problem

When restarting the Hermes CLI, the model always reverts to the global default defined in `config.yaml`. Per-session overrides via `--provider` / `--model` are lost. Users who frequently switch between models for different tasks must re-specify flags on every launch or manually edit `config.yaml`.

Closes #42111

## Solution

Add an opt-in `model.persist_last` config option that saves the last-used model and provider to `~/.hermes/last_model.json` on successful session completion. On next launch with no explicit `--model`/`--provider` flags, the persisted values are restored automatically.

### Usage

```yaml
# config.yaml
model:
  default: openrouter/claude-sonnet-4
  provider: openrouter
  persist_last: true
```

With this config, running `hermes chat --model gemini-2.5-pro --provider gemini` will:
1. Use gemini-2.5-pro for the current session
2. Save `{model: "gemini-2.5-pro", provider: "gemini"}` to `last_model.json`
3. On next bare `hermes chat`, restore gemini-2.5-pro instead of the config default

### Implementation

- **`_load_persisted_model()`** — reads `last_model.json`, returns `{model, provider}` dict; skips stale data (>30 days) and corrupt files
- **`_save_persisted_model(model, provider)`** — writes model/provider/timestamp to JSON; best-effort, never blocks on failure
- **Integration in `main()`** — load persisted values before `HermesCLI()` creation (only when no explicit `--model`/`--provider`), save after session completion
- **Backwards compatible** — defaults to disabled (`persist_last: false`), existing behavior unchanged

## Files Changed

| File | Change |
|------|--------|
| `cli.py` | Add `_load_persisted_model()`, `_save_persisted_model()`, integrate into `main()` |
| `tests/cli/test_persist_last_model.py` | 12 unit tests |

## Test Plan

- [x] `_save_persisted_model` creates file with correct model/provider/timestamp
- [x] `_save_persisted_model` handles write failures gracefully (no exception)
- [x] `_load_persisted_model` returns model/provider from valid file
- [x] `_load_persisted_model` skips stale data (>30 days)
- [x] `_load_persisted_model` accepts data within 30 days
- [x] `_load_persisted_model` handles corrupt JSON, missing file, missing timestamp
- [x] Round-trip: save then load returns the same values
- [x] 12/12 tests pass

```
$ python -m pytest tests/cli/test_persist_last_model.py -v
12 passed in 0.33s
```
