### PR TITLE
fix(gateway): skip typing indicator for internal/synth events

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4053,22 +4053,30 @@ class BasePlatformAdapter(ABC):
         self._active_sessions[session_key] = interrupt_event
         
         # Start continuous typing indicator (refreshes every 2 seconds)
+        # Skip for internal/synth events — background notifications and cron
+        # deliveries do not need typing indicators (fixes ghost typing on
+        # Telegram after background process completion).
+        _skip_typing = getattr(event, "internal", False)
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
-        _keep_typing_kwargs = {"metadata": _thread_metadata}
-        try:
-            _keep_typing_sig = inspect.signature(self._keep_typing)
-        except (TypeError, ValueError):
-            _keep_typing_sig = None
-        if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
-            _keep_typing_kwargs["stop_event"] = interrupt_event
-        typing_task = asyncio.create_task(
-            self._keep_typing(
-                event.source.chat_id,
-                **_keep_typing_kwargs,
+        typing_task: asyncio.Task | None = None
+        if not _skip_typing:
+            _keep_typing_kwargs = {"metadata": _thread_metadata}
+            try:
+                _keep_typing_sig = inspect.signature(self._keep_typing)
+            except (TypeError, ValueError):
+                _keep_typing_sig = None
+            if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
+                _keep_typing_kwargs["stop_event"] = interrupt_event
+            typing_task = asyncio.create_task(
+                self._keep_typing(
+                    event.source.chat_id,
+                    **_keep_typing_kwargs,
+                )
             )
-        )
 
         async def _stop_typing_task() -> None:
+            if typing_task is None:
+                return
             typing_task.cancel()
             try:
                 await asyncio.wait_for(asyncio.shield(typing_task), timeout=0.5)

--- a/tests/gateway/test_ghost_typing_internal_event.py
+++ b/tests/gateway/test_ghost_typing_internal_event.py
@@ -1,0 +1,169 @@
+"""Tests for ghost typing indicator fix — internal/synth events skip typing loop.
+
+Background process completions and cron deliveries inject synth events with
+``internal=True`` via ``adapter.handle_message()``.  These events should NOT
+trigger the ``_keep_typing`` loop because the agent response is typically fast
+(near-instant) and the resulting ghost typing indicator confuses users.
+
+Covered:
+
+1. Internal events skip ``_keep_typing`` entirely (no typing_task created).
+2. Normal events create the typing task as before (regression guard).
+3. ``_stop_typing_task()`` handles ``typing_task is None`` gracefully.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.session import SessionSource
+
+
+class _TestAdapter(BasePlatformAdapter):
+    """Minimal adapter for typing-indicator tests."""
+
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content="", **kwargs):
+        return SendResult(success=True, message_id="m-1")
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _make_adapter():
+    return _TestAdapter(
+        PlatformConfig(enabled=True, token="t"), Platform.TELEGRAM
+    )
+
+
+def _make_event(text="hello", chat_id="42", internal=False):
+    return MessageEvent(
+        text=text,
+        message_id="msg-1",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=chat_id,
+            user_id="u-1",
+        ),
+        message_type=MessageType.TEXT,
+        internal=internal,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal events skip _keep_typing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_internal_event_skips_keep_typing():
+    """Synth/internal events must NOT start the _keep_typing loop."""
+    adapter = _make_adapter()
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="sent-1")
+    )
+
+    async def _handler(evt):
+        return "Background process completed."
+
+    adapter.set_message_handler(_handler)
+
+    event = _make_event(internal=True)
+    session_key = "agent:main:telegram:private:42"
+
+    with patch.object(adapter, "_keep_typing", new=AsyncMock()) as mock_typing:
+        with patch("gateway.platforms.base.asyncio.sleep", AsyncMock()):
+            await adapter._process_message_background(event, session_key)
+
+    # _keep_typing must NOT be called for internal events
+    mock_typing.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_internal_event_still_sends_response():
+    """Internal events skip typing but still process and send the response."""
+    adapter = _make_adapter()
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="sent-1")
+    )
+
+    async def _handler(evt):
+        return "Process done."
+
+    adapter.set_message_handler(_handler)
+
+    event = _make_event(internal=True)
+    session_key = "agent:main:telegram:private:42"
+
+    with patch.object(adapter, "_keep_typing", new=AsyncMock()), \
+         patch("gateway.platforms.base.asyncio.sleep", AsyncMock()):
+        await adapter._process_message_background(event, session_key)
+
+    adapter._send_with_retry.assert_called_once()
+    sent_text = adapter._send_with_retry.call_args.kwargs["content"]
+    assert sent_text == "Process done."
+
+
+# ---------------------------------------------------------------------------
+# Normal events still create typing task (regression guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_normal_event_creates_typing_task():
+    """Non-internal events must still start the _keep_typing loop."""
+    adapter = _make_adapter()
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="sent-1")
+    )
+
+    async def _handler(evt):
+        return "Hello"
+
+    adapter.set_message_handler(_handler)
+
+    event = _make_event(internal=False)
+    session_key = "agent:main:telegram:private:42"
+
+    with patch.object(adapter, "_keep_typing", new=AsyncMock()) as mock_typing:
+        with patch("gateway.platforms.base.asyncio.sleep", AsyncMock()):
+            await adapter._process_message_background(event, session_key)
+
+    # _keep_typing MUST be called for normal events (via create_task)
+    mock_typing.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_default_internal_false_creates_typing_task():
+    """Events without explicit internal flag (default False) get typing."""
+    adapter = _make_adapter()
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="sent-1")
+    )
+
+    async def _handler(evt):
+        return "Hello"
+
+    adapter.set_message_handler(_handler)
+
+    event = _make_event()  # internal defaults to False
+    session_key = "agent:main:telegram:private:42"
+
+    with patch.object(adapter, "_keep_typing", new=AsyncMock()) as mock_typing:
+        with patch("gateway.platforms.base.asyncio.sleep", AsyncMock()):
+            await adapter._process_message_background(event, session_key)
+
+    mock_typing.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Skips the `_keep_typing` loop for internal/synth events in `_process_message_background`. When background processes complete or cron jobs deliver results, the gateway injects synthetic `MessageEvent(internal=True)` via `adapter.handle_message()`. These events were starting the typing indicator loop, causing a ghost "typing..." bubble on Telegram that persists 5-10 seconds after the response is delivered.

## Related Issue

Fixes #42087

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Wrap `_keep_typing` task creation in a check for `event.internal`. When the event is internal (synth notification from background process or cron), the typing task is skipped entirely. The `_stop_typing_task()` closure handles the `typing_task is None` case gracefully.
- `tests/gateway/test_ghost_typing_internal_event.py`: New test file with 4 tests — internal event skips typing, internal event still sends response, normal event creates typing task, default internal=False creates typing task.

## How to Test

1. Configure a Telegram bot and start the gateway: `hermes gateway run`
2. Run a background process: ask the agent to run `terminal(background=True)` with a long-running command
3. When the background process completes, observe the Telegram chat
4. **Before fix**: "typing..." indicator appears for 5-10 seconds after the response
5. **After fix**: No ghost typing indicator; the response appears immediately without the typing bubble
6. Run tests: `pytest tests/gateway/test_ghost_typing_internal_event.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_ghost_typing_internal_event.py tests/gateway/test_ephemeral_reply.py tests/gateway/test_keep_typing_timeout.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_process_message_background` in `gateway/platforms/base.py` (typing lifecycle for synth events)
- Blast radius: LOW — only affects typing indicator behavior for `internal=True` events, no change to message processing or response delivery
- Related patterns: `MessageEvent.internal` flag already used at line 3423 for queue-text debounce filtering; this change extends the same pattern to typing indicator management
