### PR TITLE
fix(gateway): suppress ghost typing indicator after final response on Telegram

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3080,6 +3080,10 @@ class BasePlatformAdapter(ABC):
         delivery_attempted = False
         delivery_succeeded = False
 
+        # Reset typing-stop signal so post-send typing re-triggers are
+        # active for the duration of this turn (see _stop_typing_task).
+        self._typing_stopping = False
+
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
             if result is None:
@@ -3111,6 +3115,11 @@ class BasePlatformAdapter(ABC):
         )
 
         async def _stop_typing_task() -> None:
+            # Signal platforms that post-send typing re-triggers should be
+            # suppressed (see telegram.py send() re-trigger).  Without this,
+            # the final send() fires send_chat_action("typing") *before* the
+            # task is cancelled, leaving a ghost typing indicator for ~5s.
+            self._typing_stopping = True
             typing_task.cancel()
             try:
                 await asyncio.wait_for(asyncio.shield(typing_task), timeout=0.5)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1836,10 +1836,14 @@ class TelegramAdapter(BasePlatformAdapter):
             # so without this the "...typing" bubble disappears mid-response
             # (especially noticeable when the agent sends intermediate progress
             # messages like "Checking:" before running tools).
-            try:
-                await self.send_typing(chat_id, metadata=metadata)
-            except Exception:
-                pass  # Typing failures are non-fatal
+            # Skip when _stop_typing_task has signalled that typing should stop
+            # (the final response was just sent) to avoid a ghost typing
+            # indicator that lingers for ~5s after the agent completes (#42087).
+            if not getattr(self, '_typing_stopping', False):
+                try:
+                    await self.send_typing(chat_id, metadata=metadata)
+                except Exception:
+                    pass  # Typing failures are non-fatal
 
             return SendResult(
                 success=True,


### PR DESCRIPTION
## Summary

Fixes #42087

After the agent sends its final response, Telegram's `send()` method unconditionally re-triggers `send_typing()`, which sends `send_chat_action("typing")` to Telegram's servers. This starts a fresh 5-second typing indicator even though the agent is done processing — a "ghost typing" bubble.

## Root Cause

In `telegram.py` `send()` (line 1834-1842), after every message delivery, `send_typing()` is called to keep the typing indicator alive during multi-message responses. But this also fires for the FINAL response, and by the time `_stop_typing_task()` runs in the `finally` block, the `send_chat_action` has already hit Telegram's servers.

## Fix

1. **`base.py`**: Add `_typing_stopping` flag to `BasePlatformAdapter`. `_stop_typing_task()` sets it to `True` before cancelling the typing loop. Reset to `False` at the start of each `_process_message_background` turn.
2. **`telegram.py`**: Check `_typing_stopping` before re-triggering `send_typing()` in `send()`. Skip the re-trigger when the flag is set.

## Changes

- `gateway/platforms/base.py`: +11 lines (flag init + set in `_stop_typing_task`)
- `gateway/platforms/telegram.py`: +6 lines (conditional check in `send()`)