### PR TITLE
fix(tui/pty): reap leaked slash_worker subprocesses on PTY chat disconnect

### DIFF
--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -251,7 +251,7 @@ class PtyBridge:
         self._closed = True
 
         try:
-            pgid = os.getpgid(self._proc.pid)
+            pgid = os.getpgid(self._proc.pid)  # windows-footgun: ok — POSIX-only module (imports fcntl/termios/ptyprocess at top)
         except Exception:
             pgid = None
 
@@ -264,7 +264,7 @@ class PtyBridge:
                 break
             try:
                 if pgid is not None:
-                    os.killpg(pgid, sig)
+                    os.killpg(pgid, sig)  # windows-footgun: ok — POSIX-only module (imports fcntl/termios/ptyprocess at top)
                 else:
                     self._proc.kill(sig)
             except Exception:

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -250,13 +250,23 @@ class PtyBridge:
             return
         self._closed = True
 
+        try:
+            pgid = os.getpgid(self._proc.pid)
+        except Exception:
+            pgid = None
+
         # SIGHUP is the conventional "your terminal went away" signal.
-        # We escalate if the child ignores it.
+        # Send it to the whole foreground process group, not just the PTY
+        # leader: the dashboard TUI starts helper children such as the Python
+        # slash worker, and killing only the leader can strand those helpers.
         for sig in (signal.SIGHUP, signal.SIGTERM, signal.SIGKILL):  # windows-footgun: ok — POSIX-only module (imports fcntl/termios/ptyprocess at top)
             if not self._proc.isalive():
                 break
             try:
-                self._proc.kill(sig)
+                if pgid is not None:
+                    os.killpg(pgid, sig)
+                else:
+                    self._proc.kill(sig)
             except Exception:
                 pass
             deadline = time.monotonic() + 0.5

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1260,6 +1260,7 @@ AUTHOR_MAP = {
     "leon@sgp43.com": "LeonSGP43",  # PR #18739 salvage of #14570
     "miniding@miniding.home": "Foolafroos",  # PR #20329 French locale
     "montbra@gmail.com": "Montbra",  # PR #20897 salvage of #16189 (TUI voice PTT)
+    "275835513+paulb26@users.noreply.github.com": "paulb26",  # PR #24135 salvage (pty-bridge killpg)
     "promptsiren@gmail.com": "firefly",  # PR #18123 salvage of #16660 (ContextVars)
     "wtyopenclaw@gmail.com": "WuTianyi123",  # PR #20275 salvage of #13723 (feishu markdown)
     "zhicheng.han@mathematik.uni-goettingen.de": "hanzckernel",  # PR #20311 (api-server approval events)

--- a/tests/hermes_cli/test_pty_bridge.py
+++ b/tests/hermes_cli/test_pty_bridge.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
 import sys
 import time
 
@@ -210,6 +211,75 @@ class TestPtyBridgeClose:
                 reaped = True
                 break
         assert reaped, f"pid {pid} still running after close()"
+
+    def test_close_signals_child_process_group(self, monkeypatch):
+        sent: list[tuple[int, signal.Signals]] = []
+
+        class _FakeProc:
+            pid = 12345
+            fd = -1
+
+            def __init__(self):
+                self.alive = True
+
+            def isalive(self):
+                return self.alive
+
+            def kill(self, sig):
+                raise AssertionError(f"single-process kill used: {sig}")
+
+            def close(self, force=False):
+                self.closed = force
+
+        fake = _FakeProc()
+
+        def fake_killpg(pgid, sig):
+            sent.append((pgid, sig))
+            fake.alive = False
+
+        monkeypatch.setattr(os, "getpgid", lambda pid: 67890)
+        monkeypatch.setattr(os, "killpg", fake_killpg)
+
+        bridge = PtyBridge.__new__(PtyBridge)
+        bridge._proc = fake
+        bridge._fd = -1
+        bridge._closed = False
+
+        bridge.close()
+
+        assert sent == [(67890, signal.SIGHUP)]
+        assert bridge._closed is True
+
+    def test_close_falls_back_to_single_process_signal_when_group_unknown(self, monkeypatch):
+        sent: list[signal.Signals] = []
+
+        class _FakeProc:
+            pid = 12345
+            fd = -1
+
+            def __init__(self):
+                self.alive = True
+
+            def isalive(self):
+                return self.alive
+
+            def kill(self, sig):
+                sent.append(sig)
+                self.alive = False
+
+            def close(self, force=False):
+                self.closed = force
+
+        monkeypatch.setattr(os, "getpgid", lambda pid: (_ for _ in ()).throw(OSError()))
+
+        bridge = PtyBridge.__new__(PtyBridge)
+        bridge._proc = _FakeProc()
+        bridge._fd = -1
+        bridge._closed = False
+
+        bridge.close()
+
+        assert sent == [signal.SIGHUP]
 
 
 @skip_on_windows

--- a/tests/test_slash_worker_watchdog.py
+++ b/tests/test_slash_worker_watchdog.py
@@ -1,0 +1,21 @@
+import psutil
+
+from tui_gateway import slash_worker
+
+
+def test_is_orphaned_true_when_ppid_changes():
+    # Our parent went away and we were reparented to a subreaper/init.
+    assert slash_worker._is_orphaned(1234, 1.0, getppid=lambda: 999999) is True
+
+
+def test_is_orphaned_true_when_parent_create_time_mismatch():
+    # Same ppid but a different create_time means the PID was reused.
+    me = psutil.Process()
+    assert slash_worker._is_orphaned(me.pid, 0.0, getppid=lambda: me.pid) is True
+
+
+def test_is_orphaned_false_when_parent_alive_and_matches():
+    me = psutil.Process()
+    assert (
+        slash_worker._is_orphaned(me.pid, me.create_time(), getppid=lambda: me.pid) is False
+    )

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -9,10 +9,45 @@ import io
 import json
 import os
 import sys
+import threading
+import time
+
+import psutil
 
 import cli as cli_mod
 from cli import HermesCLI
 from rich.console import Console
+
+# Env-overridable so the integration test can drive sub-second timing.
+_WATCHDOG_POLL_S = float(os.environ.get("HERMES_SLASH_WATCHDOG_POLL_S", 2.0))
+_ORPHAN_GRACE_S = float(os.environ.get("HERMES_SLASH_WATCHDOG_GRACE_S", 5.0))
+_in_flight = threading.Event()  # set while a command is executing
+
+
+def _is_orphaned(original_ppid, parent_create_time, getppid=os.getppid) -> bool:
+    """True once our spawning gateway is gone. Compare to the ORIGINAL ppid
+    (never ==1: Linux reparents to a subreaper) and guard PID reuse via
+    create_time."""
+    if getppid() != original_ppid:
+        return True
+    try:
+        if not psutil.pid_exists(original_ppid):
+            return True
+        return psutil.Process(original_ppid).create_time() != parent_create_time
+    except psutil.Error:
+        return True
+
+
+def _start_parent_death_watchdog(original_ppid, parent_create_time) -> None:
+    def _loop():
+        while not _is_orphaned(original_ppid, parent_create_time):
+            time.sleep(_WATCHDOG_POLL_S)
+        deadline = time.monotonic() + _ORPHAN_GRACE_S
+        while _in_flight.is_set() and time.monotonic() < deadline:
+            time.sleep(0.05)  # let an in-flight command finish/flush
+        os._exit(0)
+
+    threading.Thread(target=_loop, daemon=True).start()
 
 
 def _run(cli: HermesCLI, command: str) -> str:
@@ -52,6 +87,15 @@ def main():
     os.environ["HERMES_SESSION_KEY"] = args.session_key
     os.environ["HERMES_INTERACTIVE"] = "1"
 
+    # Start before the (hundreds-of-ms) HermesCLI build — that window is itself
+    # an orphan risk if the gateway dies mid-spawn.
+    orig_ppid = os.getppid()
+    try:
+        parent_create_time = psutil.Process(orig_ppid).create_time()
+    except psutil.Error:
+        parent_create_time = 0.0
+    _start_parent_death_watchdog(orig_ppid, parent_create_time)
+
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
         cli = HermesCLI(model=args.model or None, compact=True, resume=args.session_key, verbose=False)
 
@@ -60,6 +104,7 @@ def main():
         if not line:
             continue
 
+        _in_flight.set()
         rid = None
         try:
             req = json.loads(line)
@@ -70,6 +115,8 @@ def main():
         except Exception as e:
             sys.stdout.write(json.dumps({"id": rid, "ok": False, "error": str(e)}) + "\n")
             sys.stdout.flush()
+        finally:
+            _in_flight.clear()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Dashboard `/chat` PTY disconnects no longer leak `tui_gateway.slash_worker` subprocesses. Two independent, cheap guards close the leak for both Linux and macOS.

Root cause: `/api/pty` spawns `hermes --tui`, which spawns its own `tui_gateway`, which spawns `_SlashWorker` **grandchildren**. `ptyprocess` makes the PTY child a session leader (`setsid()`), but `PtyBridge.close()` only signalled the single leader PID — so the grandchild slash workers never received SIGHUP/TERM/KILL and orphaned on every refresh / proxy drop. The in-process orphan reaper (#38591) only covers the dashboard's own gateway sessions, not this subprocess tree.

## Changes
- `hermes_cli/pty_bridge.py`: `close()` now `os.killpg(os.getpgid(pid), sig)` over the whole PTY process group (falls back to single-PID kill when the group is unknown). Reaps grandchild helpers. (@paulb26, #24135)
- `tui_gateway/slash_worker.py`: daemon watchdog self-terminates the worker on parent death — `getppid()` change + `psutil` `create_time` PID-reuse guard, started before the HermesCLI build to cover the spawn window, drains an in-flight command up to a grace window before `os._exit(0)`. Cross-platform (no `PR_SET_PDEATHSIG`, so it works on macOS too). (@firefly, #35626)
- `scripts/release.py`: AUTHOR_MAP entry for @paulb26.

## Validation
| Vector | Before | After |
|---|---|---|
| PTY process-group grandchild | survives `close()` | reaped (killpg) — E2E confirmed |
| Orphaned worker (parent dies) | lingers forever | self-exits within grace — E2E confirmed |

- Targeted: `tests/hermes_cli/test_pty_bridge.py` + `tests/test_slash_worker_watchdog.py` → 23 passed.
- E2E: real PTY-spawned grandchild reaped by `bridge.close()`; real orphaned watchdog process self-terminated after parent exit.

Closes #32377. Salvaged from #24135 (@paulb26) and #35626 (@banditburai/firefly); supersedes the slash-worker-leak PR cluster.


## Infographic

![slash-worker-leak-sealed](https://v3b.fal.media/files/b/0a9d7a69/hzx-pPCId3olvZDXOVb0C_kyRiguJv.png)
