### PR TITLE
feat(kanban): add 'unguard' command to clear respawn guard for a task

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -550,6 +550,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_unblock = sub.add_parser("unblock", help="Return one or more blocked/scheduled tasks to ready")
     p_unblock.add_argument("task_ids", nargs="+")
 
+    p_unguard = sub.add_parser("unguard", help="Clear respawn guard for a task (allows immediate re-spawn)")
+    p_unguard.add_argument("task_ids", nargs="+", help="Task ID(s) to unguard")
+
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
     p_archive.add_argument("task_ids", nargs="*",
                            help="Task ids to archive (default mode)")
@@ -899,6 +902,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "block":    _cmd_block,
         "schedule": _cmd_schedule,
         "unblock":  _cmd_unblock,
+        "unguard":  _cmd_unguard,
         "archive":  _cmd_archive,
         "tail":     _cmd_tail,
         "dispatch": _cmd_dispatch,
@@ -1952,6 +1956,26 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
                 print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
             else:
                 print(f"Unblocked {tid}")
+    return 0 if not failed else 1
+
+
+def _cmd_unguard(args: argparse.Namespace) -> int:
+    ids = list(args.task_ids or [])
+    if not ids:
+        print("at least one task_id is required", file=sys.stderr)
+        return 1
+    failed: list[str] = []
+    with kb.connect() as conn:
+        for tid in ids:
+            if not kb.clear_respawn_guard(conn, tid):
+                failed.append(tid)
+                print(f"task {tid} not found", file=sys.stderr)
+            else:
+                guard = kb.check_respawn_guard(conn, tid)
+                if guard is None:
+                    print(f"✓ Unguarded {tid} — ready for dispatch")
+                else:
+                    print(f"✓ Cleared guards for {tid} (still guarded: {guard})")
     return 0 if not failed else 1
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4531,6 +4531,49 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     return None
 
 
+def clear_respawn_guard(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Clear respawn guard conditions for *task_id* so it can be re-spawned.
+
+    Removes the data that triggers the three guard reasons:
+
+    - ``recent_success``: deletes completed ``task_runs`` within the guard
+      window so ``check_respawn_guard`` no longer finds a recent success.
+    - ``blocker_auth``: clears ``last_failure_error`` on the task row.
+    - ``active_pr``: deletes recent comments containing GitHub PR URLs
+      within the PR guard window.
+
+    Returns ``True`` if the task exists (even if no guard was active),
+    ``False`` if the task ID is unknown.
+    """
+    row = conn.execute("SELECT id FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    if row is None:
+        return False
+    now = int(time.time())
+    success_cutoff = now - _RESPAWN_GUARD_SUCCESS_WINDOW
+    pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    with write_txn(conn):
+        # Remove recent completed runs that trigger "recent_success"
+        conn.execute(
+            "DELETE FROM task_runs "
+            "WHERE task_id = ? AND outcome = 'completed' AND ended_at >= ?",
+            (task_id, success_cutoff),
+        )
+        # Clear failure error to remove "blocker_auth"
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = NULL WHERE id = ?",
+            (task_id,),
+        )
+        # Remove recent comments with PR URLs that trigger "active_pr"
+        for c in conn.execute(
+            "SELECT id, body FROM task_comments "
+            "WHERE task_id = ? AND created_at >= ?",
+            (task_id, pr_cutoff),
+        ).fetchall():
+            if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+                conn.execute("DELETE FROM task_comments WHERE id = ?", (c["id"],))
+    return True
+
+
 def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
     whose assignee maps to a real Hermes profile.


### PR DESCRIPTION
## Summary

Fixes #42053

When a completed kanban task is moved back to `ready` (e.g. user adds follow-up comments with new instructions), the dispatcher silently refuses to re-spawn it with `respawn_guarded {"reason": "recent_success"}`. There was no CLI command to clear or bypass this guard.

## Changes

### `hermes_cli/kanban_db.py`

Add `clear_respawn_guard(conn, task_id)` function that clears all three guard conditions:
- **recent_success**: Deletes completed `task_runs` within the guard window
- **blocker_auth**: Clears `last_failure_error` on the task row
- **active_pr**: Removes recent comments containing GitHub PR URLs

### `hermes_cli/kanban.py`

Add `hermes kanban unguard <task_id> [...]` subcommand with per-task success/failure reporting.

## Usage

```bash
hermes kanban unguard t_abc123           # single task
hermes kanban unguard t_abc123 t_def456  # multiple tasks
```