### PR TITLE
fix(ollama): add nemotron-3-ultra to model selector

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3295,6 +3295,8 @@ def fetch_api_models(
 
 
 _OLLAMA_CLOUD_CACHE_TTL = 3600  # 1 hour
+_OLLAMA_CLOUD_NEMOTRON_ANCHORS = ("nemotron-3-nano:30b", "nemotron-3-super")
+_OLLAMA_CLOUD_NEMOTRON_ULTRA = "nemotron-3-ultra"
 
 
 def _strip_ollama_cloud_suffix(model_id: str) -> str:
@@ -3409,6 +3411,13 @@ def fetch_ollama_cloud_models(
             if normalized and normalized not in seen:
                 seen.add(normalized)
                 merged.append(normalized)
+        if _OLLAMA_CLOUD_NEMOTRON_ULTRA not in seen:
+            anchor_indexes = [
+                idx for idx, model in enumerate(merged)
+                if model in _OLLAMA_CLOUD_NEMOTRON_ANCHORS
+            ]
+            if anchor_indexes:
+                merged.insert(max(anchor_indexes) + 1, _OLLAMA_CLOUD_NEMOTRON_ULTRA)
         if merged:
             _save_ollama_cloud_cache(merged)
             return merged

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -222,6 +222,29 @@ class TestOllamaCloudMergedDiscovery:
 
         assert result == ["glm-5"]
 
+    def test_adds_curated_nemotron_ultra_when_registry_omits_it(self, tmp_path, monkeypatch):
+        from hermes_cli.models import fetch_ollama_cloud_models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {
+                    "nemotron-3-nano:30b": {"tool_call": True},
+                    "nemotron-3-super": {"tool_call": True},
+                }
+            }
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+
+        assert result == [
+            "nemotron-3-nano:30b",
+            "nemotron-3-super",
+            "nemotron-3-ultra",
+        ]
+
     def test_uses_disk_cache(self, tmp_path, monkeypatch):
         """Second call returns cached results without hitting APIs."""
         from hermes_cli.models import fetch_ollama_cloud_models


### PR DESCRIPTION
### Description

The Ollama model selector includes `nemotron-3-nano:30b` and `nemotron-3-super`, but does not include `nemotron-3-ultra`.

`nemotron-3-ultra` can already be used when it is configured as the current/custom model, so this appears to be a preset list omission rather than a provider/runtime issue.

### Expected behavior

`nemotron-3-ultra` should be available in the Ollama default model selector, near the existing Nemotron entries.

### Actual behavior

The model selector does not show `nemotron-3-ultra`, so users have to enter it manually as a custom model.

### Proposed change

Add `nemotron-3-ultra` to the Ollama model preset list.

### Scope

This only updates the selector/model preset list. It does not change Ollama provider behavior, routing, authentication, or request formatting.

### Tests

- `uv run --extra dev ruff check hermes_cli\models.py tests\hermes_cli\test_ollama_cloud_provider.py`
- `uv run --extra dev python -m pytest -o addopts="" tests\hermes_cli\test_ollama_cloud_provider.py`

Note: the repository pytest config uses `--timeout-method=signal`, which raises `AttributeError: module 'signal' has no attribute 'SIGALRM'` on Windows. The targeted pytest run overrides `addopts` for the local Windows validation run.
