### PR TITLE
feat: add self-locating version suffix for non-release builds

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -420,6 +420,56 @@ def get_latest_release_tag(repo_dir: Optional[Path] = None) -> Optional[tuple]:
     return _latest_release_cache
 
 
+_commits_since_tag_cache: Optional[tuple] = None  # (count, short_sha) or () for "at tag"
+
+
+def _get_commits_since_tag() -> Optional[tuple]:
+    """Return ``(count, short_sha)`` for commits past the latest release tag.
+
+    Returns ``None`` if the tag can't be resolved, ``(0, sha)`` if HEAD is
+    exactly at the tag, or ``(N, sha)`` if HEAD is N commits past the tag.
+    Cached per-process; cheap to call repeatedly from the banner code path.
+    """
+    global _commits_since_tag_cache
+    if _commits_since_tag_cache is not None:
+        return _commits_since_tag_cache or None
+
+    release = get_latest_release_tag()
+    if not release:
+        _commits_since_tag_cache = ()
+        return None
+    tag, _url = release
+    if not tag:
+        _commits_since_tag_cache = ()
+        return None
+
+    repo_dir = _resolve_repo_dir()
+    if repo_dir is None:
+        _commits_since_tag_cache = ()
+        return None
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-list", "--count", f"{tag}..HEAD"],
+            capture_output=True, text=True, timeout=3, cwd=str(repo_dir),
+        )
+    except Exception:
+        _commits_since_tag_cache = ()
+        return None
+    if result.returncode != 0:
+        _commits_since_tag_cache = ()
+        return None
+    try:
+        count = int((result.stdout or "0").strip() or "0")
+    except ValueError:
+        _commits_since_tag_cache = ()
+        return None
+
+    short_sha = _git_short_hash(repo_dir, "HEAD")
+    _commits_since_tag_cache = (count, short_sha)
+    return _commits_since_tag_cache
+
+
 def format_banner_version_label() -> str:
     """Return the version label shown in the startup banner title."""
     base = f"Hermes Agent v{VERSION} ({RELEASE_DATE})"
@@ -431,11 +481,21 @@ def format_banner_version_label() -> str:
     local = state["local"]
     ahead = int(state.get("ahead") or 0)
 
+    # Self-locating suffix: when HEAD is past the latest release tag, annotate
+    # the version with a git-describe-style "+N.g<sha>" stamp so operators can
+    # tell release builds from N-commit-past-release builds at a glance.
+    suffix = ""
+    tag_info = _get_commits_since_tag()
+    if tag_info:
+        n, sha = tag_info
+        if n > 0 and sha:
+            suffix = f"+{n}.g{sha}"
+
     if ahead <= 0 or upstream == local:
-        return f"{base} · upstream {upstream}"
+        return f"{base}{suffix} · upstream {upstream}"
 
     carried_word = "commit" if ahead == 1 else "commits"
-    return f"{base} · upstream {upstream} · local {local} (+{ahead} carried {carried_word})"
+    return f"{base}{suffix} · upstream {upstream} · local {local} (+{ahead} carried {carried_word})"
 
 
 # =========================================================================

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -114,3 +114,116 @@ def test_get_git_banner_state_falls_back_when_live_git_returns_nothing(tmp_path)
         state = banner.get_git_banner_state(repo_dir)
 
     assert state == {"upstream": "cafef00d", "local": "cafef00d", "ahead": 0}
+
+
+def test_format_banner_version_label_appends_past_tag_suffix():
+    """HEAD N commits past the release tag → "+N.g<sha>" stamp after the date.
+
+    Operators see at a glance whether they're running a release build or
+    N commits past the last release. The carried-commits annotation is
+    independent and remains when local is ahead of upstream/main.
+    """
+    from hermes_cli import banner
+
+    banner._commits_since_tag_cache = None  # bust process cache
+    with patch.object(
+        banner,
+        "get_git_banner_state",
+        return_value={"upstream": "b2f477a3", "local": "b2f477a3", "ahead": 0},
+    ), patch.object(banner, "_get_commits_since_tag", return_value=(171, "af08c43d")):
+        value = banner.format_banner_version_label()
+
+    assert value == (
+        f"Hermes Agent v{banner.VERSION} ({banner.RELEASE_DATE})+171.gaf08c43d"
+        f" · upstream b2f477a3"
+    )
+
+
+def test_format_banner_version_label_at_tag_has_no_suffix():
+    """HEAD exactly at the release tag → no suffix (release build)."""
+    from hermes_cli import banner
+
+    banner._commits_since_tag_cache = None
+    with patch.object(
+        banner,
+        "get_git_banner_state",
+        return_value={"upstream": "b2f477a3", "local": "b2f477a3", "ahead": 0},
+    ), patch.object(banner, "_get_commits_since_tag", return_value=(0, "abc12345")):
+        value = banner.format_banner_version_label()
+
+    head = value.split("·")[0]
+    assert "+" not in head
+    assert value == (
+        f"Hermes Agent v{banner.VERSION} ({banner.RELEASE_DATE})"
+        f" · upstream b2f477a3"
+    )
+
+
+def test_format_banner_version_label_past_tag_with_carried_commits():
+    """Past-tag suffix coexists with the carried-commits annotation."""
+    from hermes_cli import banner
+
+    banner._commits_since_tag_cache = None
+    with patch.object(
+        banner,
+        "get_git_banner_state",
+        return_value={"upstream": "b2f477a3", "local": "def5678a", "ahead": 2},
+    ), patch.object(banner, "_get_commits_since_tag", return_value=(2, "def5678a")):
+        value = banner.format_banner_version_label()
+
+    assert "· upstream b2f477a3" in value
+    assert "· local def5678a" in value
+    assert "+2 carried commits" in value
+    assert "+2.gdef5678a" in value
+
+
+def test_format_banner_version_label_no_suffix_when_tag_unavailable():
+    """If the tag can't be resolved, fall back to the existing format."""
+    from hermes_cli import banner
+
+    banner._commits_since_tag_cache = None
+    with patch.object(
+        banner,
+        "get_git_banner_state",
+        return_value={"upstream": "b2f477a3", "local": "b2f477a3", "ahead": 0},
+    ), patch.object(banner, "_get_commits_since_tag", return_value=None):
+        value = banner.format_banner_version_label()
+
+    assert value == (
+        f"Hermes Agent v{banner.VERSION} ({banner.RELEASE_DATE})"
+        f" · upstream b2f477a3"
+    )
+    assert "+" not in value
+
+
+def test_get_commits_since_tag_returns_count_and_short_sha(tmp_path):
+    """Real subprocess: count commits past the tag and resolve HEAD's short SHA."""
+    from hermes_cli import banner
+
+    banner._commits_since_tag_cache = None
+    banner._latest_release_cache = None
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    results = {
+        ("git", "describe", "--tags", "--abbrev=0"):
+            MagicMock(returncode=0, stdout="v0.16.0\n"),
+        ("git", "rev-list", "--count", "v0.16.0..HEAD"):
+            MagicMock(returncode=0, stdout="5\n"),
+        ("git", "rev-parse", "--short=8", "HEAD"):
+            MagicMock(returncode=0, stdout="af08c43d\n"),
+    }
+
+    def fake_run(cmd, **kwargs):
+        key = tuple(cmd)
+        if key not in results:
+            raise AssertionError(f"unexpected command: {cmd}")
+        return results[key]
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run), \
+         patch.object(banner, "_resolve_repo_dir", return_value=repo_dir):
+        first = banner._get_commits_since_tag()
+        second = banner._get_commits_since_tag()  # cached
+
+    assert first == (5, "af08c43d")
+    assert second == (5, "af08c43d")  # cache hit, no second subprocess call


### PR DESCRIPTION
Append a `+<N>.g<short-sha>` suffix to the version date portion when HEAD has commits past the latest release tag.

Operators can now tell at a glance whether they are running a release build or N commits past the last release, without checking git log.

```
Hermes Agent v0.16.0 (2026.6.5)                  # at a release tag
Hermes Agent v0.16.0 (2026.6.5)+171.gaf08c43     # 171 commits past last tag
```

Changes:
- Add `_get_commits_since_tag()` helper using `git rev-list --count`
- Update `format_banner_version_label()` to include the suffix
- Add 5 tests covering at-tag, past-tag, no-tag, and cached paths