### PR TITLE
fix(gateway): detect macOS launchd gui domain

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1067,16 +1067,7 @@ def _recover_pending_systemd_restart(
 def _probe_launchd_service_running() -> bool:
     if not get_launchd_plist_path().exists():
         return False
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except subprocess.TimeoutExpired:
-        return False
-    return result.returncode == 0
+    return _launchd_loaded_service() is not None
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -3067,12 +3058,64 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
+def _launchd_manager_name() -> str | None:
+    """Return launchd's current manager name, when available."""
+    proc = None
+    try:
+        proc = subprocess.Popen(
+            ["launchctl", "managername"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        stdout, _stderr = proc.communicate(timeout=5)
+        if proc.returncode == 0:
+            return stdout.strip() or None
+    except (OSError, subprocess.TimeoutExpired):
+        if proc is not None:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+        return None
+    return None
+
+
 def _launchd_domain() -> str:
-    # The `user/<uid>` domain (vs the older `gui/<uid>`) is reachable from
-    # non-Aqua/background sessions (SSH, headless, login items) and is the only
-    # one that supports service management on macOS 26+. `gui/<uid>` returns
-    # error 125 ("Domain does not support specified action") there. See #23387.
-    return f"user/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    # LaunchAgents loaded for an interactive login session live in gui/<uid>.
+    # Headless/background callers on newer macOS releases may only be able to
+    # manage user/<uid>. Pick the domain that matches the current launchd
+    # manager so status/start/restart do not misclassify a healthy Aqua service
+    # as unloaded and fall back to a detached process.
+    uid = os.getuid()  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    if _launchd_manager_name() == "Aqua":
+        return f"gui/{uid}"
+    return f"user/{uid}"
+
+
+def _launchd_candidate_domains() -> list[str]:
+    """Return launchd domains to probe, with the active manager first."""
+    uid = os.getuid()
+    preferred = _launchd_domain()
+    return list(dict.fromkeys([preferred, f"gui/{uid}", f"user/{uid}"]))
+
+
+def _launchd_loaded_service(label: str | None = None) -> tuple[str, str] | None:
+    """Return (domain, launchctl print output) when the launchd job is loaded."""
+    label = label or get_launchd_label()
+    for domain in _launchd_candidate_domains():
+        try:
+            result = subprocess.run(
+                ["launchctl", "print", f"{domain}/{label}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            continue
+        if result.returncode == 0:
+            return domain, result.stdout
+    return None
 
 
 # On macOS, exit code 125 ("Domain does not support specified action") and
@@ -3569,18 +3612,7 @@ def launchd_restart():
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        loaded = result.returncode == 0
-        loaded_output = result.stdout
-    except subprocess.TimeoutExpired:
-        loaded = False
-        loaded_output = ""
+    loaded_service = _launchd_loaded_service(label)
 
     print(f"Launchd plist: {plist_path}")
     if launchd_plist_is_current():
@@ -3589,8 +3621,9 @@ def launchd_status(deep: bool = False):
         print("⚠ Service definition is stale relative to the current Hermes install")
         print("  Run: hermes gateway start")
 
-    if loaded:
-        print("✓ Gateway service is loaded")
+    if loaded_service is not None:
+        loaded_domain, loaded_output = loaded_service
+        print(f"✓ Gateway service is loaded in {loaded_domain}")
         print(loaded_output)
     else:
         print("✗ Gateway service is not loaded")
@@ -4980,16 +5013,7 @@ def _is_service_running() -> bool:
 
         return False
     elif is_macos() and get_launchd_plist_path().exists():
-        try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            return result.returncode == 0
-        except subprocess.TimeoutExpired:
-            return False
+        return _launchd_loaded_service() is not None
     elif is_windows():
         from hermes_cli import gateway_windows
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -679,10 +679,39 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
-    def test_launchd_domain_uses_user_domain(self):
-        # The user/<uid> domain (not gui/<uid>) is the one reachable from
-        # non-Aqua/background sessions on macOS 26+ (issue #23387).
+    def test_launchd_status_detects_service_loaded_in_gui_domain(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+        uid = os.getuid()
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_launchd_manager_name", lambda: "Background")
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd == ["launchctl", "print", f"gui/{uid}/{label}"]:
+                return SimpleNamespace(returncode=0, stdout="state = running\n", stderr="")
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert f"loaded in gui/{uid}" in output
+        assert "state = running" in output
+
+    def test_launchd_domain_uses_user_domain_for_background_manager(self, monkeypatch):
+        # The user/<uid> domain is reachable from non-Aqua/background sessions
+        # on newer macOS releases (issue #23387).
+        monkeypatch.setattr(gateway_cli, "_launchd_manager_name", lambda: "Background")
         assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
+
+    def test_launchd_domain_uses_gui_domain_for_aqua_manager(self, monkeypatch):
+        # Interactive LaunchAgents are loaded in gui/<uid>; using user/<uid>
+        # makes a healthy service look unloaded in Aqua sessions.
+        monkeypatch.setattr(gateway_cli, "_launchd_manager_name", lambda: "Aqua")
+        assert gateway_cli._launchd_domain() == f"gui/{os.getuid()}"
 
     def test_launchctl_domain_unsupported_recognizes_macos26_codes(self):
         # Codes that persist after a fresh bootstrap → launchd truly unavailable.
@@ -892,6 +921,25 @@ class TestGatewayServiceDetection:
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
 
         assert gateway_cli._is_service_running() is False
+
+    def test_is_service_running_detects_launchd_job_in_gui_domain(self, monkeypatch):
+        label = gateway_cli.get_launchd_label()
+        uid = os.getuid()
+        plist = SimpleNamespace(exists=lambda: True)
+
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist)
+        monkeypatch.setattr(gateway_cli, "_launchd_manager_name", lambda: "Background")
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd == ["launchctl", "print", f"gui/{uid}/{label}"]:
+                return SimpleNamespace(returncode=0, stdout="state = running\n", stderr="")
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._is_service_running() is True
 
 class TestGatewaySystemServiceRouting:
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -45,6 +45,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         calls = []
 
@@ -68,6 +69,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         calls = []
 
@@ -91,6 +93,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         calls = []
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -947,6 +950,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(
@@ -992,6 +996,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 10.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -1051,6 +1056,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
         monkeypatch.setattr(gateway_cli, "_recover_pending_systemd_restart", lambda system=False, previous_pid=None: False)
@@ -1081,6 +1087,7 @@ class TestGatewaySystemServiceRouting:
     def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(
             "gateway.status.read_runtime_status",

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -434,9 +434,10 @@ def _assert_s6_event_dir_mode(path) -> None:
     import sys
 
     mode = stat.S_IMODE(path.stat().st_mode)
-    expected = 0o3730 if sys.platform != "darwin" else 0o1730
-    assert mode == expected, (
-        f"{path} mode = {oct(path.stat().st_mode)}, want {oct(expected)}"
+    expected = {0o3730} if sys.platform != "darwin" else {0o1730, 0o3730}
+    assert mode in expected, (
+        f"{path} mode = {oct(path.stat().st_mode)}, want one of "
+        f"{', '.join(oct(value) for value in sorted(expected))}"
     )
 
 

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -422,6 +422,24 @@ def test_s6_manager_kind_and_supports_registration() -> None:
 # tests/docker/test_s6_profile_gateway_integration.py.
 
 
+def _assert_s6_event_dir_mode(path) -> None:
+    """Assert portable event dir access bits.
+
+    Linux/s6 preserves the full 03730 mode. Some macOS filesystems strip
+    setgid from non-root temp dirs, leaving 01730. That is acceptable for
+    host-side unit tests; the live Linux container coverage verifies the
+    exact s6 runtime behavior.
+    """
+    import stat
+    import sys
+
+    mode = stat.S_IMODE(path.stat().st_mode)
+    expected = 0o3730 if sys.platform != "darwin" else 0o1730
+    assert mode == expected, (
+        f"{path} mode = {oct(path.stat().st_mode)}, want {oct(expected)}"
+    )
+
+
 def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     """Verifies the dirs + FIFO + modes the helper lays down."""
     import stat
@@ -436,9 +454,7 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # Top-level event/ — s6-svlisten1 event subscription dir.
     event = svc_dir / "event"
     assert event.is_dir(), "missing top-level event/"
-    assert stat.S_IMODE(event.stat().st_mode) == 0o3730, (
-        f"event/ mode = {oct(event.stat().st_mode)}, want 03730"
-    )
+    _assert_s6_event_dir_mode(event)
 
     # supervise/ dir.
     supervise = svc_dir / "supervise"
@@ -448,7 +464,7 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # supervise/event/.
     supervise_event = supervise / "event"
     assert supervise_event.is_dir(), "missing supervise/event/"
-    assert stat.S_IMODE(supervise_event.stat().st_mode) == 0o3730
+    _assert_s6_event_dir_mode(supervise_event)
 
     # supervise/control FIFO.
     control = supervise / "control"
@@ -483,7 +499,7 @@ def test_seed_supervise_skeleton_handles_log_subservice(tmp_path) -> None:
     log_control = log_supervise / "control"
 
     assert log_event.is_dir()
-    assert stat.S_IMODE(log_event.stat().st_mode) == 0o3730
+    _assert_s6_event_dir_mode(log_event)
     assert log_supervise.is_dir()
     assert log_supervise_event.is_dir()
     assert log_control.exists() and stat.S_ISFIFO(log_control.stat().st_mode)


### PR DESCRIPTION
Summary: Detect the active macOS launchd manager so Aqua sessions use gui/<uid>, probe both gui/<uid> and user/<uid> with launchctl print, and reuse that probe for gateway status/runtime service checks. Also makes s6 supervise skeleton mode tests portable on macOS while preserving Linux expectations. Tests: python -m pytest tests/hermes_cli/test_service_manager.py -q -o cache_dir=/private/tmp/hermes-pytest-cache; python -m pytest tests/hermes_cli/test_gateway_service.py -q -k 'launchd or detects_launchd_job' -o cache_dir=/private/tmp/hermes-pytest-cache. Live verification: hermes gateway restart; hermes gateway status reports loaded in gui/501; lsof shows 127.0.0.1:8642 listening.