### PR TITLE
fix(dashboard): bypass _require_token in gated mode to trust cookie auth

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -247,6 +247,10 @@ def _has_valid_session_token(request: Request) -> bool:
 
 def _require_token(request: Request) -> None:
     """Validate the ephemeral session token.  Raises 401 on mismatch."""
+    # In gated mode, cookie auth (gated_auth_middleware) is authoritative and
+    # the legacy _SESSION_TOKEN is never issued to clients.  Trust the gate.
+    if getattr(request.app.state, "auth_required", False):
+        return
     if not _has_valid_session_token(request):
         raise HTTPException(status_code=401, detail="Unauthorized")
 

--- a/tests/hermes_cli/test_require_token_gated.py
+++ b/tests/hermes_cli/test_require_token_gated.py
@@ -1,0 +1,74 @@
+"""Tests for _require_token() gated-mode bypass (issue #42139).
+
+In gated dashboard mode (non-loopback bind with auth), cookie auth is
+authoritative and the legacy _SESSION_TOKEN is never issued.  The
+_require_token() function must trust the gate and not reject
+cookie-authenticated clients with 401.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+
+def _make_request(auth_required: bool = False):
+    """Build a minimal stand-in that _require_token can inspect."""
+    class _State:
+        pass
+
+    class _Req:
+        pass
+
+    req = _Req()
+    req.app = type("App", (), {"state": _State()})()
+    req.app.state.auth_required = auth_required
+    return req
+
+
+# ── Non-gated mode (legacy _SESSION_TOKEN path) ──────────────────────
+
+
+def test_require_token_rejects_without_token_in_normal_mode():
+    """Non-gated mode with no token → 401."""
+    from hermes_cli.web_server import _require_token
+
+    req = _make_request(auth_required=False)
+    with patch("hermes_cli.web_server._has_valid_session_token", return_value=False):
+        with pytest.raises(HTTPException) as exc_info:
+            _require_token(req)
+    assert exc_info.value.status_code == 401
+
+
+def test_require_token_passes_with_valid_token_in_normal_mode():
+    """Non-gated mode with valid session token → passes."""
+    from hermes_cli.web_server import _require_token
+
+    req = _make_request(auth_required=False)
+    with patch("hermes_cli.web_server._has_valid_session_token", return_value=True):
+        _require_token(req)  # should not raise
+
+
+# ── Gated mode (cookie auth is authoritative) ────────────────────────
+
+
+def test_require_token_passes_without_token_in_gated_mode():
+    """Gated mode (auth_required=True) passes even without session token.
+
+    In gated mode the legacy _SESSION_TOKEN is never issued — cookie auth
+    is authoritative.  _require_token must trust the gate.  (issue #42139)
+    """
+    from hermes_cli.web_server import _require_token
+
+    req = _make_request(auth_required=True)
+    # No mock needed — the function should return before checking the token
+    _require_token(req)
+
+
+def test_require_token_passes_with_token_in_gated_mode():
+    """Gated mode with a token also passes (belt-and-suspenders)."""
+    from hermes_cli.web_server import _require_token
+
+    req = _make_request(auth_required=True)
+    with patch("hermes_cli.web_server._has_valid_session_token", return_value=True):
+        _require_token(req)


### PR DESCRIPTION
## What does this PR do?

Bypasses `_require_token()` in gated dashboard mode so that cookie-authenticated clients are not rejected with 401. In gated mode, cookie auth (via `gated_auth_middleware`) is authoritative and the legacy `_SESSION_TOKEN` is never issued — the token check must trust the gate.

## Related Issue

Fixes #42139

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Add early return in `_require_token()` when `app.state.auth_required` is set, mirroring the same check in `auth_middleware` (line 376). This restores all 9 affected endpoints in gated mode.
- `tests/hermes_cli/test_require_token_gated.py`: 4 tests covering non-gated reject, non-gated pass, gated pass-without-token, and gated pass-with-token.

## How to Test

1. Run `pytest tests/hermes_cli/test_require_token_gated.py -v` — all 4 tests should pass.
2. Manual: start a gated dashboard (`hermes dashboard --host <lan-ip>` with `HERMES_DASHBOARD_BASIC_AUTH_*` set), authenticate via cookie, then `POST /api/providers/validate` with a valid endpoint. Expected: `{"ok": true, ...}`. Before this fix: `401 {"detail":"Unauthorized"}`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_require_token()` in `hermes_cli/web_server.py` (callers: 13 endpoints)
- Blast radius: LOW — only affects gated mode; non-gated loopback path unchanged
- Related patterns: `auth_middleware` at line 376 uses the same `auth_required` check
