### PR TITLE
revert(nix): drop the cp patchPhase workaround from #41867

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -73,25 +73,24 @@ in
 
       patchPhase = ''
         runHook prePatch
+        # Normalize trailing newlines on the root lockfile so source and
+        # npm-deps always match, regardless of what fetchNpmDeps preserves.
+        sed -i -z 's/\\n*$/\\n/' package-lock.json
 
-        # prefetch-npm-deps stores a *normalized* package-lock.json in the deps
-        # cache: newer npm writes advisory fields (engines/os/cpu/funding/bin/…)
-        # into lockfile entries, and prefetch strips the ones that don't affect
-        # which tarballs are fetched. npmConfigHook then does a byte-for-byte
-        # diff of the source lockfile against the cache's copy and fails on
-        # those purely-cosmetic differences — this is what breaks cold builds
-        # on a nixpkgs whose prefetch-npm-deps strips fields the committed
-        # lockfile carries.
-        #
-        # Adopt the cache's own normalized lockfile as the source so the
-        # consistency check is trivially satisfied. The resolved dependency set
-        # (version/resolved/integrity/dependencies) is byte-identical either
-        # way — fetchNpmDeps derived the cache *from* this lockfile — so `npm
-        # ci` installs exactly the same tree; only advisory metadata is dropped.
-        # Genuine drift is still caught upstream: a changed lockfile that didn't
-        # get its npmDepsHash refreshed fails the fixed-output hash check before
-        # this phase ever runs.
-        cp --no-preserve=mode,ownership ${npmDeps}/package-lock.json package-lock.json
+        # Make npmConfigHook's byte-for-byte diff newline-agnostic by
+        # replacing its hardcoded /nix/store/.../diff with a wrapper that
+        # normalizes trailing newlines on both sides before comparing.
+        mkdir -p "$TMPDIR/bin"
+        cat > "$TMPDIR/bin/diff" << DIFFWRAP
+        #!/bin/sh
+        f1=\\$(mktemp) && sed -z 's/\\n*$/\\n/' "\\$1" > "\\$f1"
+        f2=\\$(mktemp) && sed -z 's/\\n*$/\\n/' "\\$2" > "\\$f2"
+        ${pkgs.diffutils}/bin/diff "\\$f1" "\\$f2" && rc=0 || rc=\\$?
+        rm -f "\\$f1" "\\$f2"
+        exit \\$rc
+        DIFFWRAP
+        chmod +x "$TMPDIR/bin/diff"
+        export PATH="$TMPDIR/bin:$PATH"
 
         runHook postPatch
       '';


### PR DESCRIPTION
## Summary
Reverts the `patchPhase` change from #41867. That change replaced the lockfile-consistency handling with a blunt `cp "$npmDeps/package-lock.json" package-lock.json`, based on a misdiagnosis — that `prefetch-npm-deps` strips advisory fields (`engines`/`os`/`cpu`) from the cache lockfile. It doesn't.

## What's actually true (verified from source + builds)
- `prefetch-npm-deps` copies the lockfile into the cache **verbatim** — `prefetch-npm-deps/src/main.rs` reads `package-lock.json` and writes it back unchanged; the parser only models `resolved`/`integrity` because that's all it needs to *fetch tarballs*, not to rewrite the stored file.
- Building the cache fresh from the current root lockfile yields **exactly the pinned `npmDepsHash`**, and that cache's `package-lock.json` is **byte-identical** to the source (`740` `"engines"` blocks on each side, `cmp` clean).
- With the hash correct, `npmConfigHook`'s consistency check **passes on its own**. Confirmed by building `.#tui` and `.#default` green on this (original) `patchPhase`, on the same pinned nixpkgs.

## Why revert
The `cp` was unnecessary, and it has a real downside: it bypasses the consistency check **wholesale**, so a genuinely stale `npmDepsHash` (a lockfile changed without its hash refreshed) would be **silently masked** — building old cached deps against a new lockfile — instead of failing loudly. The original `patchPhase` keeps the check meaningful while handling the one real cosmetic case it was written for (trailing newlines). Stale-hash drift is already handled by the `npmDepsHash` itself + the `nix-lockfile-fix.yml` auto-fix.

The earlier failure that motivated #41867 was a **stale/mismatched hash in a specific local checkout**, not a fundamental `engines` or nixpkgs-version problem — so the right layer is keeping the hash in sync, which already works.

## Scope
Only the `patchPhase` `cp` is reverted. The other two #41867 changes are **kept**:
- `fix-lockfiles` real-build verification (no longer trusts `prefetch-npm-deps`'s "ok").
- `nix-lockfile-fix.yml` guard/`git add` pointing at `nix/lib.nix`.

## Test plan
- `nix build .#tui` → green
- `nix build .#default` (full hermes-agent) → green
- both with the restored `patchPhase`, on the pinned nixpkgs
