### PR TITLE
fix(computer-use): route cua screenshots through aux vision

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1276,6 +1276,81 @@ class TestCaptureAppFilterNoMatch:
 
         assert backend._active_pid == 100
 
+    def test_capture_uses_requested_mode_and_structured_dimensions(self):
+        windows = [
+            {"app_name": "Calculator", "pid": 200, "window_id": 2,
+             "is_on_screen": True, "title": "Calculator", "z_index": 0},
+        ]
+        backend = _make_cua_backend_with_windows(windows)
+        backend._session.call_tool.side_effect = [
+            {"data": "", "images": [], "isError": False,
+             "structuredContent": {"windows": windows}},
+            {"data": 'window_id=2 pid=200 size=460x816 elements=1\n\n- [0] AXWindow "Calculator"',
+             "images": ["iVBORfake"], "isError": False,
+             "structuredContent": {
+                 "screenshot_width": 460,
+                 "screenshot_height": 816,
+                 "tree_markdown": '- [0] AXWindow "Calculator"',
+             }},
+        ]
+
+        cap = backend.capture(mode="som", app="Calculator")
+
+        assert backend._session.call_tool.call_args_list[1].args[0] == "get_window_state"
+        assert backend._session.call_tool.call_args_list[1].args[1]["capture_mode"] == "som"
+        assert cap.width == 460
+        assert cap.height == 816
+        assert cap.png_b64 == "iVBORfake"
+        assert cap.window_title == "Calculator"
+
+    def test_capture_ax_suppresses_image_even_if_driver_returns_one(self):
+        windows = [
+            {"app_name": "Calculator", "pid": 200, "window_id": 2,
+             "is_on_screen": True, "title": "Calculator", "z_index": 0},
+        ]
+        backend = _make_cua_backend_with_windows(windows)
+        backend._session.call_tool.side_effect = [
+            {"data": "", "images": [], "isError": False,
+             "structuredContent": {"windows": windows}},
+            {"data": 'window_id=2 pid=200 size=460x816 elements=1\n\n- [0] AXWindow "Calculator"',
+             "images": ["iVBORfake"], "isError": False,
+             "structuredContent": {
+                 "screenshot_width": 460,
+                 "screenshot_height": 816,
+                 "tree_markdown": '- [0] AXWindow "Calculator"',
+             }},
+        ]
+
+        cap = backend.capture(mode="ax", app="Calculator")
+
+        assert backend._session.call_tool.call_args_list[1].args[1]["capture_mode"] == "ax"
+        assert cap.width == 460
+        assert cap.height == 816
+        assert cap.png_b64 is None
+
+    def test_capture_vision_uses_get_window_state_not_screenshot_tool(self):
+        windows = [
+            {"app_name": "Calculator", "pid": 200, "window_id": 2,
+             "is_on_screen": True, "title": "Calculator", "z_index": 0},
+        ]
+        backend = _make_cua_backend_with_windows(windows)
+        backend._session.call_tool.side_effect = [
+            {"data": "", "images": [], "isError": False,
+             "structuredContent": {"windows": windows}},
+            {"data": 'window_id=2 pid=200 size=460x816',
+             "images": ["/9j/fake"], "isError": False,
+             "structuredContent": {"screenshot_width": 460, "screenshot_height": 816}},
+        ]
+
+        cap = backend.capture(mode="vision", app="Calculator")
+
+        assert backend._session.call_tool.call_args_list[1].args[0] == "get_window_state"
+        assert backend._session.call_tool.call_args_list[1].args[1]["capture_mode"] == "vision"
+        assert cap.width == 460
+        assert cap.height == 816
+        assert cap.png_b64 == "/9j/fake"
+        assert cap.elements == []
+
 
 class TestFocusAppFilterNoMatch:
     """focus_app(app=X) must return ok=False when X matches nothing —

--- a/tests/tools/test_computer_use_capture_routing.py
+++ b/tests/tools/test_computer_use_capture_routing.py
@@ -273,6 +273,37 @@ class TestCaptureResponseRoutedToAuxVision:
         assert observed_path["path"]
         assert not os.path.exists(observed_path["path"])
 
+    def test_routing_creates_missing_cache_directory(self, tmp_path):
+        from tools.computer_use import tool as cu_tool
+
+        missing_cache_dir = tmp_path / "missing" / "cache" / "vision"
+        cap = _make_capture(mode="som")
+
+        def _fake_get(*_args, **_kw):
+            return missing_cache_dir
+
+        def _fake_run_async(_coro):
+            return _stub_aux_analysis("description goes here")
+
+        def _fake_vat(image_path, _prompt):
+            assert os.path.exists(image_path)
+            assert str(missing_cache_dir) in image_path
+            return "<coro>"
+
+        fake_vat = MagicMock(side_effect=_fake_vat)
+
+        with patch.object(cu_tool, "_should_route_through_aux_vision",
+                          return_value=True), \
+             patch("hermes_constants.get_hermes_dir", side_effect=_fake_get), \
+             patch("model_tools._run_async", side_effect=_fake_run_async), \
+             patch("tools.vision_tools.vision_analyze_tool",
+                   new_callable=lambda: fake_vat):
+            resp = cu_tool._capture_response(cap)
+
+        assert missing_cache_dir.exists()
+        body = json.loads(resp)
+        assert body["vision_analysis_routed_via"] == "auxiliary.vision"
+
     def test_empty_aux_analysis_falls_back_to_multimodal(self, tmp_cache_dir):
         from tools.computer_use import tool as cu_tool
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -356,8 +356,12 @@ class CuaDriverBackend(ComputerUseBackend):
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
         `get_window_state` (ax/som) or `screenshot` (vision).
         """
-        # Step 1: enumerate on-screen windows to find target pid/window_id.
-        lw_out = self._session.call_tool("list_windows", {"on_screen_only": True})
+        # Step 1: enumerate windows to find target pid/window_id. Use the full
+        # WindowServer inventory instead of on_screen_only=True: cua-driver can
+        # report background-launched or other-Space windows as not on-screen even
+        # when get_window_state can capture them correctly. We still prefer
+        # on-screen candidates below via `off_screen`.
+        lw_out = self._session.call_tool("list_windows", {"on_screen_only": False})
 
         # Prefer structuredContent.windows (MCP 2024-11-05+); fall back to
         # text-line parsing for older cua-driver builds.
@@ -418,42 +422,56 @@ class CuaDriverBackend(ComputerUseBackend):
         if app or not self._last_app:
             self._last_app = app_name
 
-        # Step 2: capture.
+        # Step 2: capture. Use get_window_state for all modes: cua-driver does
+        # not expose a standalone screenshot tool in all versions, and
+        # get_window_state is the canonical screenshot path with
+        # capture_mode='vision'|'som'|'ax'.
         png_b64: Optional[str] = None
         elements: List[UIElement] = []
         width = height = 0
-        window_title = ""
+        window_title = target.get("title") or ""
 
-        if mode == "vision":
-            # screenshot tool: just the PNG, no AX walk.
-            sc_out = self._session.call_tool(
-                "screenshot",
-                {"window_id": self._active_window_id, "format": "jpeg", "quality": 85},
-            )
-            if sc_out["images"]:
-                png_b64 = sc_out["images"][0]
+        gws_out = self._session.call_tool(
+            "get_window_state",
+            {
+                "pid": self._active_pid,
+                "window_id": self._active_window_id,
+                "capture_mode": mode,
+            },
+        )
+        structured = gws_out.get("structuredContent") or {}
+        if isinstance(structured, dict):
+            width = int(structured.get("screenshot_width") or 0)
+            height = int(structured.get("screenshot_height") or 0)
+            structured_tree = structured.get("tree_markdown")
         else:
-            # get_window_state: AX tree + optional screenshot.
-            gws_out = self._session.call_tool(
-                "get_window_state",
-                {"pid": self._active_pid, "window_id": self._active_window_id},
-            )
-            text = gws_out["data"] if isinstance(gws_out["data"], str) else ""
-            summary, tree = _split_tree_text(text)
+            structured_tree = None
 
-            # Parse element count from summary e.g. "✅ AppName — 42 elements, turn 3..."
-            m = re.search(r'(\d+)\s+elements?', summary)
-            if tree and not gws_out["images"]:
-                # ax mode — no screenshot
-                elements = _parse_elements_from_tree(tree)
-            elif gws_out["images"]:
-                png_b64 = gws_out["images"][0]
-                elements = _parse_elements_from_tree(tree)
+        text = gws_out["data"] if isinstance(gws_out["data"], str) else ""
+        summary, parsed_tree = _split_tree_text(text)
+        tree = structured_tree if isinstance(structured_tree, str) else parsed_tree
 
-            # Extract window title from the AX tree first AXWindow line.
-            wt = re.search(r'AXWindow\s+"([^"]+)"', tree)
-            if wt:
-                window_title = wt.group(1)
+        # Fallback: parse `size=460x816` from cua-driver text output when
+        # structuredContent is absent/older.
+        if not width or not height:
+            size_match = re.search(r'\bsize=(\d+)x(\d+)\b', summary)
+            if size_match:
+                width = int(size_match.group(1))
+                height = int(size_match.group(2))
+        if (not width or not height) and isinstance(target.get("bounds"), dict):
+            bounds = target.get("bounds") or {}
+            width = int(bounds.get("width") or width or 0)
+            height = int(bounds.get("height") or height or 0)
+
+        if mode != "vision" and tree:
+            elements = _parse_elements_from_tree(tree)
+        if gws_out["images"] and mode != "ax":
+            png_b64 = gws_out["images"][0]
+
+        # Extract window title from the AX tree first AXWindow line.
+        wt = re.search(r'AXWindow\s+"([^"]+)"', tree or "")
+        if wt:
+            window_title = wt.group(1)
 
         png_bytes_len = 0
         if png_b64:
@@ -640,14 +658,14 @@ class CuaDriverBackend(ComputerUseBackend):
         cua-driver background-automation never needs to bring a window to the
         front: capture(app=...) already selects the right window via
         list_windows. We implement focus_app as a pure window-selector —
-        enumerate on-screen windows, find the best match for *app*, and store
+        enumerate windows, find the best match for *app*, and store
         its pid/window_id so that subsequent click/type calls hit the right
         process.
 
         raise_window=True is intentionally ignored: stealing the user's focus
         is exactly what this backend is designed to avoid.
         """
-        lw_out = self._session.call_tool("list_windows", {"on_screen_only": True})
+        lw_out = self._session.call_tool("list_windows", {"on_screen_only": False})
         sc = lw_out.get("structuredContent") or {}
         raw_windows = sc.get("windows") if sc else None
         if raw_windows:

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -615,6 +615,7 @@ def _route_capture_through_aux_vision(
         # MIME sniffing returns the right content-type.
         ext = ".jpg" if cap.png_b64[:8].startswith("/9j/") else ".png"
         cache_dir = get_hermes_dir("cache/vision", "temp_vision_images")
+        cache_dir.mkdir(parents=True, exist_ok=True)
         temp_image_path = cache_dir / f"computer_use_{_uuid.uuid4().hex}{ext}"
         temp_image_path.write_bytes(raw)
 
@@ -650,6 +651,8 @@ def _route_capture_through_aux_vision(
         try:
             parsed = json.loads(result_json)
             if isinstance(parsed, dict):
+                if parsed.get("success") is False:
+                    return None
                 analysis_text = str(parsed.get("analysis") or "").strip()
         except (TypeError, json.JSONDecodeError):
             analysis_text = result_json.strip()


### PR DESCRIPTION
## Summary
- make the Cua computer-use backend enumerate all windows, then prefer on-screen candidates, so capture/focus still work when cua-driver marks a capturable app window off-screen or on another Space
- route `som`, `vision`, and `ax` captures through `get_window_state` with explicit `capture_mode`, and read dimensions/tree data from `structuredContent`
- create the aux-vision cache directory before writing captured screenshots, and ignore failed `vision_analyze` envelopes instead of treating their error text as valid analysis

## Bug fixed
`computer_use` with cua-driver could return `0x0` geometry, use the wrong screenshot path for `vision`, miss app-filtered windows, or fall back to multimodal screenshot output when aux vision routing failed because `$HERMES_HOME/cache/vision` did not exist. For text-only main models, that fallback caused the active provider to reject the tool result image.

## Verification
- `python -m pytest tests/tools/test_computer_use_capture_routing.py tests/tools/test_computer_use.py -q -o 'addopts='`
- local live smoke on macOS with Calculator:
  - `capture app="Calculator" mode="vision"` returned `width=460 height=816`, `vision_analysis_routed_via=auxiliary.vision`, no error
  - `capture app="Calculator" mode="som"` returned `width=460 height=816`, `vision_analysis_routed_via=auxiliary.vision`, no error
