### PR TITLE
fix(discord): surface skipped attachments into agent context

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4892,6 +4892,7 @@ class DiscordAdapter(BasePlatformAdapter):
         media_urls = []
         media_types = []
         pending_text_injection: Optional[str] = None
+        skipped_attachments: list[str] = []
         for att in all_attachments:
             content_type = att.content_type or "unknown"
             if content_type.startswith("image/"):
@@ -4938,12 +4939,22 @@ class DiscordAdapter(BasePlatformAdapter):
                         "[Discord] Unsupported document type '%s' (%s), skipping",
                         ext or "unknown", content_type,
                     )
+                    fname = att.filename or "unknown"
+                    skipped_attachments.append(
+                        fname + " (type not supported; set discord.allow_any_attachment: true to receive)"
+                    )
                 else:
                     max_doc_bytes = self._discord_max_attachment_bytes()
                     if max_doc_bytes and att.size and att.size > max_doc_bytes:
                         logger.warning(
                             "[Discord] Document too large (%s bytes > cap %s), skipping: %s",
                             att.size, max_doc_bytes, att.filename,
+                        )
+                        size_mb = att.size / (1024 * 1024)
+                        cap_mb = max_doc_bytes / (1024 * 1024)
+                        fname = att.filename or "unknown"
+                        skipped_attachments.append(
+                            f"{fname} ({size_mb:.1f} MiB > {cap_mb:.0f} MiB cap; increase discord.max_attachment_bytes to receive)"
                         )
                     else:
                         try:
@@ -5002,6 +5013,11 @@ class DiscordAdapter(BasePlatformAdapter):
         event_text = normalized_content
         if pending_text_injection:
             event_text = f"{pending_text_injection}\n\n{event_text}" if event_text else pending_text_injection
+        if skipped_attachments:
+            count = len(skipped_attachments)
+            details = "; ".join(skipped_attachments)
+            skip_note = f"[Discord skipped {count} attachment{'s' if count > 1 else ''}: {details}]"
+            event_text = f"{skip_note}\n\n{event_text}" if event_text else skip_note
 
         # ── History backfill ─────────────────────────────────────────
         # When require_mention is active, the bot only processes messages

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -529,3 +529,80 @@ class TestAllowAnyAttachment:
         adapter.config.extra["max_attachment_bytes"] = "not-a-number"
         assert adapter._discord_max_attachment_bytes() == 32 * 1024 * 1024
 
+    @pytest.mark.asyncio
+    async def test_unsupported_type_skip_injects_note(self, adapter):
+        """Unsupported attachment type injects a system note into event text."""
+        adapter._text_batch_delay_seconds = 0  # bypass text batching
+        # allow_any_attachment defaults to False → .xyz will be skipped
+        msg = make_message(
+            attachments=[make_attachment(filename="design.xyz", content_type="application/x-custom")],
+            content="look at this",
+        )
+        await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert "Discord skipped 1 attachment" in event.text
+        assert "design.xyz" in event.text
+        assert "type not supported" in event.text
+        assert "allow_any_attachment" in event.text
+
+    @pytest.mark.asyncio
+    async def test_oversized_skip_injects_note(self, adapter):
+        """Oversized attachment injects a system note with size info."""
+        adapter._text_batch_delay_seconds = 0  # bypass text batching
+        adapter.config.extra["allow_any_attachment"] = True
+        adapter.config.extra["max_attachment_bytes"] = 1024  # 1 KiB
+
+        msg = make_message(
+            attachments=[
+                make_attachment(
+                    filename="big_report.pdf",
+                    content_type="application/pdf",
+                    size=5 * 1024 * 1024,  # 5 MiB
+                )
+            ],
+            content="read this",
+        )
+        await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert "Discord skipped 1 attachment" in event.text
+        assert "big_report.pdf" in event.text
+        assert "5.0 MiB" in event.text
+        assert "max_attachment_bytes" in event.text
+
+    @pytest.mark.asyncio
+    async def test_multiple_skips_combine_into_one_note(self, adapter):
+        """Multiple skipped attachments appear in a single system note."""
+        adapter._text_batch_delay_seconds = 0  # bypass text batching
+        # Neither allow_any_attachment nor max_doc_bytes override → both skipped
+        msg = make_message(
+            attachments=[
+                make_attachment(filename="a.xyz", content_type="application/x-custom"),
+                make_attachment(filename="b.abc", content_type="application/x-unknown"),
+            ],
+            content="check these",
+        )
+        await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert "Discord skipped 2 attachments" in event.text
+        assert "a.xyz" in event.text
+        assert "b.abc" in event.text
+
+    @pytest.mark.asyncio
+    async def test_no_skip_means_no_note(self, adapter):
+        """When no attachments are skipped, no note is injected."""
+        adapter.config.extra["allow_any_attachment"] = True
+        adapter.config.extra["max_attachment_bytes"] = 0  # unlimited
+
+        with _mock_aiohttp_download(b"raw bytes"):
+            msg = make_message(
+                attachments=[make_attachment(filename="ok.pdf", content_type="application/pdf")],
+                content="normal message",
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert "Discord skipped" not in event.text
+


### PR DESCRIPTION
## Problem

When the Discord adapter skips an inbound attachment — either because it exceeds `max_attachment_bytes` (default 32 MiB) or because the type is not in `SUPPORTED_DOCUMENT_TYPES` and `allow_any_attachment` is false — the skip is logged at WARNING level but **the agent itself is never told**. The agent sees the user's text message with no attachments and has no way to know the user tried to send something.

Real-world hit: user sent a ~50 MiB Perplexity-walkthrough mp4 expecting the agent to "see" it. Adapter silently dropped it past the 32 MiB cap. Agent had no signal and offered increasingly off-target suggestions.

## Solution

When an attachment is skipped, inject a small system note into the message text the agent receives:

**Unsupported type:**
```
[Discord skipped 1 attachment: design.xyz (type not supported; set discord.allow_any_attachment: true to receive)]
```

**Too large:**
```
[Discord skipped 1 attachment: big_report.pdf (5.0 MiB > 32 MiB cap; increase discord.max_attachment_bytes to receive)]
```

Multiple skipped attachments are combined into a single note with count:
```
[Discord skipped 2 attachments: a.xyz (type not supported; ...); b.abc (type not supported; ...)]
```

## Changes

- `plugins/platforms/discord/adapter.py` — collect skipped attachment info during the attachment loop, inject system note into `event_text` after the loop
- `tests/gateway/test_discord_document_handling.py` — 4 new tests covering unsupported type, oversized, multiple skips, and no-skip passthrough

## Testing

All 24 tests in `test_discord_document_handling.py` pass (20 existing + 4 new).

Fixes #42147
