### PR TITLE
fix: prevent duplicate user message writes in state.db

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8929,6 +8929,7 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                 self.session_store.append_to_transcript(
                     session_entry.session_id,
                     _user_entry,
+                    skip_db=self._session_db is not None,
                 )
             else:
                 history_len = agent_result.get("history_offset", len(history))
@@ -8936,17 +8937,20 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
 
                 # If no new messages found (edge case), fall back to simple user/assistant
                 if not new_messages:
+                    _agent_persisted = self._session_db is not None
                     _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
                     if event.message_id:
                         _user_entry["message_id"] = str(event.message_id)
                     self.session_store.append_to_transcript(
                         session_entry.session_id,
                         _user_entry,
+                        skip_db=_agent_persisted,
                     )
                     if response:
                         self.session_store.append_to_transcript(
                             session_entry.session_id,
-                            {"role": "assistant", "content": response, "timestamp": ts}
+                            {"role": "assistant", "content": response, "timestamp": ts},
+                            skip_db=_agent_persisted,
                         )
                 else:
                     # The agent already persisted these messages to SQLite via


### PR DESCRIPTION
## Problem

Two fallback paths in `_handle_message_with_agent` wrote user messages to the session store **without `skip_db`**, causing the agent's `_flush_messages_to_session_db` write and the gateway's `append_to_transcript` write to both land in `state.db`.

This results in duplicate user messages being stored in the database.

## Solution

Added `skip_db=self._session_db is not None` to both fallback paths, matching the existing guard on the normal code path (line 8879).

### Changes

**File: `gateway/run.py`** (+5/-1)

1. **First fallback path** (agent_failed_early, line 8929):
   - Added `skip_db=self._session_db is not None` to `append_to_transcript` call

2. **Second fallback path** (not-new-messages, line 8937):
   - Added `_agent_persisted = self._session_db is not None` variable
   - Added `skip_db=_agent_persisted` to both user and assistant `append_to_transcript` calls

## Testing

This fix prevents duplicate user messages from being written to `state.db` when:
- The agent fails early (agent_failed_early path)
- No new messages are found (not-new-messages edge case)

The fix ensures that when the agent has already persisted messages to SQLite via `_flush_messages_to_session_db()`, the gateway skips its own DB write to avoid duplicates.

## Related Issues

Fixes #42039

## Notes

This PR is a clean extraction of only the duplicate-message-prevention fix. It contains **only** `gateway/run.py` changes (5 insertions, 1 deletion). No other files are modified.

This replaces PR #42157 which incorrectly included unrelated changes from the fork.