### PR TITLE
fix(error-classifier): treat proxy 403 "reset after N" as transient throttle

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3199,6 +3199,18 @@ def run_conversation(
                                 _retry_after = min(float(_ra_raw), 120)  # Cap at 2 minutes
                             except (TypeError, ValueError):
                                 pass
+                    # Some proxies omit the Retry-After header and embed the
+                    # delay in the body instead (e.g. "(reset after 2m)"). The
+                    # classifier parses that into retry_after_seconds; honor it
+                    # when no header was found so a soft-throttle 403/429 waits
+                    # the advertised window instead of a too-short backoff.
+                    if _retry_after is None:
+                        _classified_ra = getattr(classified, "retry_after_seconds", None)
+                        if _classified_ra:
+                            try:
+                                _retry_after = min(float(_classified_ra), 120)
+                            except (TypeError, ValueError):
+                                pass
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 if is_rate_limited:
                     agent._buffer_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -84,6 +85,12 @@ class ClassifiedError:
     should_rotate_credential: bool = False
     should_fallback: bool = False
 
+    # Optional explicit retry delay (seconds) parsed from the error body, e.g.
+    # a proxy soft-throttle that embeds "(reset after 2m)" in its message
+    # rather than sending a standard HTTP Retry-After header. The retry loop
+    # prefers this over exponential backoff when present.
+    retry_after_seconds: Optional[float] = None
+
     @property
     def is_auth(self) -> bool:
         return self.reason in {FailoverReason.auth, FailoverReason.auth_permanent}
@@ -152,6 +159,50 @@ _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "periodic",
     "window",
 ]
+
+# Matches an embedded retry-delay hint some proxies put in the error BODY
+# instead of a standard HTTP Retry-After header, e.g. "(reset after 2m)",
+# "reset after 30s", "reset after 1h". Capture group 1 = magnitude, 2 = unit.
+_RESET_AFTER_RE = re.compile(
+    r"reset\s+after\s+(\d+(?:\.\d+)?)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\b",
+    re.IGNORECASE,
+)
+
+# Cap parsed delays so a hostile/buggy proxy advertising "reset after 99h"
+# can't wedge the retry loop. Mirrors the 120s cap already used for the
+# HTTP Retry-After header path in conversation_loop.py.
+_RESET_AFTER_MAX_SECONDS = 120.0
+
+
+def _parse_reset_after(error_msg: str) -> Optional[float]:
+    """Return the embedded "reset after N<unit>" delay in seconds, or None.
+
+    Proxies (e.g. local model routers) sometimes signal a soft throttle as an
+    HTTP 403/429 whose body says "(reset after 2m)" rather than sending a
+    standard ``Retry-After`` header. Surfacing that delay lets the retry loop
+    wait the advertised window instead of aborting or using a too-short
+    exponential backoff. The result is capped at ``_RESET_AFTER_MAX_SECONDS``.
+    """
+    if not error_msg:
+        return None
+    match = _RESET_AFTER_RE.search(error_msg)
+    if not match:
+        return None
+    try:
+        magnitude = float(match.group(1))
+    except (TypeError, ValueError):
+        return None
+    unit = match.group(2).lower()
+    if unit.startswith("h"):
+        seconds = magnitude * 3600.0
+    elif unit.startswith("m") and unit != "s":
+        # "m", "min", "mins", "minute", "minutes" — but NOT "s" units.
+        seconds = magnitude * 60.0
+    else:
+        seconds = magnitude
+    if seconds <= 0:
+        return None
+    return min(seconds, _RESET_AFTER_MAX_SECONDS)
 
 # Payload-too-large patterns detected from message text (no status_code attr).
 # Proxies and some backends embed the HTTP status in the error message.
@@ -766,6 +817,19 @@ def _classify_by_status(
                 retryable=False,
                 should_rotate_credential=True,
                 should_fallback=True,
+            )
+        # Some proxies (e.g. local model routers fronting Claude/Kiro) signal a
+        # SOFT THROTTLE as HTTP 403 with an embedded "(reset after Nm)" hint in
+        # the body, not a real credential rejection. Treat that as a transient
+        # rate limit so the retry loop waits the advertised window instead of
+        # aborting as a permanent auth failure. Real auth 403s (no reset hint)
+        # still fall through to the abort path below.
+        _reset_after = _parse_reset_after(error_msg)
+        if _reset_after is not None:
+            return result_fn(
+                FailoverReason.rate_limit,
+                retryable=True,
+                retry_after_seconds=_reset_after,
             )
         return result_fn(
             FailoverReason.auth,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1567,3 +1567,84 @@ class TestMultimodalToolContentUnsupported:
         e = MockAPIError("bad request: missing field 'model'", status_code=400)
         result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
         assert result.reason != FailoverReason.multimodal_tool_content_unsupported
+
+
+class TestResetAfterThrottle403:
+    """403 soft-throttles that embed a "(reset after N)" body hint.
+
+    Some proxies (e.g. a local model router fronting Claude/Kiro) signal a
+    transient throttle as HTTP 403 with the delay in the body text rather
+    than a real credential rejection or a standard Retry-After header.
+    These must be classified as retryable rate_limit, NOT permanent auth.
+    Regression for the desktop.log abort: provider=custom:9router-proxy,
+    "HTTP 403 (reset after 2m)" was aborting the session.
+    """
+
+    def test_403_reset_after_minutes_is_retryable_rate_limit(self):
+        e = MockAPIError(
+            "[kiro/claude-opus-4.8-thinking-agentic] [403]: HTTP 403 (reset after 2m)",
+            status_code=403,
+        )
+        result = classify_api_error(
+            e, provider="custom:9router-proxy", model="kr/claude-opus-4.8-thinking-agentic"
+        )
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+        assert result.retry_after_seconds == 120.0
+
+    def test_403_reset_after_seconds(self):
+        e = MockAPIError("HTTP 403 (reset after 30s)", status_code=403)
+        result = classify_api_error(e, provider="custom", model="m")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retry_after_seconds == 30.0
+
+    def test_403_reset_after_hours_is_capped(self):
+        e = MockAPIError("HTTP 403 (reset after 1h)", status_code=403)
+        result = classify_api_error(e, provider="custom", model="m")
+        assert result.reason == FailoverReason.rate_limit
+        # Capped at 120s so a hostile/buggy proxy can't wedge the retry loop.
+        assert result.retry_after_seconds == 120.0
+
+    def test_403_billing_still_wins_over_reset_hint(self):
+        """A 403 that is genuinely billing must NOT be downgraded to a
+        transient throttle even if a reset hint is also present."""
+        e = MockAPIError(
+            "403 insufficient credits (reset after 2m)", status_code=403
+        )
+        result = classify_api_error(e, provider="openrouter", model="m")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+    def test_403_real_auth_without_reset_hint_still_aborts(self):
+        """A real credential-rejection 403 (no reset hint) must remain a
+        non-retryable auth failure so the session fails fast with guidance."""
+        e = MockAPIError("403 Forbidden: invalid api key", status_code=403)
+        result = classify_api_error(e, provider="custom", model="m")
+        assert result.reason == FailoverReason.auth
+        assert result.retryable is False
+        assert result.retry_after_seconds is None
+
+
+class TestParseResetAfter:
+    """Unit coverage for the _parse_reset_after body-hint parser."""
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("HTTP 403 (reset after 2m)", 120.0),
+            ("reset after 30s", 30.0),
+            ("reset after 45 seconds", 45.0),
+            ("reset after 2 minutes", 120.0),
+            ("reset after 1h", 120.0),  # capped
+            ("reset after 90s", 90.0),
+            ("RESET AFTER 10S", 10.0),  # case-insensitive
+            ("no hint here", None),
+            ("reset after 0s", None),  # non-positive ignored
+            ("reset after soon", None),  # non-numeric ignored
+            ("", None),
+        ],
+    )
+    def test_parse_reset_after(self, text, expected):
+        from agent.error_classifier import _parse_reset_after
+        assert _parse_reset_after(text) == expected
+

--- a/tests/run_agent/test_proxy_403_throttle_retry.py
+++ b/tests/run_agent/test_proxy_403_throttle_retry.py
@@ -1,0 +1,121 @@
+"""Regression guard for the proxy 403-throttle retry-delay wiring.
+
+Background (desktop.log abort):
+A local model router proxy (provider ``custom:9router-proxy`` at
+localhost:20128) signalled a SOFT THROTTLE as ``HTTP 403 (reset after 2m)``
+with the delay embedded in the body — NOT a standard HTTP Retry-After header
+and NOT a real credential rejection. The error classifier now maps that to a
+retryable ``rate_limit`` carrying ``retry_after_seconds`` (see CHANGE 1 in
+``agent/error_classifier.py`` + tests/agent/test_error_classifier.py).
+
+This file guards CHANGE 2: ``agent/conversation_loop.py`` must prefer the
+classifier's body-parsed ``retry_after_seconds`` when no Retry-After *header*
+is present, so the backoff waits the advertised window instead of a too-short
+exponential delay (3 attempts × max 60s never spans a 120s window).
+
+We mirror the exact ``_retry_after`` resolution snippet from the loop, in the
+same spirit as tests/run_agent/test_31273_402_not_retried.py (which mirrors the
+``is_client_error`` predicate). If you change one, change both.
+"""
+from __future__ import annotations
+
+from agent.error_classifier import ClassifiedError, FailoverReason
+
+
+def _resolve_retry_after(*, header_value, classified):
+    """Exact shape of conversation_loop.py's _retry_after resolution.
+
+    is_rate_limited is assumed True here (the only branch that reads it).
+    Returns the resolved wait override in seconds, or None to use backoff.
+    """
+    _retry_after = None
+    # Header path (pre-existing behavior).
+    if header_value is not None:
+        try:
+            _retry_after = min(float(header_value), 120)
+        except (TypeError, ValueError):
+            pass
+    # Body-parsed path (CHANGE 2).
+    if _retry_after is None:
+        _classified_ra = getattr(classified, "retry_after_seconds", None)
+        if _classified_ra:
+            try:
+                _retry_after = min(float(_classified_ra), 120)
+            except (TypeError, ValueError):
+                pass
+    return _retry_after
+
+
+class TestRetryAfterResolution:
+    def _throttle_403(self, seconds):
+        return ClassifiedError(
+            reason=FailoverReason.rate_limit,
+            status_code=403,
+            retryable=True,
+            retry_after_seconds=seconds,
+        )
+
+    def test_body_delay_used_when_no_header(self):
+        """The desktop.log case: no Retry-After header, body says 2m."""
+        classified = self._throttle_403(120.0)
+        assert _resolve_retry_after(header_value=None, classified=classified) == 120.0
+
+    def test_header_takes_precedence_over_body(self):
+        """A real Retry-After header still wins (pre-existing behavior)."""
+        classified = self._throttle_403(120.0)
+        assert _resolve_retry_after(header_value="7", classified=classified) == 7.0
+
+    def test_body_delay_capped_at_120(self):
+        classified = self._throttle_403(600.0)
+        assert _resolve_retry_after(header_value=None, classified=classified) == 120.0
+
+    def test_no_header_no_body_falls_through_to_backoff(self):
+        """No header and no classified delay → None → loop uses jittered backoff."""
+        classified = ClassifiedError(
+            reason=FailoverReason.rate_limit, status_code=429, retryable=True
+        )
+        assert _resolve_retry_after(header_value=None, classified=classified) is None
+
+    def test_garbage_header_falls_back_to_body(self):
+        classified = self._throttle_403(30.0)
+        assert _resolve_retry_after(header_value="not-a-number", classified=classified) == 30.0
+
+
+class TestThrottle403StaysRetryable:
+    """The classified throttle 403 must NOT hit the client-error abort path.
+
+    Mirrors the is_client_error predicate from conversation_loop.py — a
+    rate_limit reason is explicitly excluded, so the loop retries instead of
+    aborting (which is what happened before CHANGE 1).
+    """
+
+    def _is_client_error(self, classified):
+        return (
+            not classified.retryable
+            and not classified.should_compress
+            and classified.reason not in {
+                FailoverReason.rate_limit,
+                FailoverReason.overloaded,
+                FailoverReason.context_overflow,
+                FailoverReason.payload_too_large,
+                FailoverReason.long_context_tier,
+                FailoverReason.thinking_signature,
+            }
+        )
+
+    def test_throttle_403_does_not_abort(self):
+        classified = ClassifiedError(
+            reason=FailoverReason.rate_limit,
+            status_code=403,
+            retryable=True,
+            retry_after_seconds=120.0,
+        )
+        assert not self._is_client_error(classified)
+
+    def test_real_auth_403_still_aborts(self):
+        classified = ClassifiedError(
+            reason=FailoverReason.auth,
+            status_code=403,
+            retryable=False,
+        )
+        assert self._is_client_error(classified)


### PR DESCRIPTION
## What does this PR do?

When the main model is served through a local/self-hosted proxy that fronts
upstream models (e.g. `custom:9router-proxy` at `http://localhost:20128/v1`
fronting `kr/claude-opus-4.8-thinking-agentic`), the proxy signals a **soft
throttle** as an HTTP 403 with the delay embedded in the body
(`HTTP 403 (reset after 2m)`), not a standard `Retry-After` header and not a
real credential rejection.

`agent/error_classifier.py` previously mapped every non-billing 403 to a
permanent `FailoverReason.auth` (`retryable=False`). In
`agent/conversation_loop.py` that becomes a non-retryable client error: it
tries the fallback chain, and with no fallback configured
(`fallback_providers: []`) it **aborts the session** — printing the misleading
"Your API key was rejected... run hermes setup" even though the key is valid.
The sibling 429 path on the same proxy retries and recovers, proving only the
403 classification is wrong.

This PR makes a 403/429 carrying an explicit `reset after N<unit>` body hint a
**transient rate limit** that the existing retry loop waits out. The approach
keys on the error *shape* (an advertised reset window) rather than the provider
name, so it is provider-agnostic and avoids adding yet another bespoke
per-provider refresh branch to the loop. Billing precedence is preserved and a
real credential-rejection 403 (no reset hint) still aborts fast with guidance.

## Related Issue

Fixes #42167

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/error_classifier.py`
  - Added `import re`.
  - Added `_RESET_AFTER_RE`, `_RESET_AFTER_MAX_SECONDS` (120s cap), and the
    `_parse_reset_after()` helper that parses `reset after N(s|m|h)` from the
    error body into capped seconds.
  - Added optional `ClassifiedError.retry_after_seconds` field.
  - In the `status_code == 403` branch, after the existing billing check, a 403
    carrying a reset hint is now classified as
    `FailoverReason.rate_limit, retryable=True, retry_after_seconds=<parsed>`.
- `agent/conversation_loop.py`
  - In the rate-limit retry path, when no `Retry-After` *header* is present,
    fall back to the classifier's body-parsed `retry_after_seconds` (capped at
    120s) so the backoff waits the advertised window.
- `tests/agent/test_error_classifier.py`
  - `TestResetAfterThrottle403` (throttle vs billing vs real-auth 403) and
    `TestParseResetAfter` (parser unit cases).
- `tests/run_agent/test_proxy_403_throttle_retry.py` (new)
  - Retry-delay resolution precedence (header > body > backoff) and a guard
    that the throttle-403 stays out of the `is_client_error` abort path.

## How to Test

1. Run the targeted tests:
   `pytest tests/agent/test_error_classifier.py tests/run_agent/test_proxy_403_throttle_retry.py -q`
   (16 new classifier cases + the new retry-wiring file; all pass.)
2. Regression sweep of adjacent auth/retry paths:
   `pytest tests/agent/test_error_classifier.py tests/run_agent/test_proxy_403_throttle_retry.py tests/run_agent/test_codex_xai_oauth_recovery.py tests/run_agent/test_31273_402_not_retried.py tests/agent/test_auxiliary_client_xai_oauth_recovery.py -q`
   → 241 passed.
3. Manual reproduction: point `model.base_url` at a proxy that returns
   `HTTP 403 (reset after Ns)` and confirm the session retries and recovers
   instead of aborting; confirm a real bad-key 403 (no reset hint) still aborts
   fast; confirm 429 still recovers.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass <!-- ran the affected suites: 241 passed -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux 6.17.0-35-generic), Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- code is self-documenting via docstrings/comments; no user-facing docs affected -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python regex/classification, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool behavior changed)

## Screenshots / Logs

Before (session aborts on the first throttle):

```
❌ Non-retryable client error (HTTP 403). Aborting.
   🔌 Provider: custom:9router-proxy  Model: kr/claude-opus-4.8-thinking-agentic
   💡 Your API key was rejected by the provider. Check:
         • Is the key valid? Run: hermes setup
```

After (classified as transient, waits the advertised window and retries):

```
$ pytest tests/agent/test_error_classifier.py::TestResetAfterThrottle403 -q
.....                                                                    [100%]
# 403 (reset after 2m) -> FailoverReason.rate_limit, retryable=True, retry_after_seconds=120.0
```