### PR TITLE
fix(desktop): require session ids for scoped gateway events

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -14,6 +14,7 @@ import {
   upsertToolPart
 } from '@/lib/chat-messages'
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
+import { gatewayEventRequiresSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { setClarifyRequest } from '@/store/clarify'
@@ -613,6 +614,9 @@ export function useMessageStream({
     (event: RpcEvent) => {
       const payload = event.payload as GatewayEventPayload | undefined
       const explicitSid = event.session_id || ''
+      if (!explicitSid && gatewayEventRequiresSessionId(event.type)) {
+        return
+      }
       const sessionId = explicitSid || activeSessionIdRef.current
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
 

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -13,6 +13,7 @@ describe('gateway event routing', () => {
   it('allows global events to remain unscoped', () => {
     expect(gatewayEventRequiresSessionId('gateway.ready')).toBe(false)
     expect(gatewayEventRequiresSessionId('preview.restart.progress')).toBe(false)
+    expect(gatewayEventRequiresSessionId('session.info')).toBe(false)
     expect(gatewayEventRequiresSessionId(undefined)).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { gatewayEventRequiresSessionId } from './gateway-events'
+
+describe('gateway event routing', () => {
+  it('requires explicit session ids for async session-scoped events', () => {
+    expect(gatewayEventRequiresSessionId('message.delta')).toBe(true)
+    expect(gatewayEventRequiresSessionId('tool.start')).toBe(true)
+    expect(gatewayEventRequiresSessionId('subagent.progress')).toBe(true)
+    expect(gatewayEventRequiresSessionId('approval.request')).toBe(true)
+  })
+
+  it('allows global events to remain unscoped', () => {
+    expect(gatewayEventRequiresSessionId('gateway.ready')).toBe(false)
+    expect(gatewayEventRequiresSessionId('preview.restart.progress')).toBe(false)
+    expect(gatewayEventRequiresSessionId(undefined)).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -17,7 +17,6 @@ const SESSION_SCOPED_EVENT_TYPES = new Set([
   'reasoning.available',
   'reasoning.delta',
   'secret.request',
-  'session.info',
   'status.update',
   'subagent.complete',
   'subagent.progress',

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -7,8 +7,38 @@ interface RpcEventLike {
   type?: string
 }
 
+const SESSION_SCOPED_EVENT_TYPES = new Set([
+  'approval.request',
+  'clarify.request',
+  'error',
+  'message.complete',
+  'message.delta',
+  'message.start',
+  'reasoning.available',
+  'reasoning.delta',
+  'secret.request',
+  'session.info',
+  'status.update',
+  'subagent.complete',
+  'subagent.progress',
+  'subagent.spawn_requested',
+  'subagent.start',
+  'subagent.thinking',
+  'subagent.tool',
+  'sudo.request',
+  'thinking.delta'
+])
+
 function asRecord(payload: unknown): Record<string, unknown> {
   return payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {}
+}
+
+export function gatewayEventRequiresSessionId(eventType: string | undefined): boolean {
+  if (!eventType) {
+    return false
+  }
+
+  return SESSION_SCOPED_EVENT_TYPES.has(eventType) || eventType.startsWith('tool.')
 }
 
 export function gatewayEventCompletedFileDiff(event: RpcEventLike): boolean {


### PR DESCRIPTION
## Summary
- Drop desktop gateway events that mutate session-scoped UI when they arrive without an explicit `session_id`.
- Cover the routing guard for message, tool, subagent, and prompt events while preserving global events.

## Test plan
- `npm run test:ui -- gateway-events.test.ts`
- `npm run type-check`


## Infographic

![session-scope-guard](https://v3b.fal.media/files/b/0a9d7eb9/8J_g4YBIo2a-9hxktUnn9_efD7DsCh.png)
