### PR TITLE
fix(goals): surface auxiliary client auth failures

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1299,6 +1299,78 @@ def _nous_base_url() -> str:
     return os.getenv("NOUS_INFERENCE_BASE_URL", _NOUS_DEFAULT_BASE_URL)
 
 
+_LAST_NOUS_RUNTIME_FAILURE: Optional[str] = None
+_WARNED_NOUS_RUNTIME_FAILURES: set[str] = set()
+
+
+def _format_nous_runtime_failure(exc: Exception) -> str:
+    """Return an actionable, user-safe description of a Nous auth failure."""
+    try:
+        from hermes_cli.auth import format_auth_error
+
+        message = format_auth_error(exc)
+    except Exception:
+        message = str(exc)
+    code = getattr(exc, "code", None)
+    if code and str(code) not in message:
+        message = f"{message} (code: {code})"
+    return message.strip() or type(exc).__name__
+
+
+def _record_nous_runtime_failure(exc: Exception) -> None:
+    global _LAST_NOUS_RUNTIME_FAILURE
+    _LAST_NOUS_RUNTIME_FAILURE = _format_nous_runtime_failure(exc)
+
+
+def _clear_nous_runtime_failure() -> None:
+    global _LAST_NOUS_RUNTIME_FAILURE
+    _LAST_NOUS_RUNTIME_FAILURE = None
+
+
+def _warn_nous_runtime_failure_once(reason: str) -> None:
+    key = reason[:240]
+    if key in _WARNED_NOUS_RUNTIME_FAILURES:
+        return
+    _WARNED_NOUS_RUNTIME_FAILURES.add(key)
+    logger.warning(
+        "Auxiliary Nous client unavailable: runtime credential resolution failed: %s",
+        reason,
+    )
+
+
+def _describe_nous_unavailable() -> str:
+    """Explain why a Nous auxiliary client could not be created."""
+    if _LAST_NOUS_RUNTIME_FAILURE:
+        return f"Nous Portal runtime credentials unavailable: {_LAST_NOUS_RUNTIME_FAILURE}"
+    if not _read_nous_auth():
+        return "Nous Portal authentication not found (run: hermes auth add nous)"
+    return (
+        "Nous Portal authentication is present but no usable inference JWT was found "
+        "(run: hermes auth add nous)"
+    )
+
+
+def describe_auxiliary_client_unavailable(task: str = "") -> str:
+    """Return an actionable reason for the latest auxiliary-client miss.
+
+    This is used by callers such as the goal judge when
+    ``get_text_auxiliary_client(task)`` returns ``(None, None)``. Keep this
+    read-only: it must not retry auth or create clients, because it runs on an
+    error-reporting path after the resolver has already failed.
+    """
+    try:
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(task or "")
+        provider = _normalize_aux_provider(provider)
+    except Exception:
+        provider = ""
+    prefix = f"{task} auxiliary client unavailable" if task else "Auxiliary client unavailable"
+    if provider == "nous":
+        return f"{prefix}: {_describe_nous_unavailable()}"
+    if provider:
+        return f"{prefix}: provider '{provider}' is unavailable or not configured"
+    return f"{prefix}: no auxiliary provider configured"
+
+
 def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[str, str]]:
     """Return fresh Nous runtime credentials when available.
 
@@ -1315,13 +1387,18 @@ def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[
             force_refresh=force_refresh,
         )
     except Exception as exc:
+        _record_nous_runtime_failure(exc)
         logger.debug("Auxiliary Nous runtime credential resolution failed: %s", exc)
         return None
 
     api_key = str(creds.get("api_key") or "").strip()
     base_url = str(creds.get("base_url") or "").strip().rstrip("/")
     if not api_key or not base_url:
+        _record_nous_runtime_failure(
+            RuntimeError("resolved credentials were missing api_key or base_url")
+        )
         return None
+    _clear_nous_runtime_failure()
     return api_key, base_url
 
 
@@ -1602,6 +1679,8 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
         _mark_provider_unhealthy("nous", ttl=60)
         return None, None
     if runtime is None and nous:
+        reason = _describe_nous_unavailable()
+        _warn_nous_runtime_failure_once(reason)
         logger.debug(
             "Auxiliary Nous: runtime JWT refresh failed; checking stored "
             "auth.json token."
@@ -3502,8 +3581,10 @@ def resolve_provider_client(
         )
         client, default = _try_nous(vision=_is_vision)
         if client is None:
-            logger.warning("resolve_provider_client: nous requested "
-                           "but Nous Portal not configured (run: hermes auth)")
+            logger.warning(
+                "resolve_provider_client: nous requested but %s",
+                _describe_nous_unavailable(),
+            )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -402,7 +402,11 @@ def judge_goal(
         return "continue", "empty response (nothing to evaluate)", False
 
     try:
-        from agent.auxiliary_client import get_auxiliary_extra_body, get_text_auxiliary_client
+        from agent.auxiliary_client import (
+            describe_auxiliary_client_unavailable,
+            get_auxiliary_extra_body,
+            get_text_auxiliary_client,
+        )
     except Exception as exc:
         logger.debug("goal judge: auxiliary client import failed: %s", exc)
         return "continue", "auxiliary client unavailable", False
@@ -414,7 +418,12 @@ def judge_goal(
         return "continue", "auxiliary client unavailable", False
 
     if client is None or not model:
-        return "continue", "no auxiliary client configured", False
+        try:
+            reason = describe_auxiliary_client_unavailable("goal_judge")
+        except Exception as exc:
+            logger.debug("goal judge: unavailable-reason formatting failed: %s", exc)
+            reason = "goal_judge auxiliary client unavailable: no auxiliary client configured"
+        return "continue", reason, False
 
     # Build the prompt — pick the with-subgoals variant when applicable.
     clean_subgoals = [s.strip() for s in (subgoals or []) if s and s.strip()]

--- a/tests/agent/test_auxiliary_client_nous_unavailable_reason.py
+++ b/tests/agent/test_auxiliary_client_nous_unavailable_reason.py
@@ -1,0 +1,95 @@
+"""Regression tests for actionable auxiliary-client auth diagnostics.
+
+The goal loop used to show only "no auxiliary client configured" when
+``get_text_auxiliary_client("goal_judge")`` returned ``(None, None)``. For
+Nous-backed auxiliary tasks that can happen when the stored OAuth refresh token
+is invalid/expired: the resolver swallowed the real AuthError at debug level,
+so operators were sent chasing config/model issues instead of re-authing.
+"""
+from __future__ import annotations
+
+import logging
+
+
+def test_nous_runtime_auth_failure_is_recorded_and_described(monkeypatch):
+    from agent import auxiliary_client as aux
+    from hermes_cli.auth import AuthError
+
+    # Keep this test hermetic and deterministic.
+    aux._clear_nous_runtime_failure()
+    aux._WARNED_NOUS_RUNTIME_FAILURES.clear()
+    monkeypatch.setattr(
+        aux,
+        "_resolve_task_provider_model",
+        lambda task=None, provider=None, model=None, base_url=None, api_key=None: (
+            "nous",
+            "deepseek/deepseek-v4-pro",
+            "",
+            "",
+            "",
+        ),
+    )
+    monkeypatch.setattr(aux, "_read_nous_auth", lambda: {"access_token": "stale"})
+
+    def _raise_invalid_grant(*args, **kwargs):
+        raise AuthError(
+            "Invalid refresh token",
+            provider="nous",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_nous_runtime_credentials",
+        _raise_invalid_grant,
+    )
+
+    assert aux._resolve_nous_runtime_api(force_refresh=False) is None
+
+    reason = aux.describe_auxiliary_client_unavailable("goal_judge")
+    assert "goal_judge auxiliary client unavailable" in reason
+    assert "Nous Portal runtime credentials unavailable" in reason
+    assert "Invalid refresh token" in reason
+    assert "invalid_grant" in reason
+    assert "hermes model" in reason
+    assert reason != "no auxiliary client configured"
+
+
+def test_try_nous_warns_once_with_recorded_runtime_failure(monkeypatch, caplog):
+    from agent import auxiliary_client as aux
+    from hermes_cli.auth import AuthError
+
+    aux._clear_nous_runtime_failure()
+    aux._WARNED_NOUS_RUNTIME_FAILURES.clear()
+    monkeypatch.setattr(aux, "_read_nous_auth", lambda: {"access_token": "stale"})
+    monkeypatch.setattr(aux, "_nous_api_key", lambda provider: "")
+    monkeypatch.setattr(
+        "hermes_cli.models.get_nous_recommended_aux_model",
+        lambda vision=False: "qwen/qwen3.6-flash",
+    )
+
+    def _raise_invalid_grant(*args, **kwargs):
+        raise AuthError(
+            "Invalid refresh token",
+            provider="nous",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_nous_runtime_credentials",
+        _raise_invalid_grant,
+    )
+
+    caplog.set_level(logging.WARNING, logger="agent.auxiliary_client")
+    assert aux._try_nous() == (None, None)
+    assert aux._try_nous() == (None, None)
+
+    messages = [record.getMessage() for record in caplog.records]
+    runtime_messages = [
+        msg for msg in messages
+        if "runtime credential resolution failed" in msg
+    ]
+    assert len(runtime_messages) == 1
+    assert "Invalid refresh token" in runtime_messages[0]
+    assert "invalid_grant" in runtime_messages[0]

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -123,6 +123,34 @@ class TestJudgeGoal:
             verdict, _, _ = goals.judge_goal("my goal", "my response")
         assert verdict == "continue"
 
+    def test_no_aux_client_reports_actionable_reason(self):
+        """Goal judge must surface why the aux client is unavailable.
+
+        Regression for the opaque "no auxiliary client configured" status:
+        when Nous auth is broken, users need the auth remediation, not a
+        generic config message.
+        """
+        from hermes_cli import goals
+
+        detailed_reason = (
+            "goal_judge auxiliary client unavailable: Nous Portal runtime "
+            "credentials unavailable: Invalid refresh token. Run `hermes model` "
+            "to re-authenticate."
+        )
+        with patch(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client.describe_auxiliary_client_unavailable",
+            return_value=detailed_reason,
+        ):
+            verdict, reason, parse_failed = goals.judge_goal("my goal", "my response")
+
+        assert verdict == "continue"
+        assert reason == detailed_reason
+        assert parse_failed is False
+        assert reason != "no auxiliary client configured"
+
     def test_api_error_continues(self):
         """Judge exception → fail-open continue (don't wedge progress on judge bugs)."""
         from hermes_cli import goals


### PR DESCRIPTION
## What does this PR do?

When the goal loop cannot create the auxiliary `goal_judge` client, Hermes used
to return the opaque status reason:

```
no auxiliary client configured
```

For Nous-backed auxiliary tasks this hid the real cause. In the observed case,
Nous runtime credential resolution failed because the stored OAuth refresh token
was invalid/expired (`invalid_grant`, `Invalid refresh token`). The lower-level
resolver logged the failure only at debug level and returned `(None, None)`, so
`hermes_cli/goals.py` collapsed it into a generic configuration-looking message.
Users saw:

```
↻ Continuing toward goal (19/20): no auxiliary client configured
```

This PR preserves and surfaces the real auxiliary-client failure reason:

- `agent/auxiliary_client.py` records the latest Nous runtime credential failure,
  formats it with existing `hermes_cli.auth.format_auth_error`, and exposes a
  read-only `describe_auxiliary_client_unavailable(task)` helper for callers.
- `hermes_cli/goals.py` uses that helper when the goal judge receives
  `(None, None)`, so the goal loop still fails open (`continue`,
  `parse_failed=False`) but now shows actionable remediation instead of the
  opaque generic message.
- The Nous runtime credential failure is emitted as a one-shot warning, so users
  can diagnose the auth problem without debug logs.

This keeps the existing fail-open behavior while making the failure truthful and
operator-actionable.

## Related Issue

Fixes #42177

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`
  - Added storage for the latest Nous runtime credential failure.
  - Added `_format_nous_runtime_failure()`, `_record_nous_runtime_failure()`,
    `_clear_nous_runtime_failure()`, `_warn_nous_runtime_failure_once()`, and
    `_describe_nous_unavailable()` helpers.
  - Added public read-only helper `describe_auxiliary_client_unavailable(task)`.
  - `_resolve_nous_runtime_api()` now records failures instead of dropping them
    behind debug-only logging, and clears the stored failure after a successful
    credential resolution.
  - `_try_nous()` now emits a one-shot warning when runtime credential
    resolution fails while Nous auth is present.
  - The explicit Nous provider branch now logs the actionable unavailable reason
    instead of the generic "Nous Portal not configured" message.
- `hermes_cli/goals.py`
  - `judge_goal()` now returns the actionable auxiliary-client unavailable
    reason when the goal judge client/model resolves to `(None, None)`.
  - Preserves fail-open behavior: verdict remains `continue`, and
    `parse_failed=False`.
- `tests/hermes_cli/test_goals.py`
  - Added regression coverage that a missing goal-judge auxiliary client returns
    the detailed reason instead of `no auxiliary client configured`.
- `tests/agent/test_auxiliary_client_nous_unavailable_reason.py`
  - Added coverage for invalid Nous refresh-token diagnostics and one-shot
    warning behavior.

## How to Test

1. Run the focused goal/auxiliary diagnostics tests:
   ```bash
   pytest tests/hermes_cli/test_goals.py::TestJudgeGoal \
     tests/agent/test_auxiliary_client_nous_unavailable_reason.py -q
   ```
   Expected result: `9 passed`.
2. Run the broader related regression sweep:
   ```bash
   pytest tests/hermes_cli/test_goals.py \
     tests/agent/test_auxiliary_client_nous_unavailable_reason.py \
     tests/agent/test_auxiliary_client_xai_oauth_recovery.py \
     tests/agent/test_nous_rate_guard.py \
     tests/hermes_cli/test_auth_nous_provider.py -q
   ```
   Expected result: `158 passed`.
3. Manual reproduction: configure `auxiliary.goal_judge.provider: nous`, put the
   Nous auth store into an invalid-refresh-token state, then run a goal. The
   judge should continue fail-open but report an actionable reason such as:
   ```
   goal_judge auxiliary client unavailable: Nous Portal runtime credentials unavailable: Invalid refresh token. Run `hermes model` to re-authenticate. (code: invalid_grant)
   ```
   It should no longer report only `no auxiliary client configured`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- Not full suite; affected suites passed: 158 passed, 1 warning -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux 6.17.0-35-generic, Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no user-facing docs changed; helper docstrings added)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python diagnostics/logging change, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema changes)

## Screenshots / Logs

Before:

```text
↻ Continuing toward goal (19/20): no auxiliary client configured
```

After:

```text
↻ Continuing toward goal (...): goal_judge auxiliary client unavailable: Nous Portal runtime credentials unavailable: Invalid refresh token. Run `hermes model` to re-authenticate. (code: invalid_grant)
```

Test output:

```text
$ pytest tests/hermes_cli/test_goals.py::TestJudgeGoal \
    tests/agent/test_auxiliary_client_nous_unavailable_reason.py -q
.........                                                                [100%]
9 passed, 1 warning in 0.72s

$ pytest tests/hermes_cli/test_goals.py \
    tests/agent/test_auxiliary_client_nous_unavailable_reason.py \
    tests/agent/test_auxiliary_client_xai_oauth_recovery.py \
    tests/agent/test_nous_rate_guard.py \
    tests/hermes_cli/test_auth_nous_provider.py -q
........................................................................ [ 45%]
........................................................................ [ 91%]
..............                                                           [100%]
158 passed, 1 warning in 4.05s
```