### PR TITLE
Suppress custom provider model warnings when discovery is disabled

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -998,6 +998,40 @@ def switch_model(
             "message": f"Could not validate `{new_model}`: {e}",
         }
 
+    # If model discovery is disabled for a custom provider, trust any model
+    # explicitly declared in config and suppress live /models mismatch notes.
+    # Some gateways intentionally expose only a subset of routable aliases.
+    if custom_providers and isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            entry_name = entry.get("name", "")
+            entry_slug = f"custom:{entry_name}" if entry_name else ""
+            entry_url = entry.get("base_url", "")
+            if entry.get("discover_models", True) is not False:
+                continue
+            if entry_slug != target_provider and entry_url != base_url:
+                continue
+
+            entry_models = entry.get("models", {})
+            declared = new_model == entry.get("model", "")
+            if isinstance(entry_models, dict):
+                declared = declared or new_model in entry_models
+            elif isinstance(entry_models, list):
+                declared = declared or new_model in entry_models or any(
+                    isinstance(m, dict) and m.get("name") == new_model
+                    for m in entry_models
+                )
+
+            if declared:
+                validation = {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "message": None,
+                }
+                break
+
     # Override rejection if model is in the user's saved provider config.
     # API /v1/models may not list cloud/aliased models even though the server supports them.
     if not validation.get("accepted"):

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -256,6 +256,54 @@ def test_list_dedupes_dict_model_matching_singular_default(monkeypatch):
 
 
 
+def test_switch_model_suppresses_custom_provider_discover_models_false_warning(monkeypatch):
+    """When discovery is disabled, declared custom-provider models should not
+    warn just because the endpoint's live /models response omits an alias."""
+    validation_with_warning = {
+        "accepted": True,
+        "persist": True,
+        "recognized": False,
+        "message": (
+            "Note: `gpt-5.5` was not found in this custom endpoint's model listing "
+            "(https://gateway.example.com/v1/models). It may still work if the "
+            "server supports hidden or aliased models."
+        ),
+    }
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "sk-test",
+            "base_url": "https://gateway.example.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: validation_with_warning)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="gpt-5.5",
+        current_provider="custom:gateway",
+        current_model="gpt-5.4",
+        current_base_url="https://gateway.example.com/v1",
+        current_api_key="sk-test",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "gateway",
+                "base_url": "https://gateway.example.com/v1",
+                "discover_models": False,
+                "model": "gpt-5.5",
+                "models": {"gpt-5.5": {"context_length": 400000}},
+            }
+        ],
+    )
+
+    assert result.success is True
+    assert result.new_model == "gpt-5.5"
+    assert result.warning_message == ""
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # #9210: group custom_providers by (base_url, api_key) in /model picker
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Treat models explicitly declared under a custom provider with `discover_models: false` as trusted during `/model` switches
- Suppress the live `/models` mismatch note for those declared hidden/aliased models
- Add a regression test for a custom gateway alias omitted from the endpoint's model listing

## Related issue
Refs #31739

## Test plan
- `uv run --extra dev pytest -q tests/hermes_cli/test_model_switch_custom_providers.py::test_switch_model_suppresses_custom_provider_discover_models_false_warning`
- `uv run --extra dev ruff check hermes_cli/model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py`