### PR TITLE
Fix URL safety fake-ip handling and runs tool events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3565,7 +3565,79 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_statuses[run_id] = current
         return current
 
-    def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
+    @staticmethod
+    def _count_run_tool_turns(tool_events: List[Dict[str, Any]]) -> int:
+        completed: set[str] = set()
+        started: set[str] = set()
+        completed_without_id = 0
+        started_without_id = 0
+
+        for event in tool_events:
+            if not isinstance(event, dict):
+                continue
+            event_type = event.get("event")
+            tool_name = str(event.get("tool") or "")
+            call_id = str(event.get("call_id") or "")
+            key = call_id or tool_name
+            if event_type == "tool.completed":
+                if key:
+                    completed.add(key)
+                else:
+                    completed_without_id += 1
+            elif event_type == "tool.started":
+                if key:
+                    started.add(key)
+                else:
+                    started_without_id += 1
+
+        completed_count = len(completed) + completed_without_id
+        if completed_count:
+            return completed_count
+        return len(started) + started_without_id
+
+    @staticmethod
+    def _summarize_run_tool_result(result: Any) -> Dict[str, Any]:
+        text = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False, default=str)
+        preview = text[:1000]
+        summary: Dict[str, Any] = {
+            "text": preview,
+            "length": len(text),
+            "truncated": len(text) > len(preview),
+        }
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                if "error" in parsed:
+                    summary["error"] = bool(parsed.get("error"))
+                for key in ("title", "url", "success"):
+                    if key in parsed:
+                        summary[key] = parsed.get(key)
+        except Exception:
+            pass
+        return summary
+
+    def _record_run_tool_event(self, run_id: str, event: Dict[str, Any]) -> None:
+        """Keep compact tool evidence available after the SSE stream closes."""
+        status = self._run_statuses.get(run_id, {})
+        current_status = str(status.get("status") or "running")
+        tool_events = list(status.get("tool_events") or [])
+        tool_events.append(event)
+        compact_tool_events = tool_events[-40:]
+        self._set_run_status(
+            run_id,
+            current_status,
+            tool_events=compact_tool_events,
+            tool_turns=self._count_run_tool_turns(compact_tool_events),
+            last_event=event.get("event"),
+        )
+
+    def _make_run_event_callback(
+        self,
+        run_id: str,
+        loop: "asyncio.AbstractEventLoop",
+        *,
+        include_tool_events: bool = True,
+    ):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
         def _push(event: Dict[str, Any]) -> None:
             self._set_run_status(
@@ -3584,6 +3656,8 @@ class APIServerAdapter(BasePlatformAdapter):
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
             ts = time.time()
             if event_type == "tool.started":
+                if not include_tool_events:
+                    return
                 _push({
                     "event": "tool.started",
                     "run_id": run_id,
@@ -3592,6 +3666,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     "preview": preview,
                 })
             elif event_type == "tool.completed":
+                if not include_tool_events:
+                    return
                 _push({
                     "event": "tool.completed",
                     "run_id": run_id,
@@ -3700,7 +3776,11 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_streams_created[run_id] = created_at
         self._run_approval_sessions[run_id] = approval_session_key
 
-        event_cb = self._make_run_event_callback(run_id, loop)
+        event_cb = self._make_run_event_callback(
+            run_id,
+            loop,
+            include_tool_events=False,
+        )
 
         # Also wire stream_delta_callback so message.delta events flow through.
         def _text_cb(delta: Optional[str]) -> None:
@@ -3713,6 +3793,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": time.time(),
                     "delta": delta,
                 })
+            except Exception:
+                pass
+
+        def _push_tool_event(event: Dict[str, Any]) -> None:
+            self._record_run_tool_event(run_id, event)
+            try:
+                loop.call_soon_threadsafe(q.put_nowait, event)
             except Exception:
                 pass
 
@@ -3735,6 +3822,56 @@ class APIServerAdapter(BasePlatformAdapter):
                     gateway_session_key=gateway_session_key,
                 )
                 self._active_run_agents[run_id] = agent
+
+                original_tool_start_callback = getattr(agent, "tool_start_callback", None)
+                original_tool_complete_callback = getattr(agent, "tool_complete_callback", None)
+
+                def _run_event_tool_start(tool_call_id, function_name, function_args):
+                    event = {
+                        "event": "tool.started",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                        "tool": function_name,
+                        "call_id": tool_call_id,
+                        "status": "started",
+                    }
+                    _push_tool_event(event)
+                    if original_tool_start_callback:
+                        return original_tool_start_callback(
+                            tool_call_id,
+                            function_name,
+                            function_args,
+                        )
+                    return None
+
+                def _run_event_tool_complete(
+                    tool_call_id,
+                    function_name,
+                    function_args,
+                    function_result,
+                ):
+                    summary = self._summarize_run_tool_result(function_result)
+                    event = {
+                        "event": "tool.completed",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                        "tool": function_name,
+                        "call_id": tool_call_id,
+                        "status": "completed",
+                        "summary": summary,
+                    }
+                    _push_tool_event(event)
+                    if original_tool_complete_callback:
+                        return original_tool_complete_callback(
+                            tool_call_id,
+                            function_name,
+                            function_args,
+                            function_result,
+                        )
+                    return None
+
+                agent.tool_start_callback = _run_event_tool_start
+                agent.tool_complete_callback = _run_event_tool_complete
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
                     event = dict(approval_data or {})

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -256,6 +256,53 @@ class TestRunStatus:
                 assert status["session_id"] == "space-session"
 
     @pytest.mark.asyncio
+    async def test_status_records_tool_events_and_tool_turns(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.tool_start_callback = None
+                mock_agent.tool_complete_callback = None
+                mock_agent.session_prompt_tokens = 4
+                mock_agent.session_completion_tokens = 2
+                mock_agent.session_total_tokens = 6
+
+                def _run_conversation(user_message=None, conversation_history=None, task_id=None):
+                    mock_agent.tool_start_callback(
+                        "call_web_extract",
+                        "web_extract",
+                        {"urls": ["https://example.com/"]},
+                    )
+                    mock_agent.tool_complete_callback(
+                        "call_web_extract",
+                        "web_extract",
+                        {"urls": ["https://example.com/"]},
+                        '{"title": "Example Domain", "content": "ok"}',
+                    )
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "use web_extract"})
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert status["status"] == "completed"
+                assert [event["event"] for event in status["tool_events"]] == [
+                    "tool.started",
+                    "tool.completed",
+                ]
+                assert status["tool_turns"] == 1
+
+    @pytest.mark.asyncio
     async def test_status_not_found_returns_404(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -15,6 +15,7 @@ from tools.url_safety import (
 
 import ipaddress
 import pytest
+import tools.url_safety as url_safety
 
 
 class TestNormalizeUrlForRequest:
@@ -221,6 +222,45 @@ class TestIsSafeUrl:
     def test_qq_multimedia_hostname_dns_failure_still_blocked(self):
         with patch("socket.getaddrinfo", side_effect=socket.gaierror("Name resolution failed")):
             assert is_safe_url("https://multimedia.nt.qq.com.cn/download?id=123") is False
+
+    def test_public_domain_with_clash_fake_ip_allowed_after_public_dns_recheck(self, monkeypatch):
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.0.23", 0)),
+        ]):
+            monkeypatch.setattr(
+                url_safety,
+                "_resolve_public_dns_ips",
+                lambda hostname: [ipaddress.ip_address("93.184.216.34")],
+                raising=False,
+            )
+
+            assert is_safe_url("https://example.com/article") is True
+
+    def test_clash_fake_ip_literal_url_still_blocked(self, monkeypatch):
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.0.23", 0)),
+        ]):
+            monkeypatch.setattr(
+                url_safety,
+                "_resolve_public_dns_ips",
+                lambda hostname: pytest.fail("literal fake-ip URL must not be rechecked"),
+                raising=False,
+            )
+
+            assert is_safe_url("http://198.18.0.23/admin") is False
+
+    def test_clash_fake_ip_recheck_blocks_real_private_dns(self, monkeypatch):
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.0.23", 0)),
+        ]):
+            monkeypatch.setattr(
+                url_safety,
+                "_resolve_public_dns_ips",
+                lambda hostname: [ipaddress.ip_address("10.0.0.5")],
+                raising=False,
+            )
+
+            assert is_safe_url("https://private.example.test/data") is False
 
 
 class TestAsyncIsSafeUrl:

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -1,9 +1,14 @@
 import json
+import ipaddress
+import socket
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import yaml
 
+from agent.web_search_provider import WebSearchProvider
+from agent.web_search_registry import register_provider
 from tests.tools.conftest import register_all_web_providers
 
 from tools.website_policy import WebsitePolicyError, check_website_access, load_website_blocklist
@@ -448,6 +453,61 @@ class TestWebToolPolicy:
         assert result["results"][0]["url"] == "https://blocked.test/final"
         assert result["results"][0]["content"] == ""
         assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"
+
+    @pytest.mark.asyncio
+    async def test_web_extract_keeps_original_url_after_clash_fake_ip_recheck(self, monkeypatch):
+        from tools import web_tools
+        import tools.url_safety as url_safety
+
+        seen_urls = []
+
+        class FakeExtractProvider(WebSearchProvider):
+            @property
+            def name(self):
+                return "fake-extract"
+
+            def is_available(self):
+                return True
+
+            def supports_search(self):
+                return False
+
+            def supports_extract(self):
+                return True
+
+            def extract(self, urls, **kwargs):
+                seen_urls.extend(urls)
+                return [{
+                    "url": urls[0],
+                    "title": "Example",
+                    "content": "public page",
+                    "raw_content": "public page",
+                    "metadata": {},
+                }]
+
+        register_provider(FakeExtractProvider())
+        monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "fake-extract")
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+        monkeypatch.setattr(
+            url_safety,
+            "_resolve_public_dns_ips",
+            lambda hostname: [ipaddress.ip_address("93.184.216.34")],
+        )
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+        with patch("socket.getaddrinfo", return_value=[
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("198.18.0.23", 0)),
+        ]):
+            result = json.loads(
+                await web_tools.web_extract_tool(
+                    ["https://example.com/article"],
+                    use_llm_processing=False,
+                )
+            )
+
+        assert seen_urls == ["https://example.com/article"]
+        assert result["results"][0]["url"] == "https://example.com/article"
+        assert result["results"][0]["content"] == "public page"
 
 
 def test_check_website_access_fails_open_on_malformed_config(tmp_path, monkeypatch):

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -24,11 +24,14 @@ Limitations (documented, not fixable at pre-flight level):
 """
 
 import ipaddress
+import json
 import logging
 import os
 import socket
 import asyncio
+import urllib.request
 from urllib.parse import quote, urlparse, urlsplit, urlunsplit
+from urllib.parse import urlencode
 
 from utils import is_truthy_value
 
@@ -121,6 +124,12 @@ _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
 # Must be blocked explicitly. Used by carrier-grade NAT, Tailscale/WireGuard
 # VPNs, and some cloud internal networks.
 _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+_CLASH_FAKE_IP_NETWORK = ipaddress.ip_network("198.18.0.0/15")
+_PUBLIC_DNS_ENDPOINTS = (
+    "https://cloudflare-dns.com/dns-query",
+    "https://dns.google/resolve",
+)
+_PUBLIC_DNS_TIMEOUT_SECONDS = 3
 
 # ---------------------------------------------------------------------------
 # Global toggle: allow private/internal IP resolution
@@ -208,6 +217,65 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     if ip in _CGNAT_NETWORK:
         return True
     return False
+
+
+def _is_clash_fake_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True for mihomo/Clash fake-ip benchmark-space addresses."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return isinstance(ip, ipaddress.IPv4Address) and ip in _CLASH_FAKE_IP_NETWORK
+
+
+def _parse_hostname_ip(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    try:
+        return ipaddress.ip_address(hostname)
+    except ValueError:
+        return None
+
+
+def _resolve_public_dns_ips(hostname: str) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Resolve a hostname through public DoH instead of the system fake-ip DNS."""
+    resolved: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    seen: set[str] = set()
+
+    for endpoint in _PUBLIC_DNS_ENDPOINTS:
+        for record_type in ("A", "AAAA"):
+            query = urlencode({"name": hostname, "type": record_type})
+            request = urllib.request.Request(
+                f"{endpoint}?{query}",
+                headers={"Accept": "application/dns-json"},
+                method="GET",
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=_PUBLIC_DNS_TIMEOUT_SECONDS) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+            except Exception as exc:
+                logger.debug(
+                    "Public DNS recheck failed for %s via %s %s: %s",
+                    hostname,
+                    endpoint,
+                    record_type,
+                    exc,
+                )
+                continue
+
+            answers = payload.get("Answer") if isinstance(payload, dict) else None
+            if not isinstance(answers, list):
+                continue
+            for answer in answers:
+                if not isinstance(answer, dict):
+                    continue
+                data = str(answer.get("data") or "").strip()
+                try:
+                    ip = ipaddress.ip_address(data)
+                except ValueError:
+                    continue
+                key = str(ip)
+                if key not in seen:
+                    seen.add(key)
+                    resolved.append(ip)
+
+    return resolved
 
 
 def is_always_blocked_url(url: str) -> bool:
@@ -341,6 +409,8 @@ def is_safe_url(url: str) -> bool:
         allow_all_private = _global_allow_private_urls()
 
         allow_private_ip = _allows_private_ip_resolution(hostname, scheme)
+        literal_host_ip = _parse_hostname_ip(hostname)
+        clash_fake_ip_candidates: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
 
         # Try to resolve and check IP
         try:
@@ -367,11 +437,41 @@ def is_safe_url(url: str) -> bool:
                 return False
 
             if not allow_all_private and not allow_private_ip and _is_blocked_ip(ip):
+                if literal_host_ip is None and _is_clash_fake_ip(ip):
+                    clash_fake_ip_candidates.append(ip)
+                    continue
                 logger.warning(
                     "Blocked request to private/internal address: %s -> %s",
                     hostname, ip_str,
                 )
                 return False
+
+        if clash_fake_ip_candidates:
+            public_dns_ips = _resolve_public_dns_ips(hostname)
+            if not public_dns_ips:
+                logger.warning(
+                    "Blocked request to Clash fake-ip address without public DNS proof: %s -> %s",
+                    hostname,
+                    ", ".join(str(ip) for ip in clash_fake_ip_candidates),
+                )
+                return False
+
+            for real_ip in public_dns_ips:
+                if real_ip in _ALWAYS_BLOCKED_IPS or any(
+                    real_ip in net for net in _ALWAYS_BLOCKED_NETWORKS
+                ) or _is_blocked_ip(real_ip):
+                    logger.warning(
+                        "Blocked request after Clash fake-ip public DNS recheck: %s -> %s",
+                        hostname,
+                        real_ip,
+                    )
+                    return False
+
+            logger.debug(
+                "Allowing Clash fake-ip candidate after public DNS recheck: %s -> %s",
+                hostname,
+                ", ".join(str(ip) for ip in public_dns_ips),
+            )
 
         if allow_all_private:
             logger.debug(


### PR DESCRIPTION
# Summary

- Restore URL safety handling for Clash/mihomo fake-ip DNS results without allowing literal `198.18.0.0/15` targets.
- Recheck hostname fake-ip candidates through public DNS and fail closed unless real A/AAAA answers are public.
- Restore `/v1/runs` compact tool start/complete evidence and `tool_turns` derivation while avoiding duplicate tool events from the progress callback.
- Add regression coverage for URL safety, `web_extract` original URL preservation, and `/v1/runs` tool event status.

# Tests

- `tests/tools/test_url_safety.py tests/tools/test_website_policy.py` = `142 passed, 1 warning`
- `tests/gateway/test_api_server_runs.py` = `23 passed, 23 warnings`
- `py_compile` for the 5 touched files = PASS
- `git diff --check origin/main..HEAD` = PASS

# Boundaries

- Does not change Clash, TUN, DNS `1053`, fake-ip config, routing rules, or Xiyou.
- Does not enable private URL access globally.
- Does not restore old 8091, CDP, current-page, or foreground-browser proof changes.
- Does not restart `8642` or `8084`, and does not include live runtime proof.
- Does not read or print secrets, tokens, keys, cookies, localStorage, or sessionStorage.

# Risk / Rollback

- Main risk: fake-ip recheck depends on public DoH availability; failure remains fail-closed.
- `/v1/runs` change is additive status/SSE evidence for tool start/complete events.
- Rollback: revert commit `59ef7537d2caaf73719965f801cbe1ea726902b7`.