### PR TITLE
fix(aux): add TCP keepalive HTTP client to auxiliary OpenAI calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -78,21 +78,44 @@ def _load_openai_cls() -> type:
     return _OPENAI_CLS_CACHE
 
 
-_keepalive_client_cache: "httpx.Client | None" = None
-_keepalive_async_client_cache: "httpx.AsyncClient | None" = None
+# ── TCP keepalive helpers for corporate-proxy resilience ────────────
+#
+# Auxiliary OpenAI calls (title, vision, compression, session_search)
+# were failing with ``SSL: UNEXPECTED_EOF_WHILE_READING`` on corporate
+# proxies / load balancers that drop idle TLS connections.  The main
+# agent loop (``run_agent.py``) avoids this via a custom httpx transport
+# with TCP keepalive socket options.  These helpers bring the same fix
+# to the auxiliary path.
+#
+# Both the sync and async clients are built once and cached at module
+# level so that every OpenAI(...) construction site does not pay the
+# httpx.Client setup cost anew.
+
+_aux_keepalive_client: "httpx.Client | None" = None
+_aux_keepalive_client_built: bool = False
+_aux_keepalive_async_client: "httpx.AsyncClient | None" = None
+_aux_keepalive_async_client_built: bool = False
 
 
-def _build_keepalive_http_client() -> "httpx.Client | None":
-    """Build an ``httpx.Client`` with TCP keepalive socket options.
+def _get_proxy_for_base_url(base_url: str = "") -> str | None:
+    """Best-effort proxy resolution that honours ``NO_PROXY``.
 
-    Returns ``None`` when httpx is not available (e.g. in a minimal venv).
-    The main agent loop (``run_agent.py``) uses an identical pattern;
-    keeping a module-level singleton avoids rebuilding the client on every
-    single auxiliary call.
+    Delegates to ``agent.process_bootstrap._get_proxy_for_base_url``
+    when available so that auxiliary calls use the same proxy env-var
+    logic as the main agent loop.
     """
-    global _keepalive_client_cache
-    if _keepalive_client_cache is not None:
-        return _keepalive_client_cache
+    try:
+        from agent.process_bootstrap import _get_proxy_for_base_url as _gp
+        return _gp(base_url)
+    except Exception:
+        return None
+
+
+def _build_aux_http_client(base_url: str = "") -> "httpx.Client | None":
+    """Build (or return cached) httpx sync Client with TCP keepalive + proxy."""
+    global _aux_keepalive_client, _aux_keepalive_client_built
+    if _aux_keepalive_client_built:
+        return _aux_keepalive_client
 
     try:
         import httpx as _httpx
@@ -106,26 +129,24 @@ def _build_keepalive_http_client() -> "httpx.Client | None":
         elif hasattr(_socket, "TCP_KEEPALIVE"):
             _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
 
-        _keepalive_client_cache = _httpx.Client(
+        _proxy = _get_proxy_for_base_url(base_url)
+        _aux_keepalive_client = _httpx.Client(
             transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+            proxy=_proxy,
         )
     except Exception:
-        _keepalive_client_cache = None
+        _aux_keepalive_client = None
+    finally:
+        _aux_keepalive_client_built = True
 
-    return _keepalive_client_cache
+    return _aux_keepalive_client
 
 
-_async_keepalive_built: bool = False
-
-
-def _build_keepalive_async_client() -> "httpx.AsyncClient | None":
-    """Build an ``httpx.AsyncClient`` with TCP keepalive socket options.
-
-    Mirrors ``_build_keepalive_http_client`` for the async path.
-    """
-    global _keepalive_async_client_cache, _async_keepalive_built
-    if _async_keepalive_built:
-        return _keepalive_async_client_cache
+def _build_aux_async_client(base_url: str = "") -> "httpx.AsyncClient | None":
+    """Build (or return cached) httpx async Client with TCP keepalive + proxy."""
+    global _aux_keepalive_async_client, _aux_keepalive_async_client_built
+    if _aux_keepalive_async_client_built:
+        return _aux_keepalive_async_client
 
     try:
         import httpx as _httpx
@@ -139,15 +160,17 @@ def _build_keepalive_async_client() -> "httpx.AsyncClient | None":
         elif hasattr(_socket, "TCP_KEEPALIVE"):
             _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
 
-        _keepalive_async_client_cache = _httpx.AsyncClient(
+        _proxy = _get_proxy_for_base_url(base_url)
+        _aux_keepalive_async_client = _httpx.AsyncClient(
             transport=_httpx.AsyncHTTPTransport(socket_options=_sock_opts),
+            proxy=_proxy,
         )
     except Exception:
-        _keepalive_async_client_cache = None
+        _aux_keepalive_async_client = None
     finally:
-        _async_keepalive_built = True
+        _aux_keepalive_async_client_built = True
 
-    return _keepalive_async_client_cache
+    return _aux_keepalive_async_client
 
 
 class _OpenAIProxy:
@@ -155,13 +178,21 @@ class _OpenAIProxy:
 
     Forwards ``OpenAI(...)`` calls and ``isinstance(x, OpenAI)`` checks to the
     real SDK class, importing the SDK lazily on first use.
+
+    When the caller does **not** supply an explicit ``http_client``, the
+    proxy automatically injects one with TCP keepalive socket options and
+    proxy-awareness so that auxiliary calls (title, vision, compression,
+    session_search) survive corporate proxies that drop idle TLS connections.
     """
 
     __slots__ = ()
 
     def __call__(self, *args, **kwargs):
-        if "http_client" not in kwargs:
-            kwargs["http_client"] = _build_keepalive_http_client()
+        if "http_client" not in kwargs and not args:
+            base_url = str(kwargs.get("base_url") or "")
+            _hk = _build_aux_http_client(base_url)
+            if _hk is not None:
+                kwargs["http_client"] = _hk
         return _load_openai_cls()(*args, **kwargs)
 
     def __instancecheck__(self, obj):
@@ -3362,9 +3393,11 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         "api_key": sync_client.api_key,
         "base_url": str(sync_client.base_url),
     }
-    if _keepalive_client_cache is not None:
-        async_kwargs["http_client"] = _build_keepalive_async_client()
     sync_base_url = str(sync_client.base_url)
+    if "http_client" not in async_kwargs:
+        _hk = _build_aux_async_client(sync_base_url)
+        if _hk is not None:
+            async_kwargs["http_client"] = _hk
     if base_url_host_matches(sync_base_url, "openrouter.ai"):
         async_kwargs["default_headers"] = build_or_headers()
     elif base_url_host_matches(sync_base_url, "api.githubcopilot.com"):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -78,6 +78,78 @@ def _load_openai_cls() -> type:
     return _OPENAI_CLS_CACHE
 
 
+_keepalive_client_cache: "httpx.Client | None" = None
+_keepalive_async_client_cache: "httpx.AsyncClient | None" = None
+
+
+def _build_keepalive_http_client() -> "httpx.Client | None":
+    """Build an ``httpx.Client`` with TCP keepalive socket options.
+
+    Returns ``None`` when httpx is not available (e.g. in a minimal venv).
+    The main agent loop (``run_agent.py``) uses an identical pattern;
+    keeping a module-level singleton avoids rebuilding the client on every
+    single auxiliary call.
+    """
+    global _keepalive_client_cache
+    if _keepalive_client_cache is not None:
+        return _keepalive_client_cache
+
+    try:
+        import httpx as _httpx
+        import socket as _socket
+
+        _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
+        if hasattr(_socket, "TCP_KEEPIDLE"):
+            _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 30))
+            _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPINTVL, 10))
+            _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPCNT, 3))
+        elif hasattr(_socket, "TCP_KEEPALIVE"):
+            _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
+
+        _keepalive_client_cache = _httpx.Client(
+            transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+        )
+    except Exception:
+        _keepalive_client_cache = None
+
+    return _keepalive_client_cache
+
+
+_async_keepalive_built: bool = False
+
+
+def _build_keepalive_async_client() -> "httpx.AsyncClient | None":
+    """Build an ``httpx.AsyncClient`` with TCP keepalive socket options.
+
+    Mirrors ``_build_keepalive_http_client`` for the async path.
+    """
+    global _keepalive_async_client_cache, _async_keepalive_built
+    if _async_keepalive_built:
+        return _keepalive_async_client_cache
+
+    try:
+        import httpx as _httpx
+        import socket as _socket
+
+        _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
+        if hasattr(_socket, "TCP_KEEPIDLE"):
+            _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 30))
+            _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPINTVL, 10))
+            _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPCNT, 3))
+        elif hasattr(_socket, "TCP_KEEPALIVE"):
+            _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
+
+        _keepalive_async_client_cache = _httpx.AsyncClient(
+            transport=_httpx.AsyncHTTPTransport(socket_options=_sock_opts),
+        )
+    except Exception:
+        _keepalive_async_client_cache = None
+    finally:
+        _async_keepalive_built = True
+
+    return _keepalive_async_client_cache
+
+
 class _OpenAIProxy:
     """Module-level proxy that looks like the ``openai.OpenAI`` class.
 
@@ -88,6 +160,8 @@ class _OpenAIProxy:
     __slots__ = ()
 
     def __call__(self, *args, **kwargs):
+        if "http_client" not in kwargs:
+            kwargs["http_client"] = _build_keepalive_http_client()
         return _load_openai_cls()(*args, **kwargs)
 
     def __instancecheck__(self, obj):
@@ -3288,6 +3362,8 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         "api_key": sync_client.api_key,
         "base_url": str(sync_client.base_url),
     }
+    if _keepalive_client_cache is not None:
+        async_kwargs["http_client"] = _build_keepalive_async_client()
     sync_base_url = str(sync_client.base_url)
     if base_url_host_matches(sync_base_url, "openrouter.ai"):
         async_kwargs["default_headers"] = build_or_headers()

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3791,3 +3791,130 @@ class TestAuxUnhealthyCache:
             )
             # After the 402, OpenRouter is in the unhealthy cache.
             assert _is_provider_unhealthy("openrouter") is True
+
+
+class TestKeepaliveHttpClient:
+    """Tests for keepalive HTTP client injection in _OpenAIProxy."""
+
+    def test_proxy_injects_keepalive_client_when_no_http_client_supplied(self):
+        """openai.OpenAI() without explicit http_client gets a keepalive one."""
+        from unittest.mock import patch, MagicMock
+        from agent.auxiliary_client import _OpenAIProxy
+
+        proxy = _OpenAIProxy()
+        real_cls = MagicMock()
+        real_cls.return_value = "client-instance"
+
+        with patch("agent.auxiliary_client._load_openai_cls", return_value=real_cls), \
+             patch("agent.auxiliary_client._build_aux_http_client", return_value="keepalive-client"):
+
+            result = proxy(base_url="https://api.openai.com/v1")
+
+        assert result == "client-instance"
+        # http_client must have been injected
+        _, kwargs = real_cls.call_args
+        assert kwargs.get("http_client") == "keepalive-client"
+
+    def test_explicit_http_client_is_preserved(self):
+        """http_client explicitly passed by caller must not be overridden."""
+        from unittest.mock import patch, MagicMock
+        from agent.auxiliary_client import _OpenAIProxy
+
+        proxy = _OpenAIProxy()
+        real_cls = MagicMock()
+        real_cls.return_value = "client-instance"
+
+        with patch("agent.auxiliary_client._load_openai_cls", return_value=real_cls), \
+             patch("agent.auxiliary_client._build_aux_http_client") as mock_builder:
+
+            result = proxy(
+                base_url="https://api.openai.com/v1",
+                http_client="my-custom-client",
+            )
+
+        assert result == "client-instance"
+        _, kwargs = real_cls.call_args
+        assert kwargs.get("http_client") == "my-custom-client"
+        # The keepalive builder must NOT have been called
+        mock_builder.assert_not_called()
+
+    def test_keepalive_not_injected_when_positional_args_present(self):
+        """OpenAI('api-key', ...) with positional args must not inject http_client."""
+        from unittest.mock import patch, MagicMock
+        from agent.auxiliary_client import _OpenAIProxy
+
+        proxy = _OpenAIProxy()
+        real_cls = MagicMock()
+        real_cls.return_value = "client-instance"
+
+        with patch("agent.auxiliary_client._load_openai_cls", return_value=real_cls), \
+             patch("agent.auxiliary_client._build_aux_http_client") as mock_builder:
+
+            result = proxy("sk-test", "gpt-4")
+
+        assert result == "client-instance"
+        _, kwargs = real_cls.call_args
+        assert "http_client" not in kwargs
+        mock_builder.assert_not_called()
+
+    def test_proxy_uses_proxy_env_var(self):
+        """_build_aux_http_client must resolve proxy from env when set."""
+        import os
+        from agent.auxiliary_client import _build_aux_http_client
+
+        os.environ["HTTPS_PROXY"] = "http://proxy.corp:8080"
+        try:
+            client = _build_aux_http_client("https://api.openai.com/v1")
+            assert client is not None
+            # The proxy should be set on the client's transport
+            assert client._proxy is not None
+            assert "proxy.corp" in str(client._proxy)
+        finally:
+            os.environ.pop("HTTPS_PROXY", None)
+
+    def test_no_proxy_bypasses_injection(self):
+        """NO_PROXY matching the base URL must suppress proxy injection."""
+        import os
+        from agent.auxiliary_client import _build_aux_http_client
+
+        os.environ["HTTPS_PROXY"] = "http://proxy.corp:8080"
+        os.environ["NO_PROXY"] = "localhost,127.0.0.1,.local"
+        try:
+            # localhost should be bypassed
+            client = _build_aux_http_client("http://localhost:11434/v1")
+            assert client is not None
+            assert client._proxy is None
+        finally:
+            os.environ.pop("HTTPS_PROXY", None)
+            os.environ.pop("NO_PROXY", None)
+
+    def test_async_keepalive_injected_in_to_async_client(self):
+        """_to_async_client must inject async keepalive client."""
+        from unittest.mock import patch, MagicMock, PropertyMock
+        from agent.auxiliary_client import _to_async_client
+
+        sync_client = MagicMock()
+        type(sync_client).api_key = PropertyMock(return_value="sk-test")
+        type(sync_client).base_url = PropertyMock(
+            return_value="https://api.openai.com/v1"
+        )
+
+        with patch("agent.auxiliary_client.AsyncOpenAI") as mock_async, \
+             patch("agent.auxiliary_client._build_aux_async_client",
+                   return_value="async-keepalive"):
+
+            _to_async_client(sync_client, "gpt-4")
+
+        _, kwargs = mock_async.call_args
+        assert kwargs.get("http_client") == "async-keepalive"
+
+    def test_no_proxy_env_returns_none(self):
+        """_get_proxy_for_base_url must return None when no proxy env set."""
+        import os
+        from agent.auxiliary_client import _get_proxy_for_base_url
+
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                    "https_proxy", "http_proxy", "all_proxy"):
+            os.environ.pop(key, None)
+
+        assert _get_proxy_for_base_url("https://api.openai.com/v1") is None


### PR DESCRIPTION
## What changed and why

Auxiliary functions (title generation, vision, compression, session_search) create OpenAI clients via the `_OpenAIProxy` in `auxiliary_client.py`. These were created **without** a custom httpx transport, so they lacked TCP keepalive socket options.

On corporate proxies or load balancers that drop idle TLS connections after a few seconds, this caused every auxiliary call to fail with `Connection error` or `SSL: UNEXPECTED_EOF_WHILE_READING` — while the main agent loop (which uses `_build_keepalive_http_client()` in `run_agent.py`) worked fine.

## Changes

`agent/auxiliary_client.py` (+76 lines):
1. Added `_build_keepalive_http_client()` — creates a cached `httpx.Client` with TCP keepalive socket options (identical pattern to `run_agent.py`'s existing `_build_keepalive_http_client`)
2. Added `_build_keepalive_async_client()` — same for the `AsyncOpenAI` path
3. `_OpenAIProxy.__call__` now injects the keepalive client when no explicit `http_client` is provided — this covers **all** sync `OpenAI(...)` construction sites (~20+ call sites) through the central proxy
4. `_to_async_client()` now injects the keepalive async client into `AsyncOpenAI(...)`

Both clients are module-level singletons, built once and reused — no per-call overhead.

## How to test

Without this fix, behind a proxy/load balancer with aggressive idle timeout:

```
Auxiliary title_generation: connection error on auto (Connection error.), trying fallback
Title generation failed: Connection error.
```

With this fix, the keepalive options (KEEPIDLE=30s, KEEPINTVL=10s, KEEPCNT=3) prevent the idle connection from being dropped, so auxiliary calls succeed.

Closes #41745