### PR TITLE
fix(gateway): persist Codex autoraise notice per session

### DIFF
--- a/docs/plans/2026-06-08-001-fix-codex-autoraise-session-notice-plan.md
+++ b/docs/plans/2026-06-08-001-fix-codex-autoraise-session-notice-plan.md
@@ -1,0 +1,172 @@
+---
+title: "fix: Show Codex gpt-5.5 autoraise notice once per gateway session"
+type: fix
+status: active
+date: 2026-06-08
+---
+
+# fix: Show Codex gpt-5.5 autoraise notice once per gateway session
+
+## Summary
+
+Hermes should keep the Codex `gpt-5.5` compression threshold autoraise, but gateway users should see its explanatory notice only once per durable gateway session. The fix persists a gateway-session notice latch and gates the existing `_compression_warning` replay when an in-memory `AIAgent` is rebuilt.
+
+---
+
+## Problem Frame
+
+The upstream Codex `gpt-5.5` autoraise feature is useful: on `openai-codex`, Hermes raises auto-compaction from `50%` to `85%` so the 272K Codex OAuth window is not half-wasted. The notification is currently latched on `AIAgent._compression_warning`, so it is cleared only for the current in-memory agent. Gateway sessions can rebuild that agent while preserving the visible Telegram or WhatsApp transcript, causing the same notice to reappear in what users reasonably consider the same session.
+
+---
+
+## Requirements
+
+### Notice behaviour
+
+- R1. Preserve the Codex `gpt-5.5` threshold autoraise behaviour for `provider=openai-codex` and keep the existing notice text for first delivery.
+- R2. Show the autoraise notice at most once per durable gateway session backed by `SessionStore`, including Telegram and WhatsApp, even when a new `AIAgent` is constructed for the same session key.
+- R3. Keep CLI behaviour unchanged: CLI users may still see the startup notice per process because there is no gateway session store.
+- R4. A new durable session created by `/new`, `/reset`, auto-reset, or normal session creation should be eligible to show the notice once.
+
+### Persistence and compatibility
+
+- R5. Persist the notice latch through gateway process restarts and agent cache eviction.
+- R6. Load existing gateway session files that do not contain the new latch without migration errors.
+- R7. Keep notice delivery gateway-owned and do not persist the notice as assistant conversation content.
+
+### Tracking and review
+
+- R8. Open a GitHub feature request/bug issue describing the gateway-session UX problem and acceptance criteria.
+- R9. Link the implementation PR to the tracking issue and include verification details.
+
+---
+
+## Key Technical Decisions
+
+- **Persist the latch on `SessionEntry`:** The repeated notice is caused by rebuilding in-memory agents, so the latch must live with durable gateway session state rather than on `AIAgent` or process-local runner sets.
+- **Use a generic notice map instead of a single boolean:** A normalized `dict[str, bool]` keeps this fix small while giving future one-shot gateway notices a reusable session-scoped mechanism.
+- **Make check-and-mark atomic:** A single `SessionStore` helper should check, set, save, and return whether the caller won first-delivery rights while holding the store lock.
+- **Gate after fresh agent construction in `gateway/run.py`:** The `status_callback` is wired after `AIAgent` construction, so the gateway can clear `agent._compression_warning` before `agent.run_conversation()` reaches the turn-context replay path.
+- **Mark before replay, not after send acknowledgement:** Status notices are best-effort user-facing lifecycle messages. Marking before replay avoids duplicates across crashes between scheduling and completion, matching the goal of suppressing repeated nags over guaranteed delivery.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[Gateway receives message] --> B{Cached AIAgent for session key?}
+  B -->|yes| C[Reuse agent]
+  B -->|no| D[Construct new AIAgent]
+  D --> E{agent has Codex gpt-5.5 autoraise warning?}
+  E -->|no| F[Run conversation]
+  E -->|yes| G{SessionEntry notices_shown contains key?}
+  G -->|yes| H[Clear agent._compression_warning]
+  G -->|no| I[Atomic mark_notice_shown_once returns first delivery]
+  H --> F
+  I --> F
+  C --> F
+  F --> J[turn_context replays remaining warning once]
+```
+
+The session store owns whether the user has already been told. The agent still owns the existing threshold and warning computation.
+
+---
+
+## Implementation Units
+
+### U1. Persist gateway notice latch on session entries
+
+- **Goal:** Add durable session-level storage for one-shot gateway notices.
+- **Requirements:** R2, R4, R5, R6, R7.
+- **Dependencies:** None.
+- **Files:**
+  - `gateway/session.py`
+  - `tests/gateway/test_session_notice_latch.py`
+- **Approach:** Add `notices_shown: Dict[str, bool] = field(default_factory=dict)` to `SessionEntry`, include it in `to_dict()`, and normalize missing or malformed values in `from_dict()`. Add a single `SessionStore` helper such as `mark_notice_shown_once(session_key, notice_key) -> bool` that checks, sets, saves, and returns `True` only for the first caller under the existing store lock.
+- **Patterns to follow:** Existing `SessionEntry` fields such as `resume_pending`, `expiry_finalized`, and `is_fresh_reset`; existing session-store mutation helpers that acquire the lock and persist `sessions.json`.
+- **Test scenarios:**
+  - Loading an existing session JSON entry without `notices_shown` returns an entry with an empty notice map.
+  - Loading malformed `notices_shown` values such as `None`, strings, lists, integers, or non-normalized dict values does not fail and produces a safe `dict[str, bool]`.
+  - Marking a notice key persists it to disk and a new `SessionStore` instance reads it back.
+  - Calling `mark_notice_shown_once()` twice for the same session and notice returns `True` then `False` without losing persisted state.
+  - Marking one notice key does not make a different notice key appear shown.
+  - A freshly reset or newly created session entry starts with no notice keys shown.
+- **Verification:** The session-store tests prove backwards-compatible load, durable persistence, and fresh-session reset behaviour.
+
+### U2. Gate Codex autoraise warning replay through the durable latch
+
+- **Goal:** Suppress repeat gateway delivery when a fresh `AIAgent` is built for an already-notified session.
+- **Requirements:** R1, R2, R3, R5, R7.
+- **Dependencies:** U1.
+- **Files:**
+  - `gateway/run.py`
+  - `tests/gateway/test_codex_autoraise_notice_once.py`
+- **Approach:** Define a stable notice key for the Codex `gpt-5.5` autoraise notice in gateway code. After a fresh `AIAgent` is constructed and before callbacks are wired for the turn, inspect `agent._compression_threshold_autoraised` and `agent._compression_warning`. Call the atomic session-store helper; if it returns `True`, leave the warning for the existing turn-context replay, and if it returns `False`, clear `agent._compression_warning`. Keep cached-agent hits unchanged because the agent-level warning is already cleared after first replay.
+- **Patterns to follow:** `_agent_cache` miss path in `GatewayRunner._run_agent()`, status callback replay in `agent/turn_context.py`, and gateway-owned one-shot UX patterns from onboarding hints and pending model notes.
+- **Test scenarios:**
+  - First fresh agent for a session with a populated Codex autoraise warning keeps the warning and marks the session notice key.
+  - Second fresh agent for the same durable session has the warning cleared before replay.
+  - An integration-style gateway test forces two fresh-agent constructions for one session and asserts exactly one lifecycle/status send reaches the fake adapter or callback path.
+  - A different session key remains eligible to show the warning once.
+  - An agent without `_compression_threshold_autoraised` is not latched or modified.
+- **Verification:** Gateway tests simulate rebuilt agents for the same session and prove only the first one remains eligible to replay the warning.
+
+### U3. Verify existing agent-level compression warning behaviour
+
+- **Goal:** Ensure the lower-level compression warning replay contract still sends once per agent when no gateway latch is involved.
+- **Requirements:** R1, R3, R7.
+- **Dependencies:** U2.
+- **Files:**
+  - `tests/agent/test_turn_context.py`
+  - `tests/run_agent/test_compression_feasibility.py`
+- **Approach:** No agent-layer production code change is expected. Keep `_replay_compression_warning()` and `build_turn_context()` clearing behaviour intact, and rely on existing tests unless the gateway gating creates a specific coverage blind spot.
+- **Patterns to follow:** Current tests that assert `_compression_warning` is replayed through `status_callback` and then cleared.
+- **Test scenarios:**
+  - Existing replay-and-clear tests continue to pass.
+  - No gateway-specific state is required for agent-only compression warning replay.
+- **Verification:** Existing agent tests stay green alongside the new gateway tests.
+
+### U4. Add tracking issue and PR linkage
+
+- **Goal:** Make the UX request durable in GitHub and connect the code change to it.
+- **Requirements:** R8, R9.
+- **Dependencies:** U1, U2.
+- **Files:**
+  - Pull request body only.
+- **Approach:** Create a GitHub issue describing the repeated notice in Telegram/WhatsApp gateway sessions, expected once-per-session behaviour, and acceptance criteria. Reference the issue in the PR body with a closing keyword if appropriate.
+- **Patterns to follow:** Repository PRs should include what changed, why, verification, risks, and follow-up without provenance language.
+- **Test scenarios:** Test expectation: none -- this unit is tracker hygiene, not runtime behaviour.
+- **Verification:** The GitHub issue URL exists, and the PR body links it.
+
+---
+
+## Scope Boundaries
+
+- This plan does not disable `compression.codex_gpt55_autoraise` or change the `0.85` threshold.
+- This plan does not hide the notice globally; it remains visible once for each eligible durable gateway session.
+- This plan does not redesign gateway lifecycle/status delivery or conversation transcript persistence.
+- This plan does not alter non-gateway CLI startup notices.
+
+### Deferred to Follow-Up Work
+
+- A broader gateway notice registry could consolidate onboarding hints, credit notices, and lifecycle notices later if more repeated-notice issues appear.
+
+---
+
+## Risks & Dependencies
+
+- **Session-store concurrency:** The latch helper must use the existing store lock and save path so concurrent gateway turns do not race into duplicate delivery.
+- **Reset semantics:** The latch must be scoped to `SessionEntry`, not global chat ID, so a real `/new` or auto-reset gets a fresh one-time notice allowance.
+- **Delivery best effort:** Marking before replay may suppress a notice if delivery fails after marking, but this is acceptable because repeated user-facing nags are the observed issue and status messages are already best-effort.
+
+---
+
+## Sources & Research
+
+- `agent/agent_init.py` builds and stores the Codex `gpt-5.5` autoraise notice on `agent._compression_warning`.
+- `agent/auxiliary_client.py` gates the `0.85` threshold override to `gpt-5.5` on `openai-codex`.
+- `agent/turn_context.py` replays `agent._compression_warning` and clears it once per in-memory agent.
+- `gateway/run.py` reuses or rebuilds `AIAgent` instances through `_agent_cache` and passes `gateway_session_key` plus `session_db` into fresh agents.
+- `gateway/session.py` persists durable `SessionEntry` state across visible Telegram and WhatsApp sessions.
+- `tests/agent/test_arcee_trinity_overrides.py`, `tests/run_agent/test_compression_feasibility.py`, and `tests/gateway/test_agent_cache.py` contain the closest existing coverage patterns.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -63,6 +63,7 @@ from hermes_cli.fallback_config import get_fallback_chain
 # from _enforce_agent_cache_cap() and _session_expiry_watcher() below.
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
+_CODEX_GPT55_AUTORAISE_NOTICE_KEY = "codex_gpt55_autoraise"
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
@@ -12555,6 +12556,20 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
             except Exception:
                 pass
 
+    def _apply_gateway_notice_latch(self, agent: Any, session_key: str) -> None:
+        """Persist one-shot gateway notices across rebuilt agent instances."""
+        if not (
+            getattr(agent, "_compression_threshold_autoraised", None)
+            and getattr(agent, "_compression_warning", None)
+        ):
+            return
+        _first_notice = self.session_store.mark_notice_shown_once(
+            session_key,
+            _CODEX_GPT55_AUTORAISE_NOTICE_KEY,
+        )
+        if not _first_notice:
+            setattr(agent, "_compression_warning", None)
+
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
         """Reset per-turn state on a cached agent before a new turn starts.
@@ -14018,6 +14033,9 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
                 )
+
+                self._apply_gateway_notice_latch(agent, session_key)
+
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
                         _cache[session_key] = (agent, _sig)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12563,7 +12563,10 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
             and getattr(agent, "_compression_warning", None)
         ):
             return
-        _first_notice = self.session_store.mark_notice_shown_once(
+        session_store = getattr(self, "session_store", None)
+        if session_store is None:
+            return
+        _first_notice = session_store.mark_notice_shown_once(
             session_key,
             _CODEX_GPT55_AUTORAISE_NOTICE_KEY,
         )

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -16,7 +16,7 @@ import threading
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -490,6 +490,7 @@ class SessionEntry:
     resume_pending: bool = False
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
+    notices_shown: Dict[str, bool] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -521,6 +522,11 @@ class SessionEntry:
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
             "reset_had_activity": self.reset_had_activity,
+            "notices_shown": {
+                str(k): True
+                for k, v in self.notices_shown.items()
+                if isinstance(k, str) and v
+            },
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -546,6 +552,15 @@ class SessionEntry:
                 last_resume_marked_at = datetime.fromisoformat(_lrma)
             except (TypeError, ValueError):
                 last_resume_marked_at = None
+
+        notices_shown: Dict[str, bool] = {}
+        raw_notices = data.get("notices_shown")
+        if isinstance(raw_notices, dict):
+            notices_shown = {
+                str(k): True
+                for k, v in raw_notices.items()
+                if isinstance(k, str) and v
+            }
 
         return cls(
             session_key=data["session_key"],
@@ -573,6 +588,7 @@ class SessionEntry:
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
             reset_had_activity=data.get("reset_had_activity", False),
+            notices_shown=notices_shown,
         )
 
 
@@ -756,6 +772,27 @@ class SessionStore:
             except OSError as e:
                 logger.debug("Could not remove temp file %s: %s", tmp_path, e)
             raise
+
+    def mark_notice_shown_once(self, session_key: str, notice_key: str) -> bool:
+        """Atomically mark a gateway notice as shown for this session.
+
+        Returns True only for the first caller that marks ``notice_key`` for
+        ``session_key``. Later callers return False so they can suppress their
+        duplicate user-facing notice while preserving the durable session.
+        """
+        if not session_key or not notice_key:
+            return False
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return False
+            if entry.notices_shown.get(notice_key):
+                return False
+            entry.notices_shown[notice_key] = True
+            entry.updated_at = _now()
+            self._save()
+            return True
     
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""

--- a/tests/gateway/test_codex_autoraise_notice_once.py
+++ b/tests/gateway/test_codex_autoraise_notice_once.py
@@ -1,0 +1,121 @@
+import inspect
+from datetime import datetime
+from types import SimpleNamespace
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource, SessionStore
+
+
+SESSION_KEY = "agent:main:telegram:dm:123"
+NOTICE = "Codex gpt-5.5 caps context at 272K"
+
+
+def _store(tmp_path) -> SessionStore:
+    store = SessionStore(tmp_path, GatewayConfig())
+    now = datetime.now()
+    store._entries[SESSION_KEY] = SessionEntry(
+        session_key=SESSION_KEY,
+        session_id="20260608_test",
+        created_at=now,
+        updated_at=now,
+        origin=SessionSource(platform=Platform.TELEGRAM, chat_id="123"),
+        platform=Platform.TELEGRAM,
+    )
+    store._loaded = True
+    store._save()
+    return store
+
+
+def _agent(warning: str = NOTICE):
+    return SimpleNamespace(
+        _compression_threshold_autoraised={"from": 0.5, "to": 0.85},
+        _compression_warning=warning,
+    )
+
+
+def _runner(store: SessionStore):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.session_store = store
+    return runner
+
+
+def test_codex_autoraise_notice_is_kept_for_first_fresh_agent(tmp_path):
+    store = _store(tmp_path)
+    agent = _agent()
+
+    GatewayRunner._apply_gateway_notice_latch(_runner(store), agent, SESSION_KEY)
+
+    assert agent._compression_warning == NOTICE
+    assert store._entries[SESSION_KEY].notices_shown == {"codex_gpt55_autoraise": True}
+
+
+def test_codex_autoraise_notice_is_cleared_for_rebuilt_agent_same_session(tmp_path):
+    store = _store(tmp_path)
+    first_agent = _agent()
+    second_agent = _agent()
+
+    GatewayRunner._apply_gateway_notice_latch(_runner(store), first_agent, SESSION_KEY)
+    GatewayRunner._apply_gateway_notice_latch(_runner(store), second_agent, SESSION_KEY)
+
+    assert first_agent._compression_warning == NOTICE
+    assert second_agent._compression_warning is None
+
+
+def test_codex_autoraise_notice_is_once_per_durable_session(tmp_path):
+    store = _store(tmp_path)
+    other_key = "agent:main:telegram:dm:456"
+    now = datetime.now()
+    store._entries[other_key] = SessionEntry(
+        session_key=other_key,
+        session_id="20260608_other",
+        created_at=now,
+        updated_at=now,
+        origin=SessionSource(platform=Platform.TELEGRAM, chat_id="456"),
+        platform=Platform.TELEGRAM,
+    )
+    store._save()
+
+    first_session_agent = _agent()
+    other_session_agent = _agent()
+
+    GatewayRunner._apply_gateway_notice_latch(_runner(store), first_session_agent, SESSION_KEY)
+    GatewayRunner._apply_gateway_notice_latch(_runner(store), other_session_agent, other_key)
+
+    assert first_session_agent._compression_warning == NOTICE
+    assert other_session_agent._compression_warning == NOTICE
+    assert store._entries[SESSION_KEY].notices_shown == {"codex_gpt55_autoraise": True}
+    assert store._entries[other_key].notices_shown == {"codex_gpt55_autoraise": True}
+
+
+def test_agents_without_codex_autoraise_warning_are_not_latched(tmp_path):
+    store = _store(tmp_path)
+    agent = SimpleNamespace(_compression_threshold_autoraised=None, _compression_warning=NOTICE)
+
+    GatewayRunner._apply_gateway_notice_latch(_runner(store), agent, SESSION_KEY)
+
+    assert agent._compression_warning == NOTICE
+    assert store._entries[SESSION_KEY].notices_shown == {}
+
+
+def test_latch_allows_exactly_one_lifecycle_replay_for_rebuilt_agents(tmp_path):
+    store = _store(tmp_path)
+    delivered = []
+
+    for agent in (_agent(), _agent()):
+        GatewayRunner._apply_gateway_notice_latch(_runner(store), agent, SESSION_KEY)
+        if agent._compression_warning:
+            delivered.append(("lifecycle", agent._compression_warning))
+            agent._compression_warning = None
+
+    assert delivered == [("lifecycle", NOTICE)]
+
+
+def test_gateway_fresh_agent_path_applies_latch_before_turn_callbacks():
+    source = inspect.getsource(GatewayRunner._run_agent)
+    latch_call = "self._apply_gateway_notice_latch(agent, session_key)"
+
+    assert latch_call in source
+    assert source.index("agent = AIAgent(") < source.index(latch_call)
+    assert source.index(latch_call) < source.index("agent.status_callback = _status_callback_sync")
+    assert source.index(latch_call) < source.index("agent.run_conversation")

--- a/tests/gateway/test_codex_autoraise_notice_once.py
+++ b/tests/gateway/test_codex_autoraise_notice_once.py
@@ -98,6 +98,15 @@ def test_agents_without_codex_autoraise_warning_are_not_latched(tmp_path):
     assert store._entries[SESSION_KEY].notices_shown == {}
 
 
+def test_gateway_latch_tolerates_minimal_test_runner_without_session_store():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    agent = _agent()
+
+    GatewayRunner._apply_gateway_notice_latch(runner, agent, SESSION_KEY)
+
+    assert agent._compression_warning == NOTICE
+
+
 def test_latch_allows_exactly_one_lifecycle_replay_for_rebuilt_agents(tmp_path):
     store = _store(tmp_path)
     delivered = []

--- a/tests/gateway/test_session_notice_latch.py
+++ b/tests/gateway/test_session_notice_latch.py
@@ -1,0 +1,102 @@
+import json
+from datetime import datetime
+
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionEntry, SessionSource, SessionStore
+
+
+def _entry(session_key: str = "agent:main:telegram:dm:123") -> SessionEntry:
+    now = datetime.now()
+    return SessionEntry(
+        session_key=session_key,
+        session_id="20260608_test",
+        created_at=now,
+        updated_at=now,
+        origin=SessionSource(platform=Platform.TELEGRAM, chat_id="123"),
+        platform=Platform.TELEGRAM,
+    )
+
+
+def test_session_entry_loads_missing_notice_map():
+    data = _entry().to_dict()
+    data.pop("notices_shown")
+
+    loaded = SessionEntry.from_dict(data)
+
+    assert loaded.notices_shown == {}
+
+
+def test_session_entry_sanitizes_malformed_notice_map():
+    base = _entry().to_dict()
+
+    for malformed in (None, "seen", ["notice"], 42):
+        data = dict(base, notices_shown=malformed)
+        loaded = SessionEntry.from_dict(data)
+        assert loaded.notices_shown == {}
+
+    data = dict(
+        base,
+        notices_shown={
+            "codex_gpt55_autoraise": True,
+            "false_value": False,
+            123: True,
+            "truthy_value": "yes",
+        },
+    )
+    loaded = SessionEntry.from_dict(data)
+
+    assert loaded.notices_shown == {
+        "codex_gpt55_autoraise": True,
+        "truthy_value": True,
+    }
+    assert loaded.to_dict()["notices_shown"] == {
+        "codex_gpt55_autoraise": True,
+        "truthy_value": True,
+    }
+
+
+def test_mark_notice_shown_once_persists_and_returns_first_caller(tmp_path):
+    store = SessionStore(tmp_path, GatewayConfig())
+    entry = _entry()
+    store._entries[entry.session_key] = entry
+    store._loaded = True
+    store._save()
+
+    assert store.mark_notice_shown_once(entry.session_key, "codex_gpt55_autoraise") is True
+    assert store.mark_notice_shown_once(entry.session_key, "codex_gpt55_autoraise") is False
+    assert store.mark_notice_shown_once(entry.session_key, "other_notice") is True
+
+    reloaded = SessionStore(tmp_path, GatewayConfig())
+    reloaded._ensure_loaded()
+
+    assert reloaded._entries[entry.session_key].notices_shown == {
+        "codex_gpt55_autoraise": True,
+        "other_notice": True,
+    }
+
+    saved = json.loads((tmp_path / "sessions.json").read_text())
+    assert saved[entry.session_key]["notices_shown"]["codex_gpt55_autoraise"] is True
+
+
+def test_fresh_session_entry_starts_with_no_notice_keys():
+    first = _entry("agent:main:telegram:dm:first")
+    second = _entry("agent:main:telegram:dm:second")
+    first.notices_shown["codex_gpt55_autoraise"] = True
+
+    assert second.notices_shown == {}
+
+
+def test_force_new_session_resets_notice_eligibility(tmp_path):
+    store = SessionStore(tmp_path, GatewayConfig())
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+
+    first = store.get_or_create_session(source)
+    assert store.mark_notice_shown_once(first.session_key, "codex_gpt55_autoraise") is True
+    assert store.mark_notice_shown_once(first.session_key, "codex_gpt55_autoraise") is False
+
+    reset = store.get_or_create_session(source, force_new=True)
+
+    assert reset.session_key == first.session_key
+    assert reset.session_id != first.session_id
+    assert reset.notices_shown == {}
+    assert store.mark_notice_shown_once(reset.session_key, "codex_gpt55_autoraise") is True


### PR DESCRIPTION
## What does this PR do?

Gateway users can currently see the Codex gpt-5.5 compression autoraise notice more than once in the same visible session when the gateway rebuilds the in-memory agent. That can happen after a restart, cache eviction, idle expiry, or runtime signature change.

This keeps the existing autoraise behaviour, but makes the notice delivery durable per gateway session. The first eligible turn can still explain why the threshold was raised, while rebuilt agents for the same session suppress duplicate notices. Fresh sessions, `/new`, `/reset`, and auto-reset sessions remain eligible to show the notice once.

The config opt-out remains available with `hermes config set compression.codex_gpt55_autoraise false`, but users should not need to disable the feature just to stop repeat notices.

## Related Issue

Fixes #42187

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a backward-compatible `notices_shown` map to `gateway/session.py` session entries.
- Added `SessionStore.mark_notice_shown_once(...)` to atomically persist one-shot gateway notices per durable session key.
- Gated the Codex gpt-5.5 autoraise warning in `gateway/run.py` through the durable session latch when fresh agents are created.
- Added gateway/session regression tests covering persistence, malformed/missing session data, fresh-session eligibility, rebuilt-agent suppression, and minimal test-runner compatibility.

## How to Test

1. Run the targeted regression suite:
   ```bash
   pytest -q tests/cron/test_codex_execution_paths.py tests/gateway/test_session_notice_latch.py tests/gateway/test_codex_autoraise_notice_once.py tests/agent/test_turn_context.py tests/run_agent/test_compression_feasibility.py
   ```
2. Confirm the result is `36 passed`.
3. For manual gateway verification, use `provider: openai-codex` with `model: gpt-5.5`, trigger the autoraise notice in a gateway session, then rebuild the agent for the same durable session. The first eligible turn can show the notice, but the rebuilt agent should not repeat it for that same session.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted local verification:

```text
pytest -q tests/cron/test_codex_execution_paths.py tests/gateway/test_session_notice_latch.py tests/gateway/test_codex_autoraise_notice_once.py tests/agent/test_turn_context.py tests/run_agent/test_compression_feasibility.py
36 passed in 3.92s
```

Browser/UI screenshots are not applicable for this gateway/session-store change.
