### PR TITLE
perf(dashboard): trim session list payloads

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3585,6 +3585,11 @@ async def get_action_status(name: str, lines: int = 200):
     }
 
 
+_PROFILES_SESSIONS_CACHE_TTL_SECONDS = 10.0
+_PROFILES_SESSIONS_CACHE_LOCK = threading.RLock()
+_PROFILES_SESSIONS_CACHE: Dict[Tuple[int, int, int, str, str, str, str, str], Tuple[float, Dict[str, Any]]] = {}
+
+
 @app.get("/api/sessions")
 async def get_sessions(
     limit: int = 20,
@@ -3643,6 +3648,7 @@ async def get_sessions(
                 include_archived=include_archived,
                 archived_only=archived_only,
                 order_by_last_active=order == "recent",
+                include_system_prompt=False,
             )
             total = db.session_count(
                 source=source or None,
@@ -3664,7 +3670,7 @@ async def get_sessions(
                     s["is_default_profile"] = profile_name == "default"
                 # SQLite stores the flag as 0/1; expose a real JSON boolean.
                 s["archived"] = bool(s.get("archived"))
-            return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}
+            return {"sessions": _trim_session_list_payload(sessions), "total": total, "limit": limit, "offset": offset}
         finally:
             db.close()
     except HTTPException:
@@ -3698,6 +3704,26 @@ def get_profiles_sessions(
         raise HTTPException(status_code=400, detail="archived must be one of: exclude, only, include")
     if order not in ("created", "recent"):
         raise HTTPException(status_code=400, detail="order must be one of: created, recent")
+
+    cache_key = None
+    if profile == "all":
+        cache_key = (
+            limit,
+            offset,
+            min_messages,
+            archived,
+            order,
+            profile,
+            source or "",
+            exclude_sources or "",
+        )
+        cached = _PROFILES_SESSIONS_CACHE.get(cache_key)
+        if cached and (time.time() - cached[0]) < _PROFILES_SESSIONS_CACHE_TTL_SECONDS:
+            return cached[1]
+        with _PROFILES_SESSIONS_CACHE_LOCK:
+            cached = _PROFILES_SESSIONS_CACHE.get(cache_key)
+            if cached and (time.time() - cached[0]) < _PROFILES_SESSIONS_CACHE_TTL_SECONDS:
+                return cached[1]
 
     from hermes_state import SessionDB
     from hermes_cli import profiles as profiles_mod
@@ -3755,6 +3781,7 @@ def get_profiles_sessions(
                 include_archived=include_archived,
                 archived_only=archived_only,
                 order_by_last_active=order == "recent",
+                include_system_prompt=False,
             )
             profile_total = db.session_count(
                 source=source_filter,
@@ -3782,8 +3809,8 @@ def get_profiles_sessions(
 
     sort_key = "last_active" if order == "recent" else "started_at"
     merged.sort(key=lambda s: s.get(sort_key) or s.get("started_at") or 0, reverse=True)
-    window = merged[offset:offset + limit]
-    return {
+    window = _trim_session_list_payload(merged[offset:offset + limit])
+    result = {
         "sessions": window,
         "total": total,
         "profile_totals": profile_totals,
@@ -3791,6 +3818,29 @@ def get_profiles_sessions(
         "offset": offset,
         "errors": errors,
     }
+    if cache_key is not None:
+        with _PROFILES_SESSIONS_CACHE_LOCK:
+            _PROFILES_SESSIONS_CACHE[cache_key] = (time.time(), result)
+    return result
+
+
+def _trim_session_list_payload(sessions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop heavy fields that session-list UIs never render.
+
+    ``SessionDB.list_sessions_rich()`` can return full ``sessions`` rows,
+    including the assembled ``system_prompt`` snapshot. On large profiles that
+    field can dominate the response body, and session-list clients usually poll
+    these endpoints during startup or sidebar refreshes. Returning it forces
+    multi-megabyte REST round trips before the UI needs full session details.
+
+    Full session detail endpoints can still expose rich fields if they need to;
+    list endpoints should stay lean.
+    """
+    heavy_fields = {"system_prompt"}
+    return [
+        {key: value for key, value in session.items() if key not in heavy_fields}
+        for session in sessions
+    ]
 
 
 @app.get("/api/sessions/search")
@@ -8037,14 +8087,29 @@ async def get_session_stats(profile: Optional[str] = None):
     db = _open_session_db_for_profile(profile)
     try:
         total = db.session_count(include_archived=True)
-        active_store = db.session_count(include_archived=False)
         archived = db.session_count(archived_only=True)
         messages = db.message_count()
+        # "Active in store" means sessions whose lifecycle was never closed,
+        # not merely "non-archived".  The old implementation used
+        # session_count(include_archived=False), which returned nearly every
+        # session on installs that have not archived anything yet and made the
+        # dashboard look like it had ~10k live conversations.
+        conn = db._conn
+        if conn is None:
+            raise RuntimeError("SessionDB connection unavailable")
+        active_store = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE end_reason IS NULL"
+        ).fetchone()[0]
         by_source: Dict[str, int] = {}
         try:
-            for s in db.list_sessions_rich(limit=10000, include_archived=True):
-                src = str(s.get("source") or "cli")
-                by_source[src] = by_source.get(src, 0) + 1
+            # Avoid materialising thousands of rich session rows just to build
+            # source badges.  The stats card only needs raw grouped counts.
+            for row in conn.execute(
+                "SELECT COALESCE(source, 'cli') AS source, COUNT(*) AS count "
+                "FROM sessions GROUP BY COALESCE(source, 'cli') "
+                "ORDER BY count DESC LIMIT 100"
+            ):
+                by_source[str(row["source"])] = int(row["count"])
         except Exception:
             pass
         return {

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -787,6 +787,44 @@ CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestam
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
 """
 
+_SESSION_LIST_COLUMNS_NO_SYSTEM_PROMPT = ", ".join(
+    f"s.{column}"
+    for column in (
+        "id",
+        "source",
+        "user_id",
+        "model",
+        "model_config",
+        "parent_session_id",
+        "started_at",
+        "ended_at",
+        "end_reason",
+        "message_count",
+        "tool_call_count",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "reasoning_tokens",
+        "cwd",
+        "billing_provider",
+        "billing_base_url",
+        "billing_mode",
+        "estimated_cost_usd",
+        "actual_cost_usd",
+        "cost_status",
+        "cost_source",
+        "pricing_version",
+        "title",
+        "api_call_count",
+        "handoff_state",
+        "handoff_platform",
+        "handoff_error",
+        "rewind_count",
+        "archived",
+    )
+)
+
 # Indexes that reference columns added in later schema versions must be
 # created AFTER _reconcile_columns() has had a chance to ADD them on
 # existing databases. SCHEMA_SQL above is run by sqlite executescript
@@ -2896,6 +2934,7 @@ class SessionDB:
         archived_only: bool = False,
         id_query: str = None,
         search_query: str = None,
+        include_system_prompt: bool = True,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -3046,6 +3085,7 @@ class SessionDB:
                 outer_where = (
                     f"{where_sql} AND {combined}" if where_sql else f"WHERE {combined}"
                 )
+            session_select = "s.*" if include_system_prompt else _SESSION_LIST_COLUMNS_NO_SYSTEM_PROMPT
             query = f"""
                 WITH RECURSIVE chain(root_id, cur_id) AS (
                     SELECT s.id, s.id FROM sessions s {where_sql}
@@ -3069,7 +3109,7 @@ class SessionDB:
                     FROM chain
                     GROUP BY root_id
                 )
-                SELECT s.*,
+                SELECT {session_select},
                     COALESCE(
                         (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                          FROM messages m
@@ -3092,8 +3132,9 @@ class SessionDB:
             # only applies to the outer select.
             params = params + params + id_params + [limit, offset]
         else:
+            session_select = "s.*" if include_system_prompt else _SESSION_LIST_COLUMNS_NO_SYSTEM_PROMPT
             query = f"""
-                SELECT s.*,
+                SELECT {session_select},
                     COALESCE(
                         (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                          FROM messages m
@@ -3144,7 +3185,10 @@ class SessionDB:
                 if tip_id == s["id"]:
                     projected.append(s)
                     continue
-                tip_row = self._get_session_rich_row(tip_id)
+                tip_row = self._get_session_rich_row(
+                    tip_id,
+                    include_system_prompt=include_system_prompt,
+                )
                 if not tip_row:
                     projected.append(s)
                     continue
@@ -3230,13 +3274,19 @@ class SessionDB:
             runs.append(s)
         return runs
 
-    def _get_session_rich_row(self, session_id: str) -> Optional[Dict[str, Any]]:
+    def _get_session_rich_row(
+        self,
+        session_id: str,
+        *,
+        include_system_prompt: bool = True,
+    ) -> Optional[Dict[str, Any]]:
         """Fetch a single session with the same enriched columns as
         ``list_sessions_rich`` (preview + last_active). Returns None if the
         session doesn't exist.
         """
-        query = """
-            SELECT s.*,
+        session_select = "s.*" if include_system_prompt else _SESSION_LIST_COLUMNS_NO_SYSTEM_PROMPT
+        query = f"""
+            SELECT {session_select},
                 COALESCE(
                     (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                      FROM messages m

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -130,6 +130,34 @@ def _install_example_plugin(_isolate_hermes_home):
 
 
 # ---------------------------------------------------------------------------
+# Session-list payload tests
+# ---------------------------------------------------------------------------
+
+
+def test_trim_session_list_payload_drops_system_prompt_only():
+    from hermes_cli import web_server
+
+    original = [
+        {
+            "id": "s1",
+            "title": "Visible",
+            "system_prompt": "x" * 100_000,
+            "preview": "hello",
+            "model_config": {"temperature": 0},
+        }
+    ]
+
+    trimmed = web_server._trim_session_list_payload(original)
+
+    assert "system_prompt" not in trimmed[0]
+    assert trimmed[0]["id"] == "s1"
+    assert trimmed[0]["title"] == "Visible"
+    assert trimmed[0]["preview"] == "hello"
+    assert trimmed[0]["model_config"] == {"temperature": 0}
+    assert "system_prompt" in original[0]
+
+
+# ---------------------------------------------------------------------------
 # reload_env tests
 # ---------------------------------------------------------------------------
 
@@ -765,7 +793,9 @@ class TestWebServerEndpoints:
         """The cross-profile aggregator returns the default profile's rows
         tagged profile="default" (single-profile parity with /api/sessions)."""
         from hermes_state import SessionDB
+        from hermes_cli import web_server
 
+        web_server._PROFILES_SESSIONS_CACHE.clear()
         db = SessionDB()
         try:
             db.create_session(session_id="agg-me", source="cli")
@@ -780,6 +810,48 @@ class TestWebServerEndpoints:
         assert row["profile"] == "default"
         assert row["is_default_profile"] is True
         assert isinstance(data.get("errors"), list)
+
+    def test_session_list_endpoints_omit_system_prompt_payload(self):
+        """List APIs should stay lean; full prompts belong to detail endpoints."""
+        from hermes_state import SessionDB
+        from hermes_cli import web_server
+
+        web_server._PROFILES_SESSIONS_CACHE.clear()
+        db = SessionDB()
+        try:
+            db.create_session(session_id="prompt-heavy", source="cli", system_prompt="x" * 100_000)
+            db.append_message(session_id="prompt-heavy", role="user", content="hi")
+        finally:
+            db.close()
+
+        for path in ("/api/sessions?limit=20", "/api/profiles/sessions?limit=20"):
+            resp = self.client.get(path)
+            assert resp.status_code == 200
+            row = next(s for s in resp.json()["sessions"] if s["id"] == "prompt-heavy")
+            assert "system_prompt" not in row
+
+    def test_profiles_sessions_cache_keeps_source_filters_separate(self):
+        """The profile=all micro-cache must not mix recents and cron lists."""
+        from hermes_state import SessionDB
+        from hermes_cli import web_server
+
+        web_server._PROFILES_SESSIONS_CACHE.clear()
+        db = SessionDB()
+        try:
+            db.create_session(session_id="cli-session", source="cli")
+            db.append_message(session_id="cli-session", role="user", content="hi")
+            db.create_session(session_id="cron-session", source="cron")
+            db.append_message(session_id="cron-session", role="user", content="tick")
+        finally:
+            db.close()
+
+        cli_resp = self.client.get("/api/profiles/sessions?limit=20&source=cli")
+        assert cli_resp.status_code == 200
+        assert [s["id"] for s in cli_resp.json()["sessions"]] == ["cli-session"]
+
+        cron_resp = self.client.get("/api/profiles/sessions?limit=20&source=cron")
+        assert cron_resp.status_code == 200
+        assert [s["id"] for s in cron_resp.json()["sessions"]] == ["cron-session"]
 
     def test_profiles_sessions_rejects_unknown_archived_value(self):
         resp = self.client.get("/api/profiles/sessions?archived=bogus")


### PR DESCRIPTION
## Summary
- omit heavy `system_prompt` snapshots from session list API responses
- add `include_system_prompt=False` to `SessionDB.list_sessions_rich()` for lean list queries
- cache `/api/profiles/sessions?profile=all` responses by source filters so recents/cron lists do not share stale data
- compute dashboard session stats with direct SQL aggregates instead of materializing rich session rows

## Motivation
Session-list clients only need summary fields for sidebars/startup views. Returning full prompt snapshots can make list endpoints unnecessarily large on profiles with many sessions or large system prompts.

In practice this was not just a LAN bandwidth issue: even over a LAN connection the untrimmed session-list payload could exceed the dashboard request's 15s timeout, because the endpoint had to materialize and transfer large prompt snapshots that the list UI never renders.

## Test plan
- `git diff --check upstream/main..HEAD`
- `python -m py_compile hermes_cli/web_server.py hermes_state.py tests/hermes_cli/test_web_server.py`
- `pytest tests/hermes_cli/test_web_server.py -q -o 'addopts='` → 260 passed
- `pytest tests/test_hermes_state.py::TestListSessionsRich -q -o 'addopts='` → 14 passed

## Duplicate check
Searched open PRs/issues for:
- `session list system_prompt`
- `dashboard session payload`
- `api/profiles/sessions`
- `list_sessions_rich system_prompt`

No open duplicate found.