### PR TITLE
fix(slash-worker): stop the watchdog killing the worker on unreadable parent create_time

### DIFF
--- a/tests/test_slash_worker_watchdog.py
+++ b/tests/test_slash_worker_watchdog.py
@@ -19,3 +19,10 @@ def test_is_orphaned_false_when_parent_alive_and_matches():
     assert (
         slash_worker._is_orphaned(me.pid, me.create_time(), getppid=lambda: me.pid) is False
     )
+
+
+def test_is_orphaned_false_when_create_time_unknown():
+    # create_time was unreadable at startup (None sentinel): the PID-reuse guard
+    # must be skipped so a live, matching parent is not treated as orphaned.
+    me = psutil.Process()
+    assert slash_worker._is_orphaned(me.pid, None, getppid=lambda: me.pid) is False

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -27,12 +27,15 @@ _in_flight = threading.Event()  # set while a command is executing
 def _is_orphaned(original_ppid, parent_create_time, getppid=os.getppid) -> bool:
     """True once our spawning gateway is gone. Compare to the ORIGINAL ppid
     (never ==1: Linux reparents to a subreaper) and guard PID reuse via
-    create_time."""
+    create_time. A ``parent_create_time`` of ``None`` means it was unreadable
+    at startup, so the PID-reuse guard is skipped rather than firing falsely."""
     if getppid() != original_ppid:
         return True
     try:
         if not psutil.pid_exists(original_ppid):
             return True
+        if parent_create_time is None:
+            return False
         return psutil.Process(original_ppid).create_time() != parent_create_time
     except psutil.Error:
         return True
@@ -93,7 +96,10 @@ def main():
     try:
         parent_create_time = psutil.Process(orig_ppid).create_time()
     except psutil.Error:
-        parent_create_time = 0.0
+        # Unreadable at startup — leave the PID-reuse guard disabled instead of
+        # pinning a 0.0 sentinel that would later read as "orphaned" against a
+        # live parent and self-terminate the worker immediately.
+        parent_create_time = None
     _start_parent_death_watchdog(orig_ppid, parent_create_time)
 
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):


### PR DESCRIPTION
## What does this PR do?

The persistent slash-command worker starts a parent-death watchdog before the
HermesCLI build. When the parent gateway's process create_time cannot be read at
startup, the worker stored a `0.0` sentinel as the expected create_time. The
watchdog's PID-reuse guard then compares the live parent's real create_time
(always a positive float) against that `0.0` sentinel; the two never match, so
`_is_orphaned` returns `True` on the very first poll even though the gateway
parent is alive. The watchdog then calls `os._exit(0)` and the worker
self-terminates immediately, defeating the persistent-worker feature on that
error path.

This change replaces the `0.0` sentinel with `None`, meaning "create_time was
unreadable, so skip the PID-reuse guard." When the sentinel is `None`, the
watchdog relies solely on the original-ppid comparison and `pid_exists`, both of
which remain sufficient to detect a departed parent. The behaviour on all other
paths is unchanged.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/slash_worker.py`: replace the `0.0` startup fallback with `None`,
  and teach `_is_orphaned` to skip the create_time PID-reuse comparison when the
  parent create_time is unknown (`None`).
- `tests/test_slash_worker_watchdog.py`: add a regression test asserting that a
  live, matching parent with an unknown (`None`) create_time is not reported as
  orphaned.

## How to Test

1. Reproduce the bug: with the previous code, call
   `slash_worker._is_orphaned(me.pid, 0.0, getppid=lambda: me.pid)` for the
   current live process; it incorrectly returns `True`.
2. Apply the fix and call
   `slash_worker._is_orphaned(me.pid, None, getppid=lambda: me.pid)`; it now
   correctly returns `False`.
3. Run `pytest tests/test_slash_worker_watchdog.py -q`; all tests pass,
   including the new `test_is_orphaned_false_when_create_time_unknown` and the
   existing ppid-change and create_time-mismatch detection tests.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — updated the `_is_orphaned` docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the change is platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A