### PR TITLE
Add desktop custom endpoint settings

### DIFF
--- a/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
@@ -1,0 +1,397 @@
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import {
+  activateCustomEndpoint,
+  deleteCustomEndpoint,
+  getCustomEndpoints,
+  saveCustomEndpoint,
+  validateCustomEndpoint
+} from '@/hermes'
+import { triggerHaptic } from '@/lib/haptics'
+import { Check, Globe, Loader2, Plus, Save, Trash2, Zap } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import { notify, notifyError } from '@/store/notifications'
+import type { CustomEndpoint, CustomEndpointUpdate } from '@/types/hermes'
+
+import { EmptyState, LoadingState, Pill, SectionHeading, SettingsContent } from './primitives'
+
+interface CustomEndpointsSettingsProps {
+  onConfigSaved?: () => void
+  onMainModelChanged?: (provider: string, model: string) => void
+}
+
+interface EndpointForm {
+  apiKey: string
+  baseUrl: string
+  contextLength: string
+  discoverModels: boolean
+  id: string
+  makeDefault: boolean
+  model: string
+  name: string
+}
+
+const EMPTY_FORM: EndpointForm = {
+  apiKey: '',
+  baseUrl: '',
+  contextLength: '',
+  discoverModels: true,
+  id: '',
+  makeDefault: true,
+  model: '',
+  name: ''
+}
+
+function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
+  return {
+    apiKey: '',
+    baseUrl: endpoint.base_url,
+    contextLength: endpoint.context_length ? String(endpoint.context_length) : '',
+    discoverModels: endpoint.discover_models,
+    id: endpoint.id,
+    makeDefault: Boolean(endpoint.is_current),
+    model: endpoint.model,
+    name: endpoint.name
+  }
+}
+
+function toPayload(form: EndpointForm): CustomEndpointUpdate {
+  const contextLength = Number.parseInt(form.contextLength, 10)
+
+  return {
+    id: form.id.trim() || undefined,
+    name: form.name.trim(),
+    base_url: form.baseUrl.trim(),
+    model: form.model.trim(),
+    api_key: form.apiKey.trim() || undefined,
+    context_length: Number.isFinite(contextLength) && contextLength > 0 ? contextLength : undefined,
+    discover_models: form.discoverModels,
+    make_default: form.makeDefault
+  }
+}
+
+export function CustomEndpointsSettings({
+  onConfigSaved,
+  onMainModelChanged
+}: CustomEndpointsSettingsProps) {
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [activating, setActivating] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState<string | null>(null)
+  const [endpoints, setEndpoints] = useState<CustomEndpoint[]>([])
+  const [form, setForm] = useState<EndpointForm>(EMPTY_FORM)
+  const [discoveredModels, setDiscoveredModels] = useState<string[]>([])
+
+  async function refresh() {
+    const data = await getCustomEndpoints()
+    setEndpoints(data.endpoints)
+  }
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      try {
+        const data = await getCustomEndpoints()
+
+        if (cancelled) {
+          return
+        }
+
+        setEndpoints(data.endpoints)
+        const current = data.endpoints.find(endpoint => endpoint.is_current) ?? data.endpoints[0]
+
+        if (current) {
+          setForm(formFromEndpoint(current))
+          setDiscoveredModels(current.models)
+        }
+      } catch (err) {
+        notifyError(err, 'Could not load custom endpoints')
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function handleSave() {
+    try {
+      setSaving(true)
+      const response = await saveCustomEndpoint(toPayload(form))
+      setEndpoints(response.endpoints)
+      const saved = response.endpoints.find(endpoint => endpoint.id === response.id)
+
+      if (saved) {
+        setForm(formFromEndpoint(saved))
+        setDiscoveredModels(saved.models)
+      }
+
+      if (saved && saved.is_current) {
+        onMainModelChanged?.(saved.id, saved.model)
+      }
+
+      triggerHaptic('success')
+      onConfigSaved?.()
+      notify({ kind: 'success', message: 'Custom endpoint saved.' })
+    } catch (err) {
+      notifyError(err, 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleValidate() {
+    try {
+      setTesting(true)
+      const response = await validateCustomEndpoint(toPayload(form))
+      setDiscoveredModels(response.models)
+
+      if (response.ok) {
+        if (!form.model && response.models[0]) {
+          setForm(current => ({ ...current, model: response.models[0] }))
+        }
+
+        notify({
+          kind: 'success',
+          message: response.models.length ? `Endpoint is reachable. Found ${response.models.length} models.` : 'Endpoint is reachable.'
+        })
+      } else {
+        notify({
+          kind: response.reachable ? 'warning' : 'error',
+          message: response.message || 'Endpoint validation failed.'
+        })
+      }
+    } catch (err) {
+      notifyError(err, 'Validation failed')
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  async function handleActivate(endpoint: CustomEndpoint) {
+    try {
+      setActivating(endpoint.id)
+      const response = await activateCustomEndpoint(endpoint.id)
+      await refresh()
+      onConfigSaved?.()
+      onMainModelChanged?.(response.provider, response.model)
+      triggerHaptic('success')
+    } catch (err) {
+      notifyError(err, 'Activation failed')
+    } finally {
+      setActivating(null)
+    }
+  }
+
+  async function handleDelete(endpoint: CustomEndpoint) {
+    if (!window.confirm(`Delete ${endpoint.name}?`)) {
+      return
+    }
+
+    try {
+      setDeleting(endpoint.id)
+      const response = await deleteCustomEndpoint(endpoint.id)
+      setEndpoints(response.endpoints)
+
+      if (form.id === endpoint.id) {
+        setForm(EMPTY_FORM)
+        setDiscoveredModels([])
+      }
+
+      onConfigSaved?.()
+      triggerHaptic('success')
+    } catch (err) {
+      notifyError(err, 'Delete failed')
+    } finally {
+      setDeleting(null)
+    }
+  }
+
+  if (loading) {
+    return <LoadingState label="Loading custom endpoints..." />
+  }
+
+  const allModelOptions = Array.from(new Set([...discoveredModels, form.model].filter(Boolean)))
+  const canSave = form.name.trim() && form.baseUrl.trim() && form.model.trim()
+
+  return (
+    <SettingsContent>
+      <div className="space-y-6">
+        <section>
+          <SectionHeading icon={Globe} meta={`${endpoints.length}`} title="Custom Endpoints" />
+          <div className="divide-y divide-border/40 rounded-md border border-border/50">
+            {endpoints.length ? (
+              endpoints.map(endpoint => (
+                <div className="grid gap-3 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center" key={endpoint.id}>
+                  <button
+                    className="min-w-0 text-left"
+                    onClick={() => {
+                      setForm(formFromEndpoint(endpoint))
+                      setDiscoveredModels(endpoint.models)
+                    }}
+                    type="button"
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="truncate text-sm font-medium">{endpoint.name}</span>
+                      {endpoint.is_current && (
+                        <Pill tone="primary">
+                          <Check className="size-3" />
+                          Active
+                        </Pill>
+                      )}
+                      {endpoint.source === 'direct-config' && <Pill>config.yaml</Pill>}
+                    </div>
+                    <div className="mt-1 truncate font-mono text-[0.7rem] text-muted-foreground">{endpoint.base_url}</div>
+                    <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                      <span>{endpoint.model}</span>
+                      {endpoint.has_api_key && <span>{endpoint.api_key_preview ?? 'API key set'}</span>}
+                    </div>
+                  </button>
+                  <div className="flex items-center gap-2 sm:justify-end">
+                    <Button
+                      disabled={endpoint.is_current || activating === endpoint.id}
+                      onClick={() => void handleActivate(endpoint)}
+                      size="sm"
+                      variant="outline"
+                    >
+                      {activating === endpoint.id ? <Loader2 className="animate-spin" /> : <Zap />}
+                      Use
+                    </Button>
+                    {endpoint.source !== 'direct-config' && (
+                      <Button
+                        className="hover:text-destructive"
+                        disabled={deleting === endpoint.id}
+                        onClick={() => void handleDelete(endpoint)}
+                        size="icon-sm"
+                        title="Delete endpoint"
+                        variant="ghost"
+                      >
+                        {deleting === endpoint.id ? <Loader2 className="animate-spin" /> : <Trash2 />}
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))
+            ) : (
+              <EmptyState description="Add an OpenAI-compatible endpoint below." title="No custom endpoints" />
+            )}
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading icon={Plus} title={form.id ? 'Edit Endpoint' : 'Add Endpoint'} />
+          <div className="grid gap-3 rounded-md border border-border/50 p-3">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="grid gap-1.5 text-xs text-muted-foreground">
+                Name
+                <Input
+                  onChange={event => setForm(current => ({ ...current, name: event.target.value }))}
+                  placeholder="Axet Proxy"
+                  value={form.name}
+                />
+              </label>
+              <label className="grid gap-1.5 text-xs text-muted-foreground">
+                Provider ID
+                <Input
+                  onChange={event => setForm(current => ({ ...current, id: event.target.value }))}
+                  placeholder="axet-proxy"
+                  value={form.id}
+                />
+              </label>
+            </div>
+            <label className="grid gap-1.5 text-xs text-muted-foreground">
+              Endpoint URL
+              <Input
+                onChange={event => setForm(current => ({ ...current, baseUrl: event.target.value }))}
+                placeholder="http://127.0.0.1:8081/v1"
+                value={form.baseUrl}
+              />
+            </label>
+            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_12rem]">
+              <label className="grid gap-1.5 text-xs text-muted-foreground">
+                Default Model
+                <Input
+                  list="custom-endpoint-models"
+                  onChange={event => setForm(current => ({ ...current, model: event.target.value }))}
+                  placeholder="gpt-5.4"
+                  value={form.model}
+                />
+                <datalist id="custom-endpoint-models">
+                  {allModelOptions.map(model => (
+                    <option key={model} value={model} />
+                  ))}
+                </datalist>
+              </label>
+              <label className="grid gap-1.5 text-xs text-muted-foreground">
+                Context
+                <Input
+                  inputMode="numeric"
+                  onChange={event => setForm(current => ({ ...current, contextLength: event.target.value }))}
+                  placeholder="Auto"
+                  value={form.contextLength}
+                />
+              </label>
+            </div>
+            <label className="grid gap-1.5 text-xs text-muted-foreground">
+              API Key
+              <Input
+                onChange={event => setForm(current => ({ ...current, apiKey: event.target.value }))}
+                placeholder={form.id ? 'Leave blank to keep current key' : 'Optional'}
+                type="password"
+                value={form.apiKey}
+              />
+            </label>
+            <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+              <label className="flex items-center gap-2">
+                <Checkbox
+                  checked={form.makeDefault}
+                  onCheckedChange={checked => setForm(current => ({ ...current, makeDefault: checked === true }))}
+                />
+                Use for new chats
+              </label>
+              <label className="flex items-center gap-2">
+                <Checkbox
+                  checked={form.discoverModels}
+                  onCheckedChange={checked => setForm(current => ({ ...current, discoverModels: checked === true }))}
+                />
+                Discover models
+              </label>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button disabled={testing || !form.baseUrl.trim()} onClick={() => void handleValidate()} variant="outline">
+                {testing ? <Loader2 className="animate-spin" /> : <Zap />}
+                Test
+              </Button>
+              <Button disabled={saving || !canSave} onClick={() => void handleSave()}>
+                {saving ? <Loader2 className="animate-spin" /> : <Save />}
+                Save
+              </Button>
+              <Button
+                className={cn(!form.id && 'hidden')}
+                onClick={() => {
+                  setForm(EMPTY_FORM)
+                  setDiscoveredModels([])
+                }}
+                type="button"
+                variant="ghost"
+              >
+                New endpoint
+              </Button>
+            </div>
+          </div>
+        </section>
+      </div>
+    </SettingsContent>
+  )
+}

--- a/apps/desktop/src/app/settings/index.tsx
+++ b/apps/desktop/src/app/settings/index.tsx
@@ -124,6 +124,13 @@ export function SettingsView({ gateway, onClose, onConfigSaved, onMainModelChang
                 nested
                 onClick={() => openProviderView('keys')}
               />
+              <OverlayNavItem
+                active={providerView === 'custom-endpoints'}
+                icon={Globe}
+                label={t.settings.nav.providerCustomEndpoints}
+                nested
+                onClick={() => openProviderView('custom-endpoints')}
+              />
             </div>
           )}
           <OverlayNavItem
@@ -220,7 +227,12 @@ export function SettingsView({ gateway, onClose, onConfigSaved, onMainModelChang
               onMainModelChanged={onMainModelChanged}
             />
           ) : activeView === 'providers' ? (
-            <ProvidersSettings onViewChange={setProviderView} view={providerView} />
+            <ProvidersSettings
+              onConfigSaved={onConfigSaved}
+              onMainModelChanged={onMainModelChanged}
+              onViewChange={setProviderView}
+              view={providerView}
+            />
           ) : activeView === 'keys' ? (
             <KeysSettings view={keysView} />
           ) : activeView === 'mcp' ? (

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -17,12 +17,13 @@ import { $desktopOnboarding, startManualProviderOAuth } from '@/store/onboarding
 import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
 import { isKeyVar, ProviderKeyRows } from './credential-key-ui'
+import { CustomEndpointsSettings } from './custom-endpoints-settings'
 import { SettingsCategoryHeading, useEnvCredentials } from './env-credentials'
 import { providerGroup, providerMeta, providerPriority } from './helpers'
 import { LoadingState, SettingsContent } from './primitives'
 
 // Sub-views surfaced as a sidebar subnav: account sign-in vs raw API keys.
-export const PROVIDER_VIEWS = ['accounts', 'keys'] as const
+export const PROVIDER_VIEWS = ['accounts', 'keys', 'custom-endpoints'] as const
 
 export type ProviderView = (typeof PROVIDER_VIEWS)[number]
 
@@ -168,7 +169,12 @@ function NoProviderKeys() {
   )
 }
 
-export function ProvidersSettings({ onViewChange, view }: ProvidersSettingsProps) {
+export function ProvidersSettings({
+  onConfigSaved,
+  onMainModelChanged,
+  onViewChange,
+  view
+}: ProvidersSettingsProps) {
   const { t } = useI18n()
   const { rowProps, vars } = useEnvCredentials()
   const [oauthProviders, setOauthProviders] = useState<OAuthProvider[]>([])
@@ -208,7 +214,7 @@ export function ProvidersSettings({ onViewChange, view }: ProvidersSettingsProps
   const hasOauth = oauthProviders.length > 0
   // The sidebar subnav owns the Accounts/API-keys split now; with no OAuth
   // providers there's nothing for the "Accounts" view to show, so fall to keys.
-  const showApiKeys = view === 'keys' || !hasOauth
+  const showApiKeys = view === 'keys' || (!hasOauth && view !== 'custom-endpoints')
 
   const keyGroups = buildProviderKeyGroups(vars)
 
@@ -235,6 +241,15 @@ export function ProvidersSettings({ onViewChange, view }: ProvidersSettingsProps
     )
   }
 
+  if (view === 'custom-endpoints') {
+    return (
+      <CustomEndpointsSettings
+        onConfigSaved={onConfigSaved}
+        onMainModelChanged={onMainModelChanged}
+      />
+    )
+  }
+
   return (
     <SettingsContent>
       <OAuthPicker onWantApiKey={() => onViewChange('keys')} providers={oauthProviders} />
@@ -253,6 +268,8 @@ interface ProviderKeyGroup {
 }
 
 interface ProvidersSettingsProps {
+  onConfigSaved?: () => void
+  onMainModelChanged?: (provider: string, model: string) => void
   onViewChange: (view: ProviderView) => void
   view: ProviderView
 }

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -12,6 +12,9 @@ import type {
   CronJob,
   CronJobCreatePayload,
   CronJobUpdates,
+  CustomEndpointsResponse,
+  CustomEndpointUpdate,
+  CustomEndpointValidationResponse,
   ElevenLabsVoicesResponse,
   EnvVarInfo,
   HermesConfig,
@@ -54,16 +57,20 @@ export type {
   AnalyticsSkillEntry,
   AnalyticsSkillsSummary,
   AnalyticsTotals,
-  BackendUpdateCheckResponse,
   AudioSpeakResponse,
   AudioTranscriptionResponse,
   AuxiliaryModelsResponse,
+  BackendUpdateCheckResponse,
   ConfigFieldSchema,
   ConfigSchemaResponse,
   CronJob,
   CronJobCreatePayload,
   CronJobSchedule,
   CronJobUpdates,
+  CustomEndpoint,
+  CustomEndpointsResponse,
+  CustomEndpointUpdate,
+  CustomEndpointValidationResponse,
   ElevenLabsVoice,
   ElevenLabsVoicesResponse,
   EnvVarInfo,
@@ -350,6 +357,42 @@ export function validateProviderCredential(
     path: '/api/providers/validate',
     method: 'POST',
     body: { key, value }
+  })
+}
+
+export function getCustomEndpoints(): Promise<CustomEndpointsResponse> {
+  return window.hermesDesktop.api<CustomEndpointsResponse>({
+    path: '/api/providers/custom-endpoints'
+  })
+}
+
+export function saveCustomEndpoint(endpoint: CustomEndpointUpdate): Promise<CustomEndpointsResponse> {
+  return window.hermesDesktop.api<CustomEndpointsResponse>({
+    path: '/api/providers/custom-endpoints',
+    method: 'POST',
+    body: endpoint
+  })
+}
+
+export function validateCustomEndpoint(endpoint: CustomEndpointUpdate): Promise<CustomEndpointValidationResponse> {
+  return window.hermesDesktop.api<CustomEndpointValidationResponse>({
+    path: '/api/providers/custom-endpoints/validate',
+    method: 'POST',
+    body: endpoint
+  })
+}
+
+export function activateCustomEndpoint(id: string): Promise<{ ok: boolean; provider: string; model: string }> {
+  return window.hermesDesktop.api<{ ok: boolean; provider: string; model: string }>({
+    path: `/api/providers/custom-endpoints/${encodeURIComponent(id)}/activate`,
+    method: 'POST'
+  })
+}
+
+export function deleteCustomEndpoint(id: string): Promise<CustomEndpointsResponse> {
+  return window.hermesDesktop.api<CustomEndpointsResponse>({
+    path: `/api/providers/custom-endpoints/${encodeURIComponent(id)}`,
+    method: 'DELETE'
   })
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -248,6 +248,7 @@ export const en: Translations = {
       providers: 'Providers',
       providerAccounts: 'Accounts',
       providerApiKeys: 'API keys',
+      providerCustomEndpoints: 'Custom Endpoints',
       gateway: 'Gateway',
       apiKeys: 'Tools & Keys',
       keysTools: 'Tools',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -171,6 +171,7 @@ export const ja = defineLocale({
       providers: 'プロバイダー',
       providerAccounts: 'アカウント',
       providerApiKeys: 'API キー',
+      providerCustomEndpoints: 'カスタムエンドポイント',
       gateway: 'ゲートウェイ',
       apiKeys: 'ツールとキー',
       keysTools: 'ツール',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -195,6 +195,7 @@ export interface Translations {
       providers: string
       providerAccounts: string
       providerApiKeys: string
+      providerCustomEndpoints: string
       gateway: string
       apiKeys: string
       keysTools: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -166,6 +166,7 @@ export const zhHant = defineLocale({
       providers: '提供方',
       providerAccounts: '帳號',
       providerApiKeys: 'API 金鑰',
+      providerCustomEndpoints: '自訂端點',
       gateway: '閘道',
       apiKeys: '工具與金鑰',
       keysTools: '工具',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -244,6 +244,7 @@ export const zh: Translations = {
       providers: '提供方',
       providerAccounts: '账号',
       providerApiKeys: 'API 密钥',
+      providerCustomEndpoints: '自定义端点',
       gateway: '网关',
       apiKeys: '工具与密钥',
       keysTools: '工具',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -108,6 +108,49 @@ export interface EnvVarInfo {
   url: null | string
 }
 
+export interface CustomEndpoint {
+  api_key_preview?: null | string
+  base_url: string
+  context_length?: null | number
+  discover_models: boolean
+  has_api_key: boolean
+  id: string
+  is_current?: boolean
+  model: string
+  models: string[]
+  name: string
+  source?: string
+}
+
+export interface CustomEndpointsResponse {
+  current: {
+    base_url: string
+    model: string
+    provider: string
+  }
+  endpoints: CustomEndpoint[]
+  id?: string
+  ok?: boolean
+}
+
+export interface CustomEndpointUpdate {
+  api_key?: string
+  base_url: string
+  context_length?: number
+  discover_models?: boolean
+  id?: string
+  make_default?: boolean
+  model: string
+  name: string
+}
+
+export interface CustomEndpointValidationResponse {
+  message: string
+  models: string[]
+  ok: boolean
+  reachable: boolean
+}
+
 export interface MessagingEnvVarInfo {
   advanced: boolean
   description: string

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1957,6 +1957,42 @@ def list_authenticated_providers(
             seen_slugs.add(slug.lower())
             _section4_emitted_slugs.add(slug.lower())
 
+    # Bare direct custom config:
+    #
+    #   model:
+    #     provider: custom
+    #     base_url: http://host/v1
+    #     default: my-model
+    #
+    # is a valid runtime configuration, but it has no providers:/custom_providers
+    # inventory entry. Surface it as a callable picker row so the Desktop can
+    # keep using the direct endpoint instead of hiding the active provider.
+    current_provider_norm = str(current_provider or "").strip().lower()
+    current_base_url_norm = _norm_url(current_base_url)
+    if (
+        current_provider_norm == "custom"
+        and current_base_url_norm
+        and current_model
+        and not any(
+            str(row.get("slug", "")).strip().lower() == "custom"
+            or (
+                bool(row.get("is_current"))
+                and _norm_url(row.get("api_url", "")) == current_base_url_norm
+            )
+            for row in results
+        )
+    ):
+        results.append({
+            "slug": "custom",
+            "name": "Custom",
+            "is_current": True,
+            "is_user_defined": True,
+            "models": [current_model],
+            "total_models": 1,
+            "source": "direct-config",
+            "api_url": current_base_url,
+        })
+
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -614,6 +614,17 @@ class EnvVarReveal(BaseModel):
     key: str
 
 
+class CustomEndpointUpdate(BaseModel):
+    id: str = ""
+    name: str
+    base_url: str
+    model: str
+    api_key: Optional[str] = None
+    context_length: Optional[int] = None
+    discover_models: bool = True
+    make_default: bool = False
+
+
 class MessagingPlatformUpdate(BaseModel):
     enabled: Optional[bool] = None
     env: Dict[str, str] = {}
@@ -2449,9 +2460,18 @@ async def set_model_assignment(body: ModelAssignment):
         if scope == "main":
             if not provider or not model:
                 raise HTTPException(status_code=400, detail="provider and model required for main")
+            if not base_url:
+                providers_cfg = cfg.get("providers")
+                provider_entry = providers_cfg.get(provider) if isinstance(providers_cfg, dict) else None
+                if isinstance(provider_entry, dict) and provider_entry.get("base_url"):
+                    base_url = str(provider_entry.get("base_url") or "").strip()
             model_cfg = _apply_main_model_assignment(
                 cfg.get("model", {}), provider, model, base_url
             )
+            providers_cfg = cfg.get("providers")
+            provider_entry = providers_cfg.get(provider) if isinstance(providers_cfg, dict) else None
+            if isinstance(provider_entry, dict) and provider_entry.get("api_key"):
+                model_cfg["api_key"] = provider_entry["api_key"]
             cfg["model"] = model_cfg
 
             # When switching the main provider to Nous, mirror the CLI's
@@ -2714,6 +2734,243 @@ def _parse_model_ids(resp: "Any") -> List[str]:
         if mid:
             ids.append(mid)
     return ids
+
+
+def _custom_endpoint_id(raw: str, fallback: str = "custom") -> str:
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "-", (raw or "").strip()).strip("-_").lower()
+    return slug or fallback
+
+
+def _models_from_custom_endpoint_entry(entry: Dict[str, Any]) -> List[str]:
+    models: List[str] = []
+    raw_models = entry.get("models")
+    if isinstance(raw_models, dict):
+        models.extend(str(model).strip() for model in raw_models.keys())
+    elif isinstance(raw_models, list):
+        models.extend(str(model).strip() for model in raw_models)
+
+    default_model = str(entry.get("model") or entry.get("default_model") or "").strip()
+    if default_model:
+        models.insert(0, default_model)
+
+    seen: set[str] = set()
+    return [model for model in models if model and not (model in seen or seen.add(model))]
+
+
+def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
+    current_provider = str(model_cfg.get("provider", "") or "")
+    current_model = str(model_cfg.get("default", model_cfg.get("name", "")) or "")
+    current_base_url = str(model_cfg.get("base_url", "") or "")
+
+    endpoints: List[Dict[str, Any]] = []
+    providers = cfg.get("providers")
+    if isinstance(providers, dict):
+        for provider_id, raw_entry in providers.items():
+            if not isinstance(raw_entry, dict):
+                continue
+            base_url = str(raw_entry.get("base_url") or raw_entry.get("url") or raw_entry.get("api") or "").strip()
+            if not base_url:
+                continue
+            endpoint_id = str(provider_id)
+            models = _models_from_custom_endpoint_entry(raw_entry)
+            endpoint_model = str(raw_entry.get("model") or raw_entry.get("default_model") or (models[0] if models else ""))
+            endpoints.append({
+                "id": endpoint_id,
+                "name": str(raw_entry.get("name") or endpoint_id),
+                "base_url": base_url,
+                "model": endpoint_model,
+                "models": models,
+                "context_length": raw_entry.get("context_length"),
+                "discover_models": bool(raw_entry.get("discover_models", True)),
+                "has_api_key": bool(str(raw_entry.get("api_key", "") or "").strip()),
+                "api_key_preview": redact_key(str(raw_entry.get("api_key", "") or "")) if raw_entry.get("api_key") else None,
+                "is_current": endpoint_id == current_provider,
+                "source": "providers",
+            })
+
+    if current_provider.lower() == "custom" and current_base_url and not any(e["id"] == "custom" for e in endpoints):
+        endpoints.insert(0, {
+            "id": "custom",
+            "name": "Custom",
+            "base_url": current_base_url,
+            "model": current_model,
+            "models": [current_model] if current_model else [],
+            "context_length": model_cfg.get("context_length"),
+            "discover_models": True,
+            "has_api_key": bool(str(model_cfg.get("api_key", "") or "").strip()),
+            "api_key_preview": redact_key(str(model_cfg.get("api_key", "") or "")) if model_cfg.get("api_key") else None,
+            "is_current": True,
+            "source": "direct-config",
+        })
+
+    return {
+        "endpoints": endpoints,
+        "current": {
+            "provider": current_provider,
+            "model": current_model,
+            "base_url": current_base_url,
+        },
+    }
+
+
+def _write_custom_endpoint(cfg: Dict[str, Any], body: CustomEndpointUpdate) -> Tuple[str, Dict[str, Any]]:
+    endpoint_id = _custom_endpoint_id(body.id or body.name)
+    name = (body.name or "").strip()
+    base_url = (body.base_url or "").strip().rstrip("/")
+    model = (body.model or "").strip()
+
+    if not name:
+        raise HTTPException(status_code=400, detail="name required")
+    if not base_url:
+        raise HTTPException(status_code=400, detail="base_url required")
+    parsed = urllib.parse.urlparse(base_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise HTTPException(status_code=400, detail="base_url must include scheme and host")
+    if not model:
+        raise HTTPException(status_code=400, detail="model required")
+
+    providers = cfg.get("providers")
+    if not isinstance(providers, dict):
+        providers = {}
+    existing = providers.get(endpoint_id)
+    if not isinstance(existing, dict):
+        existing = {}
+
+    entry: Dict[str, Any] = {
+        "name": name,
+        "base_url": base_url,
+        "model": model,
+        "models": {model: {}},
+        "discover_models": bool(body.discover_models),
+    }
+    if body.context_length and body.context_length > 0:
+        entry["context_length"] = int(body.context_length)
+        entry["models"][model]["context_length"] = int(body.context_length)
+    if body.api_key is not None and body.api_key.strip():
+        entry["api_key"] = body.api_key.strip()
+    elif isinstance(existing.get("api_key"), str) and existing.get("api_key"):
+        entry["api_key"] = existing["api_key"]
+
+    providers[endpoint_id] = entry
+    cfg["providers"] = providers
+
+    if body.make_default:
+        cfg["model"] = _apply_main_model_assignment(
+            cfg.get("model", {}), endpoint_id, model, base_url
+        )
+        if entry.get("api_key") and isinstance(cfg["model"], dict):
+            cfg["model"]["api_key"] = entry["api_key"]
+
+    return endpoint_id, entry
+
+
+@app.get("/api/providers/custom-endpoints")
+def list_custom_endpoints():
+    """Return configured OpenAI-compatible custom endpoints for Desktop."""
+    try:
+        return _custom_endpoint_response(load_config())
+    except Exception:
+        _log.exception("GET /api/providers/custom-endpoints failed")
+        raise HTTPException(status_code=500, detail="Failed to list custom endpoints")
+
+
+@app.post("/api/providers/custom-endpoints")
+def upsert_custom_endpoint(body: CustomEndpointUpdate):
+    """Create or update a v12+ ``providers`` custom endpoint entry."""
+    try:
+        cfg = load_config()
+        endpoint_id, _entry = _write_custom_endpoint(cfg, body)
+        save_config(cfg)
+        response = _custom_endpoint_response(cfg)
+        response["ok"] = True
+        response["id"] = endpoint_id
+        return response
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("POST /api/providers/custom-endpoints failed")
+        raise HTTPException(status_code=500, detail="Failed to save custom endpoint")
+
+
+@app.post("/api/providers/custom-endpoints/{endpoint_id}/activate")
+def activate_custom_endpoint(endpoint_id: str):
+    """Set a configured custom endpoint as the default model provider."""
+    try:
+        cfg = load_config()
+        provider_key = _custom_endpoint_id(endpoint_id)
+        providers = cfg.get("providers")
+        entry = providers.get(provider_key) if isinstance(providers, dict) else None
+        if not isinstance(entry, dict):
+            raise HTTPException(status_code=404, detail="custom endpoint not found")
+
+        models = _models_from_custom_endpoint_entry(entry)
+        model = str(entry.get("model") or (models[0] if models else "")).strip()
+        base_url = str(entry.get("base_url") or "").strip()
+        if not model or not base_url:
+            raise HTTPException(status_code=400, detail="custom endpoint is incomplete")
+
+        model_cfg = _apply_main_model_assignment(cfg.get("model", {}), provider_key, model, base_url)
+        if entry.get("api_key"):
+            model_cfg["api_key"] = entry["api_key"]
+        cfg["model"] = model_cfg
+        save_config(cfg)
+        return {"ok": True, "provider": provider_key, "model": model}
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("POST /api/providers/custom-endpoints/%s/activate failed", endpoint_id)
+        raise HTTPException(status_code=500, detail="Failed to activate custom endpoint")
+
+
+@app.delete("/api/providers/custom-endpoints/{endpoint_id}")
+def delete_custom_endpoint(endpoint_id: str):
+    """Remove a configured custom endpoint from ``providers``."""
+    try:
+        cfg = load_config()
+        provider_key = _custom_endpoint_id(endpoint_id)
+        providers = cfg.get("providers")
+        if not isinstance(providers, dict) or provider_key not in providers:
+            raise HTTPException(status_code=404, detail="custom endpoint not found")
+        providers.pop(provider_key, None)
+        cfg["providers"] = providers
+        save_config(cfg)
+        response = _custom_endpoint_response(cfg)
+        response["ok"] = True
+        return response
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("DELETE /api/providers/custom-endpoints/%s failed", endpoint_id)
+        raise HTTPException(status_code=500, detail="Failed to delete custom endpoint")
+
+
+@app.post("/api/providers/custom-endpoints/validate")
+async def validate_custom_endpoint(body: CustomEndpointUpdate):
+    """Probe a custom endpoint by calling its OpenAI-compatible /models URL."""
+    import httpx
+
+    base_url = (body.base_url or "").strip().rstrip("/")
+    if not base_url:
+        return {"ok": False, "reachable": True, "message": "Enter an endpoint URL first.", "models": []}
+
+    url = base_url + "/models"
+    headers = {"Accept": "application/json"}
+    if body.api_key and body.api_key.strip():
+        headers["Authorization"] = f"Bearer {body.api_key.strip()}"
+
+    try:
+        with httpx.Client(timeout=httpx.Timeout(8.0)) as client:
+            resp = client.get(url, headers=headers)
+    except Exception:
+        return {"ok": False, "reachable": False, "message": f"Could not reach {url}.", "models": []}
+
+    if resp.status_code in (401, 403):
+        return {"ok": False, "reachable": True, "message": "The endpoint rejected the API key.", "models": []}
+    if not resp.is_success:
+        return {"ok": False, "reachable": True, "message": f"Endpoint returned HTTP {resp.status_code}.", "models": []}
+
+    return {"ok": True, "reachable": True, "message": "", "models": _parse_model_ids(resp)}
 
 
 @app.post("/api/providers/validate")

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -426,6 +426,31 @@ def test_list_authenticated_providers_accepts_base_url_and_singular_model(monkey
     assert custom["total_models"] == 3
 
 
+def test_list_authenticated_providers_exposes_bare_direct_custom_config(monkeypatch):
+    """A direct ``model.provider=custom`` + ``model.base_url`` config has no
+    providers:/custom_providers entry, but it is still a valid runtime target
+    and must remain visible in Desktop's model picker.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="http://172.29.176.1:8081/v1",
+        current_model="gpt-5.4",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+    )
+
+    custom = next((p for p in providers if p["slug"] == "custom"), None)
+    assert custom is not None
+    assert custom["is_current"] is True
+    assert custom["source"] == "direct-config"
+    assert custom["api_url"] == "http://172.29.176.1:8081/v1"
+    assert custom["models"] == ["gpt-5.4"]
+
+
 def test_list_authenticated_providers_dedupes_when_user_and_custom_overlap(monkeypatch):
     """When the same slug appears in both ``providers:`` dict and
     ``custom_providers:`` list, emit exactly one row (providers: dict wins

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1761,6 +1761,101 @@ class TestWebServerEndpoints:
         assert model_cfg["provider"] == "openrouter"
         assert model_cfg.get("base_url", "") == ""
 
+    def test_custom_endpoints_list_includes_direct_custom_config(self):
+        """A bare model.provider=custom config should show up in Desktop even
+        before the user has materialized it under providers.
+        """
+        from hermes_cli.config import save_config
+
+        save_config({
+            "model": {
+                "provider": "custom",
+                "default": "gpt-5.4",
+                "base_url": "http://127.0.0.1:8081/v1",
+                "api_key": "sk-local",
+            },
+            "providers": {},
+        })
+
+        resp = self.client.get("/api/providers/custom-endpoints")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["current"] == {
+            "provider": "custom",
+            "model": "gpt-5.4",
+            "base_url": "http://127.0.0.1:8081/v1",
+        }
+        assert data["endpoints"][0]["id"] == "custom"
+        assert data["endpoints"][0]["source"] == "direct-config"
+        assert data["endpoints"][0]["has_api_key"] is True
+
+    def test_custom_endpoint_upsert_persists_provider_and_sets_default(self):
+        """Desktop can persist an OpenAI-compatible proxy in providers and make
+        it the default for new chats.
+        """
+        from hermes_cli.config import load_config
+
+        resp = self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "axet-proxy",
+                "name": "Axet Proxy",
+                "base_url": "http://127.0.0.1:8081/v1/",
+                "model": "gpt-5.4",
+                "api_key": "sk-local",
+                "context_length": 262144,
+                "make_default": True,
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["id"] == "axet-proxy"
+        endpoint = next(e for e in data["endpoints"] if e["id"] == "axet-proxy")
+        assert endpoint["base_url"] == "http://127.0.0.1:8081/v1"
+        assert endpoint["model"] == "gpt-5.4"
+        assert endpoint["is_current"] is True
+
+        cfg = load_config()
+        assert cfg["providers"]["axet-proxy"]["base_url"] == "http://127.0.0.1:8081/v1"
+        assert cfg["providers"]["axet-proxy"]["models"]["gpt-5.4"]["context_length"] == 262144
+        assert cfg["model"]["provider"] == "axet-proxy"
+        assert cfg["model"]["default"] == "gpt-5.4"
+        assert cfg["model"]["base_url"] == "http://127.0.0.1:8081/v1"
+
+    def test_set_model_main_preserves_base_url_for_named_custom_provider(self):
+        """Selecting a named custom endpoint from the Desktop model picker
+        should keep its endpoint URL attached to model config.
+        """
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "model": {"provider": "nous", "default": "hermes-4"},
+            "providers": {
+                "axet-proxy": {
+                    "name": "Axet Proxy",
+                    "base_url": "http://127.0.0.1:8081/v1",
+                    "api_key": "sk-local",
+                    "model": "gpt-5.4",
+                    "models": {"gpt-5.4": {}},
+                }
+            },
+        })
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={"scope": "main", "provider": "axet-proxy", "model": "gpt-5.4"},
+        )
+
+        assert resp.status_code == 200
+        model_cfg = load_config()["model"]
+        assert model_cfg["provider"] == "axet-proxy"
+        assert model_cfg["default"] == "gpt-5.4"
+        assert model_cfg["base_url"] == "http://127.0.0.1:8081/v1"
+        assert model_cfg["api_key"] == "sk-local"
+
     def test_set_model_main_gateway_failure_does_not_block_save(self, monkeypatch):
         """A Portal/gateway hiccup must never prevent saving the model."""
         import hermes_cli.nous_subscription as ns


### PR DESCRIPTION
## Summary
- add Desktop Settings support for OpenAI-compatible custom endpoints under providers
- expose configured custom endpoints in the model picker, including direct model.provider=custom configs
- preserve endpoint base_url when selecting custom providers from Desktop

## Tests
- `uv run --extra dev python -m pytest tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_web_server.py -k "custom or direct_custom or named_custom_provider" --timeout-method=thread`
- `npm run type-check --workspace apps/desktop`