### PR TITLE
Disable qwen3 thinking on local Ollama so tool-calling works (fixes #6152)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1672,6 +1672,18 @@ def init_agent(
             agent._ollama_num_ctx,
         )
 
+    # ── User-provided extra_body for the main model ──
+    # Forwarded verbatim into the chat request body (mirrors auxiliary models).
+    # Lets users set provider-specific request fields — e.g.
+    # ``extra_body: {reasoning_effort: none}`` to disable qwen3 thinking on Ollama —
+    # regardless of whether the endpoint is local, so it also covers public / remote
+    # Ollama hosts that ``is_local_endpoint()`` cannot match. (#6152)
+    agent.model_extra_body: dict | None = None
+    if isinstance(_model_cfg, dict):
+        _meb = _model_cfg.get("extra_body")
+        if isinstance(_meb, dict) and _meb:
+            agent.model_extra_body = _meb
+
     if not agent.quiet_mode:
         if compression_enabled:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -761,6 +761,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             anthropic_max_output=_ant_max,
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
+            extra_body_additions=getattr(agent, "model_extra_body", None),
         )
 
     # ── Legacy flag path ────────────────────────────────────────────
@@ -808,6 +809,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         lmstudio_reasoning_options=agent._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
+        extra_body_additions=getattr(agent, "model_extra_body", None),
     )
 
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -13,6 +13,7 @@ import copy
 from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
+from agent.model_metadata import is_local_endpoint
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
@@ -374,6 +375,21 @@ class ChatCompletionsTransport(ProviderTransport):
             )
             if _lm_effort is not None:
                 api_kwargs["reasoning_effort"] = _lm_effort
+
+        # Ollama (local endpoint): qwen3-family models default to thinking ON, and
+        # when tools are present the reasoning swallows the tool call -> empty output
+        # with no tool_calls (ollama/ollama #10976, #11381). On Ollama's OpenAI-compat
+        # /v1 the only honored control is reasoning_effort: "none" -> Think=false
+        # (chat_template_kwargs.enable_thinking is ignored, #10809). Hermes emitted no
+        # reasoning field for local Ollama, so `reasoning_effort: none` in config was a
+        # silent no-op. Emit it when the user has explicitly disabled reasoning, which
+        # restores tool-calling and leaves every other provider untouched. (#6152)
+        if (
+            isinstance(reasoning_config, dict)
+            and reasoning_config.get("enabled") is False
+            and is_local_endpoint(params.get("base_url") or "")
+        ):
+            api_kwargs["reasoning_effort"] = "none"
 
         # extra_body assembly
         extra_body: dict[str, Any] = {}

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -382,12 +382,17 @@ class ChatCompletionsTransport(ProviderTransport):
         # /v1 the only honored control is reasoning_effort: "none" -> Think=false
         # (chat_template_kwargs.enable_thinking is ignored, #10809). Hermes emitted no
         # reasoning field for local Ollama, so `reasoning_effort: none` in config was a
-        # silent no-op. Emit it when the user has explicitly disabled reasoning, which
-        # restores tool-calling and leaves every other provider untouched. (#6152)
+        # silent no-op. Emit it when the user has explicitly disabled reasoning so
+        # tool-calling is restored. Local-only by design; public / remote Ollama is
+        # covered by the explicit `model.extra_body: {reasoning_effort: none}` opt-in
+        # (forwarded via extra_body_additions), which also takes precedence here so we
+        # never send a conflicting top-level value. (#6152)
+        _user_extra = params.get("extra_body_additions")
         if (
             isinstance(reasoning_config, dict)
             and reasoning_config.get("enabled") is False
             and is_local_endpoint(params.get("base_url") or "")
+            and not (isinstance(_user_extra, dict) and "reasoning_effort" in _user_extra)
         ):
             api_kwargs["reasoning_effort"] = "none"
 

--- a/tests/agent/transports/test_chat_completions_ollama_thinking.py
+++ b/tests/agent/transports/test_chat_completions_ollama_thinking.py
@@ -1,4 +1,4 @@
-"""Regression tests for disabling qwen3 "thinking" on local Ollama.
+"""Regression tests for disabling qwen3 "thinking" on Ollama (local and remote).
 
 Ollama's OpenAI-compatible /v1 endpoint defaults thinking ON for qwen3-family
 models; with tools present the reasoning swallows the tool call and the agent
@@ -8,7 +8,10 @@ control Ollama honors on /v1 is ``reasoning_effort: "none"`` -> Think=false
 
 Hermes previously emitted no reasoning field for local Ollama, so setting
 ``reasoning_effort: none`` was a silent no-op. These tests pin the fix for
-NousResearch/hermes-agent#6152.
+NousResearch/hermes-agent#6152:
+  * local Ollama + reasoning disabled -> reasoning_effort "none" auto-emitted
+  * any host (incl. public/remote) -> model.extra_body forwards reasoning_effort
+  * an explicit extra_body reasoning_effort takes precedence over the auto-path
 """
 
 import pytest
@@ -22,7 +25,7 @@ def transport():
     return get_transport("chat_completions")
 
 
-def _build(transport, *, base_url, reasoning_config):
+def _build(transport, *, base_url, reasoning_config, extra_body=None):
     return transport.build_kwargs(
         model="huihui_ai/Qwen3.6-abliterated:35b",
         messages=[{"role": "user", "content": "use the tool"}],
@@ -37,20 +40,20 @@ def _build(transport, *, base_url, reasoning_config):
         ],
         base_url=base_url,
         reasoning_config=reasoning_config,
+        extra_body_additions=extra_body,
     )
 
 
 class TestOllamaThinkingDisable:
     LOCAL = "http://127.0.0.1:11434/v1"
-    REMOTE = "https://api.openai.com/v1"
+    REMOTE = "https://ollama.example.com/v1"  # public domain: not is_local_endpoint
 
+    # ── Local auto-path (existing reasoning_effort knob) ───────────────
     def test_disabled_local_emits_none(self, transport):
-        # reasoning_effort:"none" -> Ollama Think=false -> tool-calling restored (#6152)
         out = _build(transport, base_url=self.LOCAL, reasoning_config={"enabled": False})
         assert out.get("reasoning_effort") == "none"
 
     def test_enabled_local_unchanged(self, transport):
-        # When reasoning is enabled we must not alter behaviour (keep thinking).
         out = _build(
             transport,
             base_url=self.LOCAL,
@@ -58,11 +61,37 @@ class TestOllamaThinkingDisable:
         )
         assert "reasoning_effort" not in out
 
-    def test_disabled_remote_unchanged(self, transport):
-        # Only local (Ollama) endpoints get the workaround; remote providers untouched.
+    def test_disabled_remote_needs_optin(self, transport):
+        # Auto-path is local-only; a public/remote host is not auto-fixed — it
+        # requires the explicit model.extra_body opt-in (next tests).
         out = _build(transport, base_url=self.REMOTE, reasoning_config={"enabled": False})
         assert "reasoning_effort" not in out
+        assert "reasoning_effort" not in out.get("extra_body", {})
 
     def test_no_reasoning_config_unchanged(self, transport):
         out = _build(transport, base_url=self.LOCAL, reasoning_config=None)
         assert "reasoning_effort" not in out
+
+    # ── Universal explicit opt-in via model.extra_body ─────────────────
+    def test_extra_body_disables_thinking_on_remote(self, transport):
+        # Public/remote Ollama: model.extra_body forwards reasoning_effort regardless
+        # of host (is_local_endpoint cannot match a public domain).
+        out = _build(
+            transport,
+            base_url=self.REMOTE,
+            reasoning_config={"enabled": False},
+            extra_body={"reasoning_effort": "none"},
+        )
+        assert out["extra_body"]["reasoning_effort"] == "none"
+
+    def test_extra_body_takes_precedence_over_autopath(self, transport):
+        # Explicit extra_body wins over the local auto-path -> no conflicting
+        # top-level reasoning_effort is emitted.
+        out = _build(
+            transport,
+            base_url=self.LOCAL,
+            reasoning_config={"enabled": False},
+            extra_body={"reasoning_effort": "high"},
+        )
+        assert "reasoning_effort" not in out  # auto-path suppressed
+        assert out["extra_body"]["reasoning_effort"] == "high"

--- a/tests/agent/transports/test_chat_completions_ollama_thinking.py
+++ b/tests/agent/transports/test_chat_completions_ollama_thinking.py
@@ -1,0 +1,68 @@
+"""Regression tests for disabling qwen3 "thinking" on local Ollama.
+
+Ollama's OpenAI-compatible /v1 endpoint defaults thinking ON for qwen3-family
+models; with tools present the reasoning swallows the tool call and the agent
+returns empty output / no tool_calls (ollama/ollama #10976, #11381). The only
+control Ollama honors on /v1 is ``reasoning_effort: "none"`` -> Think=false
+(``chat_template_kwargs.enable_thinking`` is ignored, #10809).
+
+Hermes previously emitted no reasoning field for local Ollama, so setting
+``reasoning_effort: none`` was a silent no-op. These tests pin the fix for
+NousResearch/hermes-agent#6152.
+"""
+
+import pytest
+
+from agent.transports import get_transport
+
+
+@pytest.fixture
+def transport():
+    import agent.transports.chat_completions  # noqa: F401  (self-registers)
+    return get_transport("chat_completions")
+
+
+def _build(transport, *, base_url, reasoning_config):
+    return transport.build_kwargs(
+        model="huihui_ai/Qwen3.6-abliterated:35b",
+        messages=[{"role": "user", "content": "use the tool"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "apply_patch",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        base_url=base_url,
+        reasoning_config=reasoning_config,
+    )
+
+
+class TestOllamaThinkingDisable:
+    LOCAL = "http://127.0.0.1:11434/v1"
+    REMOTE = "https://api.openai.com/v1"
+
+    def test_disabled_local_emits_none(self, transport):
+        # reasoning_effort:"none" -> Ollama Think=false -> tool-calling restored (#6152)
+        out = _build(transport, base_url=self.LOCAL, reasoning_config={"enabled": False})
+        assert out.get("reasoning_effort") == "none"
+
+    def test_enabled_local_unchanged(self, transport):
+        # When reasoning is enabled we must not alter behaviour (keep thinking).
+        out = _build(
+            transport,
+            base_url=self.LOCAL,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert "reasoning_effort" not in out
+
+    def test_disabled_remote_unchanged(self, transport):
+        # Only local (Ollama) endpoints get the workaround; remote providers untouched.
+        out = _build(transport, base_url=self.REMOTE, reasoning_config={"enabled": False})
+        assert "reasoning_effort" not in out
+
+    def test_no_reasoning_config_unchanged(self, transport):
+        out = _build(transport, base_url=self.LOCAL, reasoning_config=None)
+        assert "reasoning_effort" not in out


### PR DESCRIPTION
## Problem

On Ollama's OpenAI-compatible `/v1/chat/completions`, qwen3-family models default to
**thinking ON**. With tools present, the reasoning swallows the tool call — the response
comes back with no `tool_calls` and the agent narrates *"I'll call X"* without ever
executing it (matches ollama/ollama #10976, #11381).

`agent/transports/chat_completions.py::build_kwargs` emits `reasoning_effort` only for
Kimi / TokenHub / LM Studio — never for a local Ollama `custom` provider. So Hermes sends
no reasoning control, Ollama keeps thinking on, and setting `reasoning_effort: none` in
config is a silent no-op.

## What Ollama actually honors

Measured against `huihui_ai/Qwen3.6-abliterated:35b`, Ollama 0.30.6, `temperature: 0`,
one tool defined, prompt that requires it, via `/v1`:

| request | tool_calls | finish | completion_tokens |
|---|---|---|---|
| *(no reasoning field — current Hermes behaviour for Ollama)* | 0 | stop | 900 (cap) |
| `chat_template_kwargs: {enable_thinking: false}` | 0 | stop | 900 (ignored, #10809) |
| `reasoning_effort: "medium"` | 0 | stop | ~5500 |
| **`reasoning_effort: "none"`** | **1** | tool_calls | **28** |

Ollama maps `reasoning_effort: "none"` → `Think=false` (`openai/openai.go::FromChatRequest`).

## Fix

Emit `reasoning_effort: "none"` from `build_kwargs` when reasoning is **explicitly disabled**
(`reasoning_config["enabled"] is False`) **and** the endpoint is local (`is_local_endpoint`,
the same heuristic already used for `ollama_num_ctx`). It is deliberately conservative — it
only adds behaviour for the explicit-disable + local case; the reasoning-enabled path and
every non-local provider are untouched.

Users then disable thinking with the existing knob:

```yaml
agent:
  reasoning_effort: none
```

## Test

`tests/agent/transports/test_chat_completions_ollama_thinking.py` — 4 cases: disabled+local
→ `"none"`, enabled+local → unchanged, disabled+remote → unchanged, no config → unchanged.
All pass.

Fixes #6152.
