### PR TITLE
fix: allow disabling macOS Keychain probes

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List, Optional, Tuple
-from utils import base_url_host_matches, normalize_proxy_env_vars
+from utils import base_url_host_matches, env_var_enabled, normalize_proxy_env_vars
 
 # NOTE: `import anthropic` is deliberately NOT at module top — the SDK pulls
 # ~220 ms of imports (anthropic.types, anthropic.lib.tools._beta_runner, etc.)
@@ -810,6 +810,10 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
     Returns dict with {accessToken, refreshToken?, expiresAt?} or None.
     """
     if platform.system() != "Darwin":
+        return None
+
+    if env_var_enabled("HERMES_DISABLE_MACOS_KEYCHAIN"):
+        logger.debug("Keychain: macOS Keychain access disabled by HERMES_DISABLE_MACOS_KEYCHAIN")
         return None
 
     try:

--- a/tests/agent/test_anthropic_keychain.py
+++ b/tests/agent/test_anthropic_keychain.py
@@ -89,6 +89,15 @@ class TestReadClaudeCodeCredentialsFromKeychain:
             assert creds["expiresAt"] == 9999999999999
             assert creds["source"] == "macos_keychain"
 
+    def test_disable_macos_keychain_env_skips_security_command(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DISABLE_MACOS_KEYCHAIN", "1")
+
+        with patch("agent.anthropic_adapter.platform.system", return_value="Darwin"), \
+             patch("agent.anthropic_adapter.subprocess.run") as mock_run:
+            assert _read_claude_code_credentials_from_keychain() is None
+
+        mock_run.assert_not_called()
+
 
 class TestReadClaudeCodeCredentialsPriority:
     """Bug 4: Keychain must be checked before the JSON file."""


### PR DESCRIPTION
## Summary
- Add HERMES_DISABLE_MACOS_KEYCHAIN to skip macOS Keychain credential probes
- Prevent provider discovery from invoking security(1) for locked login keychains
- Keep existing Claude Code Keychain discovery enabled by default

## Test Plan
- venv/bin/python -m pytest tests/agent/test_anthropic_keychain.py -q -o 'addopts='
- scripts/run_tests.sh tests/agent/test_anthropic_keychain.py
- Verified with a disposable HERMES_HOME and fake security binary: without the flag the Claude Code keychain lookup occurs; with HERMES_DISABLE_MACOS_KEYCHAIN=1 no security command is called