### PR TITLE
fix(tools): size multimodal tool results by real footprint in turn budget

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -16,6 +16,7 @@ from tools.tool_result_storage import (
     _build_persisted_message,
     _heredoc_marker,
     _resolve_storage_dir,
+    _tool_result_content_size,
     _write_to_sandbox,
     enforce_turn_budget,
     generate_preview,
@@ -491,6 +492,74 @@ class TestEnforceTurnBudget:
     def test_empty_messages(self):
         result = enforce_turn_budget([], env=None, config=BudgetConfig(turn_budget=200_000))
         assert result == []
+
+    def test_multimodal_image_counted_by_real_footprint(self):
+        """A vision tool's base64 screenshot must count toward the budget at
+        its real inline size, not ``len(parts)`` (= 2).
+
+        Regression: a multi-MB image used to be sized as 2 chars, so the
+        aggregate stayed under budget and a co-occurring text result was
+        never offloaded.
+        """
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        image_parts = [
+            {"type": "text", "text": "screenshot captured"},
+            {"type": "image_url",
+             "image_url": {"url": "data:image/png;base64," + "A" * 300_000}},
+        ]
+        msgs = [
+            {"role": "tool", "tool_call_id": "img", "content": image_parts},
+            {"role": "tool", "tool_call_id": "txt", "content": "y" * 150_000},
+        ]
+        enforce_turn_budget(msgs, env=env, config=BudgetConfig(turn_budget=200_000))
+        # The image's real footprint pushes the turn over budget, so the
+        # plain-string text result is spilled to the sandbox.
+        assert PERSISTED_OUTPUT_TAG in msgs[1]["content"]
+        # The multimodal content itself is left intact — it is never offered
+        # to the str-only persistence path.
+        assert msgs[0]["content"] is image_parts
+        assert isinstance(msgs[0]["content"], list)
+
+    def test_multimodal_content_never_offloaded_or_corrupted(self):
+        """Multimodal list content can't be spilled to the sandbox (it is not
+        a str), so enforce_turn_budget must leave its structure untouched even
+        when it alone exceeds the budget — image trimming is the strip/shrink
+        path's job, not this one.
+        """
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        image_parts = [
+            {"type": "text", "text": "big screenshot"},
+            {"type": "image_url",
+             "image_url": {"url": "data:image/png;base64," + "B" * 400_000}},
+        ]
+        msgs = [{"role": "tool", "tool_call_id": "img", "content": image_parts}]
+        enforce_turn_budget(msgs, env=env, config=BudgetConfig(turn_budget=200_000))
+        assert msgs[0]["content"] is image_parts
+        assert isinstance(msgs[0]["content"], list)
+        # maybe_persist_tool_result must never run on non-str content.
+        env.execute.assert_not_called()
+
+
+class TestToolResultContentSize:
+    def test_string_uses_len(self):
+        assert _tool_result_content_size("hello") == 5
+
+    def test_multimodal_list_counts_base64_not_part_count(self):
+        parts = [
+            {"type": "text", "text": "x"},
+            {"type": "image_url",
+             "image_url": {"url": "data:image/png;base64," + "A" * 50_000}},
+        ]
+        # Serialized footprint includes the base64 payload, so it is far
+        # larger than ``len(parts)`` (= 2).
+        assert _tool_result_content_size(parts) > 50_000
+
+    def test_circular_reference_falls_back_to_str(self):
+        d = {}
+        d["self"] = d  # json.dumps raises ValueError on circular refs
+        assert _tool_result_content_size(d) == len(str(d))
 
 
 # ── Per-tool threshold integration ────────────────────────────────────

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -22,10 +22,12 @@ Defense against context-window overflow operates at three levels:
    where many medium-sized results combine to overflow context.
 """
 
+import json
 import logging
 import os
 import shlex
 import uuid
+from typing import Any
 
 from tools.budget_config import (
     DEFAULT_PREVIEW_SIZE_CHARS,
@@ -178,6 +180,24 @@ def maybe_persist_tool_result(
     )
 
 
+def _tool_result_content_size(content: Any) -> int:
+    """Best-effort character footprint of a tool-result message's content.
+
+    Plain strings cost ``len(content)``.  Multimodal results — a list of
+    OpenAI-style content parts, or a ``{"_multimodal": True, ...}`` envelope —
+    must NOT be sized with ``len()``: that returns the number of parts (e.g. 2),
+    hiding a multi-MB base64 screenshot from the per-turn budget.  Serializing
+    instead counts the inline image payload at its real size, which is exactly
+    the footprint the char budget is meant to bound.
+    """
+    if isinstance(content, str):
+        return len(content)
+    try:
+        return len(json.dumps(content, default=str))
+    except (TypeError, ValueError):
+        return len(str(content))
+
+
 def enforce_turn_budget(
     tool_messages: list[dict],
     env=None,
@@ -195,10 +215,14 @@ def enforce_turn_budget(
     total_size = 0
     for i, msg in enumerate(tool_messages):
         content = msg.get("content", "")
-        size = len(content)
-        total_size += size
-        if PERSISTED_OUTPUT_TAG not in content:
-            candidates.append((i, size))
+        total_size += _tool_result_content_size(content)
+        # Only plain-string results can be spilled to the sandbox.  Multimodal
+        # (list/dict) content is counted above for accurate accounting but is
+        # never offered to maybe_persist_tool_result — that helper assumes a
+        # str (len()/substring/sandbox-write), and image parts are trimmed by
+        # the separate image-strip/shrink recovery path instead.
+        if isinstance(content, str) and PERSISTED_OUTPUT_TAG not in content:
+            candidates.append((i, len(content)))
 
     if total_size <= config.turn_budget:
         return tool_messages


### PR DESCRIPTION
## What does this PR do?

I noticed the per-turn output budget (`enforce_turn_budget`, Layer 3 of the
tool-result persistence system) was quietly doing nothing for vision tool
results. It sizes each tool message with `size = len(content)` and checks
`PERSISTED_OUTPUT_TAG not in content`, both of which assume `content` is a
string. But once a vision-capable model is active,
`_tool_result_content_for_active_model()` hands the executor a *list* of
OpenAI-style content parts (text + `image_url`). For a list, `len(content)`
is the number of parts — usually 2 — and the `in` check becomes element
membership that never matches.

So a multi-MB base64 screenshot was being accounted as ~2 chars. The turn
budget never tripped, the giant blob stayed inline in canonical history, and
it grew every turn — exactly the kind of oversized-request-body wedge the
image-stripping code elsewhere tries to avoid. This was tripping over the
hidden assumption that tool content is always a `str`.

The fix sizes non-string content on a serialized view so the real inline
footprint (base64 included) counts toward the budget, and it only ever offers
plain-string results to `maybe_persist_tool_result` — that helper assumes a
str, and multimodal image parts are trimmed by the separate image-strip/shrink
recovery path, not by sandbox spill.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tool_result_storage.py`: added `_tool_result_content_size()` which
  returns `len()` for strings and a serialized character count for multimodal
  list/dict content (so a base64 image counts at its real size instead of its
  part count). Reworked `enforce_turn_budget()` to use it for accounting and
  to only add plain-string results as sandbox-spill candidates, leaving
  multimodal content structurally untouched.
- `tests/tools/test_tool_result_storage.py`: added regression coverage for
  the budget sizing — a base64 image now pushes a turn over budget so a
  co-occurring text result gets offloaded, multimodal content is never
  persisted/corrupted, plus direct unit tests for the new sizing helper.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_tool_result_storage.py`
2. The new `test_multimodal_image_counted_by_real_footprint` reproduces the
   bug: a turn with a 300K base64 image part + a 150K text result. Before the
   fix the image counted as 2 chars, the turn stayed "under budget", and the
   text was never offloaded; now the image's real footprint trips the budget
   and the text result is spilled to the sandbox.
3. `test_multimodal_content_never_offloaded_or_corrupted` confirms list
   content is left intact (and `maybe_persist_tool_result` is never invoked on
   it) even when it alone exceeds the budget.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A