### PR TITLE
fix(cli): catch ImportError for ctypes in _set_process_title (#42074)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -89,7 +89,14 @@ def _set_process_title() -> None:
         pass
 
     # Strategy 2/3: platform-specific ctypes fallback
-    import ctypes
+    try:
+        import ctypes
+    except ImportError:
+        # _ctypes is a C extension that requires libffi-dev at build time.
+        # When Python is built without it (e.g. some pyenv installs on
+        # Ubuntu), ctypes cannot be imported — silently skip since this is
+        # purely cosmetic.  See #42074.
+        return
     import platform
 
     try:


### PR DESCRIPTION
Fixes #42074. Wraps the bare `import ctypes` in _set_process_title() with a try/except ImportError so that installations using a Python build without libffi-dev (some pyenv setups on Ubuntu) no longer crash during startup. The function is purely cosmetic and already handles other ImportError cases gracefully.