### PR TITLE
fix(tools): forward turn_id and api_request_id through the tool_call bridge

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -985,6 +985,8 @@ def handle_function_call(
                 task_id=task_id,
                 tool_call_id=tool_call_id,
                 session_id=session_id,
+                turn_id=turn_id,
+                api_request_id=api_request_id,
                 user_task=user_task,
                 enabled_tools=enabled_tools,
                 skip_pre_tool_call_hook=skip_pre_tool_call_hook,

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -99,6 +99,48 @@ class TestHandleFunctionCall:
             ),
         ]
 
+    def test_tool_search_bridge_forwards_turn_and_request_ids(self):
+        """The ``tool_call`` bridge unwraps to the underlying tool by
+        recursing into ``handle_function_call``.  That recursion must forward
+        ``turn_id`` and ``api_request_id`` so bridge-invoked tools keep the
+        same turn/request correlation as directly-invoked tools — the hooks,
+        middleware, and observability context all key on these IDs.
+        """
+        with (
+            patch("model_tools.get_tool_definitions", return_value=[]),
+            patch(
+                "tools.tool_search.resolve_underlying_call",
+                return_value=("web_search", {"q": "test"}, None),
+            ),
+            patch(
+                "tools.tool_search.scoped_deferrable_names",
+                return_value=frozenset({"web_search"}),
+            ),
+            patch("model_tools.registry.dispatch", return_value='{"ok":true}'),
+            patch("hermes_cli.plugins.has_hook", return_value=True),
+            patch("hermes_cli.plugins.invoke_hook") as mock_invoke_hook,
+        ):
+            result = handle_function_call(
+                "tool_call",
+                {"name": "web_search", "arguments": {"q": "test"}},
+                task_id="task-1",
+                tool_call_id="call-1",
+                session_id="session-1",
+                turn_id="turn-1",
+                api_request_id="req-1",
+            )
+
+        assert result == '{"ok":true}'
+        kwargs_by_hook = {
+            c.args[0]: c.kwargs for c in mock_invoke_hook.call_args_list
+        }
+        # Hooks fire against the real underlying tool, not the bridge.
+        assert kwargs_by_hook["pre_tool_call"]["tool_name"] == "web_search"
+        # And they carry the propagated turn/request IDs, not blanks.
+        for hook in ("pre_tool_call", "post_tool_call", "transform_tool_result"):
+            assert kwargs_by_hook[hook]["turn_id"] == "turn-1"
+            assert kwargs_by_hook[hook]["api_request_id"] == "req-1"
+
     def test_post_tool_call_receives_non_negative_integer_duration_ms(self):
         """Regression: post_tool_call and transform_tool_result hooks must
         receive a non-negative integer ``duration_ms`` kwarg measuring


### PR DESCRIPTION
When the model invokes a deferred tool through the Tool Search bridge,
handle_function_call unwraps the tool_call to the underlying tool and
recurses into itself. That recursive call forwarded task_id,
tool_call_id, session_id, the toolset scoping, and the middleware trace,
but omitted turn_id and api_request_id. Both then defaulted to None and
were passed downstream as empty strings.

Those two IDs feed the tool-request middleware, the pre_tool_call and
post_tool_call hooks, the transform_tool_result hook, and the
observability context. As a result a tool reached via the bridge ran
with blank turn/request correlation, while the same tool invoked
directly carried the real IDs. Plugins and middleware that key on
turn_id or api_request_id (per-turn scoping, trace stitching, attribution)
mis-attributed work for the deferred-tool path.

This forwards both IDs in the recursive call so bridge-invoked tools
carry the same turn/request context as directly-invoked tools.

## What does this PR do?

Forwards turn_id and api_request_id when the Tool Search bridge
(tool_call) recurses into handle_function_call to run the underlying
tool, so hooks, middleware, and the observability context receive the
real turn/request IDs instead of empty strings.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `model_tools.py`: add `turn_id=turn_id` and `api_request_id=api_request_id`
  to the recursive `handle_function_call` call in the `tool_call` bridge
  branch.
- `tests/test_model_tools.py`: add a regression test asserting the
  pre/post/transform hooks receive the propagated turn_id and
  api_request_id for a bridge-invoked tool.

## How to Test

1. Run `scripts/run_tests.sh tests/test_model_tools.py` — 27 tests pass.
2. The new test `test_tool_search_bridge_forwards_turn_and_request_ids`
   fails on the unpatched code (`turn_id` is `''`) and passes with the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A