### PR TITLE
fix(tui): preserve statusbar identity labels

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3889,10 +3889,63 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
 
+        runtime_config = getattr(self, "config", {}) or {}
+        status_label = (
+            os.getenv("HERMES_STATUS_LABEL")
+            or os.getenv("HERMES_STATUS_HOST_LABEL")
+            or str(runtime_config.get("display", {}).get("status_label") or "").strip()
+        )
+
+        reasoning_effort = ""
+        reasoning_config = getattr(agent, "reasoning_config", None) or getattr(self, "reasoning_config", None)
+        if isinstance(reasoning_config, dict):
+            if reasoning_config.get("enabled") is False:
+                reasoning_effort = "off"
+            else:
+                reasoning_effort = str(
+                    reasoning_config.get("effort")
+                    or reasoning_config.get("reasoning_effort")
+                    or reasoning_config.get("level")
+                    or ""
+                ).strip()
+        if not reasoning_effort:
+            reasoning_effort = str(
+                getattr(agent, "reasoning_effort", None)
+                or runtime_config.get("agent", {}).get("reasoning_effort")
+                or ""
+            ).strip()
+        if reasoning_effort.lower() in {"none", "false", "disabled"}:
+            reasoning_effort = "off"
+        if reasoning_effort:
+            reasoning_effort = reasoning_effort.lower()
+
+        session_title = str(getattr(self, "_pending_title", "") or "").strip()
+        if not session_title:
+            session_db = getattr(self, "_session_db", None)
+            session_id = getattr(self, "session_id", None)
+            if session_db and session_id:
+                try:
+                    if hasattr(session_db, "get_session_title"):
+                        session_title = str(session_db.get_session_title(session_id) or "").strip()
+                    else:
+                        session = session_db.get_session(session_id) if hasattr(session_db, "get_session") else None
+                        if session:
+                            session_title = str(session.get("title") or "").strip()
+                except Exception:
+                    session_title = ""
+        if len(session_title) > 28:
+            session_title = f"{session_title[:25]}..."
+
+        model_status_label = f"{model_short} {reasoning_effort}".strip()
+
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
+            "reasoning_effort": reasoning_effort,
+            "model_status_label": model_status_label,
+            "status_label": status_label,
+            "session_title": session_title,
             "duration": format_duration_compact(elapsed_seconds),
             "prompt_elapsed": self._format_prompt_elapsed(
                 getattr(self, "_prompt_start_time", None),
@@ -4013,6 +4066,77 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             out.append(ch)
             width += ch_width
         return "".join(out).rstrip() + ellipsis
+
+    @classmethod
+    def _trim_status_bar_fragments(cls, fragments, max_width: int):
+        """Trim prompt_toolkit fragments while preserving each fragment style."""
+        if max_width <= 0:
+            return []
+        total_width = sum(cls._status_bar_display_width(text) for _, text in fragments)
+        if total_width <= max_width:
+            return fragments
+        ellipsis = "..."
+        ellipsis_width = cls._status_bar_display_width(ellipsis)
+        if max_width <= ellipsis_width:
+            return [(fragments[0][0] if fragments else "class:status-bar", ellipsis[:max_width])]
+        try:
+            from prompt_toolkit.utils import get_cwidth
+        except Exception:
+            get_cwidth = None
+        out = []
+        width = 0
+        last_style = fragments[0][0] if fragments else "class:status-bar"
+        for style, text in fragments:
+            if not text:
+                continue
+            buf = []
+            for ch in text:
+                ch_width = get_cwidth(ch) if get_cwidth else len(ch)
+                if width + ch_width + ellipsis_width > max_width:
+                    if buf:
+                        out.append((style, "".join(buf).rstrip()))
+                    out.append((style, ellipsis))
+                    return [(s, t) for s, t in out if t]
+                buf.append(ch)
+                width += ch_width
+            if buf:
+                out.append((style, "".join(buf)))
+                last_style = style
+        out.append((last_style, ellipsis))
+        return [(s, t) for s, t in out if t]
+
+    @staticmethod
+    def _status_bar_identity_text(snapshot: Dict[str, Any]) -> str:
+        parts = [
+            str(snapshot.get("status_label") or "").strip(),
+            str(snapshot.get("session_title") or "").strip(),
+            str(snapshot.get("model_status_label") or snapshot.get("model_short") or "Hermes").strip(),
+        ]
+        return "⚕ " + " │ ".join(part for part in parts if part)
+
+    def _status_bar_identity_fragments(self, snapshot: Dict[str, Any]):
+        frags = [("class:status-bar", " ⚕ ")]
+        first = True
+        status_label = str(snapshot.get("status_label") or "").strip()
+        session_title = str(snapshot.get("session_title") or "").strip()
+        model_short = str(snapshot.get("model_short") or "Hermes").strip()
+        reasoning_effort = str(snapshot.get("reasoning_effort") or "").strip()
+        if status_label:
+            frags.append(("class:status-bar-strong", status_label))
+            first = False
+        if session_title:
+            if not first:
+                frags.append(("class:status-bar-dim", " │ "))
+            frags.append(("class:status-bar-dim", session_title))
+            first = False
+        if not first:
+            frags.append(("class:status-bar-dim", " │ "))
+        frags.append(("class:status-bar-strong", model_short))
+        if reasoning_effort:
+            effort_style = "class:status-bar-warn" if reasoning_effort in {"high", "xhigh"} else "class:status-bar-dim" if reasoning_effort == "off" else "class:status-bar-strong"
+            frags.append(("class:status-bar-dim", " "))
+            frags.append((effort_style, reasoning_effort))
+        return frags
 
     @staticmethod
     def _get_tui_terminal_width(default: tuple[int, int] = (80, 24)) -> int:
@@ -4172,13 +4296,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             duration_label = snapshot["duration"]
 
             yolo_active = self._is_session_yolo_active()
+            identity = self._status_bar_identity_text(snapshot)
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"{identity} · {duration_label}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [identity, percent_label]
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -4201,7 +4326,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [identity, context_label, percent_label]
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -4238,9 +4363,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             yolo_active = self._is_session_yolo_active()
 
             if width < 52:
-                frags = [
-                    ("class:status-bar", " ⚕ "),
-                    ("class:status-bar-strong", snapshot["model_short"]),
+                frags = self._status_bar_identity_fragments(snapshot) + [
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                 ]
@@ -4255,9 +4378,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
-                    frags = [
-                        ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                    frags = self._status_bar_identity_fragments(snapshot) + [
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
@@ -4290,9 +4411,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
-                    frags = [
-                        ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                    frags = self._status_bar_identity_fragments(snapshot) + [
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),
@@ -4330,9 +4449,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
             if total_width > width:
-                plain_text = "".join(text for _, text in frags)
-                trimmed = self._trim_status_bar_text(plain_text, width)
-                return [("class:status-bar", trimmed)]
+                return self._trim_status_bar_fragments(frags, width)
             return frags
         except Exception:
             return [("class:status-bar", f" {self._build_status_bar_text()} ")]

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -82,6 +82,62 @@ class TestCLIStatusBar:
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
 
+
+    def test_identity_status_label_and_reasoning_render_in_wide_text(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.config = {"display": {"status_label": "맥북"}, "agent": {"reasoning_effort": "high"}}
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "⚕ 맥북 │ gpt-5.5 high" in text
+
+    def test_identity_includes_live_session_title(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.config = {"display": {"status_label": "맥북"}, "agent": {"reasoning_effort": "high"}}
+        cli_obj._pending_title = "상태바 세션명"
+
+        text = cli_obj._build_status_bar_text(width=140)
+
+        assert "⚕ 맥북 │ 상태바 세션명 │ gpt-5.5 high" in text
+
+    def test_fragment_trim_preserves_statusbar_semantic_styles(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.config = {"display": {"status_label": "맥북"}, "agent": {"reasoning_effort": "high"}}
+        cli_obj._status_bar_visible = True
+
+        with patch.object(HermesCLI, "_get_tui_terminal_width", return_value=62):
+            frags = cli_obj._get_status_bar_fragments()
+
+        total_text = "".join(text for _, text in frags)
+        assert cli_obj._status_bar_display_width(total_text) <= 62
+        styles = {style for style, _ in frags}
+        assert "class:status-bar-strong" in styles
+        assert "class:status-bar-warn" in styles
+
     def test_post_compression_sentinel_does_not_render_negative(self):
         """Right after a compression, last_prompt_tokens is parked at the -1
         sentinel until the next API call reports real usage. The status bar

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7395,3 +7395,22 @@ def test_reap_idle_sessions_closes_only_evictable(monkeypatch):
         assert closed == [("stale", "idle_timeout")]
     finally:
         server._sessions.clear()
+
+
+def test_statusbar_session_title_paths_are_best_effort(monkeypatch):
+    """Statusbar identity payload must not 500 when title lookup fails."""
+    monkeypatch.setattr(
+        server,
+        "_session_live_title",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    monkeypatch.setattr(server, "_load_reasoning_config", lambda: {"enabled": True, "effort": "high"})
+    session = {"session_key": "broken-title", "pending_title": "Fallback title"}
+
+    info = server._fallback_session_info(session)
+    assert info["title"] == "Fallback title"
+    assert info["reasoning_effort"] == "high"
+    assert "status_label" in info
+
+    item = server._session_live_item("sid", session)
+    assert item["title"] == "Fallback title"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2367,6 +2367,33 @@ def _current_profile_name() -> str:
 DESKTOP_BACKEND_CONTRACT = 2
 
 
+def _status_label() -> str:
+    return (
+        os.getenv("HERMES_STATUS_LABEL")
+        or os.getenv("HERMES_STATUS_HOST_LABEL")
+        or str((_load_cfg().get("display") or {}).get("status_label") or "").strip()
+    )
+
+
+def _reasoning_effort_label(reasoning_config: object = None) -> str:
+    effort = ""
+    if isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is False:
+            effort = "off"
+        else:
+            effort = str(
+                reasoning_config.get("effort")
+                or reasoning_config.get("reasoning_effort")
+                or reasoning_config.get("level")
+                or ""
+            ).strip()
+    if not effort:
+        effort = str((_load_cfg().get("agent") or {}).get("reasoning_effort", "") or "").strip()
+    if effort.lower() in {"none", "false", "disabled"}:
+        effort = "off"
+    return effort.lower() if effort else ""
+
+
 def _session_info(agent, session: dict | None = None) -> dict:
     if session is None:
         for candidate in _sessions.values():
@@ -2377,13 +2404,10 @@ def _session_info(agent, session: dict | None = None) -> dict:
     cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
-    reasoning_effort = ""
-    if (
-        isinstance(reasoning_config, dict)
-        and reasoning_config.get("enabled") is not False
-    ):
-        reasoning_effort = str(reasoning_config.get("effort", "") or "")
+    reasoning_effort = _reasoning_effort_label(reasoning_config)
     service_tier = getattr(agent, "service_tier", None) or ""
+    session_key = str((session or {}).get("session_key") or getattr(agent, "session_id", "") or "")
+    title = _session_safe_title(session or {}, session_key) if session_key else ""
     # Effective approval-bypass state — the same three sources that
     # check_all_command_guards() ORs together: persistent config
     # (approvals.mode=off), the process-scoped --yolo env, and the
@@ -2408,6 +2432,8 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "provider": getattr(agent, "provider", ""),
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
+        "status_label": _status_label(),
+        "title": title,
         "fast": service_tier == "priority",
         "yolo": yolo,
         "tools": {},
@@ -4390,6 +4416,13 @@ def _session_live_title(session: dict, key: str) -> str:
     return title
 
 
+def _session_safe_title(session: dict, key: str) -> str:
+    try:
+        return _session_live_title(session, key)
+    except Exception:
+        return str((session or {}).get("pending_title") or "").strip()
+
+
 def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
     key = str(session.get("session_key") or sid)
     agent = session.get("agent")
@@ -4411,7 +4444,7 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
         "session_key": key,
         "started_at": float(session.get("created_at") or now),
         "status": status,
-        "title": _session_live_title(session, key),
+        "title": _session_safe_title(session, key),
     }
 
 
@@ -4427,11 +4460,15 @@ def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
 def _fallback_session_info(session: dict) -> dict:
     agent = session.get("agent")
     if agent is not None:
-        return _session_info(agent)
+        return _session_info(agent, session)
+    reasoning_config = _load_reasoning_config()
     return {
         "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
         "lazy": True,
         "model": _resolve_model(),
+        "reasoning_effort": _reasoning_effort_label(reasoning_config),
+        "status_label": _status_label(),
+        "title": _session_safe_title(session, str(session.get("session_key") or "")),
         "skills": {},
         "tools": {},
     }

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -163,6 +163,43 @@ describe('StatusRule session count click target', () => {
   })
 })
 
+
+describe('StatusRule identity contract', () => {
+  it('renders host label, session title, model, and high reasoning effort', () => {
+    const element = StatusRule({
+      ...baseProps,
+      cols: 140,
+      model: 'gpt-5.5',
+      modelReasoningEffort: 'high',
+      sessionTitle: '상태바 세션명',
+      statusLabel: '맥북'
+    })
+
+    const rendered = textContent(element)
+
+    expect(rendered).toContain('맥북')
+    expect(rendered).toContain('상태바 세션명')
+    expect(rendered).toContain('gpt 5.5 high')
+  })
+
+  it('keeps host label visible while busy', () => {
+    const element = StatusRule({
+      ...baseProps,
+      busy: true,
+      cols: 120,
+      model: 'gpt-5.5',
+      modelReasoningEffort: 'high',
+      statusLabel: '맥북',
+      turnStartedAt: Date.now()
+    })
+
+    const rendered = textContent(element)
+
+    expect(rendered).toContain('맥북')
+    expect(rendered).toContain('gpt 5.5 high')
+  })
+})
+
 describe('StatusRule credits notice render priority', () => {
   it('replaces the idle status with the notice text and keeps model + context', () => {
     const element = StatusRule({
@@ -241,7 +278,9 @@ describe('StatusRule credits notice render priority', () => {
         if (Array.isArray(node)) {
           for (const c of node) {
             const f = findShrinkBoxContaining(c)
-            if (f) return f
+            if (f) {
+              return f
+            }
           }
         }
         return null

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -238,6 +238,7 @@ export const coreCommands: SlashCommand[] = [
           ctx.guarded<SessionTitleResponse>(r => {
             const next = (r?.title ?? title).trim()
             const suffix = r?.pending ? ' (queued while session initializes)' : ''
+            patchUiState({ info: ctx.ui.info ? { ...ctx.ui.info, title: next } : ctx.ui.info })
             ctx.transcript.sys(`session title set: ${next}${suffix}`)
           })
         )

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -411,6 +411,8 @@ export function StatusRule({
   model,
   modelFast,
   modelReasoningEffort,
+  statusLabel,
+  sessionTitle,
   indicatorStyle = 'kaomoji',
   notice,
   usage,
@@ -440,6 +442,7 @@ export function StatusRule({
 
   const bar = !segs.compactCtx && usage.context_max ? ctxBar(pct) : ''
   const modelText = modelLabel(model, modelReasoningEffort, modelFast)
+  const identityText = [statusLabel, sessionTitle].map(v => String(v ?? '').trim()).filter(Boolean).join(' │ ')
 
   // A credits notice replaces the status/verb slot, but only when idle —
   // while busy the FaceTicker always wins (R1 render priority). The notice
@@ -467,6 +470,7 @@ export function StatusRule({
   const essentialWidth =
     stringWidth('─ ') +
     slotWidth +
+    (identityText ? stringWidth(' │ ') + stringWidth(identityText) : 0) +
     stringWidth(' │ ') +
     stringWidth(modelText) +
     (ctxLabel ? stringWidth(' │ ') + stringWidth(ctxLabel) : 0)
@@ -562,6 +566,12 @@ export function StatusRule({
           {DEV_CREDITS_MODE ? (
             <Text color={t.color.warn} wrap="truncate-end">
               {' (dev credits)'}
+            </Text>
+          ) : null}
+          {identityText ? (
+            <Text color={t.color.accent} wrap="truncate-end">
+              {' │ '}
+              {identityText}
             </Text>
           ) : null}
           <Text color={t.color.muted} wrap="truncate-end">
@@ -759,6 +769,8 @@ interface StatusRuleProps {
   model: string
   modelFast?: boolean
   modelReasoningEffort?: string
+  statusLabel?: string
+  sessionTitle?: string
   indicatorStyle?: IndicatorStyle
   notice?: Notice | null
   sessionStartedAt?: null | number

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -374,9 +374,11 @@ const StatusRulePane = memo(function StatusRulePane({
         notice={ui.notice}
         onSessionCountClick={() => patchOverlayState({ sessions: true })}
         sessionStartedAt={status.sessionStartedAt}
+        sessionTitle={ui.info?.title}
         showCost={ui.showCost}
         status={ui.status}
         statusColor={status.statusColor}
+        statusLabel={ui.info?.status_label}
         t={ui.theme}
         turnStartedAt={status.turnStartedAt}
         usage={ui.usage}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -157,7 +157,9 @@ export interface SessionInfo {
   reasoning_effort?: string
   release_date?: string
   service_tier?: string
+  status_label?: string
   skills: Record<string, string[]>
+  title?: string
   system_prompt?: string
   tools: Record<string, string[]>
   update_behind?: number | null


### PR DESCRIPTION
## Summary
- include status_label/title/reasoning_effort in TUI session info, including lazy fallback sessions
- render host label + session title + model reasoning effort in the bottom statusbar
- update /title to patch live UI state immediately
- add regression coverage for host/session/model identity labels

## Verification
- ./venv/bin/python -m py_compile tui_gateway/server.py
- npm --prefix ui-tui test -- appChromeStatusRule.test.tsx --run
- npm --prefix ui-tui run build
- npm exec eslint src/components/appChrome.tsx src/components/appLayout.tsx src/types.ts src/app/slash/commands/core.ts src/__tests__/appChromeStatusRule.test.tsx (0 errors; existing warnings only)