### PR TITLE
fix(#42197): Cron jobs fail with PluginManager._middleware AttributeError

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1468,6 +1468,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # construction costs.
     # ---------------------------------------------------------------
     from run_agent import AIAgent
+    
+    # Ensure plugins are discovered and loaded before AIAgent uses middleware
+    # during its first LLM API call. This is idempotent and safe to call multiple times.
+    from hermes_cli.plugins import discover_plugins
+    discover_plugins()
 
     # Initialize SQLite session store so cron job messages are persisted
     # and discoverable via session_search (same pattern as gateway/run.py).

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -234,7 +234,11 @@ def _has_middleware(kind: str) -> bool:
 def _get_middleware_callbacks(kind: str) -> List[Callable]:
     from hermes_cli.plugins import get_plugin_manager
 
-    return list(get_plugin_manager()._middleware.get(kind, []))
+    manager = get_plugin_manager()
+    # Defensive: _middleware may not exist if PluginManager is deserialized
+    # from pickle or under certain race conditions. Use getattr with fallback.
+    middleware = getattr(manager, "_middleware", {})
+    return list(middleware.get(kind, []))
 
 
 def _run_execution_chain(

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -231,13 +231,23 @@ def _has_middleware(kind: str) -> bool:
     return has_middleware(kind)
 
 
+_middleware_fallback_warned = False
+
+
 def _get_middleware_callbacks(kind: str) -> List[Callable]:
     from hermes_cli.plugins import get_plugin_manager
+    global _middleware_fallback_warned
 
     manager = get_plugin_manager()
     # Defensive: _middleware may not exist if PluginManager is deserialized
     # from pickle or under certain race conditions. Use getattr with fallback.
     middleware = getattr(manager, "_middleware", {})
+    if not middleware and not _middleware_fallback_warned:
+        _middleware_fallback_warned = True
+        logger.warning(
+            "PluginManager missing _middleware (deserialized or race condition). "
+            "Middleware callbacks may be inactive. This warning is logged once per session."
+        )
     return list(middleware.get(kind, []))
 
 


### PR DESCRIPTION
Fixes #42197

**Root Cause:**
Cron jobs fail when AIAgent calls middleware hooks. The middleware module directly accessed PluginManager._middleware without defensive checking, causing AttributeError in certain conditions.

**Solution:**
1. Add defensive getattr() in middleware.py (matches plugins.py pattern)
2. Call discover_plugins() before AIAgent in cron scheduler

**Files Changed:**
- hermes_cli/middleware.py:237 - Defensive attribute access
- cron/scheduler.py:1472 - Plugin discovery call