### PR TITLE
fix(terminal): prefer $SHELL over bash for background process spawning

### DIFF
--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -1,0 +1,77 @@
+"""Tests for _find_shell — user-login-shell preference on POSIX.
+
+Regression tests for #42203: on macOS, ``_find_shell`` used to return
+``/bin/bash`` (bash 3.2) which silently swallowed background commands
+when ``~/.bash_profile`` contained ``exec /bin/zsh -l``.
+"""
+
+import os
+import platform
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments.local import _find_bash, _find_shell
+
+
+class TestFindShellPrefersUserShell:
+    """_find_shell should prefer $SHELL over bash on POSIX."""
+
+    def test_returns_shell_env_when_set_and_exists(self, tmp_path):
+        """When $SHELL points to an existing binary, _find_shell returns it."""
+        fake_zsh = tmp_path / "zsh"
+        fake_zsh.touch()
+        with patch.dict(os.environ, {"SHELL": str(fake_zsh)}):
+            assert _find_shell() == str(fake_zsh)
+
+    def test_falls_back_to_find_bash_when_shell_unset(self):
+        """When $SHELL is unset, _find_shell delegates to _find_bash."""
+        env = {k: v for k, v in os.environ.items() if k != "SHELL"}
+        with patch.dict(os.environ, env, clear=True):
+            assert _find_shell() == _find_bash()
+
+    def test_falls_back_to_find_bash_when_shell_not_a_file(self, tmp_path):
+        """When $SHELL points to a non-existent path, _find_shell delegates."""
+        fake_path = str(tmp_path / "nonexistent_shell")
+        with patch.dict(os.environ, {"SHELL": fake_path}):
+            assert _find_shell() == _find_bash()
+
+    def test_falls_back_to_find_bash_when_shell_empty(self):
+        """When $SHELL is empty string, _find_shell delegates."""
+        with patch.dict(os.environ, {"SHELL": ""}):
+            assert _find_shell() == _find_bash()
+
+
+class TestFindShellWindowsBehavior:
+    """On Windows, _find_shell always delegates to _find_bash."""
+
+    def test_windows_ignores_shell_env(self):
+        """On Windows, $SHELL is ignored — _find_shell delegates to _find_bash."""
+        with patch("tools.environments.local._IS_WINDOWS", True):
+            # Even if SHELL is set, it should be ignored on Windows
+            with patch.dict(os.environ, {"SHELL": "/usr/bin/zsh"}):
+                result = _find_shell()
+                assert result == _find_bash()
+
+
+class TestFindShellReturnsString:
+    """_find_shell must return a string, never None."""
+
+    def test_returns_string(self):
+        """_find_shell always returns a non-empty string on any platform."""
+        result = _find_shell()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+class TestFindBashUnchanged:
+    """_find_bash should be unaffected by the _find_shell change."""
+
+    def test_find_bash_still_prefers_bash(self):
+        """_find_bash still returns bash (not $SHELL) on POSIX."""
+        result = _find_bash()
+        # On any system, _find_bash should return something containing "bash"
+        # or fall back to $SHELL or /bin/sh — but it should NOT prefer $SHELL
+        # over bash the way _find_shell does.
+        assert isinstance(result, str)
+        assert len(result) > 0

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -289,8 +289,33 @@ def _find_bash() -> str:
     )
 
 
-# Backward compat — process_registry.py imports this name
-_find_shell = _find_bash
+def _find_shell() -> str:
+    """Find the user's login shell for background process spawning.
+
+    Unlike ``_find_bash`` (which always returns a bash binary for callers
+    that explicitly need bash), this function prefers the user's configured
+    ``$SHELL`` on POSIX so that ``spawn_local`` uses the shell the user
+    actually logs in with.
+
+    On macOS Catalina+ the default login shell is zsh, but
+    ``shutil.which("bash")`` still finds the system ``/bin/bash`` (GNU bash
+    3.2).  When bash 3.2 is invoked with ``-l`` (login) and stdin is
+    ``/dev/null``, it sources ``~/.bash_profile`` which on many macOS setups
+    contains ``exec /bin/zsh -l``.  That ``exec`` replaces bash with zsh but
+    drops the ``-c`` argument, so the background command never runs — the
+    subprocess exits 0 with no output and no side effects.
+
+    Preferring ``$SHELL`` avoids this entirely because zsh handles ``-lic``
+    correctly even with redirected stdin.
+
+    On Windows, ``$SHELL`` is typically bash (Git Bash), so behaviour is
+    unchanged — we fall through to ``_find_bash``.
+    """
+    if not _IS_WINDOWS:
+        user_shell = os.environ.get("SHELL")
+        if user_shell and os.path.isfile(user_shell):
+            return user_shell
+    return _find_bash()
 
 
 # Standard PATH entries for environments with minimal PATH.


### PR DESCRIPTION
## What does this PR do?

Fixes background process spawning on macOS by preferring the user's `$SHELL` (typically `/bin/zsh`) over bash for `spawn_local`. On macOS Catalina+, `_find_shell` returned `/bin/bash` (bash 3.2) which silently swallowed commands when `~/.bash_profile` contained `exec /bin/zsh -l`.

## Related Issue

Fixes #42203

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/local.py`: Replace `_find_shell = _find_bash` alias with a proper function that prefers `$SHELL` on POSIX, falling back to `_find_bash` when `$SHELL` is unset or invalid. On Windows, behavior is unchanged.
- `tests/tools/test_find_shell.py`: 7 regression tests covering `$SHELL` preference, fallback to `_find_bash`, empty/missing `$SHELL`, Windows passthrough, and return-type invariant.

## How to Test

1. On macOS, verify `_find_shell()` returns `/bin/zsh` (or whatever `$SHELL` is set to):
   ```python
   from tools.environments.local import _find_shell
   print(_find_shell())  # Should print /bin/zsh on macOS Catalina+
   ```
2. Unset `$SHELL` and verify fallback to bash:
   ```bash
   SHELL="" python -c "from tools.environments.local import _find_shell; print(_find_shell())"
   ```
3. Run the new tests:
   ```bash
   pytest tests/tools/test_find_shell.py -v
   ```
4. Run existing process_registry tests to verify no regression:
   ```bash
   pytest tests/tools/test_process_registry.py -v -k "spawn_local"
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_find_shell`, `_find_bash` in `tools/environments/local.py`; `spawn_local` in `tools/process_registry.py`
- Callers of `_find_shell`: `process_registry.py` (PTY spawn at line 550, pipe spawn at line 588)
- Callers of `_find_bash`: `local.py` (`_run_bash` at line 502), `local.py` (`_find_shell` fallback)
- Blast radius: LOW — `_find_shell` is only used by `spawn_local` for background processes; foreground terminal execution uses `_find_bash` via `LocalEnvironment._run_bash`
- Related patterns: The `_find_bash` function is unchanged — callers that explicitly need bash continue to get it
