### PR TITLE
fix: prefer authenticated Kimi CN provider for model switching

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -859,7 +859,37 @@ def switch_model(
                                 resolved_in_current_catalog = True
                                 break
 
-        # --- Step e: detect_provider_for_model() as last resort ---
+        # --- Step e: prefer authenticated provider matches for exact model IDs ---
+        # Some regional providers share the same model IDs (e.g. kimi-coding and
+        # kimi-coding-cn both expose `kimi-k2.6`).  A blind static catalog scan
+        # can pick the first provider in _PROVIDER_MODELS even when the user only
+        # has credentials for the regional alias.  Before falling back to global
+        # catalog detection, prefer exact matches from authenticated providers.
+        if (
+            target_provider == current_provider
+            and not resolved_alias
+            and not resolved_in_current_catalog
+        ):
+            try:
+                from hermes_cli.models import _PROVIDER_MODELS
+
+                authed = get_authenticated_provider_slugs(
+                    current_provider=current_provider,
+                    user_providers=user_providers,
+                    custom_providers=custom_providers,
+                )
+                model_lower = new_model.lower()
+                for provider in authed:
+                    if provider == current_provider:
+                        continue
+                    models = _PROVIDER_MODELS.get(provider, [])
+                    if any(model_lower == str(model).lower() for model in models):
+                        target_provider = provider
+                        break
+            except Exception:
+                pass
+
+        # --- Step f: detect_provider_for_model() as last resort ---
         _base = current_base_url or ""
         is_custom = current_provider in {"custom", "local"} or (
             "localhost" in _base or "127.0.0.1" in _base
@@ -1355,9 +1385,11 @@ def list_authenticated_providers(
             continue
         # Skip aliases that map to the same models.dev provider (e.g.
         # kimi-coding and kimi-coding-cn both → kimi-for-coding).
-        # The first one with valid credentials wins (#10526).
-        if mdev_id in seen_mdev_ids:
-            continue
+        # The first one with valid credentials wins (#10526).  Do the
+        # duplicate check *after* credential detection below: otherwise an
+        # unauthenticated alias that appears earlier in PROVIDER_TO_MODELS_DEV
+        # (kimi-coding) can hide the authenticated regional provider that
+        # appears later (kimi-coding-cn).
         pdata = data.get(mdev_id)
         if not isinstance(pdata, dict):
             continue
@@ -1388,6 +1420,9 @@ def list_authenticated_providers(
             except Exception:
                 pass
         if not has_creds:
+            continue
+
+        if mdev_id in seen_mdev_ids:
             continue
 
         # Unified pathway: route through cached_provider_model_ids() so the

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -109,7 +109,19 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
     "kimi-for-coding": HermesOverlay(
         transport="openai_chat",
+        extra_env_vars=("KIMI_CODING_API_KEY",),
         base_url_env_var="KIMI_BASE_URL",
+    ),
+    "kimi-coding": HermesOverlay(
+        transport="openai_chat",
+        extra_env_vars=("KIMI_API_KEY", "KIMI_CODING_API_KEY"),
+        base_url_env_var="KIMI_BASE_URL",
+    ),
+    "kimi-coding-cn": HermesOverlay(
+        transport="openai_chat",
+        extra_env_vars=("KIMI_CN_API_KEY",),
+        base_url_override="https://api.moonshot.cn/v1",
+        base_url_env_var="KIMI_CN_BASE_URL",
     ),
     "stepfun": HermesOverlay(
         transport="openai_chat",
@@ -264,8 +276,8 @@ ALIASES: Dict[str, str] = {
 
     # kimi-for-coding (models.dev ID)
     "kimi": "kimi-for-coding",
-    "kimi-coding": "kimi-for-coding",
-    "kimi-coding-cn": "kimi-for-coding",
+    "kimi-coding": "kimi-coding",
+    "kimi-coding-cn": "kimi-coding-cn",
     "moonshot": "kimi-for-coding",
 
     # stepfun
@@ -367,6 +379,8 @@ ALIASES: Dict[str, str] = {
 _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
+    "kimi-coding": "Kimi / Kimi Coding Plan",
+    "kimi-coding-cn": "Kimi / Moonshot (China)",
     "copilot-acp": "GitHub Copilot ACP",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",

--- a/tests/hermes_cli/test_kimi_cn_model_switch.py
+++ b/tests/hermes_cli/test_kimi_cn_model_switch.py
@@ -1,0 +1,63 @@
+"""Regression tests for Kimi CN /model routing."""
+
+from hermes_cli import model_switch
+from hermes_cli.providers import get_label, get_provider
+
+
+def test_kimi_cn_provider_overlay_has_china_label_and_endpoint():
+    """The explicit CN provider must not collapse to the shared models.dev label/URL."""
+    pdef = get_provider("kimi-coding-cn")
+
+    assert pdef is not None
+    assert get_label("kimi-coding-cn") == "Kimi / Moonshot (China)"
+    assert pdef.base_url == "https://api.moonshot.cn/v1"
+    assert "KIMI_CN_API_KEY" in pdef.api_key_env_vars
+
+
+def test_exact_kimi_model_prefers_authenticated_cn_provider(monkeypatch):
+    """Bare `/model kimi-k2.6` should use authenticated CN before static global fallback."""
+    model_switch.DIRECT_ALIASES.clear()
+    monkeypatch.setattr(model_switch, "_load_direct_aliases", lambda: {})
+    monkeypatch.setattr(
+        model_switch,
+        "get_authenticated_provider_slugs",
+        lambda **_kwargs: ["kimi-coding-cn"],
+    )
+
+    # If the authenticated-provider preference fails, the old last-resort static
+    # catalog detection would choose the global provider first.
+    monkeypatch.setattr(
+        "hermes_cli.models.detect_provider_for_model",
+        lambda model, _current: ("kimi-coding", model),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested, target_model: {
+            "provider": requested,
+            "api_key": "sk-test",
+            "base_url": "https://api.moonshot.cn/v1"
+            if requested == "kimi-coding-cn"
+            else "https://api.kimi.com/coding/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *_args, **_kwargs: {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+        },
+    )
+
+    res = model_switch.switch_model(
+        "kimi-k2.6",
+        current_provider="openai-codex",
+        current_model="gpt-5.5",
+        current_base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert res.success is True
+    assert res.target_provider == "kimi-coding-cn"
+    assert res.provider_label == "Kimi / Moonshot (China)"
+    assert res.base_url == "https://api.moonshot.cn/v1"

--- a/tests/hermes_cli/test_overlay_slug_resolution.py
+++ b/tests/hermes_cli/test_overlay_slug_resolution.py
@@ -68,6 +68,24 @@ def test_kimi_for_coding_overlay_uses_hermes_slug():
     assert kimi_mdev is None, "kimi-for-coding slug should not appear (resolved to kimi-coding)"
 
 
+@patch.dict(os.environ, {"KIMI_CN_API_KEY": "fake-cn-key"}, clear=False)
+def test_kimi_cn_not_shadowed_by_unauthenticated_global_alias(monkeypatch):
+    """Regional Kimi should appear when only KIMI_CN_API_KEY is configured.
+
+    Regression: kimi-coding and kimi-coding-cn both map to the same
+    models.dev provider (kimi-for-coding).  The duplicate filter must run
+    after credential detection so an unauthenticated global alias does not
+    hide an authenticated regional alias.
+    """
+    monkeypatch.delenv("KIMI_API_KEY", raising=False)
+    monkeypatch.delenv("MOONSHOT_API_KEY", raising=False)
+
+    providers = list_authenticated_providers(current_provider="custom:freemodel")
+
+    assert next((p for p in providers if p["slug"] == "kimi-coding-cn"), None) is not None
+    assert next((p for p in providers if p["slug"] == "kimi-coding"), None) is None
+
+
 @patch.dict(os.environ, {"KILOCODE_API_KEY": "fake-key"}, clear=False)
 def test_kilo_overlay_uses_hermes_slug():
     """kilo overlay should resolve to slug='kilocode'."""


### PR DESCRIPTION
## Summary
- Add explicit Kimi Coding and Kimi CN provider overlays so regional Kimi credentials keep their own labels and endpoint.
- Prefer authenticated provider exact model matches before static catalog fallback, so `/model kimi-k2.6` can choose `kimi-coding-cn` when only `KIMI_CN_API_KEY` is configured.
- Move shared models.dev duplicate filtering after credential detection so unauthenticated global aliases do not hide authenticated regional aliases.

## Test Plan
- `scripts/run_tests.sh tests/hermes_cli/test_kimi_cn_model_switch.py tests/hermes_cli/test_overlay_slug_resolution.py`