### PR TITLE
fix(artifacts): convert DB timestamps from seconds to ms for Date()

### DIFF
--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -301,7 +301,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         label: artifactLabel(value),
         sessionId: session.id,
         sessionTitle: title,
-        timestamp: message.timestamp || session.last_active || session.started_at || Date.now()
+        timestamp: (message.timestamp ?? session.last_active ?? session.started_at ?? Date.now() / 1000) * 1000
       })
     })
   }

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -301,6 +301,9 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         label: artifactLabel(value),
         sessionId: session.id,
         sessionTitle: title,
+        // DB timestamps (message.timestamp, session.last_active, session.started_at)
+        // are Unix epoch **seconds**. JS Date() expects **milliseconds**, so multiply by 1000.
+        // Date.now() returns ms, so divide by 1000 to keep the conversion uniform.
         timestamp: (message.timestamp ?? session.last_active ?? session.started_at ?? Date.now() / 1000) * 1000
       })
     })


### PR DESCRIPTION
Description
The Artifacts view in Hermes Desktop shows incorrect dates — all artifact timestamps display as January 1970 dates instead of the correct date.

Root cause: The SQLite database stores timestamps as Unix epoch seconds (float, e.g. 1780927371.42). The frontend passes these directly to JavaScript's new Date(timestamp), which expects milliseconds — so 1780927371 is misinterpreted as only ~20 days after epoch (January 21, 1970).

Fix: Multiply the database timestamp by 1000 to convert seconds to milliseconds before passing it to Date(). Also switch from || (logical OR) to ?? (nullish coalescing) so that a valid 0 timestamp is not skipped.

Testing
npx vitest run src/app/artifacts/index.test.ts — 2/2 passing
npx tsc --noEmit — zero errors
Verified that new Date(timestamp * 1000) produces correct dates

Data flow
SQLite (seconds: 1780927371) → Python API (no conversion, sends 1780927371.42) → Frontend ArtifactRecord (multiply by 1000) → new Date(1780927371420) → correct ✅