### PR TITLE
feat(skills): add deterministic opt-in protection for personal skills

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -167,7 +167,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("skills", "Search, install, inspect, or manage skills",
                "Tools & Skills", cli_only=True,
-               subcommands=("search", "browse", "inspect", "install", "audit")),
+               subcommands=("search", "browse", "inspect", "install", "audit", "protect")),
     CommandDef("bundles", "List skill bundles (aliases /<name> for multiple skills)",
                "Tools & Skills"),
     CommandDef("cron", "Manage scheduled tasks", "Tools & Skills",

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1012,6 +1012,49 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
         c.print()
 
 
+def do_protect(name: str, unprotect: bool = False,
+               console: Optional[Console] = None) -> None:
+    """Protect or unprotect a skill from agent modifications.
+
+    Creates or removes a .protected dotfile in the skill directory.
+    Protected skills are immutable at the tool level: no edit, patch,
+    write_file, remove_file, or delete.
+    """
+    from tools.skill_manager_tool import find_skill_dir
+
+    c = console or _console
+
+    skill_dir = find_skill_dir(name)
+    if not skill_dir:
+        c.print(f"[bold red]Error:[/] Skill '{name}' not found. "
+                f"Run [cyan]hermes skills list[/] to see available skills.\n")
+        return
+
+    marker = skill_dir / ".protected"
+
+    if unprotect:
+        if not marker.exists():
+            c.print(f"[yellow]Skill '{name}' is not protected.[/]\n")
+            return
+        try:
+            marker.unlink()
+            c.print(f"[green]✓[/] Skill '{name}' is now [bold]unprotected[/] — "
+                    f"the agent can modify it again.\n")
+        except OSError as e:
+            c.print(f"[bold red]Error:[/] Failed to remove .protected marker: {e}\n")
+    else:
+        if marker.exists():
+            c.print(f"[yellow]Skill '{name}' is already protected.[/]\n")
+            return
+        try:
+            marker.touch()
+            c.print(f"[green]✓[/] Skill '{name}' is now [bold]protected[/] — "
+                    f"the agent cannot modify it.\n"
+                    f"  To remove protection: [cyan]hermes skills unprotect {name}[/]\n")
+        except OSError as e:
+            c.print(f"[bold red]Error:[/] Failed to create .protected marker: {e}\n")
+
+
 def do_uninstall(name: str, console: Optional[Console] = None,
                  skip_confirm: bool = False,
                  invalidate_cache: bool = True) -> None:
@@ -1562,6 +1605,8 @@ def skills_command(args) -> None:
     elif action == "audit":
         do_audit(name=getattr(args, "name", None),
                  deep=getattr(args, "deep", False))
+    elif action == "protect":
+        do_protect(args.name, unprotect=getattr(args, "unprotect", False))
     elif action == "uninstall":
         do_uninstall(args.name)
     elif action == "reset":
@@ -1597,7 +1642,7 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|protect|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -135,6 +135,22 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Run AST-level analysis on Python files (opt-in diagnostic)",
     )
 
+    skills_protect = skills_subparsers.add_parser(
+        "protect",
+        help="Protect a skill from agent modifications (immutable)",
+        description=(
+            "Mark a skill as protected so the agent cannot modify it. "
+            "Protected skills are immutable: no edit, patch, write_file, "
+            "remove_file, or delete. Uses a .protected dotfile marker."
+        ),
+    )
+    skills_protect.add_argument("name", help="Skill name to protect")
+    skills_protect.add_argument(
+        "--unprotect",
+        action="store_true",
+        help="Remove protection instead of adding it",
+    )
+
     skills_uninstall = skills_subparsers.add_parser(
         "uninstall", help="Remove a hub-installed skill"
     )

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -957,3 +957,104 @@ class TestPinnedGuard:
                        side_effect=RuntimeError("sidecar broken")):
                 result = _delete_skill("my-skill")
         assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Protected guard (.protected dotfile)
+# ---------------------------------------------------------------------------
+
+
+class TestProtectedGuard:
+    """Test the .protected dotfile mechanism that blocks all agent mutations."""
+
+    @staticmethod
+    @contextmanager
+    def _protect(skill_dir: Path):
+        """Context manager that creates a .protected marker for the duration."""
+        marker = skill_dir / ".protected"
+        marker.touch()
+        try:
+            yield
+        finally:
+            marker.unlink(missing_ok=True)
+
+    def test_edit_refuses_protected(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            with self._protect(tmp_path / "my-skill"):
+                result = _edit_skill("my-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is False
+        assert "protected" in result["error"].lower()
+        assert "immutable" in result["error"].lower()
+
+    def test_patch_refuses_protected(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            with self._protect(tmp_path / "my-skill"):
+                result = _patch_skill("my-skill", "Do the thing.", "Do the new thing.")
+        assert result["success"] is False
+        assert "protected" in result["error"].lower()
+
+    def test_delete_refuses_protected(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            with self._protect(tmp_path / "my-skill"):
+                result = _delete_skill("my-skill")
+        assert result["success"] is False
+        assert "protected" in result["error"].lower()
+        # Skill still exists
+        assert (tmp_path / "my-skill" / "SKILL.md").exists()
+
+    def test_write_file_refuses_protected(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            with self._protect(tmp_path / "my-skill"):
+                result = _write_file("my-skill", "references/api.md", "content")
+        assert result["success"] is False
+        assert "protected" in result["error"].lower()
+
+    def test_remove_file_refuses_protected(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            _write_file("my-skill", "references/api.md", "content")
+            with self._protect(tmp_path / "my-skill"):
+                result = _remove_file("my-skill", "references/api.md")
+        assert result["success"] is False
+        assert "protected" in result["error"].lower()
+        # File still exists
+        assert (tmp_path / "my-skill" / "references" / "api.md").exists()
+
+    def test_unprotected_skills_still_editable(self, tmp_path):
+        """Sanity check: unprotected skills are not affected by the guard."""
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _edit_skill("my-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is True
+
+    def test_create_not_blocked_by_protection(self, tmp_path):
+        """Create is not a mutation of an existing skill — protection doesn't apply."""
+        with _skill_dir(tmp_path):
+            result = _create_skill("new-skill", VALID_SKILL_CONTENT)
+        assert result["success"] is True
+
+    def test_protection_error_message_includes_unprotect_hint(self, tmp_path):
+        """Error message tells the user how to remove protection."""
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            with self._protect(tmp_path / "my-skill"):
+                result = _patch_skill("my-skill", "old", "new")
+        assert "hermes skills unprotect" in result["error"]
+
+    def test_find_skill_dir_returns_path(self, tmp_path):
+        """find_skill_dir() public API returns the skill directory."""
+        from tools.skill_manager_tool import find_skill_dir
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = find_skill_dir("my-skill")
+        assert result == tmp_path / "my-skill"
+
+    def test_find_skill_dir_returns_none_for_missing(self, tmp_path):
+        from tools.skill_manager_tool import find_skill_dir
+        with _skill_dir(tmp_path):
+            result = find_skill_dir("nonexistent")
+        assert result is None

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -161,6 +161,55 @@ def _pinned_guard(name: str) -> Optional[str]:
     return None
 
 
+def _protected_guard(name: str) -> Optional[str]:
+    """Return a refusal message if *name* is protected, else None.
+
+    Protection blocks **all** mutations: edit, patch, write_file,
+    remove_file, and delete.  Unlike ``pinned`` (which only guards
+    deletion), ``protected`` makes a skill fully immutable at the tool
+    level — the agent cannot modify it in any way.
+
+    The marker is a ``.protected`` dotfile inside the skill directory.
+    This is deliberately *not* stored in SKILL.md frontmatter to avoid
+    any risk of YAML corruption.
+
+    Fail-closed: if we can't determine the skill's path or read the
+    dotfile, we assume protected and refuse the mutation.
+    """
+    result = _find_skill(name)
+    if not result:
+        return None  # skill not found — let the caller handle that
+    skill_dir = result["path"]
+    marker = skill_dir / ".protected"
+    try:
+        if marker.exists():
+            return (
+                f"Skill '{name}' is protected and cannot be modified. "
+                f"Protected skills are immutable: no edit, patch, write_file, "
+                f"remove_file, or delete. To remove protection, run "
+                f"`hermes skills unprotect {name}` or delete the "
+                f".protected file in {skill_dir}."
+            )
+    except OSError:
+        # Fail-closed: if we can't check, assume protected
+        logger.warning("Failed to check .protected marker for %s at %s", name, marker, exc_info=True)
+        return (
+            f"Cannot verify protection status for skill '{name}'. "
+            f"Refusing mutation as a safety precaution."
+        )
+    return None
+
+
+def find_skill_dir(name: str) -> Optional[Path]:
+    """Public API: return the directory path for a skill, or None.
+
+    Wraps internal ``_find_skill()`` so external callers (CLI, plugins)
+    don't depend on the private implementation.
+    """
+    result = _find_skill(name)
+    return result["path"] if result else None
+
+
 MAX_SKILL_CONTENT_CHARS = 100_000   # ~36k tokens at 2.75 chars/token
 MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
 
@@ -553,6 +602,10 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
 
+    protected_err = _protected_guard(name)
+    if protected_err:
+        return {"success": False, "error": protected_err}
+
     skill_md = existing["path"] / "SKILL.md"
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
@@ -592,6 +645,10 @@ def _patch_skill(
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
+
+    protected_err = _protected_guard(name)
+    if protected_err:
+        return {"success": False, "error": protected_err}
 
     skill_dir = existing["path"]
 
@@ -682,6 +739,10 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
 
+    protected_err = _protected_guard(name)
+    if protected_err:
+        return {"success": False, "error": protected_err}
+
     pinned_err = _pinned_guard(name)
     if pinned_err:
         return {"success": False, "error": pinned_err}
@@ -751,6 +812,10 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name, " Create it first with action='create'.")}
 
+    protected_err = _protected_guard(name)
+    if protected_err:
+        return {"success": False, "error": protected_err}
+
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
@@ -784,6 +849,10 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
+
+    protected_err = _protected_guard(name)
+    if protected_err:
+        return {"success": False, "error": protected_err}
 
     skill_dir = existing["path"]
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -653,11 +653,15 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
                 category = _get_category_from_path(skill_md)
 
+                # Check for .protected dotfile
+                protected = (skill_dir / ".protected").exists()
+
                 seen_names.add(name)
                 skills.append({
                     "name": name,
                     "description": description,
                     "category": category,
+                    "protected": protected,
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:


### PR DESCRIPTION
## Summary

Adds deterministic, tool-level protection for personal skills via a `.protected` dotfile marker. Protected skills are **fully immutable** — the agent cannot edit, patch, write_file, remove_file, or delete them.

This addresses the real-world problem of agents aggressively "improving" skills that represent weeks of careful curation, discarding valuable information in the process.

## Key Design Decisions

- **Dotfile over YAML frontmatter** — zero risk of corrupting SKILL.md; guard is a simple file-exists check
- **Separate from `pinned`** — pin blocks deletion only; protect blocks **all** mutations (edit, patch, write_file, remove_file, delete)
- **Fail-closed** — `_protected_guard()` returns a refusal message on OSError rather than silently allowing edits
- **`find_skill_dir()` public API** — wraps internal `_find_skill()` so CLI and plugins don't depend on private implementation

## What Changed

| File | Change |
|------|--------|
| `tools/skill_manager_tool.py` | Added `find_skill_dir()` public API, `_protected_guard()` guard, guard calls in all 5 mutation actions |
| `tools/skills_tool.py` | Surfaces `"protected"` boolean in `_find_all_skills()` |
| `hermes_cli/subcommands/skills.py` | Added `protect` subcommand parser |
| `hermes_cli/commands.py` | Registered `protect` in skills subcommands |
| `hermes_cli/skills_hub.py` | Added `do_protect()` handler |
| `tests/tools/test_skill_manager_tool.py` | 10 new tests covering all mutation paths + public API |

## Usage

```bash
# Protect a skill (agent cannot modify it)
hermes skills protect my-important-skill

# Remove protection (agent can modify it again)
hermes skills protect my-important-skill --unprotect
```

## Test Results

```
tests/tools/test_skill_manager_tool.py::TestProtectedGuard::test_edit_refuses_protected PASSED
tests/tools/test_skill_manager_tool.py::TestProtectedGuard::test_patch_refuses_protected PASSED
tests/tools/test_skill_manager_tool.py::TestProtectedGuard::test_delete_refuses_protected PASSED
tests/tools/test_skill_manager_tool.py::TestProtectedGuard::test_write_file_refuses_protected PASSED
tests/tools/test_skill_manager_tool.py::TestProtectedGuard::test_remove_file_refuses_protected PASSED
tests/tools/test_skill_manager_tool.py::TestProtectedGuard::test_unprotected_skills_still_editable PASSED
tests/tools/test_skill_manager_tool.py::TestProtectedGuard::test_create_not_blocked_by_protection PASSED
tests/tools/test_skill_manager_tool.py::TestProtectedGuard::test_protection_error_message_includes_unprotect_hint PASSED
tests/tools/test_skill_manager_tool.py::TestProtectedGuard::test_find_skill_dir_returns_path PASSED
tests/tools/test_skill_manager_tool.py::TestProtectedGuard::test_find_skill_dir_returns_none_for_missing PASSED
```

All 100 tests in the file pass (90 existing + 10 new).

## Related

- Closes #41939
- Revives the approach from #36924 (closed without merge)
