### PR TITLE
fix(hindsight): auto-install hindsight-client in cloud mode via lazy_deps

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -924,6 +924,13 @@ class HindsightMemoryProvider(MemoryProvider):
                 kwargs["idle_timeout"] = idle_timeout
                 self._client = HindsightEmbedded(**kwargs)
             else:
+                try:
+                    from tools.lazy_deps import ensure as _lazy_ensure
+                    _lazy_ensure("memory.hindsight", prompt=False)
+                except ImportError:
+                    pass
+                except Exception as _e:
+                    raise ImportError(str(_e))
                 from hindsight_client import Hindsight
                 timeout = self._timeout or _DEFAULT_TIMEOUT
                 kwargs = {"base_url": self._api_url, "timeout": float(timeout)}


### PR DESCRIPTION
## Problem

When using Hindsight in `cloud` mode, the `hindsight-client` Python package is required at `from hindsight_client import Hindsight` (line 927). However, the auto-install via `lazy_deps.ensure("memory.hindsight")` was only called in the `local_embedded` code path (line 897). 

If the package is not pre-installed in the venv — e.g., after a venv recreation or initial setup — cloud mode users hit an unhandled `ModuleNotFoundError: No module named 'hindsight_client'`.

## Fix

Add the same `_lazy_ensure("memory.hindsight", prompt=False)` call before the import in the `else` (cloud) branch, matching the pattern already used for `local_embedded`.

- If `tools.lazy_deps` itself is unavailable (`ImportError`), silently pass (same behavior as local_embedded).
- Other exceptions are re-raised as `ImportError` (same as local_embedded).

## Testing

Verified the `lazy_deps` module has `"memory.hindsight": ("hindsight-client==0.6.1",)` registered. The fix applies the identical auto-install ladder (uv → pip with ensurepip) that runs for local_embedded. After applying this fix and installing the missing package, `hindsight_retain`, `hindsight_recall`, and `hindsight_reflect` all function correctly.

Fixes cloud-mode users experiencing a bare `ModuleNotFoundError` when `hindsight-client` is not present in the active venv.