### PR TITLE
fix(gateway): add code file extensions to MEDIA_DELIVERY_EXTS

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1199,6 +1199,10 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     ".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz", ".7z", ".rar", ".apk", ".ipa",
     # Web / rendered output
     ".html", ".htm",
+    # Code / scripts
+    ".py", ".pyw", ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx",
+    ".sh", ".bash", ".zsh", ".rb", ".go", ".rs", ".java",
+    ".c", ".cpp", ".h", ".hpp", ".css", ".sql", ".toml", ".ini", ".cfg",
 )
 
 # Regex alternation fragment of bare extensions (no leading dot), e.g.

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -559,7 +559,8 @@ class TestMediaExtensionAllowlistParity:
     """
 
     DROPPED_BEFORE = ["md", "json", "yaml", "yml", "xml", "html", "htm",
-                      "tsv", "svg"]
+                      "tsv", "svg", "py", "js", "ts", "sh", "go", "rs",
+                      "java", "css", "sql", "toml"]
 
     def test_previously_dropped_extensions_now_extract(self):
         for ext in self.DROPPED_BEFORE:
@@ -592,6 +593,37 @@ class TestMediaExtensionAllowlistParity:
         assert "MEDIA:" not in stripped
         assert "/tmp/report.md" not in stripped
         assert "Here is your report:" in stripped
+
+
+class TestCodeFileMediaExtraction:
+    """Regression tests for #42206 — code files not delivered via MEDIA: tag."""
+
+    def test_py_file_extracted(self):
+        content = "Here is the script:\nMEDIA:/root/file.py"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/root/file.py", False)]
+        assert "MEDIA:" not in cleaned
+        assert "Here is the script:" in cleaned
+
+    def test_multiple_code_files_extracted(self):
+        content = "MEDIA:/root/config.json\nMEDIA:/root/script.py"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 2
+        paths = [p for p, _ in media]
+        assert "/root/config.json" in paths
+        assert "/root/script.py" in paths
+
+    def test_js_ts_sh_files_extracted(self):
+        for ext in ("js", "ts", "sh", "go", "rs", "java", "css", "sql", "toml"):
+            content = f"MEDIA:/tmp/file.{ext}"
+            media, _ = BasePlatformAdapter.extract_media(content)
+            assert media == [(f"/tmp/file.{ext}", False)], f".{ext} should extract"
+
+    def test_code_extension_in_delivery_exts(self):
+        from gateway.platforms.base import MEDIA_DELIVERY_EXTS
+        for ext in (".py", ".js", ".ts", ".sh", ".go", ".rs", ".java", ".css",
+                     ".sql", ".toml", ".tsx", ".jsx", ".c", ".cpp"):
+            assert ext in MEDIA_DELIVERY_EXTS, f"{ext} missing from MEDIA_DELIVERY_EXTS"
 
 
 class TestMediaDeliveryPathValidation:


### PR DESCRIPTION
## What does this PR do?

Adds common code/script file extensions (`.py`, `.js`, `.ts`, `.sh`, `.go`, `.rs`, `.java`, `.css`, `.sql`, `.toml`, etc.) to `MEDIA_DELIVERY_EXTS` so that `MEDIA:/path/to/file.py` tags are properly extracted and delivered as file attachments instead of being silently dropped.

## Related Issue

Fixes #42206

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Add "Code / scripts" category to `MEDIA_DELIVERY_EXTS` with 20 common code file extensions (.py, .pyw, .js, .mjs, .cjs, .ts, .tsx, .jsx, .sh, .bash, .zsh, .rb, .go, .rs, .java, .c, .cpp, .h, .hpp, .css, .sql, .toml, .ini, .cfg)
- `tests/gateway/test_platform_base.py`: Add `TestCodeFileMediaExtraction` class with 4 tests; extend `DROPPED_BEFORE` list in existing `TestMediaExtensionAllowlistParity` with 11 new code extensions

## How to Test

1. Verify `.py` files are now extracted:
   ```python
   from gateway.platforms.base import BasePlatformAdapter
   media, cleaned = BasePlatformAdapter.extract_media("MEDIA:/tmp/script.py")
   assert media == [("/tmp/script.py", False)]
   ```
2. Verify multiple code files are extracted:
   ```python
   media, _ = BasePlatformAdapter.extract_media("MEDIA:/a.json\nMEDIA:/b.py")
   assert len(media) == 2
   ```
3. Run the tests:
   ```bash
   pytest tests/gateway/test_platform_base.py -v -k "TestCodeFileMediaExtraction or TestMediaExtensionAllowlistParity"
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `MEDIA_DELIVERY_EXTS` in `gateway/platforms/base.py` (line 1185)
- Callers: `extract_media()` (line 2893), `extract_local_files()` (line 2977), `filter_media_delivery_paths()`, `MEDIA_TAG_CLEANUP_RE` (line 1221)
- Blast radius: LOW — adding extensions to an existing allowlist; no control flow changes
- Related patterns: The `_MEDIA_EXT_ALTERNATION` regex fragment is auto-derived from `MEDIA_DELIVERY_EXTS` (line 1208), so `MEDIA_TAG_CLEANUP_RE` automatically includes the new extensions
