### PR TITLE
fix(desktop): disable Chromium/GPU sandbox on Windows to resolve STATUS_BREAKPOINT crashes

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -110,13 +110,16 @@ const APP_ROOT = app.getAppPath()
 // switches only apply pre-launch. Override with HERMES_DESKTOP_DISABLE_GPU
 // (1/true → always disable, 0/false → keep GPU on).
 const REMOTE_DISPLAY_REASON = detectRemoteDisplay()
-if (REMOTE_DISPLAY_REASON) {
+if (REMOTE_DISPLAY_REASON || IS_WINDOWS) {
   app.disableHardwareAcceleration()
   // Belt-and-suspenders for X11/VNC, where the Viz compositor can still glitch
   // with only --disable-gpu: force compositing onto the CPU too.
   app.commandLine.appendSwitch('disable-gpu-compositing')
+  // Disable sandbox to prevent STATUS_BREAKPOINT crashes on Windows
+  app.commandLine.appendSwitch('no-sandbox')
+  app.commandLine.appendSwitch('disable-gpu-sandbox')
   console.log(
-    `[hermes] remote display detected (${REMOTE_DISPLAY_REASON}); disabling GPU hardware acceleration to prevent flicker`
+    `[hermes] remote display or Windows environment detected; disabling GPU hardware acceleration and sandbox to prevent crashes`
   )
 }
 const SOURCE_REPO_ROOT = path.resolve(APP_ROOT, '../..')
@@ -4687,7 +4690,7 @@ function createWindow() {
       preload: path.join(__dirname, 'preload.cjs'),
       contextIsolation: true,
       webviewTag: true,
-      sandbox: true,
+      sandbox: !IS_WINDOWS,
       nodeIntegration: false,
       devTools: true
     }
@@ -4769,12 +4772,11 @@ function createWindow() {
     const details = detailsOrLevel && typeof detailsOrLevel === 'object' ? detailsOrLevel : null
     const level = details ? details.level : detailsOrLevel
 
-    if (level !== 3) return
-
     const text = details ? details.message : message
     const src = details ? details.sourceUrl : sourceId
     const lineNo = details ? details.lineNumber : line
-    rememberLog(`[renderer console] ${text} (${src}:${lineNo})`)
+    const levelStr = ['log', 'info', 'warn', 'error'][level] || String(level)
+    rememberLog(`[renderer console ${levelStr}] ${text} (${src}:${lineNo})`)
   })
 
   if (DEV_SERVER) {


### PR DESCRIPTION
Do not merge. This PR is submitted to report and discuss a packaged crash loop on Windows.

### Problem
A crash loop occurs on Windows in the packaged version of the Hermes Desktop application. The application launches, shows the boot/loading sequence, initializes the Python backend, accepts the WebSocket connection, and then the renderer process crashes immediately with `STATUS_BREAKPOINT` (`0x80000003` / `-2147483645` at offset `0x76ab0b6` in `Hermes.exe`).

This issue does not affect Dev mode (`npm run dev`) because assets are served over HTTP rather than the `file://` protocol, which has different origin checks.

### Diagnostics
- **Exception Code:** `ExceptionCode.EXCEPTION_BREAKPOINT`
- **Exception Address:** `0x7ff64188b0b6` (mapped to `Hermes.exe + 0x76ab0b6` inside the renderer process)
- **Symptoms:** `desktop.log` shows repetitive `render-process-gone` crashes exactly after the WebSocket connection is established.

### Fix
Adding `no-sandbox` and `disable-gpu-sandbox` to the command line switches resolves the crash loop on Windows:
```javascript
  // Disable sandbox to prevent STATUS_BREAKPOINT crashes on Windows
  app.commandLine.appendSwitch('no-sandbox')
  app.commandLine.appendSwitch('disable-gpu-sandbox')
```
This lifts the Chromium sandbox limitations on file access under the virtual file system environment in packaged builds.
