### PR TITLE
fix(providers): add base_url_override to minimax and minimax-cn for anthropic transport

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -120,6 +120,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     "minimax": HermesOverlay(
         transport="anthropic_messages",
         base_url_env_var="MINIMAX_BASE_URL",
+        # MiniMax serves the Anthropic Messages API under /anthropic; the bare
+        # models.dev base (/v1) is OpenAI-only and 404s the anthropic transport.
+        # Mirror minimax-oauth. MINIMAX_BASE_URL still overrides at resolution.
+        base_url_override="https://api.minimax.io/anthropic",
     ),
     "minimax-oauth": HermesOverlay(
         transport="anthropic_messages",
@@ -129,6 +133,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     "minimax-cn": HermesOverlay(
         transport="anthropic_messages",
         base_url_env_var="MINIMAX_CN_BASE_URL",
+        base_url_override="https://api.minimaxi.com/anthropic",
     ),
     "deepseek": HermesOverlay(
         transport="openai_chat",


### PR DESCRIPTION
The minimax and minimax-cn provider overlays hard-set
transport=anthropic_messages but shipped no base_url_override. Without
it, get_provider_def() falls back to the models.dev base (/v1) which
only serves MiniMax's OpenAI-compatible path. Every anthropic transport
request to /v1/messages returns 404.

Mirror the minimax-oauth fix: set base_url_override to the /anthropic
endpoint. The base_url_env_var escape hatch is preserved so custom/self-
hosted bases keep working.

- minimax: https://api.minimax.io/anthropic (matches minimax-oauth)
- minimax-cn: https://api.minimaxi.com/anthropic (China endpoint)

Fixes #42235