### PR TITLE
fix(agent): inherit parent session cwd during compression rotation

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -500,8 +500,10 @@ def compress_context(
 
     if agent._session_db:
         try:
-            # Propagate title to the new session with auto-numbering
+            # Propagate title and workspace (cwd) to the new session.
             old_title = agent._session_db.get_session_title(agent.session_id)
+            old_session_row = agent._session_db.get_session(agent.session_id)
+            old_cwd = old_session_row.get("cwd") if old_session_row else None
             # Trigger memory extraction on the old session before it rotates.
             agent.commit_memory_session(messages)
             agent._session_db.end_session(agent.session_id, "compression")
@@ -537,6 +539,7 @@ def compress_context(
                 model=agent.model,
                 model_config=agent._session_init_model_config,
                 parent_session_id=old_session_id,
+                cwd=old_cwd,
             )
             agent._session_db_created = True
             # Auto-number the title for the continuation session

--- a/tests/agent/test_compression_cwd_inheritance.py
+++ b/tests/agent/test_compression_cwd_inheritance.py
@@ -1,0 +1,150 @@
+"""Regression: compression continuation must inherit the parent session's cwd.
+
+When a session with an explicit workspace (cwd) is compressed, the continuation
+session should preserve that cwd. Otherwise list_sessions_rich() projects the
+tip's NULL cwd over the root's valid cwd, and the conversation disappears into
+the "No workspace" group in Desktop/TUI.
+
+See: https://github.com/NousResearch/hermes-agent/issues/42228
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _build_agent_with_db(db: SessionDB, session_id: str, cwd: str = None):
+    """Build an AIAgent wired to db with a specific session cwd."""
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    # Create the initial session with a cwd
+    db.create_session(
+        session_id=session_id,
+        source="cli",
+        model="test/model",
+        cwd=cwd,
+    )
+
+    # Stub compressor to return deterministic output without LLM calls
+    compressor = MagicMock()
+
+    def _compress(*_a, **_kw):
+        return [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "user", "content": "tail"},
+        ]
+
+    compressor.compress.side_effect = _compress
+    compressor.compression_count = 1
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    agent.context_compressor = compressor
+    return agent
+
+
+class TestCompressionCwdInheritance:
+    """Continuation sessions must inherit the parent's cwd."""
+
+    def test_continuation_inherits_cwd(self, tmp_path: Path):
+        """After compression, the new session should have the same cwd as the old one."""
+        db_path = tmp_path / "test.db"
+        db = SessionDB(db_path)
+
+        session_id = "20260608_120000_abc123"
+        workspace = "/Users/test/my-project"
+        agent = _build_agent_with_db(db, session_id, cwd=workspace)
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello " * 2000},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+        from agent.conversation_compression import compress_context
+
+        with patch.object(agent, "_build_system_prompt", return_value="system"):
+            compress_context(agent, messages, "You are helpful.", force=True)
+
+        # The session_id should have changed (new continuation)
+        assert agent.session_id != session_id
+
+        # The new session should have inherited the cwd
+        new_session = db.get_session(agent.session_id)
+        assert new_session is not None
+        assert new_session["cwd"] == workspace
+
+    def test_continuation_inherits_null_cwd(self, tmp_path: Path):
+        """Sessions without a workspace should keep cwd=None after compression."""
+        db_path = tmp_path / "test.db"
+        db = SessionDB(db_path)
+
+        session_id = "20260608_120000_def456"
+        agent = _build_agent_with_db(db, session_id, cwd=None)
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello " * 2000},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+        from agent.conversation_compression import compress_context
+
+        with patch.object(agent, "_build_system_prompt", return_value="system"):
+            compress_context(agent, messages, "You are helpful.", force=True)
+
+        new_session = db.get_session(agent.session_id)
+        assert new_session is not None
+        assert new_session["cwd"] is None
+
+    def test_tip_projection_preserves_cwd(self, tmp_path: Path):
+        """list_sessions_rich tip projection should show the inherited cwd."""
+        db_path = tmp_path / "test.db"
+        db = SessionDB(db_path)
+
+        root_id = "20260608_120000_root01"
+        workspace = "/Users/test/my-project"
+        agent = _build_agent_with_db(db, root_id, cwd=workspace)
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello " * 2000},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+
+        from agent.conversation_compression import compress_context
+
+        with patch.object(agent, "_build_system_prompt", return_value="system"):
+            compress_context(agent, messages, "You are helpful.", force=True)
+
+        tip_id = agent.session_id
+
+        # list_sessions_rich should project the tip's cwd onto the root
+        sessions = db.list_sessions_rich(source="cli", project_compression_tips=True)
+        # Find the projected session (root projected to tip)
+        projected = [s for s in sessions if s.get("_lineage_root_id") == root_id]
+        assert len(projected) == 1
+        assert projected[0]["cwd"] == workspace
+        assert projected[0]["id"] == tip_id


### PR DESCRIPTION
## What does this PR do?

Inherits the parent session's `cwd` (workspace path) into the continuation session created during context compression. Previously, the continuation was created without `cwd`, causing `list_sessions_rich()` tip projection to surface `cwd=null` — moving the conversation into the "No workspace" group in Desktop/TUI.

## Related Issue

Fixes #42228

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py`: Read the old session's `cwd` via `get_session()` before ending it, and pass `cwd=old_cwd` to the continuation `create_session()` call
- `tests/agent/test_compression_cwd_inheritance.py`: 3 regression tests — continuation inherits cwd, null cwd stays null, tip projection preserves cwd

## How to Test

1. Open Desktop/TUI with a workspace selected (e.g., `/Users/test/project`)
2. Have a long conversation that triggers context compression
3. After compression, verify the session still appears under the correct workspace group (not "No workspace")
4. Run `pytest tests/agent/test_compression_cwd_inheritance.py -v` — all 3 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/conversation_compression.py` (compress_context → create_session call chain)
- Blast radius: LOW — single parameter addition to existing create_session call; no control flow changes
- Related patterns: Title propagation (old_title) already follows the same pattern at lines 504/526-531
