### PR TITLE
feat(desktop): add optional API key field for custom endpoint onboarding

### DIFF
--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -442,7 +442,7 @@ export function Picker({ ctx }: { ctx: OnboardingContext }) {
         <ApiKeyForm
           canGoBack={hasOauth}
           onBack={() => setOnboardingMode('oauth')}
-          onSave={(envKey, value, name) => saveOnboardingApiKey(envKey, value, name, ctx)}
+          onSave={(envKey, value, name, apiKey) => saveOnboardingApiKey(envKey, value, name, ctx, apiKey)}
           options={apiKeyOptions}
         />
         {manual ? null : (
@@ -641,13 +641,14 @@ export function ApiKeyForm({
   isSet?: (envKey: string) => boolean
   onBack: () => void
   onClear?: (envKey: string) => void
-  onSave: (envKey: string, value: string, name: string) => Promise<{ message?: string; ok: boolean }>
+  onSave: (envKey: string, value: string, name: string, apiKey?: string) => Promise<{ message?: string; ok: boolean }>
   options?: ApiKeyOption[]
   redactedValue?: (envKey: string) => null | string | undefined
 }) {
   const { t } = useI18n()
   const [option, setOption] = useState<ApiKeyOption>(options[0])
   const [value, setValue] = useState('')
+  const [apiKey, setApiKey] = useState('')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<null | string>(null)
   // `options` can change at runtime when callers filter the catalog (e.g. the
@@ -668,6 +669,7 @@ export function ApiKeyForm({
   const pick = (o: ApiKeyOption) => {
     setOption(o)
     setValue('')
+    setApiKey('')
     setError(null)
     requestAnimationFrame(() => {
       entryRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
@@ -693,7 +695,7 @@ export function ApiKeyForm({
 
     setSaving(true)
     setError(null)
-    const result = await onSave(option.envKey, value, option.name)
+    const result = await onSave(option.envKey, value, option.name, isLocal ? apiKey || undefined : undefined)
 
     if (result.ok) {
       setValue('')
@@ -759,6 +761,17 @@ export function ApiKeyForm({
           type={isLocal ? 'text' : 'password'}
           value={value}
         />
+        {isLocal ? (
+          <Input
+            autoComplete="off"
+            className="font-mono"
+            onChange={e => setApiKey(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && void submit()}
+            placeholder="API key (optional — leave empty for unauthenticated endpoints)"
+            type="password"
+            value={apiKey}
+          />
+        ) : null}
         {error ? <p className="text-xs text-destructive">{error}</p> : null}
       </div>
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -343,13 +343,14 @@ export function setEnvVar(key: string, value: string): Promise<{ ok: boolean }> 
 
 export function validateProviderCredential(
   key: string,
-  value: string
+  value: string,
+  apiKey?: string
 ): Promise<{ ok: boolean; reachable: boolean; message: string; models?: string[] }> {
   return window.hermesDesktop.api<{ ok: boolean; reachable: boolean; message: string; models?: string[] }>({
     ...profileScoped(),
     path: '/api/providers/validate',
     method: 'POST',
-    body: { key, value }
+    body: { key, value, api_key: apiKey || undefined }
   })
 }
 

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -701,7 +701,7 @@ export async function recheckExternalSignin(ctx: OnboardingContext) {
   )
 }
 
-export async function saveOnboardingApiKey(envKey: string, value: string, label: string, ctx: OnboardingContext) {
+export async function saveOnboardingApiKey(envKey: string, value: string, label: string, ctx: OnboardingContext, apiKey?: string) {
   const trimmed = value.trim()
 
   if (!trimmed) {
@@ -712,7 +712,7 @@ export async function saveOnboardingApiKey(envKey: string, value: string, label:
   // It must be wired into config (provider=custom + base_url + model), not
   // dropped into .env — runtime resolution ignores OPENAI_BASE_URL.
   if (envKey === 'OPENAI_BASE_URL') {
-    return saveOnboardingLocalEndpoint(trimmed, ctx)
+    return saveOnboardingLocalEndpoint(trimmed, ctx, apiKey)
   }
 
   // No key validation here on purpose: we previously live-probed the key and
@@ -754,7 +754,7 @@ export async function saveOnboardingApiKey(envKey: string, value: string, label:
 // re-assigns the model from /api/model/options WITHOUT a base_url, which would
 // wipe the base_url we just wrote. We have a concrete model already, so we
 // verify the runtime directly and finish.
-export async function saveOnboardingLocalEndpoint(baseUrl: string, ctx: OnboardingContext) {
+export async function saveOnboardingLocalEndpoint(baseUrl: string, ctx: OnboardingContext, apiKey?: string) {
   const url = baseUrl.trim()
 
   if (!url) {
@@ -767,7 +767,7 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, ctx: Onboardi
   let model = ''
 
   try {
-    const probe = await validateProviderCredential('OPENAI_BASE_URL', url)
+    const probe = await validateProviderCredential('OPENAI_BASE_URL', url, apiKey)
 
     if (!probe.ok && probe.reachable) {
       return { ok: false, message: probe.message || 'Could not reach that endpoint.' }
@@ -790,6 +790,12 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, ctx: Onboardi
   }
 
   try {
+    // Save the API key to .env if provided — the runtime resolver checks
+    // CUSTOM_API_KEY as a fallback for custom endpoints.
+    if (apiKey?.trim()) {
+      await setEnvVar('CUSTOM_API_KEY', apiKey.trim())
+    }
+
     await setModelAssignment({ scope: 'main', provider: 'custom', model, base_url: url })
     await ctx.requestGateway('reload.env').catch(() => undefined)
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -733,6 +733,9 @@ def _resolve_named_custom_runtime(
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
         os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        # Generic custom endpoint key — set via Desktop onboarding or
+        # `hermes auth add custom`.
+        os.getenv("CUSTOM_API_KEY", "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
         (os.getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -604,6 +604,7 @@ class ConfigUpdate(BaseModel):
 class EnvVarUpdate(BaseModel):
     key: str
     value: str
+    api_key: Optional[str] = None
 
 
 class EnvVarDelete(BaseModel):
@@ -2741,7 +2742,11 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
         url = value.rstrip("/") + "/models"
         try:
             with httpx.Client(timeout=httpx.Timeout(8.0)) as client:
-                resp = client.get(url)
+                headers = {}
+                api_key = (body.api_key or "").strip()
+                if api_key:
+                    headers["Authorization"] = f"Bearer {api_key}"
+                resp = client.get(url, headers=headers)
             return {"ok": True, "reachable": True, "message": "", "models": _parse_model_ids(resp)}
         except Exception:
             return {"ok": False, "reachable": False, "message": f"Could not reach {url}."}

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4593,6 +4593,79 @@ class TestValidateProviderCredential:
         data = self._post("OPENAI_API_KEY", "   ").json()
         assert data["ok"] is False
 
+    def test_custom_endpoint_without_api_key(self, monkeypatch):
+        """OPENAI_BASE_URL validation works without an API key (unauthenticated)."""
+        monkeypatch.setattr("httpx.Client", _fake_httpx_client(status=200))
+        resp = self.client.post(
+            "/api/providers/validate",
+            json={"key": "OPENAI_BASE_URL", "value": "http://127.0.0.1:8000/v1"},
+        )
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["reachable"] is True
+
+    def test_custom_endpoint_with_api_key_passes_bearer_header(self, monkeypatch):
+        """OPENAI_BASE_URL validation sends Authorization header when api_key is provided."""
+        captured_headers = {}
+
+        class _CaptureClient:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def get(self, url, *a, **k):
+                captured_headers.update(k.get("headers", {}))
+                return type("R", (), {"status_code": 200, "is_success": True})()
+
+        monkeypatch.setattr("httpx.Client", _CaptureClient)
+        resp = self.client.post(
+            "/api/providers/validate",
+            json={
+                "key": "OPENAI_BASE_URL",
+                "value": "http://127.0.0.1:8000/v1",
+                "api_key": "***",
+            },
+        )
+        data = resp.json()
+        assert data["ok"] is True
+        assert captured_headers.get("Authorization") == "Bearer ***"
+
+    def test_custom_endpoint_with_empty_api_key_no_header(self, monkeypatch):
+        """OPENAI_BASE_URL validation skips Authorization when api_key is empty."""
+        captured_headers = {}
+
+        class _CaptureClient:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def get(self, url, *a, **k):
+                captured_headers.update(k.get("headers", {}))
+                return type("R", (), {"status_code": 200, "is_success": True})()
+
+        monkeypatch.setattr("httpx.Client", _CaptureClient)
+        resp = self.client.post(
+            "/api/providers/validate",
+            json={
+                "key": "OPENAI_BASE_URL",
+                "value": "http://127.0.0.1:8000/v1",
+                "api_key": "",
+            },
+        )
+        data = resp.json()
+        assert data["ok"] is True
+        assert "Authorization" not in captured_headers
+
 
 class TestDesktopCronTicker:
     """The dashboard backend fires cron jobs itself only when desktop-spawned."""


### PR DESCRIPTION
## Problem

Authenticated OpenAI-compatible endpoints (LiteLLM gateways, self-hosted routers, custom API proxies) require a Bearer token to serve `/v1/models`. The Desktop onboarding "Local / custom endpoint" flow previously only accepted a base URL — users with authenticated endpoints had to leave the app and manually edit `config.yaml` or `.env` to add the token. This breaks the Desktop experience: custom models almost work from the UI, but the last required field forces a terminal/config-file workflow.

## Solution

Add an optional API key input field to the Desktop custom endpoint onboarding flow:

1. **UI**: Second input field below the base URL (password type, optional) — only shown for "Local / custom endpoint"
2. **Validation**: `Authorization: Bearer ***` header sent when probing `/v1/models` with an API key
3. **Persistence**: API key saved to `.env` as `CUSTOM_API_KEY` for runtime resolution
4. **Runtime**: `CUSTOM_API_KEY` added to the custom provider's API key candidate list

## Changes

| File | Change |
|------|--------|
| `hermes_cli/web_server.py` | Add `api_key` optional field to `EnvVarUpdate`; send Bearer header when probing custom endpoints |
| `hermes_cli/runtime_provider.py` | Add `CUSTOM_API_KEY` to API key fallback candidates |
| `apps/desktop/src/hermes.ts` | Pass `api_key` in validate request body |
| `apps/desktop/src/store/onboarding.ts` | Accept and save API key in `saveOnboardingLocalEndpoint` |
| `apps/desktop/src/components/desktop-onboarding-overlay.tsx` | Add optional API key input field |
| `tests/hermes_cli/test_web_server.py` | 3 new tests for validate endpoint with/without API key |

## Testing

- `test_custom_endpoint_without_api_key` — unauthenticated endpoints still work
- `test_custom_endpoint_with_api_key_passes_bearer_header` — Bearer header sent when key provided
- `test_custom_endpoint_with_empty_api_key_no_header` — no header when key is empty

All 9 `TestValidateProviderCredential` tests pass.

Fixes #42042
