### PR TITLE
fix(classifier): extract body.param for Xiaomi MiMo error

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -518,6 +518,14 @@ def classify_api_error(
         parts.append(_body_msg)
     if _metadata_msg and _metadata_msg not in _raw_msg and _metadata_msg not in _body_msg:
         parts.append(_metadata_msg)
+    # Include body.param — some providers (Xiaomi MiMo) put the real
+    # diagnostic in a top-level "param" field, e.g.
+    # {"code":"400","message":"Param Incorrect","param":"`text` is not set"}
+    _param_msg = ""
+    if isinstance(body, dict):
+        _param_msg = str(body.get("param") or "").lower()
+    if _param_msg and _param_msg not in error_msg:
+        parts.append(_param_msg)
     error_msg = " ".join(parts)
     provider_lower = (provider or "").strip().lower()
     model_lower = (model or "").strip().lower()


### PR DESCRIPTION
## Problem

The Xiaomi MiMo API returns errors with the diagnostic in a top-level `param` field rather than in `message`:

```json
{"code":"400","message":"Param Incorrect","param":"`text` is not set"}
```

The error classifier only extracted `body.message` (`Param Incorrect`) but NOT `body.param` (`` `text` is not set ``). This caused the `multimodal_tool_content_unsupported` pattern to never match, resulting in the error being classified as a non-retryable `format_error` and aborting the session.

## Fix

Added extraction of `body.param` into the `error_msg` used for pattern matching. Now the `` `text` is not set `` pattern correctly triggers the multimodal tool content recovery path (strip images from tool messages and retry).

## Before
```
error_msg = "badrequesterror [http 400] param incorrect"
# Pattern "text is not set" NOT found → classified as format_error → non-retryable → ABORT
```

## After
```
error_msg = "badrequesterror [http 400] param incorrect `text` is not set"
# Pattern "`text` is not set" FOUND → classified as multimodal_tool_content_unsupported → retryable → strip images + RETRY
```

## Testing

Verified that the pattern matching works with the exact error from the user's session:
```python
error_msg = 'badrequesterror [http 400] param incorrect `text` is not set'
pattern = '`text` is not set'
assert pattern in error_msg  # True
```

Fixes #27344
