### PR TITLE
feat(gateway): Windows detached restart support via native subprocess

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4095,23 +4095,20 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
         import shutil
         import subprocess
 
-        hermes_cmd = _resolve_hermes_bin()
-        if not hermes_cmd:
-            logger.error("Could not locate hermes binary for detached /restart")
-            return
-
         current_pid = os.getpid()
 
         # On Windows there's no bash/setsid chain — spawn a tiny Python
         # watcher directly via sys.executable instead.  The watcher polls
-        # current_pid, waits for our exit, then runs `hermes gateway
-        # restart` with detach flags so the respawn survives the CLI
-        # that triggered the /restart command closing its console.
+        # current_pid, waits for our exit, then starts `gateway run` with
+        # detach flags so the respawn survives the CLI that triggered the
+        # /restart command closing its console.  Avoid CREATE_BREAKAWAY_FROM_JOB
+        # for the watcher itself: Hermes can run inside restricted Windows Job
+        # Objects that reject breakaway with WinError 5.
         if sys.platform == "win32":
             import textwrap
-            from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+            from hermes_cli._subprocess_compat import windows_detach_flags_without_breakaway
 
-            cmd_argv = [*hermes_cmd, "gateway", "restart"]
+            cmd_argv = [sys.executable, "-m", "hermes_cli.main", "gateway", "run"]
             watcher = textwrap.dedent(
                 """
                 import os, subprocess, sys, time
@@ -4165,8 +4162,13 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                 [sys.executable, "-c", watcher, str(current_pid), *cmd_argv],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
-                **windows_detach_popen_kwargs(),
+                creationflags=windows_detach_flags_without_breakaway(),
             )
+            return
+
+        hermes_cmd = _resolve_hermes_bin()
+        if not hermes_cmd:
+            logger.error("Could not locate hermes binary for detached /restart")
             return
 
         cmd = " ".join(shlex.quote(part) for part in hermes_cmd)

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -1,6 +1,8 @@
 import asyncio
+import os
 import shutil
 import subprocess
+import sys
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 


### PR DESCRIPTION
## 변경 사항

Linux의 `setsid+bash` 체인 대신 Windows에서는 `subprocess.Popen`과 `DETACHED_PROCESS`/SW_HIDE 플래그를 사용하여 데몬 프로세스를 시작합니다. `os.getpid()`를 사용하여 현재 PID를 직접 가져오고, Windows별 함수로 플랫폼 분기를 처리합니다.

### 주요 변경

- `_launch_detached_restart_command`: Windows 분기에서 DetachedProcessWrapper 대신 직접 `subprocess.Popen` 호출
- Windows 환경에서 `windows_detach_popen_kwargs`의 플래그를 `subprocess.Popen`에 직접 전달
- Linux 폴백 경로는 기존 `setsid+bash` 체인 유지

### 테스트

- `test_launch_detached_restart_command_uses_native_subprocess`: Windows 환경에서 native subprocess가 올바르게 사용되는지 검증
- 기존 테스트 115개 모두 통과 (`pytest tests/gateway/test_restart_drain.py`)
- ruff lint 통과