### PR TITLE
fix(gateway): correct stale systemd restart guidance

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4400,8 +4400,9 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                 logger.warning(
                     "Stale systemd unit detected: %s has TimeoutStopSec=%.0fs but "
                     "drain_timeout=%.0fs (expected >=%.0fs). systemd may SIGKILL the "
-                    "gateway mid-drain. Run `hermes gateway service install --replace` "
-                    "to regenerate the unit, or shorten agent.restart_drain_timeout.",
+                    "gateway mid-drain. Run `hermes gateway restart` to refresh "
+                    "the unit, or `sudo hermes gateway restart --system` for a system "
+                    "service. Alternatively, shorten agent.restart_drain_timeout.",
                     _alignment.get("unit", "(unknown)"),
                     _alignment["timeout_stop_sec"],
                     _alignment["drain_timeout"],

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from unittest.mock import AsyncMock
 
@@ -114,6 +116,40 @@ async def test_runner_allows_cron_only_mode_when_no_platforms_are_enabled(monkey
     assert runner.adapters == {}
     state = read_runtime_status()
     assert state["gateway_state"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_runner_stale_systemd_warning_uses_existing_commands(
+    monkeypatch, tmp_path, caplog
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=False, token="***")
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    monkeypatch.setattr(
+        "gateway.shutdown_forensics.check_systemd_timing_alignment",
+        lambda _timeout: {
+            "unit": "hermes-gateway.service",
+            "timeout_stop_sec": 60.0,
+            "drain_timeout": 120.0,
+            "expected_min": 150.0,
+            "mismatch": True,
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        ok = await runner.start()
+
+    assert ok is True
+    assert "Stale systemd unit detected" in caplog.text
+    assert "hermes gateway restart" in caplog.text
+    assert "sudo hermes gateway restart --system" in caplog.text
+    assert "hermes gateway service install --replace" not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

## What does this PR do?

Previously the stale systemd unit warning told users to run a nonexistent gateway service install command. This commit points the warning at the restart commands that actually refresh installed systemd units.

- Replace `hermes gateway service install --replace` in `gateway/run.py`
- Mention the user and system-scope `gateway restart` repair paths
- Add a regression test for the stale systemd warning text

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
