### PR TITLE
fix(approval): gate resolved Hermes config paths (salvage #41455)

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import patch as mock_patch
 
 import tools.approval as approval_module
+from hermes_constants import get_hermes_home
 from tools.approval import (
     _get_approval_mode,
     _smart_approve,
@@ -424,6 +425,22 @@ class TestHermesConfigWriteProtection:
         dangerous, key, desc = detect_dangerous_command("sed --in-place 's/manual/off/' ~/.hermes/config.yaml")
         assert dangerous is True
 
+    def test_sed_in_place_absolute_hermes_home_config(self):
+        config_path = get_hermes_home() / "config.yaml"
+        dangerous, key, desc = detect_dangerous_command(
+            f"sed -i 's/manual/off/' {config_path}"
+        )
+        assert dangerous is True
+        assert "hermes config" in desc.lower() or "in-place" in desc.lower()
+
+    def test_sed_in_place_absolute_hermes_home_env(self):
+        env_path = get_hermes_home() / ".env"
+        dangerous, key, desc = detect_dangerous_command(
+            f"sed -i 's/API_KEY=.*/API_KEY=x/' {env_path}"
+        )
+        assert dangerous is True
+        assert "hermes config" in desc.lower() or "in-place" in desc.lower()
+
     def test_custom_hermes_home(self):
         dangerous, key, desc = detect_dangerous_command("echo x | tee $HERMES_HOME/config.yaml")
         assert dangerous is True
@@ -437,11 +454,32 @@ class TestHermesConfigWriteProtection:
         assert dangerous is True
         assert "in-place" in desc.lower() or "perl" in desc.lower()
 
+    def test_perl_in_place_absolute_hermes_home_config(self):
+        config_path = get_hermes_home() / "config.yaml"
+        dangerous, key, desc = detect_dangerous_command(
+            f"perl -i -pe 's/approvals.mode: on/approvals.mode: off/' {config_path}"
+        )
+        assert dangerous is True
+        assert "in-place" in desc.lower() or "perl" in desc.lower()
+
     def test_ruby_in_place_config(self):
         dangerous, key, desc = detect_dangerous_command(
             "ruby -i -pe 'gsub(/manual/, \"off\")' ~/.hermes/config.yaml"
         )
         assert dangerous is True
+
+    def test_ruby_in_place_absolute_hermes_home_env(self):
+        env_path = get_hermes_home() / ".env"
+        dangerous, key, desc = detect_dangerous_command(
+            f"ruby -i -pe 'gsub(/API_KEY=.*/, \"API_KEY=x\")' {env_path}"
+        )
+        assert dangerous is True
+
+    def test_regular_absolute_config_path_still_uses_project_rule(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "sed -i 's/a/b/' /srv/app/config.yaml"
+        )
+        assert dangerous is False
 
     def test_perl_in_place_env(self):
         dangerous, key, desc = detect_dangerous_command(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -152,30 +152,15 @@ def _is_gateway_approval_context() -> bool:
 
 # Sensitive write targets that should trigger approval even when referenced
 # via shell expansions like $HOME or $HERMES_HOME, or by the resolved absolute
-# active profile home path such as /home/hermes/.hermes/config.yaml.
+# active profile home path such as /home/hermes/.hermes/config.yaml. The
+# resolved-absolute form is folded into the ~/.hermes/ patterns at detection
+# time by _normalize_command_for_detection() — see the rewrite step there — so
+# these static patterns stay free of any import-time path snapshot (which would
+# go stale when HERMES_HOME is set after this module is imported, e.g. under the
+# hermetic test conftest or any deferred-profile-resolution path).
 _SSH_SENSITIVE_PATH = r'(?:~|\$home|\$\{home\})/\.ssh(?:/|$)'
-
-
-def _resolved_hermes_home_path_pattern() -> str:
-    try:
-        from hermes_constants import get_hermes_home
-        home = get_hermes_home().expanduser()
-        candidates = [
-            str(home).rstrip("/"),
-            str(home.resolve(strict=False)).rstrip("/"),
-        ]
-    except Exception:
-        candidates = []
-    escaped = [re.escape(path) for path in dict.fromkeys(candidates) if path]
-    if not escaped:
-        return r"(?!)"
-    return r"(?:" + "|".join(escaped) + r")/"
-
-
-_RESOLVED_HERMES_HOME_PATH = _resolved_hermes_home_path_pattern()
 _HERMES_ENV_PATH = (
     r'(?:~\/\.hermes/|'
-    rf'{_RESOLVED_HERMES_HOME_PATH}|'
     r'(?:\$home|\$\{home\})/\.hermes/|'
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
     r'\.env\b'
@@ -190,7 +175,6 @@ _HERMES_ENV_PATH = (
 # well as ~/.hermes/.
 _HERMES_CONFIG_PATH = (
     r'(?:~\/\.hermes/|'
-    rf'{_RESOLVED_HERMES_HOME_PATH}|'
     r'(?:\$home|\$\{home\})/\.hermes/|'
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
     r'config\.yaml\b'
@@ -561,8 +545,49 @@ def _normalize_command_for_detection(command: str) -> str:
     command = unicodedata.normalize('NFKC', command)
     # Strip shell backslash-escapes: r\m → rm. Prevents \-injection bypass.
     command = re.sub(r'\\([^\n])', r'\1', command)
-    # Strip empty-string literals that split tokens: r''m → rm, r""m → rm.
+    # Strip empty-string literals that split tokens: r''m → rm, r"\"m → rm.
     command = re.sub(r"''|\"\"", '', command)
+    # Fold the resolved absolute active-profile home path into the canonical
+    # ~/.hermes/ form so the Hermes config/env patterns catch it. In Docker and
+    # gateway deployments the agent often references the resolved absolute path
+    # directly (e.g. `sed -i ... /home/hermes/.hermes/config.yaml`) rather than
+    # ~, $HOME, or $HERMES_HOME. Done at detection time (not via an import-time
+    # pattern snapshot) so it tracks the live HERMES_HOME even when that is set
+    # after this module is imported — as the hermetic test conftest does.
+    command = _rewrite_resolved_hermes_home(command)
+    return command
+
+
+def _rewrite_resolved_hermes_home(command: str) -> str:
+    """Rewrite the resolved absolute Hermes home prefix to ``~/.hermes/``.
+
+    Resolves the active ``HERMES_HOME`` at call time (and its symlink-resolved
+    form) and replaces an occurrence of ``<home>/`` in *command* with
+    ``~/.hermes/`` so the static ``_HERMES_CONFIG_PATH`` / ``_HERMES_ENV_PATH``
+    patterns match. No-op when the path can't be resolved or doesn't appear.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+        home = get_hermes_home().expanduser()
+        candidates = [
+            str(home).rstrip("/"),
+            str(home.resolve(strict=False)).rstrip("/"),
+        ]
+    except Exception:
+        return command
+    seen: set[str] = set()
+    for path in candidates:
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        # Guard against a degenerate HERMES_HOME (e.g. "/" or "") rewriting
+        # unrelated paths: require an absolute path with at least one non-root
+        # component. The active profile home is always a real directory like
+        # /home/hermes/.hermes or a per-test tempdir, never a bare root.
+        normalized = path.rstrip("/")
+        if not normalized.startswith("/") or normalized.count("/") < 2:
+            continue
+        command = command.replace(normalized + "/", "~/.hermes/")
     return command
 
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -151,10 +151,31 @@ def _is_gateway_approval_context() -> bool:
     return bool(_get_session_platform())
 
 # Sensitive write targets that should trigger approval even when referenced
-# via shell expansions like $HOME or $HERMES_HOME.
+# via shell expansions like $HOME or $HERMES_HOME, or by the resolved absolute
+# active profile home path such as /home/hermes/.hermes/config.yaml.
 _SSH_SENSITIVE_PATH = r'(?:~|\$home|\$\{home\})/\.ssh(?:/|$)'
+
+
+def _resolved_hermes_home_path_pattern() -> str:
+    try:
+        from hermes_constants import get_hermes_home
+        home = get_hermes_home().expanduser()
+        candidates = [
+            str(home).rstrip("/"),
+            str(home.resolve(strict=False)).rstrip("/"),
+        ]
+    except Exception:
+        candidates = []
+    escaped = [re.escape(path) for path in dict.fromkeys(candidates) if path]
+    if not escaped:
+        return r"(?!)"
+    return r"(?:" + "|".join(escaped) + r")/"
+
+
+_RESOLVED_HERMES_HOME_PATH = _resolved_hermes_home_path_pattern()
 _HERMES_ENV_PATH = (
     r'(?:~\/\.hermes/|'
+    rf'{_RESOLVED_HERMES_HOME_PATH}|'
     r'(?:\$home|\$\{home\})/\.hermes/|'
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
     r'\.env\b'
@@ -169,6 +190,7 @@ _HERMES_ENV_PATH = (
 # well as ~/.hermes/.
 _HERMES_CONFIG_PATH = (
     r'(?:~\/\.hermes/|'
+    rf'{_RESOLVED_HERMES_HOME_PATH}|'
     r'(?:\$home|\$\{home\})/\.hermes/|'
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
     r'config\.yaml\b'


### PR DESCRIPTION
## Summary
Closes the terminal-approval gap that let the agent edit its own config via the resolved absolute Hermes-home path (e.g. `sed -i '...' /home/hermes/.hermes/config.yaml`). The file/patch guard already blocked direct writes; the terminal guard only covered `~`, `$HOME`, and `$HERMES_HOME` forms — not the resolved absolute path used in Docker/gateway deployments.

Salvage of #41455 by @helix4u, with a follow-up that resolves the home path at detection time instead of import time.

## Changes
- `tools/approval.py`: `_normalize_command_for_detection()` now rewrites the live resolved absolute Hermes-home prefix (and its symlink-resolved form) to the canonical `~/.hermes/` form before pattern matching. This folds the absolute form into the shared `_SENSITIVE_WRITE_TARGET`, so `sed -i`/`perl -i`/`ruby -i` **and** `>` redirects, `tee`, `cp`, etc. are all covered.
- `tests/tools/test_approval.py`: @helix4u's regression coverage for sed/perl/ruby in-place edits against the resolved config/env paths, plus a negative control for non-Hermes absolute paths.

## Why the follow-up
@helix4u's original snapshotted the resolved `HERMES_HOME` into the static patterns at module-import time. That goes stale when `HERMES_HOME` is set *after* `tools.approval` is imported — which the hermetic test conftest does (per-test tempdir), so the PR's own 4 new tests were red. Detection-time resolution tracks the live env, needs no regex recompile, and is strictly more correct.

## Validation
| Command (HERMES_HOME=/home/hermes/.hermes) | Before | After |
|---|---|---|
| `sed -i ... /home/hermes/.hermes/config.yaml` | allowed | **blocked** |
| `echo x > /home/hermes/.hermes/config.yaml` | allowed | **blocked** |
| `tee /home/hermes/.hermes/.env` | allowed | **blocked** |
| `sed -i ... /srv/app/config.yaml` | allowed | allowed (unchanged) |
| `sed -i ... /home/other/.hermes/config.yaml` | allowed | allowed (other user's home) |
| `cat /home/hermes/.hermes/config.yaml` (read-only) | allowed | allowed |
| `sed -i ... ~/.hermes/config.yaml` | blocked | blocked (unchanged) |

`tests/tools/test_approval.py`: all 4 new path tests pass; the contributor's negative control passes.

Original PR: #41455. Discord thread: `1513220599286071418`.

## Infographic

![approval-guard-resolved-config-paths](https://v3b.fal.media/files/b/0a9d7e80/baFUyTVrVDVWXQTnYDSJk_J8jy6Yjf.png)
