### PR TITLE
feat(gateway): TELEGRAM_PASSTHROUGH_PREFIXES env for slash-command pass-through

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7578,32 +7578,70 @@ class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
                         event.text = msg
                         # Fall through to normal message processing with skill content
                 else:
-                    # Not an active skill — check if it's a known-but-disabled or
-                    # uninstalled skill and give actionable guidance.
-                    _unavail_msg = _check_unavailable_skill(command)
-                    if _unavail_msg:
-                        return _unavail_msg
-                    # Genuinely unrecognized /command: not a built-in, not a
-                    # plugin, not a skill, not a known-inactive skill. Warn
-                    # the user instead of silently forwarding it to the LLM
-                    # as free text (which leads to silent-failure behavior
-                    # like the model inventing a delegate_task call).
-                    # Normalize to hyphenated form before checking known
-                    # built-ins (command may be an alias target set by the
-                    # quick-command block above, so _cmd_def can be stale).
-                    if command.replace("_", "-") not in GATEWAY_KNOWN_COMMANDS:
-                        logger.warning(
-                            "Unrecognized slash command /%s from %s — "
-                            "replying with unknown-command notice",
+                    # Operator-tunable pass-through whitelist. Slash tokens
+                    # listed in TELEGRAM_PASSTHROUGH_PREFIXES are delivered
+                    # verbatim to the agent (event.text keeps its leading
+                    # slash) instead of being short-circuited as "Unknown
+                    # command". This is a deliberate escape hatch for
+                    # operators who register custom slash commands in their
+                    # agent prompt / system instructions (e.g. SOUL.md
+                    # branches that pattern-match on a leading slash) and
+                    # want the gateway to forward them unmodified.
+                    #
+                    # Format: comma-separated, with or without leading
+                    # slash. Matching is case-insensitive.
+                    #   TELEGRAM_PASSTHROUGH_PREFIXES="/foo,bar,/baz"
+                    #
+                    # Backwards compatible: when the env var is unset or
+                    # empty, behaviour is identical to before (unknown
+                    # commands return the unknown-command notice).
+                    _env_passthrough = os.environ.get(
+                        "TELEGRAM_PASSTHROUGH_PREFIXES", ""
+                    )
+                    _passthrough_commands: set[str] = set()
+                    if _env_passthrough:
+                        for _tok in _env_passthrough.split(","):
+                            _tok = _tok.strip().lstrip("/").lower()
+                            if _tok:
+                                _passthrough_commands.add(_tok)
+                    if command.lower() in _passthrough_commands:
+                        logger.info(
+                            "[passthrough] /%s from %s — delivering verbatim "
+                            "to agent (event.text preserved with leading "
+                            "slash; TELEGRAM_PASSTHROUGH_PREFIXES match)",
                             command,
                             source.platform.value if source.platform else "?",
                         )
-                        return (
-                            f"Unknown command `/{command}`. "
-                            f"Type /commands to see what's available, "
-                            f"or resend without the leading slash to send "
-                            f"as a regular message."
-                        )
+                        # Fall through to normal message processing — do
+                        # NOT mutate event.text; the agent decides what to
+                        # do with the prefixed message.
+                    else:
+                        # Not an active skill — check if it's a known-but-disabled or
+                        # uninstalled skill and give actionable guidance.
+                        _unavail_msg = _check_unavailable_skill(command)
+                        if _unavail_msg:
+                            return _unavail_msg
+                        # Genuinely unrecognized /command: not a built-in, not a
+                        # plugin, not a skill, not a known-inactive skill. Warn
+                        # the user instead of silently forwarding it to the LLM
+                        # as free text (which leads to silent-failure behavior
+                        # like the model inventing a delegate_task call).
+                        # Normalize to hyphenated form before checking known
+                        # built-ins (command may be an alias target set by the
+                        # quick-command block above, so _cmd_def can be stale).
+                        if command.replace("_", "-") not in GATEWAY_KNOWN_COMMANDS:
+                            logger.warning(
+                                "Unrecognized slash command /%s from %s — "
+                                "replying with unknown-command notice",
+                                command,
+                                source.platform.value if source.platform else "?",
+                            )
+                            return (
+                                f"Unknown command `/{command}`. "
+                                f"Type /commands to see what's available, "
+                                f"or resend without the leading slash to send "
+                                f"as a regular message."
+                            )
             except Exception as e:
                 logger.debug("Skill command check failed (non-fatal): %s", e)
         

--- a/tests/gateway/test_telegram_passthrough_prefixes.py
+++ b/tests/gateway/test_telegram_passthrough_prefixes.py
@@ -1,0 +1,231 @@
+"""Tests for the TELEGRAM_PASSTHROUGH_PREFIXES env-var slash whitelist in
+gateway/run.py.
+
+Drives the real ``GatewayRunner._handle_message`` path with a stub session
+store so we exercise the actual env-var check inserted at the dispatch
+site. Uses the same ``object.__new__`` runner construction pattern as
+test_slash_access_dispatch.py.
+
+Coverage targets:
+  - Backward compat: env var unset → unknown command still returns the
+    standard ``Unknown command `/foo`...`` notice.
+  - Match (with leading slash): ``TELEGRAM_PASSTHROUGH_PREFIXES="/foo"`` +
+    ``/foo`` from user → notice is NOT returned (request falls through to
+    the agent dispatch path, which we stub).
+  - Match (without leading slash): same as above but with
+    ``TELEGRAM_PASSTHROUGH_PREFIXES="foo"``.
+  - Case insensitive: ``/FOO`` matches when env lists ``foo``.
+  - Multiple comma-separated entries with surrounding whitespace.
+  - Non-matching token with env var set: still returns the standard notice.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+
+
+def _make_source(
+    *,
+    platform: Platform = Platform.TELEGRAM,
+    user_id: str = "user1",
+    chat_type: str = "dm",
+    chat_id: str = "c1",
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name=f"name-{user_id}",
+        chat_type=chat_type,
+    )
+
+
+def _make_event(text: str, source: SessionSource) -> MessageEvent:
+    return MessageEvent(text=text, source=source, message_id="m1")
+
+
+def _make_runner(*, platform: Platform = Platform.TELEGRAM):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            platform: PlatformConfig(
+                enabled=True,
+                token="***",
+                extra={},
+            )
+        }
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {platform: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    runner.session_store = MagicMock()
+    session_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:c1",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=platform,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._session_run_generation = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_sources = {}
+    runner._session_db = MagicMock()
+    runner._session_db.get_session_title.return_value = None
+    runner._session_db.get_session.return_value = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    # Stub the agent path so passthrough fall-through returns a sentinel
+    # we can detect (instead of attempting a real agent run, which would
+    # require the full plugin stack).
+    runner._handle_message_with_agent = AsyncMock(return_value="<agent-dispatch>")
+    runner._begin_session_run_generation = lambda *_a, **_kw: 1
+    runner._is_telegram_topic_root_lobby = lambda *_a, **_kw: False
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Backward compat — env var unset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_returns_notice_when_env_var_unset(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_PASSTHROUGH_PREFIXES", raising=False)
+    runner = _make_runner()
+    result = await runner._handle_message(
+        _make_event("/totallymadeup", _make_source())
+    )
+    assert result is not None
+    assert "Unknown command `/totallymadeup`" in result
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_returns_notice_when_env_var_empty(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_PASSTHROUGH_PREFIXES", "")
+    runner = _make_runner()
+    result = await runner._handle_message(
+        _make_event("/totallymadeup", _make_source())
+    )
+    assert result is not None
+    assert "Unknown command `/totallymadeup`" in result
+
+
+# ---------------------------------------------------------------------------
+# Match — env-var-listed token is passed through to the agent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_passthrough_with_leading_slash_in_env(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_PASSTHROUGH_PREFIXES", "/customcmd")
+    runner = _make_runner()
+    result = await runner._handle_message(
+        _make_event("/customcmd hello", _make_source())
+    )
+    # The unknown-command notice MUST NOT be returned — the fall-through
+    # should reach the (stubbed) agent dispatch.
+    assert "Unknown command" not in (result or "")
+
+
+@pytest.mark.asyncio
+async def test_passthrough_without_leading_slash_in_env(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_PASSTHROUGH_PREFIXES", "customcmd")
+    runner = _make_runner()
+    result = await runner._handle_message(
+        _make_event("/customcmd hello", _make_source())
+    )
+    assert "Unknown command" not in (result or "")
+
+
+@pytest.mark.asyncio
+async def test_passthrough_match_is_case_insensitive(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_PASSTHROUGH_PREFIXES", "customcmd")
+    runner = _make_runner()
+    result = await runner._handle_message(
+        _make_event("/CUSTOMCMD hello", _make_source())
+    )
+    assert "Unknown command" not in (result or "")
+
+
+@pytest.mark.asyncio
+async def test_passthrough_handles_multiple_comma_separated_entries(monkeypatch):
+    monkeypatch.setenv(
+        "TELEGRAM_PASSTHROUGH_PREFIXES", " /foo , bar ,/baz "
+    )
+    runner = _make_runner()
+    for cmd in ("/foo", "/bar", "/baz"):
+        result = await runner._handle_message(
+            _make_event(f"{cmd} hi", _make_source())
+        )
+        assert "Unknown command" not in (result or ""), (
+            f"{cmd} should be passed through"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Non-matching token with env var set — still returns notice
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_matching_token_still_returns_notice(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_PASSTHROUGH_PREFIXES", "foo,bar")
+    runner = _make_runner()
+    result = await runner._handle_message(
+        _make_event("/somethingelse", _make_source())
+    )
+    assert result is not None
+    assert "Unknown command `/somethingelse`" in result
+
+
+# ---------------------------------------------------------------------------
+# event.text must NOT be mutated by passthrough — the agent receives the
+# original message with the leading slash intact.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_passthrough_preserves_leading_slash_in_event_text(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_PASSTHROUGH_PREFIXES", "customcmd")
+    runner = _make_runner()
+    event = _make_event("/customcmd hello world", _make_source())
+    await runner._handle_message(event)
+    # The agent stub was called; event.text must still start with the
+    # leading slash because SOUL.md / system prompt branches rely on it.
+    assert event.text.startswith("/customcmd"), (
+        f"event.text was mutated: {event.text!r}"
+    )


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in env-var whitelist — `TELEGRAM_PASSTHROUGH_PREFIXES` — that lets operators forward specific slash commands verbatim to the agent instead of having `gateway/run.py` short-circuit them as `Unknown command \`/foo\``.

### Motivation

Some operators register custom slash commands in their agent prompt / system instructions (e.g. a SOUL.md / system prompt that pattern-matches on `/critic` to trigger a critique-loop branch). With the current code, the gateway intercepts the unknown command, returns the `Unknown command \`/...\``  notice, and the agent never sees the message.

Concrete use case from a downstream operator:

- Operator wants `/critic what time is it?` from Telegram to reach their orchestrator agent, which has an explicit-override branch for `/critic` in its system prompt.
- Today the gateway returns the unknown-command notice and the agent never runs.
- With `TELEGRAM_PASSTHROUGH_PREFIXES=/critic`, the gateway logs `[passthrough] /critic …` and falls through to normal message processing with `event.text` unchanged (leading slash preserved), so the agent's own branch sees it.

This is an alternative to the operator's current local maintenance burden of a private patch against `gateway/run.py`.

## Related Issue

None — opening cold per the contribution guide. Happy to file an issue first if reviewers prefer.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/run.py` — in the unknown-slash-command branch, read `TELEGRAM_PASSTHROUGH_PREFIXES`. If the current `command` (lowercased, stripped of leading `/`) matches an entry, log at INFO and fall through to normal message processing without mutating `event.text`. Otherwise behaviour is unchanged (the existing `_check_unavailable_skill` + `Unknown command \`/...\``  path runs).
- `tests/gateway/test_telegram_passthrough_prefixes.py` — 8 new test cases. See **How to Test**.

### Path picked + why

I considered two implementation approaches:

- **Path A** — Add a `passthrough=True` flag to entries in `hermes_cli/commands.py`'s `COMMAND_REGISTRY` so unknown-command dispatch consults a single registry.
- **Path B** — Keep the env-var intercept local to `gateway/run.py` and drop any hardcoded defaults.

I picked **Path B** because:

1. Recent merged PR #41886 just extracted slash-command handlers from `gateway/run.py` into a `GatewaySlashCommandsMixin` (god-file decomposition), showing that gateway-local logic for slash dispatch is acceptable / preferred while the larger refactor is in flight.
2. CONTRIBUTING.md says *"Keep PRs focused: One logical change per PR. Don't mix a bug fix with a refactor with a new feature."* Path A would mix a registry rework with a new feature.
3. The env-var pattern is purely additive — zero behaviour change when unset — so it can land in front of any future `COMMAND_REGISTRY` rework without conflict.

Happy to switch to Path A if maintainers prefer.

## How to Test

1. **Run the new tests**:
   ```bash
   pytest tests/gateway/test_telegram_passthrough_prefixes.py -q
   ```
   Expected: 8 passed.

2. **Regression on the closest existing surface**:
   ```bash
   pytest tests/gateway/test_slash_access_dispatch.py -q
   ```
   Expected: 18 passed.

3. **Manual** (Telegram-shaped, but the env var name is `TELEGRAM_*` only because that was the originating use case — the code path runs for any platform):
   - Without env var set: send `/somethingmadeup` from Telegram → expect the standard `Unknown command \`/somethingmadeup\`...` reply.
   - With `TELEGRAM_PASSTHROUGH_PREFIXES=somethingmadeup` exported in the gateway service environment, restart the gateway, send `/somethingmadeup hello` → expect the agent to receive the message verbatim (with leading slash) instead of the unknown-command notice.

### Test coverage and gaps

Tests cover:

- Backward compat: env var unset / empty → unknown command still returns the notice.
- Match with leading slash, without leading slash, case-insensitive.
- Comma-separated entries with surrounding whitespace.
- Non-matching token with env var set → still returns the notice.
- `event.text` is NOT mutated by passthrough (leading slash preserved).

Gap: no end-to-end Telegram-adapter integration test. The new test file uses the same `object.__new__(GatewayRunner)` harness as `tests/gateway/test_slash_access_dispatch.py` (the closest existing test surface). There is no `tests/messaging/telegram/` directory upstream, so I matched the existing pattern rather than inventing a new one.

### Platforms tested

- Linux (Ubuntu 24.04, Python 3.11 via the project venv).

## Backwards Compatibility

Purely additive. When `TELEGRAM_PASSTHROUGH_PREFIXES` is unset or empty, the unknown-slash-command code path is identical to before (verified by `test_unknown_command_returns_notice_when_env_var_unset` and `test_unknown_command_returns_notice_when_env_var_empty`).

No CLI flags, config keys, or public API changes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway):`)
- [x] I searched for existing PRs and didn't find a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the relevant tests (`pytest tests/gateway/test_telegram_passthrough_prefixes.py -q` + `test_slash_access_dispatch.py`); all pass
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04 / Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (env var is documented in the source-code docstring; happy to add a `docs/` entry if maintainers point me at the right file)
- [ ] I've updated `cli-config.yaml.example` — N/A (env var, not a config key)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture / workflow change)
- [x] I've considered cross-platform impact — env var reads via `os.environ.get` work identically on macOS / Linux / WSL2
- [ ] I've updated tool descriptions/schemas — N/A (gateway-internal, no tool surface)