### PR TITLE
fix(cron): inject chained response payloads

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2227,6 +2227,41 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+def _extract_context_payload_from_job_output(raw_output: str) -> str:
+    """Reduce stored cron markdown to the most useful downstream context payload.
+
+    For chained cron jobs, the downstream agent usually needs the upstream
+    model/script result, not the full wrapper with repeated prompts and schedule
+    metadata. Prefer the ``## Response`` body, then ``## Error`` for failed runs,
+    otherwise fall back to the full stored text.
+    """
+    document = raw_output or ""
+    length_match = re.match(r"\A\*\*Result Chars:\*\*[ \t]*(\d+)[ \t]*\r?\n", document)
+    if length_match:
+        result_chars = int(length_match.group(1))
+        content_end = len(document) - 1 if document.endswith("\n") else len(document)
+        if 0 < result_chars <= content_end:
+            return document[content_end - result_chars:content_end]
+
+    text = document.strip()
+    if not text:
+        return ""
+
+    headings = list(re.finditer(r"(?m)^## (?:Response|Error)[ \t]*\r?$", text))
+    if headings:
+        payload = text[headings[-1].end():].lstrip()
+        if payload:
+            return payload
+    return text
+
+
+def _truncate_context_payload(text: str, max_chars: int = 8000) -> str:
+    """Clamp injected cron context without dropping the response header entirely."""
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "\n\n[... output truncated ...]"
+
+
 def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
@@ -2306,11 +2341,9 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 )
                 if not output_files:
                     continue  # silent skip — no output yet
-                latest_output = output_files[0].read_text(encoding="utf-8").strip()
-                # Truncate to 8K characters to avoid prompt bloat
-                _MAX_CONTEXT_CHARS = 8000
-                if len(latest_output) > _MAX_CONTEXT_CHARS:
-                    latest_output = latest_output[:_MAX_CONTEXT_CHARS] + "\n\n[... output truncated ...]"
+                latest_output = output_files[0].read_text(encoding="utf-8")
+                latest_output = _extract_context_payload_from_job_output(latest_output)
+                latest_output = _truncate_context_payload(latest_output)
                 if latest_output:
                     prompt = (
                         f"## Output from job '{source_job_id}'\n"
@@ -3398,7 +3431,8 @@ def run_job(
         # for delivery logic (empty response = no delivery).
         logged_response = final_response if final_response else "(No response generated)"
         
-        output = f"""# Cron Job: {job_name}
+        output = f"""**Result Chars:** {len(logged_response)}
+# Cron Job: {job_name}
 
 **Job ID:** {job_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
@@ -3419,8 +3453,10 @@ def run_job(
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
-        
-        output = f"""# Cron Job: {job_name} (FAILED)
+        error_payload = f"```\n{error_msg}\n```"
+
+        output = f"""**Result Chars:** {len(error_payload)}
+# Cron Job: {job_name} (FAILED)
 
 **Job ID:** {job_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
@@ -3432,9 +3468,7 @@ def run_job(
 
 ## Error
 
-```
-{error_msg}
-```
+{error_payload}
 """
         return False, output, "", error_msg
 

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -181,6 +181,141 @@ class TestBuildJobPromptContextFrom:
         prompt_pos = prompt.find("Process the data above")
         assert context_pos < prompt_pos
 
+    def test_cron_output_prefers_response_section_over_prompt_wrapper(self, cron_env):
+        """Cron output chaining should inject the upstream response body, not the wrapper preamble."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find data", schedule="every 1h")
+        out_dir = OUTPUT_DIR / job_a["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        cron_doc = (
+            "# Cron Job: Example\n\n"
+            "## Prompt\n\n" + ("P" * 9000) +
+            "\n\n## Response\n\n"
+            "status: candidate_unverified\n"
+            "generated_at: 2026-05-29T08:30:25+02:00\n"
+            "fresh payload\n"
+        )
+        (out_dir / "2026-04-22_10-00-00.md").write_text(cron_doc, encoding="utf-8")
+
+        job_b = create_job(
+            prompt="Verify upstream draft", schedule="every 2h", context_from=job_a["id"]
+        )
+        prompt = _build_job_prompt(job_b)
+
+        assert "fresh payload" in prompt
+        assert "generated_at: 2026-05-29T08:30:25+02:00" in prompt
+        assert "P" * 8500 not in prompt
+
+    def test_cron_output_uses_final_structural_heading_when_preamble_contains_response(self, cron_env):
+        """A heading copied into prompt data must not eclipse the final artifact response."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find data", schedule="every 1h")
+        out_dir = OUTPUT_DIR / job_a["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        cron_doc = (
+            "# Cron Job: Example\n\n"
+            "## Prompt\n\n"
+            "Script emitted this literal heading:\n"
+            "## Response\n\n"
+            "preamble data that must not be injected\n\n"
+            "## Response\n\n"
+            "authoritative final payload\n"
+        )
+        (out_dir / "2026-04-22_10-00-00.md").write_text(cron_doc, encoding="utf-8")
+
+        job_b = create_job(
+            prompt="Verify upstream draft", schedule="every 2h", context_from=job_a["id"]
+        )
+        prompt = _build_job_prompt(job_b)
+
+        assert "authoritative final payload" in prompt
+        assert "preamble data that must not be injected" not in prompt
+
+    def test_cron_output_preserves_structural_headings_inside_result_body(self, cron_env):
+        """Length metadata prevents result-body headings from becoming delimiters."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find data", schedule="every 1h")
+        out_dir = OUTPUT_DIR / job_a["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        response = "answer intro\n\n## Error\n\nquoted subheading"
+        cron_doc = (
+            f"**Result Chars:** {len(response)}\n"
+            "# Cron Job: Example\n**Result Chars:** 1\n\n"
+            "## Prompt\n\n"
+            "preamble data that must not be injected\n\n"
+            "## Response\n\n"
+            f"{response}\n"
+        )
+        (out_dir / "2026-04-22_10-00-00.md").write_text(cron_doc, encoding="utf-8")
+
+        job_b = create_job(
+            prompt="Verify upstream draft", schedule="every 2h", context_from=job_a["id"]
+        )
+        prompt = _build_job_prompt(job_b)
+
+        assert response in prompt
+        assert "preamble data that must not be injected" not in prompt
+
+    def test_cron_output_truncation_preserves_response_header_when_wrapper_is_huge(self, cron_env):
+        """If a cron wrapper is huge, truncation should still preserve the response start."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find data", schedule="every 1h")
+        out_dir = OUTPUT_DIR / job_a["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        big_response = "Y" * 9000
+        cron_doc = (
+            "# Cron Job: Example\n\n"
+            "## Prompt\n\n" + ("P" * 12000) +
+            "\n\n## Response\n\n"
+            "**Candidate Report**\n"
+            "**Generated at:** `2026-05-29T08:30:25+02:00`\n" +
+            big_response
+        )
+        (out_dir / "2026-04-22_10-00-00.md").write_text(cron_doc, encoding="utf-8")
+
+        job_b = create_job(
+            prompt="Verify upstream draft", schedule="every 2h", context_from=job_a["id"]
+        )
+        prompt = _build_job_prompt(job_b)
+
+        assert "**Candidate Report**" in prompt
+        assert "**Generated at:** `2026-05-29T08:30:25+02:00`" in prompt
+        assert "[... output truncated ...]" in prompt
+
+    def test_cron_output_prefers_error_section_when_response_absent(self, cron_env):
+        """Failed upstream cron runs should pass the useful error body, not the whole wrapper."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find data", schedule="every 1h")
+        out_dir = OUTPUT_DIR / job_a["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        cron_doc = (
+            "# Cron Job: Example\n\n"
+            "## Prompt\n\n" + ("P" * 9000) +
+            "\n\n## Error\n\n"
+            "Script exited with code 2\n"
+            "missing feed URL\n"
+        )
+        (out_dir / "2026-04-22_10-00-00.md").write_text(cron_doc, encoding="utf-8")
+
+        job_b = create_job(
+            prompt="Verify upstream draft", schedule="every 2h", context_from=job_a["id"]
+        )
+        prompt = _build_job_prompt(job_b)
+
+        assert "missing feed URL" in prompt
+        assert "Script exited with code 2" in prompt
+        assert "P" * 8500 not in prompt
+
     def test_output_truncated_at_8k_chars(self, cron_env):
         """Output longer than 8000 chars should be truncated."""
         from cron.jobs import create_job, OUTPUT_DIR


### PR DESCRIPTION
## Summary
- extract the useful `## Response` body from stored cron job output before injecting `context_from` prompt context
- fall back to `## Error` when a failed upstream job has no response section
- keep the existing 8K context clamp, but apply it after wrapper extraction so large prompt wrappers do not hide the actual result
- add regression tests for response extraction, error extraction, and truncation behavior

## Motivation
`context_from` lets one cron job use a previous job's output as context. Stored cron output markdown includes wrapper sections such as the original prompt, schedule metadata, and the final response. When the wrapper is large, downstream jobs can receive mostly prompt/history boilerplate while the useful response is truncated away.

This makes job chaining less reliable: downstream verifier/summarizer jobs should see the previous job's actual result, not the wrapper preamble.

## Test plan
- `git diff --check upstream/main..HEAD`
- `python -m py_compile cron/scheduler.py tests/cron/test_cron_context_from.py`
- `pytest tests/cron/test_cron_context_from.py -q -o 'addopts='` → 24 passed
- `env -u MATRIX_HOME_CHANNEL -u MATRIX_HOME_ROOM_ID -u MATRIX_HOME_CHANNEL_ID -u MATRIX_HOME_ROOM -u MATRIX_HOME_ROOM_THREAD_ID HERMES_HOME=$(mktemp -d) pytest tests/cron/test_cron_context_from.py tests/cron/test_scheduler.py tests/cron/test_cron_no_agent.py -q -o 'addopts='` → 176 passed

## Duplicate check
Searched open PRs/issues for:
- `context_from`
- `cron context_from`
- `context_from output`
- `recent completed output`

Nearest open PRs were cron test coverage and path hardening; neither changes `context_from` output extraction.