### PR TITLE
feat: add natural Discord voice mode preset

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1861,16 +1861,14 @@ DEFAULT_CONFIG = {
             "enabled": False,         # master switch for the mixer subsystem
             "ambient_enabled": True,  # play the idle "thinking" bed while tools run
             "ambient_path": "",       # custom loop audio file; "" = synthesised pad
-            "ambient_gain": 0.18,     # idle bed loudness, 0.0–1.0
-            "duck_gain": 0.06,        # ambient loudness while speech plays
+            "ambient_gain": 0.12,     # idle bed loudness, 0.0–1.0
+            "duck_gain": 0.04,        # ambient loudness while speech plays
             "speech_gain": 1.0,       # TTS / ack loudness, 0.0–1.0
             "ack_enabled": True,      # speak a short phrase before the first tool call
             "ack_phrases": [          # picked at random; set [] to disable phrases
-                "Let me look into that.",
-                "One moment.",
-                "Checking on that now.",
-                "Give me a sec.",
-                "On it.",
+                "Let me check that.",
+                "One sec.",
+                "I'm on it.",
             ],
         },
     },

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1945,16 +1945,14 @@ class DiscordAdapter(BasePlatformAdapter):
             "enabled": False,        # master switch for the mixer subsystem
             "ambient_enabled": True, # idle "thinking" bed while tools run
             "ambient_path": "",      # optional custom loop file; "" = synthesised
-            "ambient_gain": 0.18,    # idle bed loudness (0..1)
-            "duck_gain": 0.06,       # ambient loudness while speech plays
+            "ambient_gain": 0.12,    # idle bed loudness (0..1)
+            "duck_gain": 0.04,       # ambient loudness while speech plays
             "speech_gain": 1.0,      # TTS / ack loudness
             "ack_enabled": True,     # speak a short phrase before tool calls
             "ack_phrases": [
-                "Let me look into that.",
-                "One moment.",
-                "Checking on that now.",
-                "Give me a sec.",
-                "On it.",
+                "Let me check that.",
+                "One sec.",
+                "I'm on it.",
             ],
         }
         try:
@@ -2007,8 +2005,8 @@ class DiscordAdapter(BasePlatformAdapter):
             from .voice_mixer import VoiceMixer
 
         mixer = VoiceMixer(
-            ambient_gain=float(self._voice_fx_cfg.get("ambient_gain", 0.18)),
-            duck_gain=float(self._voice_fx_cfg.get("duck_gain", 0.06)),
+            ambient_gain=float(self._voice_fx_cfg.get("ambient_gain", 0.12)),
+            duck_gain=float(self._voice_fx_cfg.get("duck_gain", 0.04)),
             speech_gain=float(self._voice_fx_cfg.get("speech_gain", 1.0)),
         )
         ambient = await asyncio.to_thread(self._get_ambient_pcm)
@@ -2039,7 +2037,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return False
         if phrase is None:
             import random
-            phrases = self._voice_fx_cfg.get("ack_phrases") or ["One moment."]
+            phrases = self._voice_fx_cfg.get("ack_phrases") or ["One sec."]
             phrase = random.choice(phrases)
 
         # Synthesise the ack via the configured TTS provider, then layer it.
@@ -6291,6 +6289,60 @@ def _clean_discord_user_ids(raw: str) -> list:
     return cleaned
 
 
+NATURAL_VOICE_FX_PRESET: Dict[str, Any] = {
+    "enabled": True,
+    "ambient_enabled": True,
+    "ambient_path": "",
+    "ambient_gain": 0.12,
+    "duck_gain": 0.04,
+    "speech_gain": 1.0,
+    "ack_enabled": True,
+    "ack_phrases": ["Let me check that.", "One sec.", "I'm on it."],
+}
+
+
+def apply_natural_voice_fx_preset_to_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return config with the opt-in natural Discord VC voice preset applied.
+
+    The preset intentionally lives under ``discord.voice_fx`` in config.yaml,
+    not .env, because it is behavior/tuning rather than a secret. It only runs
+    when setup (or a future CLI command) explicitly opts in.
+    """
+    updated = dict(config or {})
+    discord_cfg = updated.get("discord")
+    if not isinstance(discord_cfg, dict):
+        discord_cfg = {}
+    else:
+        discord_cfg = dict(discord_cfg)
+    existing_fx = discord_cfg.get("voice_fx")
+    merged_fx = dict(existing_fx) if isinstance(existing_fx, dict) else {}
+    merged_fx.update(NATURAL_VOICE_FX_PRESET)
+    discord_cfg["voice_fx"] = merged_fx
+    updated["discord"] = discord_cfg
+    return updated
+
+
+def _offer_natural_voice_fx_preset() -> None:
+    """Offer the low-gain ambient + ack preset for Discord voice channels."""
+    from hermes_cli.cli_output import prompt_yes_no, print_info, print_success
+    from hermes_cli.config import load_config, save_config
+
+    print()
+    print_info("🎙 Natural Discord voice-channel mode")
+    print_info("   For the most seamless voice mode, join a Discord voice channel,")
+    print_info("   run /voice join in a text channel, then talk to Hermes in the VC.")
+    print_info("   Optional voice effects can reduce dead air while tools run:")
+    print_info("   short acknowledgements plus a very low thinking bed under TTS.")
+    print_info("   This is opt-in and can be disabled with discord.voice_fx.enabled: false.")
+    if not prompt_yes_no("Enable the natural Discord voice mode preset?", False):
+        return
+
+    config = load_config() or {}
+    save_config(apply_natural_voice_fx_preset_to_config(config))
+    print_success("Enabled discord.voice_fx natural voice-channel preset")
+    print_info("   Use it in Discord with: join a VC → /voice join → speak normally")
+
+
 def interactive_setup() -> None:
     """Guide the user through Discord bot setup.
 
@@ -6321,6 +6373,7 @@ def interactive_setup() -> None:
                         cleaned_ids = _clean_discord_user_ids(allowed_users)
                         save_env_value("DISCORD_ALLOWED_USERS", ",".join(cleaned_ids))
                         print_success("Discord allowlist configured")
+            _offer_natural_voice_fx_preset()
             return
 
     print_info("Create a bot at https://discord.com/developers/applications")
@@ -6357,6 +6410,8 @@ def interactive_setup() -> None:
     home_channel = prompt("Home channel ID (leave empty to set later with /set-home)")
     if home_channel:
         save_env_value("DISCORD_HOME_CHANNEL", home_channel)
+
+    _offer_natural_voice_fx_preset()
 
 
 def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -30,6 +30,48 @@ import voice_mixer as vm  # noqa: E402
 
 
 # =====================================================================
+# Config preset helpers
+# =====================================================================
+class TestNaturalVoiceFxPreset:
+    def test_preset_is_opt_in_and_uses_safe_gains(self):
+        from plugins.platforms.discord.adapter import NATURAL_VOICE_FX_PRESET
+
+        assert NATURAL_VOICE_FX_PRESET == {
+            "enabled": True,
+            "ambient_enabled": True,
+            "ambient_path": "",
+            "ambient_gain": 0.12,
+            "duck_gain": 0.04,
+            "speech_gain": 1.0,
+            "ack_enabled": True,
+            "ack_phrases": ["Let me check that.", "One sec.", "I'm on it."],
+        }
+
+    def test_apply_preset_preserves_unrelated_discord_config(self):
+        from plugins.platforms.discord.adapter import apply_natural_voice_fx_preset_to_config
+
+        original = {
+            "discord": {
+                "require_mention": False,
+                "voice_fx": {"enabled": False, "ambient_gain": 0.5},
+            },
+            "tts": {"provider": "edge"},
+        }
+        updated = apply_natural_voice_fx_preset_to_config(original)
+
+        assert updated["discord"]["require_mention"] is False
+        assert updated["tts"] == {"provider": "edge"}
+        assert updated["discord"]["voice_fx"]["enabled"] is True
+        assert updated["discord"]["voice_fx"]["ambient_gain"] == 0.12
+        assert updated["discord"]["voice_fx"]["duck_gain"] == 0.04
+        assert updated["discord"]["voice_fx"]["ack_phrases"] == [
+            "Let me check that.", "One sec.", "I'm on it."
+        ]
+        # The helper should return a new tree, not mutate the caller's object.
+        assert original["discord"]["voice_fx"] == {"enabled": False, "ambient_gain": 0.5}
+
+
+# =====================================================================
 # Pure mixer unit tests
 # =====================================================================
 
@@ -149,8 +191,9 @@ def _make_adapter(fx_cfg=None):
     adapter._ambient_pcm_cache = None
     adapter._voice_fx_cfg = fx_cfg if fx_cfg is not None else {
         "enabled": True, "ambient_enabled": True, "ambient_path": "",
-        "ambient_gain": 0.18, "duck_gain": 0.06, "speech_gain": 1.0,
-        "ack_enabled": True, "ack_phrases": ["One moment."],
+        "ambient_gain": 0.12, "duck_gain": 0.04, "speech_gain": 1.0,
+        "ack_enabled": True,
+        "ack_phrases": ["Let me check that.", "One sec.", "I'm on it."],
     }
     return adapter
 

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -386,6 +386,36 @@ In a Discord text channel where the bot is present:
 - keep `DISCORD_ALLOWED_USERS` tight
 - use a dedicated bot/testing channel at first
 - verify STT and TTS work in ordinary text-chat voice mode before trying VC mode
+- for the most natural/seamless flow, enable the opt-in preset in `hermes gateway setup` → Discord → **Enable the natural Discord voice mode preset?**; it turns on low-gain `discord.voice_fx` acknowledgements and a subtle thinking bed while leaving the global default off for everyone else
+
+### Natural Discord voice-channel preset
+
+The setup preset writes this conservative config:
+
+```yaml
+discord:
+  voice_fx:
+    enabled: true
+    ambient_enabled: true
+    ambient_path: ""
+    ambient_gain: 0.12
+    duck_gain: 0.04
+    speech_gain: 1.0
+    ack_enabled: true
+    ack_phrases:
+      - "Let me check that."
+      - "One sec."
+      - "I'm on it."
+```
+
+Then use it like this:
+
+1. start `hermes gateway`
+2. join a Discord voice channel yourself
+3. run `/voice join` in the associated text channel
+4. speak normally; Hermes transcribes you, runs tools, gives a short acknowledgement when work starts, and speaks the final answer back into the VC
+
+Set `discord.voice_fx.enabled: false` to return to the original one-shot voice-channel playback path.
 
 ## Voice quality recommendations
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -689,7 +689,9 @@ When the bot is in a voice channel, you can give it a more conversational feel: 
 
 discord.py plays only one audio stream per connection, so Hermes installs a software mixer on the outgoing stream that sums an ambient loop, acknowledgements, and TTS replies into that single stream — they overlap instead of cutting each other off.
 
-This is **off by default**. Enable it in `config.yaml`:
+This is **off by default**. The easiest opt-in path is `hermes gateway setup` → Discord → answer **yes** to **Enable the natural Discord voice mode preset?**. That writes the conservative preset below to `config.yaml`.
+
+You can also enable or tune it manually:
 
 ```yaml
 discord:
@@ -697,14 +699,14 @@ discord:
     enabled: true          # master switch
     ambient_enabled: true  # idle "thinking" bed while tools run
     ambient_path: ""       # custom loop file (any audio format); "" = built-in synthesised pad
-    ambient_gain: 0.18     # idle bed loudness (0.0–1.0)
-    duck_gain: 0.06        # ambient loudness while the bot is speaking
+    ambient_gain: 0.12     # idle bed loudness (0.0–1.0)
+    duck_gain: 0.04        # ambient loudness while the bot is speaking
     speech_gain: 1.0       # TTS / acknowledgement loudness
     ack_enabled: true      # speak a short phrase before the first tool call of a turn
     ack_phrases:           # picked at random; set to [] to disable the spoken ack
-      - "Let me look into that."
-      - "One moment."
-      - "Checking on that now."
+      - "Let me check that."
+      - "One sec."
+      - "I'm on it."
 ```
 
 Notes:


### PR DESCRIPTION
## Summary
- add an opt-in natural Discord voice-channel preset during Discord gateway setup
- tune voice FX defaults to conservative ack phrases plus lower ambient/duck gains
- document the recommended flow: join VC, run /voice join, and use voice FX for more seamless tool waits

## Test plan
- git diff --check
- uv run --extra dev --extra voice --extra messaging pytest tests/gateway/test_discord_voice_mixer.py -q
- uv run python -m py_compile hermes_cli/config.py plugins/platforms/discord/adapter.py tests/gateway/test_discord_voice_mixer.py