### PR TITLE
fix(tui_gateway): persist full message history when branching a session

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6096,3 +6096,83 @@ def test_sniff_image_ext_magic_and_filename():
     assert server._sniff_image_ext(b"unknown") == ".png"  # fallback
     # filename hint wins over magic bytes
     assert server._sniff_image_ext(b"\x89PNG", "photo.jpeg") == ".jpeg"
+
+
+def test_session_branch_persists_tool_calls_for_resume(monkeypatch, tmp_path):
+    """Branching a session that contains a tool call must persist the full
+    tool linkage to the DB, not just role+content.
+
+    Regression test: the branch handler used to write each message with only
+    role and content, so tool_calls/tool_call_id/tool_name were dropped. The
+    in-memory branch looked fine, but once the branch was reloaded from the DB
+    (close/reopen, then /resume), the assistant tool call had no matching tool
+    result and the next prompt was rejected by the provider. Here we branch a
+    session with a tool-call round-trip and assert the persisted transcript
+    still has those fields.
+    """
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "branch_state.db")
+
+    parent_key = "parent-session-key"
+    db.create_session(parent_key, source="tui", model="anthropic/claude-opus-4.6")
+
+    history = [
+        {"role": "user", "content": "what's the weather?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_abc123",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_abc123",
+            "tool_name": "get_weather",
+            "content": "sunny, 21C",
+        },
+        {"role": "assistant", "content": "It's sunny and 21C."},
+    ]
+
+    parent_sid = "parentsd"
+    server._sessions[parent_sid] = {
+        "session_key": parent_key,
+        "history": history,
+        "history_lock": threading.Lock(),
+        "cwd": str(tmp_path),
+        "cols": 80,
+    }
+
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "anthropic/claude-opus-4.6")
+    monkeypatch.setattr(server, "_new_session_key", lambda: "branch-session-key")
+    monkeypatch.setattr(server, "_make_agent", lambda *a, **k: object())
+    monkeypatch.setattr(server, "_init_session", lambda *a, **k: None)
+
+    try:
+        resp = server._methods["session.branch"](
+            "rid-1", {"session_id": parent_sid, "name": "my branch"}
+        )
+    finally:
+        server._sessions.pop(parent_sid, None)
+
+    assert "error" not in resp, resp
+    assert resp["result"]["parent"] == parent_key
+
+    # Reload the branch straight from the DB — the source of truth on resume.
+    persisted = db.get_messages_as_conversation("branch-session-key")
+    assert len(persisted) == len(history)
+
+    assistant_call = persisted[1]
+    assert assistant_call["tool_calls"][0]["id"] == "call_abc123"
+    assert assistant_call["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    tool_result = persisted[2]
+    assert tool_result["tool_call_id"] == "call_abc123"
+    assert tool_result["tool_name"] == "get_weather"
+    assert tool_result["content"] == "sunny, 21C"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4053,12 +4053,16 @@ def _(rid, params: dict) -> dict:
             parent_session_id=old_key,
             cwd=_session_cwd(session),
         )
-        for msg in history:
-            db.append_message(
-                session_id=new_key,
-                role=msg.get("role", "user"),
-                content=msg.get("content"),
-            )
+        # Persist the full message history, not just role+content. A naive
+        # append loop that only forwarded role/content dropped tool_calls,
+        # tool_call_id and tool_name, so any branched agent session became
+        # corrupt once reloaded from the DB (the source of truth on resume):
+        # assistant tool calls lost their matching results and the provider
+        # rejected the next prompt with a 400. replace_messages serializes
+        # every field (tool linkage + reasoning) atomically — the same path
+        # /undo, /retry and /compress already rely on. The session is freshly
+        # created above, so the internal DELETE is a no-op here.
+        db.replace_messages(new_key, history)
         db.set_session_title(new_key, title)
     except Exception as e:
         return _err(rid, 5008, f"branch failed: {e}")


### PR DESCRIPTION
## What does this PR do?

When you branch (fork) a TUI conversation, the gateway copies the
current history into a brand-new session row in the SQLite store. The
problem is *how* it copied: it walked the history and called
`append_message` with only `role` and `content`. Everything else that
ties an agent turn together — `tool_calls`, `tool_call_id`, `tool_name`
and the reasoning fields — was silently dropped on the floor.

Here's why that bites you only later. Right after branching, the new
session is fine, because `_init_session` is handed the full in-memory
history list, so the live branch still has its tool linkage. The DB
copy is the *persisted* one, though, and the DB is the source of truth
on resume. So the moment you close the app (or it restarts) and `/resume`
the branch, the transcript is rebuilt from those incomplete rows by
`get_messages_as_conversation`. Now the assistant's tool call has no
matching tool result, and the tool result has no `tool_call_id` pointing
back at it. The next prompt ships that broken sequence to the provider,
and Anthropic/OpenAI reject it with a 400 — or quietly drop context. In
practice that means any branched agent session containing a tool call
(i.e. almost all of them) is unusable after a restart.

The fix is to reuse `replace_messages`, the same atomic, field-complete
path that `/undo`, `/retry` and `/compress` already use. It serializes
the whole message (tool linkage plus reasoning) and commits it in one
transaction. Because the branch session is freshly created one line
above, its internal `DELETE` is just a no-op, so we get the correct
behavior with less code.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: in the `session.branch` handler, replaced the
  per-message `append_message` loop (which forwarded only `role` and
  `content`) with a single `db.replace_messages(new_key, history)` call
  so the branched session persists `tool_calls`, `tool_call_id`,
  `tool_name` and reasoning fields. Added a comment explaining why.
- `tests/test_tui_gateway_server.py`: added
  `test_session_branch_persists_tool_calls_for_resume`, which branches a
  session containing a tool-call round-trip and asserts the persisted
  transcript still round-trips the tool linkage through
  `get_messages_as_conversation`.

## How to Test

1. Run the new regression test:
   `scripts/run_tests.sh tests/test_tui_gateway_server.py -- -k test_session_branch_persists_tool_calls_for_resume`
2. It passes with the fix. To see the bug, revert the `server.py` change
   and rerun — the test fails because the persisted assistant message has
   no `tool_calls` and the tool result has no `tool_call_id`/`tool_name`.
3. Manual: in the TUI, run a prompt that triggers a tool call, branch the
   session, restart, then `/resume` the branch and send a follow-up — it
   no longer errors out on a malformed message sequence.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A