### PR TITLE
fix(cron): scope no_agent job workdir to the script subprocess

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -954,7 +954,9 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(
+    script_path: str, cwd_override: Optional[str] = None
+) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -976,6 +978,14 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         script_path: Path to the script.  Relative paths are resolved
             against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
             are also validated to ensure they stay within the scripts dir.
+        cwd_override: Optional working directory for the script subprocess
+            (a job's configured ``workdir``).  When set and pointing at an
+            existing directory, the script runs from there so its relative
+            paths resolve predictably; otherwise it falls back to the
+            script's own directory.  This is passed straight to
+            ``subprocess.run(cwd=...)`` and never mutates the scheduler's
+            process-global cwd, so it cannot bleed into other jobs running
+            concurrently in the parallel pool.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -1043,6 +1053,24 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     except Exception:
         pass
 
+    # Resolve the subprocess working directory.  Default to the script's own
+    # directory (legacy behaviour); honour an explicit ``cwd_override`` only
+    # when it points at an existing directory.  This is scoped to the child
+    # process — we deliberately do NOT os.chdir() the scheduler, which is
+    # process-global and would corrupt jobs running concurrently in the
+    # parallel pool.
+    run_cwd = str(path.parent)
+    if cwd_override:
+        override_path = Path(cwd_override)
+        if override_path.is_dir():
+            run_cwd = str(override_path)
+        else:
+            logger.warning(
+                "Cron script %s: configured workdir %r is not a directory — "
+                "running from the script's own directory instead",
+                path.name, cwd_override,
+            )
+
     try:
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
         result = subprocess.run(
@@ -1050,7 +1078,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             capture_output=True,
             text=True,
             timeout=script_timeout,
-            cwd=str(path.parent),
+            cwd=run_cwd,
             env=run_env,
             **popen_kwargs,
         )
@@ -1385,24 +1413,14 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
         # Apply workdir if configured — lets scripts use predictable relative
         # paths. For no_agent jobs this is just the subprocess cwd (not an
-        # agent TERMINAL_CWD bridge).
+        # agent TERMINAL_CWD bridge).  We pass it straight through to the
+        # subprocess instead of os.chdir()-ing the scheduler: os.chdir is
+        # process-global, and the sequential (workdir/profile) pool runs
+        # concurrently with the parallel pool, so a global cwd change here
+        # bleeds into workdir-less jobs that rely on the scheduler's cwd.
         _job_workdir = (job.get("workdir") or "").strip() or None
-        _prior_cwd = None
-        if _job_workdir and Path(_job_workdir).is_dir():
-            _prior_cwd = os.getcwd()
-            try:
-                os.chdir(_job_workdir)
-            except OSError:
-                _prior_cwd = None
 
-        try:
-            ok, output = _run_job_script(script_path)
-        finally:
-            if _prior_cwd is not None:
-                try:
-                    os.chdir(_prior_cwd)
-                except OSError:
-                    pass
+        ok, output = _run_job_script(script_path, cwd_override=_job_workdir)
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -12,6 +12,8 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -329,3 +331,75 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+# ---------------------------------------------------------------------------
+# _run_job_script: cwd_override (per-job workdir) — process-cwd isolation
+# ---------------------------------------------------------------------------
+
+
+def test_run_job_script_honours_cwd_override(hermes_env, tmp_path):
+    """A configured workdir becomes the script subprocess cwd."""
+    from cron.scheduler import _run_job_script
+
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+
+    script_path = hermes_env / "scripts" / "where.sh"
+    script_path.write_text("#!/bin/bash\npwd\n")
+
+    ok, output = _run_job_script("where.sh", cwd_override=str(workdir))
+    assert ok is True
+    # Compare resolved paths — on macOS /tmp is a symlink to /private/tmp.
+    assert Path(output.strip()).resolve() == workdir.resolve()
+
+
+def test_run_job_script_invalid_cwd_override_falls_back(hermes_env):
+    """A workdir that no longer exists falls back to the script's own dir
+    instead of failing the run."""
+    from cron.scheduler import _run_job_script
+
+    script_path = hermes_env / "scripts" / "where2.sh"
+    script_path.write_text("#!/bin/bash\npwd\n")
+
+    ok, output = _run_job_script("where2.sh", cwd_override="/no/such/dir/xyz")
+    assert ok is True
+    assert Path(output.strip()).resolve() == (hermes_env / "scripts").resolve()
+
+
+def test_run_job_no_agent_does_not_mutate_process_cwd(hermes_env, tmp_path):
+    """Regression: a no_agent job with a workdir runs its script from that
+    workdir WITHOUT os.chdir()-ing the scheduler process.
+
+    os.chdir is process-global. tick() dispatches workdir/profile jobs on a
+    sequential pool concurrently with the workdir-less parallel pool, and
+    those parallel jobs rely on the scheduler's own cwd. A global cwd change
+    here would bleed into them, so the workdir must be scoped to the script
+    subprocess only.
+    """
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+
+    script_path = hermes_env / "scripts" / "where3.sh"
+    script_path.write_text("#!/bin/bash\npwd\n")
+
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="where3.sh",
+        no_agent=True,
+        deliver="local",
+        workdir=str(workdir),
+    )
+
+    cwd_before = os.getcwd()
+    success, _doc, final_response, error = run_job(job)
+    assert success is True
+    assert error is None
+    # The script saw the configured workdir as its cwd...
+    assert Path(final_response.strip()).resolve() == workdir.resolve()
+    # ...but the scheduler's own process cwd was never changed.
+    assert os.getcwd() == cwd_before


### PR DESCRIPTION
## What does this PR do?

A `no_agent` cron job with a configured `workdir` changed the scheduler's
process-global working directory via `os.chdir()` for the duration of its
script run. That mutation is not isolated to the job: `tick()` partitions due
jobs into a single-thread sequential pool (workdir/profile jobs) and a parallel
pool (everything else), and dispatches both fire-and-forget in the same tick.
While the sequential `no_agent` job held the altered cwd, any workdir-less job
running concurrently in the parallel pool — which deliberately leaves
`TERMINAL_CWD` unset and relies on the scheduler's own cwd for its
terminal/file/code-exec tools — resolved its relative paths against the foreign
job's directory.

The `os.chdir()` was also inert for its stated purpose: `_run_job_script`
already passes an explicit `cwd=str(path.parent)` to `subprocess.run`, which
overrides the process cwd, so the documented "script runs from the workdir"
behaviour never actually took effect.

The fix threads the workdir through to the subprocess as an explicit
`cwd_override` instead of mutating the process. This scopes the working
directory to the child process — removing the cross-job contamination — and, as
a side effect, makes the documented per-job workdir behaviour work correctly.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: added an optional `cwd_override` parameter to
  `_run_job_script`; when set to an existing directory it becomes the
  subprocess `cwd`, otherwise the call falls back to the script's own directory
  (with a logged warning for a stale/invalid override).
- `cron/scheduler.py`: removed the process-global `os.chdir()`/restore block in
  the `no_agent` branch of `_run_job_impl` and now pass the job's `workdir`
  through as `cwd_override`.
- `tests/cron/test_cron_no_agent.py`: added coverage for `cwd_override`
  (honoured / fallback) and a regression test asserting a `no_agent`+`workdir`
  job runs its script from the workdir without changing the scheduler's process
  cwd.

## How to Test

1. Run the targeted suite: `scripts/run_tests.sh tests/cron/test_cron_no_agent.py`.
2. Confirm `test_run_job_no_agent_does_not_mutate_process_cwd` passes — it
   asserts the script's `pwd` equals the configured workdir while
   `os.getcwd()` is unchanged before and after the run.
3. Run the surrounding suites for regressions:
   `scripts/run_tests.sh tests/cron/`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring for `_run_job_script` updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — `subprocess.run(cwd=...)` is portable; no platform-specific paths added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A