### PR TITLE
fix(model_metadata): stop endpoint context-length probe binding to the wrong model

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -798,6 +798,64 @@ def fetch_endpoint_model_metadata(
     return {}
 
 
+def _match_endpoint_metadata_entry(
+    model: str, endpoint_metadata: Dict[str, Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    """Best-effort match of *model* against an endpoint ``/models`` catalog.
+
+    The catalog often lists models under a publisher prefix or a
+    quantization suffix (e.g. ``org/llama-3.3-70b-instruct-fp8``) while the
+    user configures a shorter name (``llama-3.3-70b-instruct``), so some
+    fuzzy matching is genuinely needed.
+
+    The previous logic — a bidirectional substring scan that returned the
+    FIRST hit while iterating an unordered dict — would silently bind the
+    requested model to an unrelated sibling that merely shared a substring.
+    Requesting ``qwen3`` against a catalog serving both ``qwen3-coder`` and
+    ``qwen3-max`` matched whichever happened to iterate first, and callers
+    persist that value to ``context_length_cache.yaml`` — freezing a wrong
+    context window across runs (over-report → requests exceed the real
+    limit; under-report → premature compaction discards history).
+
+    Resolution order (deterministic, never guesses between conflicting
+    siblings):
+      1. Exact basename match — the id after the last ``/`` equals *model*.
+         Unambiguous, so always preferred.
+      2. Substring fallback — accepted only when it is unambiguous: if
+         several siblings match with *different* context lengths, return
+         None so the caller falls through to provider-aware / hardcoded
+         resolution instead of caching an arbitrary value.
+    """
+    items = sorted(endpoint_metadata.items())
+    model_base = model.rsplit("/", 1)[-1]
+
+    # 1. Exact basename match wins outright.
+    for key, entry in items:
+        if key.rsplit("/", 1)[-1] == model_base:
+            return entry
+
+    # 2. Substring fallback — only when it doesn't conflict.
+    candidates = [
+        entry for key, entry in items if model in key or key in model
+    ]
+    if not candidates:
+        return None
+    distinct_lengths = {
+        entry.get("context_length")
+        for entry in candidates
+        if isinstance(entry.get("context_length"), int)
+    }
+    if len(distinct_lengths) > 1:
+        logger.info(
+            "Endpoint /models catalog has %d substring matches for %r with "
+            "conflicting context lengths %s — refusing to guess; falling "
+            "through to provider-aware/hardcoded resolution.",
+            len(candidates), model, sorted(distinct_lengths),
+        )
+        return None
+    return candidates[0]
+
+
 def _resolve_endpoint_context_length(
     model: str,
     base_url: str,
@@ -810,10 +868,7 @@ def _resolve_endpoint_context_length(
         if len(endpoint_metadata) == 1:
             matched = next(iter(endpoint_metadata.values()))
         else:
-            for key, entry in endpoint_metadata.items():
-                if model in key or key in model:
-                    matched = entry
-                    break
+            matched = _match_endpoint_metadata_entry(model, endpoint_metadata)
     if matched:
         context_length = matched.get("context_length")
         if isinstance(context_length, int):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -19,6 +19,7 @@ from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
     DEFAULT_FALLBACK_CONTEXT,
+    _resolve_endpoint_context_length,
     _strip_provider_prefix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
@@ -923,6 +924,92 @@ class TestGetModelContextLength:
             assert ctx3 == DEFAULT_FALLBACK_CONTEXT, (
                 f"Expected {DEFAULT_FALLBACK_CONTEXT}, got {ctx3}"
             )
+
+
+# =========================================================================
+# Endpoint /models catalog matching — must not bind to the wrong sibling
+# =========================================================================
+
+class TestResolveEndpointContextLength:
+    """Regression tests for ``_resolve_endpoint_context_length`` matching.
+
+    The matcher used to do a bidirectional substring scan and return the
+    first hit while iterating an unordered dict, so a short configured name
+    could bind to an unrelated sibling that merely shared a substring (and
+    callers persist that wrong value to disk).
+    """
+
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_ambiguous_substring_siblings_return_none(self, mock_fetch):
+        """A name that is a substring of several catalog entries with
+        DIFFERENT context lengths is ambiguous — refuse to guess instead of
+        returning whichever happens to iterate first."""
+        mock_fetch.return_value = {
+            "org/qwen3-coder": {"context_length": 262144},
+            "org/qwen3-max": {"context_length": 1000000},
+        }
+
+        result = _resolve_endpoint_context_length(
+            "qwen3", base_url="https://api.example.com/v1", api_key="k"
+        )
+
+        assert result is None, (
+            "Ambiguous substring siblings with conflicting windows must not "
+            f"resolve to an arbitrary value; got {result}"
+        )
+
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_match_order_is_deterministic(self, mock_fetch):
+        """Result must not depend on dict insertion order — both orderings of
+        the same conflicting catalog yield the same (None) answer."""
+        forward = {
+            "org/qwen3-coder": {"context_length": 262144},
+            "org/qwen3-max": {"context_length": 1000000},
+        }
+        reverse = {
+            "org/qwen3-max": {"context_length": 1000000},
+            "org/qwen3-coder": {"context_length": 262144},
+        }
+        url = "https://api.example.com/v1"
+
+        mock_fetch.return_value = forward
+        a = _resolve_endpoint_context_length("qwen3", base_url=url)
+        mock_fetch.return_value = reverse
+        b = _resolve_endpoint_context_length("qwen3", base_url=url)
+
+        assert a == b is None
+
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_exact_basename_match_wins_over_substring_sibling(self, mock_fetch):
+        """An exact basename match (publisher/slug) must beat any substring
+        sibling, even when a longer sibling sorts first."""
+        mock_fetch.return_value = {
+            "org/qwen3-coder": {"context_length": 262144},
+            "org/qwen3": {"context_length": 131072},
+        }
+
+        result = _resolve_endpoint_context_length(
+            "qwen3", base_url="https://api.example.com/v1"
+        )
+
+        assert result == 131072, (
+            f"Exact basename match should win; got {result}"
+        )
+
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_single_substring_match_still_resolves(self, mock_fetch):
+        """The legitimate quantization-suffix case still works: a lone
+        substring match (no conflicting sibling) resolves normally."""
+        mock_fetch.return_value = {
+            "org/llama-3.3-70b-instruct-fp8": {"context_length": 131072},
+            "org/qwen-2.5-72b": {"context_length": 32768},
+        }
+
+        result = _resolve_endpoint_context_length(
+            "llama-3.3-70b-instruct", base_url="https://api.example.com/v1"
+        )
+
+        assert result == 131072
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

While poking around the context-length resolution path I noticed `_resolve_endpoint_context_length` was tripping over itself when a custom/Nous/GMI/Novita endpoint serves several models with overlapping names. When the exact lookup misses, it fell back to a bidirectional substring scan (`if model in key or key in model`) and grabbed the *first* hit while iterating an unordered dict. So asking for `qwen3` against a catalog that has both `qwen3-coder` and `qwen3-max` would match whichever happened to come out of the dict first — and that's effectively random.

That matters because the value is treated as authoritative: the Nous, GMI and Novita branches all `save_context_length(...)` on it, so a wrong window gets frozen into `context_length_cache.yaml` and sticks across runs. An over-reported window lets the conversation grow past the model's real limit (request rejected or input silently truncated → lost history); an under-reported one triggers premature compaction that throws away real history. Either way it's a data-integrity problem, not just a cosmetic mismatch.

The fix keeps the genuinely useful fuzzy matching (publisher prefixes like `org/...`, quantization suffixes like `-fp8`) but stops it from guessing between unrelated siblings: prefer an exact basename match, and when several substring candidates disagree on context length, refuse to pick and fall through to provider-aware/hardcoded resolution instead of caching a coin-flip.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: extracted the endpoint-catalog matching into a new `_match_endpoint_metadata_entry()` helper that (1) prefers an exact basename match, (2) iterates deterministically (sorted), and (3) returns `None` when multiple substring siblings report conflicting context lengths instead of taking the first arbitrary hit. `_resolve_endpoint_context_length` now delegates to it.
- `tests/agent/test_model_metadata.py`: added `TestResolveEndpointContextLength` covering the ambiguous-sibling case, order-independence, exact-basename precedence, and that a lone substring match (the `-fp8` quantization case) still resolves.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_model_metadata.py` — 102 passing, including the 4 new cases.
2. Reproduction: point at a custom endpoint whose `/models` lists `org/qwen3-coder` (262144) and `org/qwen3-max` (1000000), then resolve `qwen3`. Before: returns one of the two siblings' windows (order-dependent) and caches it. After: returns `None` and falls through to provider-aware/hardcoded resolution.
3. Regression check: the existing `test_custom_endpoint_fuzzy_substring_match` (lone `-fp8` suffix) and `test_custom_endpoint_single_model_fallback` still pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A