### PR TITLE
fix(tools): restore separator after backgrounded compound rewrite

### DIFF
--- a/tests/tools/test_terminal_compound_background.py
+++ b/tests/tools/test_terminal_compound_background.py
@@ -12,6 +12,10 @@ The rewriter fixes this by wrapping the tail in a brace group —
 the current shell. No subshell fork, no wait.
 """
 
+import shutil
+import subprocess
+
+import pytest
 
 from tools.terminal_tool import _rewrite_compound_background as rewrite
 
@@ -177,3 +181,88 @@ class TestEdgeCases:
 
     def test_tabs_between_tokens(self):
         assert rewrite("A\t&&\tB\t&") == "A\t&&\t{ B\t& }"
+
+
+class TestTrailingStatementSeparator:
+    """A statement after the backgrounded compound on the SAME line.
+
+    In ``A && B & C`` the trailing ``&`` is both the background operator and
+    the separator between the compound and ``C``. The rewrite consumes that
+    ``&`` into the brace group; without restoring a separator the result is
+    ``A && { B & } C`` — a bash syntax error (a brace group must be terminated
+    by ``;``, ``&``, ``|``, a newline, or ``)``/``}`` before the next command).
+    That mangles a valid command into one that fails entirely.
+    """
+
+    def test_trailing_command_gets_separator(self):
+        assert rewrite("echo hi && sleep 5 & echo done") == (
+            "echo hi && { sleep 5 & } ; echo done"
+        )
+
+    def test_trailing_chain_gets_separator(self):
+        assert rewrite("a && b & c && d") == "a && { b & } ; c && d"
+
+    def test_redirect_then_trailing_command(self):
+        assert rewrite("echo hi && sleep 5 &>/dev/null & echo done") == (
+            "echo hi && { sleep 5 &>/dev/null & } ; echo done"
+        )
+
+    def test_existing_semicolon_separator_untouched(self):
+        # An explicit `;` already separates the group; don't add a second one.
+        assert rewrite("a && b &; c") == "a && { b & }; c"
+
+    def test_newline_separator_untouched(self):
+        # A newline already terminates the brace group — no `;` needed.
+        assert rewrite("a && b &\necho next") == "a && { b & }\necho next"
+
+    def test_pipe_after_group_untouched(self):
+        # `{ ...; } | cmd` is valid; the pipe is its own terminator.
+        assert rewrite("a && b & | cat") == "a && { b & } | cat"
+
+    def test_second_background_then_trailing(self):
+        assert rewrite("echo a && sleep 5 & echo b & echo c") == (
+            "echo a && { sleep 5 & } ; echo b & echo c"
+        )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+class TestRewriteIsValidBash:
+    """The rewrite must always produce syntactically valid bash.
+
+    This is the crux of the trailing-statement bug: a mangled command fails
+    with a confusing syntax error and neither half runs. ``bash -n`` parses
+    without executing, so it catches the corruption directly.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo hi && sleep 5 & echo done",
+            "a && b & c && d",
+            "echo hi && sleep 5 &>/dev/null & echo done",
+            "echo a && sleep 5 & echo b & echo c",
+            "A && B &",
+            "A && B &; C",
+            "A && B &\nC",
+            "cd /tmp && python3 -m http.server 0 &>/dev/null & curl localhost",
+        ],
+    )
+    def test_rewrite_parses(self, command):
+        rewritten = rewrite(command)
+        result = subprocess.run(
+            ["bash", "-n", "-c", rewritten],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"rewrite produced invalid bash: {rewritten!r}\n{result.stderr}"
+        )
+
+    def test_trailing_statement_actually_runs(self):
+        # End-to-end: the command after the backgrounded compound must run.
+        rewritten = rewrite("echo first && true & echo SECOND_RAN")
+        result = subprocess.run(
+            ["bash", "-c", rewritten], capture_output=True, text=True
+        )
+        assert result.returncode == 0
+        assert "SECOND_RAN" in result.stdout

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -744,7 +744,19 @@ def _rewrite_compound_background(command: str) -> str:
         suffix = result[amp_pos + 1 :]
         # `{` needs a trailing space in bash; the closing `}` needs to be
         # preceded by `;` or `&` — we're providing `&` from the backgrounding.
-        result = prefix + "{ " + middle + "& }" + suffix
+        #
+        # The source `&` we consumed into the group also served as the
+        # statement separator when another command followed on the SAME line
+        # (`A && B & C`). A brace group must be terminated by `;`, `&`, `|`,
+        # a newline, or `)`/`}` before the next command, so `{ B & } C` is a
+        # bash syntax error that fails the entire command. Restore a `;`
+        # separator after `}` whenever the suffix resumes with command text.
+        # Strip only spaces/tabs (not newlines) — a newline already terminates
+        # the group, and an existing separator (`;`/`&`/`|`/`)`/`}`) needs no
+        # help.
+        tail = suffix.lstrip(" \t")
+        separator = " ;" if tail and tail[0] not in ";\n&|)}" else ""
+        result = prefix + "{ " + middle + "& }" + separator + suffix
 
     return result
 


### PR DESCRIPTION
`_rewrite_compound_background` rewrites `A && B &` into `A && { B & }` to
avoid the subshell-wait process leak. When another statement follows the
backgrounded compound on the same line (`A && B & C`), the trailing `&`
was the only separator between the compound and `C`. The rewrite consumed
that `&` into the brace group and produced `A && { B & } C`. A brace group
must be terminated by `;`, `&`, `|`, a newline, or `)`/`}` before the next
command, so the result is a bash syntax error and the entire command fails
to run — neither `A`, `B`, nor `C` execute. The rewrite is applied by
default to every foreground command, so a valid command is silently
mangled into one that errors out.

This restores a `;` separator after the closing `}` when the suffix
resumes with command text. Only spaces and tabs are stripped before the
check; a newline already terminates the group, and an existing separator
(`;`, `&`, `|`, `)`, `}`) is left untouched, so previously-correct rewrites
are unchanged.

## What does this PR do?

Fixes a rewrite in `_rewrite_compound_background` that turned a valid
foreground command of the form `A && B & C` into the bash syntax error
`A && { B & } C`, causing the whole command to fail. A `;` is now inserted
after the brace group whenever a further statement follows on the same
line, while leaving commands that already end in a separator/newline
untouched.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/terminal_tool.py`: in `_rewrite_compound_background`, insert a `;`
  after the rewritten `{ ... & }` brace group when the trailing suffix
  begins with command text rather than a separator/terminator.
- `tests/tools/test_terminal_compound_background.py`: add
  `TestTrailingStatementSeparator` for the string-level rewrites and
  `TestRewriteIsValidBash`, which runs the rewriter output through
  `bash -n` for parse validity plus one end-to-end execution check.

## How to Test

1. Run `pytest tests/tools/test_terminal_compound_background.py -q`.
2. Before the fix, `_rewrite_compound_background("echo hi && sleep 5 & echo done")`
   returns `echo hi && { sleep 5 & } echo done`; `bash -n -c` on that string
   exits 2 with `syntax error near unexpected token 'echo'`.
3. After the fix it returns `echo hi && { sleep 5 & } ; echo done`, which
   parses and runs, and the trailing statement executes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/tools/test_terminal_compound_background.py -q` (50 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact: the rewrite is
  platform-independent; the `bash -n` test is skipped when bash is absent
- [x] I've updated tool descriptions/schemas — N/A