### PR TITLE
fix(gateway): narrow systemd restart shortcut to stepped units

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4220,21 +4220,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 service_name = "hermes-gateway"
 
+            def _systemctl_show_value(prop: str) -> str:
+                result = subprocess.run(
+                    [
+                        systemctl,
+                        "--user",
+                        "show",
+                        service_name,
+                        f"--property={prop}",
+                        "--value",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=2,
+                )
+                return (result.stdout or "").strip()
+
+            # The shortcut is only needed for stepped-restart units. On the
+            # default Restart=always user service, clean exit already causes
+            # an immediate relaunch; injecting an extra `systemctl restart`
+            # job can flap the freshly-started replacement.
+            try:
+                restart_steps = int(_systemctl_show_value("RestartSteps") or "0")
+            except ValueError:
+                restart_steps = 0
+            if restart_steps <= 0:
+                return
+
             current_pid = os.getpid()
-            show = subprocess.run(
-                [
-                    systemctl,
-                    "--user",
-                    "show",
-                    service_name,
-                    "--property=MainPID",
-                    "--value",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=2,
-            )
-            if (show.stdout or "").strip() != str(current_pid):
+            if _systemctl_show_value("MainPID") != str(current_pid):
                 return
 
             systemctl_user = "systemctl --user"

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,4 +1,5 @@
 import asyncio
+import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -139,6 +140,7 @@ async def test_gateway_stop_systemd_service_restart_exits_cleanly(tmp_path, monk
     runner, adapter = make_restart_runner()
     adapter.disconnect = AsyncMock()
     monkeypatch.setenv("INVOCATION_ID", "systemd-test")
+    monkeypatch.setattr("gateway.run.sys.platform", "linux")
     runner._launch_systemd_restart_shortcut = MagicMock()
 
     with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
@@ -147,6 +149,56 @@ async def test_gateway_stop_systemd_service_restart_exits_cleanly(tmp_path, monk
     runner._launch_systemd_restart_shortcut.assert_called_once_with()
     assert runner._exit_code == 0
     assert (tmp_path / ".restart_pending.json").exists()
+
+
+def test_systemd_restart_shortcut_skips_units_without_restart_steps(monkeypatch):
+    runner, _adapter = make_restart_runner()
+    popen = MagicMock()
+
+    monkeypatch.setenv("INVOCATION_ID", "systemd-test")
+    monkeypatch.setattr("gateway.run.sys.platform", "linux")
+    monkeypatch.setattr("gateway.run.os.getpid", lambda: 321)
+    monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(subprocess, "Popen", popen)
+
+    def _fake_run(cmd, capture_output, text, timeout):
+        if "--property=RestartSteps" in cmd:
+            return MagicMock(stdout="0\n")
+        raise AssertionError(f"unexpected systemctl show call: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    runner._launch_systemd_restart_shortcut()
+
+    popen.assert_not_called()
+
+
+def test_systemd_restart_shortcut_launches_only_for_stepped_units(monkeypatch):
+    runner, _adapter = make_restart_runner()
+    popen = MagicMock()
+    show_calls = []
+
+    monkeypatch.setenv("INVOCATION_ID", "systemd-test")
+    monkeypatch.setattr("gateway.run.sys.platform", "linux")
+    monkeypatch.setattr("gateway.run.os.getpid", lambda: 321)
+    monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(subprocess, "Popen", popen)
+
+    def _fake_run(cmd, capture_output, text, timeout):
+        show_calls.append(cmd)
+        if "--property=RestartSteps" in cmd:
+            return MagicMock(stdout="5\n")
+        if "--property=MainPID" in cmd:
+            return MagicMock(stdout="321\n")
+        raise AssertionError(f"unexpected systemctl show call: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    runner._launch_systemd_restart_shortcut()
+
+    assert any("--property=RestartSteps" in call for call in show_calls)
+    assert any("--property=MainPID" in call for call in show_calls)
+    popen.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Stops the gateway's systemd planned-restart shortcut from running on every generic `INVOCATION_ID` service. The shortcut now only activates when the unit actually uses `RestartSteps`, which keeps ordinary `Restart=always` user services on systemd's normal clean-exit restart path instead of injecting an extra `systemctl restart` job that can flap the freshly-started replacement.

## Related Issue

Refs #42126

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: gate `_launch_systemd_restart_shortcut()` on `systemctl show ... RestartSteps` so the helper only launches for stepped-restart units, and reuse a single `systemctl show` helper for the property lookups.
- `tests/gateway/test_gateway_shutdown.py`: add regression coverage that the shortcut is skipped when `RestartSteps=0` and still launches when `RestartSteps>0`; make the existing systemd restart test explicitly emulate Linux.

## How to Test

1. Run `pytest tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_drain.py tests/gateway/test_restart_notification.py -q`.
2. Confirm the new shortcut tests pass: one path should skip `systemd-run` when `RestartSteps` is `0`, and another should still launch it when `RestartSteps` is positive.
3. On a Linux systemd user service using the default `Restart=always` / `RestartSec=5` pattern without `RestartSteps`, restart the gateway and verify it comes back via systemd's normal clean-exit path without an extra immediate restart of the replacement instance.

## What platforms tested on

- macOS 15 / darwin-arm64 (local unit tests)
- Linux systemd behavior covered by targeted unit tests only; not exercised on a live Linux service in this workspace

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local verification notes:

- `pytest tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_drain.py tests/gateway/test_restart_notification.py -q` → passed (`60 passed`).
- `ruff check gateway/run.py tests/gateway/test_gateway_shutdown.py` → passed.
- `python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_gateway_shutdown.py` → passed.
- `git diff --check` → passed.
- The bounded full-suite command stopped during collection in this environment with `ModuleNotFoundError: No module named 'fastapi'` from `tests/hermes_cli/test_dashboard_auth_401_reauth.py`, so CI should cover the remaining breadth once the normal test environment is available.

<!-- autocontrib:worker-id=issue-new-3cbc1424 kind=pr-open -->