### PR TITLE
fix(cron): guard _middleware access and ensure plugin discovery (#42197)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1467,6 +1467,13 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # at module top keeps no_agent ticks from paying for AIAgent / SessionDB
     # construction costs.
     # ---------------------------------------------------------------
+    # Ensure the plugin system is initialized before any agent code runs
+    # middleware through the PluginManager. Without this, cron jobs that
+    # are the first to touch middleware in a fresh scheduler process can
+    # fail with "'PluginManager' object has no attribute '_middleware'".
+    from hermes_cli.plugins import discover_plugins
+    discover_plugins()
+
     from run_agent import AIAgent
 
     # Initialize SQLite session store so cron job messages are persisted

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -234,7 +234,8 @@ def _has_middleware(kind: str) -> bool:
 def _get_middleware_callbacks(kind: str) -> List[Callable]:
     from hermes_cli.plugins import get_plugin_manager
 
-    return list(get_plugin_manager()._middleware.get(kind, []))
+    manager = get_plugin_manager()
+    return list(getattr(manager, "_middleware", {}).get(kind, []))
 
 
 def _run_execution_chain(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1614,7 +1614,7 @@ class PluginManager:
 
     def has_middleware(self, kind: str) -> bool:
         """Return True when at least one callback is registered for middleware."""
-        return bool(self._middleware.get(kind))
+        return bool(getattr(self, "_middleware", {}).get(kind))
 
     def invoke_middleware(self, kind: str, **kwargs: Any) -> List[Any]:
         """Call registered middleware callbacks for *kind*.
@@ -1623,7 +1623,7 @@ class PluginManager:
         path. Middleware that wants to change behavior must return the shape
         documented by the caller-specific contract.
         """
-        callbacks = self._middleware.get(kind, [])
+        callbacks = getattr(self, "_middleware", {}).get(kind, [])
         results: List[Any] = []
         for cb in callbacks:
             try:


### PR DESCRIPTION
Fixes #42197. Make PluginManager._middleware access defensive with getattr fallbacks and ensure discover_plugins() is called before cron jobs run the LLM agent path.