### PR TITLE
fix(desktop): prefer text over image when pasting rich-text clipboard content

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -471,6 +471,25 @@ export function ChatBar({
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
     const imageBlobs = extractClipboardImageBlobs(event.clipboardData)
 
+    // Trim surrounding whitespace so a copy that dragged along leading/trailing
+    // blank lines (common when selecting from terminals, code blocks, web pages)
+    // doesn't dump multiline padding into the composer. Internal newlines are
+    // preserved — only the edges are cleaned up.
+    const pastedText = event.clipboardData.getData('text').trim()
+
+    // When the clipboard carries both text and image flavors (common with
+    // rich-text editors like Microsoft Word), prefer inserting the text.
+    // The image is usually a rendered copy of the same content, not an
+    // intentional attachment.
+    if (imageBlobs.length > 0 && pastedText) {
+      event.preventDefault()
+      document.execCommand('insertText', false, pastedText)
+      const nextDraft = composerPlainText(event.currentTarget)
+      draftRef.current = nextDraft
+      aui.composer().setText(nextDraft)
+      return
+    }
+
     if (imageBlobs.length > 0) {
       event.preventDefault()
 
@@ -484,12 +503,6 @@ export function ChatBar({
 
       return
     }
-
-    // Trim surrounding whitespace so a copy that dragged along leading/trailing
-    // blank lines (common when selecting from terminals, code blocks, web pages)
-    // doesn't dump multiline padding into the composer. Internal newlines are
-    // preserved — only the edges are cleaned up.
-    const pastedText = event.clipboardData.getData('text').trim()
 
     if (!pastedText) {
       event.preventDefault()


### PR DESCRIPTION
## Problem

When copying text from Microsoft Word (or any app that puts both plain text and an image rendering on the clipboard), pasting into the Hermes Desktop composer attaches it as an image instead of inserting it as plain text.

**Steps to reproduce:**
1. Copy any text from a Microsoft Word document (Cmd+C)
2. Focus the Hermes Desktop composer input
3. Press Cmd+V

**Expected:** Plain text is inserted into the composer input field.
**Actual:** The clipboard content is attached as an image file (e.g. `composer_2026-06-08_17-....jpg`).

Fixes #42280

## Root Cause

The `handlePaste` handler in the composer checks for image blobs **before** checking for text content. When the clipboard carries both flavors (common with rich-text editors like Word), the image check wins and the text is never inserted.

## Fix

Reorder the checks so that when the clipboard has **both** text and image flavors, text insertion takes priority. Pure-image pastes (screenshots, copied images) are unaffected — the image-only path still runs when there's no text content.

**Before:** `imageBlobs → return` → `text` → `insertText`
**After:** `imageBlobs + text → insertText, return` → `imageBlobs → return` → `text` → `insertText`

## Testing

- Paste text from Word → text is inserted (not attached as image)
- Paste a screenshot → image is attached (unchanged)
- Paste plain text → text is inserted (unchanged)
- Paste image-only clipboard (e.g. Snipping Tool) → image is attached (unchanged)
