### PR TITLE
fix(gateway): replace hardcoded Spanish fallback text in Google Chat attachment notice

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2890,12 +2890,11 @@ class GoogleChatAdapter(BasePlatformAdapter):
         if caption:
             lines.append(caption)
         lines.extend([
-            f"⚠️ No he podido adjuntar **{filename}**.",
-            "Google Chat sólo permite adjuntar archivos cuando el bot tiene "
-            "permiso explícito tuyo (OAuth de usuario). Es un consentimiento "
-            "único que se hace desde este chat.",
-            "**Para activarlo:** envía `/setup-files` y sigue las instrucciones.",
-            f"Mientras tanto el archivo está en el host: `{path}`",
+            f"⚠️ Could not attach **{filename}**.",
+            "Google Chat requires explicit user permission (OAuth) to send "
+            "files. This is a one-time consent from this chat.",
+            "**To enable:** send `/setup-files` and follow the instructions.",
+            f"The file is available on the host at: `{path}`",
         ])
         body: Dict[str, Any] = {"text": "\n".join(lines)}
         if thread_id:

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1359,6 +1359,8 @@ class TestNativeAttachmentDelivery:
         sent_body = adapter._create_message.call_args.args[1]
         assert "/setup-files" in sent_body["text"]
         assert "report.pdf" in sent_body["text"]
+        assert "Could not attach" in sent_body["text"]
+        assert "No he podido adjuntar" not in sent_body["text"]
 
     @pytest.mark.asyncio
     async def test_send_file_two_step_native_upload_when_user_oauth_ready(self, adapter, tmp_path):


### PR DESCRIPTION
## What

Replaces hardcoded Spanish user-facing text in `_post_fallback_notice()` (Google Chat adapter) with English.

## Why

The attachment-failure fallback message was written in Spanish:

```python
f"⚠️ No he podido adjuntar **{filename}**.",
"Google Chat sólo permite adjuntar archivos cuando el bot tiene "
"permiso explícito tuyo (OAuth de usuario)..."
```

- No other platform adapter has hardcoded non-English strings
- The repo i18n system (`agent/i18n.py`, `locales/`) does not cover platform-adapter fallback messages
- This was likely a copy-paste oversight

## How to test

Trigger a MEDIA: file attachment from the agent on Google Chat without /setup-files configured. The fallback notice now reads in English.

## Related

Found in production by a German-speaking user whose agent suddenly started responding in Spanish.