### PR TITLE
feat(desktop): add cron session inbox toggle

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -49,6 +49,7 @@ import {
   $pinnedSessionIds,
   $sidebarAgentsGrouped,
   $sidebarCronOpen,
+  $sidebarCronSessionsInRecents,
   $sidebarMessagingOpenIds,
   $sidebarOpen,
   $sidebarOverlayMounted,
@@ -336,6 +337,7 @@ export function ChatSidebar({
   const pinsOpen = useStore($sidebarPinsOpen)
   const agentsOpen = useStore($sidebarRecentsOpen)
   const cronOpen = useStore($sidebarCronOpen)
+  const cronSessionsInRecents = useStore($sidebarCronSessionsInRecents)
   const selectedSessionId = useStore($selectedStoredSessionId)
   const sessions = useStore($sessions)
   const cronSessions = useStore($cronSessions)
@@ -425,15 +427,20 @@ export function ChatSidebar({
 
   const workingSessionIdSet = useMemo(() => new Set(workingSessionIds), [workingSessionIds])
 
+  const visibleCronSessions = useMemo(
+    () => (cronSessionsInRecents ? [] : cronSessions),
+    [cronSessions, cronSessionsInRecents]
+  )
+
   // Index sessions by both their live id and their lineage-root id so a pin
   // stored as the pre-compression root resolves to the live continuation tip.
   const sessionByAnyId = useMemo(() => {
     const map = new Map<string, SessionInfo>()
 
-    // Cron sessions are listed separately but can still be pinned, so index
-    // them too — otherwise a pinned cron job can't resolve into the Pinned
-    // section. Recents take precedence on id collisions (set last).
-    for (const s of [...cronSessions, ...visibleSessions]) {
+    // Cron sessions are listed separately unless the user opted into showing
+    // them in recents. Index whichever surface is active so pinned cron runs
+    // resolve into the Pinned section.
+    for (const s of [...visibleCronSessions, ...visibleSessions]) {
       map.set(s.id, s)
 
       if (s._lineage_root_id && !map.has(s._lineage_root_id)) {
@@ -442,7 +449,7 @@ export function ChatSidebar({
     }
 
     return map
-  }, [visibleSessions, cronSessions])
+  }, [visibleSessions, visibleCronSessions])
 
   const pinnedSessions = useMemo(() => {
     const seen = new Set<string>()
@@ -533,6 +540,7 @@ export function ChatSidebar({
 
     if (!next.length && agentOrderIds.length) {
       setSidebarSessionOrderIds([])
+
       return
     }
 

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -26,6 +26,7 @@ import {
   $panesFlipped,
   $pinnedSessionIds,
   $sessionsLimit,
+  $sidebarCronSessionsInRecents,
   bumpSessionsLimit,
   FILE_BROWSER_DEFAULT_WIDTH,
   FILE_BROWSER_MAX_WIDTH,
@@ -133,18 +134,15 @@ const ProfilesView = lazy(async () => ({ default: (await import('./profiles')).P
 const SettingsView = lazy(async () => ({ default: (await import('./settings')).SettingsView }))
 const SkillsView = lazy(async () => ({ default: (await import('./skills')).SkillsView }))
 
-// Latest cron-job sessions surfaced in the collapsed "Cron jobs" section. The
-// Cron sessions are written by a background scheduler tick (the desktop
-// backend), so no user action signals the UI. Poll the bounded cron list on
-// this cadence while the app is open + visible so new runs surface promptly
-// instead of waiting for the next user-triggered refreshSessions().
+// Latest cron-job sessions surface in the collapsed "Cron sessions" section
+// unless the user opts into treating cron runs as normal Sessions inbox rows. The
+// scheduler writes runs in the background, so no user action signals the UI.
+// Poll on this cadence while the app is visible so new runs surface promptly.
 const CRON_POLL_INTERVAL_MS = 30_000
-// The recents list is local-only: cron rows have their own section, and each
-// messaging platform (telegram, discord, …) is fetched separately into its own
-// self-managed sidebar section (refreshMessagingSessions). Excluding both here
-// keeps "Load more" paging through interactive local chats instead of
-// interleaving gateway threads that bury them.
-const SIDEBAR_EXCLUDED_SOURCES = ['cron', 'subagent', 'tool', ...MESSAGING_SESSION_SOURCE_IDS]
+// The recents list excludes implementation-only rows and messaging platforms,
+// which render in their own sections. Cron rows are excluded only when the user
+// has not opted into showing scheduled runs in the Sessions inbox.
+const SIDEBAR_HIDDEN_SOURCES = ['subagent', 'tool']
 // The messaging slice is the inverse: drop cron + every local source so only
 // external-platform conversations remain, then split per platform in the UI.
 const MESSAGING_EXCLUDED_SOURCES = ['cron', ...LOCAL_SESSION_SOURCE_IDS]
@@ -197,6 +195,7 @@ export function DesktopController() {
   const gatewayState = useStore($gatewayState)
   const activeSessionId = useStore($activeSessionId)
   const currentCwd = useStore($currentCwd)
+  const cronSessionsInRecents = useStore($sidebarCronSessionsInRecents)
   const freshDraftReady = useStore($freshDraftReady)
   const filePreviewTarget = useStore($filePreviewTarget)
   const previewTarget = useStore($previewTarget)
@@ -343,11 +342,16 @@ export function DesktopController() {
     }
   }, [])
 
-  // Cron-job sessions as their own list (latest N). Independent of the recents
-  // page so the two never compete for slots. Cheap + bounded. Kept (even though
-  // the sidebar now lists cron *jobs*, not run sessions) so a pinned cron run
-  // still resolves into the Pinned section via sessionByAnyId.
+  // Cron-job sessions as their own list (latest N) unless the user opts into
+  // surfacing them in the normal Sessions list. Independent of the recents page
+  // by default so the two never compete for slots. Cheap + bounded.
   const refreshCronSessions = useCallback(async () => {
+    if (cronSessionsInRecents) {
+      setCronSessions([])
+
+      return
+    }
+
     try {
       const { sessions } = await listAllProfileSessions(CRON_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
         source: 'cron'
@@ -357,7 +361,7 @@ export function DesktopController() {
     } catch {
       // Non-fatal: the cron section just stays empty/stale.
     }
-  }, [])
+  }, [cronSessionsInRecents])
 
   // Messaging-platform sessions as their own slice, fetched separately from
   // local recents so each platform renders a self-managed section and never
@@ -431,16 +435,22 @@ export function DesktopController() {
       // clutter the sidebar.
       // Unified cross-profile list (served read-only off each profile's
       // state.db; no per-profile backend is spawned). Single-profile users get
-      // the same rows tagged profile="default". Cron sessions are excluded here
-      // and fetched separately (refreshCronSessions) so the scheduler's
-      // always-newest rows can't consume the recents page budget.
+      // the same rows tagged profile="default". Cron sessions stay in their own
+      // bounded section by default, but users can opt into showing scheduled runs
+      // in Sessions if they triage cron output there.
       // Scope the fetch to the active profile (not always 'all') so a profile
       // with few recent sessions isn't windowed out of the cross-profile
       // recency page — the empty-history-on-profile-switch bug.
       const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
 
+      const excludeSources = [
+        ...SIDEBAR_HIDDEN_SOURCES,
+        ...(cronSessionsInRecents ? [] : ['cron']),
+        ...MESSAGING_SESSION_SOURCE_IDS
+      ]
+
       const result = await listAllProfileSessions(limit, 1, 'exclude', 'recent', sessionProfile, {
-        excludeSources: SIDEBAR_EXCLUDED_SOURCES
+        excludeSources
       })
 
       if (refreshSessionsRequestRef.current === requestId) {
@@ -457,7 +467,7 @@ export function DesktopController() {
     void refreshCronSessions()
     void refreshCronJobs()
     void refreshMessagingSessions()
-  }, [profileScope, refreshCronSessions, refreshCronJobs, refreshMessagingSessions])
+  }, [cronSessionsInRecents, profileScope, refreshCronSessions, refreshCronJobs, refreshMessagingSessions])
 
   const loadMoreSessions = useCallback(() => {
     bumpSessionsLimit()
@@ -471,8 +481,14 @@ export function DesktopController() {
     const inKey = (s: SessionInfo) => normalizeProfileKey(s.profile) === key
     const loaded = $sessions.get().filter(inKey).length
 
+    const excludeSources = [
+      ...SIDEBAR_HIDDEN_SOURCES,
+      ...(cronSessionsInRecents ? [] : ['cron']),
+      ...MESSAGING_SESSION_SOURCE_IDS
+    ]
+
     const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', key, {
-      excludeSources: SIDEBAR_EXCLUDED_SOURCES
+      excludeSources
     })
 
     const keep = sessionsToKeep(key)
@@ -484,7 +500,7 @@ export function DesktopController() {
 
     const total = result.profile_totals?.[key] ?? result.total ?? result.sessions.length
     setSessionProfileTotals(prev => ({ ...prev, [key]: Math.max(total, result.sessions.length) }))
-  }, [])
+  }, [cronSessionsInRecents])
 
   const toggleSelectedPin = useCallback(() => {
     const sessionId = $selectedStoredSessionId.get()
@@ -792,9 +808,9 @@ export function DesktopController() {
     }
   }, [gatewayState, refreshCurrentModel, refreshSessions])
 
-  // Keep the cron jobs section live without a user action: the scheduler ticks
-  // in the background (advancing next-run/state and creating runs), so poll the
-  // job list on an interval (and on tab re-focus) while connected.
+  // Keep the cron jobs section and scheduler-created run sessions live without a
+  // user action. The scheduler ticks in the background, so poll the job list and
+  // whichever session surface is active on an interval while connected.
   useEffect(() => {
     if (gatewayState !== 'open') {
       return
@@ -803,6 +819,12 @@ export function DesktopController() {
     const tick = () => {
       if (document.visibilityState === 'visible') {
         void refreshCronJobs()
+
+        if (cronSessionsInRecents) {
+          void refreshSessions().catch(() => undefined)
+        } else {
+          void refreshCronSessions()
+        }
       }
     }
 
@@ -813,7 +835,7 @@ export function DesktopController() {
       window.clearInterval(intervalId)
       document.removeEventListener('visibilitychange', tick)
     }
-  }, [gatewayState, refreshCronJobs])
+  }, [cronSessionsInRecents, gatewayState, refreshCronJobs, refreshCronSessions, refreshSessions])
 
   useEffect(() => {
     if (gatewayState === 'open' && !activeSessionId && freshDraftReady) {

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
@@ -7,6 +8,7 @@ import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { Archive, ArchiveOff, FolderOpen, Loader2, Trash2 } from '@/lib/icons'
+import { $sidebarCronSessionsInRecents, setSidebarCronSessionsInRecents } from '@/store/layout'
 import { notify, notifyError } from '@/store/notifications'
 import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
@@ -38,6 +40,7 @@ export function SessionsSettings() {
   const [sessions, setLocalSessions] = useState<SessionInfo[]>([])
   const [loading, setLoading] = useState(true)
   const [busyId, setBusyId] = useState<string | null>(null)
+  const cronSessionsInRecents = useStore($sidebarCronSessionsInRecents)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -104,6 +107,30 @@ export function SessionsSettings() {
   return (
     <SettingsContent>
       <DefaultProjectDirSetting />
+
+      <div className="mb-6">
+        <SectionHeading icon={Archive} title={s.sidebarTitle} />
+        <div className="mt-2 divide-y divide-(--ui-stroke-tertiary)">
+          <ListRow
+            action={
+              <label className="inline-flex cursor-pointer items-center gap-2 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-secondary)">
+                <input
+                  checked={cronSessionsInRecents}
+                  className="size-4 accent-(--dt-primary)"
+                  onChange={event => {
+                    triggerHaptic('selection')
+                    setSidebarCronSessionsInRecents(event.target.checked)
+                  }}
+                  type="checkbox"
+                />
+                <span>{cronSessionsInRecents ? s.enabled : s.disabled}</span>
+              </label>
+            }
+            description={s.cronInRecentsDesc}
+            title={s.cronInRecentsTitle}
+          />
+        </div>
+      </div>
 
       <SectionHeading
         icon={Archive}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -589,6 +589,12 @@ export const en: Translations = {
       defaultDirDesc:
         'New sessions start in this folder unless you pick another. Leave it unset to use your home directory.',
       defaultDirUpdated: 'Default project directory updated — start a new chat (Ctrl/⌘+N) for it to take effect',
+      sidebarTitle: 'Sidebar',
+      cronInRecentsTitle: 'Show cron runs in Sessions',
+      cronInRecentsDesc:
+        'When enabled, scheduled run sessions appear in the normal Sessions list until archived. Leave this off to keep cron runs out of recents and available from Cron jobs.',
+      enabled: 'Enabled',
+      disabled: 'Disabled',
       defaultsTo: label => `Defaults to ${label}.`,
       change: 'Change',
       choose: 'Choose',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -719,6 +719,12 @@ export const ja = defineLocale({
       defaultDirDesc:
         '別のフォルダーを選択しない限り、新しいセッションはこのフォルダーで開始します。未設定の場合はホームディレクトリが使用されます。',
       defaultDirUpdated: 'デフォルトのプロジェクトディレクトリを更新しました',
+      sidebarTitle: 'サイドバー',
+      cronInRecentsTitle: 'Cron 実行をセッションに表示',
+      cronInRecentsDesc:
+        '有効にすると、スケジュール実行のセッションがアーカイブされるまで通常のセッション一覧に表示されます。無効の場合、Cron 実行は通常の最近のセッションから分離されます。',
+      enabled: '有効',
+      disabled: '無効',
       defaultsTo: label => `デフォルト: ${label}。`,
       change: '変更',
       choose: '選択',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -470,6 +470,11 @@ export interface Translations {
       defaultDirTitle: string
       defaultDirDesc: string
       defaultDirUpdated: string
+      sidebarTitle: string
+      cronInRecentsTitle: string
+      cronInRecentsDesc: string
+      enabled: string
+      disabled: string
       defaultsTo: (label: string) => string
       change: string
       choose: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -694,6 +694,12 @@ export const zhHant = defineLocale({
       defaultDirTitle: '預設專案目錄',
       defaultDirDesc: '新工作階段預設從此資料夾開始，除非您選擇其他目錄。留空則使用您的家目錄。',
       defaultDirUpdated: '預設專案目錄已更新',
+      sidebarTitle: '側邊欄',
+      cronInRecentsTitle: '在工作階段中顯示排程執行',
+      cronInRecentsDesc:
+        '啟用後，排程工作執行會以一般工作階段顯示在工作階段清單中，直到封存。關閉則讓排程執行不佔用最近工作階段。',
+      enabled: '已啟用',
+      disabled: '已停用',
       defaultsTo: label => `預設使用 ${label}。`,
       change: '變更',
       choose: '選擇',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -781,6 +781,12 @@ export const zh: Translations = {
       defaultDirTitle: '默认项目目录',
       defaultDirDesc: '新会话默认从此文件夹开始，除非你选择其他目录。留空则使用你的 home 目录。',
       defaultDirUpdated: '默认项目目录已更新',
+      sidebarTitle: '侧边栏',
+      cronInRecentsTitle: '在会话中显示定时运行',
+      cronInRecentsDesc:
+        '启用后，定时任务运行会作为普通会话显示在会话列表中，直到归档。关闭则让定时运行不占用最近会话。',
+      enabled: '已启用',
+      disabled: '已禁用',
       defaultsTo: label => `默认使用 ${label}。`,
       change: '更改',
       choose: '选择',

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -23,6 +23,7 @@ export const SIDEBAR_SESSIONS_PAGE_SIZE = 50
 const SIDEBAR_PINNED_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
 const SIDEBAR_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.agentsGroupedByWorkspace'
 const SIDEBAR_CRON_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarCronOpen'
+const SIDEBAR_CRON_IN_RECENTS_STORAGE_KEY = 'hermes.desktop.sidebarCronSessionsInRecents'
 const SIDEBAR_MESSAGING_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarMessagingOpen'
 const SIDEBAR_SESSION_ORDER_STORAGE_KEY = 'hermes.desktop.sessionOrder'
 const SIDEBAR_SESSION_ORDER_MANUAL_STORAGE_KEY = 'hermes.desktop.sessionOrder.manual'
@@ -71,6 +72,10 @@ export const $sidebarPinsOpen = atom(true)
 // rows on `sidebarOpen || this`.
 export const $sidebarOverlayMounted = atom(false)
 export const $sidebarRecentsOpen = atom(true)
+// Optional inbox mode for users who triage scheduled work through Sessions.
+// Off by default so bursty cron jobs keep using the bounded Cron sessions
+// section and do not starve ordinary conversations from the recents page.
+export const $sidebarCronSessionsInRecents = atom(storedBoolean(SIDEBAR_CRON_IN_RECENTS_STORAGE_KEY, false))
 // Cron-job sessions live in their own section below recents, collapsed by
 // default (it only renders at all when cron sessions exist) so the
 // scheduler's `[IMPORTANT: …]` first-message previews don't spam recents.
@@ -87,6 +92,7 @@ export const $isSidebarResizing = atom(false)
 export const $sessionsLimit = atom(SIDEBAR_SESSIONS_PAGE_SIZE)
 
 $pinnedSessionIds.subscribe(ids => persistStringArray(SIDEBAR_PINNED_STORAGE_KEY, [...ids]))
+$sidebarCronSessionsInRecents.subscribe(enabled => persistBoolean(SIDEBAR_CRON_IN_RECENTS_STORAGE_KEY, enabled))
 $sidebarCronOpen.subscribe(open => persistBoolean(SIDEBAR_CRON_OPEN_STORAGE_KEY, open))
 $sidebarMessagingOpenIds.subscribe(ids => persistStringArray(SIDEBAR_MESSAGING_OPEN_STORAGE_KEY, [...ids]))
 $sidebarSessionOrderIds.subscribe(ids => persistStringArray(SIDEBAR_SESSION_ORDER_STORAGE_KEY, [...ids]))
@@ -149,6 +155,10 @@ export function setSidebarOverlayMounted(mounted: boolean) {
 
 export function setSidebarRecentsOpen(open: boolean) {
   $sidebarRecentsOpen.set(open)
+}
+
+export function setSidebarCronSessionsInRecents(enabled: boolean) {
+  $sidebarCronSessionsInRecents.set(enabled)
 }
 
 export function setSidebarCronOpen(open: boolean) {


### PR DESCRIPTION
## Summary
- Adds a **Settings → Sessions → Sidebar** toggle for users who want cron run sessions to appear in the normal Sessions inbox.
- Keeps the default behavior conservative: cron runs remain excluded from recents unless the user enables the toggle, so bursty scheduled jobs do not starve ordinary conversations.
- When enabled, the desktop recents query stops excluding `source='cron'`, clears the separate cron-run slice, and polls the normal Sessions list so scheduler-created runs surface until archived.

## Rationale
This preserves the existing anti-starvation behavior by default while supporting the workflow where Sessions is treated as an inbox for human triage. Users who want cron outputs mixed into their normal session-processing flow can opt in without imposing that behavior on everyone.

## Verification
- `npm run typecheck`
- `npm run test:ui -- src/app/session/hooks/use-session-actions.test.tsx src/hermes.test.ts`
- `npm run build`
- Focused ESLint on touched desktop files
