### PR TITLE
fix(kanban): make touch scrolling safe on mobile

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -349,23 +349,97 @@
   // -------------------------------------------------------------------------
   // Touch drag-drop helper.
   //
-  // HTML5 DnD is desktop-only. On touch devices we attach a pointerdown
-  // handler that simulates a drag proxy and fires a custom event on the
-  // column under the finger when released. Columns listen for both the
-  // standard `drop` event and our `hermes-kanban:drop` event.
+  // HTML5 DnD is desktop-only. On touch devices we wait for a short long-press
+  // before activating drag so a normal swipe can scroll the column. Once drag
+  // is active we simulate a proxy and fire a custom event on the column under
+  // the finger when released. Columns listen for both the standard `drop`
+  // event and our `hermes-kanban:drop` event.
   // -------------------------------------------------------------------------
+
+  const TOUCH_DRAG_HOLD_MS = 260;
+  const TOUCH_DRAG_SLOP_PX = 8;
+  const TOUCH_SCROLL_INTENT_PX = 12;
+  const TOUCH_SUPPRESS_CLICK_MS = 400;
+
+  function markTouchSuppressClick(el) {
+    if (!el || !el.dataset) return;
+    el.dataset.hermesKanbanSuppressClickUntil = String(Date.now() + TOUCH_SUPPRESS_CLICK_MS);
+  }
+
+  function shouldSuppressTouchClick(el) {
+    if (!el || !el.dataset) return false;
+    return Number(el.dataset.hermesKanbanSuppressClickUntil || 0) > Date.now();
+  }
 
   function attachTouchDrag(el, taskId) {
     if (!el) return;
     function onDown(e) {
       if (e.pointerType !== "touch") return;
-      e.preventDefault();
-      const proxy = el.cloneNode(true);
-      proxy.classList.add("hermes-kanban-touch-proxy");
-      document.body.appendChild(proxy);
+      const startX = e.clientX;
+      const startY = e.clientY;
       let lastTarget = null;
+      let dragging = false;
+      let proxy = null;
+      let holdTimer = null;
+      let cancelled = false;
+
+      function clearTarget() {
+        if (lastTarget) lastTarget.classList.remove("hermes-kanban-column--drop");
+        lastTarget = null;
+      }
+
+      function cleanup() {
+        if (holdTimer) {
+          clearTimeout(holdTimer);
+          holdTimer = null;
+        }
+        document.removeEventListener("pointermove", move);
+        document.removeEventListener("pointerup", up);
+        document.removeEventListener("pointercancel", up);
+        clearTarget();
+        if (proxy) {
+          proxy.remove();
+          proxy = null;
+        }
+      }
+
+      function startDrag(originEvent) {
+        if (cancelled || dragging) return;
+        dragging = true;
+        markTouchSuppressClick(el);
+        proxy = el.cloneNode(true);
+        proxy.classList.add("hermes-kanban-touch-proxy");
+        document.body.appendChild(proxy);
+        proxy.style.position = "fixed";
+        proxy.style.pointerEvents = "none";
+        proxy.style.opacity = "0.85";
+        proxy.style.zIndex = "9999";
+        proxy.style.width = `${el.offsetWidth}px`;
+        proxy.style.left = `${originEvent.clientX - el.offsetWidth / 2}px`;
+        proxy.style.top = `${originEvent.clientY - 24}px`;
+      }
 
       function move(ev) {
+        const dx = ev.clientX - startX;
+        const dy = ev.clientY - startY;
+        if (!dragging) {
+          const absX = Math.abs(dx);
+          const absY = Math.abs(dy);
+          if (absY >= TOUCH_SCROLL_INTENT_PX && absY >= absX) {
+            cancelled = true;
+            markTouchSuppressClick(el);
+            cleanup();
+            return;
+          }
+          if (Math.hypot(dx, dy) > TOUCH_DRAG_SLOP_PX) {
+            cancelled = true;
+            markTouchSuppressClick(el);
+            cleanup();
+            return;
+          }
+          return;
+        }
+        if (ev.cancelable) ev.preventDefault();
         proxy.style.left = `${ev.clientX - proxy.offsetWidth / 2}px`;
         proxy.style.top = `${ev.clientY - 24}px`;
         proxy.style.display = "none";
@@ -380,12 +454,13 @@
           lastTarget = target;
         }
       }
+
       function up() {
-        document.removeEventListener("pointermove", move);
-        document.removeEventListener("pointerup", up);
-        document.removeEventListener("pointercancel", up);
+        if (!dragging) {
+          cleanup();
+          return;
+        }
         if (lastTarget) {
-          lastTarget.classList.remove("hermes-kanban-column--drop");
           const status = lastTarget.getAttribute("data-kanban-column");
           const isTrash = lastTarget.hasAttribute("data-kanban-trash");
           if (isTrash) {
@@ -400,17 +475,11 @@
             }));
           }
         }
-        proxy.remove();
+        cleanup();
       }
-      // Kick off proxy at the pointer origin.
-      proxy.style.position = "fixed";
-      proxy.style.pointerEvents = "none";
-      proxy.style.opacity = "0.85";
-      proxy.style.zIndex = "9999";
-      proxy.style.width = `${el.offsetWidth}px`;
-      proxy.style.left = `${e.clientX - el.offsetWidth / 2}px`;
-      proxy.style.top = `${e.clientY - 24}px`;
-      document.addEventListener("pointermove", move);
+
+      holdTimer = setTimeout(function () { startDrag(e); }, TOUCH_DRAG_HOLD_MS);
+      document.addEventListener("pointermove", move, { passive: false });
       document.addEventListener("pointerup", up);
       document.addEventListener("pointercancel", up);
     }
@@ -2460,6 +2529,14 @@
       }
     };
     const handleClick = function (e) {
+      if (shouldSuppressTouchClick(cardRef.current)) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+      if (e.target && e.target.closest && e.target.closest(".hermes-kanban-card-check-wrap")) {
+        return;
+      }
       if (e.shiftKey) {
         e.preventDefault();
         e.stopPropagation();

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -67,6 +67,7 @@
   gap: 0.75rem;
   align-items: start;
   overflow-x: auto;
+  padding: 0 0.1rem 0.35rem;
 }
 
 .hermes-kanban-column {
@@ -139,8 +140,20 @@
   gap: 0.45rem;
   overflow-y: auto;
   padding-right: 0.1rem;
+  padding-bottom: 0.35rem;
   flex: 1;
   min-height: 0;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--color-muted-foreground) 45%, transparent) transparent;
+}
+
+.hermes-kanban-column-body::-webkit-scrollbar {
+  width: 0.4rem;
+}
+
+.hermes-kanban-column-body::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-muted-foreground) 45%, transparent);
+  border-radius: 999px;
 }
 
 .hermes-kanban-empty {
@@ -240,6 +253,30 @@
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
+}
+
+@media (max-width: 1023px) {
+  .hermes-kanban-columns {
+    padding-bottom: 0.55rem;
+  }
+
+  .hermes-kanban-column {
+    padding: 0.55rem 0.45rem 0.75rem;
+  }
+
+  .hermes-kanban-column-body {
+    gap: 0.6rem;
+    padding-right: 0.15rem;
+    padding-bottom: 1rem;
+  }
+
+  .hermes-kanban-card {
+    touch-action: pan-y;
+  }
+
+  .hermes-kanban-card-content {
+    padding: 0.6rem 0.65rem !important;
+  }
 }
 
 .hermes-kanban-card-row {

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -247,6 +247,43 @@ def test_dashboard_initial_board_uses_backend_current_when_unpinned():
     assert 'readSelectedBoard() || "default"' not in js
 
 
+def test_dashboard_touch_drag_waits_for_long_press_and_preserves_scroll_intent():
+    """Mobile cards should scroll on swipe and only drag after a deliberate hold.
+
+    Regression for dense mobile columns where every touchable area was also an
+    immediate drag target. The bundle should keep click suppression for swipe
+    gestures and only activate drag after a long-press threshold.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert "const TOUCH_DRAG_HOLD_MS = 260;" in js
+    assert "const TOUCH_SCROLL_INTENT_PX = 12;" in js
+    assert "el.dataset.hermesKanbanSuppressClickUntil" in js
+    assert "holdTimer = setTimeout(function () { startDrag(e); }, TOUCH_DRAG_HOLD_MS);" in js
+    assert "if (absY >= TOUCH_SCROLL_INTENT_PX && absY >= absX)" in js
+    assert "if (shouldSuppressTouchClick(cardRef.current))" in js
+
+
+def test_dashboard_mobile_css_surfaces_scroll_affordance_and_pan_y_cards():
+    """Mobile CSS should leave clearer scroll gutters and allow vertical pan.
+
+    The fix should not rely purely on transient overlay scrollbars; cards need
+    `touch-action: pan-y` and columns need extra mobile breathing room.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert "scrollbar-width: thin;" in css
+    assert ".hermes-kanban-column-body::-webkit-scrollbar-thumb" in css
+    assert "@media (max-width: 1023px)" in css
+    assert "touch-action: pan-y;" in css
+    assert "padding-bottom: 1rem;" in css
+
+
 # ---------------------------------------------------------------------------
 # GET /tasks/:id returns body + comments + events + links
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make kanban card touch interactions mobile-safe by delaying touch drag activation behind a short hold
- preserve scroll intent by cancelling touch drag when the gesture becomes a vertical swipe
- suppress accidental post-swipe clicks and improve mobile scroll affordances in column/card CSS
- add regression coverage for the bundled JS/CSS behavior

## Problem
On mobile, kanban cards were both draggable and tappable from nearly the full card surface. The touch helper started drag immediately on `pointerdown` and called `preventDefault()` up front, which made normal vertical scrolling hard and could lead to accidental card-open behavior.

## Fix
- wait for a short long-press before activating touch drag
- cancel touch drag setup when the gesture becomes a vertical scroll gesture
- suppress the follow-up click after swipe/drag intent so the drawer does not open accidentally
- add mobile CSS improvements: `touch-action: pan-y`, extra bottom/gutter spacing, and clearer scrollbar styling

## Validation
### Automated
- `python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q -o 'addopts='`
  - result: `97 passed`

### Browser-based
Validated against a local dashboard instance at `http://127.0.0.1:9131/kanban` using in-page browser control scripts:
- swipe-like touch sequence over a card (`pointerdown` + vertical `pointermove`) no longer opened the drawer
- deliberate hold (>260ms) created the touch-drag proxy without opening the drawer
- the page-level evidence screenshot was captured during validation

## Notes
The kanban plugin in this checkout appears to be committed as built bundle assets under `plugins/kanban/dashboard/dist/`, so this PR patches the shipped bundle directly and adds regression tests that assert on those bundle artifacts.
