### PR TITLE
Add BurnBar gateway platform plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -363,6 +363,14 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # EMAIL_ALLOWED_USERS=your@email.com
 # EMAIL_HOME_ADDRESS=your@email.com
 
+# BurnBar Cloud (Hermes Gateway API — configured by `hermes gateway setup`)
+# BURNBAR_ACCESS_TOKEN=                  # Device-code bearer token
+# BURNBAR_API_BASE_URL=https://api.burnbar.ai/v1/hermes-gateway
+# BURNBAR_HOME_CHANNEL=                  # Default BurnBar destination for cron delivery
+# BURNBAR_HOME_CHANNEL_NAME=             # Display name for the home destination
+# BURNBAR_ALLOWED_USERS=                 # Comma-separated BurnBar sender IDs
+# BURNBAR_ALLOW_ALL_USERS=false          # Only set true for a trusted account/workspace
+
 # Gateway-wide: allow ALL users without an allowlist (default: false = deny)
 # Only set to true if you intentionally want open access.
 # GATEWAY_ALLOW_ALL_USERS=false

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -158,6 +158,14 @@ class PlatformEntry:
     # targets when the gateway is not co-resident with the cron process.
     standalone_sender_fn: Optional[Callable[..., Awaitable[dict]]] = None
 
+    # True only when the standalone sender is a first-class media path.
+    #
+    # ``standalone_sender_fn`` by itself means "can send out-of-process text",
+    # usually for cron delivery. Some plugins accept ``media_files`` only for
+    # signature parity and ignore them, so send_message must not treat the
+    # hook's existence as attachment support.
+    supports_standalone_media: bool = False
+
 
 class PlatformRegistry:
     """Central registry of platform adapters.

--- a/plugins/platforms/burnbar/README.md
+++ b/plugins/platforms/burnbar/README.md
@@ -1,0 +1,56 @@
+# BurnBar Cloud platform plugin
+
+This plugin adds BurnBar Cloud as a Hermes messaging platform. It is a
+gateway adapter only: messages, attachments, approvals, and runtime state flow
+through the BurnBar Hermes Gateway API; this first platform-plugin layer does
+not add end-to-end encryption.
+
+- device-code setup against BurnBar's Hermes Gateway API
+- human-in-the-loop oversight (supervised / autonomous gating of slash-confirms)
+- runtime status / model-catalog publication for the BurnBar model picker
+- event polling with durable cursor persistence
+- Hermes replies through `/messages`
+- typing state through `/typing`
+- native attachment delivery through `/attachments/init`
+- standalone cron delivery with `deliver=burnbar`
+
+## Configuration
+
+`hermes gateway setup` writes these values after the device-code flow:
+
+- `BURNBAR_API_BASE_URL` - gateway base URL.
+- `BURNBAR_ACCESS_TOKEN` - scoped bearer token from the approved device grant.
+- `BURNBAR_HOME_CHANNEL` - default BurnBar destination for cron and notification delivery.
+- `BURNBAR_ALLOW_ALL_USERS` / `BURNBAR_ALLOWED_USERS` - sender allowlist controls.
+
+## Setup
+
+```bash
+hermes gateway setup
+hermes gateway restart
+hermes gateway status
+```
+
+Choose `BurnBar Cloud`, approve the displayed device code in BurnBar, then
+restart the gateway and send a message from BurnBar. To point the adapter at a
+non-default gateway, set `BURNBAR_API_BASE_URL` before running setup.
+
+## Tests
+
+The plugin ships a deterministic, dependency-light test suite that loads the
+adapter via `tests/gateway/_plugin_adapter_loader.load_plugin_adapter("burnbar")`
+(no `sys.path` tricks — the `tests/gateway/conftest.py` guard enforces this):
+
+```bash
+scripts/run_tests.sh tests/gateway/test_burnbar_plugin.py
+```
+
+It exercises:
+
+- plugin registration + `Platform("burnbar")` dynamic resolution
+- config / env-enablement / yaml-precedence
+- `/events` mapping to `MessageEvent` and `model_switch`
+- `/messages` send happy path + error → `SendResult(success=False)`
+- `/attachments/init` + signed upload
+- cursor round-trip
+- oversight (`/state`) refresh + autonomous auto-approve, runtime-status payload

--- a/plugins/platforms/burnbar/__init__.py
+++ b/plugins/platforms/burnbar/__init__.py
@@ -1,0 +1,7 @@
+def register(ctx):
+    """Register the BurnBar platform plugin."""
+    from .adapter import register as _register
+
+    return _register(ctx)
+
+__all__ = ["register"]

--- a/plugins/platforms/burnbar/adapter.py
+++ b/plugins/platforms/burnbar/adapter.py
@@ -1,0 +1,1030 @@
+"""BurnBar Cloud platform adapter for Hermes Agent.
+
+The adapter uses the BurnBar Hermes Gateway API:
+
+    https://api.burnbar.ai/v1/hermes-gateway
+
+It intentionally depends only on ``httpx``, already present in Hermes core.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import mimetypes
+import os
+import re
+import secrets
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_constants import display_hermes_home, get_hermes_home
+
+try:
+    import httpx
+
+    HTTPX_AVAILABLE = True
+except ImportError:  # pragma: no cover - Hermes installs httpx in core.
+    HTTPX_AVAILABLE = False
+    httpx = None  # type: ignore[assignment]
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_BASE_URL = "https://api.burnbar.ai/v1/hermes-gateway"
+DEFAULT_HOME_CHANNEL = "burnbar:home"
+MAX_MESSAGE_LENGTH = 64000
+CURSOR_FILE = Path(
+    os.getenv("HERMES_BURNBAR_CURSOR_FILE", str(get_hermes_home() / "cache" / "burnbar_cursor.json"))
+).expanduser()
+MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024
+MAX_RUNTIME_MODELS = 100
+RUNTIME_STATUS_INTERVAL_SECONDS = 30.0
+# How often to refresh the human-in-the-loop oversight toggle from /state.
+OVERSIGHT_REFRESH_SECONDS = 15.0
+_SAFE_MODEL_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,179}$")
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"\b(access[_-]?token|api[_-]?key|auth[_-]?token|device[_-]?secret|signature|sig|token)\s*=\s*([^\s,;&]+)",
+    re.IGNORECASE,
+)
+_SECRET_JSON_RE = re.compile(
+    r'("(?:accessToken|deviceSecret|uploadURL|token)"\s*:\s*")[^"]+(")',
+    re.IGNORECASE,
+)
+_BEARER_RE = re.compile(r"\bBearer\s+[^,\s]+", re.IGNORECASE)
+_URL_RE = re.compile(r"https?://[^\s'\"<>]+")
+
+
+def _is_safe_model_id(model_id: str) -> bool:
+    """True for model ids that are safe to interpolate into ``/model <id>``.
+
+    Rejects empty ids, ids outside the conservative character class
+    (``_SAFE_MODEL_ID``), and — critically — any id containing a ``--`` run.
+    The double-dash guard matters because the ``/model`` slash parser
+    (:func:`hermes_cli.model_switch.parse_model_flags`) matches ``--global`` and
+    ``--refresh`` as *substrings* rather than whitespace-delimited tokens, so a
+    no-whitespace id such as ``sonnet--global`` would otherwise pass the
+    character class yet smuggle a persistent global-config flag into the slash
+    command. Real model ids never contain consecutive dashes, so this rejects
+    nothing legitimate.
+    """
+    if not model_id or "--" in model_id:
+        return False
+    return bool(_SAFE_MODEL_ID.fullmatch(model_id))
+
+
+def _safe_exception_message(exc: BaseException) -> str:
+    """Return a concise error string without bearer tokens or signed URLs."""
+    text = str(exc) or exc.__class__.__name__
+    text = _SECRET_JSON_RE.sub(r"\1[redacted]\2", text)
+    text = _SECRET_ASSIGNMENT_RE.sub(lambda m: f"{m.group(1)}=[redacted]", text)
+    text = _BEARER_RE.sub("Bearer [redacted]", text)
+    text = _URL_RE.sub("[redacted-url]", text)
+    return text[:500]
+
+
+def _agent_version() -> str:
+    """Best-effort Hermes Agent build string for truthful gateway-version display.
+
+    Reads the installed hermes_agent/hermes_cli version when available; falls back
+    to an env override or empty (the server simply omits the version then).
+    """
+    override = os.getenv("HERMES_BURNBAR_AGENT_VERSION")
+    if override:
+        return override[:120]
+    for module_name in ("hermes_agent", "hermes_cli", "hermes"):
+        try:
+            from importlib import metadata as _metadata
+
+            return f"{module_name}/{_metadata.version(module_name)}"[:120]
+        except Exception:
+            continue
+    return ""
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _api_base(config: PlatformConfig | None = None) -> str:
+    extra = getattr(config, "extra", {}) or {}
+    return (extra.get("api_base_url") or os.getenv("BURNBAR_API_BASE_URL") or DEFAULT_API_BASE_URL).rstrip("/")
+
+
+def _access_token(config: PlatformConfig | None = None) -> str:
+    extra = getattr(config, "extra", {}) or {}
+    return (extra.get("access_token") or os.getenv("BURNBAR_ACCESS_TOKEN") or "").strip()
+
+
+def _home_channel(config: PlatformConfig | None = None) -> str:
+    extra = getattr(config, "extra", {}) or {}
+    return (extra.get("home_channel") or os.getenv("BURNBAR_HOME_CHANNEL") or DEFAULT_HOME_CHANNEL).strip()
+
+
+def check_requirements() -> bool:
+    return HTTPX_AVAILABLE and bool(_access_token())
+
+
+def validate_config(config: PlatformConfig) -> bool:
+    return bool(_access_token(config))
+
+
+def is_connected(config: PlatformConfig) -> bool:
+    return bool(_access_token(config))
+
+
+def _home_channel_payload(config: PlatformConfig | None = None) -> dict:
+    home = _home_channel(config)
+    return {"chat_id": home, "name": os.getenv("BURNBAR_HOME_CHANNEL_NAME") or "BurnBar Home"}
+
+
+def _env_enablement() -> Optional[dict]:
+    token = _access_token()
+    if not token:
+        return None
+    return {
+        "api_base_url": _api_base(),
+        "access_token": token,
+        "home_channel": _home_channel_payload(),
+    }
+
+
+def _headers(token: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": "hermes-agent-burnbar-platform/1.0",
+    }
+
+
+def _read_cursor() -> int:
+    try:
+        data = json.loads(CURSOR_FILE.read_text())
+        value = int(data.get("cursor", 0))
+        return value if value > 0 else 0
+    except Exception:
+        return 0
+
+
+def _write_cursor(cursor: int) -> None:
+    CURSOR_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CURSOR_FILE.write_text(json.dumps({"cursor": cursor}))
+
+
+def _guess_content_type(path: Path) -> str:
+    return mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+
+
+async def _init_attachment(
+    client: "httpx.AsyncClient",
+    *,
+    api_base: str,
+    token: str,
+    destination_id: str,
+    file_path: Path,
+    content_type: str,
+) -> tuple[str, str]:
+    byte_count = file_path.stat().st_size
+    if byte_count < 1:
+        raise ValueError(f"{file_path} is empty")
+    if byte_count > MAX_ATTACHMENT_BYTES:
+        raise ValueError(f"{file_path} exceeds BurnBar's {MAX_ATTACHMENT_BYTES} byte attachment limit")
+
+    response = await client.post(
+        f"{api_base}/attachments/init",
+        headers=_headers(token),
+        json={
+            "destinationId": destination_id,
+            "fileName": file_path.name,
+            "contentType": content_type,
+            "byteCount": byte_count,
+        },
+    )
+    response.raise_for_status()
+    payload = response.json()
+    attachment = payload.get("attachment") or {}
+    attachment_id = attachment.get("id")
+    upload_url = payload.get("uploadURL")
+    if not attachment_id or not upload_url:
+        raise RuntimeError("BurnBar attachment init response was missing attachment.id or uploadURL")
+    return str(attachment_id), str(upload_url)
+
+
+async def _upload_attachment(
+    client: "httpx.AsyncClient",
+    *,
+    upload_url: str,
+    file_path: Path,
+    content_type: str,
+) -> None:
+    data = file_path.read_bytes()
+    response = await client.put(upload_url, content=data, headers={"Content-Type": content_type})
+    response.raise_for_status()
+
+
+async def _create_attachments(
+    client: "httpx.AsyncClient",
+    *,
+    api_base: str,
+    token: str,
+    destination_id: str,
+    media_files: list | None,
+) -> list[str]:
+    attachment_ids: list[str] = []
+    for item in media_files or []:
+        raw_path = item[0] if isinstance(item, (tuple, list)) else item
+        file_path = Path(str(raw_path)).expanduser()
+        if not file_path.is_file():
+            raise FileNotFoundError(f"Attachment not found: {file_path}")
+        content_type = _guess_content_type(file_path)
+        attachment_id, upload_url = await _init_attachment(
+            client,
+            api_base=api_base,
+            token=token,
+            destination_id=destination_id,
+            file_path=file_path,
+            content_type=content_type,
+        )
+        await _upload_attachment(client, upload_url=upload_url, file_path=file_path, content_type=content_type)
+        attachment_ids.append(attachment_id)
+    return attachment_ids
+
+
+async def _post_message(
+    client: "httpx.AsyncClient",
+    *,
+    api_base: str,
+    token: str,
+    destination_id: str,
+    text: str,
+    thread_id: str | None = None,
+    reply_to: str | None = None,
+    attachment_ids: list[str] | None = None,
+) -> dict:
+    response = await client.post(
+        f"{api_base}/messages",
+        headers=_headers(token),
+        json={
+            "destinationId": destination_id,
+            "threadId": thread_id,
+            "replyToEventId": reply_to,
+            "text": text[:MAX_MESSAGE_LENGTH],
+            "attachmentIds": attachment_ids or [],
+        },
+    )
+    response.raise_for_status()
+    return response.json().get("message", {})
+
+
+def _runtime_status_payload() -> dict:
+    """Build a compact current-model/catalog status payload for BurnBar.
+
+    The gateway adapter sits inside Hermes Agent, so it can reuse Hermes'
+    own curated model inventory instead of inventing a second catalog. If the
+    local checkout is older or inventory probing fails, the adapter still
+    works as a messaging platform; it just skips catalog publication.
+    """
+    try:
+        from hermes_cli.inventory import build_models_payload, load_picker_context
+
+        payload = build_models_payload(load_picker_context(), max_models=MAX_RUNTIME_MODELS)
+    except Exception:
+        logger.debug("[%s] Could not build Hermes model inventory", "burnbar", exc_info=True)
+        return {}
+
+    options: list[dict[str, str]] = []
+    for provider in payload.get("providers") or []:
+        if not isinstance(provider, dict):
+            continue
+        provider_id = str(provider.get("slug") or provider.get("provider") or "hermes").strip() or "hermes"
+        provider_name = str(provider.get("label") or provider.get("name") or provider_id).strip() or provider_id
+        for model in provider.get("models") or []:
+            if isinstance(model, dict):
+                model_id = str(model.get("id") or model.get("model") or model.get("name") or "").strip()
+                display_name = str(model.get("display_name") or model.get("displayName") or model_id).strip()
+            else:
+                model_id = str(model or "").strip()
+                display_name = model_id
+            if not model_id:
+                continue
+            options.append(
+                {
+                    "providerId": provider_id[:80],
+                    "providerName": provider_name[:120],
+                    "modelId": model_id[:180],
+                    "displayName": (display_name or model_id)[:180],
+                }
+            )
+            if len(options) >= MAX_RUNTIME_MODELS:
+                break
+        if len(options) >= MAX_RUNTIME_MODELS:
+            break
+
+    current_model = str(payload.get("model") or "").strip()
+    current_provider = str(payload.get("provider") or "").strip()
+    body: dict[str, object] = {"modelOptions": options}
+    if current_model:
+        body["currentModelId"] = current_model[:180]
+    if current_provider:
+        body["currentProviderId"] = current_provider[:80]
+    agent_version = _agent_version()
+    if agent_version:
+        body["agentVersion"] = agent_version
+    return body
+
+
+class BurnBarAdapter(BasePlatformAdapter):
+    """BurnBar Cloud adapter backed by the BurnBar Hermes Gateway API."""
+
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config=config, platform=Platform("burnbar"))
+        self._api_base = _api_base(config)
+        self._token = _access_token(config)
+        self._home_channel = _home_channel(config)
+        self._client: Optional["httpx.AsyncClient"] = None
+        self._poll_task: Optional[asyncio.Task] = None
+        self._cursor = _read_cursor()
+        self._last_runtime_publish = 0.0
+        # Human-in-the-loop oversight. The toggle lives on the server (the phone
+        # sets it); the adapter mirrors it here and obeys it. Default is the safe
+        # option (supervised) until /state says otherwise.
+        self._oversight_mode = "supervised"
+        self._oversight_checked_at = 0.0
+        # Armed approval gates awaiting a phone decision: actionId -> context.
+        self._pending_confirms: Dict[str, Dict[str, Any]] = {}
+
+    async def connect(self) -> bool:
+        if not HTTPX_AVAILABLE:
+            logger.warning("[%s] httpx is unavailable", self.name)
+            return False
+        if not self._token:
+            logger.warning("[%s] BURNBAR_ACCESS_TOKEN is not configured", self.name)
+            return False
+        # A send path (e.g. _send_local_file) may have lazily created a client
+        # before connect(); close it first so reconnects don't leak sockets.
+        if self._client is not None:
+            await self._client.aclose()
+        self._client = httpx.AsyncClient(timeout=30)
+        try:
+            response = await self._client.get(f"{self._api_base}/destinations", headers=_headers(self._token))
+            response.raise_for_status()
+        except Exception as exc:
+            logger.warning("[%s] BurnBar connection check failed: %s", self.name, _safe_exception_message(exc))
+            await self.disconnect()
+            return False
+        await self._publish_runtime_status(force=True)
+        self._poll_task = asyncio.create_task(self._poll_loop())
+        self._mark_connected()
+        logger.info("[%s] Connected to BurnBar Cloud", self.name)
+        return True
+
+    async def disconnect(self) -> None:
+        if self._poll_task:
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+        self._poll_task = None
+        if self._client:
+            await self._client.aclose()
+        self._client = None
+        self._mark_disconnected()
+
+    async def _poll_loop(self) -> None:
+        backoff = 1.0
+        while self._running:
+            try:
+                await self._poll_once()
+                backoff = 1.0
+                await asyncio.sleep(1.0)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("[%s] BurnBar event poll failed: %s", self.name, exc)
+                await asyncio.sleep(backoff)
+                backoff = min(30.0, backoff * 2)
+
+    async def _poll_once(self) -> None:
+        assert self._client is not None
+        await self._publish_runtime_status()
+        await self._refresh_oversight_mode()
+        # Resolve any oversight gates the phone has decided since the last poll.
+        if self._pending_confirms:
+            await self._resolve_pending_confirms()
+        response = await self._client.get(
+            f"{self._api_base}/events",
+            headers=_headers(self._token),
+            params={"cursor": str(self._cursor), "limit": "50"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        for raw in payload.get("events", []):
+            # Isolate each event: one malformed/poison event must not abort the
+            # batch (which would leave the cursor unadvanced and replay the whole
+            # page forever). Log and skip it; siblings still process and the
+            # cursor advances past it below.
+            try:
+                await self._handle_burnbar_event(raw)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "[%s] dropped malformed BurnBar event %r",
+                    self.name,
+                    raw.get("id") if isinstance(raw, dict) else None,
+                    exc_info=True,
+                )
+        next_cursor = int(payload.get("nextCursor") or self._cursor)
+        if next_cursor > self._cursor:
+            self._cursor = next_cursor
+            _write_cursor(self._cursor)
+
+    async def _handle_burnbar_event(self, raw: dict) -> None:
+        is_model_switch = raw.get("kind") == "model_switch"
+        if is_model_switch:
+            model_id = str(raw.get("modelId") or "").strip()
+            if not _is_safe_model_id(model_id):
+                logger.warning("[%s] dropped model_switch with unsafe modelId %r", self.name, model_id)
+                return
+            text = f"/model {model_id}".strip()
+        else:
+            text = str(raw.get("text") or "").strip()
+        if not text:
+            return
+        destination_id = str(raw.get("destinationId") or self._home_channel)
+        sender_id = str(raw.get("senderId") or "burnbar-user")
+        source = self.build_source(
+            chat_id=destination_id,
+            chat_name=destination_id,
+            chat_type="dm",
+            user_id=sender_id,
+            user_name=raw.get("senderDisplayName") or sender_id,
+            thread_id=raw.get("threadId"),
+            message_id=raw.get("id"),
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=raw,
+            message_id=raw.get("id"),
+        )
+        await self.handle_message(event)
+        if is_model_switch:
+            # Republish immediately so the server reflects the newly applied model
+            # in ~1s instead of waiting out the 30s heartbeat. Also reset the
+            # throttle so the next poll re-confirms once Hermes has fully applied.
+            self._last_runtime_publish = 0.0
+            await self._publish_runtime_status(force=True)
+
+    async def _publish_runtime_status(self, *, force: bool = False) -> None:
+        if self._client is None:
+            return
+        now = time.monotonic()
+        if not force and now - self._last_runtime_publish < RUNTIME_STATUS_INTERVAL_SECONDS:
+            return
+        body = _runtime_status_payload()
+        if not body:
+            self._last_runtime_publish = now
+            return
+        try:
+            response = await self._client.post(
+                f"{self._api_base}/runtime",
+                headers=_headers(self._token),
+                json=body,
+            )
+            response.raise_for_status()
+            self._last_runtime_publish = now
+        except Exception:
+            logger.debug("[%s] BurnBar runtime status publish failed", self.name, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Human-in-the-loop oversight
+    # ------------------------------------------------------------------
+    async def _refresh_oversight_mode(self) -> None:
+        """Mirror the server-owned oversight toggle (the phone sets it)."""
+        if self._client is None:
+            return
+        now = time.monotonic()
+        if now - self._oversight_checked_at < OVERSIGHT_REFRESH_SECONDS:
+            return
+        self._oversight_checked_at = now
+        try:
+            response = await self._client.get(f"{self._api_base}/state", headers=_headers(self._token))
+            response.raise_for_status()
+            mode = str(response.json().get("oversightMode") or "").strip()
+            if mode in ("supervised", "autonomous"):
+                self._oversight_mode = mode
+        except Exception:
+            logger.debug("[%s] BurnBar oversight refresh failed", self.name, exc_info=True)
+
+    async def send_slash_confirm(
+        self,
+        chat_id: str,
+        title: str,
+        message: str,
+        session_key: str,
+        confirm_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Gate Hermes slash-confirm prompts through BurnBar oversight.
+
+        Autonomous mode auto-approves so the agent runs unattended. Supervised
+        mode arms an approval gate on the BurnBar gateway and surfaces it to the
+        phone; the decision is applied from the poll loop via
+        ``tools.slash_confirm.resolve``. If the gateway is unreachable while
+        supervised, we fall back to Hermes' built-in text confirm (which still
+        requires an explicit ``/approve``) rather than silently proceeding.
+        """
+        if self._client is None:
+            return SendResult(success=False, error="Not connected")
+        if self._oversight_mode == "autonomous":
+            await self._resolve_slash_confirm(session_key, confirm_id, "once", chat_id, metadata)
+            return SendResult(success=True)
+        armed = await self._arm_approval(
+            action_id=confirm_id, summary=message, tool_name=title, destination_id=chat_id
+        )
+        if not armed:
+            return await super().send_slash_confirm(
+                chat_id, title, message, session_key, confirm_id, metadata
+            )
+        self._pending_confirms[confirm_id] = {
+            "session_key": session_key,
+            "chat_id": chat_id,
+            "metadata": metadata,
+        }
+        card = f"{title}\n\n{message}\n\nApprove this action on your BurnBar device to continue."
+        await self._post_confirm_followup(chat_id, card, metadata)
+        return SendResult(success=True)
+
+    async def _arm_approval(
+        self, *, action_id: str, summary: str, tool_name: str, destination_id: str
+    ) -> bool:
+        if self._client is None:
+            return False
+        body: Dict[str, Any] = {"actionId": action_id, "summary": summary}
+        if tool_name:
+            body["toolName"] = tool_name
+        if destination_id:
+            body["destinationId"] = destination_id
+        try:
+            response = await self._client.post(
+                f"{self._api_base}/approvals", headers=_headers(self._token), json=body
+            )
+            response.raise_for_status()
+            return True
+        except Exception:
+            logger.debug("[%s] BurnBar approval arm failed", self.name, exc_info=True)
+            return False
+
+    async def _resolve_pending_confirms(self) -> None:
+        if self._client is None:
+            return
+        for action_id, ctx in list(self._pending_confirms.items()):
+            try:
+                response = await self._client.get(
+                    f"{self._api_base}/approvals",
+                    headers=_headers(self._token),
+                    params={"actionId": action_id},
+                )
+                if response.status_code == 404:
+                    logger.debug(
+                        "[%s] BurnBar approval %s not found while polling; retaining pending confirm",
+                        self.name,
+                        action_id,
+                    )
+                    continue
+                response.raise_for_status()
+                status = str((response.json().get("approval") or {}).get("status") or "").strip()
+            except Exception:
+                logger.debug("[%s] BurnBar approval poll failed", self.name, exc_info=True)
+                continue
+            if status == "waiting_for_approval":
+                continue
+            self._pending_confirms.pop(action_id, None)
+            choice = "once" if status == "approved" else "cancel"
+            fallback = None
+            if status == "rejected":
+                fallback = "Action denied from your BurnBar device."
+            elif status == "expired":
+                fallback = "Approval request expired without a decision."
+            await self._resolve_slash_confirm(
+                ctx["session_key"], action_id, choice, ctx.get("chat_id"), ctx.get("metadata"), fallback
+            )
+
+    async def _resolve_slash_confirm(
+        self,
+        session_key: str,
+        confirm_id: str,
+        choice: str,
+        chat_id: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+        fallback: Optional[str] = None,
+    ) -> None:
+        output: Optional[str] = None
+        try:
+            from tools import slash_confirm as _slash_confirm
+
+            output = await _slash_confirm.resolve(session_key, confirm_id, choice)
+        except Exception:
+            logger.debug("[%s] slash-confirm resolve failed", self.name, exc_info=True)
+        message = output or fallback
+        if message and chat_id:
+            await self._post_confirm_followup(chat_id, message, metadata)
+
+    async def _post_confirm_followup(
+        self, chat_id: Optional[str], text: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        if self._client is None or not text:
+            return
+        try:
+            await self._client.post(
+                f"{self._api_base}/messages",
+                headers=_headers(self._token),
+                json={
+                    "destinationId": chat_id or self._home_channel,
+                    "text": str(text)[:MAX_MESSAGE_LENGTH],
+                },
+            )
+        except Exception:
+            logger.debug("[%s] BurnBar confirm follow-up post failed", self.name, exc_info=True)
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=30)
+        destination_id = chat_id or self._home_channel
+        try:
+            message = await _post_message(
+                self._client,
+                api_base=self._api_base,
+                token=self._token,
+                destination_id=destination_id,
+                text=content,
+                thread_id=(metadata or {}).get("thread_id"),
+                reply_to=reply_to,
+            )
+            return SendResult(success=True, message_id=message.get("id"))
+        except Exception as exc:
+            error = _safe_exception_message(exc)
+            logger.warning("[%s] BurnBar send failed: %s", self.name, error)
+            return SendResult(success=False, error=error)
+
+    async def _send_local_file(
+        self,
+        chat_id: str,
+        file_path: str,
+        *,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=30)
+        destination_id = chat_id or self._home_channel
+        try:
+            attachment_ids = await _create_attachments(
+                self._client,
+                api_base=self._api_base,
+                token=self._token,
+                destination_id=destination_id,
+                media_files=[file_path],
+            )
+            message = await _post_message(
+                self._client,
+                api_base=self._api_base,
+                token=self._token,
+                destination_id=destination_id,
+                text=caption or "",
+                thread_id=(metadata or {}).get("thread_id"),
+                reply_to=reply_to,
+                attachment_ids=attachment_ids,
+            )
+            return SendResult(success=True, message_id=message.get("id"))
+        except Exception as exc:
+            error = _safe_exception_message(exc)
+            logger.warning("[%s] BurnBar attachment send failed: %s", self.name, error)
+            return SendResult(success=False, error=error)
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_file(chat_id, file_path, caption=caption, reply_to=reply_to, metadata=metadata)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_file(chat_id, image_path, caption=caption, reply_to=reply_to, metadata=metadata)
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_file(chat_id, audio_path, caption=caption, reply_to=reply_to, metadata=metadata)
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_file(chat_id, video_path, caption=caption, reply_to=reply_to, metadata=metadata)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=15)
+        try:
+            await self._client.post(
+                f"{self._api_base}/typing",
+                headers=_headers(self._token),
+                json={"destinationId": chat_id or self._home_channel, "threadId": (metadata or {}).get("thread_id")},
+            )
+        except Exception:
+            logger.debug("[%s] BurnBar typing failed", self.name, exc_info=True)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"chat_id": chat_id, "name": chat_id or "BurnBar Home", "type": "dm"}
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id,
+    message,
+    *,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+) -> dict:
+    if not HTTPX_AVAILABLE:
+        return {"error": "httpx is not available"}
+    token = _access_token(pconfig)
+    if not token:
+        return {"error": "BURNBAR_ACCESS_TOKEN is not configured"}
+    destination_id = chat_id or _home_channel(pconfig)
+    async with httpx.AsyncClient(timeout=30) as client:
+        try:
+            attachment_ids = await _create_attachments(
+                client,
+                api_base=_api_base(pconfig),
+                token=token,
+                destination_id=destination_id,
+                media_files=media_files,
+            )
+            posted = await _post_message(
+                client,
+                api_base=_api_base(pconfig),
+                token=token,
+                destination_id=destination_id,
+                thread_id=thread_id,
+                text=message,
+                attachment_ids=attachment_ids,
+            )
+        except Exception as exc:
+            return {"error": f"BurnBar standalone send failed: {_safe_exception_message(exc)}"}
+        return {
+            "success": True,
+            "platform": "burnbar",
+            "chat_id": destination_id,
+            "message_id": posted.get("id"),
+            "attachment_ids": attachment_ids,
+        }
+
+
+def _apply_yaml_config(yaml_cfg: dict, platform_cfg: dict) -> Optional[dict]:
+    """Translate BurnBar's config.yaml keys into PlatformConfig.extra.
+
+    Environment variables still win; this hook only lets users configure
+    BurnBar in structured YAML without core Hermes knowing BurnBar-specific
+    field names.
+    """
+    extra = dict(platform_cfg.get("extra") or {})
+    for yaml_key, env_key, extra_key in (
+        ("api_base_url", "BURNBAR_API_BASE_URL", "api_base_url"),
+        ("access_token", "BURNBAR_ACCESS_TOKEN", "access_token"),
+        ("home_channel", "BURNBAR_HOME_CHANNEL", "home_channel"),
+    ):
+        value = yaml_cfg.get(yaml_key)
+        if value is None:
+            continue
+        value = str(value).strip()
+        if not value:
+            continue
+        extra[extra_key] = value
+        os.environ.setdefault(env_key, value)
+    return extra or None
+
+
+def _poll_device_authorization(
+    api_base: str,
+    device_code: str,
+    device_secret: str,
+    interval: int,
+    timeout_seconds: float = 600.0,
+) -> dict:
+    # Bound the wait so `hermes gateway setup` cannot hang forever on a stuck
+    # `pending` if the server never reports denied/expired. The deadline tracks the
+    # grant's own `expiresIn` (capped at a sane default by the caller).
+    deadline = time.monotonic() + max(1.0, timeout_seconds)
+    with httpx.Client(timeout=30) as client:
+        while True:
+            poll = client.post(
+                f"{api_base}/device/poll",
+                json={"deviceCode": device_code, "deviceSecret": device_secret},
+            )
+            poll.raise_for_status()
+            status = poll.json()
+            if status.get("status") == "approved":
+                return status
+            if status.get("status") in {"denied", "expired"}:
+                raise RuntimeError(f"BurnBar link {status['status']}")
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    "BurnBar link approval timed out; re-run `hermes gateway setup` and "
+                    "approve the device code in BurnBar before it expires"
+                )
+            time.sleep(interval)
+
+
+def _configure_interactive_access_control(
+    *,
+    get_env_value,
+    print_info,
+    print_success,
+    print_warning,
+    prompt,
+    prompt_yes_no,
+    save_env_value,
+) -> None:
+    if get_env_value("BURNBAR_ALLOWED_USERS") or get_env_value("BURNBAR_ALLOW_ALL_USERS"):
+        return
+
+    print()
+    print_info("Access control")
+    print_info("BurnBar senders are denied unless you configure an allowlist or explicitly allow all.")
+    allow_all = prompt_yes_no(
+        "Allow every BurnBar sender in this workspace to talk to Hermes?",
+        False,
+    )
+    if allow_all:
+        save_env_value("BURNBAR_ALLOW_ALL_USERS", "true")
+        save_env_value("BURNBAR_ALLOWED_USERS", "")
+        print_warning(
+            "Open access enabled for BurnBar. Any sender in the connected workspace can command Hermes."
+        )
+        return
+
+    save_env_value("BURNBAR_ALLOW_ALL_USERS", "false")
+    allowed = prompt(
+        "Allowed BurnBar sender IDs (comma-separated, leave empty to deny everyone)",
+        default="",
+    )
+    allowed_ids = ",".join(part.strip() for part in allowed.split(",") if part.strip())
+    if allowed_ids:
+        save_env_value("BURNBAR_ALLOWED_USERS", allowed_ids)
+        print_success("BurnBar sender allowlist configured.")
+    else:
+        print_warning(
+            "No BurnBar sender allowlist configured. Unknown BurnBar senders will be denied "
+            "until BURNBAR_ALLOWED_USERS is set or BURNBAR_ALLOW_ALL_USERS=true is selected."
+        )
+
+
+def interactive_setup() -> None:
+    """Device-code setup helper for ``hermes gateway setup``."""
+    from hermes_cli.setup import (
+        get_env_value,
+        print_header,
+        print_info,
+        print_success,
+        print_warning,
+        prompt,
+        prompt_yes_no,
+        save_env_value,
+    )
+
+    print_header("BurnBar Cloud")
+    existing_token = get_env_value("BURNBAR_ACCESS_TOKEN")
+    if existing_token:
+        print_info("BurnBar Cloud is already configured.")
+        if not prompt_yes_no("Reconfigure BurnBar Cloud?", False):
+            return
+
+    api_base = (
+        prompt(
+            "BurnBar Hermes Gateway API base URL",
+            default=get_env_value("BURNBAR_API_BASE_URL") or DEFAULT_API_BASE_URL,
+        ).strip()
+        or DEFAULT_API_BASE_URL
+    ).rstrip("/")
+
+    device_secret = secrets.token_urlsafe(32)
+    payload = {
+        "clientName": "Hermes Agent",
+        "deviceSecretHash": _sha256(device_secret),
+        "scopes": ["hermes.gateway.read", "hermes.gateway.write", "hermes.gateway.manage"],
+    }
+    try:
+        with httpx.Client(timeout=30) as client:
+            start = client.post(f"{api_base}/device/start", json=payload)
+            start.raise_for_status()
+            body = start.json()
+    except Exception as exc:
+        print_warning(f"Could not start BurnBar device authorization: {exc}")
+        return
+
+    print()
+    print_info("Open BurnBar, sign in, and approve this code:")
+    print_info(f"  {body['userCode']}")
+    print_info(f"  {body['verificationUriComplete']}")
+    print_info("Waiting for approval...")
+
+    try:
+        approved = _poll_device_authorization(
+            api_base,
+            body["deviceCode"],
+            device_secret,
+            int(body.get("interval", 3)),
+            timeout_seconds=float(body.get("expiresIn", 600)),
+        )
+    except Exception as exc:
+        print_warning(f"BurnBar authorization failed: {exc}")
+        return
+
+    save_env_value("BURNBAR_API_BASE_URL", api_base)
+    save_env_value("BURNBAR_ACCESS_TOKEN", approved["accessToken"])
+    save_env_value("BURNBAR_HOME_CHANNEL", approved.get("homeDestinationId") or DEFAULT_HOME_CHANNEL)
+    _configure_interactive_access_control(
+        get_env_value=get_env_value,
+        print_info=print_info,
+        print_success=print_success,
+        print_warning=print_warning,
+        prompt=prompt,
+        prompt_yes_no=prompt_yes_no,
+        save_env_value=save_env_value,
+    )
+    print_success(f"BurnBar Cloud configuration saved to {display_hermes_home()}/.env")
+    print_info("Restart the gateway for changes to take effect: hermes gateway restart")
+
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="burnbar",
+        label="BurnBar Cloud",
+        adapter_factory=lambda cfg: BurnBarAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["BURNBAR_ACCESS_TOKEN"],
+        install_hint="Configure from BurnBar Cloud with `hermes gateway setup`.",
+        setup_fn=interactive_setup,
+        env_enablement_fn=_env_enablement,
+        apply_yaml_config_fn=_apply_yaml_config,
+        allowed_users_env="BURNBAR_ALLOWED_USERS",
+        allow_all_env="BURNBAR_ALLOW_ALL_USERS",
+        cron_deliver_env_var="BURNBAR_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        supports_standalone_media=True,
+        max_message_length=MAX_MESSAGE_LENGTH,
+        emoji="🔥",
+        platform_hint=(
+            "You are speaking through BurnBar Cloud. Keep replies concise, "
+            "mobile-friendly, and explicit about completed actions. Use plain "
+            "Markdown that renders cleanly in compact app chat surfaces."
+        ),
+        allow_update_command=True,
+    )

--- a/plugins/platforms/burnbar/plugin.yaml
+++ b/plugins/platforms/burnbar/plugin.yaml
@@ -1,0 +1,36 @@
+name: burnbar-platform
+label: BurnBar Cloud
+kind: platform
+version: 1.0.0
+description: >
+  BurnBar Cloud gateway adapter for Hermes Agent. Connects Hermes to BurnBar
+  Cloud through the BurnBar Hermes Gateway API, using device-code auth, scoped
+  bearer tokens, event polling with durable cursor persistence, typing state,
+  message delivery, and signed attachment upload initiation.
+author: BurnBar contributors
+requires_env:
+  - name: BURNBAR_ACCESS_TOKEN
+    description: "BurnBar Hermes Gateway bearer token from the device-code setup flow"
+    prompt: "BurnBar access token"
+    password: true
+optional_env:
+  - name: BURNBAR_API_BASE_URL
+    description: "BurnBar Hermes Gateway API base URL"
+    prompt: "BurnBar API base URL"
+    password: false
+  - name: BURNBAR_HOME_CHANNEL
+    description: "Default BurnBar destination for cron / notification delivery"
+    prompt: "BurnBar home destination"
+    password: false
+  - name: BURNBAR_HOME_CHANNEL_NAME
+    description: "Human label for the BurnBar home destination"
+    prompt: "BurnBar home destination name"
+    password: false
+  - name: BURNBAR_ALLOWED_USERS
+    description: "Comma-separated BurnBar sender IDs allowed to talk to Hermes"
+    prompt: "Allowed BurnBar sender IDs"
+    password: false
+  - name: BURNBAR_ALLOW_ALL_USERS
+    description: "Allow any BurnBar sender from this account to talk to Hermes"
+    prompt: "Allow all BurnBar senders? (true/false)"
+    password: false

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -1182,6 +1182,13 @@ def register(ctx) -> None:
         # adapter" when cron runs separately from the gateway.  Mirrors
         # the Discord / Teams pattern.
         standalone_sender_fn=_standalone_send,
+        # ``_standalone_send`` genuinely uploads attachments via POST /files and
+        # references the returned file_ids on the post, so it is a first-class
+        # out-of-process media path, not a text-only cron fallback. Declare it
+        # so send_message_tool forwards ``media_files`` instead of stripping
+        # them; without this flag ``deliver=mattermost`` cron attachments are
+        # silently dropped.
+        supports_standalone_media=True,
         # Mattermost practical post-length limit (server default is 16383
         # but 4000 is the readable threshold the adapter has used since
         # day one).

--- a/tests/gateway/test_burnbar_plugin.py
+++ b/tests/gateway/test_burnbar_plugin.py
@@ -1,0 +1,649 @@
+"""Tests for the BurnBar Cloud platform-plugin adapter.
+
+Covers the messaging surface: registration, config, inbound mapping, send,
+attachments, cursor, and oversight/runtime-status.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_burnbar = load_plugin_adapter("burnbar")
+
+BurnBarAdapter = _burnbar.BurnBarAdapter
+check_requirements = _burnbar.check_requirements
+validate_config = _burnbar.validate_config
+is_connected = _burnbar.is_connected
+_env_enablement = _burnbar._env_enablement
+_apply_yaml_config = _burnbar._apply_yaml_config
+
+
+# ---------------------------------------------------------------------------
+# httpx test doubles
+# ---------------------------------------------------------------------------
+class _FakeResponse:
+    def __init__(self, json_body=None, status_code=200, content=b"{}"):
+        self._json = json_body if json_body is not None else {}
+        self.status_code = status_code
+        self.content = content
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._json
+
+
+class _RecordingClient:
+    """Minimal async httpx.AsyncClient stand-in that records calls.
+
+    ``post_responses`` maps a URL suffix to either a response or a callable
+    ``(json_body) -> _FakeResponse`` so a test can both assert on the request
+    body and shape the reply.
+    """
+
+    def __init__(self, *, post_responses=None, put_response=None, get_responses=None):
+        self.post_responses = post_responses or {}
+        self.put_response = put_response or _FakeResponse()
+        self.get_responses = get_responses or {}
+        self.posts = []  # list of (url, json)
+        self.puts = []  # list of (url, content, headers)
+        self.gets = []  # list of (url, params)
+
+    def _match(self, mapping, url):
+        for suffix, value in mapping.items():
+            if url.endswith(suffix):
+                return value
+        return None
+
+    async def post(self, url, headers=None, json=None):
+        self.posts.append((url, json))
+        match = self._match(self.post_responses, url)
+        if callable(match):
+            return match(json)
+        if match is not None:
+            return match
+        return _FakeResponse({})
+
+    async def put(self, url, content=None, headers=None):
+        self.puts.append((url, content, headers))
+        return self.put_response
+
+    async def get(self, url, headers=None, params=None):
+        self.gets.append((url, params))
+        match = self._match(self.get_responses, url)
+        if callable(match):
+            return match(params)
+        if match is not None:
+            return match
+        return _FakeResponse({})
+
+    async def aclose(self):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Registration / config
+# ---------------------------------------------------------------------------
+def test_platform_enum_resolves_via_plugin_scan():
+    from gateway.config import Platform
+
+    platform = Platform("burnbar")
+    assert platform.value == "burnbar"
+    assert Platform("burnbar") is platform
+
+
+def test_check_requirements_requires_httpx_and_token(monkeypatch):
+    monkeypatch.setattr(_burnbar, "HTTPX_AVAILABLE", True)
+    monkeypatch.delenv("BURNBAR_ACCESS_TOKEN", raising=False)
+    assert check_requirements() is False
+
+    monkeypatch.setenv("BURNBAR_ACCESS_TOKEN", "tok")
+    assert check_requirements() is True
+
+    monkeypatch.setattr(_burnbar, "HTTPX_AVAILABLE", False)
+    assert check_requirements() is False
+
+
+def test_validate_config_and_is_connected_use_extra_or_env(monkeypatch):
+    monkeypatch.delenv("BURNBAR_ACCESS_TOKEN", raising=False)
+    empty = PlatformConfig(enabled=True, extra={})
+    configured = PlatformConfig(enabled=True, extra={"access_token": "tok"})
+
+    assert validate_config(empty) is False
+    assert is_connected(empty) is False
+    assert validate_config(configured) is True
+    assert is_connected(configured) is True
+
+    monkeypatch.setenv("BURNBAR_ACCESS_TOKEN", "env-token")
+    assert validate_config(empty) is True
+    assert is_connected(empty) is True
+
+
+def test_env_enablement_seeds_api_token_and_home_channel(monkeypatch):
+    monkeypatch.setenv("BURNBAR_ACCESS_TOKEN", "tok")
+    monkeypatch.setenv("BURNBAR_API_BASE_URL", "https://example.com/v1/hermes-gateway/")
+    monkeypatch.setenv("BURNBAR_HOME_CHANNEL", "burnbar:phone")
+    monkeypatch.setenv("BURNBAR_HOME_CHANNEL_NAME", "Phone")
+
+    assert _env_enablement() == {
+        "api_base_url": "https://example.com/v1/hermes-gateway",
+        "access_token": "tok",
+        "home_channel": {"chat_id": "burnbar:phone", "name": "Phone"},
+    }
+
+
+def test_env_enablement_none_when_token_missing(monkeypatch):
+    monkeypatch.delenv("BURNBAR_ACCESS_TOKEN", raising=False)
+    assert _env_enablement() is None
+
+
+def test_apply_yaml_config_preserves_env_precedence(monkeypatch):
+    monkeypatch.setenv("BURNBAR_ACCESS_TOKEN", "env-token")
+    platform_cfg = {"extra": {"existing": "value"}}
+
+    extra = _apply_yaml_config(
+        {
+            "api_base_url": "https://api.example/v1/hermes-gateway",
+            "access_token": "yaml-token",
+            "home_channel": "burnbar:home",
+        },
+        platform_cfg,
+    )
+
+    assert extra == {
+        "existing": "value",
+        "api_base_url": "https://api.example/v1/hermes-gateway",
+        "access_token": "yaml-token",
+        "home_channel": "burnbar:home",
+    }
+    assert os.environ["BURNBAR_ACCESS_TOKEN"] == "env-token"
+    assert os.environ["BURNBAR_API_BASE_URL"] == "https://api.example/v1/hermes-gateway"
+
+
+def test_adapter_identity_and_defaults(monkeypatch):
+    from gateway.config import Platform
+
+    monkeypatch.delenv("BURNBAR_API_BASE_URL", raising=False)
+    cfg = PlatformConfig(enabled=True, extra={"access_token": "tok", "home_channel": "burnbar:phone"})
+    adapter = BurnBarAdapter(cfg)
+
+    assert adapter.platform is Platform("burnbar")
+    assert adapter._api_base == _burnbar.DEFAULT_API_BASE_URL
+    assert adapter._token == "tok"
+    assert adapter._home_channel == "burnbar:phone"
+
+
+def test_safe_exception_message_redacts_upload_urls_and_tokens():
+    error = RuntimeError(
+        "PUT https://signed.example/upload?X-Amz-Signature=secret&token=tok "
+        "failed with Authorization: Bearer bearer-secret"
+    )
+
+    text = _burnbar._safe_exception_message(error)
+
+    assert "signed.example" not in text
+    assert "secret" not in text
+    assert "tok" not in text
+    assert "[redacted-url]" in text
+    assert "Bearer [redacted]" in text
+
+
+def test_register_shape_matches_platform_registry():
+    ctx = MagicMock()
+
+    _burnbar.register(ctx)
+
+    ctx.register_platform.assert_called_once()
+    kwargs = ctx.register_platform.call_args.kwargs
+    assert kwargs["name"] == "burnbar"
+    assert kwargs["label"] == "BurnBar Cloud"
+    assert kwargs["required_env"] == ["BURNBAR_ACCESS_TOKEN"]
+    assert kwargs["allowed_users_env"] == "BURNBAR_ALLOWED_USERS"
+    assert kwargs["allow_all_env"] == "BURNBAR_ALLOW_ALL_USERS"
+    assert kwargs["cron_deliver_env_var"] == "BURNBAR_HOME_CHANNEL"
+    assert kwargs["max_message_length"] == _burnbar.MAX_MESSAGE_LENGTH
+    assert callable(kwargs["adapter_factory"])
+    assert callable(kwargs["setup_fn"])
+    assert callable(kwargs["standalone_sender_fn"])
+    assert kwargs["supports_standalone_media"] is True
+    assert "supports_media" not in kwargs
+
+
+def _run_interactive_setup(monkeypatch, *, allow_all: bool, allowed_response: str = ""):
+    import hermes_cli.setup as setup_mod
+
+    saved = {}
+    env = {}
+    output = {"info": [], "success": [], "warning": []}
+
+    class _SetupClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def post(self, url, json=None):
+            assert url.endswith("/device/start")
+            return _FakeResponse(
+                {
+                    "deviceCode": "device-code",
+                    "userCode": "BURN-BAR",
+                    "verificationUriComplete": "https://burnbar.example/device",
+                    "interval": 1,
+                    "expiresIn": 60,
+                }
+            )
+
+    def fake_save_env_value(key, value):
+        saved[key] = value
+        env[key] = value
+
+    def fake_prompt(question, default=None, password=False):
+        if "Allowed BurnBar sender IDs" in question:
+            return allowed_response
+        return default or ""
+
+    def fake_prompt_yes_no(question, default=True):
+        if "Allow every BurnBar sender" in question:
+            return allow_all
+        return False
+
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda key: env.get(key))
+    monkeypatch.setattr(setup_mod, "save_env_value", fake_save_env_value)
+    monkeypatch.setattr(setup_mod, "prompt", fake_prompt)
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", fake_prompt_yes_no)
+    monkeypatch.setattr(setup_mod, "print_header", lambda text: output["info"].append(text))
+    monkeypatch.setattr(setup_mod, "print_info", lambda text: output["info"].append(text))
+    monkeypatch.setattr(setup_mod, "print_success", lambda text: output["success"].append(text))
+    monkeypatch.setattr(setup_mod, "print_warning", lambda text: output["warning"].append(text))
+    monkeypatch.setattr(_burnbar.httpx, "Client", _SetupClient)
+    monkeypatch.setattr(
+        _burnbar,
+        "_poll_device_authorization",
+        lambda *args, **kwargs: {"accessToken": "token", "homeDestinationId": "burnbar:home"},
+    )
+
+    _burnbar.interactive_setup()
+    return saved, output
+
+
+def test_interactive_setup_defaults_burnbar_access_closed(monkeypatch):
+    saved, output = _run_interactive_setup(monkeypatch, allow_all=False)
+
+    assert saved["BURNBAR_ACCESS_TOKEN"] == "token"
+    assert saved["BURNBAR_HOME_CHANNEL"] == "burnbar:home"
+    assert saved["BURNBAR_ALLOW_ALL_USERS"] == "false"
+    assert "BURNBAR_ALLOWED_USERS" not in saved
+    assert not any(value == "true" for key, value in saved.items() if key == "BURNBAR_ALLOW_ALL_USERS")
+    assert any("No BurnBar sender allowlist configured" in text for text in output["warning"])
+
+
+def test_interactive_setup_allow_all_requires_explicit_opt_in_and_warns(monkeypatch):
+    saved, output = _run_interactive_setup(monkeypatch, allow_all=True)
+
+    assert saved["BURNBAR_ALLOW_ALL_USERS"] == "true"
+    assert saved["BURNBAR_ALLOWED_USERS"] == ""
+    assert any("Open access enabled" in text for text in output["warning"])
+
+
+def test_interactive_setup_normalizes_explicit_sender_allowlist(monkeypatch):
+    saved, output = _run_interactive_setup(
+        monkeypatch,
+        allow_all=False,
+        allowed_response="sender-1, sender-2,, ",
+    )
+
+    assert saved["BURNBAR_ALLOW_ALL_USERS"] == "false"
+    assert saved["BURNBAR_ALLOWED_USERS"] == "sender-1,sender-2"
+    assert any("allowlist configured" in text.lower() for text in output["success"])
+
+
+# ---------------------------------------------------------------------------
+# Inbound mapping + cursor
+# ---------------------------------------------------------------------------
+def _adapter(monkeypatch, tmp_path):
+    monkeypatch.setattr(_burnbar, "CURSOR_FILE", tmp_path / "cursor.json")
+    cfg = PlatformConfig(enabled=True, extra={"access_token": "tok", "home_channel": "burnbar:home"})
+    return BurnBarAdapter(cfg)
+
+
+@pytest.mark.asyncio
+async def test_inbound_event_maps_to_gateway_message_event(tmp_path, monkeypatch):
+    adapter = _adapter(monkeypatch, tmp_path)
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    adapter.handle_message = capture
+    await adapter._handle_burnbar_event(
+        {
+            "id": "evt_1",
+            "destinationId": "burnbar:home",
+            "senderId": "sender_1",
+            "senderDisplayName": "Test User",
+            "threadId": "thread_1",
+            "text": "hello hermes",
+        }
+    )
+
+    assert len(received) == 1
+    event = received[0]
+    assert event.text == "hello hermes"
+    assert event.message_id == "evt_1"
+    assert event.source.platform.value == "burnbar"
+    assert event.source.chat_id == "burnbar:home"
+    assert event.source.user_id == "sender_1"
+    assert event.source.user_name == "Test User"
+    assert event.source.thread_id == "thread_1"
+
+
+@pytest.mark.asyncio
+async def test_model_switch_event_synthesizes_model_command(tmp_path, monkeypatch):
+    adapter = _adapter(monkeypatch, tmp_path)
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    adapter.handle_message = capture
+    # _publish_runtime_status would need a client; stub it out.
+    adapter._publish_runtime_status = lambda *a, **k: _noop()
+    await adapter._handle_burnbar_event(
+        {"id": "evt_m", "kind": "model_switch", "modelId": "anthropic/claude", "destinationId": "burnbar:home"}
+    )
+    assert received and received[0].text == "/model anthropic/claude"
+
+
+@pytest.mark.asyncio
+async def test_model_switch_rejects_unsafe_model_id(tmp_path, monkeypatch):
+    adapter = _adapter(monkeypatch, tmp_path)
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    adapter.handle_message = capture
+    bad_ids = [
+        "model --provider evil",  # whitespace-separated flag
+        "-rf",  # leading dash
+        "evil id",  # whitespace
+        "x;y",  # shell metachar
+        "a" * 200,  # over length
+        # No-whitespace glued flags: these pass the character class but the
+        # /model parser matches --global / --refresh as substrings, so they must
+        # be rejected by the double-dash guard or they smuggle a persistent
+        # global-config write from the untrusted relay.
+        "sonnet--global",
+        "gpt-5--refresh",
+        "anthropic/claude--global",
+    ]
+    for i, bad in enumerate(bad_ids):
+        await adapter._handle_burnbar_event(
+            {"id": f"evt_bad_{i}", "kind": "model_switch", "modelId": bad, "destinationId": "burnbar:home"}
+        )
+
+    assert received == []
+    # The guard predicate rejects the glued forms while still accepting
+    # legitimate single-dash ids.
+    assert _burnbar._is_safe_model_id("anthropic/claude-opus-4-8") is True
+    assert _burnbar._is_safe_model_id("gpt-5") is True
+    assert _burnbar._is_safe_model_id("sonnet--global") is False
+    assert _burnbar._is_safe_model_id("gpt-5--refresh") is False
+
+
+async def _noop():
+    return None
+
+
+def test_cursor_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setattr(_burnbar, "CURSOR_FILE", tmp_path / "cursor.json")
+    assert _burnbar._read_cursor() == 0
+    _burnbar._write_cursor(42)
+    assert _burnbar._read_cursor() == 42
+    # Non-positive / corrupt values floor to 0.
+    _burnbar._write_cursor(0)
+    assert _burnbar._read_cursor() == 0
+
+
+# ---------------------------------------------------------------------------
+# Send happy / error + attachment
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_send_happy_path_posts_message(tmp_path, monkeypatch):
+    adapter = _adapter(monkeypatch, tmp_path)
+    client = _RecordingClient(
+        post_responses={"/messages": _FakeResponse({"message": {"id": "msg_1"}})}
+    )
+    adapter._client = client
+
+    result = await adapter.send("burnbar:home", "all done", reply_to="evt_9")
+
+    assert result.success is True
+    assert result.message_id == "msg_1"
+    url, body = client.posts[-1]
+    assert url.endswith("/messages")
+    assert body["text"] == "all done"
+    assert body["replyToEventId"] == "evt_9"
+
+
+@pytest.mark.asyncio
+async def test_send_error_returns_failure(tmp_path, monkeypatch):
+    adapter = _adapter(monkeypatch, tmp_path)
+    client = _RecordingClient(post_responses={"/messages": _FakeResponse(status_code=500)})
+    adapter._client = client
+
+    result = await adapter.send("burnbar:home", "boom")
+    assert result.success is False
+    assert result.error
+
+
+@pytest.mark.asyncio
+async def test_send_local_file_inits_uploads_and_posts(tmp_path, monkeypatch):
+    adapter = _adapter(monkeypatch, tmp_path)
+    f = tmp_path / "report.txt"
+    f.write_text("payload-bytes")
+    client = _RecordingClient(
+        post_responses={
+            "/attachments/init": _FakeResponse(
+                {"attachment": {"id": "att_1"}, "uploadURL": "https://signed.example/put"}
+            ),
+            "/messages": _FakeResponse({"message": {"id": "msg_att"}}),
+        }
+    )
+    adapter._client = client
+
+    result = await adapter.send_document("burnbar:home", str(f), caption="see attached")
+
+    assert result.success is True
+    assert result.message_id == "msg_att"
+    # init carried the fileName.
+    init_url, init_body = next((u, b) for (u, b) in client.posts if u.endswith("/attachments/init"))
+    assert init_body["fileName"] == "report.txt"
+    # body uploaded verbatim to the signed URL.
+    assert client.puts and client.puts[0][1] == b"payload-bytes"
+    # the message references the attachment id.
+    _, msg_body = next((u, b) for (u, b) in client.posts if u.endswith("/messages"))
+    assert msg_body["attachmentIds"] == ["att_1"]
+
+
+# ---------------------------------------------------------------------------
+# Oversight + runtime status
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_refresh_oversight_mode_reads_state(tmp_path, monkeypatch):
+    adapter = _adapter(monkeypatch, tmp_path)
+    adapter._client = _RecordingClient(
+        get_responses={"/state": _FakeResponse({"oversightMode": "autonomous"})}
+    )
+    assert adapter._oversight_mode == "supervised"
+    await adapter._refresh_oversight_mode()
+    assert adapter._oversight_mode == "autonomous"
+
+
+@pytest.mark.asyncio
+async def test_autonomous_oversight_auto_approves(tmp_path, monkeypatch):
+    adapter = _adapter(monkeypatch, tmp_path)
+    adapter._client = _RecordingClient()
+    adapter._oversight_mode = "autonomous"
+    resolved = {}
+
+    async def fake_resolve(session_key, confirm_id, choice, chat_id, metadata, fallback=None):
+        resolved["choice"] = choice
+
+    adapter._resolve_slash_confirm = fake_resolve
+    result = await adapter.send_slash_confirm("burnbar:home", "Run tool", "details", "sk", "cid")
+    assert result.success is True
+    assert resolved["choice"] == "once"
+
+
+@pytest.mark.asyncio
+async def test_supervised_oversight_arms_gate_and_waits(tmp_path, monkeypatch):
+    """Supervised mode must NOT auto-approve: it arms the BurnBar approval gate,
+    records a pending confirm, and waits for the phone decision."""
+    adapter = _adapter(monkeypatch, tmp_path)
+    adapter._client = _RecordingClient(
+        post_responses={"/approvals": _FakeResponse({}), "/messages": _FakeResponse({"message": {"id": "m"}})}
+    )
+    adapter._oversight_mode = "supervised"
+    auto_resolved = {"called": False}
+
+    async def fail_if_resolved(*a, **k):
+        auto_resolved["called"] = True
+
+    adapter._resolve_slash_confirm = fail_if_resolved
+    result = await adapter.send_slash_confirm("burnbar:home", "Run tool", "rm -rf /tmp/x", "sk", "cid")
+
+    assert result.success is True
+    # The decision was NOT auto-applied; it is pending the phone.
+    assert auto_resolved["called"] is False
+    assert "cid" in adapter._pending_confirms
+    assert adapter._pending_confirms["cid"]["session_key"] == "sk"
+    # An approval gate was armed and a card was posted.
+    armed = [(u, b) for (u, b) in adapter._client.posts if u.endswith("/approvals")]
+    assert armed and armed[0][1]["actionId"] == "cid"
+
+
+@pytest.mark.asyncio
+async def test_supervised_falls_back_when_arm_fails(tmp_path, monkeypatch):
+    """If the approval gate cannot be armed, supervised mode falls back to the
+    base text-confirm (which still requires an explicit /approve) instead of
+    silently proceeding."""
+    adapter = _adapter(monkeypatch, tmp_path)
+    adapter._client = _RecordingClient(post_responses={"/approvals": _FakeResponse(status_code=500)})
+    adapter._oversight_mode = "supervised"
+    fell_back = {"called": False}
+
+    async def fake_super(*a, **k):
+        fell_back["called"] = True
+        return _burnbar.SendResult(success=True)
+
+    monkeypatch.setattr(type(adapter).__bases__[0], "send_slash_confirm", fake_super, raising=False)
+    result = await adapter.send_slash_confirm("burnbar:home", "Run tool", "details", "sk", "cid")
+
+    assert result.success is True
+    assert fell_back["called"] is True
+    assert "cid" not in adapter._pending_confirms
+
+
+@pytest.mark.asyncio
+async def test_supervised_approval_poll_404_keeps_pending_confirm(tmp_path, monkeypatch):
+    """A transient 404 from the approval poll must not silently drop a pending
+    slash-confirm without an explicit approve/reject/expire decision."""
+    adapter = _adapter(monkeypatch, tmp_path)
+    adapter._client = _RecordingClient(get_responses={"/approvals": _FakeResponse(status_code=404)})
+    adapter._pending_confirms["cid"] = {
+        "session_key": "sk",
+        "chat_id": "burnbar:home",
+        "metadata": {"request": "test"},
+    }
+    resolved = {"called": False}
+
+    async def fake_resolve(*args, **kwargs):
+        resolved["called"] = True
+
+    adapter._resolve_slash_confirm = fake_resolve
+
+    await adapter._resolve_pending_confirms()
+
+    assert "cid" in adapter._pending_confirms
+    assert resolved["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_attachment_over_limit_fails_cleanly(tmp_path, monkeypatch):
+    """A file over MAX_ATTACHMENT_BYTES is rejected as a clean SendResult
+    failure before any upload, and an empty file is likewise rejected."""
+    monkeypatch.setattr(_burnbar, "MAX_ATTACHMENT_BYTES", 8)
+    adapter = _adapter(monkeypatch, tmp_path)
+    client = _RecordingClient(
+        post_responses={"/attachments/init": _FakeResponse({"attachment": {"id": "x"}})}
+    )
+    adapter._client = client
+
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"0123456789")  # 10 bytes > 8-byte limit
+    result = await adapter.send_document("burnbar:home", str(big))
+    assert result.success is False and result.error
+    # Failed fast: no attachments/init was attempted for the oversized file.
+    assert not any(u.endswith("/attachments/init") for (u, _) in client.posts)
+
+    empty = tmp_path / "empty.bin"
+    empty.write_bytes(b"")
+    result = await adapter.send_document("burnbar:home", str(empty))
+    assert result.success is False and result.error
+
+
+@pytest.mark.asyncio
+async def test_poll_isolates_one_malformed_event_in_a_batch(tmp_path, monkeypatch):
+    """One poison event must not abort the batch or stall the cursor: siblings
+    still dispatch and the cursor advances past the whole page."""
+    adapter = _adapter(monkeypatch, tmp_path)
+    events = [
+        {"id": "evt_a", "destinationId": "burnbar:home", "text": "first"},
+        {"id": "evt_bad", "destinationId": "burnbar:home", "text": "boom"},
+        {"id": "evt_c", "destinationId": "burnbar:home", "text": "third"},
+    ]
+    adapter._client = _RecordingClient(
+        get_responses={
+            "/events": _FakeResponse({"events": events, "nextCursor": 7}),
+            "/state": _FakeResponse({}),
+        }
+    )
+    adapter._publish_runtime_status = lambda *a, **k: _noop()
+    adapter._refresh_oversight_mode = lambda *a, **k: _noop()
+    monkeypatch.setattr(_burnbar, "CURSOR_FILE", tmp_path / "cursor.json")
+
+    received = []
+
+    async def capture(event):
+        if event.message_id == "evt_bad":
+            raise ValueError("poison event")
+        received.append(event.message_id)
+
+    adapter.handle_message = capture
+    await adapter._poll_once()
+
+    assert received == ["evt_a", "evt_c"]  # poison skipped, siblings dispatched
+    assert adapter._cursor == 7  # cursor advanced past the whole page
+
+
+def test_runtime_status_payload_shape(monkeypatch):
+    # Force the inventory import to fail -> empty payload, but still importable.
+    body = _burnbar._runtime_status_payload()
+    assert isinstance(body, dict)
+    # When inventory is available it has modelOptions; when not, it's {}.
+    if body:
+        assert "modelOptions" in body

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -2469,7 +2469,7 @@ class TestSendViaAdapterStandaloneFallback:
     """
 
     @staticmethod
-    def _make_entry(send_fn):
+    def _make_entry(send_fn, *, max_message_length=0, supports_standalone_media=False):
         from gateway.platform_registry import PlatformEntry
 
         return PlatformEntry(
@@ -2478,6 +2478,8 @@ class TestSendViaAdapterStandaloneFallback:
             adapter_factory=lambda cfg: None,
             check_fn=lambda: True,
             standalone_sender_fn=send_fn,
+            max_message_length=max_message_length,
+            supports_standalone_media=supports_standalone_media,
         )
 
     @pytest.mark.asyncio
@@ -2560,7 +2562,7 @@ class TestSendViaAdapterStandaloneFallback:
             recorded["force_document"] = force_document
             return {"success": True, "message_id": "x"}
 
-        platform_registry.register(self._make_entry(fake_send))
+        platform_registry.register(self._make_entry(fake_send, supports_standalone_media=True))
         try:
             monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
 
@@ -2653,6 +2655,176 @@ class TestSendViaAdapterStandaloneFallback:
         assert result["success"] is True
         assert result["message_id"] == "abc-123"
         assert result["extra_field"] == "preserved"
+
+    @pytest.mark.asyncio
+    async def test_send_to_platform_media_only_plugin_requires_media_capability(self, monkeypatch):
+        """A cron-only standalone hook is not enough to claim attachment support."""
+        from gateway.platform_registry import platform_registry
+
+        async def fake_send(pconfig, chat_id, message, **kwargs):
+            return {"success": True, "message_id": "should-not-send"}
+
+        platform_registry.register(self._make_entry(fake_send))
+        try:
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+            result = await _send_to_platform(
+                _FakePlatform("fakeplatform"),
+                SimpleNamespace(extra={}),
+                "chat-1",
+                "",
+                media_files=[("/tmp/artifact.png", False)],
+            )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert "error" in result
+        assert "MEDIA delivery is currently only supported" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_send_to_platform_text_media_plugin_omits_unsupported_media(self, monkeypatch):
+        """Cron-only standalone hooks receive text, not undeclared attachments."""
+        from gateway.platform_registry import platform_registry
+
+        recorded = {}
+
+        async def fake_send(pconfig, chat_id, message, *, media_files=None, **kwargs):
+            recorded["chat_id"] = chat_id
+            recorded["message"] = message
+            recorded["media_files"] = media_files
+            return {"success": True, "message_id": "text-only"}
+
+        platform_registry.register(self._make_entry(fake_send))
+        try:
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+            result = await _send_to_platform(
+                _FakePlatform("fakeplatform"),
+                SimpleNamespace(extra={}),
+                "chat-1",
+                "hello",
+                media_files=[("/tmp/artifact.png", False)],
+            )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert result["success"] is True
+        assert result["message_id"] == "text-only"
+        assert recorded == {
+            "chat_id": "chat-1",
+            "message": "hello",
+            "media_files": [],
+        }
+        assert result["warnings"] == [
+            "MEDIA attachments were omitted for fakeplatform; "
+            "send_message media delivery is currently only supported for "
+            "telegram, discord, matrix, weixin, signal, yuanbao, feishu, "
+            "or plugin platforms that explicitly declare standalone media support"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_to_platform_media_only_plugin_uses_declared_media_sender(self, monkeypatch):
+        """Plugin platforms with an explicit media-capable sender can own media-only sends."""
+        from gateway.platform_registry import platform_registry
+
+        recorded = {}
+
+        async def fake_send(pconfig, chat_id, message, *, thread_id=None,
+                            media_files=None, force_document=False):
+            recorded["chat_id"] = chat_id
+            recorded["message"] = message
+            recorded["thread_id"] = thread_id
+            recorded["media_files"] = media_files
+            recorded["force_document"] = force_document
+            return {"success": True, "message_id": "media-1"}
+
+        platform_registry.register(self._make_entry(fake_send, supports_standalone_media=True))
+        try:
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+            media = [("/tmp/artifact.png", False)]
+
+            result = await _send_to_platform(
+                _FakePlatform("fakeplatform"),
+                SimpleNamespace(extra={}),
+                "chat-1",
+                "",
+                thread_id="thread-1",
+                media_files=media,
+                force_document=True,
+            )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert result == {"success": True, "message_id": "media-1"}
+        assert recorded == {
+            "chat_id": "chat-1",
+            "message": "",
+            "thread_id": "thread-1",
+            "media_files": media,
+            "force_document": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_send_to_platform_plugin_media_attaches_only_to_final_chunk(self, monkeypatch):
+        """Long plugin sends should not duplicate attachments on every chunk."""
+        from gateway.platform_registry import platform_registry
+
+        calls = []
+
+        async def fake_send(pconfig, chat_id, message, *, media_files=None, **kwargs):
+            calls.append({"message": message, "media_files": media_files})
+            return {"success": True, "message_id": f"chunk-{len(calls)}"}
+
+        platform_registry.register(
+            self._make_entry(fake_send, max_message_length=40, supports_standalone_media=True)
+        )
+        try:
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+
+            result = await _send_to_platform(
+                _FakePlatform("fakeplatform"),
+                SimpleNamespace(extra={}),
+                "chat-1",
+                "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda",
+                media_files=[("/tmp/artifact.png", False)],
+            )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert result["success"] is True
+        assert len(calls) > 1
+        assert all(call["media_files"] == [] for call in calls[:-1])
+        assert calls[-1]["media_files"] == [("/tmp/artifact.png", False)]
+
+    @pytest.mark.asyncio
+    async def test_live_adapter_not_bypassed_for_cron_only_standalone_media(self, monkeypatch):
+        """Media on a live plugin platform still uses the live adapter unless the
+        plugin explicitly declares standalone media support."""
+        from gateway.platform_registry import platform_registry
+        from gateway.platforms.base import SendResult
+        from tools.send_message_tool import _send_via_adapter
+
+        standalone = AsyncMock(return_value={"success": True, "message_id": "standalone"})
+        live_adapter = SimpleNamespace(
+            send=AsyncMock(return_value=SendResult(success=True, message_id="live"))
+        )
+        runner = SimpleNamespace(adapters={_FakePlatform("fakeplatform"): live_adapter})
+        platform = next(iter(runner.adapters.keys()))
+
+        platform_registry.register(self._make_entry(standalone))
+        try:
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+            result = await _send_via_adapter(
+                platform,
+                SimpleNamespace(extra={}),
+                "chat-1",
+                "text",
+                media_files=[("/tmp/artifact.png", False)],
+            )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert result == {"success": True, "message_id": "live"}
+        live_adapter.send.assert_awaited_once()
+        standalone.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -2846,3 +3018,77 @@ class TestSendTelegramThreadNotFoundRetry:
         finally:
             if media_path and os.path.exists(media_path):
                 os.unlink(media_path)
+
+
+# ---------------------------------------------------------------------------
+# Regression: plugin standalone-media gating (PlatformEntry.supports_standalone_media)
+#
+# A media-capable standalone sender (Mattermost shape: uploads attachments
+# out-of-process) must receive media_files when its PlatformEntry declares
+# supports_standalone_media=True, and must have them stripped (with a warning)
+# when it does not. This pins the flag as the single control point and guards
+# against silently dropping cron attachments for a non-BurnBar platform.
+# ---------------------------------------------------------------------------
+class TestPluginStandaloneMediaGating:
+    @staticmethod
+    def _run(flag, tmp_path):
+        from gateway.platform_registry import platform_registry
+
+        received = {}
+
+        async def recorder(pconfig, chat_id, chunk, *, thread_id=None, media_files=None, force_document=False):
+            received["media_files"] = media_files
+            return {"success": True, "message_id": "ok"}
+
+        fake_entry = SimpleNamespace(standalone_sender_fn=recorder, supports_standalone_media=flag)
+        media = tmp_path / "report.pdf"
+        media.write_bytes(b"PDF-BYTES")
+        with patch.object(platform_registry, "get", return_value=fake_entry), \
+                patch("gateway.run._gateway_runner_ref", return_value=None):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.MATTERMOST,
+                    SimpleNamespace(enabled=True, token="***", extra={}),
+                    "town-square",
+                    "see attached",
+                    media_files=[(str(media), False)],
+                )
+            )
+        return result, received
+
+    def test_media_reaches_sender_when_flag_declared(self, tmp_path):
+        result, received = self._run(True, tmp_path)
+        assert result.get("success") is True
+        # The media-capable standalone sender RECEIVED the attachment.
+        assert received.get("media_files")
+        assert received["media_files"][0][0].endswith("report.pdf")
+        assert not result.get("warnings")
+
+    def test_media_stripped_with_warning_when_flag_absent(self, tmp_path):
+        result, received = self._run(False, tmp_path)
+        # Without the flag, media is stripped (the old behavior) and a warning
+        # tells the caller delivery was omitted — never silently dropped.
+        assert received.get("media_files") in ([], None)
+        warnings_text = " ".join(result.get("warnings") or []).lower()
+        assert "omitted" in warnings_text
+
+    def test_mattermost_register_declares_standalone_media(self):
+        """The real Mattermost plugin opts in via register(), so a
+        ``deliver=mattermost`` cron job's attachments survive the gate."""
+        import importlib
+
+        mm = importlib.import_module("plugins.platforms.mattermost.adapter")
+        captured = {}
+
+        class _Ctx:
+            manifest = SimpleNamespace(name="mattermost")
+
+            def register_platform(self, **kwargs):
+                captured.update(kwargs)
+
+            def __getattr__(self, _name):  # tolerate other ctx.* calls
+                return lambda *a, **k: None
+
+        mm.register(_Ctx())
+        assert captured.get("standalone_sender_fn") is not None
+        assert captured.get("supports_standalone_media") is True

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -65,6 +65,10 @@ _GENERIC_SECRET_ASSIGN_RE = re.compile(
     r"\b(access_token|api[_-]?key|auth[_-]?token|signature|sig)\s*=\s*([^\s,;]+)",
     re.IGNORECASE,
 )
+_MEDIA_DELIVERY_SUPPORT_TEXT = (
+    "telegram, discord, matrix, weixin, signal, yuanbao, feishu, "
+    "or plugin platforms that explicitly declare standalone media support"
+)
 
 
 def _sanitize_error_text(text) -> str:
@@ -613,6 +617,19 @@ async def _send_via_adapter(
       3. A descriptive error explaining both options.
     """
     platform_name = platform.value if hasattr(platform, "value") else str(platform)
+    entry = None
+    try:
+        from gateway.platform_registry import platform_registry
+        entry = platform_registry.get(platform_name)
+    except Exception:
+        entry = None
+
+    can_send_standalone_media = bool(
+        entry is not None
+        and entry.standalone_sender_fn is not None
+        and getattr(entry, "supports_standalone_media", False)
+    )
+
     runner = None
     try:
         from gateway.run import _gateway_runner_ref
@@ -620,7 +637,11 @@ async def _send_via_adapter(
     except Exception:
         runner = None
 
-    if runner is not None:
+    # Prefer the live adapter whenever it exists. Only bypass it for media when
+    # the platform explicitly declares its standalone hook as a native media
+    # path; most plugin standalone hooks are cron text fallbacks and may accept
+    # media_files only for signature parity.
+    if runner is not None and not (media_files and can_send_standalone_media):
         try:
             adapter = runner.adapters.get(platform)
         except Exception:
@@ -643,21 +664,15 @@ async def _send_via_adapter(
                 return {"success": True, "message_id": result.message_id}
             return {"error": f"Adapter send failed: {result.error}"}
 
-    entry = None
-    try:
-        from gateway.platform_registry import platform_registry
-        entry = platform_registry.get(platform_name)
-    except Exception:
-        entry = None
-
     if entry is not None and entry.standalone_sender_fn is not None:
+        standalone_media_files = media_files if can_send_standalone_media else []
         try:
             result = await entry.standalone_sender_fn(
                 pconfig,
                 chat_id,
                 chunk,
                 thread_id=thread_id,
-                media_files=media_files,
+                media_files=standalone_media_files,
                 force_document=force_document,
             )
         except asyncio.CancelledError:
@@ -870,22 +885,36 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         return last_result
 
     # --- Non-media platforms ---
-    if media_files and not message.strip():
+    plugin_media_sender_available = False
+    if media_files:
+        try:
+            from gateway.platform_registry import platform_registry
+            plugin_entry = platform_registry.get(platform.value)
+            plugin_media_sender_available = bool(
+                plugin_entry is not None
+                and plugin_entry.standalone_sender_fn is not None
+                and getattr(plugin_entry, "supports_standalone_media", False)
+            )
+        except Exception:
+            plugin_media_sender_available = False
+
+    if media_files and not message.strip() and not plugin_media_sender_available:
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for {_MEDIA_DELIVERY_SUPPORT_TEXT}; "
                 f"target {platform.value} had only media attachments"
             )
         }
     warning = None
-    if media_files:
+    if media_files and not plugin_media_sender_available:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            f"send_message media delivery is currently only supported for {_MEDIA_DELIVERY_SUPPORT_TEXT}"
         )
 
     last_result = None
-    for chunk in chunks:
+    for i, chunk in enumerate(chunks):
+        is_last = (i == len(chunks) - 1)
         if platform == Platform.SLACK:
             result = await _send_slack(pconfig.token, chat_id, chunk, thread_ts=thread_id)
         elif platform == Platform.WHATSAPP:
@@ -913,13 +942,16 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         else:
             # Plugin platform: route through the gateway's live adapter if
             # available, otherwise the plugin's standalone_sender_fn.
+            plugin_media_files = (
+                media_files if (plugin_media_sender_available and is_last) else []
+            )
             result = await _send_via_adapter(
                 platform,
                 pconfig,
                 chat_id,
                 chunk,
                 thread_id=thread_id,
-                media_files=media_files,
+                media_files=plugin_media_files,
                 force_document=force_document,
             )
 

--- a/website/docs/user-guide/messaging/burnbar.md
+++ b/website/docs/user-guide/messaging/burnbar.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 9
+title: "BurnBar Cloud"
+description: "Connect Hermes Agent to BurnBar Cloud through the BurnBar Hermes Gateway API"
+---
+
+# BurnBar Cloud Setup
+
+BurnBar Cloud connects to Hermes through the BurnBar Hermes Gateway API. Hermes
+runs the gateway adapter locally; BurnBar provides the mobile and cloud surface
+that sends events to the adapter and receives replies.
+
+Use this integration when you want BurnBar to act as a mobile control surface for
+a local Hermes agent: send messages, receive replies, approve sensitive actions,
+and route scheduled `deliver=burnbar` notifications to a home destination.
+
+## Capabilities
+
+| Surface | Behavior |
+|---------|----------|
+| **Inbound events** | Hermes polls BurnBar `/events` with a durable cursor. |
+| **Replies** | Hermes sends through `/messages`. |
+| **Typing** | Hermes publishes typing state through `/typing`. |
+| **Attachments** | Hermes initializes signed uploads through `/attachments/init`. |
+| **Oversight** | Supervised mode gates slash confirmations; autonomous mode auto-approves. |
+| **Cron delivery** | `deliver=burnbar` sends to `BURNBAR_HOME_CHANNEL`. |
+
+## Setup
+
+Run the gateway setup wizard and choose **BurnBar Cloud**:
+
+```bash
+hermes gateway setup
+hermes gateway restart
+hermes gateway status
+```
+
+The setup flow starts a device-code grant. Approve the displayed code in BurnBar,
+then restart the gateway. The approved token is written to your active Hermes
+home `.env`.
+
+## Configuration
+
+The setup flow writes the required token automatically:
+
+| Variable | Purpose |
+|----------|---------|
+| `BURNBAR_ACCESS_TOKEN` | Scoped bearer token from the approved device grant. |
+| `BURNBAR_API_BASE_URL` | Gateway API base URL. Defaults to the BurnBar Cloud API. |
+| `BURNBAR_HOME_CHANNEL` | Default destination for cron and notification delivery. |
+| `BURNBAR_HOME_CHANNEL_NAME` | Human-readable label for the home destination. |
+| `BURNBAR_ALLOWED_USERS` | Comma-separated BurnBar sender IDs allowed to reach Hermes. |
+| `BURNBAR_ALLOW_ALL_USERS` | Set to `true` only for a trusted account/workspace. |
+
+You can also set non-secret defaults in `config.yaml` under the BurnBar platform
+entry. Secrets belong in `.env`.
+
+## Access Control
+
+BurnBar uses the same gateway access-control model as other Hermes messaging
+platforms:
+
+- set `BURNBAR_ALLOWED_USERS` for an explicit sender allowlist
+- set `BURNBAR_ALLOW_ALL_USERS=true` only when every sender in the connected
+  BurnBar account is trusted
+- use `/whoami` from BurnBar to confirm the active scope and command access
+
+## Oversight Mode
+
+BurnBar's server-owned `/state` response controls the current oversight mode:
+
+- `supervised` arms a phone approval gate before slash-confirm actions proceed
+- `autonomous` allows the adapter to auto-approve those actions
+
+The adapter refreshes this state while polling, so the phone remains the control
+surface for changing the mode.
+
+## Troubleshooting
+
+Check the gateway status first:
+
+```bash
+hermes gateway status
+hermes logs --level warning
+```
+
+Common causes:
+
+- `BURNBAR_ACCESS_TOKEN` is missing or expired: rerun `hermes gateway setup`
+- the home channel is unset: send from BurnBar once or set `BURNBAR_HOME_CHANNEL`
+- the sender is denied: add the sender to `BURNBAR_ALLOWED_USERS` or explicitly
+  enable `BURNBAR_ALLOW_ALL_USERS`
+
+## Tests
+
+The plugin tests load the adapter through the same plugin-loader guard used by
+the Hermes gateway tests:
+
+```bash
+scripts/run_tests.sh tests/gateway/test_burnbar_plugin.py
+```

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, BurnBar Cloud, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, BurnBar Cloud, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes).
 
@@ -28,6 +28,7 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 | Email | — | ✅ | ✅ | ✅ | — | — | — |
 | Home Assistant | — | — | — | — | — | — | — |
 | Mattermost | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
+| BurnBar Cloud | — | ✅ | ✅ | — | — | ✅ | — |
 | Matrix | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | DingTalk | — | ✅ | ✅ | — | ✅ | — | ✅ |
 | Feishu/Lark | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -59,6 +60,7 @@ flowchart TB
             em[Email]
             ha[Home Assistant]
             mm[Mattermost]
+            bbar[BurnBar Cloud]
             mx[Matrix]
             dt[DingTalk]
     fs[Feishu/Lark]
@@ -88,6 +90,7 @@ flowchart TB
     em --> store
     ha --> store
     mm --> store
+    bbar --> store
     mx --> store
     dt --> store
     fs --> store
@@ -453,6 +456,7 @@ Each platform has its own toolset:
 | Email | `hermes-email` | Full tools including terminal |
 | Home Assistant | `hermes-homeassistant` | Full tools + HA device control (ha_list_entities, ha_get_state, ha_call_service, ha_list_services) |
 | Mattermost | `hermes-mattermost` | Full tools including terminal |
+| BurnBar Cloud | `hermes-burnbar` | Full tools including terminal |
 | Matrix | `hermes-matrix` | Full tools including terminal |
 | DingTalk | `hermes-dingtalk` | Full tools including terminal |
 | Feishu/Lark | `hermes-feishu` | Full tools including terminal |
@@ -581,6 +585,7 @@ Defaults to `false`. Only platforms whose adapter implements `delete_message` ho
 - [Email Setup](email.md)
 - [Home Assistant Integration](homeassistant.md)
 - [Mattermost Setup](mattermost.md)
+- [BurnBar Cloud Setup](burnbar.md)
 - [Matrix Setup](matrix.md)
 - [DingTalk Setup](dingtalk.md)
 - [Feishu/Lark Setup](feishu.md)


### PR DESCRIPTION
## Summary

Adds a BurnBar messaging platform plugin so a Hermes agent can be driven from BurnBar Cloud. This PR also adds a generic `supports_standalone_media` platform capability so platforms can explicitly declare whether their standalone sender can upload media.

## Why

BurnBar users want to operate a Hermes agent from their phone. While adding the platform, I found a shared media-routing gap: platforms with standalone media support need a way to opt in without changing behavior for platforms that should warn and omit attachments.

## What changed

- Added `plugins/platforms/burnbar/` with adapter, plugin metadata, and docs.
- Added `PlatformEntry.supports_standalone_media`.
- Updated the shared send-message path to respect that capability.
- Opted Mattermost into standalone media support.
- Added BurnBar user docs and `.env.example` entries.

## How I tested

- `PYTHONSAFEPATH=1 uv run pytest tests/gateway/test_burnbar_plugin.py tests/tools/test_send_message_tool.py -q`
  - 167 passed
- `PYTHONSAFEPATH=1 uv run ruff check plugins/platforms/burnbar tools/send_message_tool.py gateway/platform_registry.py tests/gateway/test_burnbar_plugin.py tests/tools/test_send_message_tool.py`
  - passed

## Platforms tested

- BurnBar gateway plugin path.
- Mattermost standalone-media regression path.
- Shared send-message path for platforms without standalone media support.

## Known limitations / non-goals

- No E2EE is included in this PR.
- This layer trusts the configured BurnBar gateway.
- MIME and file-size checks are local safeguards; server-side enforcement remains the authoritative boundary.

## Feedback requested

I would especially appreciate feedback on whether a single-vendor platform plugin like this belongs in-tree, and whether `supports_standalone_media` is the capability shape maintainers would prefer. I am happy to split, rename, shrink, or rework the PR if another structure would be easier to review.