### PR TITLE
docs(skills): note himalaya's terminal dependency and prompt-injection risk

### DIFF
--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -22,6 +22,37 @@ adapter lets people email the agent and uses Hermes' built-in IMAP/SMTP
 adapter; this skill lets the agent operate a mailbox from terminal tools and
 requires the external `himalaya` CLI.
 
+## Security: this skill needs `terminal`
+
+Himalaya runs as shell commands, so this skill only functions when the agent
+holds the `terminal` tool. That is fine on a trusted operator surface (your
+CLI). It needs care on any surface that ingests untrusted content: an inbox the
+agent reads, a chat channel, or fetched web pages.
+
+Indirect prompt injection fires when the agent *reads*, not when it acts. An
+agent reading untrusted mail while holding `terminal` can be steered by a
+crafted message into running arbitrary commands, not just email ones. The
+himalaya binary is not the issue; granting a shell to a mail-reading surface is.
+
+Recommended:
+
+- Cap untrusted-input surfaces with `platform_toolsets` so they do not carry
+  `terminal`/`web`/browser tools. A capability the agent does not hold cannot be
+  abused, which bounds the blast radius (least privilege).
+- Keep `approvals.mode: manual` so dangerous commands prompt before running.
+- If a surface needs email without a shell, prefer a native, API-based mail tool
+  over this terminal-driven skill.
+
+Native, shell-free alternatives that let a capability-capped surface do email
+and calendar without holding `terminal`:
+
+- hardmail (native email tools): https://github.com/orlyjamie/hardmail
+- hardcal (native Google Calendar tools): https://github.com/orlyjamie/hardcal
+- youshallnotpass (per-tool, per-platform approval gate): https://github.com/orlyjamie/youshallnotpass
+
+A worked example capping a Telegram-driven Hermes agent to these tools:
+https://x.com/theonejvo/status/2064042129396211938
+
 ## References
 
 - `references/configuration.md` (config file setup + IMAP/SMTP authentication)


### PR DESCRIPTION
## What does this PR do?

Adds a **Security** section to the himalaya email skill (`skills/email/himalaya/SKILL.md`) documenting that the skill drives email through the `terminal` tool, and the prompt-injection exposure that creates on surfaces that ingest untrusted content.

The himalaya binary itself is fine; the point is architectural. Because the skill operates email by running shell commands, using it requires the agent to hold `terminal`. On a surface whose job is to read untrusted mail (or a chat channel, or fetched web pages), an indirect prompt injection fires at read time and can then steer the agent into running arbitrary commands, not just email ones. The note makes that dependency explicit and points users at the existing mitigations.

## Related Issue

Related to #42307 (proposal: native, shell-free mail tool for untrusted-input surfaces). This PR is the docs-only first step; the issue tracks the broader recommendation.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `skills/email/himalaya/SKILL.md`: new "Security: this skill needs `terminal`" section recommending:
  - capping untrusted-input surfaces with `platform_toolsets` (least privilege bounds the blast radius),
  - keeping `approvals.mode: manual`,
  - preferring a native, API-based mail tool over the terminal-driven skill on untrusted-input surfaces.
- Adds "Further reading" pointing at native, shell-free alternatives (hardmail, hardcal, youshallnotpass) and a worked example.

## How to Test

Docs-only change. Render `skills/email/himalaya/SKILL.md` and confirm the new Security section reads correctly and the existing content is unchanged.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`docs(skills): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass <!-- docs-only; no code paths touched -->
- [ ] I've added tests for my changes <!-- N/A: documentation -->
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (this PR is documentation)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (docs)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

N/A (documentation).
