### PR TITLE
fix(cli): tolerate missing ctypes during process title setup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -89,15 +89,16 @@ def _set_process_title() -> None:
         pass
 
     # Strategy 2/3: platform-specific ctypes fallback
-    import ctypes
-    import platform
+    try:
+        import ctypes
+    except ImportError:
+        return
 
     try:
-        system = platform.system()
-        if system == "Linux":
+        if sys.platform.startswith("linux"):
             libc = ctypes.CDLL("libc.so.6", use_errno=True)
             libc.prctl(15, b"hermes", 0, 0, 0)  # PR_SET_NAME = 15
-        elif system == "Darwin":
+        elif sys.platform == "darwin":
             libc = ctypes.CDLL("libc.dylib", use_errno=True)
             libc.pthread_setname_np(b"hermes")
         # Windows: the .exe name is already ``hermes.exe`` — nothing to do.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1949,6 +1949,30 @@ run_setup_wizard() {
 
     cd "$INSTALL_DIR"
 
+    # Sanity check: a Python built without the _ctypes extension (commonly a
+    # pyenv build done before libffi was installed) crashes at startup. Surface
+    # a clear, actionable message here instead of a raw traceback.
+    # See NousResearch/hermes-agent#42074.
+    if [ "$USE_VENV" = true ]; then
+        _ctypes_python="$INSTALL_DIR/venv/bin/python"
+    else
+        _ctypes_python="python"
+    fi
+    if ! "$_ctypes_python" -c "import ctypes" >/dev/null 2>&1; then
+        log_warn "Python's ctypes module is unavailable (missing _ctypes extension)."
+        log_info "This usually means libffi was not present when Python was compiled."
+        if command -v pyenv >/dev/null 2>&1; then
+            _ctypes_pyver=$("$_ctypes_python" -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" 2>/dev/null)
+            log_info "Detected pyenv — reinstall Python with libffi support:"
+            log_info "  sudo apt-get install -y libffi-dev   # Debian/Ubuntu"
+            log_info "  pyenv install ${_ctypes_pyver:-<version>}"
+        else
+            log_info "Install libffi-dev and rebuild/reinstall your Python:"
+            log_info "  sudo apt-get install -y libffi-dev   # Debian/Ubuntu"
+        fi
+        log_info "Continuing anyway — process-title setup is cosmetic and now degrades gracefully."
+    fi
+
     # Run hermes setup using the venv Python directly (no activation needed).
     # Redirect stdin from /dev/tty so interactive prompts work when piped from curl.
     if [ "$USE_VENV" = true ]; then

--- a/tests/hermes_cli/test_main_process_title.py
+++ b/tests/hermes_cli/test_main_process_title.py
@@ -1,0 +1,66 @@
+import builtins
+import types
+
+from hermes_cli import main
+
+
+def test_set_process_title_tolerates_missing_ctypes(monkeypatch):
+    real_import = builtins.__import__
+    imported = []
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        imported.append(name)
+        if name == "setproctitle":
+            raise ImportError("No module named 'setproctitle'")
+        if name == "ctypes":
+            raise ModuleNotFoundError("No module named '_ctypes'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    main._set_process_title()
+
+    tracked = [name for name in imported if name in {"ctypes", "platform"}]
+    assert tracked == ["ctypes"]
+
+
+def test_set_process_title_prefers_setproctitle(monkeypatch):
+    real_import = builtins.__import__
+    calls = []
+
+    fake_setproctitle = types.SimpleNamespace(
+        setproctitle=lambda title: calls.append(("setproctitle", title))
+    )
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "setproctitle":
+            return fake_setproctitle
+        if name == "ctypes":
+            raise AssertionError("ctypes should not be imported after setproctitle")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    main._set_process_title()
+
+    assert calls == [("setproctitle", "hermes")]
+
+
+def test_set_process_title_tolerates_ctypes_call_failures(monkeypatch):
+    real_import = builtins.__import__
+
+    fake_ctypes = types.SimpleNamespace(
+        CDLL=lambda *args, **kwargs: (_ for _ in ()).throw(OSError("libc unavailable"))
+    )
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "setproctitle":
+            raise ImportError("No module named 'setproctitle'")
+        if name == "ctypes":
+            return fake_ctypes
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(main.sys, "platform", "linux")
+
+    main._set_process_title()


### PR DESCRIPTION
## Summary

Hermes startup currently treats process-title setup as cosmetic, but the `ctypes` fallback imported `ctypes` unconditionally after `setproctitle` was unavailable. On Python builds without `_ctypes`, that import raises `ModuleNotFoundError` and stops startup before Hermes can continue.

This keeps `_set_process_title()` non-fatal by returning cleanly when the optional `ctypes` fallback is unavailable. It also uses the already-imported `sys.platform` instead of importing `platform` in the same fragile path.

## Changes

- Guard the optional `ctypes` process-title fallback import.
- Switch Linux/macOS detection in `_set_process_title()` from `platform.system()` to `sys.platform`.
- Add focused regression coverage for missing `_ctypes`.
- Add behavior coverage for `setproctitle` short-circuiting and native `ctypes` call failures.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_main_process_title.py` — 3/3
- `/Users/harjothk/Documents/cowork/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_main_process_title.py -q` — 3/3 on a clean PR worktree
- `/Users/harjothk/Documents/cowork/hermes-agent/.venv/bin/python -c 'import hermes_cli.main; print("ok")'` — ok

AI-assisted implementation prepared with Codex.