### PR TITLE
fix(desktop): enable F11 fullscreen toggle on Linux/Windows

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3183,7 +3183,7 @@ function buildApplicationMenu() {
         }
       },
       { type: 'separator' },
-      { role: 'togglefullscreen' }
+      { role: 'togglefullscreen', accelerator: 'F11' }
     ]
   })
   template.push({
@@ -5786,11 +5786,7 @@ ipcMain.handle('hermes:uninstall:run', async (_event, payload) => {
 
 
 app.whenReady().then(() => {
-  if (IS_MAC) {
-    Menu.setApplicationMenu(buildApplicationMenu())
-  } else {
-    Menu.setApplicationMenu(null)
-  }
+  Menu.setApplicationMenu(buildApplicationMenu())
   installMediaPermissions()
   registerMediaProtocol()
   ensureWslWindowsFonts()


### PR DESCRIPTION
## Problem

On Linux (and Windows), Hermes Desktop has no application menu bar and
F11 does not trigger fullscreen mode. The `buildApplicationMenu()` function
includes `{ role: "togglefullscreen" }` but two things block it:

1. **No accelerator** — Electron togglefullscreen role only binds F11 on macOS by default; Linux/Windows gets nothing.
2. **Menu set to null** — \`Menu.setApplicationMenu(null)\` on non-macOS platforms discards the entire menu, so even registered accelerators never fire.

## Fix

- Add explicit \`accelerator: "F11"\` to the togglefullscreen item.
- Call \`Menu.setApplicationMenu(buildApplicationMenu())\` for all platforms instead of only macOS. The menu bar is accessible via Alt key on Linux and works as expected with custom titleBarStyle.