### PR TITLE
fix(gateway): preserve /setup-files through Google Chat slash command normalisation

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -1546,8 +1546,16 @@ class GoogleChatAdapter(BasePlatformAdapter):
             self._last_sender_by_chat[space_name] = sender_email.strip().lower()
 
         chat_type = "dm" if space_type in {"DIRECT_MESSAGE", "DM"} else "group"
-        text = msg.get("argumentText") or msg.get("text") or ""
+        # Prefer argumentText for commands, but preserve /setup-files
+        # so the OAuth interceptor can recognise it. Google Chat sends
+        # slash commands as argumentText (just the args), stripping the
+        # command name; without this guard /setup-files start becomes
+        # /cmd_NNN start and the interceptor never fires.
+        raw_text = (msg.get("text") or "").strip()
+        text = msg.get("argumentText") or raw_text or ""
         text = text.strip()
+        if raw_text.startswith("/setup-files"):
+            text = raw_text
 
         # Slash command: emit MessageType.COMMAND with normalized text.
         slash = msg.get("slashCommand") or {}


### PR DESCRIPTION
## What

Fixes the `/setup-files` OAuth flow being silently broken when sent as a Google Chat slash command.

## Root cause

`_build_message_event` (line 1543) prefers `argumentText` over `text` for slash commands. Google Chat sends `/setup-files start` with `argumentText: "start"`, stripping the command prefix. The code then normalises this to `/cmd_NNN start`. The `/setup-files` interceptor in `_handle_oauth_command` checks for the raw prefix and never fires.

This means all three forms of the command silently fail:
- `/setup-files start` → becomes `/cmd_1 start`
- `/setup-files <code_url>` → becomes `/cmd_1 <code_url>`

Only bare `/setup-files` works (because empty argumentText falls through to text).

## Fix

When `msg.text` starts with `/setup-files`, preserve the full text instead of using argumentText. This lets the interceptor recognise and process the command.

## How to test

Send `/setup-files start` as a slash command in a Google Chat DM with the bot. The bot should respond with the OAuth URL instead of the agent processing it as a regular message.

## Related

Found in production: user completed the OAuth browser flow but the gateway never received the code because the interceptor never triggered.