### PR TITLE
fix(stream): don't report dropped mid-tool-call streams as output truncation

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1986,6 +1986,58 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 "(possible upstream error or malformed SSE response)."
             )
 
+        # A stream that delivered a tool call but only partial/unparseable
+        # JSON args splits into two very different cases:
+        #
+        #   1. Provider sent finish_reason="length" → a genuine output-cap
+        #      truncation.  Boosting max_tokens on retry is the right move.
+        #
+        #   2. Provider sent NO finish_reason (the SSE simply stopped after
+        #      the opening "{" with no terminator and no [DONE]) → the
+        #      upstream dropped/stalled the connection mid tool-call.  This
+        #      is NOT an output cap — the model never reported hitting one.
+        #      Some dedicated endpoints (e.g. NVIDIA Nemotron Ultra on the
+        #      Nous dedicated endpoint) stall for minutes during large
+        #      tool-arg generation, then close the stream cleanly without a
+        #      finish_reason.  Stamping "length" here sends it down the
+        #      max_tokens-boost truncation path, which retries 3× to no
+        #      effect and finally reports the misleading "Response truncated
+        #      due to output length limit" — the red herring this guards
+        #      against.  Route it through the partial-stream-stub path
+        #      instead so the loop reports an honest mid-tool-call stream
+        #      drop and fails fast rather than escalating output budget.
+        _tool_args_dropped_no_finish = has_truncated_tool_args and finish_reason is None
+        if _tool_args_dropped_no_finish:
+            _dropped_names = [
+                (tool_calls_acc[idx]["function"]["name"] or "?")
+                for idx in sorted(tool_calls_acc)
+            ]
+            logger.warning(
+                "Stream ended with no finish_reason while a tool call's "
+                "arguments were still incomplete (tools=%s); treating as a "
+                "mid-tool-call stream drop, not an output-length truncation.",
+                _dropped_names,
+            )
+            full_reasoning = "".join(reasoning_parts) or None
+            mock_message = SimpleNamespace(
+                role=role,
+                content=full_content,
+                tool_calls=None,
+                reasoning_content=full_reasoning,
+            )
+            mock_choice = SimpleNamespace(
+                index=0,
+                message=mock_message,
+                finish_reason=FINISH_REASON_LENGTH,
+            )
+            return SimpleNamespace(
+                id=PARTIAL_STREAM_STUB_ID,
+                model=model_name,
+                choices=[mock_choice],
+                usage=usage_obj,
+                _dropped_tool_names=_dropped_names or None,
+            )
+
         effective_finish_reason = finish_reason or "stop"
         if has_truncated_tool_args:
             effective_finish_reason = "length"

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -136,6 +136,101 @@ class TestPartialStreamStubFinishReason:
         assert "write_file" in content
 
 
+# ── Clean stream-end mid-tool-call (no exception, no finish_reason) ─────────
+
+class TestCleanStreamEndMidToolCall:
+    """The upstream closes the SSE stream cleanly after delivering a tool
+    name + the opening '{' of its arguments — NO exception, NO finish_reason,
+    NO [DONE].  Observed live on NVIDIA Nemotron Ultra via the Nous dedicated
+    endpoint: it stalls/drops during large tool-arg generation.
+
+    The mock-builder must NOT stamp this as finish_reason='length' (which
+    routes it through the max_tokens-boost truncation path and finally
+    reports the misleading 'Response truncated due to output length limit').
+    It must route through the partial-stream-stub path so the loop reports
+    an honest mid-tool-call drop and asks the model to chunk its output.
+    """
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_no_finish_reason_partial_tool_args_routes_to_stub(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        def _clean_ending_stream():
+            # Reasoning + tool name + the lone opening brace, then the
+            # generator simply RETURNS (StopIteration) — no raise, no
+            # finish_reason chunk, no [DONE].
+            yield _make_stream_chunk(content="\n")
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_x", name="execute_code"),
+            ])
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments="{"),
+            ])
+            # falls off the end — clean close, no terminator
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _clean_ending_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_stream_delta = lambda text: None
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID, (
+            "A clean stream-end mid tool-call (no finish_reason) must be "
+            "tagged as a partial-stream stub, not a 'stream-<uuid>' "
+            "truncation — otherwise the loop reports the false 'output "
+            "length limit' error."
+        )
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert response.choices[0].message.tool_calls is None, (
+            "Incomplete tool args must never auto-execute."
+        )
+        assert getattr(response, "_dropped_tool_names", None) == ["execute_code"]
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_real_length_truncation_still_uses_uuid_id(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """Control: when the provider DOES send finish_reason='length' with
+        partial tool args, it is a genuine output cap — keep the existing
+        non-stub behaviour (boost max_tokens and retry)."""
+
+        def _capped_stream():
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_y", name="execute_code"),
+            ])
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments="{"),
+            ])
+            # Provider explicitly reports the output cap.
+            yield _make_stream_chunk(finish_reason="length")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _capped_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_stream_delta = lambda text: None
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id != PARTIAL_STREAM_STUB_ID, (
+            "A provider-reported finish_reason='length' is a real output cap "
+            "and must keep the existing truncation path, not the stream-drop "
+            "stub path."
+        )
+        assert response.id.startswith("stream-")
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+
+
 # ── Length-continuation prompt branching ──────────────────────────────────
 
 class TestLengthContinuationPromptBranching:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5788,9 +5788,35 @@ class TestStreamingApiCall:
         assert tc[0].function.name == "search"
         assert tc[1].function.name == "read"
 
-    def test_truncated_tool_call_args_upgrade_finish_reason_to_length(self, agent):
+    def test_truncated_tool_call_args_no_finish_reason_routes_to_stub(self, agent):
+        # Stream delivers a tool call with incomplete JSON args and then ENDS
+        # with no finish_reason (the SSE just stops — no terminator, no
+        # [DONE]).  This is an upstream mid-tool-call drop, NOT an output cap.
+        # The builder must route it through the partial-stream-stub path
+        # (id=PARTIAL_STREAM_STUB_ID, tool_calls=None so it can't execute,
+        # finish_reason=length so the loop's continuation machinery fires with
+        # chunking guidance) rather than stamping a normal 'length' truncation.
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
         chunks = [
             _make_chunk(tool_calls=[_make_tc_delta(0, "call_1", "write_file", '{"path":"x.txt","content":"hel')]),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        assert resp.id == PARTIAL_STREAM_STUB_ID
+        assert resp.choices[0].finish_reason == "length"
+        assert resp.choices[0].message.tool_calls is None
+        assert getattr(resp, "_dropped_tool_names", None) == ["write_file"]
+
+    def test_truncated_tool_call_args_with_length_finish_reason_upgrades(self, agent):
+        # Control: when the provider explicitly reports finish_reason='length'
+        # alongside incomplete tool args, it IS a genuine output cap.  Keep the
+        # existing behaviour — tool_calls preserved, finish_reason 'length' —
+        # so the max_tokens-boost truncation retry path still applies.
+        chunks = [
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_1", "write_file", '{"path":"x.txt","content":"hel')]),
+            _make_chunk(finish_reason="length"),
         ]
         agent.client.chat.completions.create.return_value = iter(chunks)
 


### PR DESCRIPTION
## Summary

A streaming tool call that the upstream drops mid-arguments — delivering the tool name + the opening `{` then closing the SSE cleanly with **no `finish_reason`** and no `[DONE]` — now reports an honest mid-tool-call stream drop and retries with chunking guidance, instead of the misleading "Response truncated due to output length limit."

**Root cause:** the streaming mock-builder stamped `finish_reason="length"` whenever tool args were unparseable, regardless of whether the provider actually reported an output cap. A clean stream-end with only a `{` got routed into the output-cap truncation path: 3 useless `max_tokens`-boosted retries, then the false truncation error. The model never hit any cap — the connection just dropped mid-generation.

Rob Maron called this out: the error is synthesized by Hermes when the provider gets cut off, not a real limit. This is the fix for that.

## Reproduced live

Against `nvidia/nemotron-3-ultra:free` (Nous dedicated endpoint) with Rob's exact prompt, through the real `run_conversation` loop:

```
⚠️ Response truncated (finish_reason='length') - model hit max output tokens   ← synthesized, false
⚠️ Truncated tool call detected — retrying API call (1/3)... (2/3)... (3/3)...
   Error: Response truncated due to output length limit
Duration: 4m 57s
```

The model emitted reasoning + tool name `execute_code` + the lone `{`, then the upstream closed the stream with no finish_reason. (Non-streaming was also tested as an alternative fix — the dedicated endpoint hangs ~300s then returns HTTP 502, so it's not a viable client-side recovery. The real cure is server-side; this PR makes Hermes stop misreporting it.)

## Changes

- `agent/chat_completion_helpers.py` — in the streaming mock-builder, split the truncated-tool-args case: if the provider sent **no** finish_reason (stream just stopped), tag the response with `PARTIAL_STREAM_STUB_ID` + `_dropped_tool_names` and route it through the existing partial-stream-stub path. A provider-reported `finish_reason="length"` still takes the real-truncation path unchanged.
- `tests/run_agent/test_partial_stream_finish_reason.py` — regression tests: clean stream-end mid-tool-call → stub path (not "length" truncation); control test that a real provider `length` still uses the truncation path.

## Validation

| Scenario | Before | After |
|---|---|---|
| Stream drops mid tool-call, no finish_reason | "Response truncated due to output length limit" after 3 max_tokens-boost retries | honest mid-tool-call drop → continuation prompt asks model to chunk output (<~8K tokens/call) |
| Provider sends real `finish_reason="length"` | output-cap truncation path | unchanged |
| Recovery turn | n/a (hard fail) | model re-emits chunked work, turn completes |

E2E-tested end-to-end against real `AIAgent.run_conversation` (transport + persistence stubbed): the false "output length limit" error is gone, the loop fires the chunking continuation naming the dropped tool, and the recovery turn's response is returned. Targeted suite: `tests/run_agent/test_partial_stream_finish_reason.py` 11 passed; `test_streaming.py` 43 passed (2 unrelated Anthropic tests fail locally only — `anthropic` pkg not installed; CI has `[all]` extras).

## Infographic

![mid-tool-call-stream-drop](https://v3b.fal.media/files/b/0a9d8115/l845epMlEG7Ey-MV5D_5b_YIoOTF0g.png)
