### PR TITLE
fix(cron): bump skill usage before wake-gate so script-gated jobs aren't seen as stale

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1220,7 +1220,6 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         return _scan_assembled_cron_prompt(prompt, job, has_skills=False)
 
     from tools.skills_tool import skill_view
-    from tools.skill_usage import bump_use
     from agent.skill_bundles import build_bundle_invocation_message, resolve_bundle_command_key
 
     parts = []
@@ -1263,11 +1262,10 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
             skipped.append(skill_name)
             continue
 
-        # Bump usage so the curator sees this skill as actively used.
-        try:
-            bump_use(skill_name)
-        except Exception:
-            logger.debug("Cron job: failed to bump skill usage for '%s'", skill_name, exc_info=True)
+        # Usage bumping happens in _bump_cron_job_skill_usage, called from
+        # _run_job_impl BEFORE the wake-gate so script-gated jobs that don't
+        # wake the agent still record activity. Skill loading here is the
+        # prompt-injection step only.
 
         content = str(loaded.get("content") or "").strip()
         if parts:
@@ -1341,6 +1339,43 @@ def _scan_assembled_cron_prompt(assembled: str, job: dict, *, has_skills: bool =
     return assembled
 
 
+def _bump_cron_job_skill_usage(job: dict) -> None:
+    """Bump skill usage counters for every skill declared on *job*.
+
+    Called once per tick from ``_run_job_impl`` BEFORE the wake-gate or any
+    other short-circuit. The fact that a skill is declared on a scheduled
+    job (via ``skills:`` / legacy ``skill:``) is the usage signal — whether
+    this particular tick actually wakes the agent is incidental. Without
+    this, script-gated jobs (which usually return ``wakeAgent=false``) leave
+    their skills with no telemetry, and the curator eventually prunes them
+    as stale.
+
+    Best-effort: errors are logged at DEBUG so a usage-tracker hiccup never
+    blocks a real cron run.
+    """
+    raw = job.get("skills")
+    if raw is None:
+        legacy = job.get("skill")
+        raw = [legacy] if legacy else []
+    elif isinstance(raw, str):
+        raw = [raw]
+    skill_names = [str(n).strip() for n in raw if str(n).strip()]
+    if not skill_names:
+        return
+    try:
+        from tools.skill_usage import bump_use
+    except Exception:
+        logger.debug("bump_cron_job_skill_usage: bump_use import failed", exc_info=True)
+        return
+    for name in skill_names:
+        try:
+            bump_use(name)
+        except Exception:
+            logger.debug(
+                "bump_cron_job_skill_usage: bump_use(%s) failed", name, exc_info=True
+            )
+
+
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """Execute a single cron job, applying any per-job profile override."""
     job_id = job["id"]
@@ -1351,12 +1386,18 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
-    
+
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+
+    # Record skill usage up-front so script-gated jobs (which may return
+    # wakeAgent=false on quiet ticks) and no_agent jobs still produce a
+    # usage signal for every tick. The declaration on the job is the
+    # signal; the agent waking is incidental.
+    _bump_cron_job_skill_usage(job)
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2203,6 +2203,51 @@ class TestRunJobWakeGate:
         script_fn.assert_not_called()
         agent_cls.assert_called_once()
 
+    def test_wake_false_still_bumps_declared_skills(self):
+        """Gap 1: skills declared on a script-gated cron job MUST bump
+        usage even when the gate returns ``wakeAgent=false``. Otherwise
+        the curator sees these skills as stale and prunes them."""
+        import cron.scheduler as scheduler
+
+        job = self._make_job()
+        job["skills"] = ["drive-planner"]
+        with patch.object(scheduler, "_run_job_script",
+                          return_value=(True, '{"wakeAgent": false}')), \
+             patch("tools.skill_usage.bump_use") as mock_bump, \
+             patch("run_agent.AIAgent") as agent_cls:
+            success, _doc, _final, _err = scheduler.run_job(job)
+
+        # Gate short-circuited (agent not woken) but bump fired anyway.
+        agent_cls.assert_not_called()
+        mock_bump.assert_called_once_with("drive-planner")
+        assert success is True
+
+    def test_wake_true_bumps_each_skill_exactly_once(self):
+        """Regression: no double-counting now that bump is hoisted out of
+        _build_job_prompt — wake-true path bumps each skill exactly once."""
+        import cron.scheduler as scheduler
+
+        job = self._make_job()
+        job["skills"] = ["alpha", "beta"]
+        agent = MagicMock()
+        agent.run_conversation = MagicMock(return_value={
+            "final_response": "ok", "messages": []
+        })
+
+        def _skill_view(name: str) -> str:
+            return json.dumps({"success": True, "content": f"Content for {name}."})
+
+        with patch.object(scheduler, "_run_job_script",
+                          return_value=(True, '{"wakeAgent": true}')), \
+             patch("tools.skills_tool.skill_view", side_effect=_skill_view), \
+             patch("tools.skill_usage.bump_use") as mock_bump, \
+             patch("run_agent.AIAgent", return_value=agent):
+            scheduler.run_job(job)
+
+        assert mock_bump.call_count == 2
+        names = [c[0][0] for c in mock_bump.call_args_list]
+        assert sorted(names) == ["alpha", "beta"]
+
 
 class TestBuildJobPromptMissingSkill:
     """Verify that a missing skill logs a warning and does not crash the job."""
@@ -2245,52 +2290,76 @@ class TestBuildJobPromptMissingSkill:
         assert "go" in result
 
 
-class TestBuildJobPromptBumpUse:
-    """Verify that cron jobs bump skill usage counters so the curator sees them as active."""
+class TestBumpCronJobSkillUsage:
+    """Verify that cron jobs bump skill usage counters so the curator sees them as active.
 
-    def test_bump_use_called_for_loaded_skill(self):
-        """bump_use is called for each successfully loaded skill."""
+    Bumping is hoisted to the top of _run_job_impl (before the wake-gate)
+    so script-gated jobs that don't wake the agent still record activity.
+    The helper itself is provenance-agnostic — declaration is the signal.
+    """
+
+    def test_helper_bumps_every_declared_skill(self):
+        """The helper iterates over ``skills:`` and bumps each, regardless of load."""
+        from cron.scheduler import _bump_cron_job_skill_usage
+
+        with patch("tools.skill_usage.bump_use") as mock_bump:
+            _bump_cron_job_skill_usage({"skills": ["alpha", "beta"]})
+
+        assert mock_bump.call_count == 2
+        names = [c[0][0] for c in mock_bump.call_args_list]
+        assert names == ["alpha", "beta"]
+
+    def test_helper_supports_legacy_singular_skill_field(self):
+        """Older cron jobs used ``skill:`` (singular) — must still bump."""
+        from cron.scheduler import _bump_cron_job_skill_usage
+
+        with patch("tools.skill_usage.bump_use") as mock_bump:
+            _bump_cron_job_skill_usage({"skill": "legacy-name"})
+
+        mock_bump.assert_called_once_with("legacy-name")
+
+    def test_helper_bumps_even_if_skill_will_fail_to_load(self):
+        """A missing-from-disk skill still bumps — declaration is the signal."""
+        from cron.scheduler import _bump_cron_job_skill_usage
+
+        with patch("tools.skill_usage.bump_use") as mock_bump:
+            _bump_cron_job_skill_usage({"skills": ["ghost"]})
+
+        mock_bump.assert_called_once_with("ghost")
+
+    def test_helper_handles_empty_and_blank(self):
+        """No skills declared → no bump; blank strings are skipped."""
+        from cron.scheduler import _bump_cron_job_skill_usage
+
+        with patch("tools.skill_usage.bump_use") as mock_bump:
+            _bump_cron_job_skill_usage({"skills": []})
+            _bump_cron_job_skill_usage({"skills": ["", "   "]})
+            _bump_cron_job_skill_usage({})
+
+        mock_bump.assert_not_called()
+
+    def test_helper_bump_failure_is_swallowed(self, caplog):
+        """bump_use raising must not block the cron run."""
+        from cron.scheduler import _bump_cron_job_skill_usage
+
+        with patch("tools.skill_usage.bump_use", side_effect=RuntimeError("boom")), \
+             caplog.at_level(logging.DEBUG, logger="cron.scheduler"):
+            _bump_cron_job_skill_usage({"skills": ["good-skill"]})
+
+        assert any("bump_use(good-skill) failed" in r.message for r in caplog.records)
+
+    def test_build_job_prompt_no_longer_bumps(self):
+        """Regression: bump was hoisted OUT of _build_job_prompt to avoid
+        double-counting now that _run_job_impl bumps once per tick."""
 
         def _skill_view(name: str) -> str:
             return json.dumps({"success": True, "content": f"Content for {name}."})
 
         with patch("tools.skills_tool.skill_view", side_effect=_skill_view), \
              patch("tools.skill_usage.bump_use") as mock_bump:
-            _build_job_prompt({"skills": ["alpha", "beta"], "prompt": "go"})
+            _build_job_prompt({"skills": ["alpha"], "prompt": "go"})
 
-        assert mock_bump.call_count == 2
-        calls = [c[0][0] for c in mock_bump.call_args_list]
-        assert "alpha" in calls
-        assert "beta" in calls
-
-    def test_bump_use_not_called_for_missing_skill(self):
-        """bump_use is NOT called when a skill fails to load."""
-
-        def _missing_view(name: str) -> str:
-            return json.dumps({"success": False, "error": "not found"})
-
-        with patch("tools.skills_tool.skill_view", side_effect=_missing_view), \
-             patch("tools.skill_usage.bump_use") as mock_bump:
-            _build_job_prompt({"skills": ["ghost"], "prompt": "go"})
-
-        assert mock_bump.call_count == 0
-
-    def test_bump_failure_does_not_break_prompt(self, caplog):
-        """If bump_use raises, the prompt still builds — error is logged at DEBUG."""
-
-        def _skill_view(name: str) -> str:
-            return json.dumps({"success": True, "content": "Works."})
-
-        with patch("tools.skills_tool.skill_view", side_effect=_skill_view), \
-             patch("tools.skill_usage.bump_use", side_effect=RuntimeError("boom")), \
-             caplog.at_level(logging.DEBUG, logger="cron.scheduler"):
-            result = _build_job_prompt({"skills": ["good-skill"], "prompt": "go"})
-
-        # Prompt should still contain the skill content and original instruction
-        assert "Works." in result
-        assert "go" in result
-        # The error should be logged at DEBUG level, not crash
-        assert any("failed to bump" in r.message for r in caplog.records)
+        mock_bump.assert_not_called()
 
 
 class TestSendMediaViaAdapter:


### PR DESCRIPTION
Closes #42303.

## Problem

`bump_use` lives inside `_build_job_prompt`, which is only reached *after* the wake-gate check in `_run_job_impl`. Cron jobs whose pre-check script returns `{"wakeAgent": false}` (the common case for script-gated jobs — Drive Planner sweep, exec briefings, methodology menu, etc.) `return` at the gate without ever calling `_build_job_prompt`, so their declared skills never have `use_count` or `last_used_at` bumped. After a few weeks the curator classifies them as stale and prunes them — even though they were running every tick.

## Repro from a real install (v0.15.1)

Six of seven script-gated cron-driven skills had no usage record despite weeks of scheduled runs, and were archived by today's curator pass. The one cron-driven skill *without* a script gate (so the agent wakes every tick and `_build_job_prompt` runs) was recorded fine:

| skill | cron pattern | `.usage.json` |
|---|---|---|
| `drive-planner` | every 180m, 128 ticks, script-gated | **NO RECORD** |
| `anthropic-receipts` | daily, script-gated | **NO RECORD** |
| `daily-briefing` | every 10m, script-gated | **NO RECORD** |
| `methodology` | weekly, script-gated | **NO RECORD** |
| `schedulemaster` | weekly, script-gated | **NO RECORD** |
| `where-am-i` | daily, script-gated | **NO RECORD** |
| `general-aviation-operations` | weekly, **no script gate** | use_count=27 |
| `hermes-agent` | daily, **no script gate** | use_count=11 |

Code path:

```python
# cron/scheduler.py — _run_job_impl, line ~1490
if script_path:
    prerun_script = _run_job_script(script_path)
    if _ran_ok and not _parse_wake_gate(_script_output):
        return True, silent_doc, SILENT_MARKER, None   # ← bump never reached

prompt = _build_job_prompt(job, prerun_script=prerun_script)
# bump_use is buried inside _build_job_prompt at line 1268
```

## Fix

Hoist the bump out of `_build_job_prompt` into a new helper `_bump_cron_job_skill_usage(job)` and call it once at the top of `_run_job_impl`, **before** either the `no_agent` short-circuit or the agent-branch wake-gate. The bump happens on every tick the job is scheduled — regardless of whether the gate fires, whether the agent wakes, or whether the skill even loads successfully later.

The semantic rephrasing: **declaring a skill on a scheduled job is the usage signal.** Not "the skill loaded successfully," not "the agent woke up this tick." Same semantics as interactive `/skill-name`, which bumps regardless of whether the user reads the response.

This also closes Gap 2 from #42303 for the common case (script + `skills:` listed) — by the time the gate runs, the bump has already fired. The remaining edge case (script that uses a skill internally without declaring it in `skills:`) is left as-is, since the declarative answer is "list the skill in `skills:`" — peeking inside scripts to guess intent would be brittle and undermine that contract.

## Trade-off

A "zombie" declaration (skill listed on a cron but never actually exercised by the agent) will keep bumping. Acknowledged in the issue — preferable to the current state where actively-used skills get silently deleted because the safety net (`.archive/` + `hermes curator restore`) is non-functional (#26655). A separate `hermes cron audit`-style follow-up could surface zombies later without making the usage tracker pretend they're useful.

## Tests

New `TestBumpCronJobSkillUsage` class — unit tests on the helper:
- bumps every declared `skills:` entry
- supports legacy singular `skill:` field
- bumps even for a not-yet-existing skill (declaration is the signal)
- empty / blank-string lists are no-ops
- `bump_use` raising never blocks the cron run
- regression: `_build_job_prompt` no longer bumps (confirms no double-count)

New `TestRunJobWakeGate` integration tests:
- `test_wake_false_still_bumps_declared_skills` — exact Gap 1 repro: script returns `wakeAgent=false`, agent is never woken, but bump still fired
- `test_wake_true_bumps_each_skill_exactly_once` — regression that the hoist didn't introduce double-counting on the happy path

Full suite passes locally — all 450 tests under `tests/cron/` and `tests/tools/test_skill_usage.py`.

## Related

- #18810 — fixed the post-gate prompt-build bump. Closed COMPLETED, but didn't cover the early-return path. This PR finishes that work.
- #17782 — fixed `bump_use` having zero call sites.
- #29912 — curator fail-open archive. Independent root cause, related symptom.
