### PR TITLE
fix(memory): sync Hindsight bank missions

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -61,8 +61,8 @@ Config file: `~/.hermes/hindsight/config.json`
 |-----|---------|-------------|
 | `bank_id` | `hermes` | Memory bank name (static fallback used when `bank_id_template` is unset or resolves empty) |
 | `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
-| `bank_mission` | — | Reflect mission (identity/framing for reflect reasoning). Applied via Banks API. |
-| `bank_retain_mission` | — | Retain mission (steers what gets extracted). Applied via Banks API. |
+| `bank_mission` | — | Reflect mission (identity/framing for reflect reasoning). Synced at startup through Hindsight's generated/public Banks API; set to an empty string or `null` to clear the bank override. |
+| `bank_retain_mission` | — | Retain mission (steers what gets extracted). Synced at startup through Hindsight's generated/public Banks API; set to an empty string or `null` to clear the bank override. |
 
 ### Recall
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import hashlib
 import importlib
 import json
 import logging
@@ -41,6 +42,7 @@ import sys
 import threading
 import time
 
+from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
@@ -548,6 +550,119 @@ def _normalize_observation_scopes(value: Any) -> Any:
         return scopes or None
 
     return None
+
+
+_BankConfigUpdates = Dict[str, str | None]
+_BankConfigSyncKey = tuple[
+    str,
+    str,
+    str,
+    tuple[tuple[str, str | None], ...],
+]
+_BANK_CONFIG_SYNC_CACHE_MAX = 64
+_BANK_CONFIG_SYNC_SUCCESS_TTL = 300.0
+_BANK_CONFIG_SYNC_FAILURE_TTL = 30.0
+_BANK_CONFIG_SYNC_CACHE: OrderedDict[_BankConfigSyncKey, tuple[bool, float]] = (
+    OrderedDict()
+)
+_BANK_CONFIG_SYNC_LOCK = threading.Lock()
+
+
+def _hindsight_response_dict(response: Any) -> dict[str, Any]:
+    """Normalize generated Hindsight response models and plain dicts."""
+    if isinstance(response, dict):
+        return response
+    model_dump = getattr(response, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump(mode="json")
+        return dumped if isinstance(dumped, dict) else {}
+    to_dict = getattr(response, "to_dict", None)
+    if callable(to_dict):
+        dumped = to_dict()
+        return dumped if isinstance(dumped, dict) else {}
+    return {}
+
+
+def _hindsight_bank_config_section(
+    config_response: Any, section: str
+) -> dict[str, Any]:
+    """Extract a dict section from Hindsight's bank-config response shape."""
+    values = _hindsight_response_dict(config_response).get(section)
+    return values if isinstance(values, dict) else {}
+
+
+def _hindsight_bank_config_value(config_response: Any, key: str) -> Any:
+    """Extract a resolved bank config value from Hindsight's response shape."""
+    config = _hindsight_response_dict(config_response)
+    for section in ("overrides", "config"):
+        values = config.get(section)
+        if isinstance(values, dict) and values.get(key) is not None:
+            return values.get(key)
+    return config.get(key)
+
+
+def _hindsight_bank_config_needs_update(
+    config_response: Any,
+    key: str,
+    desired_value: str | None,
+) -> bool:
+    """Return whether a bank config key needs a Hindsight override update."""
+    if desired_value is None:
+        overrides = _hindsight_bank_config_section(config_response, "overrides")
+        return key in overrides and overrides.get(key) is not None
+    return _hindsight_bank_config_value(config_response, key) != desired_value
+
+
+def _bank_config_auth_fingerprint(api_key: str | None) -> str:
+    """Return a non-secret auth fingerprint for bank-config sync scoping."""
+    if not api_key:
+        return ""
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:12]
+
+
+def _config_presence_value(
+    config: dict[str, Any], key: str
+) -> tuple[bool, str | None]:
+    """Return whether a key is present and its normalized mission value."""
+    if key not in config:
+        return False, None
+    value = config.get(key)
+    if value is None:
+        return True, None
+    normalized = str(value).strip()
+    return True, normalized or None
+
+
+def _bank_config_sync_is_suppressed(
+    cache_key: _BankConfigSyncKey, now: float
+) -> bool:
+    """Return whether a recent success/failure suppresses this exact sync."""
+    with _BANK_CONFIG_SYNC_LOCK:
+        cached = _BANK_CONFIG_SYNC_CACHE.get(cache_key)
+        if cached is None:
+            return False
+        succeeded, recorded_at = cached
+        ttl = (
+            _BANK_CONFIG_SYNC_SUCCESS_TTL
+            if succeeded
+            else _BANK_CONFIG_SYNC_FAILURE_TTL
+        )
+        if now - recorded_at >= ttl:
+            _BANK_CONFIG_SYNC_CACHE.pop(cache_key, None)
+            return False
+        _BANK_CONFIG_SYNC_CACHE.move_to_end(cache_key)
+        return True
+
+
+def _record_bank_config_sync(
+    cache_key: _BankConfigSyncKey, *, succeeded: bool, now: float
+) -> None:
+    """Store a bounded, short-lived sync result for one exact bank scope."""
+    with _BANK_CONFIG_SYNC_LOCK:
+        _BANK_CONFIG_SYNC_CACHE[cache_key] = (succeeded, now)
+        _BANK_CONFIG_SYNC_CACHE.move_to_end(cache_key)
+        while len(_BANK_CONFIG_SYNC_CACHE) > _BANK_CONFIG_SYNC_CACHE_MAX:
+            _BANK_CONFIG_SYNC_CACHE.popitem(last=False)
 
 
 def _utc_timestamp() -> str:
@@ -1549,6 +1664,125 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client = client
             return self._run_sync(operation(client))
 
+    def _configured_bank_config_updates(self) -> _BankConfigUpdates:
+        """Return mission overrides explicitly requested by Hermes config."""
+        config = self._config or {}
+        updates: _BankConfigUpdates = {}
+        reflect_configured, reflect_mission = _config_presence_value(
+            config, "bank_mission"
+        )
+        retain_configured, retain_mission = _config_presence_value(
+            config, "bank_retain_mission"
+        )
+        if reflect_configured:
+            updates["reflect_mission"] = reflect_mission
+        if retain_configured:
+            updates["retain_mission"] = retain_mission
+        return updates
+
+    @staticmethod
+    def _generated_banks_api(client: Any) -> Any:
+        """Return the generated/public Banks API exposed by Hindsight clients."""
+        banks = getattr(client, "banks", None)
+        if (
+            callable(getattr(banks, "get_bank_config", None))
+            and callable(getattr(banks, "update_bank_config", None))
+        ):
+            return banks
+        embedded_client = getattr(client, "_client", None)
+        embedded_banks = getattr(embedded_client, "banks", None)
+        if (
+            callable(getattr(embedded_banks, "get_bank_config", None))
+            and callable(getattr(embedded_banks, "update_bank_config", None))
+        ):
+            return embedded_banks
+        raise AttributeError("Hindsight generated Banks API is unavailable")
+
+    async def _get_hindsight_bank_config(self, client: Any) -> dict[str, Any]:
+        """Read bank config through the generated/public Hindsight Banks API."""
+        banks = self._generated_banks_api(client)
+        response = await banks.get_bank_config(
+            self._bank_id, _request_timeout=self._timeout
+        )
+        return _hindsight_response_dict(response)
+
+    async def _update_hindsight_bank_config(
+        self, client: Any, updates: _BankConfigUpdates
+    ) -> dict[str, Any]:
+        """Patch bank config through the generated/public Hindsight Banks API."""
+        from hindsight_client_api.models.bank_config_update import BankConfigUpdate
+
+        banks = self._generated_banks_api(client)
+        request = BankConfigUpdate(updates=dict(updates))
+        response = await banks.update_bank_config(
+            self._bank_id,
+            request,
+            _request_timeout=self._timeout,
+        )
+        return _hindsight_response_dict(response)
+
+    def _apply_configured_bank_config(self) -> None:
+        """Best-effort synchronize configured mission overrides at startup."""
+        updates = self._configured_bank_config_updates()
+        if not updates or self._mode == "disabled":
+            return
+
+        cache_key: _BankConfigSyncKey = (
+            self._probe_url(),
+            _bank_config_auth_fingerprint(self._api_key),
+            self._bank_id,
+            tuple(sorted(updates.items())),
+        )
+        now = time.monotonic()
+        if _bank_config_sync_is_suppressed(cache_key, now):
+            return
+
+        async def _apply(client: Any) -> None:
+            current = await self._get_hindsight_bank_config(client)
+            changed = {
+                key: value
+                for key, value in updates.items()
+                if _hindsight_bank_config_needs_update(current, key, value)
+            }
+            if changed:
+                logger.info(
+                    "Updating Hindsight bank config for %s: %s",
+                    self._bank_id,
+                    ", ".join(sorted(changed)),
+                )
+                await self._update_hindsight_bank_config(client, changed)
+
+        try:
+            self._run_hindsight_operation(_apply)
+        except ImportError as exc:
+            _record_bank_config_sync(cache_key, succeeded=False, now=now)
+            logger.warning(
+                "Hindsight bank mission sync unavailable because the generated "
+                "client could not be imported: %s",
+                exc,
+            )
+            return
+        except Exception as exc:
+            _record_bank_config_sync(cache_key, succeeded=False, now=now)
+            generated_api_missing = (
+                isinstance(exc, AttributeError)
+                and "generated Banks API is unavailable" in str(exc)
+            )
+            if generated_api_missing:
+                logger.warning(
+                    "Hindsight bank mission sync unavailable because the "
+                    "generated Banks API is not exposed by this client"
+                )
+            else:
+                logger.warning(
+                    "Failed to apply configured Hindsight bank config for %s: %s",
+                    self._bank_id,
+                    exc,
+                    exc_info=True,
+                )
+            return
+        _record_bank_config_sync(cache_key, succeeded=True, now=now)
+
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
 
@@ -1830,6 +2064,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     client._ensure_started()
                     with open(log_path, "a", encoding="utf-8") as f:
                         f.write("\n=== Daemon started successfully ===\n")
+                    self._apply_configured_bank_config()
                 except Exception as e:
                     with open(log_path, "a", encoding="utf-8") as f:
                         f.write(f"\n=== Daemon startup failed: {e} ===\n")
@@ -1837,6 +2072,8 @@ class HindsightMemoryProvider(MemoryProvider):
 
             t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
             t.start()
+        else:
+            self._apply_configured_bank_config()
 
     def system_prompt_block(self) -> str:
         if self._memory_mode == "context":

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import hashlib
 import importlib
 import json
 import logging
@@ -41,6 +42,7 @@ import sys
 import threading
 import time
 
+from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
@@ -489,6 +491,119 @@ def _normalize_observation_scopes(value: Any) -> Any:
         return scopes or None
 
     return None
+
+
+_BankConfigUpdates = Dict[str, str | None]
+_BankConfigSyncKey = tuple[
+    str,
+    str,
+    str,
+    tuple[tuple[str, str | None], ...],
+]
+_BANK_CONFIG_SYNC_CACHE_MAX = 64
+_BANK_CONFIG_SYNC_SUCCESS_TTL = 300.0
+_BANK_CONFIG_SYNC_FAILURE_TTL = 30.0
+_BANK_CONFIG_SYNC_CACHE: OrderedDict[_BankConfigSyncKey, tuple[bool, float]] = (
+    OrderedDict()
+)
+_BANK_CONFIG_SYNC_LOCK = threading.Lock()
+
+
+def _hindsight_response_dict(response: Any) -> dict[str, Any]:
+    """Normalize generated Hindsight response models and plain dicts."""
+    if isinstance(response, dict):
+        return response
+    model_dump = getattr(response, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump(mode="json")
+        return dumped if isinstance(dumped, dict) else {}
+    to_dict = getattr(response, "to_dict", None)
+    if callable(to_dict):
+        dumped = to_dict()
+        return dumped if isinstance(dumped, dict) else {}
+    return {}
+
+
+def _hindsight_bank_config_section(
+    config_response: Any, section: str
+) -> dict[str, Any]:
+    """Extract a dict section from Hindsight's bank-config response shape."""
+    values = _hindsight_response_dict(config_response).get(section)
+    return values if isinstance(values, dict) else {}
+
+
+def _hindsight_bank_config_value(config_response: Any, key: str) -> Any:
+    """Extract a resolved bank config value from Hindsight's response shape."""
+    config = _hindsight_response_dict(config_response)
+    for section in ("overrides", "config"):
+        values = config.get(section)
+        if isinstance(values, dict) and values.get(key) is not None:
+            return values.get(key)
+    return config.get(key)
+
+
+def _hindsight_bank_config_needs_update(
+    config_response: Any,
+    key: str,
+    desired_value: str | None,
+) -> bool:
+    """Return whether a bank config key needs a Hindsight override update."""
+    if desired_value is None:
+        overrides = _hindsight_bank_config_section(config_response, "overrides")
+        return key in overrides and overrides.get(key) is not None
+    return _hindsight_bank_config_value(config_response, key) != desired_value
+
+
+def _bank_config_auth_fingerprint(api_key: str | None) -> str:
+    """Return a non-secret auth fingerprint for bank-config sync scoping."""
+    if not api_key:
+        return ""
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:12]
+
+
+def _config_presence_value(
+    config: dict[str, Any], key: str
+) -> tuple[bool, str | None]:
+    """Return whether a key is present and its normalized mission value."""
+    if key not in config:
+        return False, None
+    value = config.get(key)
+    if value is None:
+        return True, None
+    normalized = str(value).strip()
+    return True, normalized or None
+
+
+def _bank_config_sync_is_suppressed(
+    cache_key: _BankConfigSyncKey, now: float
+) -> bool:
+    """Return whether a recent success/failure suppresses this exact sync."""
+    with _BANK_CONFIG_SYNC_LOCK:
+        cached = _BANK_CONFIG_SYNC_CACHE.get(cache_key)
+        if cached is None:
+            return False
+        succeeded, recorded_at = cached
+        ttl = (
+            _BANK_CONFIG_SYNC_SUCCESS_TTL
+            if succeeded
+            else _BANK_CONFIG_SYNC_FAILURE_TTL
+        )
+        if now - recorded_at >= ttl:
+            _BANK_CONFIG_SYNC_CACHE.pop(cache_key, None)
+            return False
+        _BANK_CONFIG_SYNC_CACHE.move_to_end(cache_key)
+        return True
+
+
+def _record_bank_config_sync(
+    cache_key: _BankConfigSyncKey, *, succeeded: bool, now: float
+) -> None:
+    """Store a bounded, short-lived sync result for one exact bank scope."""
+    with _BANK_CONFIG_SYNC_LOCK:
+        _BANK_CONFIG_SYNC_CACHE[cache_key] = (succeeded, now)
+        _BANK_CONFIG_SYNC_CACHE.move_to_end(cache_key)
+        while len(_BANK_CONFIG_SYNC_CACHE) > _BANK_CONFIG_SYNC_CACHE_MAX:
+            _BANK_CONFIG_SYNC_CACHE.popitem(last=False)
 
 
 def _utc_timestamp() -> str:
@@ -1417,6 +1532,129 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client = client
             return self._run_sync(operation(client))
 
+    def _configured_bank_config_updates(self) -> _BankConfigUpdates:
+        """Return mission overrides explicitly requested by Hermes config."""
+        config = self._config or {}
+        updates: _BankConfigUpdates = {}
+        reflect_configured, reflect_mission = _config_presence_value(
+            config, "bank_mission"
+        )
+        retain_configured, retain_mission = _config_presence_value(
+            config, "bank_retain_mission"
+        )
+        if reflect_configured:
+            updates["reflect_mission"] = reflect_mission
+        if retain_configured:
+            updates["retain_mission"] = retain_mission
+        return updates
+
+    @staticmethod
+    def _generated_banks_api(client: Any) -> Any:
+        """Return the generated/public Banks API exposed by Hindsight clients."""
+        banks = getattr(client, "banks", None)
+        if (
+            callable(getattr(banks, "get_bank_config", None))
+            and callable(getattr(banks, "update_bank_config", None))
+        ):
+            return banks
+
+        # HindsightEmbedded.banks is a small sync namespace in 0.6.1. Once
+        # started, its underlying public Hindsight client exposes the generated
+        # Banks API and can use the same async event-loop path as cloud mode.
+        embedded_client = getattr(client, "_client", None)
+        embedded_banks = getattr(embedded_client, "banks", None)
+        if (
+            callable(getattr(embedded_banks, "get_bank_config", None))
+            and callable(getattr(embedded_banks, "update_bank_config", None))
+        ):
+            return embedded_banks
+        raise AttributeError("Hindsight generated Banks API is unavailable")
+
+    async def _get_hindsight_bank_config(self, client: Any) -> dict[str, Any]:
+        """Read bank config through the generated/public Hindsight Banks API."""
+        banks = self._generated_banks_api(client)
+        response = await banks.get_bank_config(
+            self._bank_id, _request_timeout=self._timeout
+        )
+        return _hindsight_response_dict(response)
+
+    async def _update_hindsight_bank_config(
+        self, client: Any, updates: _BankConfigUpdates
+    ) -> dict[str, Any]:
+        """Patch bank config through the generated/public Hindsight Banks API."""
+        from hindsight_client_api.models.bank_config_update import BankConfigUpdate
+
+        banks = self._generated_banks_api(client)
+        request = BankConfigUpdate(updates=dict(updates))
+        response = await banks.update_bank_config(
+            self._bank_id,
+            request,
+            _request_timeout=self._timeout,
+        )
+        return _hindsight_response_dict(response)
+
+    def _apply_configured_bank_config(self) -> None:
+        """Best-effort synchronize configured mission overrides at startup."""
+        updates = self._configured_bank_config_updates()
+        if not updates or self._mode == "disabled":
+            return
+
+        cache_key: _BankConfigSyncKey = (
+            self._probe_url(),
+            _bank_config_auth_fingerprint(self._api_key),
+            self._bank_id,
+            tuple(sorted(updates.items())),
+        )
+        now = time.monotonic()
+        if _bank_config_sync_is_suppressed(cache_key, now):
+            return
+
+        async def _apply(client: Any) -> None:
+            current = await self._get_hindsight_bank_config(client)
+            changed = {
+                key: value
+                for key, value in updates.items()
+                if _hindsight_bank_config_needs_update(current, key, value)
+            }
+            if changed:
+                logger.info(
+                    "Updating Hindsight bank config for %s: %s",
+                    self._bank_id,
+                    ", ".join(sorted(changed)),
+                )
+                await self._update_hindsight_bank_config(client, changed)
+
+        try:
+            self._run_hindsight_operation(_apply)
+        except ImportError as exc:
+            _record_bank_config_sync(cache_key, succeeded=False, now=now)
+            logger.warning(
+                "Hindsight bank mission sync unavailable because the generated "
+                "client could not be imported: %s",
+                exc,
+            )
+            return
+        except Exception as exc:
+            _record_bank_config_sync(cache_key, succeeded=False, now=now)
+            generated_api_missing = (
+                isinstance(exc, AttributeError)
+                and "generated Banks API is unavailable" in str(exc)
+            )
+            if generated_api_missing:
+                logger.warning(
+                    "Hindsight bank mission sync unavailable because the "
+                    "generated Banks API is not exposed by this client"
+                )
+            else:
+                logger.warning(
+                    "Failed to apply configured Hindsight bank config for %s: %s",
+                    self._bank_id,
+                    exc,
+                    exc_info=True,
+                )
+            return
+        _record_bank_config_sync(cache_key, succeeded=True, now=now)
+
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
 
@@ -1683,6 +1921,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     client._ensure_started()
                     with open(log_path, "a", encoding="utf-8") as f:
                         f.write("\n=== Daemon started successfully ===\n")
+                    self._apply_configured_bank_config()
                 except Exception as e:
                     with open(log_path, "a", encoding="utf-8") as f:
                         f.write(f"\n=== Daemon startup failed: {e} ===\n")
@@ -1690,6 +1929,8 @@ class HindsightMemoryProvider(MemoryProvider):
 
             t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
             t.start()
+        else:
+            self._apply_configured_bank_config()
 
     def system_prompt_block(self) -> str:
         if self._memory_mode == "context":

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -90,6 +90,10 @@ def _make_mock_client():
         return_value=SimpleNamespace(text="Synthesized answer")
     )
     client.aretain_batch = AsyncMock()
+    client.banks.get_bank_config = AsyncMock(
+        return_value={"config": {}, "overrides": {}}
+    )
+    client.banks.update_bank_config = AsyncMock(return_value={"ok": True})
     client.aclose = AsyncMock()
     return client
 
@@ -334,6 +338,147 @@ class TestConfig:
         p = provider_with_config(retain_source="cogoport")
         assert p._retain_source == "cogoport"
         assert p._build_metadata(message_count=2, turn_index=1)["source"] == "cogoport"
+
+
+class TestBankMissionSync:
+    @pytest.fixture(autouse=True)
+    def _clear_sync_state(self):
+        from plugins.memory import hindsight as hindsight_mod
+
+        hindsight_mod._BANK_CONFIG_SYNC_CACHE.clear()
+        yield
+        hindsight_mod._BANK_CONFIG_SYNC_CACHE.clear()
+
+    def test_initialize_applies_configured_missions_with_generated_banks_api(
+        self, tmp_path, monkeypatch
+    ):
+        from hindsight_client_api.models.bank_config_update import BankConfigUpdate
+
+        config = {
+            "mode": "cloud",
+            "apiKey": "test-key",
+            "api_url": "http://localhost:9999",
+            "bank_id": "test-bank",
+            "bank_mission": " Reflect with operational context ",
+            "bank_retain_mission": " Extract durable facts ",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        client = _make_mock_client()
+        client.banks.get_bank_config.return_value = {
+            "config": {"reflect_mission": None, "retain_mission": None},
+            "overrides": {},
+        }
+        monkeypatch.setattr(HindsightMemoryProvider, "_get_client", lambda self: client)
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+        client.banks.get_bank_config.assert_awaited_once_with("test-bank", _request_timeout=120)
+        client.banks.update_bank_config.assert_awaited_once()
+        bank_id, request = client.banks.update_bank_config.await_args.args
+        assert bank_id == "test-bank"
+        assert isinstance(request, BankConfigUpdate)
+        assert request.updates == {
+            "reflect_mission": "Reflect with operational context",
+            "retain_mission": "Extract durable facts",
+        }
+        assert client.banks.update_bank_config.await_args.kwargs == {"_request_timeout": 120}
+
+    def test_explicit_empty_missions_clear_only_active_overrides(self, provider):
+        from hindsight_client_api.models.bank_config_update import BankConfigUpdate
+
+        provider._config["bank_mission"] = ""
+        provider._config["bank_retain_mission"] = None
+        provider._client.banks.get_bank_config.return_value = {
+            "config": {
+                "reflect_mission": "server default reflect",
+                "retain_mission": "server default retain",
+            },
+            "overrides": {
+                "reflect_mission": "stale reflect override",
+                "retain_mission": "stale retain override",
+            },
+        }
+
+        provider._apply_configured_bank_config()
+
+        provider._client.banks.update_bank_config.assert_awaited_once()
+        request = provider._client.banks.update_bank_config.await_args.args[1]
+        assert isinstance(request, BankConfigUpdate)
+        assert request.updates == {"reflect_mission": None, "retain_mission": None}
+
+    def test_sync_cache_is_bounded_and_scoped_by_auth_bank_and_config(self, provider, monkeypatch):
+        from plugins.memory import hindsight as hindsight_mod
+
+        monkeypatch.setattr(hindsight_mod, "_BANK_CONFIG_SYNC_CACHE_MAX", 2)
+        provider._config["bank_mission"] = "mission-a"
+        provider._client.banks.get_bank_config.return_value = {
+            "config": {"reflect_mission": None}, "overrides": {}
+        }
+
+        provider._apply_configured_bank_config()
+        provider._api_key = "key-b"
+        provider._apply_configured_bank_config()
+        provider._bank_id = "bank-c"
+        provider._config["bank_mission"] = "mission-c"
+        provider._apply_configured_bank_config()
+
+        assert len(hindsight_mod._BANK_CONFIG_SYNC_CACHE) == 2
+        assert provider._client.banks.get_bank_config.await_count == 3
+        assert provider._client.banks.update_bank_config.await_count == 3
+
+    def test_failed_sync_is_suppressed_only_for_matching_scope(self, provider, monkeypatch):
+        from plugins.memory import hindsight as hindsight_mod
+
+        now = [100.0]
+        monkeypatch.setattr(hindsight_mod.time, "monotonic", lambda: now[0])
+        provider._config["bank_mission"] = "mission-a"
+        provider._client.banks.get_bank_config.side_effect = RuntimeError("API down")
+
+        provider._apply_configured_bank_config()
+        provider._apply_configured_bank_config()
+        assert provider._client.banks.get_bank_config.await_count == 1
+
+        provider._bank_id = "different-bank"
+        provider._apply_configured_bank_config()
+        assert provider._client.banks.get_bank_config.await_count == 2
+
+        now[0] += 31.0
+        provider._bank_id = "test-bank"
+        provider._apply_configured_bank_config()
+        assert provider._client.banks.get_bank_config.await_count == 3
+
+    def test_missing_generated_client_falls_back_without_blocking_initialize(self, tmp_path, monkeypatch, caplog):
+        import builtins
+
+        config = {
+            "mode": "cloud", "apiKey": "test-key",
+            "api_url": "http://localhost:9999", "bank_id": "test-bank",
+            "bank_mission": "mission",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        client = _make_mock_client()
+        monkeypatch.setattr(HindsightMemoryProvider, "_get_client", lambda self: client)
+        real_import = builtins.__import__
+
+        def import_without_generated_client(name, *args, **kwargs):
+            if name.startswith("hindsight_client_api"):
+                raise ImportError("generated client unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", import_without_generated_client)
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+        assert provider._mode == "cloud"
+        assert "bank mission sync unavailable" in caplog.text.lower()
 
     def test_embedded_profile_env_includes_idle_timeout_from_config(self):
         env = _build_embedded_profile_env({

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -88,6 +88,10 @@ def _make_mock_client():
         return_value=SimpleNamespace(text="Synthesized answer")
     )
     client.aretain_batch = AsyncMock()
+    client.banks = SimpleNamespace(
+        get_bank_config=AsyncMock(return_value={"config": {}, "overrides": {}}),
+        update_bank_config=AsyncMock(return_value={"ok": True}),
+    )
     client.aclose = AsyncMock()
     return client
 
@@ -207,7 +211,9 @@ def provider_with_config(tmp_path, monkeypatch):
         )
 
         p = HindsightMemoryProvider()
+        p._apply_configured_bank_config = lambda: None
         p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+        del p._apply_configured_bank_config
         p._client = _make_mock_client()
         return p
     return _make
@@ -317,6 +323,180 @@ class TestConfig:
         assert p._recall_prompt_preamble == "Custom preamble:"
         assert p._recall_max_input_chars == 500
         assert p._bank_mission == "Test agent mission"
+
+
+class TestBankMissionSync:
+    @pytest.fixture(autouse=True)
+    def _clear_sync_state(self):
+        from plugins.memory import hindsight as hindsight_mod
+
+        hindsight_mod._BANK_CONFIG_SYNC_CACHE.clear()
+        yield
+        hindsight_mod._BANK_CONFIG_SYNC_CACHE.clear()
+
+    def test_initialize_applies_configured_missions_with_generated_banks_api(
+        self, tmp_path, monkeypatch
+    ):
+        from hindsight_client_api.models.bank_config_update import BankConfigUpdate
+
+        config = {
+            "mode": "cloud",
+            "apiKey": "test-key",
+            "api_url": "http://localhost:9999",
+            "bank_id": "test-bank",
+            "bank_mission": " Reflect with operational context ",
+            "bank_retain_mission": " Extract durable facts ",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        client = _make_mock_client()
+        client.banks.get_bank_config.return_value = {
+            "config": {"reflect_mission": None, "retain_mission": None},
+            "overrides": {},
+        }
+        monkeypatch.setattr(
+            HindsightMemoryProvider, "_get_client", lambda self: client
+        )
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(
+            session_id="test-session", hermes_home=str(tmp_path), platform="cli"
+        )
+
+        client.banks.get_bank_config.assert_awaited_once_with(
+            "test-bank", _request_timeout=120
+        )
+        client.banks.update_bank_config.assert_awaited_once()
+        bank_id, request = client.banks.update_bank_config.await_args.args
+        assert bank_id == "test-bank"
+        assert isinstance(request, BankConfigUpdate)
+        assert request.updates == {
+            "reflect_mission": "Reflect with operational context",
+            "retain_mission": "Extract durable facts",
+        }
+        assert client.banks.update_bank_config.await_args.kwargs == {
+            "_request_timeout": 120
+        }
+
+    def test_explicit_empty_missions_clear_only_active_overrides(self, provider):
+        from hindsight_client_api.models.bank_config_update import BankConfigUpdate
+
+        provider._config["bank_mission"] = ""
+        provider._config["bank_retain_mission"] = None
+        provider._client.banks.get_bank_config.return_value = {
+            "config": {
+                "reflect_mission": "server default reflect",
+                "retain_mission": "server default retain",
+            },
+            "overrides": {
+                "reflect_mission": "stale reflect override",
+                "retain_mission": "stale retain override",
+            },
+        }
+
+        provider._apply_configured_bank_config()
+
+        provider._client.banks.update_bank_config.assert_awaited_once()
+        request = provider._client.banks.update_bank_config.await_args.args[1]
+        assert isinstance(request, BankConfigUpdate)
+        assert request.updates == {
+            "reflect_mission": None,
+            "retain_mission": None,
+        }
+
+    def test_sync_cache_is_bounded_and_scoped_by_auth_bank_and_config(
+        self, provider, monkeypatch
+    ):
+        from plugins.memory import hindsight as hindsight_mod
+
+        monkeypatch.setattr(hindsight_mod, "_BANK_CONFIG_SYNC_CACHE_MAX", 2)
+        provider._config["bank_mission"] = "mission-a"
+        provider._client.banks.get_bank_config.return_value = {
+            "config": {"reflect_mission": None},
+            "overrides": {},
+        }
+
+        provider._apply_configured_bank_config()
+        provider._api_key = "key-b"
+        provider._apply_configured_bank_config()
+        provider._bank_id = "bank-c"
+        provider._config["bank_mission"] = "mission-c"
+        provider._apply_configured_bank_config()
+
+        assert len(hindsight_mod._BANK_CONFIG_SYNC_CACHE) == 2
+        assert provider._client.banks.get_bank_config.await_count == 3
+        assert provider._client.banks.update_bank_config.await_count == 3
+
+    def test_failed_sync_is_suppressed_only_for_matching_scope(
+        self, provider, monkeypatch
+    ):
+        from plugins.memory import hindsight as hindsight_mod
+
+        now = [100.0]
+        monkeypatch.setattr(hindsight_mod.time, "monotonic", lambda: now[0])
+        monkeypatch.setattr(hindsight_mod, "_BANK_CONFIG_SYNC_FAILURE_TTL", 30.0)
+        provider._config["bank_mission"] = "mission-a"
+        provider._client.banks.get_bank_config.side_effect = RuntimeError("API down")
+
+        provider._apply_configured_bank_config()
+        provider._apply_configured_bank_config()
+        assert provider._client.banks.get_bank_config.await_count == 1
+
+        provider._bank_id = "different-bank"
+        provider._apply_configured_bank_config()
+        assert provider._client.banks.get_bank_config.await_count == 2
+
+        now[0] += 31.0
+        provider._bank_id = "test-bank"
+        provider._apply_configured_bank_config()
+        assert provider._client.banks.get_bank_config.await_count == 3
+
+    def test_missing_generated_client_falls_back_without_blocking_initialize(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        import builtins
+
+        config = {
+            "mode": "cloud",
+            "apiKey": "test-key",
+            "api_url": "http://localhost:9999",
+            "bank_id": "test-bank",
+            "bank_mission": "mission",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        client = _make_mock_client()
+        client.banks.get_bank_config.return_value = {
+            "config": {"reflect_mission": None},
+            "overrides": {},
+        }
+        monkeypatch.setattr(
+            HindsightMemoryProvider, "_get_client", lambda self: client
+        )
+        real_import = builtins.__import__
+
+        def import_without_generated_client(name, *args, **kwargs):
+            if name.startswith("hindsight_client_api"):
+                raise ImportError("generated client unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", import_without_generated_client)
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(
+            session_id="test-session", hermes_home=str(tmp_path), platform="cli"
+        )
+
+        assert provider._mode == "cloud"
+        assert "bank mission sync unavailable" in caplog.text.lower()
 
 
     def test_embedded_profile_env_includes_idle_timeout_from_config(self):


### PR DESCRIPTION
## Summary

Synchronize configured Hindsight bank missions during provider startup so Hermes config and the live bank do not silently diverge.

- Use Hindsight's generated/public `client.banks.get_bank_config` and `update_bank_config` API.
- Map `bank_mission` → `reflect_mission` and `bank_retain_mission` → `retain_mission`.
- Read before writing and patch only values that differ.
- Distinguish an absent config key (leave the live bank unchanged) from an explicit empty string/`null` (clear the active override and fall back to the server default).
- Support generated model and plain-dict response shapes.
- Handle cloud/local-external clients directly and unwrap the generated client behind `HindsightEmbedded` after daemon startup.
- Keep initialization best-effort when optional generated client pieces or the server endpoint are unavailable.
- Suppress repeated startup requests with a bounded TTL cache scoped by API URL, bank, desired values, and a non-secret authentication fingerprint.

## Verification

- Immutable current-main provider suite: **62 passed**.
- Focused bank mission sync tests: **7 passed**.
- Ruff, `py_compile`, and `git diff --check` pass.

Fixes #18774.
