### PR TITLE
fix(cli): pass user_id to AIAgent for correct Hindsight bank_id_template rendering

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -370,6 +370,7 @@ class CLIAgentSetupMixin:
                 openrouter_min_coding_score=self._openrouter_min_coding_score,
                 session_id=self.session_id,
                 platform="cli",
+                user_id="tui-local" if not getattr(self, "_user_id", None) else self._user_id,
                 session_db=self._session_db,
                 clarify_callback=self._clarify_callback,
                 reasoning_callback=self._current_reasoning_callback(),


### PR DESCRIPTION
Fixes #42321

When using Hermes **TUI** with Hindsight memory, the AIAgent constructor doesn't receive a `user_id`, causing `bank_id_template` variables like `{user}` to render as empty strings.

## Change

One-line addition to `hermes_cli/cli_agent_setup_mixin.py`:

```python
user_id="tui-local" if not getattr(self, "_user_id", None) else self._user_id,
```

- Falls back to `"tui-local"` when no user identity is configured (TUI default)
- Respects an explicitly set `_user_id` when available
- No functional change for CLI/gateway modes (they pass their own user_id)
