### PR TITLE
feat(hindsight): populate universal metadata fields extraction_method and feedback_score

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1407,6 +1407,10 @@ class HindsightMemoryProvider(MemoryProvider):
             metadata["thread_id"] = self._thread_id
         if self._agent_identity:
             metadata["agent_identity"] = self._agent_identity
+        # Universal metadata fields
+        metadata["extraction_method"] = "auto"
+        metadata["feedback_score"] = "0"
+
         return metadata
 
     def _build_retain_kwargs(


### PR DESCRIPTION
**Problem:** Hindsight's `_build_metadata()` populates platform, session, and agent identity fields but omits `extraction_method` and `feedback_score` — two universal fields that downstream consumers (analysis pipelines, dashboards, ML training) rely on for provenance and quality assessment.

**Fix:** Add two always-populated metadata fields:

- `extraction_method`: `"auto"` — documents that extraction was automatic (agent-driven). Consumers can distinguish auto-extracted from human-curated entries.
- `feedback_score`: `"0"` — neutral default. Establishes the schema contract so consumers always find the field present. Human reviewers or feedback loops can update it later.

These are safe defaults that establish the schema without breaking existing consumers.
