### PR TITLE
fix(langfuse): accumulate usage across hook invocations for traces (#42306)

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -50,6 +50,11 @@ class TraceState:
     pending_tools_by_name: Dict[str, list] = field(default_factory=dict)
     turn_tool_calls: list[dict[str, Any]] = field(default_factory=list)
     last_updated_at: float = field(default_factory=time.time)
+    # Accumulated usage/cost from post_api_request hooks.  Used as a
+    # fallback when post_llm_call fires without a response or usage dict
+    # (see #42306 — turn_finalizer.py doesn't forward usage to post_llm_call).
+    accumulated_usage_details: Dict[str, int] = field(default_factory=dict)
+    accumulated_cost_details: Dict[str, float] = field(default_factory=dict)
 
 
 _STATE_LOCK = threading.Lock()
@@ -668,6 +673,19 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
         if final_output is not None:
             state.root_span.set_trace_io(output=final_output)
             state.root_span.update(output=final_output)
+        # Attach accumulated usage/cost to the root trace so the Langfuse
+        # dashboard shows totals even when individual generation spans
+        # were ended without usage data (#42306).
+        trace_update: Dict[str, Any] = {}
+        if state.accumulated_usage_details:
+            trace_update["usage_details"] = state.accumulated_usage_details
+        if state.accumulated_cost_details:
+            trace_update["cost_details"] = state.accumulated_cost_details
+        if trace_update:
+            try:
+                state.root_span.update(**trace_update)
+            except Exception:
+                pass
         state.root_span.end()
     except Exception as exc:  # pragma: no cover - fail-open
         _debug(f"finish trace failed: {exc}")
@@ -837,7 +855,12 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
     if output.get("tool_calls"):
         state.turn_tool_calls.extend(output["tool_calls"])
 
-    # Extract usage: prefer response object, fall back to usage dict from post_api_request
+    # Extract usage: prefer response object, fall back to usage dict from post_api_request.
+    # When neither is available (e.g. post_llm_call from turn_finalizer.py which
+    # doesn't forward response/usage), fall back to values accumulated from
+    # earlier post_api_request calls for this trace (#42306).
+    usage_details: Dict[str, int] = {}
+    cost_details: Dict[str, float] = {}
     if response is not None:
         usage_details, cost_details = _usage_and_cost(
             response,
@@ -866,7 +889,6 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
             usage_details["cache_creation_input_tokens"] = _cache_write
         if _reasoning:
             usage_details["reasoning_tokens"] = _reasoning
-        cost_details = {}
         # Estimate per-type cost from the summary if possible
         try:
             from agent.usage_pricing import CanonicalUsage, estimate_usage_cost, get_pricing_entry
@@ -896,7 +918,22 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
         except Exception:
             pass
     else:
-        usage_details, cost_details = {}, {}
+        # Neither response nor usage dict — use accumulated values from
+        # earlier post_api_request calls for this trace.  This handles the
+        # case where post_llm_call fires (from turn_finalizer.py) without
+        # usage data, but post_api_request already provided it per-call.
+        usage_details = dict(state.accumulated_usage_details)
+        cost_details = dict(state.accumulated_cost_details)
+
+    # Accumulate usage/cost into trace state so that subsequent hook
+    # invocations (e.g. post_llm_call after post_api_request) can fall
+    # back to these values when they don't receive usage data directly.
+    if usage_details:
+        for k, v in usage_details.items():
+            state.accumulated_usage_details[k] = state.accumulated_usage_details.get(k, 0) + v
+    if cost_details:
+        for k, v in cost_details.items():
+            state.accumulated_cost_details[k] = state.accumulated_cost_details.get(k, 0.0) + v
 
     tool_count = len(output.get("tool_calls", [])) or assistant_tool_call_count
     gen_metadata: Dict[str, Any] = {"tool_call_count": tool_count}

--- a/tests/plugins/test_langfuse_usage_accumulation.py
+++ b/tests/plugins/test_langfuse_usage_accumulation.py
@@ -1,0 +1,233 @@
+"""Tests for observability/langfuse usage accumulation (#42306).
+
+When post_api_request fires per-API-call with usage data, the values must
+be accumulated in TraceState so that a subsequent post_llm_call (which
+does not receive response/usage from turn_finalizer.py) can still attach
+usage to the generation span and root trace.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+def _fresh_mod():
+    sys.modules.pop("plugins.observability.langfuse", None)
+    return importlib.import_module("plugins.observability.langfuse")
+
+
+class _FakeClient:
+    """Minimal Langfuse client stand-in."""
+    def flush(self):
+        pass
+
+
+class TestUsageAccumulation:
+    """post_api_request usage must accumulate in TraceState."""
+
+    def test_usage_accumulated_from_post_api_request(self, monkeypatch):
+        mod = _fresh_mod()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _FakeClient())
+
+        gen = object()
+        state = mod.TraceState(trace_id="t", root_ctx=None, root_span=None)
+        state.generations["0"] = gen
+
+        task_key = mod._trace_key("task-1", "sess-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        ended = {}
+
+        def fake_end(obs, *, output=None, usage_details=None, cost_details=None, metadata=None):
+            ended["usage"] = usage_details
+            ended["cost"] = cost_details
+
+        monkeypatch.setattr(mod, "_end_observation", fake_end)
+
+        # Simulate post_api_request firing with usage dict
+        mod.on_post_llm_call(
+            task_id="task-1",
+            session_id="sess-1",
+            api_call_count=0,
+            usage={"input_tokens": 1000, "output_tokens": 500},
+            assistant_content_chars=100,
+            assistant_tool_call_count=0,
+        )
+
+        assert ended["usage"]["input"] == 1000
+        assert ended["usage"]["output"] == 500
+        # Accumulated in state
+        assert state.accumulated_usage_details["input"] == 1000
+        assert state.accumulated_usage_details["output"] == 500
+
+    def test_usage_accumulates_across_multiple_api_calls(self, monkeypatch):
+        mod = _fresh_mod()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _FakeClient())
+
+        state = mod.TraceState(trace_id="t", root_ctx=None, root_span=None)
+        # Use a no-op root_span to prevent _finish_trace from crashing
+        state.root_span = type("S", (), {
+            "update": lambda self, **kw: None,
+            "end": lambda self: None,
+            "set_trace_io": lambda self, **kw: None,
+        })()
+
+        task_key = mod._trace_key("task-1", "sess-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        ended_calls = []
+
+        def fake_end(obs, *, output=None, usage_details=None, cost_details=None, metadata=None):
+            ended_calls.append({"usage": usage_details, "cost": cost_details})
+
+        monkeypatch.setattr(mod, "_end_observation", fake_end)
+
+        # First API call — has tool calls so _finish_trace is NOT called
+        state.generations["0"] = object()
+        mod.on_post_llm_call(
+            task_id="task-1", session_id="sess-1", api_call_count=0,
+            usage={"input_tokens": 1000, "output_tokens": 500},
+            assistant_content_chars=100, assistant_tool_call_count=2,
+        )
+
+        # Re-inject state since _finish_trace may have popped it
+        # (it won't because has_tools=True, but be safe)
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        # Second API call — also has tool calls
+        state.generations["1"] = object()
+        mod.on_post_llm_call(
+            task_id="task-1", session_id="sess-1", api_call_count=1,
+            usage={"input_tokens": 2000, "output_tokens": 800},
+            assistant_content_chars=200, assistant_tool_call_count=1,
+        )
+
+        # Accumulated totals
+        assert state.accumulated_usage_details["input"] == 3000
+        assert state.accumulated_usage_details["output"] == 1300
+
+    def test_fallback_uses_accumulated_usage(self, monkeypatch):
+        """When post_llm_call fires without response/usage, accumulated
+        values from earlier post_api_request calls must be used."""
+        mod = _fresh_mod()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _FakeClient())
+
+        gen = object()
+        state = mod.TraceState(trace_id="t", root_ctx=None, root_span=None)
+        state.generations["0"] = gen
+        # Pre-populate accumulated usage (as if post_api_request already ran)
+        state.accumulated_usage_details = {"input": 1500, "output": 700}
+        state.accumulated_cost_details = {"input": 0.003, "output": 0.007}
+
+        task_key = mod._trace_key("task-1", "sess-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        ended = {}
+
+        def fake_end(obs, *, output=None, usage_details=None, cost_details=None, metadata=None):
+            ended["usage"] = usage_details
+            ended["cost"] = cost_details
+
+        monkeypatch.setattr(mod, "_end_observation", fake_end)
+
+        # Simulate post_llm_call from turn_finalizer.py (no response, no usage)
+        mod.on_post_llm_call(
+            task_id="task-1",
+            session_id="sess-1",
+            assistant_response="Hello world",
+        )
+
+        # Should use accumulated values as fallback
+        assert ended["usage"]["input"] == 1500
+        assert ended["usage"]["output"] == 700
+        assert ended["cost"]["input"] == 0.003
+        assert ended["cost"]["output"] == 0.007
+
+    def test_fallback_empty_when_no_prior_accumulation(self, monkeypatch):
+        """When post_llm_call fires without response/usage AND no prior
+        post_api_request ran, usage should be empty (no crash)."""
+        mod = _fresh_mod()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _FakeClient())
+
+        gen = object()
+        state = mod.TraceState(trace_id="t", root_ctx=None, root_span=None)
+        state.generations["0"] = gen
+
+        task_key = mod._trace_key("task-1", "sess-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        ended = {}
+
+        def fake_end(obs, *, output=None, usage_details=None, cost_details=None, metadata=None):
+            ended["usage"] = usage_details
+            ended["cost"] = cost_details
+
+        monkeypatch.setattr(mod, "_end_observation", fake_end)
+
+        mod.on_post_llm_call(
+            task_id="task-1",
+            session_id="sess-1",
+            assistant_response="Hello world",
+        )
+
+        # No prior accumulation — should be empty, not crash
+        assert ended["usage"] == {}
+        assert ended["cost"] == {}
+
+
+class TestFinishTraceUsageAttachment:
+    """_finish_trace must attach accumulated usage to the root span."""
+
+    def test_finish_trace_attaches_usage_to_root_span(self, monkeypatch):
+        mod = _fresh_mod()
+
+        root_span = type("FakeSpan", (), {
+            "update": lambda self, **kw: setattr(self, "_update_kwargs", kw),
+            "end": lambda self: None,
+            "set_trace_io": lambda self, **kw: None,
+        })()
+
+        state = mod.TraceState(trace_id="t", root_ctx=None, root_span=root_span)
+        state.accumulated_usage_details = {"input": 5000, "output": 2000}
+        state.accumulated_cost_details = {"input": 0.01, "output": 0.02}
+
+        task_key = mod._trace_key("task-1", "sess-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _FakeClient())
+
+        mod._finish_trace(task_key, output="done")
+
+        # Verify usage was attached to root span
+        assert hasattr(root_span, "_update_kwargs")
+        kwargs = root_span._update_kwargs
+        assert kwargs["usage_details"]["input"] == 5000
+        assert kwargs["usage_details"]["output"] == 2000
+        assert kwargs["cost_details"]["input"] == 0.01
+        assert kwargs["cost_details"]["output"] == 0.02
+
+    def test_finish_trace_no_usage_when_accumulated_empty(self, monkeypatch):
+        mod = _fresh_mod()
+
+        update_calls = []
+        root_span = type("FakeSpan", (), {
+            "update": lambda self, **kw: update_calls.append(kw),
+            "end": lambda self: None,
+            "set_trace_io": lambda self, **kw: None,
+        })()
+
+        state = mod.TraceState(trace_id="t", root_ctx=None, root_span=root_span)
+        # No accumulated usage
+
+        task_key = mod._trace_key("task-1", "sess-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _FakeClient())
+
+        mod._finish_trace(task_key, output="done")
+
+        # Only one update call (for output), no usage_details
+        assert len(update_calls) == 1
+        assert "usage_details" not in update_calls[0]


### PR DESCRIPTION
## What does this PR do?

Accumulates usage/cost data in the langfuse plugin's `TraceState` so that when `post_llm_call` fires without `response` or `usage` kwargs (as happens via `turn_finalizer.py`), the handler can fall back to values already collected from earlier `post_api_request` invocations. Also attaches accumulated usage totals to the root trace in `_finish_trace`.

## Related Issue

Fixes #42306

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/observability/langfuse/__init__.py`: Added `accumulated_usage_details` and `accumulated_cost_details` fields to `TraceState`. Modified `on_post_llm_call` to accumulate usage/cost from each invocation and use accumulated values as fallback when `post_llm_call` fires without `response`/`usage`. Modified `_finish_trace` to attach accumulated usage/cost to the root trace span.
- `tests/plugins/test_langfuse_usage_accumulation.py`: Added 6 tests covering accumulation across API calls, fallback to accumulated values, empty fallback safety, and root-trace usage attachment.

## How to Test

1. Enable the langfuse plugin: `hermes plugins enable observability/langfuse`
2. Set valid Langfuse credentials in `~/.hermes/.env` (HERMES_LANGFUSE_PUBLIC_KEY, HERMES_LANGFUSE_SECRET_KEY)
3. Run a conversation: `hermes -p <profile> -m "test"`
4. Check the Langfuse dashboard — GENERATION spans should now show usage/token counts and cost
5. Run `pytest tests/plugins/test_langfuse_plugin.py tests/plugins/test_langfuse_usage_accumulation.py -v` — all 43 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/plugins/test_langfuse_plugin.py tests/plugins/test_langfuse_usage_accumulation.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/observability/langfuse/__init__.py` — `TraceState`, `on_post_llm_call`, `_finish_trace`
- Blast radius: LOW — changes are confined to the langfuse plugin's internal state management; no external APIs or other plugins affected
- Related patterns: `post_api_request` vs `post_llm_call` hook parameter asymmetry — `turn_finalizer.py` fires `post_llm_call` without `response`/`usage` kwargs while `conversation_loop.py` fires `post_api_request` with full usage data
