### PR TITLE
fix(hindsight): guard _get_client() against writer/prefetch TOCTOU

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -543,6 +543,14 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = ""
         self._turn_index = 0
         self._client = None
+        # Guards _get_client() against the TOCTOU race between the writer
+        # thread (_writer_loop calls _get_client via _run_hindsight_operation)
+        # and the prefetch thread (queue_prefetch._run() does the same).
+        # Without this lock both threads can pass the ``is None`` guard
+        # concurrently on the first turn and each construct a client,
+        # leaking the loser's connection — and for local_embedded mode,
+        # starting two HindsightEmbedded daemon processes.
+        self._client_lock = threading.Lock()
         self._timeout = _DEFAULT_TIMEOUT
         self._idle_timeout = _DEFAULT_IDLE_TIMEOUT
         self._prefetch_result = ""
@@ -883,8 +891,21 @@ class HindsightMemoryProvider(MemoryProvider):
         ]
 
     def _get_client(self):
-        """Return the cached Hindsight client (created once, reused)."""
-        if self._client is None:
+        """Return the cached Hindsight client (created once, reused).
+
+        Thread-safe: ``_client_lock`` serializes the first build so the
+        writer thread and the prefetch thread can't both pass the
+        ``is None`` guard concurrently and each construct a client,
+        leaking the loser's connection (and, for ``local_embedded`` mode,
+        starting two HindsightEmbedded daemon processes).
+        """
+        # Fast path — already built; no lock needed.
+        if self._client is not None:
+            return self._client
+        with self._client_lock:
+            # Re-check: a racing thread may have completed init while we waited.
+            if self._client is not None:
+                return self._client
             if self._mode == "local_embedded":
                 available, reason = _check_local_runtime()
                 if not available:


### PR DESCRIPTION
## Summary

`HindsightMemoryProvider._get_client()` uses a bare `if self._client is None`
check with no lock. The provider runs two internal threads concurrently:

- **writer thread** (`_writer_loop` → `_run_hindsight_operation` → `_get_client`)
- **prefetch thread** (`queue_prefetch._run()` → same chain)

On the first turn of a session (when `_client` is still `None`) both threads
can pass the `is None` guard simultaneously, each construct a client, and the
loser's instance is abandoned — leaking an open connection. For
`local_embedded` mode this means spawning **two HindsightEmbedded daemon
processes**, one of which is never shut down.

This is the same TOCTOU class fixed for the Honcho and FAL singletons in
`plugins/plugin_utils.py` (PR #24759 / commit `47d5177a7`), now applied to
the instance-level Hindsight client.

**Changes:**

- Add `self._client_lock = threading.Lock()` in `__init__`, right next to
  `self._client = None`.
- Wrap the build body of `_get_client()` with double-checked locking:
  fast-path `is not None` check stays outside the lock (no contention on
  every call after the first), full re-check inside the lock before building.
- No behavior change for the single-threaded path.

## Test plan

- [ ] `tests/plugins/memory/test_hindsight_provider.py` — 418 existing tests
  all pass (including skipped optionals)
- [ ] Fast path (`_client` already set) unchanged: single `is not None` check,
  no lock acquired
- [ ] `_client_lock` init is co-located with `_client = None` so it is always
  present when `_get_client()` is called