### PR TITLE
fix(transports/codex): clamp 'xhigh' reasoning effort to 'high' for xAI Grok

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -125,6 +125,8 @@ class ResponsesApiTransport(ProviderTransport):
                 reasoning_effort = reasoning_config["effort"]
 
         _effort_clamp = {"minimal": "low"}
+        if is_xai_responses:
+            _effort_clamp["xhigh"] = "high"
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
         response_tools = _responses_tools(tools)

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -187,6 +187,15 @@ class TestCodexBuildKwargs:
         # "minimal" should be clamped to "low"
         assert kw.get("reasoning", {}).get("effort") == "low"
 
+    def test_xhigh_effort_not_clamped_for_generic_codex(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4", messages=messages, tools=[],
+            reasoning_config={"effort": "xhigh"},
+        )
+        # "xhigh" should NOT be clamped to "high" for non-xAI models
+        assert kw.get("reasoning", {}).get("effort") == "xhigh"
+
     def test_xai_reasoning_effort_passed(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
@@ -223,6 +232,16 @@ class TestCodexBuildKwargs:
         )
         # "minimal" should be clamped to "low" for xAI as well
         assert kw.get("reasoning", {}).get("effort") == "low"
+
+    def test_xai_xhigh_effort_clamped(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4.3", messages=messages, tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": "xhigh"},
+        )
+        # "xhigh" should be clamped to "high" for xAI as well
+        assert kw.get("reasoning", {}).get("effort") == "high"
 
     # --- Grok reasoning-effort capability allowlist ---
     # api.x.ai 400s with "Model X does not support parameter reasoningEffort"


### PR DESCRIPTION
The xAI Responses API for Grok supports 'low', 'medium', and 'high' reasoning effort levels, but lacks native support for 'xhigh'. When 'xhigh' effort is passed to Grok models that accept reasoning.effort, it fails or reverts to default settings. This PR updates the Codex responses transport to clamp 'xhigh' to 'high' specifically when is_xai_responses is True, preventing errors when calling Grok models with 'xhigh' effort. It also adds unit tests to verify the behavior under both xAI and generic Codex responses paths.