### PR TITLE
fix: handle dashboard paste chords from dictation tools

### DIFF
--- a/ui-tui/src/__tests__/useComposerState.test.ts
+++ b/ui-tui/src/__tests__/useComposerState.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { looksLikeDroppedPath } from '../app/useComposerState.js'
+import { looksLikeDroppedPath, shouldSuppressClipboardFallbackForDashboard } from '../app/useComposerState.js'
 
 describe('looksLikeDroppedPath', () => {
   it('recognizes macOS screenshot temp paths and file URIs', () => {
@@ -55,5 +55,16 @@ describe('looksLikeDroppedPath', () => {
     expect(looksLikeDroppedPath('/usr/bin/test')).toBe(true)
     expect(looksLikeDroppedPath('/tmp/file.txt')).toBe(true)
     expect(looksLikeDroppedPath('/etc/hosts')).toBe(true) // has second /
+  })
+})
+
+
+describe('shouldSuppressClipboardFallbackForDashboard', () => {
+  it('suppresses server clipboard fallback inside the embedded dashboard TUI', () => {
+    expect(shouldSuppressClipboardFallbackForDashboard(true)).toBe(true)
+  })
+
+  it('keeps native TUI clipboard fallback enabled outside the dashboard', () => {
+    expect(shouldSuppressClipboardFallbackForDashboard(false)).toBe(false)
   })
 })

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -13,6 +13,7 @@ import type { ClipboardPasteResponse, ImageAttachResponse, InputDetectDropRespon
 import { useCompletion } from '../hooks/useCompletion.js'
 import { useInputHistory } from '../hooks/useInputHistory.js'
 import { useQueue } from '../hooks/useQueue.js'
+import { DASHBOARD_TUI_MODE } from '../config/env.js'
 import { isUsableClipboardText, readClipboardText } from '../lib/clipboard.js'
 import { resolveEditor } from '../lib/editor.js'
 import { readOsc52Clipboard } from '../lib/osc52.js'
@@ -103,6 +104,10 @@ export function looksLikeDroppedPath(text: string): boolean {
   }
 
   return false
+}
+
+export function shouldSuppressClipboardFallbackForDashboard(dashboardTuiMode = DASHBOARD_TUI_MODE): boolean {
+  return dashboardTuiMode
 }
 
 export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions): UseComposerStateResult {
@@ -332,6 +337,15 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
         return readPreferredText.then(async preferredText => {
           if (isUsableClipboardText(preferredText)) {
             return handleResolvedPaste({ bracketed: false, cursor, text: preferredText, value })
+          }
+
+          if (shouldSuppressClipboardFallbackForDashboard()) {
+            // Browser-embedded chat cannot safely read the user's local clipboard
+            // from the server-side Ink process. If a paste chord leaks through
+            // here, the dashboard's browser handler missed it; do not fall into
+            // the image-clipboard path, which only produces the misleading
+            // "No image found in clipboard" curse instead of inserting text.
+            return null
           }
 
           // No text on the clipboard — an image paste looks exactly like this.

--- a/web/src/lib/dashboard-keyboard.test.ts
+++ b/web/src/lib/dashboard-keyboard.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { isDashboardPasteShortcut, type DashboardKeyEvent } from "./dashboard-keyboard";
+
+function key(overrides: Partial<DashboardKeyEvent>): DashboardKeyEvent {
+  return { altKey: false, ctrlKey: false, key: "v", metaKey: false, ...overrides };
+}
+
+describe("isDashboardPasteShortcut", () => {
+  it("accepts Cmd+V and Ctrl+V on macOS for dashboard dictation paste chords", () => {
+    expect(isDashboardPasteShortcut(key({ metaKey: true }), true)).toBe(true);
+    expect(isDashboardPasteShortcut(key({ ctrlKey: true }), true)).toBe(true);
+  });
+
+  it("accepts Ctrl+V and Ctrl+Shift+V on non-mac platforms", () => {
+    expect(isDashboardPasteShortcut(key({ ctrlKey: true }), false)).toBe(true);
+  });
+
+  it("does not hijack Alt/AltGr-modified chords", () => {
+    expect(isDashboardPasteShortcut(key({ altKey: true, ctrlKey: true }), false)).toBe(false);
+    expect(isDashboardPasteShortcut(key({ altKey: true, metaKey: true }), true)).toBe(false);
+  });
+
+  it("rejects non-v keys", () => {
+    expect(isDashboardPasteShortcut(key({ ctrlKey: true, key: "c" }), false)).toBe(false);
+  });
+});

--- a/web/src/lib/dashboard-keyboard.ts
+++ b/web/src/lib/dashboard-keyboard.ts
@@ -1,0 +1,12 @@
+export interface DashboardKeyEvent {
+  altKey: boolean;
+  ctrlKey: boolean;
+  key: string;
+  metaKey: boolean;
+}
+
+export function isDashboardPasteShortcut(ev: DashboardKeyEvent, isMac: boolean): boolean {
+  if (ev.key.toLowerCase() !== "v") return false;
+  if (ev.altKey) return false;
+  return isMac ? ev.metaKey || ev.ctrlKey : ev.ctrlKey;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -36,6 +36,7 @@ import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
 import { latchChatActivation } from "@/lib/chat-activation";
+import { isDashboardPasteShortcut } from "@/lib/dashboard-keyboard";
 import { normalizeSessionTitle } from "@/lib/chat-title";
 import { PtyResumeSanitizer } from "@/lib/pty-resume-sanitizer";
 import {
@@ -647,9 +648,16 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // konsole / Windows Terminal. Ctrl+Shift+C only copies if a selection exists;
       // without a selection it passes through to the TUI so agents can still
       // react to the keypress.
-      // Paste: Cmd+Shift+V on macOS, Ctrl+Shift+V on others.
+      // Paste: Cmd+V on macOS, Ctrl+V / Ctrl+Shift+V elsewhere.
+      //
+      // The embedded dashboard TUI runs on the server, so if bare Ctrl+V is
+      // allowed through to the PTY the inner Ink app receives ``\x16`` and
+      // tries to read *the server's* clipboard. Browser/macOS dictation tools
+      // such as Wispr Flow can emit Ctrl+V even on Macs; without intercepting
+      // that here, dictated text is swallowed and Hermes reports the cursed
+      // "No image found in clipboard" fallback. Always read the browser
+      // clipboard for paste chords before bytes reach the PTY.
       const copyModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
-      const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
 
       if (copyModifier && ev.key.toLowerCase() === "c") {
         const sel = term.getSelection();
@@ -669,7 +677,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         // (or the bare ev if the user used a different modifier).
       }
 
-      if (pasteModifier && ev.key.toLowerCase() === "v") {
+      if (isDashboardPasteShortcut(ev, isMac)) {
         // preventDefault suppresses the DOM paste event, so image paste must
         // be handled here via clipboard.read() — readText() alone misses
         // image-only clipboards (the Discord / #24860 failure mode).


### PR DESCRIPTION
## Summary
- Treat bare Ctrl+V as a dashboard paste shortcut so dictation tools that synthesize Ctrl+V, including Wispr Flow, paste through the browser clipboard instead of leaking bytes to the embedded TUI.
- Suppress the server-side clipboard/image fallback when a paste hotkey leaks into the dashboard TUI, avoiding the misleading "No image found in clipboard" message.
- Add regression coverage for the dashboard-TUI fallback guard.

## Test plan
- `npm run test -- useComposerState.test.ts clipboard.test.ts` from `ui-tui/`
- `npm run build` from `ui-tui/`
- `npm run build` from `web/`
