### PR TITLE
feat: add context file brief helper

### DIFF
--- a/docs/context-file-brief-plan.md
+++ b/docs/context-file-brief-plan.md
@@ -1,0 +1,28 @@
+# Context file brief helper plan
+
+## Problem
+
+Hermes loads repo and profile context files such as `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `SOUL.md`. These files can silently grow until they consume or truncate useful prompt budget. Joe's nightly workflow needs a small, local-only check that turns context bloat into a reviewable signal without printing private context contents.
+
+## Scope
+
+Build a stdlib-only script at `scripts/context_file_brief.py` that:
+
+1. Deterministically discovers known context files at the workspace root and `.hermes/` subdirectory.
+2. Reports character count, line count, budget ratio, and status (`ok`, `warn`, `over`).
+3. Emits actionable cleanup guidance for `warn` / `over` files.
+4. Supports JSON output for automation.
+5. Supports exact `[SILENT]` when `--silent-ok` is set and every discovered file is OK.
+
+## Non-goals
+
+- Do not print file contents.
+- Do not rewrite, split, or delete context files.
+- Do not inspect secrets or expand data access.
+
+## Acceptance tests
+
+- Discovery includes root + `.hermes/` context files and ignores unrelated files.
+- Oversized files produce `over` and a specific split-to-skills/references suggestion.
+- `--silent-ok` emits exactly `[SILENT]` only when all discovered files are OK.
+- JSON output uses stable relative paths.

--- a/scripts/context_file_brief.py
+++ b/scripts/context_file_brief.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Audit Hermes/agent context files for prompt-budget hygiene.
+
+This helper is intentionally local-only: it reports file sizes and stable
+relative paths without printing context file contents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+CONTEXT_FILENAMES = ("AGENTS.md", "CLAUDE.md", "GEMINI.md", "SOUL.md")
+CONTEXT_DIRS = (".", ".hermes")
+DEFAULT_MAX_CHARS = 14_000
+DEFAULT_WARN_RATIO = 0.75
+SILENT_MARKER = "[SILENT]"
+
+
+@dataclass(frozen=True)
+class ContextFile:
+    path: Path
+    relative_path: str
+
+
+@dataclass(frozen=True)
+class ContextReport:
+    path: str
+    char_count: int
+    line_count: int
+    max_chars: int
+    budget_ratio: float
+    status: str
+    suggestion: str
+
+
+def _stable_relative(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def discover_context_files(root: Path) -> list[ContextFile]:
+    """Return known context files in deterministic root-then-.hermes order."""
+    root = root.resolve()
+    found: list[ContextFile] = []
+    for directory in CONTEXT_DIRS:
+        base = root if directory == "." else root / directory
+        for filename in CONTEXT_FILENAMES:
+            path = base / filename
+            if path.is_file():
+                found.append(ContextFile(path=path, relative_path=_stable_relative(path, root)))
+    return found
+
+
+def _line_count(text: str) -> int:
+    if not text:
+        return 0
+    return text.count("\n") + (0 if text.endswith("\n") else 1)
+
+
+def _status_for(char_count: int, max_chars: int, warn_ratio: float) -> str:
+    if char_count > max_chars:
+        return "over"
+    if char_count >= max_chars * warn_ratio:
+        return "warn"
+    return "ok"
+
+
+def _suggestion_for(status: str) -> str:
+    if status == "ok":
+        return "No action needed."
+    if status == "warn":
+        return "Review soon: split durable procedures into skills/references before this context file becomes a prompt-budget sink."
+    return "Action recommended: split durable procedures into skills/references and keep only routing-critical guidance in the context file."
+
+
+def analyze_file(path: Path, root: Path, *, max_chars: int, warn_ratio: float = DEFAULT_WARN_RATIO) -> ContextReport:
+    """Measure one context file without exposing its contents."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    char_count = len(text)
+    status = _status_for(char_count, max_chars, warn_ratio)
+    ratio = 0.0 if max_chars <= 0 else char_count / max_chars
+    return ContextReport(
+        path=_stable_relative(path.resolve(), root.resolve()),
+        char_count=char_count,
+        line_count=_line_count(text),
+        max_chars=max_chars,
+        budget_ratio=round(ratio, 3),
+        status=status,
+        suggestion=_suggestion_for(status),
+    )
+
+
+def analyze_root(root: Path, *, max_chars: int, warn_ratio: float = DEFAULT_WARN_RATIO) -> list[ContextReport]:
+    return [
+        analyze_file(item.path, root, max_chars=max_chars, warn_ratio=warn_ratio)
+        for item in discover_context_files(root)
+    ]
+
+
+def has_attention_items(reports: Iterable[ContextReport]) -> bool:
+    return any(report.status != "ok" for report in reports)
+
+
+def render_human(reports: list[ContextReport], root: Path) -> str:
+    if not reports:
+        return f"No known context files found under {root}."
+
+    lines = [f"Context file prompt-budget brief for {root}:"]
+    for report in reports:
+        percent = report.budget_ratio * 100
+        lines.append(
+            f"- {report.path}: {report.status} — {report.char_count:,} chars, "
+            f"{report.line_count:,} lines ({percent:.1f}% of {report.max_chars:,})"
+        )
+        if report.status != "ok":
+            lines.append(f"  ↳ {report.suggestion}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audit agent context files for prompt-budget hygiene.")
+    parser.add_argument("--root", default=".", help="Repository/workspace root to scan (default: current directory).")
+    parser.add_argument("--max-chars", type=int, default=DEFAULT_MAX_CHARS, help=f"Per-file character budget (default: {DEFAULT_MAX_CHARS}).")
+    parser.add_argument("--warn-ratio", type=float, default=DEFAULT_WARN_RATIO, help=f"Warn at this fraction of --max-chars (default: {DEFAULT_WARN_RATIO}).")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument("--silent-ok", action="store_true", help=f"Print exact {SILENT_MARKER} when every discovered file is OK.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = Path(args.root).expanduser().resolve()
+    reports = analyze_root(root, max_chars=args.max_chars, warn_ratio=args.warn_ratio)
+
+    attention = has_attention_items(reports)
+    if args.silent_ok and not attention:
+        print(SILENT_MARKER)
+        return 0
+
+    if args.json:
+        payload = {"root": str(root), "files": [asdict(report) for report in reports]}
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(render_human(reports, root))
+
+    return 1 if attention else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_context_file_brief.py
+++ b/tests/scripts/test_context_file_brief.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "context_file_brief.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("context_file_brief", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_discovers_root_and_hermes_context_files(tmp_path: Path) -> None:
+    module = load_module()
+    (tmp_path / "AGENTS.md").write_text("root\n", encoding="utf-8")
+    (tmp_path / ".hermes").mkdir()
+    (tmp_path / ".hermes" / "SOUL.md").write_text("soul\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("ignored\n", encoding="utf-8")
+
+    found = module.discover_context_files(tmp_path)
+
+    assert [item.relative_path for item in found] == ["AGENTS.md", ".hermes/SOUL.md"]
+
+
+def test_analyzes_oversized_file_with_actionable_suggestion(tmp_path: Path) -> None:
+    module = load_module()
+    path = tmp_path / "AGENTS.md"
+    path.write_text("x" * 45, encoding="utf-8")
+
+    report = module.analyze_file(path, tmp_path, max_chars=30, warn_ratio=0.5)
+
+    assert report.status == "over"
+    assert report.char_count == 45
+    assert report.line_count == 1
+    assert "split durable procedures" in report.suggestion
+
+
+def test_silent_ok_is_exact_only_when_all_files_ok(tmp_path: Path, capsys) -> None:
+    module = load_module()
+    (tmp_path / "AGENTS.md").write_text("short\n", encoding="utf-8")
+
+    code = module.main(["--root", str(tmp_path), "--max-chars", "100", "--silent-ok"])
+
+    assert code == 0
+    assert capsys.readouterr().out == "[SILENT]\n"
+
+
+def test_cli_json_uses_stable_relative_paths(tmp_path: Path) -> None:
+    (tmp_path / ".hermes").mkdir()
+    (tmp_path / ".hermes" / "CLAUDE.md").write_text("hello\nworld\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--root",
+            str(tmp_path),
+            "--max-chars",
+            "100",
+            "--json",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["root"] == str(tmp_path)
+    assert payload["files"][0]["path"] == ".hermes/CLAUDE.md"
+    assert payload["files"][0]["status"] == "ok"
+
+
+def test_silent_ok_does_not_suppress_warning(tmp_path: Path, capsys) -> None:
+    module = load_module()
+    (tmp_path / "SOUL.md").write_text("x" * 75, encoding="utf-8")
+
+    code = module.main(["--root", str(tmp_path), "--max-chars", "100", "--silent-ok"])
+
+    output = capsys.readouterr().out
+    assert code == 1
+    assert "SOUL.md" in output
+    assert "warn" in output
+    assert output != "[SILENT]\n"


### PR DESCRIPTION
## Summary
- add a local-only context file brief helper for AGENTS/CLAUDE/GEMINI/SOUL prompt-budget hygiene
- include a small spec/plan documenting scope, non-goals, and acceptance tests
- cover discovery, oversized analysis, exact [SILENT] behavior, and JSON output

## Tests
- scripts/run_tests.sh tests/scripts/test_context_file_brief.py
- python -m py_compile scripts/context_file_brief.py tests/scripts/test_context_file_brief.py
- python -m ruff check scripts/context_file_brief.py tests/scripts/test_context_file_brief.py
- python scripts/context_file_brief.py --root . --max-chars 14000
- python scripts/context_file_brief.py --root . --max-chars 14000 --json

## Notes
- The smoke checks intentionally exit 1 when AGENTS.md is over budget; output correctly reports the attention item without printing file contents.