### PR TITLE
fix(model_metadata): prefer catalog 1M over stale probe for MiniMax M3

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1788,6 +1788,17 @@ def get_model_context_length(
         from agent.models_dev import lookup_models_dev_context
         ctx = lookup_models_dev_context(effective_provider, model)
         if ctx:
+            # MiniMax M3: models.dev reports 512K but actual context is 1M.
+            # Prefer hardcoded catalog over stale probe value.
+            if _model_name_suggests_minimax_m3(model):
+                catalog = DEFAULT_CONTEXT_LENGTHS.get("minimax-m3")
+                if catalog and ctx < catalog:
+                    logger.info(
+                        "Rejecting models.dev context=%s for %r "
+                        "(MiniMax-M3 underreport); using hardcoded default %s",
+                        ctx, model, f"{catalog:,}",
+                    )
+                    ctx = catalog
             return ctx
 
     # 6. OpenRouter live API metadata — provider-unaware fallback.


### PR DESCRIPTION
## What does this PR do?

When `lookup_models_dev_context()` returns a stale value (512K) for MiniMax M3 from models.dev, the hardcoded catalog entries in `DEFAULT_CONTEXT_LENGTHS` (1M) are ignored. This causes the boot banner to print `Context: 512,000 tokens (detected)` even when the model truly has 1M context.

This PR adds a guard after the models.dev probe: if the model name suggests MiniMax M3 and the probe returns a value smaller than the hardcoded catalog (1M), prefer the catalog value instead.

## Related Issue

Fixes #42333

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`: After `lookup_models_dev_context()` returns, check if the model is MiniMax M3 via `_model_name_suggests_minimax_m3()` and if the probed value is smaller than the hardcoded `DEFAULT_CONTEXT_LENGTHS["minimax-m3"]` (1M). If so, prefer the catalog value and log a warning about the stale probe.

## How to Test

1. Run the existing test suite: `pytest tests/agent/test_minimax_provider.py -q` — 47/47 passed
2. With a MiniMax M3 provider configured, verify the boot banner shows `Context: 1,000,000 tokens`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_minimax_provider.py -q` — 47/47 passed
- [x] I've tested on my platform: Docker/Linux

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
