### PR TITLE
fix(cli): raise model picker max_models cap from 50 to 200

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6666,7 +6666,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             try:
                 if ctx is None:
                     raise RuntimeError("inventory context unavailable")
-                providers = build_models_payload(ctx, max_models=50)["providers"]
+                providers = build_models_payload(ctx, max_models=200)["providers"]
             except Exception:
                 providers = []
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -961,7 +961,7 @@ class GatewaySlashCommandsMixin:
                         current_model=current_model,
                         user_providers=user_provs,
                         custom_providers=custom_provs,
-                        max_models=50,
+                        max_models=200,
                     )
                 except Exception:
                     providers = []

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -117,7 +117,7 @@ def build_models_payload(
     pricing: bool = False,
     capabilities: bool = False,
     force_fresh_nous_tier: bool = False,
-    max_models: int = 50,
+    max_models: int = 200,
 ) -> dict:
     """Build the ``{providers, model, provider}`` shape every consumer
     needs from a single substrate call.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1162,7 +1162,7 @@ def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:
                 current_model=ctx.current_model,
                 user_providers=ctx.user_providers,
                 custom_providers=ctx.custom_providers,
-                max_models=50,
+                max_models=200,
             )
         except Exception:
             # Best-effort warmup — never surface errors into the session.
@@ -1180,7 +1180,7 @@ def list_authenticated_providers(
     custom_providers: list | None = None,
     *,
     force_fresh_nous_tier: bool = False,
-    max_models: int = 8,
+    max_models: int = 200,
     current_model: str = "",
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
@@ -1968,7 +1968,7 @@ def list_picker_providers(
     current_base_url: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
-    max_models: int = 8,
+    max_models: int = 200,
     current_model: str = "",
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2298,7 +2298,7 @@ def get_model_options():
         # affordance instead of hiding the provider entirely.
         return build_models_payload(
             load_picker_context(),
-            max_models=50,
+            max_models=200,
             include_unconfigured=True,
             picker_hints=True,
             canonical_order=True,
@@ -2371,7 +2371,7 @@ def get_recommended_default_model(provider: str = ""):
     try:
         from hermes_cli.inventory import build_models_payload, load_picker_context
 
-        payload = build_models_payload(load_picker_context(), max_models=50)
+        payload = build_models_payload(load_picker_context(), max_models=200)
         for row in payload.get("providers", []):
             if str(row.get("slug", "")).lower() == slug:
                 models = row.get("models") or []

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -235,6 +235,27 @@ def test_list_authenticated_providers_force_fresh_is_keyword_only():
     assert param.default is False
 
 
+def test_build_models_payload_default_max_models_is_200():
+    # Regression: default max_models must be high enough for providers
+    # with large catalogs (e.g. NVIDIA NIM with 100+ models).
+    # Issue #42270 -- the previous default of 50 truncated the model list.
+    import inspect
+
+    sig = inspect.signature(build_models_payload)
+    assert sig.parameters["max_models"].default == 200
+
+
+def test_list_authenticated_providers_default_max_models_is_200():
+    # Regression: default max_models must match build_models_payload.
+    # Issue #42270 -- the previous default of 8 was too low.
+    import inspect
+
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    sig = inspect.signature(list_authenticated_providers)
+    assert sig.parameters["max_models"].default == 200
+
+
 def test_pricing_uses_cached_nous_tier_by_default():
     rows = [_nous_row()]
     ctx = _empty_ctx(provider="nous", model="openai/gpt-5.5")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7692,7 +7692,7 @@ def _(rid, params: dict) -> dict:
             canonical_order=True,
             pricing=True,
             capabilities=True,
-            max_models=50,
+            max_models=200,
         )
         return _ok(rid, payload)
     except Exception as e:
@@ -7758,7 +7758,7 @@ def _(rid, params: dict) -> dict:
             current_base_url=getattr(agent, "base_url", "") if agent else "",
         )
         payload = build_models_payload(
-            ctx, picker_hints=True, max_models=50,
+            ctx, picker_hints=True, max_models=200,
         )
         provider_data = next(
             (p for p in payload["providers"] if p["slug"] == slug), None


### PR DESCRIPTION
## Problem

The `/model` picker (CLI, TUI, Desktop, and gateway) was hard-capped at **50 models per provider**. Providers with large catalogs (e.g. NVIDIA NIM with 100+ models) had their model list silently truncated — users could only see the first 50 alphabetically.

Affected call sites:
- `build_models_payload()` default: `max_models=50`
- `list_authenticated_providers()` default: `max_models=8`
- `list_picker_providers()` default: `max_models=8`
- `prewarm_picker_cache_async()`: `max_models=50`
- CLI `_handle_model_command()`: `max_models=50`
- TUI `model.list` / `model.detail`: `max_models=50`
- Web server `get_model_options()` / `get_recommended_default_model()`: `max_models=50`
- Gateway `/model` slash command: `max_models=50`

## Fix

Raise all `max_models` caps from 50 (or 8) to **200**. This accommodates providers with large catalogs while keeping the list manageable for UI rendering. The picker already supports search/filter, so 200 models per provider is well within usability bounds.

## Changes

| File | Change |
|------|--------|
| `hermes_cli/inventory.py` | `build_models_payload()` default: 50 → 200 |
| `hermes_cli/model_switch.py` | `list_authenticated_providers()` default: 8 → 200 |
| `hermes_cli/model_switch.py` | `list_picker_providers()` default: 8 → 200 |
| `hermes_cli/model_switch.py` | `prewarm_picker_cache_async()`: 50 → 200 |
| `cli.py` | `_handle_model_command()`: 50 → 200 |
| `hermes_cli/web_server.py` | 2 endpoints: 50 → 200 |
| `tui_gateway/server.py` | 2 RPC handlers: 50 → 200 |
| `gateway/slash_commands.py` | `/model` handler: 50 → 200 |
| `tests/hermes_cli/test_inventory.py` | 2 regression tests for default values |

## Testing

- `test_inventory.py`: 25/25 passed (2 new regression tests)
- `test_tui_gateway/`: 105/105 passed
- `tests/gateway/`: 451/453 passed (2 pre-existing failures unrelated to this change)

Fixes #42270
