### PR TITLE
fix(matrix): mark threaded replies as genuine

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4384,21 +4384,28 @@ class MatrixAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Apply Matrix reply/thread relation metadata to an outbound payload."""
-        thread_id = str((metadata or {}).get("thread_id") or "")
+        meta = metadata or {}
+        thread_id = str(meta.get("thread_id") or "")
+        fallback_to = str(
+            meta.get("matrix_thread_fallback_event_id")
+            or meta.get("thread_fallback_event_id")
+            or ""
+        )
         if reply_to:
             msg_content["m.relates_to"] = {"m.in_reply_to": {"event_id": reply_to}}
         if thread_id:
             relates_to = msg_content.get("m.relates_to", {})
             relates_to["rel_type"] = "m.thread"
             relates_to["event_id"] = thread_id
-            relates_to["is_falling_back"] = True
-            # Matrix clients that do not render threads still use reply
-            # fallback. If no explicit reply target is available, fall back
-            # to the thread root.
-            relates_to.setdefault(
-                "m.in_reply_to",
-                {"event_id": reply_to or thread_id},
-            )
+            if reply_to:
+                # A rich reply inside a thread is not a fallback relation.
+                relates_to.setdefault("m.in_reply_to", {"event_id": reply_to})
+                relates_to["is_falling_back"] = False
+            elif fallback_to:
+                # Only explicit compatibility anchors should be marked as
+                # fallback replies for clients that do not render threads.
+                relates_to["m.in_reply_to"] = {"event_id": fallback_to}
+                relates_to["is_falling_back"] = True
             msg_content["m.relates_to"] = relates_to
 
     def _extract_outbound_mentions(self, text: str) -> list[str]:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -631,7 +631,7 @@ class TestMatrixRenderingPayloads:
 
 
     @pytest.mark.asyncio
-    async def test_thread_payload_uses_m_thread_with_reply_fallback(self):
+    async def test_plain_thread_payload_omits_reply_fallback(self):
         result = await self.adapter.send(
             "!room:example.org",
             "threaded",
@@ -643,10 +643,96 @@ class TestMatrixRenderingPayloads:
         assert relates_to == {
             "rel_type": "m.thread",
             "event_id": "$root",
-            "is_falling_back": True,
-            "m.in_reply_to": {"event_id": "$root"},
         }
 
+    @pytest.mark.asyncio
+    async def test_thread_payload_preserves_explicit_reply_target(self):
+        result = await self.adapter.send(
+            "!room:example.org",
+            "threaded reply",
+            reply_to="$reply",
+            metadata={"thread_id": "$root"},
+        )
+
+        assert result.success is True
+        relates_to = self._sent_contents()[0]["m.relates_to"]
+        assert relates_to["event_id"] == "$root"
+        assert relates_to["m.in_reply_to"] == {"event_id": "$reply"}
+        assert relates_to["is_falling_back"] is False
+
+    @pytest.mark.asyncio
+    async def test_thread_payload_can_emit_explicit_fallback_anchor(self):
+        result = await self.adapter.send(
+            "!room:example.org",
+            "threaded fallback",
+            metadata={
+                "thread_id": "$root",
+                "matrix_thread_fallback_event_id": "$latest",
+            },
+        )
+
+        assert result.success is True
+        relates_to = self._sent_contents()[0]["m.relates_to"]
+        assert relates_to == {
+            "rel_type": "m.thread",
+            "event_id": "$root",
+            "m.in_reply_to": {"event_id": "$latest"},
+            "is_falling_back": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_thread_payload_accepts_unprefixed_fallback_anchor_alias(self):
+        result = await self.adapter.send(
+            "!room:example.org",
+            "threaded fallback",
+            metadata={
+                "thread_id": "$root",
+                "thread_fallback_event_id": "$latest-via-alias",
+            },
+        )
+
+        assert result.success is True
+        relates_to = self._sent_contents()[0]["m.relates_to"]
+        assert relates_to == {
+            "rel_type": "m.thread",
+            "event_id": "$root",
+            "m.in_reply_to": {"event_id": "$latest-via-alias"},
+            "is_falling_back": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_matrix_prefixed_fallback_anchor_takes_precedence(self):
+        result = await self.adapter.send(
+            "!room:example.org",
+            "threaded fallback",
+            metadata={
+                "thread_id": "$root",
+                "matrix_thread_fallback_event_id": "$matrix-prefixed",
+                "thread_fallback_event_id": "$unprefixed-alias",
+            },
+        )
+
+        assert result.success is True
+        relates_to = self._sent_contents()[0]["m.relates_to"]
+        assert relates_to["m.in_reply_to"] == {"event_id": "$matrix-prefixed"}
+        assert relates_to["is_falling_back"] is True
+
+    @pytest.mark.asyncio
+    async def test_edit_payload_uses_m_replace(self):
+        result = await self.adapter.edit_message(
+            "!room:example.org",
+            "$original",
+            "edited **body**",
+        )
+
+        assert result.success is True
+        content = self._sent_contents()[0]
+        assert content["m.relates_to"] == {
+            "rel_type": "m.replace",
+            "event_id": "$original",
+        }
+        assert content["m.new_content"]["body"] == "edited **body**"
+        assert content["body"] == "* edited **body**"
 
     @pytest.mark.asyncio
     async def test_long_response_split_preserves_thread_context(self):
@@ -667,7 +753,8 @@ class TestMatrixRenderingPayloads:
         for content in contents:
             assert content["m.relates_to"]["rel_type"] == "m.thread"
             assert content["m.relates_to"]["event_id"] == "$root"
-            assert content["m.relates_to"]["m.in_reply_to"] == {"event_id": "$root"}
+            assert "m.in_reply_to" not in content["m.relates_to"]
+            assert "is_falling_back" not in content["m.relates_to"]
             assert content["body"].count("```") % 2 == 0
 
 
@@ -1402,7 +1489,39 @@ class TestMatrixUploadAndSend:
         assert sent["body"] == "Chart caption"
         assert sent["m.relates_to"]["rel_type"] == "m.thread"
         assert sent["m.relates_to"]["event_id"] == "$root"
-        assert sent["m.relates_to"]["m.in_reply_to"] == {"event_id": "$root"}
+        assert "m.in_reply_to" not in sent["m.relates_to"]
+        assert "is_falling_back" not in sent["m.relates_to"]
+
+    @pytest.mark.asyncio
+    async def test_send_multiple_images_preserves_logical_batch_order_and_thread(self, tmp_path):
+        adapter = _make_adapter()
+        mock_client = MagicMock()
+        mock_client.upload_media = AsyncMock(side_effect=[
+            "mxc://example.org/one",
+            "mxc://example.org/two",
+        ])
+        mock_client.send_message_event = AsyncMock(side_effect=["$one", "$two"])
+        adapter._client = mock_client
+        first = tmp_path / "one.png"
+        second = tmp_path / "two.png"
+        first.write_bytes(b"one")
+        second.write_bytes(b"two")
+
+        await adapter.send_multiple_images(
+            "!room:example.org",
+            [(f"file://{first}", "First image"), (f"file://{second}", "Second image")],
+            metadata={"thread_id": "$root"},
+        )
+
+        assert mock_client.send_message_event.await_count == 2
+        bodies = [call.args[2]["body"] for call in mock_client.send_message_event.await_args_list]
+        assert bodies == ["First image (1/2)", "Second image (2/2)"]
+        for call in mock_client.send_message_event.await_args_list:
+            sent = call.args[2]
+            assert sent["msgtype"] == "m.image"
+            assert sent["m.relates_to"]["event_id"] == "$root"
+            assert "m.in_reply_to" not in sent["m.relates_to"]
+            assert "is_falling_back" not in sent["m.relates_to"]
 
 
 class TestMatrixDiagnostics:


### PR DESCRIPTION
## Summary
- centralize outbound Matrix `m.thread` relation construction in a small helper
- mark `m.in_reply_to` as a genuine rich reply (`is_falling_back=false`) when Hermes sends a threaded reply with an explicit `reply_to` event
- omit `is_falling_back` for plain thread sends without an `m.in_reply_to` fallback relation
- support an explicit fallback anchor (`matrix_thread_fallback_event_id` / `thread_fallback_event_id`) for callers that deliberately want a backwards-compatible reply chain
- add regression tests for genuine threaded replies, plain thread sends, and explicit fallback-chain sends

## Why this is legitimate
Hermes currently sets `is_falling_back=true` whenever outbound Matrix content has `metadata.thread_id`. That over-applies the fallback flag.

In Matrix threading, `is_falling_back=true` is not a generic "this is in a thread" marker. It specifically means the accompanying `m.in_reply_to` relation is a backwards-compatibility fallback chain for clients that do not understand threads.

The Matrix threading MSC makes this distinction:
- a genuine rich reply inside a thread uses `rel_type: "m.thread"`, the thread root `event_id`, `m.in_reply_to`, and `is_falling_back: false`
- the backwards-compatibility chain uses `m.in_reply_to` to point at the latest known message in the thread and sets `is_falling_back: true`
- when omitted, `is_falling_back` defaults to false

Reference: MSC3440, "Rich replies in a thread" and "Backwards compatibility":
https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3440-threading-via-relations.md

This also matches Element's client behavior. `matrix-react-sdk` sets `is_falling_back=false` for replies to events with `threadRootId`, and suppresses rich-reply display when a thread relation has `is_falling_back=true`:
https://github.com/element-hq/matrix-react-sdk/blob/develop/src/utils/Reply.ts

So the fix is not "always false". The helper now encodes the three cases explicitly:

```text
thread_id + reply_to:
  rel_type=m.thread
  event_id=<thread root>
  m.in_reply_to=<actual replied event>
  is_falling_back=false

thread_id + explicit fallback anchor:
  rel_type=m.thread
  event_id=<thread root>
  m.in_reply_to=<latest known thread event>
  is_falling_back=true

thread_id only:
  rel_type=m.thread
  event_id=<thread root>
  no m.in_reply_to
  no is_falling_back flag
```

That keeps the true fallback case available, but stops labeling genuine replies and plain thread sends as fallback chains.

## Test plan
- `git diff --check` → passed
- `python -m py_compile gateway/platforms/matrix.py` → passed
- focused thread relation regression tests → 7 passed
- `pytest tests/gateway/test_matrix_mention.py -q -o 'addopts='` → 52 passed
- `pytest tests/gateway/test_matrix.py -q -o 'addopts='` → 231 passed
- broader Matrix gateway sweep (`test_matrix_mention.py test_matrix.py test_matrix_voice.py`) → 284 passed, 6 failed in `test_matrix_voice.py`; the same 6 voice-test failures reproduce on clean `upstream/main` at 046f444dd, so they are unrelated to this branch

## Duplicate check
Searched open PRs/issues for:
- `matrix is_falling_back`
- `Matrix thread fallback`
- `m.thread is_falling_back`
- `matrix threaded reply fallback`

No open duplicate found.
