### PR TITLE
feat(cron): allow memory store for jobs that opt in via allow_memory flag

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1796,7 +1796,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             # Without a workdir, keep cwd context discovery disabled.
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
-            skip_memory=True,  # Cron system prompts would corrupt user representations
+            skip_memory=not job.get("allow_memory", False),  # Allow memory for jobs that opt in (e.g. Dreaming)
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,


### PR DESCRIPTION
## Summary

Fixes Dreaming/memory consolidation cron jobs that need to write to the memory store. Previously `skip_memory=True` was hardcoded for all cron agents, making memory consolidation impossible from a cron context.

Jobs can now set `allow_memory: true` in jobs.json to enable memory writes in their cron agent session.

## Change

`cron/scheduler.py` line 1799:

```diff
- skip_memory=True,  # Cron system prompts would corrupt user representations
+ skip_memory=not job.get("allow_memory", False),  # Allow memory for jobs that opt in (e.g. Dreaming)
```

## Use case

This enables the "Dreaming" memory consolidation cron job to actually write to the memory store, which was the intended behavior but was blocked by the hardcoded flag.

## Backward compatibility

All existing jobs are unaffected — they default to `skip_memory=True` (the original behavior). Only jobs that explicitly set `allow_memory: true` opt in.