### PR TITLE
docs(config): list API server env vars in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -367,6 +367,12 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # Only set to true if you intentionally want open access.
 # GATEWAY_ALLOW_ALL_USERS=false
 
+# OpenAI-compatible API server (for Open WebUI, Desktop remote mode, etc.)
+# API_SERVER_ENABLED=false
+# API_SERVER_KEY=
+# API_SERVER_HOST=127.0.0.1
+# API_SERVER_PORT=8642
+
 # =============================================================================
 # RESPONSE PACING
 # =============================================================================


### PR DESCRIPTION
## Summary
- Adds missing API server environment variable examples to `.env.example`.
- Addresses item 1 from #39598.
- Docs/config example only; runtime behavior is unchanged.

## Validation
- Manually verified the change only updates `.env.example`.
- No runtime tests needed for this documentation/example-only change.