### PR TITLE
feat(gateway): persist received attachments to configurable storage path

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -474,7 +474,7 @@ def is_host_excluded_by_no_proxy(hostname: str, no_proxy_value: str | None = Non
 
 import dataclasses
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
 from enum import Enum
@@ -1331,12 +1331,95 @@ def _resolve_media_ext(filename: str, mime_type: str) -> str:
     return ""
 
 
+def _get_attachment_storage_path() -> Optional[Path]:
+    """Return the configured attachment storage path, or None if disabled."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        raw = cfg.get("gateway", {}).get("attachment_storage_path", "")
+        if raw and isinstance(raw, str):
+            p = Path(os.path.expanduser(raw))
+            p.mkdir(parents=True, exist_ok=True)
+            return p
+    except Exception:
+        pass
+    return None
+
+
+def _persist_attachment(
+    data: bytes,
+    *,
+    filename: str = "",
+    platform: str = "unknown",
+) -> None:
+    """Copy attachment bytes to the durable storage directory.
+
+    Silently no-ops if ``gateway.attachment_storage_path`` is empty or the
+    write fails — persistence is best-effort and must never break the cache
+    path that the agent actually consumes.
+    """
+    storage_root = _get_attachment_storage_path()
+    if storage_root is None:
+        return
+    try:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        # Strip directory components first, then sanitize
+        raw_name = Path(filename).name if filename else "file"
+        safe_name = re.sub(r"[^\w.\- ]", "_", raw_name).strip()
+        if not safe_name or safe_name in {".", ".."}:
+            safe_name = "file"
+        dest_dir = storage_root / platform
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / f"{ts}_{safe_name}"
+        # Deduplicate: append counter if file already exists
+        if dest.exists():
+            counter = 1
+            while dest.exists():
+                stem = dest.stem.rsplit("_", 1)[0]
+                dest = dest_dir / f"{stem}_{counter}_{safe_name}"
+                counter += 1
+        dest.write_bytes(data)
+        logger.debug("Persisted attachment to %s (%d bytes)", dest, len(data))
+    except Exception as exc:
+        logger.warning("Failed to persist attachment: %s", exc)
+
+
+def cleanup_persisted_attachments() -> int:
+    """Delete persisted attachments older than the configured retention days.
+
+    Returns the number of files removed.  No-op if persistence is disabled
+    or retention_days is 0 (keep forever).
+    """
+    storage_root = _get_attachment_storage_path()
+    if storage_root is None:
+        return 0
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        retention = cfg.get("gateway", {}).get("attachment_retention_days", 30)
+        if not isinstance(retention, (int, float)) or retention <= 0:
+            return 0
+    except Exception:
+        retention = 30
+    cutoff = time.time() - retention * 86400
+    removed = 0
+    try:
+        for f in storage_root.rglob("*"):
+            if f.is_file() and f.stat().st_mtime < cutoff:
+                f.unlink()
+                removed += 1
+    except Exception as exc:
+        logger.warning("Attachment cleanup error: %s", exc)
+    return removed
+
+
 def cache_media_bytes(
     data: bytes,
     *,
     filename: str = "",
     mime_type: str = "",
     default_kind: Optional[str] = None,
+    platform: str = "unknown",
 ) -> Optional[CachedMedia]:
     """Classify and cache raw attachment bytes; return a CachedMedia or None.
 
@@ -1345,12 +1428,18 @@ def cache_media_bytes(
     file has no usable name. Unsupported document types return None so the
     caller can record an "unsupported" note. Images that fail validation
     (``cache_image_from_bytes`` raises ValueError) also return None.
+
+    If ``gateway.attachment_storage_path`` is configured, the raw bytes are
+    also persisted to a durable directory before being returned.
     """
     from tools.credential_files import to_agent_visible_cache_path
 
     ext = _resolve_media_ext(filename, mime_type)
     mime = (mime_type or "").lower()
     display = re.sub(r"[^\w.\- ]", "_", filename) if filename else (ext.lstrip(".") or "file")
+
+    # Persist to durable storage if configured (best-effort, before cache write)
+    _persist_attachment(data, filename=filename or display, platform=platform)
 
     is_image = (
         mime.startswith("image/")

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4996,7 +4996,7 @@ class TelegramAdapter(BasePlatformAdapter):
             data = bytes(await file_obj.download_as_bytearray())
             if not filename:
                 filename = os.path.basename(getattr(file_obj, "file_path", "") or "")
-            cached = cache_media_bytes(data, filename=filename, mime_type=mime, default_kind=kind)
+            cached = cache_media_bytes(data, filename=filename, mime_type=mime, default_kind=kind, platform="telegram")
         except Exception as exc:
             logger.warning("[Telegram] Failed to cache observed group media: %s", exc, exc_info=True)
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15250,7 +15250,7 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     once per hour.
     """
     from cron.scheduler import tick as cron_tick
-    from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache, cleanup_persisted_attachments
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -15299,6 +15299,12 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
                     logger.info("Document cache cleanup: removed %d stale file(s)", removed)
             except Exception as e:
                 logger.debug("Document cache cleanup error: %s", e)
+            try:
+                removed = cleanup_persisted_attachments()
+                if removed:
+                    logger.info("Persisted attachment cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("Persisted attachment cleanup error: %s", e)
 
         if tick_count % PASTE_SWEEP_EVERY == 0:
             try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2185,6 +2185,17 @@ DEFAULT_CONFIG = {
         # multi-tool agent turn. Bridged to HERMES_MEDIA_TRUST_RECENT_SECONDS.
         # Only consulted when ``strict`` is true.
         "trust_recent_files_seconds": 600,
+        # Persist received attachments to a durable directory so they survive
+        # cache cleanup.  When non-empty, every inbound attachment is copied
+        # to ``<attachment_storage_path>/<platform>/<timestamp>_<filename>``
+        # *before* being passed to the agent.  Default "" (empty) disables
+        # persistence — files live only in the temp cache and are cleaned up
+        # after ``cleanup_*_cache(max_age_hours)``.  Tilde paths are expanded.
+        "attachment_storage_path": "",
+        # How many days to keep persisted attachments.  Files older than this
+        # are deleted by the periodic cleanup pass.  Only consulted when
+        # ``attachment_storage_path`` is non-empty.  Set to 0 to keep forever.
+        "attachment_retention_days": 30,
     },
 
     # Real-time token streaming to messaging platforms (Telegram, Discord,

--- a/tests/gateway/test_attachment_persistence.py
+++ b/tests/gateway/test_attachment_persistence.py
@@ -1,0 +1,236 @@
+"""Tests for gateway attachment persistence (issue #41979)."""
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _get_attachment_storage_path
+# ---------------------------------------------------------------------------
+
+class TestGetAttachmentStoragePath:
+    """Tests for _get_attachment_storage_path()."""
+
+    def test_returns_none_when_disabled(self, tmp_path):
+        """Empty string means persistence is off."""
+        from gateway.platforms.base import _get_attachment_storage_path
+
+        with patch("hermes_cli.config.load_config", return_value={"gateway": {"attachment_storage_path": ""}}):
+            assert _get_attachment_storage_path() is None
+
+    def test_returns_none_on_missing_key(self):
+        """Missing key defaults to disabled."""
+        from gateway.platforms.base import _get_attachment_storage_path
+
+        with patch("hermes_cli.config.load_config", return_value={"gateway": {}}):
+            assert _get_attachment_storage_path() is None
+
+    def test_returns_path_when_configured(self, tmp_path):
+        """Non-empty path is expanded and created."""
+        from gateway.platforms.base import _get_attachment_storage_path
+
+        target = str(tmp_path / "attachments")
+        with patch("hermes_cli.config.load_config", return_value={"gateway": {"attachment_storage_path": target}}):
+            result = _get_attachment_storage_path()
+            assert result == Path(target)
+            assert result.exists()
+
+    def test_expands_tilde(self, tmp_path):
+        """Tilde paths are expanded."""
+        from gateway.platforms.base import _get_attachment_storage_path
+
+        with patch("hermes_cli.config.load_config", return_value={"gateway": {"attachment_storage_path": "~/test_attachments"}}):
+            result = _get_attachment_storage_path()
+            # Should return a path (may not exist if ~/test_attachments can't be created)
+            # The important thing is it doesn't raise
+
+    def test_returns_none_on_config_error(self):
+        """Config load failure is handled gracefully."""
+        from gateway.platforms.base import _get_attachment_storage_path
+
+        with patch("hermes_cli.config.load_config", side_effect=Exception("config error")):
+            assert _get_attachment_storage_path() is None
+
+
+# ---------------------------------------------------------------------------
+# _persist_attachment
+# ---------------------------------------------------------------------------
+
+class TestPersistAttachment:
+    """Tests for _persist_attachment()."""
+
+    def test_noop_when_disabled(self, tmp_path):
+        """Does nothing when persistence is disabled."""
+        from gateway.platforms.base import _persist_attachment
+
+        with patch("gateway.platforms.base._get_attachment_storage_path", return_value=None):
+            # Should not raise
+            _persist_attachment(b"hello", filename="test.txt", platform="telegram")
+
+    def test_creates_platform_subdirectory(self, tmp_path):
+        """Creates <root>/<platform>/ subdirectory."""
+        from gateway.platforms.base import _persist_attachment
+
+        storage = tmp_path / "storage"
+        with patch("gateway.platforms.base._get_attachment_storage_path", return_value=storage):
+            _persist_attachment(b"hello world", filename="test.txt", platform="discord")
+
+        plat_dir = storage / "discord"
+        assert plat_dir.exists()
+        files = list(plat_dir.iterdir())
+        assert len(files) == 1
+        assert files[0].name.endswith("_test.txt")
+        assert files[0].read_bytes() == b"hello world"
+
+    def test_deduplicates_on_name_collision(self, tmp_path):
+        """Appends counter when filename already exists."""
+        from gateway.platforms.base import _persist_attachment
+
+        storage = tmp_path / "storage"
+        with patch("gateway.platforms.base._get_attachment_storage_path", return_value=storage):
+            _persist_attachment(b"first", filename="same.txt", platform="test")
+            _persist_attachment(b"second", filename="same.txt", platform="test")
+
+        files = list((storage / "test").iterdir())
+        assert len(files) == 2
+        contents = {f.read_bytes() for f in files}
+        assert contents == {b"first", b"second"}
+
+    def test_sanitizes_filename(self, tmp_path):
+        """Unsafe characters in filename are replaced; directory components stripped."""
+        from gateway.platforms.base import _persist_attachment
+
+        storage = tmp_path / "storage"
+        with patch("gateway.platforms.base._get_attachment_storage_path", return_value=storage):
+            _persist_attachment(b"data", filename="../etc/passwd", platform="test")
+
+        files = list((storage / "test").iterdir())
+        assert len(files) == 1
+        # Directory components should be stripped; only "passwd" remains
+        assert ".." not in files[0].name
+        assert "/" not in files[0].name
+        assert "passwd" in files[0].name
+
+    def test_noop_on_write_error(self, tmp_path):
+        """Write failures are swallowed (best-effort)."""
+        from gateway.platforms.base import _persist_attachment
+
+        # Point to a read-only directory
+        storage = tmp_path / "readonly"
+        storage.mkdir()
+        os.chmod(storage, 0o444)
+        try:
+            with patch("gateway.platforms.base._get_attachment_storage_path", return_value=storage):
+                # Should not raise
+                _persist_attachment(b"data", filename="test.txt", platform="test")
+        finally:
+            os.chmod(storage, 0o755)
+
+
+# ---------------------------------------------------------------------------
+# cleanup_persisted_attachments
+# ---------------------------------------------------------------------------
+
+class TestCleanupPersistedAttachments:
+    """Tests for cleanup_persisted_attachments()."""
+
+    def test_noop_when_disabled(self):
+        """Returns 0 when persistence is disabled."""
+        from gateway.platforms.base import cleanup_persisted_attachments
+
+        with patch("gateway.platforms.base._get_attachment_storage_path", return_value=None):
+            assert cleanup_persisted_attachments() == 0
+
+    def test_removes_old_files(self, tmp_path):
+        """Files older than retention_days are deleted."""
+        from gateway.platforms.base import cleanup_persisted_attachments
+
+        storage = tmp_path / "storage"
+        plat = storage / "telegram"
+        plat.mkdir(parents=True)
+
+        # Create a file with old mtime
+        old_file = plat / "20200101_120000_old.txt"
+        old_file.write_bytes(b"old")
+        old_time = time.time() - 40 * 86400  # 40 days ago
+        os.utime(old_file, (old_time, old_time))
+
+        # Create a recent file
+        new_file = plat / "20260608_120000_new.txt"
+        new_file.write_bytes(b"new")
+
+        with patch("gateway.platforms.base._get_attachment_storage_path", return_value=storage), \
+             patch("hermes_cli.config.load_config", return_value={"gateway": {"attachment_retention_days": 30}}):
+            removed = cleanup_persisted_attachments()
+
+        assert removed == 1
+        assert not old_file.exists()
+        assert new_file.exists()
+
+    def test_keep_forever_when_zero(self, tmp_path):
+        """retention_days=0 means keep forever."""
+        from gateway.platforms.base import cleanup_persisted_attachments
+
+        storage = tmp_path / "storage"
+        plat = storage / "test"
+        plat.mkdir(parents=True)
+        old_file = plat / "old.txt"
+        old_file.write_bytes(b"old")
+        old_time = time.time() - 100 * 86400
+        os.utime(old_file, (old_time, old_time))
+
+        with patch("gateway.platforms.base._get_attachment_storage_path", return_value=storage), \
+             patch("hermes_cli.config.load_config", return_value={"gateway": {"attachment_retention_days": 0}}):
+            removed = cleanup_persisted_attachments()
+
+        assert removed == 0
+        assert old_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# cache_media_bytes integration
+# ---------------------------------------------------------------------------
+
+class TestCacheMediaBytesPersistence:
+    """Test that cache_media_bytes calls _persist_attachment."""
+
+    def test_persistence_called_with_platform(self, tmp_path):
+        """cache_media_bytes passes platform to _persist_attachment."""
+        from gateway.platforms.base import cache_media_bytes
+
+        # We need a valid image to avoid None return
+        # Use a minimal PNG (1x1 pixel)
+        png_data = (
+            b"\x89PNG\r\n\x1a\n"  # PNG magic
+            + b"\x00" * 100  # padding (not a real PNG, but enough for _looks_like_image)
+        )
+
+        with patch("gateway.platforms.base._persist_attachment") as mock_persist, \
+             patch("gateway.platforms.base._get_attachment_storage_path", return_value=None), \
+             patch("gateway.platforms.base.cache_image_from_bytes", return_value=str(tmp_path / "img.jpg")):
+            # cache_image_from_bytes needs to return a valid path
+            (tmp_path / "img.jpg").write_bytes(png_data)
+            result = cache_media_bytes(png_data, filename="photo.jpg", platform="discord", default_kind="image")
+
+        mock_persist.assert_called_once()
+        call_kwargs = mock_persist.call_args
+        assert call_kwargs[1]["platform"] == "discord"
+        assert call_kwargs[1]["filename"] == "photo.jpg"
+
+    def test_persistence_called_for_document(self, tmp_path):
+        """cache_media_bytes calls persist for document type too."""
+        from gateway.platforms.base import cache_media_bytes
+
+        pdf_data = b"%PDF-1.4 fake pdf content"
+
+        with patch("gateway.platforms.base._persist_attachment") as mock_persist, \
+             patch("gateway.platforms.base._get_attachment_storage_path", return_value=None), \
+             patch("gateway.platforms.base.cache_document_from_bytes", return_value=str(tmp_path / "doc.pdf")):
+            (tmp_path / "doc.pdf").write_bytes(pdf_data)
+            result = cache_media_bytes(pdf_data, filename="report.pdf", platform="telegram")
+
+        mock_persist.assert_called_once()


### PR DESCRIPTION
## Problem

Hermes Agent's messaging gateway supports receiving file attachments from Discord, Telegram, and 15+ other platforms. But received files have **no persistence** — they exist only as temporary cache during agent processing, then are silently discarded after cache cleanup (24h TTL).

This violates the principle of least surprise: files sent through a chat platform are expected to land somewhere durable. Document-oriented use cases (legal, research, creative writing, system administration) routinely send files that need to be referenced later.

## Solution

Add a `gateway.attachment_storage_path` config option. When set, every inbound attachment is **copied** to a durable directory before being passed to the agent. The temp cache path continues to work as before — persistence is additive and best-effort.

### Config options

```yaml
gateway:
  # Persist received attachments to this directory (default: "" = disabled)
  attachment_storage_path: ~/.hermes/attachments/
  # How many days to keep persisted files (default: 30, 0 = keep forever)
  attachment_retention_days: 30
```

### Storage layout

```
~/.hermes/attachments/
  telegram/
    20260608_194530_photo.jpg
    20260608_195121_report.pdf
  discord/
    20260608_200115_data.csv
```

Files are named `<timestamp>_<original_filename>` with automatic deduplication (counter appended on collision).

### Behavior

- **Disabled by default** — empty `attachment_storage_path` means no persistence (backward compatible)
- **Best-effort** — write failures are logged as warnings but never break the agent's cache path
- **Path sanitization** — directory components stripped, unsafe characters replaced
- **Automatic cleanup** — old files removed hourly via the gateway cron ticker, respecting `attachment_retention_days`

## Changes

| File | Change |
|------|--------|
| `hermes_cli/config.py` | Add `attachment_storage_path` and `attachment_retention_days` config keys |
| `gateway/platforms/base.py` | Add `_get_attachment_storage_path()`, `_persist_attachment()`, `cleanup_persisted_attachments()`; wire into `cache_media_bytes()` |
| `gateway/platforms/telegram.py` | Pass `platform="telegram"` to `cache_media_bytes()` |
| `gateway/run.py` | Add `cleanup_persisted_attachments()` to hourly cron ticker |
| `tests/gateway/test_attachment_persistence.py` | 15 tests covering config resolution, persistence, cleanup, dedup, sanitization, and integration |

Fixes #41979
