### PR TITLE
fix(desktop): close previous session when starting new chat; fix(pty): SIGTERM before SIGHUP

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -333,6 +333,17 @@ export function useSessionActions({
         // Route the new chat to the chosen profile's backend (null = primary,
         // so single-profile users are unaffected).
         await ensureGatewayProfile($newChatProfile.get())
+
+        // Close the previous runtime session (if any) so its `ended_at` is set
+        // in the DB and it appears as a closed/resumable session in the sidebar.
+        // Without this, the old session stays open in-memory until the gateway
+        // process shuts down, and an unclean shutdown (PtyBridge kill, desktop
+        // close) never persists `ended_at`.
+        const prevActiveId = activeSessionIdRef.current
+        if (prevActiveId) {
+          await requestGateway('session.close', { session_id: prevActiveId }).catch(() => undefined)
+        }
+
         const cwd = $currentCwd.get().trim() || getRememberedWorkspaceCwd()
         // Pass the owning profile so a new chat under a non-launch profile (global
         // remote mode) builds its agent + persists against THAT profile's home/db.

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -241,7 +241,14 @@ class PtyBridge:
     # -- teardown ---------------------------------------------------------
 
     def close(self) -> None:
-        """Terminate the child (SIGTERM → 0.5s grace → SIGKILL) and close fds.
+        """Terminate the child (SIGTERM → 2s grace → SIGHUP → SIGKILL) and close fds.
+
+        SIGTERM is sent first (not SIGHUP) so Python's ``atexit`` handlers
+        (notably ``_shutdown_sessions`` → ``end_session()`` in
+        ``tui_gateway.server``) have a chance to persist session state
+        before the process dies.  SIGHUP is used as the escalation — the
+        PtyBridge always represents a browser tab that disconnected, so the
+        sentinel is ``"your terminal went away"`` semantics.
 
         Idempotent.  Reaping the child is important so we don't leak
         zombies across the lifetime of the dashboard process.
@@ -255,11 +262,10 @@ class PtyBridge:
         except Exception:
             pgid = None
 
-        # SIGHUP is the conventional "your terminal went away" signal.
-        # Send it to the whole foreground process group, not just the PTY
-        # leader: the dashboard TUI starts helper children such as the Python
-        # slash worker, and killing only the leader can strand those helpers.
-        for sig in (signal.SIGHUP, signal.SIGTERM, signal.SIGKILL):  # windows-footgun: ok — POSIX-only module (imports fcntl/termios/ptyprocess at top)
+        # Send SIGTERM FIRST so Python processes in the group can run
+        # atexit handlers and persist session state (end_session etc.).
+        # Give a generous 2s grace window for flush + cleanup.
+        for sig in (signal.SIGTERM, signal.SIGHUP, signal.SIGKILL):  # windows-footgun: ok — POSIX-only module (imports fcntl/termios/ptyprocess at top)
             if not self._proc.isalive():
                 break
             try:
@@ -269,7 +275,8 @@ class PtyBridge:
                     self._proc.kill(sig)
             except Exception:
                 pass
-            deadline = time.monotonic() + 0.5
+            grace = 2.0 if sig == signal.SIGTERM else 0.5
+            deadline = time.monotonic() + grace
             while self._proc.isalive() and time.monotonic() < deadline:
                 time.sleep(0.02)
 


### PR DESCRIPTION
## Problem

Two bugs cause sessions to be left with `ended_at=NULL` after closing, making them invisible in the session history list:

**1. Desktop app doesn't close old session on new chat**
When `createBackendSessionForSend` creates a new backend session, the previous active session was never closed via `session.close` RPC. It stayed in-memory with `ended_at=NULL` until gateway shutdown. Any unclean shutdown (PtyBridge kill, desktop exit) never persisted the ended state.

**2. PtyBridge kills before Python atexit handlers can run**
`PtyBridge.close()` sent `SIGHUP` first, which kills the process group immediately — Python's `atexit` handlers (notably `_shutdown_sessions` → `end_session()`) never ran. `SIGHUP` → `SIGTERM` → `SIGKILL` with only 0.5s between each.

## Fix

**1. `use-session-actions.ts`** — Call `requestGateway('session.close', { session_id: prevActiveId })` before creating the new session so `ended_at` is set immediately.

**2. `pty_bridge.py`** — Swap signal order to `SIGTERM` → `SIGHUP` → `SIGKILL` (SIGTERM first so Python runs atexit), and give 2s grace for SIGTERM instead of 0.5s so DB writes have time to flush.

## Testing

- Verified on Linux: rebuilt Desktop app, confirmed sessions now appear in history after starting a new chat.
- The `end_session()` path was verified by manually inspecting `state.db` — session rows now have `ended_at` set after close.