### PR TITLE
test(run_agent): fix racy ordering in test_concurrent_handles_tool_error

### DIFF
--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2402,15 +2402,20 @@ class TestConcurrentToolExecution:
 
     def test_concurrent_handles_tool_error(self, agent):
         """If one tool raises, others should still complete."""
-        tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
-        tc2 = _mock_tool_call(name="web_search", arguments='{}', call_id="c2")
+        # Distinguish the two calls by their arguments so the error is tied to
+        # a SPECIFIC tool call rather than invocation order. Concurrent
+        # execution gives no guarantee that c1's handler runs before c2's, so
+        # keying the raise on a call-order counter is racy: under thread-pool
+        # scheduling c2 could be invoked first, take the "first call raises"
+        # branch, and the error would land in messages[1] instead of
+        # messages[0]. Keying on args makes the assertion deterministic.
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q": "boom"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q": "ok"}', call_id="c2")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
         messages = []
 
-        call_count = [0]
         def fake_handle(name, args, task_id, **kwargs):
-            call_count[0] += 1
-            if call_count[0] == 1:
+            if args.get("q") == "boom":
                 raise RuntimeError("boom")
             return "success"
 
@@ -2418,9 +2423,11 @@ class TestConcurrentToolExecution:
             agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
 
         assert len(messages) == 2
-        # First tool should have error
+        # Results are ordered by tool_call_id; c1 raised, c2 succeeded.
+        assert messages[0]["tool_call_id"] == "c1"
         assert "Error" in messages[0]["content"] or "boom" in messages[0]["content"]
         # Second tool should succeed
+        assert messages[1]["tool_call_id"] == "c2"
         assert "success" in messages[1]["content"]
 
     def test_concurrent_interrupt_before_start(self, agent):


### PR DESCRIPTION
## Summary
`test_concurrent_handles_tool_error` is now deterministic under parallel CI — it no longer depends on which of two concurrent tool handlers the thread pool happens to invoke first.

## Root cause
The test keyed "which call raises" on a shared invocation counter (1st call raises, 2nd returns success), then asserted the error landed in `messages[0]` (c1) and success in `messages[1]` (c2). But `_execute_tool_calls_concurrent` runs the two `web_search` calls on a thread pool with no ordering guarantee. When c2's handler is invoked first it takes the "first call raises" branch, so the error ends up tied to c2. Results are ordered by `tool_call_id`, so `messages[0]` (c1) became `"success"` and the assertion failed.

Passed in isolation; failed reliably under CI's full parallel slice (8 xdist workers) where the two handlers actually interleave.

## Changes
- `tests/run_agent/test_run_agent.py`: tie the raise to a specific call via its arguments (`q=boom` raises, `q=ok` succeeds) instead of invocation order; assert `tool_call_id` ↔ content pairing explicitly.

## Validation
| | Before | After |
|---|---|---|
| Failing test, isolated | passes (race not triggered) | passes |
| Failing test, 10× | racy | 10/10 pass |
| `TestConcurrentToolExecution` (32) | 1 racy | 32 pass |
| CI `test (2)` slice | flaky FAILURE | deterministic |

## Infographic

![Concurrent tool-error test ordering fix](https://v3b.fal.media/files/b/0a9d8329/_-gnCIuTqiuUx8JQP93Tl_3GgLuwkC.png)
