### PR TITLE
fix(desktop): don't drop the focused chat's own stream when unscoped

### DIFF
--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -3,11 +3,19 @@ import { describe, expect, it } from 'vitest'
 import { gatewayEventRequiresSessionId } from './gateway-events'
 
 describe('gateway event routing', () => {
-  it('requires explicit session ids for async session-scoped events', () => {
-    expect(gatewayEventRequiresSessionId('message.delta')).toBe(true)
-    expect(gatewayEventRequiresSessionId('tool.start')).toBe(true)
+  it('drops only unscoped subagent events (genuinely background work)', () => {
     expect(gatewayEventRequiresSessionId('subagent.progress')).toBe(true)
-    expect(gatewayEventRequiresSessionId('approval.request')).toBe(true)
+    expect(gatewayEventRequiresSessionId('subagent.start')).toBe(true)
+  })
+
+  it('attributes unscoped foreground turn events to the active chat', () => {
+    // These must NOT be dropped when unscoped — they are the focused turn's own
+    // output, and dropping them loses the live response until a refetch (#42178).
+    expect(gatewayEventRequiresSessionId('message.delta')).toBe(false)
+    expect(gatewayEventRequiresSessionId('message.complete')).toBe(false)
+    expect(gatewayEventRequiresSessionId('reasoning.delta')).toBe(false)
+    expect(gatewayEventRequiresSessionId('tool.start')).toBe(false)
+    expect(gatewayEventRequiresSessionId('approval.request')).toBe(false)
   })
 
   it('allows global events to remain unscoped', () => {

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -7,37 +7,24 @@ interface RpcEventLike {
   type?: string
 }
 
-const SESSION_SCOPED_EVENT_TYPES = new Set([
-  'approval.request',
-  'clarify.request',
-  'error',
-  'message.complete',
-  'message.delta',
-  'message.start',
-  'reasoning.available',
-  'reasoning.delta',
-  'secret.request',
-  'status.update',
-  'subagent.complete',
-  'subagent.progress',
-  'subagent.spawn_requested',
-  'subagent.start',
-  'subagent.thinking',
-  'subagent.tool',
-  'sudo.request',
-  'thinking.delta'
-])
-
 function asRecord(payload: unknown): Record<string, unknown> {
   return payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {}
 }
 
+/**
+ * Whether an unscoped event (no `session_id`) must be dropped rather than
+ * attributed to the focused chat.
+ *
+ * Only `subagent.*` qualifies: it describes background/async work that must
+ * never attach to whichever chat happens to be focused. Every other scoped
+ * event — message/reasoning/thinking/tool/status/prompt — is, when unscoped,
+ * the active turn's own output. The gateway always stamps a *background*
+ * session's events with that session's id, so a missing id can only mean "the
+ * focused turn". #42178 dropped those too, which silently swallowed the live
+ * answer; it then reappeared only after a transcript refetch (manual refresh).
+ */
 export function gatewayEventRequiresSessionId(eventType: string | undefined): boolean {
-  if (!eventType) {
-    return false
-  }
-
-  return SESSION_SCOPED_EVENT_TYPES.has(eventType) || eventType.startsWith('tool.')
+  return eventType?.startsWith('subagent.') ?? false
 }
 
 export function gatewayEventCompletedFileDiff(event: RpcEventLike): boolean {


### PR DESCRIPTION
## Summary

Follow-up to #42178. That guard dropped **every** session-scoped gateway event lacking an explicit `session_id` to stop background activity attaching to the focused chat. The intent is right, but the net was too wide: the gateway already stamps background sessions with their own id, so an unscoped `message.*` / `reasoning.*` / `thinking.delta` / `tool.*` / `*.request` event can **only** be the focused turn's own output. Dropping those swallowed the live response — it then reappeared only after a transcript refetch (i.e. "I have to refresh to see the reply").

This narrows `gatewayEventRequiresSessionId` to `subagent.*` only — the one genuinely background/async family where an unscoped event can't be safely attributed and must be dropped. Everything else falls back to the active session exactly as before #42178. No change to `use-message-stream.ts` (its `!explicitSid && gatewayEventRequiresSessionId(...)` drop now only fires for unscoped subagent events).

## Test plan

- [x] `vitest run --environment jsdom src/lib/gateway-events.test.ts` (updated: subagent.* still required; message/reasoning/tool/approval no longer dropped when unscoped)
- [x] `eslint` clean on changed files
- [x] `tsc -b` clean
- [ ] Manual: send a prompt in the desktop app, confirm the reply streams live (no refresh needed); run a subagent/delegate task and confirm it still attaches only to its own chat