### PR TITLE
fix: allow gateway platforms to skip repo context

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -19,6 +19,7 @@ preserved.
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import re
@@ -66,6 +67,32 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+def _tool_loop_guardrail_config_for_platform(config: dict, platform: str | None) -> dict:
+    """Return tool-loop guardrail config with optional platform override applied."""
+    guardrail_cfg = config.get("tool_loop_guardrails", {})
+    if not isinstance(guardrail_cfg, dict):
+        return {}
+
+    merged = copy.deepcopy({k: v for k, v in guardrail_cfg.items() if k != "platforms"})
+    platforms_cfg = guardrail_cfg.get("platforms")
+    platform_key = str(platform or "").strip().lower()
+    if not platform_key or not isinstance(platforms_cfg, dict):
+        return merged
+
+    override = platforms_cfg.get(platform_key)
+    if not isinstance(override, dict):
+        return merged
+
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            nested = copy.deepcopy(merged[key])
+            nested.update(value)
+            merged[key] = nested
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
 
 
 def _normalized_custom_base_url(value: Any) -> str:
@@ -1050,7 +1077,7 @@ def init_agent(
     try:
         agent._tool_guardrails = ToolCallGuardrailController(
             ToolCallGuardrailConfig.from_mapping(
-                _agent_cfg.get("tool_loop_guardrails", {})
+                _tool_loop_guardrail_config_for_platform(_agent_cfg, agent.platform)
             )
         )
     except Exception as _tlg_err:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16005,6 +16005,44 @@ class GatewayRunner:
             )
         )
 
+    @staticmethod
+    def _resolve_agent_max_iterations(user_config: dict, platform_key: str) -> int:
+        """Return the max tool-calling iterations for a gateway-created agent."""
+        try:
+            default_max = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+        except (TypeError, ValueError):
+            default_max = 90
+
+        platform_override = cfg_get(
+            user_config,
+            "gateway",
+            "agent",
+            "platforms",
+            platform_key,
+            "max_turns",
+            default=None,
+        )
+        if platform_override is None:
+            return default_max
+
+        try:
+            max_turns = int(platform_override)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Ignoring invalid gateway.agent.platforms.%s.max_turns=%r",
+                platform_key,
+                platform_override,
+            )
+            return default_max
+        if max_turns <= 0:
+            logger.warning(
+                "Ignoring non-positive gateway.agent.platforms.%s.max_turns=%r",
+                platform_key,
+                platform_override,
+            )
+            return default_max
+        return max_turns
+
     def _apply_session_model_override(
         self, session_key: str, model: str, runtime_kwargs: dict
     ) -> tuple:
@@ -17383,9 +17421,6 @@ class GatewayRunner:
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
-            # Read from env var or use default (same as CLI)
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
-            
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
@@ -17403,6 +17438,7 @@ class GatewayRunner:
             # keys may change without restart). Keep config.yaml authoritative for
             # runtime budget settings bridged into env vars.
             _reload_runtime_env_preserving_config_authority()
+            max_iterations = self._resolve_agent_max_iterations(user_config, platform_key)
 
             try:
                 model, runtime_kwargs = self._resolve_session_agent_runtime(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12380,6 +12380,10 @@ class GatewayRunner:
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+            skip_context_files = self._resolve_agent_skip_context_files(
+                user_config,
+                platform_key,
+            )
 
             pr = self._provider_routing
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
@@ -12433,6 +12437,7 @@ class GatewayRunner:
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
                     session_db=self._session_db,
+                    skip_context_files=skip_context_files,
                     fallback_model=self._fallback_model,
                 )
                 try:
@@ -15973,6 +15978,33 @@ class GatewayRunner:
         )
         return hashlib.sha256(blob.encode()).hexdigest()[:16]
 
+    @staticmethod
+    def _resolve_agent_skip_context_files(user_config: dict, platform_key: str) -> bool:
+        """Return whether gateway-created agents should skip cwd context files."""
+        platform_override = cfg_get(
+            user_config,
+            "gateway",
+            "agent",
+            "platforms",
+            platform_key,
+            "skip_context_files",
+            default=None,
+        )
+        if platform_override is not None:
+            return bool(is_truthy_value(platform_override, default=False))
+        return bool(
+            is_truthy_value(
+                cfg_get(
+                    user_config,
+                    "gateway",
+                    "agent",
+                    "skip_context_files",
+                    default=False,
+                ),
+                default=False,
+            )
+        )
+
     def _apply_session_model_override(
         self, session_key: str, model: str, runtime_kwargs: dict
     ) -> tuple:
@@ -16696,6 +16728,10 @@ class GatewayRunner:
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
+        skip_context_files = self._resolve_agent_skip_context_files(
+            user_config,
+            platform_key,
+        )
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):
@@ -17561,6 +17597,7 @@ class GatewayRunner:
                     thread_id=source.thread_id,
                     gateway_session_key=session_key,
                     session_db=self._session_db,
+                    skip_context_files=skip_context_files,
                     fallback_model=self._fallback_model,
                 )
                 if _cache_lock and _cache is not None:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2004,6 +2004,8 @@ DEFAULT_CONFIG = {
             # (AGENTS.md, CLAUDE.md, etc.). Chat platforms can opt out to
             # keep short message turns from carrying repo-sized prompts.
             "skip_context_files": False,
+            # Optional per-platform overrides, e.g.
+            # platforms.telegram.skip_context_files or platforms.telegram.max_turns.
             "platforms": {},
         },
         # When false (default), any file path the agent emits is delivered

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1998,6 +1998,13 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        "agent": {
+            # Gateway-created agents normally inherit cwd context files
+            # (AGENTS.md, CLAUDE.md, etc.). Chat platforms can opt out to
+            # keep short message turns from carrying repo-sized prompts.
+            "skip_context_files": False,
+            "platforms": {},
+        },
         # When false (default), any file path the agent emits is delivered
         # as a native attachment as long as it isn't under the credential /
         # system-path denylist (/etc, /proc, ~/.ssh, ~/.aws, ~/.hermes/.env,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1050,6 +1050,7 @@ DEFAULT_CONFIG = {
             "same_tool_failure": 8,
             "idempotent_no_progress": 5,
         },
+        "platforms": {},
     },
 
     "compression": {

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -348,6 +348,106 @@ async def test_run_agent_platform_can_skip_context_files(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_run_agent_platform_can_override_max_turns(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", "90")
+
+    CaptureKwargsAgent.last_kwargs = None
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CaptureKwargsAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "gateway": {
+                "agent": {
+                    "platforms": {
+                        "telegram": {"max_turns": 12},
+                    },
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-max-turns-platform",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    assert CaptureKwargsAgent.last_kwargs["max_iterations"] == 12
+
+
+@pytest.mark.asyncio
+async def test_run_agent_uses_global_max_turns_without_platform_override(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", "90")
+
+    CaptureKwargsAgent.last_kwargs = None
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CaptureKwargsAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "gateway": {
+                "agent": {
+                    "platforms": {
+                        "telegram": {"skip_context_files": True},
+                    },
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-max-turns-default",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    assert CaptureKwargsAgent.last_kwargs["max_iterations"] == 90
+
+
+@pytest.mark.asyncio
 async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -144,6 +144,21 @@ class FakeAgent:
         }
 
 
+class CaptureKwargsAgent:
+    last_kwargs = None
+
+    def __init__(self, **kwargs):
+        type(self).last_kwargs = kwargs
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class LongPreviewAgent:
     """Agent that emits a tool call with a very long preview string."""
     LONG_CMD = "cd /home/teknium/.hermes/hermes-agent/.worktrees/hermes-d8860339 && source .venv/bin/activate && python -m pytest tests/gateway/test_run_progress_topics.py -n0 -q"
@@ -243,6 +258,93 @@ def _make_runner(adapter):
         stt_enabled=False,
     )
     return runner
+
+
+@pytest.mark.asyncio
+async def test_run_agent_default_keeps_context_files(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    CaptureKwargsAgent.last_kwargs = None
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CaptureKwargsAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-context-default",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    assert CaptureKwargsAgent.last_kwargs["skip_context_files"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_agent_platform_can_skip_context_files(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    CaptureKwargsAgent.last_kwargs = None
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CaptureKwargsAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "gateway": {
+                "agent": {
+                    "skip_context_files": False,
+                    "platforms": {
+                        "telegram": {"skip_context_files": True},
+                    },
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-context-platform",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    assert CaptureKwargsAgent.last_kwargs["skip_context_files"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -36,7 +36,12 @@ def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
     return SimpleNamespace(choices=[choice], model="test/model", usage=None)
 
 
-def _make_agent(*tool_names: str, max_iterations: int = 10, config: dict | None = None) -> AIAgent:
+def _make_agent(
+    *tool_names: str,
+    max_iterations: int = 10,
+    config: dict | None = None,
+    platform: str | None = None,
+) -> AIAgent:
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
         patch("run_agent.check_toolset_requirements", return_value={}),
@@ -50,6 +55,7 @@ def _make_agent(*tool_names: str, max_iterations: int = 10, config: dict | None 
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
+            platform=platform,
         )
     agent.client = MagicMock()
     agent._cached_system_prompt = "You are helpful."
@@ -84,6 +90,28 @@ def _hard_stop_config(**overrides) -> dict:
     }
     cfg["tool_loop_guardrails"].update(overrides)
     return cfg
+
+
+def _telegram_hard_stop_config() -> dict:
+    return {
+        "tool_loop_guardrails": {
+            "warnings_enabled": True,
+            "hard_stop_enabled": False,
+            "hard_stop_after": {
+                "exact_failure": 5,
+                "same_tool_failure": 8,
+                "idempotent_no_progress": 5,
+            },
+            "platforms": {
+                "telegram": {
+                    "hard_stop_enabled": True,
+                    "hard_stop_after": {
+                        "exact_failure": 2,
+                    },
+                },
+            },
+        },
+    }
 
 
 def test_default_sequential_path_warns_repeated_exact_failure_without_blocking_execution():
@@ -236,6 +264,23 @@ def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
     mock_hfc.assert_not_called()
     assert "plugin policy" in messages[0]["content"]
     assert agent._tool_guardrails.before_call("web_search", args).action == "allow"
+
+
+def test_platform_guardrail_override_hard_stops_telegram_only():
+    cfg = _telegram_hard_stop_config()
+    same_args = {"query": "same"}
+
+    cli_agent = _make_agent("web_search", config=cfg, platform="cli")
+    _seed_exact_failures(cli_agent, "web_search", same_args)
+    assert cli_agent._tool_guardrails.before_call("web_search", same_args).action == "allow"
+
+    telegram_agent = _make_agent("web_search", config=cfg, platform="telegram")
+    _seed_exact_failures(telegram_agent, "web_search", same_args)
+    decision = telegram_agent._tool_guardrails.before_call("web_search", same_args)
+
+    assert decision.action == "block"
+    assert decision.code == "repeated_exact_failure_block"
+    assert decision.count == 2
 
 
 def test_default_run_conversation_warns_without_guardrail_halt():


### PR DESCRIPTION
## Summary
- add gateway agent config for skipping cwd context files globally or per platform
- pass the resolved skip_context_files flag into gateway-created AIAgent instances
- add regression coverage for default behavior and Telegram platform override

## Reuse scan
- reused existing AIAgent(skip_context_files=...) behavior instead of adding a new context subsystem
- reused existing gateway config/cache-busting path under gateway.agent
- kept platform tool reduction as config-only via existing platform_toolsets

## Tests
- /Users/mac-studio/projects/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_run_progress_topics.py::test_run_agent_default_keeps_context_files tests/gateway/test_run_progress_topics.py::test_run_agent_platform_can_skip_context_files tests/hermes_cli/test_tools_config.py::test_save_platform_tools_preserves_mcp_server_names tests/hermes_cli/test_tools_config.py::test_agent_disabled_toolsets_with_explicit_platform_config -q
- git diff --check

Linear: AGE-194