### PR TITLE
fix: recover MCP sessions after read-only timeouts

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4193,6 +4193,17 @@ def _client_cache_key(
     is_vision: bool = False,
 ) -> tuple:
     runtime = _normalize_main_runtime(main_runtime)
+    if provider == "auto":
+        if not runtime.get("provider") and _RUNTIME_MAIN_PROVIDER:
+            runtime["provider"] = _RUNTIME_MAIN_PROVIDER
+        if not runtime.get("model") and _RUNTIME_MAIN_MODEL:
+            runtime["model"] = _RUNTIME_MAIN_MODEL
+        if not runtime.get("base_url") and _RUNTIME_MAIN_BASE_URL:
+            runtime["base_url"] = _RUNTIME_MAIN_BASE_URL
+        if not runtime.get("api_key") and _RUNTIME_MAIN_API_KEY:
+            runtime["api_key"] = _RUNTIME_MAIN_API_KEY
+        if not runtime.get("api_mode") and _RUNTIME_MAIN_API_MODE:
+            runtime["api_mode"] = _RUNTIME_MAIN_API_MODE
     runtime_key = tuple(runtime.get(field, "") for field in _MAIN_RUNTIME_FIELDS) if provider == "auto" else ()
     pool_hint = _pool_cache_hint(provider, main_runtime=main_runtime)
     return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key, is_vision, pool_hint)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -103,6 +103,16 @@ def estimate_request_context_tokens(api_payload: Any) -> int:
     return _chars(api_payload) // 4
 
 
+def _gateway_local_stream_policy(agent) -> dict[str, Any]:
+    """Return gateway-only local stream failover policy for this agent."""
+    cfg = getattr(agent, "_gateway_local_failover", None)
+    if not isinstance(cfg, dict) or not cfg.get("enabled"):
+        return {}
+    if not (getattr(agent, "base_url", None) and is_local_endpoint(agent.base_url)):
+        return {}
+    return cfg
+
+
 def _is_openai_codex_backend(agent) -> bool:
     base_url_lower = str(getattr(agent, "_base_url_lower", "") or "")
     base_url_hostname = str(getattr(agent, "_base_url_hostname", "") or "")
@@ -1140,6 +1150,17 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
+        try:
+            from agent.auxiliary_client import set_runtime_main
+            set_runtime_main(
+                fb_provider,
+                fb_model,
+                base_url=fb_base_url,
+                api_key=agent.api_key if isinstance(agent.api_key, str) else "",
+                api_mode=fb_api_mode,
+            )
+        except Exception:
+            pass
 
         # Clear the credential pool when the fallback provider doesn't match
         # the pool's provider.  The pool was seeded for the primary provider;
@@ -1662,6 +1683,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
     last_chunk_time = {"t": time.time()}
+    first_stream_chunk_seen = {"yes": False}
+    gateway_stream_policy = _gateway_local_stream_policy(agent)
 
     def _fire_first_delta():
         if not first_delta_fired["done"] and on_first_delta:
@@ -1721,6 +1744,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Reset stale-stream timer so the detector measures from this
         # attempt's start, not a previous attempt's last chunk.
         last_chunk_time["t"] = time.time()
+        first_stream_chunk_seen["yes"] = False
         agent._touch_activity("waiting for provider response (streaming)")
         # Initialize per-attempt stream diagnostics so the retry block can
         # reach for them after the stream dies.  Lives on
@@ -1757,6 +1781,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         usage_obj = None
         for chunk in stream:
             last_chunk_time["t"] = time.time()
+            first_stream_chunk_seen["yes"] = True
             agent._touch_activity("receiving stream response")
 
             # Update per-attempt diagnostic counters.  Best-effort —
@@ -1970,6 +1995,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
         # Reset stale-stream timer for this attempt
         last_chunk_time["t"] = time.time()
+        first_stream_chunk_seen["yes"] = False
         # Per-attempt diagnostic dict for the retry block to consume.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
@@ -1993,6 +2019,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # actively arriving (the chat_completions path
                 # already does this at the top of its chunk loop).
                 last_chunk_time["t"] = time.time()
+                first_stream_chunk_seen["yes"] = True
                 agent._touch_activity("receiving stream response")
 
                 # Update per-attempt diagnostic counters (best-effort).
@@ -2044,6 +2071,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         import httpx as _httpx
 
         _max_stream_retries = int(os.getenv("HERMES_STREAM_RETRIES", 2))
+        _gateway_max_primary_retries = gateway_stream_policy.get("max_primary_retries")
+        if isinstance(_gateway_max_primary_retries, int) and _gateway_max_primary_retries > 0:
+            _max_stream_retries = min(
+                _max_stream_retries,
+                max(0, _gateway_max_primary_retries - 1),
+            )
 
         try:
             for _stream_attempt in range(_max_stream_retries + 1):
@@ -2313,6 +2346,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         else:
             _stream_stale_timeout = _stream_stale_timeout_base
 
+    _gateway_no_first_chunk_timeout = gateway_stream_policy.get(
+        "no_first_chunk_timeout_seconds"
+    )
+    _gateway_stale_chunk_timeout = gateway_stream_policy.get(
+        "stale_chunk_timeout_seconds"
+    )
+
     t = threading.Thread(target=_call, daemon=True)
     t.start()
     _last_heartbeat = time.time()
@@ -2340,12 +2380,31 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # but delivering no real chunks.  Kill the client so the
         # inner retry loop can start a fresh connection.
         _stale_elapsed = time.time() - last_chunk_time["t"]
-        if _stale_elapsed > _stream_stale_timeout:
+        _effective_stream_timeout = _stream_stale_timeout
+        _stream_timeout_phase = "stale stream"
+        if gateway_stream_policy:
+            if (
+                not first_stream_chunk_seen["yes"]
+                and isinstance(_gateway_no_first_chunk_timeout, (int, float))
+                and _gateway_no_first_chunk_timeout > 0
+            ):
+                _effective_stream_timeout = float(_gateway_no_first_chunk_timeout)
+                _stream_timeout_phase = "no first stream chunk"
+            elif (
+                first_stream_chunk_seen["yes"]
+                and isinstance(_gateway_stale_chunk_timeout, (int, float))
+                and _gateway_stale_chunk_timeout > 0
+            ):
+                _effective_stream_timeout = float(_gateway_stale_chunk_timeout)
+                _stream_timeout_phase = "stale stream chunk"
+
+        if _stale_elapsed > _effective_stream_timeout:
             _est_ctx = estimate_request_context_tokens(api_kwargs)
             logger.warning(
-                "Stream stale for %.0fs (threshold %.0fs) — no chunks received. "
+                "%s for %.0fs (threshold %.0fs). "
                 "model=%s context=~%s tokens. Killing connection.",
-                _stale_elapsed, _stream_stale_timeout,
+                _stream_timeout_phase,
+                _stale_elapsed, _effective_stream_timeout,
                 api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
             )
             agent._buffer_status(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -48,6 +48,7 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
     get_context_length_from_provider_error,
+    is_local_endpoint,
     parse_available_output_tokens_from_error,
     save_context_length,
 )
@@ -62,6 +63,42 @@ from tools.skill_provenance import set_current_write_origin
 from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
+
+
+def _gateway_local_failover_policy(agent: Any) -> dict[str, Any]:
+    cfg = getattr(agent, "_gateway_local_failover", None)
+    if not isinstance(cfg, dict) or not cfg.get("enabled"):
+        return {}
+    if not (getattr(agent, "base_url", None) and is_local_endpoint(agent.base_url)):
+        return {}
+    return cfg
+
+
+def _iter_error_chain(error: BaseException):
+    seen: set[int] = set()
+    current = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+
+
+def _gateway_stream_error_matches(error: BaseException, patterns: Any) -> bool:
+    if isinstance(patterns, str):
+        patterns = (patterns,)
+    normalized_patterns = tuple(
+        str(pattern).strip().lower()
+        for pattern in (patterns or ())
+        if str(pattern).strip()
+    )
+    if not normalized_patterns:
+        return False
+    haystack_parts: list[str] = []
+    for item in _iter_error_chain(error):
+        haystack_parts.append(type(item).__name__.lower())
+        haystack_parts.append(str(item).lower())
+    haystack = " ".join(haystack_parts)
+    return any(pattern in haystack for pattern in normalized_patterns)
 
 
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
@@ -2743,6 +2780,40 @@ def run_conversation(
                             )
                         else:
                             agent._buffer_status("⚠️ Rate limited — switching to fallback provider...")
+                        if agent._try_activate_fallback(reason=classified.reason):
+                            retry_count = 0
+                            compression_attempts = 0
+                            primary_recovery_attempted = False
+                            continue
+
+                gateway_failover_policy = _gateway_local_failover_policy(agent)
+                if (
+                    gateway_failover_policy
+                    and classified.reason == FailoverReason.timeout
+                    and agent._has_pending_fallback()
+                ):
+                    _stream_error_match = _gateway_stream_error_matches(
+                        api_error,
+                        gateway_failover_policy.get("failover_on_stream_errors"),
+                    )
+                    _max_gateway_primary_retries = gateway_failover_policy.get(
+                        "max_primary_retries"
+                    )
+                    _primary_retries_exhausted = (
+                        isinstance(_max_gateway_primary_retries, int)
+                        and _max_gateway_primary_retries > 0
+                        and retry_count >= _max_gateway_primary_retries
+                    )
+                    if _stream_error_match or _primary_retries_exhausted:
+                        reason_text = (
+                            "stream transport error"
+                            if _stream_error_match
+                            else f"{_max_gateway_primary_retries} local retry"
+                        )
+                        agent._buffer_status(
+                            "⚠️ Local gateway model stalled or disconnected "
+                            f"({reason_text}) — switching to fallback provider..."
+                        )
                         if agent._try_activate_fallback(reason=classified.reason):
                             retry_count = 0
                             compression_attempts = 0

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -66,6 +66,10 @@ _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
+_YOUTUBE_URL_RE = re.compile(
+    r"https?://(?:www\.)?(?:youtube\.com|youtu\.be)/(?:\S+)",
+    re.IGNORECASE,
+)
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
@@ -1338,6 +1342,14 @@ def _compression_auto_reset_on_abort_platforms(user_config: Optional[dict]) -> s
     if not isinstance(raw, (list, tuple, set)):
         return set()
     return {str(item).strip().lower() for item in raw if str(item).strip()}
+
+
+def _transient_auto_skills_for_event(event) -> list[str]:
+    """Return turn-scoped skills to inject for matching gateway messages."""
+    text = str(getattr(event, "text", "") or "")
+    if _YOUTUBE_URL_RE.search(text):
+        return ["youtube-content"]
+    return []
 
 
 def _resolve_gateway_override_runtime(
@@ -9005,12 +9017,20 @@ class GatewayRunner:
             session_entry.auto_reset_reason = None
 
         # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
-        # Discord channel_skill_bindings).  Supports a single name or ordered list.
-        # Only inject on NEW sessions — ongoing conversations already have the
-        # skill content in their conversation history from the first message.
+        # Discord channel_skill_bindings) and turn-scoped URL triggers.
+        # Bound skills inject only on new sessions because ongoing
+        # conversations already have their payload in history. Transient
+        # triggers inject on every matching turn so a long-lived Telegram DM
+        # can still handle a YouTube URL without the user remembering /new.
         _auto = getattr(event, "auto_skill", None)
-        if _is_new_session and _auto:
-            _skill_names = [_auto] if isinstance(_auto, str) else list(_auto)
+        _bound_skill_names = [_auto] if isinstance(_auto, str) else list(_auto or [])
+        _transient_skill_names = _transient_auto_skills_for_event(event)
+        _skill_names = []
+        if _is_new_session:
+            _skill_names.extend(_bound_skill_names)
+        _skill_names.extend(_transient_skill_names)
+        _skill_names = list(dict.fromkeys(_skill_names))
+        if _skill_names:
             try:
                 from agent.skill_commands import _load_skill_payload, _build_skill_message
                 _combined_parts: list[str] = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15856,6 +15856,23 @@ class GatewayRunner:
                         f"image_url: {path} ~]"
                     )
                 else:
+                    error_text = " ".join(
+                        str(result.get(key) or "")
+                        for key in ("error", "analysis")
+                    ).lower()
+                    if (
+                        "no llm provider configured" in error_text
+                        or "no vision provider" in error_text
+                        or "provider configured for task=vision" in error_text
+                    ):
+                        enriched_parts.append(
+                            "[The user sent an image, but Hermes could not "
+                            "analyze it because no vision-capable provider is "
+                            "configured for image analysis. Tell the user that "
+                            "you cannot inspect the image right now; do not "
+                            "guess or ask them to describe it as if you saw it.]"
+                        )
+                        continue
                     enriched_parts.append(
                         "[The user sent an image but I couldn't quite see it "
                         "this time (>_<) You can try looking at it yourself "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -86,6 +86,35 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+
+def _telegram_runtime_context_prompt(user_config: dict) -> str:
+    """Return fresh Telegram-only runtime context for one agent turn."""
+    cfg = user_config if isinstance(user_config, dict) else {}
+    tz_name = str(cfg.get("timezone") or "").strip()
+    now = None
+    timezone_label = tz_name or "server-local"
+    if tz_name:
+        try:
+            from zoneinfo import ZoneInfo
+
+            now = datetime.now(ZoneInfo(tz_name))
+        except Exception:
+            logger.warning(
+                "Invalid timezone configured for Telegram runtime context: %s",
+                tz_name,
+            )
+    if now is None:
+        now = datetime.now().astimezone()
+
+    return (
+        "<runtime_context>\n"
+        f"Current date/time: {now.strftime('%Y-%m-%d %H:%M:%S %Z')}\n"
+        f"Timezone: {timezone_label}\n"
+        "For simple Telegram time/date questions, use this runtime context; "
+        "do not call terminal just to determine the current time or date.\n"
+        "</runtime_context>"
+    )
+
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r"("  # infrastructure/provider error preambles, not ordinary assistant prose
     r"api\s+(?:call\s+)?failed"
@@ -1263,6 +1292,92 @@ def _try_resolve_fallback_provider() -> dict | None:
     except Exception:
         pass
     return None
+
+
+def _coerce_positive_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _coerce_positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _gateway_agent_config(user_config: Optional[dict]) -> dict:
+    cfg = user_config if isinstance(user_config, dict) else {}
+    gateway_cfg = cfg.get("gateway") if isinstance(cfg.get("gateway"), dict) else {}
+    agent_cfg = gateway_cfg.get("agent") if isinstance(gateway_cfg.get("agent"), dict) else {}
+    return agent_cfg if isinstance(agent_cfg, dict) else {}
+
+
+def _gateway_model_override_config(user_config: Optional[dict]) -> dict:
+    agent_cfg = _gateway_agent_config(user_config)
+    override_cfg = agent_cfg.get("model_override")
+    return override_cfg if isinstance(override_cfg, dict) else {}
+
+
+def _gateway_local_failover_config(user_config: Optional[dict]) -> dict:
+    agent_cfg = _gateway_agent_config(user_config)
+    failover_cfg = agent_cfg.get("local_failover")
+    return failover_cfg if isinstance(failover_cfg, dict) else {}
+
+
+def _compression_auto_reset_on_abort_platforms(user_config: Optional[dict]) -> set[str]:
+    cfg = user_config if isinstance(user_config, dict) else {}
+    comp_cfg = cfg.get("compression") if isinstance(cfg.get("compression"), dict) else {}
+    raw = comp_cfg.get("hygiene_auto_reset_on_abort_platforms") or []
+    if isinstance(raw, str):
+        raw = [part.strip() for part in raw.split(",")]
+    if not isinstance(raw, (list, tuple, set)):
+        return set()
+    return {str(item).strip().lower() for item in raw if str(item).strip()}
+
+
+def _resolve_gateway_override_runtime(
+    override_cfg: dict,
+    runtime_kwargs: dict,
+) -> tuple[str | None, dict | None]:
+    """Resolve a gateway-only model/provider override without mutating globals."""
+    if not bool(override_cfg.get("enabled")):
+        return None, None
+    provider = str(override_cfg.get("provider") or "").strip()
+    model = str(override_cfg.get("model") or "").strip()
+    if not provider or not model:
+        return None, None
+
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    explicit_api_key = override_cfg.get("api_key")
+    if not explicit_api_key:
+        key_env = str(
+            override_cfg.get("key_env") or override_cfg.get("api_key_env") or ""
+        ).strip()
+        if key_env:
+            explicit_api_key = os.getenv(key_env, "").strip() or None
+
+    runtime = resolve_runtime_provider(
+        requested=provider,
+        explicit_base_url=override_cfg.get("base_url"),
+        explicit_api_key=explicit_api_key,
+    )
+    resolved_runtime = {
+        **runtime_kwargs,
+        "api_key": runtime.get("api_key"),
+        "base_url": runtime.get("base_url"),
+        "provider": runtime.get("provider"),
+        "api_mode": runtime.get("api_mode"),
+        "command": runtime.get("command"),
+        "args": list(runtime.get("args") or []),
+        "credential_pool": runtime.get("credential_pool"),
+    }
+    return model, resolved_runtime
 
 
 def _build_media_placeholder(event) -> str:
@@ -2621,7 +2736,13 @@ class GatewayRunner:
 
         return model, runtime_kwargs
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _resolve_turn_agent_config(
+        self,
+        user_message: str,
+        model: str,
+        runtime_kwargs: dict,
+        user_config: Optional[dict] = None,
+    ) -> dict:
         """Build the effective model/runtime config for a single turn.
 
         Always uses the session's primary model/provider.  If `/fast` is
@@ -2640,9 +2761,64 @@ class GatewayRunner:
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
         }
+        fallback_model = getattr(self, "_fallback_model", None)
+
+        override_cfg = _gateway_model_override_config(user_config)
+        if bool(override_cfg.get("enabled")):
+            try:
+                override_model, override_runtime = _resolve_gateway_override_runtime(
+                    override_cfg,
+                    runtime,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Gateway model override failed; using default runtime. error=%s",
+                    exc,
+                )
+                override_model, override_runtime = None, None
+            if override_model and override_runtime:
+                model = override_model
+                runtime = override_runtime
+                override_fallbacks = get_fallback_chain(
+                    {"fallback_providers": override_cfg.get("fallback_providers")}
+                )
+                if override_fallbacks:
+                    fallback_model = override_fallbacks
+                logger.info(
+                    "Gateway model override active: provider=%s model=%s",
+                    runtime.get("provider"),
+                    model,
+                )
+
+        local_failover_cfg = _gateway_local_failover_config(user_config)
+        gateway_local_failover: dict = {"enabled": False}
+        if bool(local_failover_cfg.get("enabled")):
+            stream_errors = local_failover_cfg.get("failover_on_stream_errors")
+            if isinstance(stream_errors, str):
+                stream_errors = [stream_errors]
+            normalized_errors = [
+                str(item).strip().lower()
+                for item in (stream_errors or [])
+                if str(item).strip()
+            ]
+            gateway_local_failover = {
+                "enabled": True,
+                "no_first_chunk_timeout_seconds": _coerce_positive_float(
+                    local_failover_cfg.get("no_first_chunk_timeout_seconds")
+                ),
+                "stale_chunk_timeout_seconds": _coerce_positive_float(
+                    local_failover_cfg.get("stale_chunk_timeout_seconds")
+                ),
+                "max_primary_retries": _coerce_positive_int(
+                    local_failover_cfg.get("max_primary_retries")
+                ),
+                "failover_on_stream_errors": tuple(normalized_errors),
+            }
         route = {
             "model": model,
             "runtime": runtime,
+            "fallback_model": fallback_model,
+            "gateway_local_failover": gateway_local_failover,
             "signature": (
                 model,
                 runtime["provider"],
@@ -2650,6 +2826,15 @@ class GatewayRunner:
                 runtime["api_mode"],
                 runtime["command"],
                 tuple(runtime["args"]),
+                tuple(
+                    (key, tuple(value) if isinstance(value, list) else value)
+                    for key, value in sorted(gateway_local_failover.items())
+                ),
+                tuple(
+                    (f.get("provider"), f.get("model"))
+                    for f in (fallback_model or [])
+                    if isinstance(f, dict)
+                ),
             ),
         }
 
@@ -8896,6 +9081,7 @@ class GatewayRunner:
             _hyg_base_url = None
             _hyg_api_key = None
             _hyg_data = {}
+            _hyg_auto_reset_on_abort_platforms: set[str] = set()
             try:
                 _hyg_data = _load_gateway_config()
                 if _hyg_data:
@@ -8933,6 +9119,9 @@ class GatewayRunner:
                                     _hyg_hard_msg_limit = _parsed
                             except (TypeError, ValueError):
                                 pass
+                        _hyg_auto_reset_on_abort_platforms = (
+                            _compression_auto_reset_on_abort_platforms(_hyg_data)
+                        )
 
                 try:
                     _hyg_model, _hyg_runtime = self._resolve_session_agent_runtime(
@@ -9123,14 +9312,32 @@ class GatewayRunner:
                                     _comp = getattr(_hyg_agent, "context_compressor", None)
                                     if _comp is not None and getattr(_comp, "_last_compress_aborted", False):
                                         _err = getattr(_comp, "_last_summary_error", None) or "unknown error"
-                                        _warn_msg = (
-                                            "⚠️ Context compression aborted "
-                                            f"({_err}). No messages were dropped — "
-                                            "conversation is unchanged. Run /compress "
-                                            "to retry, /reset for a clean session, or "
-                                            "check your auxiliary.compression model "
-                                            "configuration."
+                                        _platform_value = (
+                                            source.platform.value
+                                            if getattr(source, "platform", None)
+                                            else ""
+                                        ).lower()
+                                        _auto_reset_after_abort = (
+                                            _platform_value
+                                            and _platform_value in _hyg_auto_reset_on_abort_platforms
                                         )
+                                        if _auto_reset_after_abort and session_key:
+                                            _warn_msg = (
+                                                "⚠️ Context compression aborted "
+                                                f"({_err}). No messages were dropped. "
+                                                "I rotated this chat to a fresh Hermes "
+                                                "session and will handle your current "
+                                                "message without the oversized history."
+                                            )
+                                        else:
+                                            _warn_msg = (
+                                                "⚠️ Context compression aborted "
+                                                f"({_err}). No messages were dropped — "
+                                                "conversation is unchanged. Run /compress "
+                                                "to retry, /reset for a clean session, or "
+                                                "check your auxiliary.compression model "
+                                                "configuration."
+                                            )
                                         try:
                                             _adapter = self.adapters.get(source.platform)
                                             if _adapter and source.chat_id:
@@ -9140,6 +9347,24 @@ class GatewayRunner:
                                                 "Failed to deliver compression-failure warning to user: %s",
                                                 _werr,
                                             )
+                                        if _auto_reset_after_abort and session_key:
+                                            _new_entry = await self._auto_reset_session_boundary(
+                                                session_key=session_key,
+                                                source=source,
+                                                reason="hygiene_compression_abort",
+                                            )
+                                            if _new_entry is not None:
+                                                session_entry = _new_entry
+                                                history = []
+                                                context_prompt += (
+                                                    "\n\n[System note: The previous "
+                                                    "Telegram session was automatically "
+                                                    "rotated because gateway session "
+                                                    "hygiene could not compress its "
+                                                    "oversized transcript. Treat the "
+                                                    "current user message as the start "
+                                                    "of a fresh conversation.]"
+                                                )
                                     # Separately: if the user's CONFIGURED aux
                                     # model failed and we recovered by falling
                                     # back to the main model, tell them — a
@@ -9787,12 +10012,26 @@ class GatewayRunner:
             except Exception:
                 pass
 
-        # Resolve runtime credentials for probing
+        # Resolve runtime credentials for probing.  Gateway slash-command
+        # status should report the same gateway-wide model override that
+        # normal Telegram/Slack/etc. turns use, rather than the global CLI
+        # default.
         try:
             runtime = _resolve_runtime_agent_kwargs()
             provider = provider or runtime.get("provider")
             base_url = base_url or runtime.get("base_url")
             api_key = runtime.get("api_key")
+            override_cfg = _gateway_model_override_config(data)
+            if bool(override_cfg.get("enabled")):
+                override_model, override_runtime = _resolve_gateway_override_runtime(
+                    override_cfg,
+                    runtime,
+                )
+                if override_model and override_runtime:
+                    model = override_model
+                    provider = override_runtime.get("provider") or provider
+                    base_url = override_runtime.get("base_url") or base_url
+                    api_key = override_runtime.get("api_key") or api_key
         except Exception:
             pass
 
@@ -9980,6 +10219,92 @@ class GatewayRunner:
         if session_info:
             return EphemeralReply(f"{header}\n\n{session_info}{_tip_line}")
         return EphemeralReply(f"{header}{_tip_line}")
+
+    async def _auto_reset_session_boundary(
+        self,
+        *,
+        session_key: str,
+        source: SessionSource,
+        reason: str,
+    ) -> Optional["SessionEntry"]:
+        """Rotate a gateway session without treating the user's message as a command."""
+        self._invalidate_session_run_generation(session_key, reason=reason)
+
+        old_entry = self.session_store._entries.get(session_key)
+
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        if _cache_lock is not None:
+            with _cache_lock:
+                _cached = self._agent_cache.get(session_key)
+                _old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
+            if _old_agent is not None:
+                self._cleanup_agent_resources(_old_agent)
+        self._evict_cached_agent(session_key)
+
+        _qe = getattr(self, "_queued_events", None)
+        if _qe is not None:
+            _qe.pop(session_key, None)
+
+        try:
+            from tools.env_passthrough import clear_env_passthrough
+            clear_env_passthrough()
+        except Exception:
+            pass
+
+        try:
+            from tools.credential_files import clear_credential_files
+            clear_credential_files()
+        except Exception:
+            pass
+
+        new_entry = self.session_store.reset_session(session_key)
+
+        self._session_model_overrides.pop(session_key, None)
+        self._set_session_reasoning_override(session_key, None)
+        if hasattr(self, "_pending_model_notes"):
+            self._pending_model_notes.pop(session_key, None)
+        self._clear_session_boundary_security_state(session_key)
+
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _old_sid = old_entry.session_id if old_entry else None
+            _invoke_hook(
+                "on_session_finalize",
+                session_id=_old_sid,
+                platform=source.platform.value if source.platform else "",
+            )
+        except Exception:
+            pass
+
+        await self.hooks.emit("session:end", {
+            "platform": source.platform.value if source.platform else "",
+            "user_id": source.user_id,
+            "session_key": session_key,
+        })
+        await self.hooks.emit("session:reset", {
+            "platform": source.platform.value if source.platform else "",
+            "user_id": source.user_id,
+            "session_key": session_key,
+        })
+
+        if self._is_telegram_topic_lane(source) and new_entry is not None:
+            try:
+                self._record_telegram_topic_binding(source, new_entry)
+            except Exception:
+                logger.debug("Failed to rebind Telegram topic after automatic reset", exc_info=True)
+
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _new_sid = new_entry.session_id if new_entry else None
+            _invoke_hook(
+                "on_session_reset",
+                session_id=_new_sid,
+                platform=source.platform.value if source.platform else "",
+            )
+        except Exception:
+            pass
+
+        return new_entry
 
     async def _handle_profile_command(self, event: MessageEvent) -> str:
         """Handle /profile — show active profile name and home directory."""
@@ -12386,7 +12711,12 @@ class GatewayRunner:
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(
+                prompt,
+                model,
+                runtime_kwargs,
+                user_config=user_config,
+            )
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -12433,7 +12763,7 @@ class GatewayRunner:
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
                     session_db=self._session_db,
-                    fallback_model=self._fallback_model,
+                    fallback_model=turn_route.get("fallback_model", self._fallback_model),
                 )
                 try:
                     return agent.run_conversation(
@@ -15821,6 +16151,7 @@ class GatewayRunner:
         ("compression", "protect_last_n"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
+        ("gateway", "agent"),
     )
 
     _HONCHO_CACHE_BUSTING_KEYS = (
@@ -17362,6 +17693,16 @@ class GatewayRunner:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
             if self._ephemeral_system_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
+            stable_ephemeral = combined_ephemeral
+            turn_runtime_context = (
+                _telegram_runtime_context_prompt(user_config)
+                if platform_key == "telegram"
+                else ""
+            )
+            if turn_runtime_context:
+                combined_ephemeral = (
+                    combined_ephemeral + "\n\n" + turn_runtime_context
+                ).strip()
 
             # Re-read .env and config for fresh credentials (gateway is long-lived,
             # keys may change without restart). Keep config.yaml authoritative for
@@ -17497,7 +17838,12 @@ class GatewayRunner:
                     log_message="interim_assistant_callback scheduling error",
                 )
 
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(
+                message,
+                model,
+                runtime_kwargs,
+                user_config=user_config,
+            )
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -17506,7 +17852,7 @@ class GatewayRunner:
                 turn_route["model"],
                 turn_route["runtime"],
                 enabled_toolsets,
-                combined_ephemeral,
+                stable_ephemeral,
                 cache_keys=self._extract_cache_busting_config(user_config),
                 user_id=getattr(source, "user_id", None),
                 user_id_alt=getattr(source, "user_id_alt", None),
@@ -17519,6 +17865,7 @@ class GatewayRunner:
                     cached = _cache.get(session_key)
                     if cached and cached[1] == _sig:
                         agent = cached[0]
+                        agent.ephemeral_system_prompt = combined_ephemeral or None
                         # Refresh LRU order so the cap enforcement evicts
                         # truly-oldest entries, not the one we just used.
                         if hasattr(_cache, "move_to_end"):
@@ -17561,7 +17908,7 @@ class GatewayRunner:
                     thread_id=source.thread_id,
                     gateway_session_key=session_key,
                     session_db=self._session_db,
-                    fallback_model=self._fallback_model,
+                    fallback_model=turn_route.get("fallback_model", self._fallback_model),
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
@@ -17579,6 +17926,12 @@ class GatewayRunner:
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
+            agent._gateway_local_failover = turn_route.get("gateway_local_failover") or {"enabled": False}
+            turn_fallback = turn_route.get("fallback_model", self._fallback_model)
+            if turn_fallback is not None:
+                agent._fallback_chain = list(turn_fallback or [])
+                agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
+                agent._fallback_index = 0
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1333,15 +1333,25 @@ def _gateway_local_failover_config(user_config: Optional[dict]) -> dict:
     return failover_cfg if isinstance(failover_cfg, dict) else {}
 
 
+def _gateway_semantic_escalation_config(user_config: Optional[dict]) -> dict:
+    agent_cfg = _gateway_agent_config(user_config)
+    escalation_cfg = agent_cfg.get("semantic_escalation")
+    return escalation_cfg if isinstance(escalation_cfg, dict) else {}
+
+
+def _as_normalized_set(value: Any) -> set[str]:
+    if isinstance(value, str):
+        value = [part.strip() for part in value.split(",")]
+    if not isinstance(value, (list, tuple, set)):
+        return set()
+    return {str(item).strip().lower() for item in value if str(item).strip()}
+
+
 def _compression_auto_reset_on_abort_platforms(user_config: Optional[dict]) -> set[str]:
     cfg = user_config if isinstance(user_config, dict) else {}
     comp_cfg = cfg.get("compression") if isinstance(cfg.get("compression"), dict) else {}
     raw = comp_cfg.get("hygiene_auto_reset_on_abort_platforms") or []
-    if isinstance(raw, str):
-        raw = [part.strip() for part in raw.split(",")]
-    if not isinstance(raw, (list, tuple, set)):
-        return set()
-    return {str(item).strip().lower() for item in raw if str(item).strip()}
+    return _as_normalized_set(raw)
 
 
 def _compression_auto_reset_message_limit_config(
@@ -1365,12 +1375,9 @@ def _compression_auto_reset_message_limit_config(
     if limit <= 0:
         return 0, set()
 
-    raw = comp_cfg.get("hygiene_auto_reset_message_limit_platforms") or []
-    if isinstance(raw, str):
-        raw = [part.strip() for part in raw.split(",")]
-    if not isinstance(raw, (list, tuple, set)):
-        return 0, set()
-    platforms = {str(item).strip().lower() for item in raw if str(item).strip()}
+    platforms = _as_normalized_set(
+        comp_cfg.get("hygiene_auto_reset_message_limit_platforms") or []
+    )
     if not platforms:
         return 0, set()
     return limit, platforms
@@ -1422,6 +1429,49 @@ def _resolve_gateway_override_runtime(
         "credential_pool": runtime.get("credential_pool"),
     }
     return model, resolved_runtime
+
+
+def _resolve_gateway_semantic_escalation(
+    escalation_cfg: dict,
+    runtime_kwargs: dict,
+    *,
+    platform_key: str,
+    route_hints: Optional[dict] = None,
+) -> tuple[str | None, dict | None, str | None]:
+    """Resolve an opt-in gateway escalation route for obvious capability gaps."""
+    if not bool(escalation_cfg.get("enabled")):
+        return None, None, None
+
+    platforms = _as_normalized_set(escalation_cfg.get("platforms") or [])
+    if platforms and platform_key.lower() not in platforms:
+        return None, None, None
+
+    triggers = _as_normalized_set(escalation_cfg.get("triggers") or [])
+    hints = route_hints if isinstance(route_hints, dict) else {}
+    reason = None
+    if "image" in triggers and bool(hints.get("has_image")):
+        reason = "image"
+    if reason is None:
+        return None, None, None
+
+    provider = str(escalation_cfg.get("provider") or "").strip()
+    model = str(escalation_cfg.get("model") or "").strip()
+    if not provider or not model:
+        return None, None, None
+
+    override_cfg = {
+        "enabled": True,
+        "provider": provider,
+        "model": model,
+        "base_url": escalation_cfg.get("base_url"),
+        "api_key": escalation_cfg.get("api_key"),
+        "key_env": escalation_cfg.get("key_env") or escalation_cfg.get("api_key_env"),
+    }
+    override_model, override_runtime = _resolve_gateway_override_runtime(
+        override_cfg,
+        runtime_kwargs,
+    )
+    return override_model, override_runtime, reason
 
 
 def _build_media_placeholder(event) -> str:
@@ -2005,6 +2055,7 @@ class GatewayRunner:
         # preserve the queue.
         self._queued_events: Dict[str, List[MessageEvent]] = {}
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
+        self._pending_route_hints_by_session: Dict[str, Dict[str, Any]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
         # LRU cache of live SessionSources keyed by session_key. Used by
@@ -2786,6 +2837,9 @@ class GatewayRunner:
         model: str,
         runtime_kwargs: dict,
         user_config: Optional[dict] = None,
+        *,
+        platform_key: str = "",
+        route_hints: Optional[dict] = None,
     ) -> dict:
         """Build the effective model/runtime config for a single turn.
 
@@ -2830,6 +2884,33 @@ class GatewayRunner:
                     fallback_model = override_fallbacks
                 logger.info(
                     "Gateway model override active: provider=%s model=%s",
+                    runtime.get("provider"),
+                    model,
+                )
+
+        escalation_cfg = _gateway_semantic_escalation_config(user_config)
+        if bool(escalation_cfg.get("enabled")):
+            try:
+                escalated_model, escalated_runtime, escalation_reason = (
+                    _resolve_gateway_semantic_escalation(
+                        escalation_cfg,
+                        runtime,
+                        platform_key=platform_key or "",
+                        route_hints=route_hints,
+                    )
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Gateway semantic escalation failed; using current route. error=%s",
+                    exc,
+                )
+                escalated_model, escalated_runtime, escalation_reason = None, None, None
+            if escalated_model and escalated_runtime:
+                model = escalated_model
+                runtime = escalated_runtime
+                logger.info(
+                    "Gateway semantic escalation active: reason=%s provider=%s model=%s",
+                    escalation_reason or "unknown",
                     runtime.get("provider"),
                     model,
                 )
@@ -8605,6 +8686,7 @@ class GatewayRunner:
         # Reset only this session's per-call buffer; other sessions may be
         # concurrently preparing multimodal turns on the same runner.
         self._consume_pending_native_image_paths(session_key)
+        self._consume_pending_route_hints(session_key)
 
         _is_shared_multi_user = is_shared_multi_user_session(
             source,
@@ -8642,6 +8724,11 @@ class GatewayRunner:
                     audio_paths.append(path)
 
             if image_paths:
+                pending_hints = getattr(self, "_pending_route_hints_by_session", None)
+                if pending_hints is None:
+                    pending_hints = {}
+                    self._pending_route_hints_by_session = pending_hints
+                pending_hints[session_key] = {"has_image": True}
                 # Decide routing: native (attach pixels) vs text (vision_analyze
                 # pre-run + prepend description).  See agent/image_routing.py.
                 _img_mode = self._decide_image_input_mode()
@@ -8817,6 +8904,13 @@ class GatewayRunner:
         if not pending_native:
             return []
         return list(pending_native.pop(session_key, []) or [])
+
+    def _consume_pending_route_hints(self, session_key: str) -> Dict[str, Any]:
+        pending_hints = getattr(self, "_pending_route_hints_by_session", None)
+        if not pending_hints:
+            return {}
+        hints = pending_hints.pop(session_key, {}) or {}
+        return dict(hints) if isinstance(hints, dict) else {}
 
     def _cache_session_source(self, session_key: str, source) -> None:
         if not session_key or source is None:
@@ -12832,6 +12926,7 @@ class GatewayRunner:
                 model,
                 runtime_kwargs,
                 user_config=user_config,
+                platform_key=platform_key,
             )
 
             # Enrich the prompt with image descriptions so the background
@@ -17980,6 +18075,8 @@ class GatewayRunner:
                 model,
                 runtime_kwargs,
                 user_config=user_config,
+                platform_key=platform_key,
+                route_hints=self._consume_pending_route_hints(session_key),
             )
 
             # Check agent cache — reuse the AIAgent from the previous message

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9226,6 +9226,7 @@ class GatewayRunner:
             _hyg_provider = None
             _hyg_base_url = None
             _hyg_api_key = None
+            _hyg_runtime = {}
             _hyg_data = {}
             _hyg_auto_reset_on_abort_platforms: set[str] = set()
             _hyg_auto_reset_message_limit = 0
@@ -9281,6 +9282,28 @@ class GatewayRunner:
                         session_key=session_key,
                         user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
                     )
+                    _hyg_provider = _hyg_runtime.get("provider") or _hyg_provider
+                    _hyg_base_url = _hyg_runtime.get("base_url") or _hyg_base_url
+                    _hyg_api_key = _hyg_runtime.get("api_key") or _hyg_api_key
+                except Exception:
+                    pass
+
+                try:
+                    _platform_key = _platform_config_key(source.platform)
+                    _route_hints = {}
+                    _pending_hints = getattr(self, "_pending_route_hints_by_session", None)
+                    if session_key and isinstance(_pending_hints, dict):
+                        _route_hints = dict(_pending_hints.get(session_key) or {})
+                    _turn_route = self._resolve_turn_agent_config(
+                        event.text or "",
+                        _hyg_model,
+                        _hyg_runtime,
+                        user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
+                        platform_key=_platform_key,
+                        route_hints=_route_hints,
+                    )
+                    _hyg_model = _turn_route.get("model") or _hyg_model
+                    _hyg_runtime = _turn_route.get("runtime") or _hyg_runtime
                     _hyg_provider = _hyg_runtime.get("provider") or _hyg_provider
                     _hyg_base_url = _hyg_runtime.get("base_url") or _hyg_base_url
                     _hyg_api_key = _hyg_runtime.get("api_key") or _hyg_api_key
@@ -9437,11 +9460,6 @@ class GatewayRunner:
                     try:
                         from run_agent import AIAgent
 
-                        _hyg_model, _hyg_runtime = self._resolve_session_agent_runtime(
-                            source=source,
-                            session_key=session_key,
-                            user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
-                        )
                         if _hyg_runtime.get("api_key"):
                             _hyg_msgs = [
                                 {"role": m.get("role"), "content": m.get("content")}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1344,6 +1344,38 @@ def _compression_auto_reset_on_abort_platforms(user_config: Optional[dict]) -> s
     return {str(item).strip().lower() for item in raw if str(item).strip()}
 
 
+def _compression_auto_reset_message_limit_config(
+    user_config: Optional[dict],
+) -> tuple[int, set[str]]:
+    """Return the opt-in gateway session auto-reset limit and platforms.
+
+    ``hygiene_hard_message_limit`` preserves the historical behavior: attempt
+    compression first. This separate opt-in is for chatty messaging surfaces
+    where a very long transcript is itself a reliability smell, and rotating
+    before agent startup is safer than trying to replay/compress the whole
+    session again.
+    """
+    cfg = user_config if isinstance(user_config, dict) else {}
+    comp_cfg = cfg.get("compression") if isinstance(cfg.get("compression"), dict) else {}
+
+    try:
+        limit = int(comp_cfg.get("hygiene_auto_reset_message_limit") or 0)
+    except (TypeError, ValueError):
+        limit = 0
+    if limit <= 0:
+        return 0, set()
+
+    raw = comp_cfg.get("hygiene_auto_reset_message_limit_platforms") or []
+    if isinstance(raw, str):
+        raw = [part.strip() for part in raw.split(",")]
+    if not isinstance(raw, (list, tuple, set)):
+        return 0, set()
+    platforms = {str(item).strip().lower() for item in raw if str(item).strip()}
+    if not platforms:
+        return 0, set()
+    return limit, platforms
+
+
 def _transient_auto_skills_for_event(event) -> list[str]:
     """Return turn-scoped skills to inject for matching gateway messages."""
     text = str(getattr(event, "text", "") or "")
@@ -9102,6 +9134,8 @@ class GatewayRunner:
             _hyg_api_key = None
             _hyg_data = {}
             _hyg_auto_reset_on_abort_platforms: set[str] = set()
+            _hyg_auto_reset_message_limit = 0
+            _hyg_auto_reset_message_limit_platforms: set[str] = set()
             try:
                 _hyg_data = _load_gateway_config()
                 if _hyg_data:
@@ -9142,6 +9176,10 @@ class GatewayRunner:
                         _hyg_auto_reset_on_abort_platforms = (
                             _compression_auto_reset_on_abort_platforms(_hyg_data)
                         )
+                        (
+                            _hyg_auto_reset_message_limit,
+                            _hyg_auto_reset_message_limit_platforms,
+                        ) = _compression_auto_reset_message_limit_config(_hyg_data)
 
                 try:
                     _hyg_model, _hyg_runtime = self._resolve_session_agent_runtime(
@@ -9217,6 +9255,64 @@ class GatewayRunner:
                     # 85% * 1.4 = 119% of context — which exceeds the model's limit
                     # and prevented hygiene from ever firing for ~200K models (GLM-5).
 
+                _platform_value = (
+                    source.platform.value
+                    if getattr(source, "platform", None)
+                    else ""
+                ).lower()
+                _auto_reset_by_message_limit = (
+                    bool(session_key)
+                    and _platform_value in _hyg_auto_reset_message_limit_platforms
+                    and _hyg_auto_reset_message_limit > 0
+                    and _msg_count >= _hyg_auto_reset_message_limit
+                )
+                if _auto_reset_by_message_limit:
+                    logger.info(
+                        "Session hygiene: %s messages exceeds auto-reset limit "
+                        "%s for platform=%s — rotating before agent startup",
+                        _msg_count,
+                        _hyg_auto_reset_message_limit,
+                        _platform_value,
+                    )
+                    _hyg_meta = self._thread_metadata_for_source(
+                        source, self._reply_anchor_for_event(event)
+                    )
+                    try:
+                        _adapter = self.adapters.get(source.platform)
+                        if _adapter and source.chat_id:
+                            await _adapter.send(
+                                source.chat_id,
+                                (
+                                    "🔄 This chat had grown large enough to risk "
+                                    "slow or unreliable replies, so I rotated it "
+                                    "to a fresh Hermes session and will handle "
+                                    "your current message without the oversized "
+                                    "history."
+                                ),
+                                metadata=_hyg_meta,
+                            )
+                    except Exception as _werr:
+                        logger.warning(
+                            "Failed to deliver hygiene auto-reset notice to user: %s",
+                            _werr,
+                        )
+
+                    _new_entry = await self._auto_reset_session_boundary(
+                        session_key=session_key,
+                        source=source,
+                        reason="hygiene_message_limit",
+                    )
+                    if _new_entry is not None:
+                        session_entry = _new_entry
+                        history = []
+                        context_prompt += (
+                            "\n\n[System note: The previous Telegram session "
+                            "was automatically rotated because the gateway "
+                            "transcript exceeded the configured hygiene "
+                            "message limit. Treat the current user message as "
+                            "the start of a fresh conversation.]"
+                        )
+
                 # Hard safety valve: force compression if message count is
                 # extreme, regardless of token estimates.  This breaks the
                 # death spiral where API disconnects prevent token data
@@ -9232,7 +9328,7 @@ class GatewayRunner:
                     or _msg_count >= _HARD_MSG_LIMIT
                 )
 
-                if _needs_compress:
+                if _needs_compress and not _auto_reset_by_message_limit:
                     logger.info(
                         "Session hygiene: %s messages, ~%s tokens (%s) — auto-compressing "
                         "(threshold: %s%% of %s = %s tokens)",
@@ -16169,6 +16265,10 @@ class GatewayRunner:
         ("compression", "threshold"),
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
+        ("compression", "hygiene_hard_message_limit"),
+        ("compression", "hygiene_auto_reset_message_limit"),
+        ("compression", "hygiene_auto_reset_message_limit_platforms"),
+        ("compression", "hygiene_auto_reset_on_abort_platforms"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
         ("gateway", "agent"),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1058,6 +1058,7 @@ DEFAULT_CONFIG = {
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 400,  # gateway session-hygiene force-compress threshold by message count
+        "hygiene_auto_reset_on_abort_platforms": [],  # gateway platforms that should auto-/new if hygiene compression aborts
         "protect_first_n": 3,         # non-system head messages always preserved
                                       # verbatim, in ADDITION to the system prompt
                                       # (which is always implicitly protected). Set to
@@ -1998,6 +1999,21 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        "agent": {
+            "model_override": {
+                "enabled": False,
+                "provider": "",
+                "model": "",
+                "fallback_providers": [],
+            },
+            "local_failover": {
+                "enabled": False,
+                "no_first_chunk_timeout_seconds": 0,
+                "stale_chunk_timeout_seconds": 0,
+                "max_primary_retries": 0,
+                "failover_on_stream_errors": [],
+            },
+        },
         # When false (default), any file path the agent emits is delivered
         # as a native attachment as long as it isn't under the credential /
         # system-path denylist (/etc, /proc, ~/.ssh, ~/.aws, ~/.hermes/.env,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1058,6 +1058,8 @@ DEFAULT_CONFIG = {
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 400,  # gateway session-hygiene force-compress threshold by message count
+        "hygiene_auto_reset_message_limit": 0,  # opt-in gateway auto-/new threshold by message count; 0 disables
+        "hygiene_auto_reset_message_limit_platforms": [],  # gateway platforms allowed to auto-/new at the message limit
         "hygiene_auto_reset_on_abort_platforms": [],  # gateway platforms that should auto-/new if hygiene compression aborts
         "protect_first_n": 3,         # non-system head messages always preserved
                                       # verbatim, in ADDITION to the system prompt

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2015,6 +2015,13 @@ DEFAULT_CONFIG = {
                 "max_primary_retries": 0,
                 "failover_on_stream_errors": [],
             },
+            "semantic_escalation": {
+                "enabled": False,
+                "platforms": [],
+                "triggers": [],
+                "provider": "",
+                "model": "",
+            },
         },
         # When false (default), any file path the agent emits is delivered
         # as a native attachment as long as it isn't under the credential /

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -722,10 +722,8 @@ def run_doctor(args):
                     provider_ids_to_accept.add(catalog_provider)
 
             if provider and provider != "auto":
-                if catalog_provider is None or (
-                    known_providers
-                    and not (provider_ids_to_accept & valid_provider_ids)
-                ):
+                provider_known = bool(provider_ids_to_accept & valid_provider_ids)
+                if catalog_provider is None and not provider_known:
                     known_list = ", ".join(sorted(known_providers)) if known_providers else "(unavailable)"
                     _fail_and_issue(
                         f"model.provider '{provider_raw}' is not a recognised provider",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11580,6 +11580,11 @@ def _command_has_dedicated_mcp_startup(args) -> bool:
 def _should_background_mcp_startup(args) -> bool:
     if _is_tui_chat_launch(args):
         return False
+    if getattr(args, "oneshot", None):
+        # One-shot snapshots tools immediately inside run_oneshot().  If MCP
+        # discovery is still in the background, configured MCP toolsets can
+        # appear empty for the whole run.
+        return False
     return args.command in {None, "chat", "rl"}
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -73,6 +73,7 @@ CONFIGURABLE_TOOLSETS = [
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
+    ("kanban",          "📌 Kanban Workflow",           "kanban task/status tools"),
     ("messaging",       "📨 Cross-Platform Messaging",  "send_message"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
     ("spotify",          "🎵 Spotify",                  "playback, search, playlists, library"),
@@ -96,7 +97,7 @@ CONFIGURABLE_TOOLSETS = [
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "kanban"}
 
 
 def _xai_credentials_present() -> bool:

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -161,6 +161,56 @@ class TestResolveAutoMainFirst:
         assert mock_resolve.call_args.args[0] == "anthropic"
         assert mock_resolve.call_args.args[1] == "runtime-model"
 
+    def test_auto_cache_key_tracks_runtime_global_fallback(self):
+        """Auto auxiliary cache must not pair a fallback provider with a stale model."""
+        from agent import auxiliary_client as mod
+
+        local_client = MagicMock()
+        local_client.base_url = "http://127.0.0.1:8000/v1"
+        fallback_client = MagicMock()
+        fallback_client.base_url = "https://openrouter.ai/api/v1/"
+
+        def _resolve(provider, model, *args, **kwargs):
+            if provider == "auto" and mod._RUNTIME_MAIN_PROVIDER == "omlx":
+                return local_client, mod._RUNTIME_MAIN_MODEL
+            if provider == "auto" and mod._RUNTIME_MAIN_PROVIDER == "openrouter":
+                return fallback_client, mod._RUNTIME_MAIN_MODEL
+            return None, None
+
+        mod.shutdown_cached_clients()
+        mod.clear_runtime_main()
+        try:
+            with patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                side_effect=_resolve,
+            ) as mock_resolve:
+                mod.set_runtime_main(
+                    "omlx",
+                    "qwen3-4b-instruct-2507-4bit",
+                    base_url="http://127.0.0.1:8000/v1",
+                    api_key="local",
+                    api_mode="chat_completions",
+                )
+                client, model = mod._get_cached_client("auto")
+                assert client is local_client
+                assert model == "qwen3-4b-instruct-2507-4bit"
+
+                mod.set_runtime_main(
+                    "openrouter",
+                    "deepseek/deepseek-v4-pro",
+                    base_url="https://openrouter.ai/api/v1/",
+                    api_key="or-key",
+                    api_mode="chat_completions",
+                )
+                client, model = mod._get_cached_client("auto")
+
+            assert client is fallback_client
+            assert model == "deepseek/deepseek-v4-pro"
+            assert mock_resolve.call_count == 2
+        finally:
+            mod.shutdown_cached_clients()
+            mod.clear_runtime_main()
+
 
 # ── Vision — resolve_vision_provider_client ─────────────────────────────────
 

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -87,6 +87,18 @@ def _make_event(text: str) -> MessageEvent:
     return MessageEvent(text=text, source=_make_source(), message_id="m1")
 
 
+def test_transient_auto_skills_detects_youtube_urls():
+    event = _make_event("check this https://youtube.com/shorts/11K3tGgFnJs")
+
+    assert gateway_run._transient_auto_skills_for_event(event) == ["youtube-content"]
+
+
+def test_transient_auto_skills_ignores_regular_chat():
+    event = _make_event("just chatting about something")
+
+    assert gateway_run._transient_auto_skills_for_event(event) == []
+
+
 def test_turn_route_injects_priority_processing_without_changing_runtime():
     runner = _make_runner()
     runner._service_tier = "priority"

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -18,9 +18,12 @@ from gateway.session import SessionSource
 class _CapturingAgent:
     last_init = None
     last_run = None
+    instances = []
 
     def __init__(self, *args, **kwargs):
         type(self).last_init = dict(kwargs)
+        type(self).instances.append(self)
+        self.ephemeral_system_prompt = kwargs.get("ephemeral_system_prompt")
         self.tools = []
 
     def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
@@ -29,6 +32,7 @@ class _CapturingAgent:
             "conversation_history": conversation_history,
             "task_id": task_id,
             "persist_user_message": persist_user_message,
+            "ephemeral_system_prompt": self.ephemeral_system_prompt,
         }
         return {
             "final_response": "ok",
@@ -121,6 +125,196 @@ def test_turn_route_skips_priority_processing_for_unsupported_models():
     assert route["request_overrides"] == {}
 
 
+def test_gateway_model_override_uses_scoped_primary_and_fallback(monkeypatch):
+    runner = _make_runner()
+    runner._service_tier = None
+    runner._fallback_model = [
+        {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}
+    ]
+    runtime_kwargs = {
+        "api_key": "primary-key",
+        "base_url": "http://127.0.0.1:8020/v1",
+        "provider": "omlx",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": "primary-pool",
+    }
+
+    def _fake_resolve_runtime_provider(**kwargs):
+        assert kwargs["requested"] == "omlx"
+        return {
+            "api_key": "override-key",
+            "base_url": "http://127.0.0.1:8020/v1",
+            "provider": "omlx",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _fake_resolve_runtime_provider,
+    )
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "hi",
+        "qwen3-30b-a3b-instruct-2507-4bit",
+        runtime_kwargs,
+        user_config={
+            "gateway": {
+                "agent": {
+                    "model_override": {
+                        "enabled": True,
+                        "provider": "omlx",
+                        "model": "qwen3-4b-instruct-2507-4bit",
+                        "fallback_providers": [
+                            {
+                                "provider": "openrouter",
+                                "model": "deepseek/deepseek-v4-pro",
+                            }
+                        ],
+                    },
+                    "local_failover": {
+                        "enabled": True,
+                        "no_first_chunk_timeout_seconds": 20,
+                        "stale_chunk_timeout_seconds": 30,
+                        "max_primary_retries": 1,
+                        "failover_on_stream_errors": [
+                            "RemoteProtocolError",
+                            "incomplete chunked read",
+                        ],
+                    },
+                }
+            }
+        },
+    )
+
+    assert route["model"] == "qwen3-4b-instruct-2507-4bit"
+    assert route["runtime"]["provider"] == "omlx"
+    assert route["runtime"]["credential_pool"] is None
+    assert route["fallback_model"] == [
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+    ]
+    assert route["gateway_local_failover"] == {
+        "enabled": True,
+        "no_first_chunk_timeout_seconds": 20.0,
+        "stale_chunk_timeout_seconds": 30.0,
+        "max_primary_retries": 1,
+        "failover_on_stream_errors": (
+            "remoteprotocolerror",
+            "incomplete chunked read",
+        ),
+    }
+
+
+def test_gateway_model_override_defaults_off_keep_global_route():
+    runner = _make_runner()
+    runner._service_tier = None
+    runner._fallback_model = [
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+    ]
+    runtime_kwargs = {
+        "api_key": "primary-key",
+        "base_url": "http://127.0.0.1:8020/v1",
+        "provider": "omlx",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": "primary-pool",
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "hi",
+        "qwen3-30b-a3b-instruct-2507-4bit",
+        runtime_kwargs,
+        user_config={},
+    )
+
+    assert route["model"] == "qwen3-30b-a3b-instruct-2507-4bit"
+    assert route["runtime"]["provider"] == "omlx"
+    assert route["runtime"]["credential_pool"] == "primary-pool"
+    assert route["fallback_model"] == [
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+    ]
+    assert route["gateway_local_failover"] == {"enabled": False}
+
+
+def test_session_info_reports_gateway_model_override(monkeypatch):
+    runner = _make_runner()
+
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "qwen3-30b-a3b-instruct-2507-4bit")
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "model": {
+                "provider": "omlx",
+                "default": "qwen3-30b-a3b-instruct-2507-4bit",
+            },
+            "gateway": {
+                "agent": {
+                    "model_override": {
+                        "enabled": True,
+                        "provider": "openrouter",
+                        "model": "deepseek/deepseek-v4-flash",
+                        "fallback_providers": [
+                            {
+                                "provider": "openrouter",
+                                "model": "deepseek/deepseek-v4-pro",
+                            }
+                        ],
+                    }
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "api_key": "global-key",
+            "base_url": "http://127.0.0.1:8000/v1",
+            "provider": "omlx",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        },
+    )
+
+    def _fake_resolve_runtime_provider(**kwargs):
+        assert kwargs["requested"] == "openrouter"
+        return {
+            "api_key": "override-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _fake_resolve_runtime_provider,
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *args, **kwargs: 128000,
+    )
+
+    info = gateway_run.GatewayRunner._format_session_info(runner)
+
+    assert "deepseek/deepseek-v4-flash" in info
+    assert "Provider: openrouter" in info
+    assert "qwen3-30b-a3b-instruct-2507-4bit" not in info
+    assert "Endpoint: http://127.0.0.1:8000/v1" not in info
+
+
 @pytest.mark.asyncio
 async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
     runner = _make_runner()
@@ -185,3 +379,102 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["service_tier"] == "priority"
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_injects_telegram_runtime_time_context(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    (tmp_path / "config.yaml").write_text("timezone: America/Chicago\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"timezone": "America/Chicago"},
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    _CapturingAgent.last_init = None
+    result = await runner._run_agent(
+        message="what time is it?",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "ok"
+    prompt = _CapturingAgent.last_init["ephemeral_system_prompt"]
+    assert "Context prompt" in prompt
+    assert "<runtime_context>" in prompt
+    assert "Timezone: America/Chicago" in prompt
+    assert "do not call terminal just to determine the current time or date" in prompt
+
+
+@pytest.mark.asyncio
+async def test_cached_telegram_agent_refreshes_runtime_time_context(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    (tmp_path / "config.yaml").write_text("timezone: America/Chicago\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"timezone": "America/Chicago"},
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+    contexts = iter(["<runtime_context>first</runtime_context>", "<runtime_context>second</runtime_context>"])
+    monkeypatch.setattr(gateway_run, "_telegram_runtime_context_prompt", lambda user_config: next(contexts))
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    _CapturingAgent.instances = []
+    session_key = "agent:main:telegram:dm:12345"
+    for message in ("first", "second"):
+        result = await runner._run_agent(
+            message=message,
+            context_prompt="",
+            history=[],
+            source=_make_source(),
+            session_id="session-1",
+            session_key=session_key,
+        )
+        assert result["final_response"] == "ok"
+
+    assert len(_CapturingAgent.instances) == 1
+    assert _CapturingAgent.last_run["ephemeral_system_prompt"] == (
+        "<runtime_context>second</runtime_context>"
+    )

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -255,6 +255,139 @@ def test_gateway_model_override_defaults_off_keep_global_route():
     assert route["gateway_local_failover"] == {"enabled": False}
 
 
+def test_gateway_semantic_escalation_routes_image_turn_to_pro(monkeypatch):
+    runner = _make_runner()
+    runner._service_tier = None
+    runtime_kwargs = {
+        "api_key": "primary-key",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "provider": "omlx",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    def _fake_resolve_runtime_provider(**kwargs):
+        assert kwargs["requested"] == "openrouter"
+        return {
+            "api_key": "override-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _fake_resolve_runtime_provider,
+    )
+
+    user_config = {
+        "gateway": {
+            "agent": {
+                "model_override": {
+                    "enabled": True,
+                    "provider": "openrouter",
+                    "model": "deepseek/deepseek-v4-flash",
+                    "fallback_providers": [
+                        {
+                            "provider": "openrouter",
+                            "model": "deepseek/deepseek-v4-pro",
+                        }
+                    ],
+                },
+                "semantic_escalation": {
+                    "enabled": True,
+                    "platforms": ["telegram"],
+                    "triggers": ["image"],
+                    "provider": "openrouter",
+                    "model": "deepseek/deepseek-v4-pro",
+                },
+            }
+        }
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "what is in this image?",
+        "qwen3-30b-a3b-instruct-2507-4bit",
+        runtime_kwargs,
+        user_config=user_config,
+        platform_key="telegram",
+        route_hints={"has_image": True},
+    )
+
+    assert route["model"] == "deepseek/deepseek-v4-pro"
+    assert route["runtime"]["provider"] == "openrouter"
+    assert route["fallback_model"] == [
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+    ]
+
+
+def test_gateway_semantic_escalation_leaves_plain_text_on_flash(monkeypatch):
+    runner = _make_runner()
+    runner._service_tier = None
+    runtime_kwargs = {
+        "api_key": "primary-key",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "provider": "omlx",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    def _fake_resolve_runtime_provider(**kwargs):
+        assert kwargs["requested"] == "openrouter"
+        return {
+            "api_key": "override-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _fake_resolve_runtime_provider,
+    )
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "what time is it?",
+        "qwen3-30b-a3b-instruct-2507-4bit",
+        runtime_kwargs,
+        user_config={
+            "gateway": {
+                "agent": {
+                    "model_override": {
+                        "enabled": True,
+                        "provider": "openrouter",
+                        "model": "deepseek/deepseek-v4-flash",
+                    },
+                    "semantic_escalation": {
+                        "enabled": True,
+                        "platforms": ["telegram"],
+                        "triggers": ["image"],
+                        "provider": "openrouter",
+                        "model": "deepseek/deepseek-v4-pro",
+                    },
+                }
+            }
+        },
+        platform_key="telegram",
+        route_hints={},
+    )
+
+    assert route["model"] == "deepseek/deepseek-v4-flash"
+    assert route["runtime"]["provider"] == "openrouter"
+
+
 def test_session_info_reports_gateway_model_override(monkeypatch):
     runner = _make_runner()
 

--- a/tests/gateway/test_native_image_buffer_isolation.py
+++ b/tests/gateway/test_native_image_buffer_isolation.py
@@ -59,6 +59,22 @@ async def test_native_image_buffer_isolated_per_session():
 
 
 @pytest.mark.asyncio
+async def test_image_turn_buffers_route_hint_for_semantic_escalation():
+    runner = _make_runner()
+    source = _source("chat-a")
+    session_key = build_session_key(source)
+
+    await runner._prepare_inbound_message_text(
+        event=_image_event(source, "/tmp/a.png"),
+        source=source,
+        history=[],
+    )
+
+    assert runner._consume_pending_route_hints(session_key) == {"has_image": True}
+    assert runner._consume_pending_route_hints(session_key) == {}
+
+
+@pytest.mark.asyncio
 async def test_native_image_buffer_not_cleared_by_other_sessions_without_images():
     runner = _make_runner()
     source_a = _source("chat-a")

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -515,6 +515,142 @@ async def test_session_hygiene_warns_user_when_compression_aborts(monkeypatch, t
 
 
 @pytest.mark.asyncio
+async def test_session_hygiene_auto_resets_configured_platform_after_abort(
+    monkeypatch, tmp_path
+):
+    """Configured messaging platforms should rotate after hygiene aborts.
+
+    This keeps chatty Telegram sessions from repeatedly replaying the same
+    oversized transcript when the compression model cannot summarize it.
+    """
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgentWithSummaryFailure:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+            self.context_compressor = SimpleNamespace(
+                _last_compress_aborted=True,
+                _last_summary_fallback_used=False,
+                _last_summary_dropped_count=0,
+                _last_summary_error="context too large for compression model",
+            )
+            type(self).last_instance = self
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            return (messages, None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgentWithSummaryFailure
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "compression:\n"
+        "  enabled: true\n"
+        "  hygiene_hard_message_limit: 4\n"
+        "  hygiene_auto_reset_on_abort_platforms:\n"
+        "    - telegram\n"
+    )
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    old_entry = SessionEntry(
+        session_key="agent:main:telegram:private:12345",
+        session_id="sess-old",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="private",
+    )
+    new_entry = SessionEntry(
+        session_key="agent:main:telegram:private:12345",
+        session_id="sess-new",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="private",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {old_entry.session_key: old_entry}
+    runner.session_store.get_or_create_session.return_value = old_entry
+    runner.session_store.reset_session.return_value = new_entry
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store._save = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._queued_events = {}
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="private",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    runner.session_store.reset_session.assert_called_once_with(old_entry.session_key)
+    assert runner._run_agent.await_args.kwargs["history"] == []
+    warning_messages = [
+        s for s in adapter.sent if "rotated this chat to a fresh Hermes session" in s["content"]
+    ]
+    assert len(warning_messages) == 1
+    runner._cleanup_agent_resources.assert_called_with(
+        FakeCompressAgentWithSummaryFailure.last_instance
+    )
+
+
+@pytest.mark.asyncio
 async def test_session_hygiene_informs_user_when_aux_model_fails_but_recovers(monkeypatch, tmp_path):
     """When the user's configured ``auxiliary.compression.model`` errors out
     and we recover via the main model, compression succeeds but the user's

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -772,6 +772,129 @@ async def test_session_hygiene_auto_resets_telegram_at_configured_message_limit(
 
 
 @pytest.mark.asyncio
+async def test_session_hygiene_uses_gateway_turn_route_for_context_check(
+    monkeypatch, tmp_path
+):
+    """Gateway hygiene must use the effective per-turn route.
+
+    Telegram can override the global CLI/local model. If hygiene checks the
+    global model context before the turn route is applied, it can repeatedly
+    attempt compression against an unrelated 32K local model even though the
+    actual Telegram turn is routed to a large-context gateway model.
+    """
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgent:
+        last_instance = None
+
+        def __init__(self, **_kwargs):
+            type(self).last_instance = self
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:private:12345",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="private",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._pending_route_hints_by_session = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=(
+            "qwen3-30b-a3b-instruct-2507-4bit",
+            {"provider": "omlx", "base_url": "http://127.0.0.1:8000/v1", "api_key": "fake"},
+        )
+    )
+    runner._resolve_turn_agent_config = MagicMock(
+        return_value={
+            "model": "deepseek/deepseek-v4-flash",
+            "runtime": {
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "fake",
+            },
+            "fallback_model": [
+                {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+            ],
+        }
+    )
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    context_calls = []
+
+    def fake_context_length(model, **kwargs):
+        context_calls.append((model, kwargs))
+        if model == "qwen3-30b-a3b-instruct-2507-4bit":
+            return 100
+        if model == "deepseek/deepseek-v4-flash":
+            return 1_000_000
+        return 64_000
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        fake_context_length,
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="private",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    runner._resolve_turn_agent_config.assert_called_once()
+    assert context_calls[0][0] == "deepseek/deepseek-v4-flash"
+    assert context_calls[0][1]["provider"] == "openrouter"
+    assert FakeCompressAgent.last_instance is None
+
+
+@pytest.mark.asyncio
 async def test_session_hygiene_informs_user_when_aux_model_fails_but_recovers(monkeypatch, tmp_path):
     """When the user's configured ``auxiliary.compression.model`` errors out
     and we recover via the main model, compression succeeds but the user's

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -651,6 +651,127 @@ async def test_session_hygiene_auto_resets_configured_platform_after_abort(
 
 
 @pytest.mark.asyncio
+async def test_session_hygiene_auto_resets_telegram_at_configured_message_limit(
+    monkeypatch, tmp_path
+):
+    """Opt-in messaging platforms can rotate before attempting compression.
+
+    Telegram DMs are often casual, long-lived chats. Once a transcript has
+    already become pathological, replaying it into the compression path can be
+    the failure mode. The message-limit auto-reset starts a fresh session and
+    handles the current message without the oversized history.
+    """
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgent:
+        last_instance = None
+
+        def __init__(self, **_kwargs):
+            type(self).last_instance = self
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "compression:\n"
+        "  enabled: true\n"
+        "  hygiene_auto_reset_message_limit: 4\n"
+        "  hygiene_auto_reset_message_limit_platforms:\n"
+        "    - telegram\n"
+    )
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    old_entry = SessionEntry(
+        session_key="agent:main:telegram:private:12345",
+        session_id="sess-old",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="private",
+    )
+    new_entry = SessionEntry(
+        session_key="agent:main:telegram:private:12345",
+        session_id="sess-new",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="private",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {old_entry.session_key: old_entry}
+    runner.session_store.get_or_create_session.return_value = old_entry
+    runner.session_store.reset_session.return_value = new_entry
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store._save = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._queued_events = {}
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 1_000_000,
+    )
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="private",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    runner.session_store.reset_session.assert_called_once_with(old_entry.session_key)
+    assert runner._run_agent.await_args.kwargs["history"] == []
+    assert FakeCompressAgent.last_instance is None
+    notices = [
+        s for s in adapter.sent if "rotated it to a fresh Hermes session" in s["content"]
+    ]
+    assert len(notices) == 1
+
+
+@pytest.mark.asyncio
 async def test_session_hygiene_informs_user_when_aux_model_fails_but_recovers(monkeypatch, tmp_path):
     """When the user's configured ``auxiliary.compression.model`` errors out
     and we recover via the main model, compression succeeds but the user's

--- a/tests/gateway/test_vision_memory_leak.py
+++ b/tests/gateway/test_vision_memory_leak.py
@@ -78,3 +78,32 @@ class TestEnrichMessageWithVision:
         assert "photograph of a dog" in out
         assert "fenced leak" not in out
         assert "<memory-context>" not in out
+
+    def test_no_vision_provider_tells_model_not_to_guess(self, gateway_runner):
+        """If image pre-analysis cannot resolve a vision backend, the main
+        model must not receive a prompt that invites guessing or fake vision."""
+        fake_result = json.dumps({
+            "success": False,
+            "error": (
+                "Error analyzing image: No LLM provider configured for "
+                "task=vision provider=auto. Run: hermes setup"
+            ),
+            "analysis": "There was a problem with the request.",
+        })
+        with patch("tools.vision_tools.vision_analyze_tool", new=AsyncMock(return_value=fake_result)):
+            out = _run(gateway_runner._enrich_message_with_vision("caption", ["/tmp/img.jpg"]))
+        assert "could not analyze it because no vision-capable provider" in out
+        assert "do not guess" in out
+        assert "vision_analyze using image_url" not in out
+
+    def test_transient_vision_failure_keeps_retry_hint(self, gateway_runner):
+        """Non-configuration failures still leave the existing retry path
+        available so the agent can re-run vision_analyze if useful."""
+        fake_result = json.dumps({
+            "success": False,
+            "error": "Error analyzing image: provider timeout",
+            "analysis": "The vision request timed out.",
+        })
+        with patch("tools.vision_tools.vision_analyze_tool", new=AsyncMock(return_value=fake_result)):
+            out = _run(gateway_runner._enrich_message_with_vision("caption", ["/tmp/img.jpg"]))
+        assert "vision_analyze using image_url: /tmp/img.jpg" in out

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -72,6 +72,23 @@ class TestLoadConfigDefaults:
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
 
+    def test_gateway_agent_stage1_defaults_are_disabled(self):
+        agent_cfg = DEFAULT_CONFIG["gateway"]["agent"]
+
+        assert agent_cfg["model_override"] == {
+            "enabled": False,
+            "provider": "",
+            "model": "",
+            "fallback_providers": [],
+        }
+        assert agent_cfg["local_failover"] == {
+            "enabled": False,
+            "no_first_chunk_timeout_seconds": 0,
+            "stale_chunk_timeout_seconds": 0,
+            "max_primary_retries": 0,
+            "failover_on_stream_errors": [],
+        }
+
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             config_path = tmp_path / "config.yaml"
@@ -892,4 +909,3 @@ class TestEnvWriteDenylist:
         # But the write path still refuses to update it
         with pytest.raises(ValueError, match="denylist"):
             save_env_value("LD_PRELOAD", "/tmp/evil.so")
-

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -407,6 +407,49 @@ def test_run_doctor_accepts_named_provider_from_providers_section(monkeypatch, t
     assert "model.provider 'volcengine-plan' is not a recognised provider" not in out
 
 
+def test_run_doctor_accepts_registry_provider_without_catalog_entry(monkeypatch, tmp_path):
+    """Registry-known providers do not need a models.dev catalog row.
+
+    Regression: ``omlx`` was listed as a known provider but still failed
+    validation because resolve_provider_full() returned no catalog entry.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: omlx\n"
+        "  default: qwen3-30b-a3b-instruct-2507-4bit\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "model.provider 'omlx' is not a recognised provider" not in out
+    assert "model.provider 'omlx' is unknown" not in out
+
+
 def test_run_doctor_accepts_bare_custom_provider(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -86,6 +86,14 @@ def test_configurable_toolsets_include_context_engine():
     assert any(ts_key == "context_engine" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 
 
+def test_configurable_toolsets_include_kanban_default_off():
+    keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+
+    assert "kanban" in keys
+    assert "kanban" in _DEFAULT_OFF_TOOLSETS
+    assert "kanban" not in _get_platform_tools({}, "telegram")
+
+
 def test_get_platform_tools_active_context_engine_is_enabled_for_explicit_config():
     config = {
         "context": {"engine": "lcm"},
@@ -1453,4 +1461,3 @@ def test_apply_provider_selection_does_not_prompt_or_post_setup(monkeypatch):
     config = {}
     tools_config.apply_provider_selection("tts", "Microsoft Edge TTS", config)
     assert config["tts"]["provider"] == "edge"
-

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -792,6 +792,12 @@ def test_oneshot_distinguishes_disabled_mcp_from_unknown(monkeypatch, capsys):
     assert "mcp-off" in err
 
 
+def test_oneshot_uses_inline_mcp_discovery(main_mod):
+    args = Namespace(command=None, oneshot="hello", tui=False)
+
+    assert main_mod._should_background_mcp_startup(args) is False
+
+
 def test_oneshot_wires_session_db_for_recall(monkeypatch):
     """hermes -z bypasses HermesCLI, but recall still needs SessionDB."""
     from hermes_cli.oneshot import _run_agent

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3334,6 +3334,64 @@ class TestRunConversation:
         assert result["completed"] is True
         assert result["final_response"] == "Fallback answer."
 
+    def test_gateway_local_stream_error_triggers_fast_fallback(self, agent):
+        """Gateway-local stream transport errors use fallback before max retries."""
+        import httpx
+        from agent.error_classifier import FailoverReason
+
+        self._setup_agent(agent)
+        agent.base_url = "http://127.0.0.1:8020/v1"
+        agent.provider = "omlx"
+        agent.model = "qwen3-4b-instruct-2507-4bit"
+        agent.stream_delta_callback = lambda text: None
+        agent._fallback_chain = [
+            {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+        ]
+        agent._fallback_index = 0
+        agent._fallback_activated = False
+        agent._gateway_local_failover = {
+            "enabled": True,
+            "no_first_chunk_timeout_seconds": 20,
+            "stale_chunk_timeout_seconds": 30,
+            "max_primary_retries": 1,
+            "failover_on_stream_errors": (
+                "remoteprotocolerror",
+                "incomplete chunked read",
+            ),
+        }
+
+        fallback_reasons = []
+
+        def _mock_fallback(reason=None):
+            fallback_reasons.append(reason)
+            agent._fallback_index = 1
+            agent._fallback_activated = True
+            agent.model = "deepseek/deepseek-v4-pro"
+            agent.provider = "openrouter"
+            agent.base_url = "https://openrouter.ai/api/v1"
+            return True
+
+        with (
+            patch.object(
+                agent,
+                "_interruptible_streaming_api_call",
+                side_effect=[
+                    httpx.RemoteProtocolError("incomplete chunked read"),
+                    _mock_response(content="Fallback answer.", finish_reason="stop"),
+                ],
+            ) as mock_stream,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_try_activate_fallback", side_effect=_mock_fallback),
+        ):
+            result = agent.run_conversation("answer me")
+
+        assert fallback_reasons == [FailoverReason.timeout]
+        assert mock_stream.call_count == 2
+        assert result["completed"] is True
+        assert result["final_response"] == "Fallback answer."
+
     def test_empty_response_fallback_also_empty_returns_empty(self, agent):
         """If fallback also returns empty, final response is (empty)."""
         self._setup_agent(agent)

--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -250,3 +250,65 @@ def test_circuit_breaker_cleared_on_reconnect(monkeypatch, tmp_path):
         )
     finally:
         _cleanup(mcp_tool, "srv")
+
+
+def test_circuit_breaker_cleared_after_successful_tool_discovery(monkeypatch, tmp_path):
+    """A successful transport reconnect should close a stale breaker.
+
+    ``MCPServerTask.run`` rediscovers tools after initial connect and after
+    reconnect. If list_tools succeeds, the transport is viable again and the
+    breaker should not keep short-circuiting future tool calls.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    server = MCPServerTask("srv")
+    session = MagicMock()
+    tools_result = MagicMock()
+    tools_result.tools = []
+    session.list_tools = MagicMock()
+
+    async def _list_tools():
+        return tools_result
+
+    session.list_tools = _list_tools
+    server.session = session
+
+    mcp_tool._server_error_counts["srv"] = mcp_tool._CIRCUIT_BREAKER_THRESHOLD
+    mcp_tool._server_breaker_opened_at["srv"] = 1000.0
+
+    try:
+        import asyncio
+
+        asyncio.run(server._discover_tools())
+
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+        assert "srv" not in mcp_tool._server_breaker_opened_at
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
+def test_fresh_session_replaces_rpc_lock(monkeypatch, tmp_path):
+    """Reconnect installs a new RPC lock instead of reusing a wedged one."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.mcp_tool import MCPServerTask
+
+    async def _check():
+        server = MCPServerTask("srv")
+        old_lock = server._rpc_lock
+        await old_lock.acquire()
+
+        fresh_session = object()
+        server._install_session(fresh_session)
+
+        assert server.session is fresh_session
+        assert server._rpc_lock is not old_lock
+        assert old_lock.locked()
+        assert not server._rpc_lock.locked()
+
+    import asyncio
+
+    asyncio.run(_check())

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -569,6 +569,150 @@ class TestToolHandler:
         finally:
             _servers.pop("test_srv", None)
 
+    def test_timeout_signals_reconnect_and_opens_breaker(self):
+        from tools import mcp_tool
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        server = _make_mock_server("test_srv", session=mock_session)
+        reconnect_requested = threading.Event()
+
+        class _ReconnectEvent:
+            def set(self):
+                reconnect_requested.set()
+
+        class _Loop:
+            def is_running(self):
+                return True
+
+            def call_soon_threadsafe(self, callback, *args):
+                callback(*args)
+
+        server._reconnect_event = _ReconnectEvent()
+        _servers["test_srv"] = server
+        mcp_tool._server_error_counts.pop("test_srv", None)
+        mcp_tool._server_breaker_opened_at.pop("test_srv", None)
+        old_loop = mcp_tool._mcp_loop
+        mcp_tool._mcp_loop = _Loop()
+
+        try:
+            handler = _make_tool_handler("test_srv", "slow_tool", 30)
+
+            def _timeout_run(coro_or_factory, timeout=30):
+                coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+                coro.close()
+                raise TimeoutError("MCP call timed out after 30.0s")
+
+            with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_timeout_run):
+                result = json.loads(handler({}))
+
+            assert "TimeoutError" in result["error"]
+            assert reconnect_requested.is_set()
+            assert (
+                mcp_tool._server_error_counts["test_srv"]
+                >= mcp_tool._CIRCUIT_BREAKER_THRESHOLD
+            )
+            assert "test_srv" in mcp_tool._server_breaker_opened_at
+        finally:
+            mcp_tool._mcp_loop = old_loop
+            _servers.pop("test_srv", None)
+            mcp_tool._server_error_counts.pop("test_srv", None)
+            mcp_tool._server_breaker_opened_at.pop("test_srv", None)
+
+    def test_timeout_opened_breaker_short_circuits_followup_call(self):
+        from tools import mcp_tool
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+        mcp_tool._server_error_counts["test_srv"] = (
+            mcp_tool._CIRCUIT_BREAKER_THRESHOLD
+        )
+        mcp_tool._server_breaker_opened_at["test_srv"] = time.monotonic()
+
+        try:
+            handler = _make_tool_handler("test_srv", "slow_tool", 30)
+            with patch("tools.mcp_tool._run_on_mcp_loop") as mock_run:
+                result = json.loads(handler({}))
+
+            assert "unreachable" in result["error"].lower()
+            mock_run.assert_not_called()
+        finally:
+            _servers.pop("test_srv", None)
+            mcp_tool._server_error_counts.pop("test_srv", None)
+            mcp_tool._server_breaker_opened_at.pop("test_srv", None)
+
+    def test_read_only_timeout_reconnects_and_retries_once(self):
+        from tools import mcp_tool
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+        mcp_tool._mcp_read_only_tool_names.add("mcp_test_srv_slow_tool")
+        mcp_tool._server_error_counts.pop("test_srv", None)
+        mcp_tool._server_breaker_opened_at.pop("test_srv", None)
+
+        calls = {"count": 0}
+
+        def _timeout_then_success(coro_or_factory, timeout=30):
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+            coro.close()
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise TimeoutError("MCP call timed out after 30.0s")
+            return json.dumps({"result": "fresh calendar data"})
+
+        try:
+            handler = _make_tool_handler("test_srv", "slow_tool", 30)
+            with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_timeout_then_success), \
+                 patch("tools.mcp_tool._request_server_reconnect_and_wait", return_value=True) as reconnect:
+                result = json.loads(handler({}))
+
+            assert result == {"result": "fresh calendar data"}
+            assert calls["count"] == 2
+            reconnect.assert_called_once()
+            assert mcp_tool._server_error_counts.get("test_srv", 0) == 0
+            assert "test_srv" not in mcp_tool._server_breaker_opened_at
+        finally:
+            _servers.pop("test_srv", None)
+            mcp_tool._mcp_read_only_tool_names.discard("mcp_test_srv_slow_tool")
+            mcp_tool._server_error_counts.pop("test_srv", None)
+            mcp_tool._server_breaker_opened_at.pop("test_srv", None)
+
+    def test_non_read_only_timeout_does_not_retry(self):
+        from tools import mcp_tool
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+        mcp_tool._server_error_counts.pop("test_srv", None)
+        mcp_tool._server_breaker_opened_at.pop("test_srv", None)
+
+        calls = {"count": 0}
+
+        def _timeout_run(coro_or_factory, timeout=30):
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+            coro.close()
+            calls["count"] += 1
+            raise TimeoutError("MCP call timed out after 30.0s")
+
+        try:
+            handler = _make_tool_handler("test_srv", "write_tool", 30)
+            with patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_timeout_run), \
+                 patch("tools.mcp_tool._request_server_reconnect_and_wait") as reconnect:
+                result = json.loads(handler({}))
+
+            assert "TimeoutError" in result["error"]
+            assert calls["count"] == 1
+            reconnect.assert_not_called()
+        finally:
+            _servers.pop("test_srv", None)
+            mcp_tool._server_error_counts.pop("test_srv", None)
+            mcp_tool._server_breaker_opened_at.pop("test_srv", None)
+
 
 class TestRunOnMCPLoopInterrupts:
     def test_interrupt_cancels_waiting_mcp_call(self):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1151,6 +1151,18 @@ class MCPServerTask:
         """Check if this server uses HTTP transport."""
         return "url" in self._config
 
+    def _install_session(self, session: Any) -> None:
+        """Install a fresh initialized MCP session.
+
+        ``_rpc_lock`` is scoped to one transport session.  A timed-out
+        ``call_tool`` coroutine may keep the old lock held until the SDK
+        fully tears down that transport.  Reusing that lock after reconnect
+        lets the first post-reconnect retry block behind dead session state,
+        so each fresh session gets its own lock.
+        """
+        self._rpc_lock = asyncio.Lock()
+        self.session = session
+
     # ----- Dynamic tool discovery (notifications/tools/list_changed) -----
 
     async def _refresh_tools_task(self):
@@ -1415,7 +1427,7 @@ class MCPServerTask:
                     read_stream, write_stream, **sampling_kwargs
                 ) as session:
                     self.initialize_result = await session.initialize()
-                    self.session = session
+                    self._install_session(session)
                     await self._discover_tools()
                     self._ready.set()
                     # stdio transport does not use OAuth, but we still honor
@@ -1564,7 +1576,7 @@ class MCPServerTask:
                     read_stream, write_stream, **sampling_kwargs
                 ) as session:
                     self.initialize_result = await session.initialize()
-                    self.session = session
+                    self._install_session(session)
                     await self._discover_tools()
                     self._ready.set()
                     reason = await self._wait_for_lifecycle_event()
@@ -1613,7 +1625,7 @@ class MCPServerTask:
                 ):
                     async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
                         self.initialize_result = await session.initialize()
-                        self.session = session
+                        self._install_session(session)
                         await self._discover_tools()
                         self._ready.set()
                         reason = await self._wait_for_lifecycle_event()
@@ -1636,7 +1648,7 @@ class MCPServerTask:
             ):
                 async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
                     self.initialize_result = await session.initialize()
-                    self.session = session
+                    self._install_session(session)
                     await self._discover_tools()
                     self._ready.set()
                     reason = await self._wait_for_lifecycle_event()
@@ -1657,6 +1669,7 @@ class MCPServerTask:
             if hasattr(tools_result, "tools")
             else []
         )
+        _reset_server_error(self.name)
 
     async def run(self, config: dict):
         """Long-lived coroutine: connect, discover tools, wait, disconnect.
@@ -1901,6 +1914,15 @@ def _bump_server_error(server_name: str) -> None:
         _server_breaker_opened_at[server_name] = time.monotonic()
 
 
+def _open_server_breaker(server_name: str) -> None:
+    """Open the circuit breaker immediately for a known-bad server state."""
+    _server_error_counts[server_name] = max(
+        _server_error_counts.get(server_name, 0),
+        _CIRCUIT_BREAKER_THRESHOLD,
+    )
+    _server_breaker_opened_at[server_name] = time.monotonic()
+
+
 def _reset_server_error(server_name: str) -> None:
     """Fully close the breaker for ``server_name``.
 
@@ -1910,6 +1932,56 @@ def _reset_server_error(server_name: str) -> None:
     """
     _server_error_counts[server_name] = 0
     _server_breaker_opened_at.pop(server_name, None)
+
+
+def _signal_server_reconnect(server_name: str, reason: str) -> bool:
+    """Ask an MCP server task to rebuild its transport session."""
+    with _lock:
+        srv = _servers.get(server_name)
+        loop = _mcp_loop
+    if srv is None or not hasattr(srv, "_reconnect_event"):
+        return False
+    if loop is None or not loop.is_running():
+        return False
+    logger.info(
+        "MCP server '%s': signalling transport reconnect (%s)",
+        server_name,
+        reason,
+    )
+    loop.call_soon_threadsafe(srv._reconnect_event.set)
+    return True
+
+
+def _request_server_reconnect_and_wait(
+    server_name: str,
+    reason: str,
+    *,
+    previous_session: Any = None,
+    timeout: float = 15.0,
+) -> bool:
+    """Signal an MCP reconnect and wait for a fresh session object."""
+    with _lock:
+        srv = _servers.get(server_name)
+    if srv is None:
+        return False
+    if not _signal_server_reconnect(server_name, reason):
+        return False
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        current_session = getattr(srv, "session", None)
+        if current_session is not None and current_session is not previous_session:
+            return True
+        time.sleep(0.25)
+
+    logger.warning(
+        "MCP server '%s': reconnect did not ready within %.0fs after %s; "
+        "falling through to error response.",
+        server_name,
+        timeout,
+        reason,
+    )
+    return False
 
 # ---------------------------------------------------------------------------
 # Auth-failure detection helpers (Task 6 of MCP OAuth consolidation)
@@ -2197,22 +2269,12 @@ def _handle_session_expired_and_retry(
         server_name, op_description, exc,
     )
 
-    # Trigger the same reconnect mechanism the OAuth recovery path
-    # uses, then wait briefly for the new session to come back ready.
-    loop.call_soon_threadsafe(srv._reconnect_event.set)
-    deadline = time.monotonic() + 15
-    ready = False
-    while time.monotonic() < deadline:
-        if srv.session is not None and srv._ready.is_set():
-            ready = True
-            break
-        time.sleep(0.25)
-    if not ready:
-        logger.warning(
-            "MCP server '%s': reconnect did not ready within 15s after "
-            "session-expired error; falling through to error response.",
-            server_name,
-        )
+    if not _request_server_reconnect_and_wait(
+        server_name,
+        f"session-expired error during {op_description}",
+        previous_session=srv.session,
+        timeout=15.0,
+    ):
         return None
 
     try:
@@ -2233,6 +2295,60 @@ def _handle_session_expired_and_retry(
     return None
 
 
+def _handle_read_only_timeout_and_retry(
+    server_name: str,
+    tool_name: str,
+    exc: BaseException,
+    retry_call,
+):
+    """Reconnect and retry once when a read-only MCP call times out."""
+    if not isinstance(exc, TimeoutError):
+        return None
+
+    tool_name_prefixed = (
+        f"mcp_{sanitize_mcp_name_component(server_name)}_"
+        f"{sanitize_mcp_name_component(tool_name)}"
+    )
+    with _lock:
+        is_read_only = tool_name_prefixed in _mcp_read_only_tool_names
+        srv = _servers.get(server_name)
+    if not is_read_only or srv is None:
+        return None
+
+    logger.info(
+        "MCP server '%s': read-only tool '%s' timed out; reconnecting "
+        "transport and retrying once.",
+        server_name,
+        tool_name,
+    )
+    if not _request_server_reconnect_and_wait(
+        server_name,
+        f"read-only tool call timed out: {tool_name}",
+        previous_session=srv.session,
+        timeout=15.0,
+    ):
+        return None
+
+    try:
+        result = retry_call()
+        try:
+            parsed = json.loads(result)
+            if "error" not in parsed:
+                _reset_server_error(server_name)
+                return result
+        except (json.JSONDecodeError, TypeError):
+            _reset_server_error(server_name)
+            return result
+    except Exception as retry_exc:
+        logger.warning(
+            "MCP %s/%s retry after timeout reconnect failed: %s",
+            server_name,
+            tool_name,
+            retry_exc,
+        )
+    return None
+
+
 # Sanitized server names whose ``supports_parallel_tool_calls`` config is True.
 # Populated during ``register_mcp_servers()`` and queried by
 # ``is_mcp_tool_parallel_safe()`` for the parallel-execution check in run_agent.
@@ -2245,6 +2361,7 @@ _parallel_safe_servers: set = set()
 # captured at registration time so parallel safety never relies on prefix
 # guessing.
 _mcp_tool_server_names: Dict[str, str] = {}
+_mcp_read_only_tool_names: set[str] = set()
 
 # Dedicated event loop running in a background daemon thread.
 _mcp_loop: Optional[asyncio.AbstractEventLoop] = None
@@ -2600,7 +2717,24 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             if recovered is not None:
                 return recovered
 
-            _bump_server_error(server_name)
+            recovered = _handle_read_only_timeout_and_retry(
+                server_name,
+                tool_name,
+                exc,
+                _call_once,
+            )
+            if recovered is not None:
+                return recovered
+
+            if isinstance(exc, TimeoutError):
+                _open_server_breaker(server_name)
+                _signal_server_reconnect(
+                    server_name,
+                    f"tool call timed out: {tool_name}",
+                )
+            else:
+                _bump_server_error(server_name)
+
             logger.error(
                 "MCP tool %s/%s call failed: %s",
                 server_name, tool_name, exc,
@@ -3147,17 +3281,37 @@ _UTILITY_CAPABILITY_ATTRS = {
 }
 
 
-def _track_mcp_tool_server(tool_name: str, server_name: str) -> None:
-    """Remember the exact MCP server that registered *tool_name*."""
+def _track_mcp_tool_server(
+    tool_name: str,
+    server_name: str,
+    *,
+    read_only: bool = False,
+) -> None:
+    """Remember the exact MCP server and safety hints for *tool_name*."""
     safe_server_name = sanitize_mcp_name_component(server_name)
     with _lock:
         _mcp_tool_server_names[tool_name] = safe_server_name
+        if read_only:
+            _mcp_read_only_tool_names.add(tool_name)
+        else:
+            _mcp_read_only_tool_names.discard(tool_name)
 
 
 def _forget_mcp_tool_server(tool_name: str) -> None:
     """Forget MCP server provenance for a deregistered tool."""
     with _lock:
         _mcp_tool_server_names.pop(tool_name, None)
+        _mcp_read_only_tool_names.discard(tool_name)
+
+
+def _mcp_tool_is_read_only(mcp_tool) -> bool:
+    """Return True when an MCP tool advertises read-only semantics."""
+    annotations = getattr(mcp_tool, "annotations", None)
+    if annotations is None:
+        return False
+    if isinstance(annotations, dict):
+        return bool(annotations.get("readOnlyHint"))
+    return bool(getattr(annotations, "readOnlyHint", False))
 
 
 def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dict) -> List[dict]:
@@ -3294,7 +3448,11 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             is_async=False,
             description=schema["description"],
         )
-        _track_mcp_tool_server(tool_name_prefixed, name)
+        _track_mcp_tool_server(
+            tool_name_prefixed,
+            name,
+            read_only=_mcp_tool_is_read_only(mcp_tool),
+        )
         registered_names.append(tool_name_prefixed)
 
     # Register MCP Resources & Prompts utility tools, filtered by config and

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -633,6 +633,8 @@ compression:
   protect_last_n: 20                                # Min recent messages to keep uncompressed
   protect_first_n: 3                                # Non-system head messages pinned across compactions (0 = pin nothing)
   hygiene_hard_message_limit: 400                   # Gateway safety valve — see below
+  hygiene_auto_reset_message_limit: 0               # Gateway auto-reset safety valve; 0 disables
+  hygiene_auto_reset_message_limit_platforms: []     # Platforms allowed to auto-reset at that limit
 
 # The summarization model/provider is configured under auxiliary:
 auxiliary:
@@ -647,6 +649,8 @@ Older configs with `compression.summary_model`, `compression.summary_provider`, 
 :::
 
 `hygiene_hard_message_limit` is a gateway-only **pre-compression safety valve**. Runaway sessions with thousands of messages can hit model context limits before the normal percent-of-context threshold fires; when message count crosses this ceiling, Hermes forces compression regardless of token usage. Default `400` — raise it for platforms where very long sessions are normal, lower it to force more aggressive compression. Editing this value on a running gateway takes effect on the next message (see below).
+
+`hygiene_auto_reset_message_limit` is a stricter, opt-in gateway safety valve for chatty messaging platforms. When the current platform appears in `hygiene_auto_reset_message_limit_platforms` and the transcript reaches this message count, Hermes rotates to a fresh session before starting the agent, then answers the current message without replaying the oversized history. Default `0` disables it. This is useful for mobile chat surfaces where stale long-running context is more harmful than a fresh boundary.
 
 `protect_first_n` controls how many **non-system** head messages are pinned across every compaction. Default `3` — the opening user/assistant exchange survives every summarizer pass so the original goal stays visible. On long-running rolling-compaction sessions where the opening turn is no longer relevant, set `protect_first_n: 0` to pin nothing but the system prompt + summary + tail. The system prompt itself is always preserved regardless of this setting.
 


### PR DESCRIPTION
## Summary
- replace MCP RPC locks when a fresh transport session is installed
- open/reconnect the MCP circuit breaker on tool-call timeouts
- retry read-only MCP tool calls once after reconnect and clear stale breakers after successful tool discovery

## Tests
- /Users/mac-studio/projects/hermes-agent/.venv/bin/python -m pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_circuit_breaker.py -q
- git diff --check

## Linear
- AGE-193