### PR TITLE
fix(cron): don't crash on `cron list` when a job's deliver is null

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -89,7 +89,10 @@ def cron_list(show_all: bool = False):
         repeat_completed = repeat_info.get("completed", 0)
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"
 
-        deliver = job.get("deliver", ["local"])
+        # `deliver` may be present-but-null (e.g. a no-agent script job that
+        # only writes to the vault), so coalesce to the default rather than
+        # relying on the dict-default, which only applies to a missing key.
+        deliver = job.get("deliver") or ["local"]
         if isinstance(deliver, str):
             deliver = [deliver]
         deliver_str = ", ".join(deliver)


### PR DESCRIPTION
## Problem

`cron list` raises `TypeError: can only join an iterable` for any job persisted with `"deliver": null`.

`cron_list` (`hermes_cli/cron.py`) coalesces the `deliver` field via `job.get("deliver", ["local"])`. The dict-default only applies when the key is **absent** — a job whose key is present-but-null (e.g. a `no_agent` script job that only writes to the vault and intentionally has no channel delivery) yields `None`, and the following `", ".join(deliver)` then throws.

## Fix

Coalesce with `or` so a null value is treated like a missing key:

```python
deliver = job.get("deliver") or ["local"]
```

This is the exact same bug — and the exact same fix — already applied to the sibling `repeat` field five lines above (commit `b0d234f0`, *"don't crash on cron list when a job's repeat is null"*). The `deliver` case was simply missed.

## Repro

A job record with `"deliver": null` (valid, written by no-agent vault-only jobs) makes `hermes <profile> cron list` crash on render. With the fix it prints `Deliver: local`.

One-line change, mirrors existing precedent in the same function.