### PR TITLE
fix(signal): replace set with deque for ordered timestamp eviction

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -13,6 +13,7 @@ Requires:
 
 import asyncio
 import base64
+import collections
 import json
 import logging
 import os
@@ -233,8 +234,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         # Track recently sent message timestamps to prevent echo-back loops
         # in Note to Self / self-chat mode (mirrors WhatsApp recentlySentIds)
-        self._recent_sent_timestamps: set = set()
-        self._max_recent_timestamps = 50
+        self._recent_sent_timestamps: collections.deque = collections.deque(maxlen=50)
         # Signal increasingly exposes ACI/PNI UUIDs as stable recipient IDs.
         # Keep a best-effort mapping so outbound sends can upgrade from a
         # phone number to the corresponding UUID when signal-cli prefers it.
@@ -459,7 +459,10 @@ class SignalAdapter(BasePlatformAdapter):
                     if dest == self._account_normalized or sent_msg_group_id:
                         # Check if this is an echo of our own outbound reply
                         if sent_ts and sent_ts in self._recent_sent_timestamps:
-                            self._recent_sent_timestamps.discard(sent_ts)
+                            try:
+                                self._recent_sent_timestamps.remove(sent_ts)
+                            except ValueError:
+                                pass
                             return
                         # Genuine user Note to Self — promote to dataMessage
                         is_note_to_self = True
@@ -998,9 +1001,7 @@ class SignalAdapter(BasePlatformAdapter):
         """Record outbound message timestamp for echo-back filtering."""
         ts = rpc_result.get("timestamp") if isinstance(rpc_result, dict) else None
         if ts:
-            self._recent_sent_timestamps.add(ts)
-            if len(self._recent_sent_timestamps) > self._max_recent_timestamps:
-                self._recent_sent_timestamps.pop()
+            self._recent_sent_timestamps.append(ts)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send a typing indicator.


### PR DESCRIPTION
## What does this PR do?
`_track_sent_timestamp` uses a `set` with `set.pop()` to cap the echo-back dedup window at 50 entries. `set.pop()` removes an arbitrary element — not the oldest timestamp — so recent timestamps can be evicted while old ones are kept, silently breaking the dedup window.

## Related Issue
Fixes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `gateway/platforms/signal.py`: `_recent_sent_timestamps` changed from `set` to `collections.deque(maxlen=50)`
- Removed `_max_recent_timestamps` attribute (now handled by `deque.maxlen`)
- `add()` → `append()`, manual length-cap block removed
- `discard()` → `remove()` wrapped in `try/except ValueError` (deque has no discard)

## How to Test
1. Configure Signal gateway in Note-to-Self / self-chat mode
2. Send > 50 messages and verify oldest timestamps are evicted correctly
3. Verify echo-back filtering still works (own messages not re-processed)

## Checklist
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — no duplicate found
- [x] My PR contains only changes related to this fix
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've considered cross-platform impact — or N/A