### PR TITLE
fix(cron): keep one-shot/repeat-limited jobs alive when delivery fails

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -928,11 +928,23 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
-                
-                # Increment completed count
-                if job.get("repeat"):
+
+                # A delivery failure means the user never actually received this
+                # run's output (the platform was down / unreachable, a network
+                # blip, or the gateway adapter was unavailable). Such a run must
+                # NOT be counted toward the repeat limit and must NOT trigger the
+                # auto-delete below: there is no delivery-retry path anywhere, so
+                # consuming the slot would permanently remove a one-shot (or any
+                # repeat-limited) job whose output survives only as a local .md
+                # the user has no reason to open — silently losing the report.
+                delivery_failed = bool(delivery_error)
+
+                # Increment completed count — but only for runs that reached the
+                # user. An undelivered run does not consume a repeat slot, so the
+                # job stays around to retry (recurring) or be retriggered (once).
+                if job.get("repeat") and not delivery_failed:
                     job["repeat"]["completed"] = job["repeat"].get("completed", 0) + 1
-                    
+
                     # Check if we've hit the repeat limit
                     times = job["repeat"].get("times")
                     completed = job["repeat"]["completed"]
@@ -941,7 +953,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         jobs.pop(i)
                         save_jobs(jobs)
                         return
-                
+
                 # Compute next run
                 job["next_run_at"] = compute_next_run(job["schedule"], now)
 
@@ -967,6 +979,21 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                             "job is not silently disabled.",
                             job.get("name", job["id"]),
                             kind,
+                        )
+                    elif delivery_failed:
+                        # One-shot whose output never reached the user. Do NOT
+                        # mark it completed — that would hide an undelivered
+                        # report behind a "done" state and disable the job.
+                        # Surface it as state=error (with last_delivery_error
+                        # set) so the operator notices and can retrigger it once
+                        # the platform recovers.
+                        job["state"] = "error"
+                        logger.warning(
+                            "Job '%s': one-shot output produced but delivery "
+                            "failed (%s); keeping the job (state=error) instead "
+                            "of deleting it so the report is not lost.",
+                            job.get("name", job["id"]),
+                            delivery_error,
                         )
                     else:
                         job["enabled"] = False

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -584,6 +584,74 @@ class TestMarkJobRun:
         assert updated["enabled"] is False
         assert updated["state"] == "completed"
 
+    def test_repeat_limited_job_not_removed_when_delivery_fails(self, tmp_cron_dir):
+        """Agent succeeded but delivery to the platform failed (transient
+        outage): the run must NOT consume the repeat slot, so a repeat-limited
+        job is preserved instead of being popped and silently losing its output.
+        """
+        # Recurring interval with a finite repeat limit — the failed run must
+        # not advance ``completed`` toward that limit.
+        job = create_job(prompt="Report", schedule="every 30m", repeat=1)
+        assert job["schedule"]["kind"] == "interval"
+        mark_job_run(job["id"], success=True,
+                     delivery_error="platform 'telegram' not configured")
+        updated = get_job(job["id"])
+        assert updated is not None, "job was deleted despite a failed delivery"
+        # The failed run does not count toward the repeat limit.
+        assert updated["repeat"]["completed"] == 0
+        assert updated["last_delivery_error"] == "platform 'telegram' not configured"
+        # Interval schedule re-computes a next run, so the job stays scheduled
+        # and will retry delivery on the next occurrence.
+        assert updated["next_run_at"] is not None
+        assert updated["state"] == "scheduled"
+
+    def test_repeat_limit_consumed_only_after_successful_delivery(self, tmp_cron_dir):
+        """A failed delivery followed by a successful one: only the delivered
+        run advances the counter, and the job is removed exactly once the
+        limit is reached with output the user actually received.
+        """
+        job = create_job(prompt="Report", schedule="every 30m", repeat=1)
+        # First fire fails delivery → preserved, counter untouched.
+        mark_job_run(job["id"], success=True, delivery_error="network timeout")
+        assert get_job(job["id"]) is not None
+        assert get_job(job["id"])["repeat"]["completed"] == 0
+        # Second fire delivers → counter hits the limit → removed.
+        mark_job_run(job["id"], success=True, delivery_error=None)
+        assert get_job(job["id"]) is None
+
+    def test_oneshot_kept_in_error_state_when_delivery_fails(self, tmp_cron_dir):
+        """A true 'once' job whose delivery fails must not flip to
+        enabled=false/state=completed (which hides an undelivered report and
+        disables the job). It stays as state=error with the delivery error
+        recorded so the operator can retrigger it once the platform recovers.
+        """
+        jobs = [{
+            "id": "oneshot-deliver-fail",
+            "prompt": "Once",
+            "schedule": {"kind": "once", "run_at": "2020-01-01T00:00:00+00:00", "display": "once"},
+            "repeat": {"times": 1, "completed": 0},
+            "enabled": True,
+            "state": "scheduled",
+            "next_run_at": "2020-01-01T00:00:00+00:00",
+            "last_run_at": None,
+            "last_status": None,
+            "last_error": None,
+            "last_delivery_error": None,
+            "created_at": "2020-01-01T00:00:00+00:00",
+        }]
+        save_jobs(jobs)
+
+        mark_job_run("oneshot-deliver-fail", success=True,
+                     delivery_error="platform 'discord' not enabled")
+
+        updated = get_job("oneshot-deliver-fail")
+        assert updated is not None, "one-shot was deleted despite a failed delivery"
+        assert updated["repeat"]["completed"] == 0
+        assert updated["next_run_at"] is None
+        assert updated["state"] == "error"
+        assert updated["state"] != "completed"
+        assert updated["last_delivery_error"] == "platform 'discord' not enabled"
+
 
 class TestAdvanceNextRun:
     """Tests for advance_next_run() — crash-safety for recurring jobs."""


### PR DESCRIPTION
A scheduled job whose agent succeeded but whose output could not be
delivered to the platform (Telegram/Discord/Slack down, network blip,
or an unavailable gateway adapter) was permanently destroyed, silently
losing the report it had already produced.

## What does this PR do?

`mark_job_run()` in `cron/jobs.py` incremented `job["repeat"]["completed"]`
unconditionally — it never inspected the `delivery_error` argument it
receives. `_process_job()` in `cron/scheduler.py` calls
`mark_job_run(job["id"], success, error, delivery_error=delivery_error)`
with `success=True` and a non-empty `delivery_error` whenever the agent
ran fine but `_deliver_result()` failed. For a one-shot job (`repeat.times`
defaults to 1 for `once` schedules in `create_job()`) or any repeat-limited
job, `completed` then reached `times`, so `mark_job_run()` ran
`jobs.pop(i)` + `save_jobs(jobs)` and the job was gone. Because there is no
delivery-retry path anywhere (`last_delivery_error` is only read for display
in `tools/cronjob_tools.py` and `hermes_cli/cron.py`), the run's output
survived solely as a local `.md` file the user has no reason to open, and
the job never re-fired.

This change makes a failed delivery a non-consuming run: the slot is only
spent when the output actually reaches the user.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py` — in `mark_job_run()`, derive `delivery_failed = bool(delivery_error)`
  and gate the `repeat["completed"]` increment (and the limit-reached
  `jobs.pop()`/`save_jobs()`) on `not delivery_failed`, so an undelivered run
  no longer counts toward the repeat limit. In the `next_run_at is None`
  branch, a `once` job whose delivery failed is now left as `state="error"`
  with `last_delivery_error` recorded instead of flipping to
  `enabled=false`/`state="completed"`, so an undelivered report is not hidden
  behind a "done" state. Recurring (`interval`/`cron`) jobs re-compute their
  next run as before and retry on the next occurrence.
- `tests/cron/test_jobs.py` — added three `TestMarkJobRun` cases:
  `test_repeat_limited_job_not_removed_when_delivery_fails`,
  `test_repeat_limit_consumed_only_after_successful_delivery`, and
  `test_oneshot_kept_in_error_state_when_delivery_fails`.

## How to Test

1. `scripts/run_tests.sh tests/cron/test_jobs.py` — the new
   `TestMarkJobRun` cases assert a repeat-limited job survives a
   `mark_job_run(..., delivery_error=...)` call with `completed` untouched,
   that the slot is consumed only once a later delivery succeeds, and that a
   `once` job lands in `state="error"` (not `completed`/deleted) on delivery
   failure.
2. `scripts/run_tests.sh tests/cron/test_scheduler.py tests/cron/test_jobs.py`
   — full cron job + scheduler suites pass (224 tests), confirming the
   existing repeat-limit-deletes-on-success and `#16265` recurring paths
   still hold.
3. `ruff check cron/jobs.py tests/cron/test_jobs.py` and
   `python scripts/check-windows-footguns.py --all` both pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the cron test suites (`tests/cron/test_jobs.py`, `tests/cron/test_scheduler.py`) and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A