### PR TITLE
fix(feishu): log WebSocket startup failure instead of silently swallowing

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1322,8 +1322,8 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     _apply_runtime_ws_overrides()
     try:
         ws_client.start()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.error("[feishu] WebSocket client startup failed: %s", exc, exc_info=True)
     finally:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:


### PR DESCRIPTION
## What does this PR do?
`_run_official_feishu_ws_client` runs in a thread via `loop.run_in_executor`. If `ws_client.start()` raises — bad app ID, wrong secret, network unreachable, TLS error — the exception was silently swallowed with a bare `except Exception: pass`. The adapter appeared to be running but received no messages, with no indication of the failure anywhere in the logs.

## Related Issue
Fixes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `gateway/platforms/feishu.py`: `except Exception: pass` → `except Exception as exc: logger.error(...)`

## How to Test
1. Configure Feishu gateway with an invalid app ID or secret
2. Start the gateway and verify the startup failure is now logged at ERROR level
3. Confirm no regression with valid credentials

## Checklist
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — no duplicate found
- [x] My PR contains only changes related to this fix
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've considered cross-platform impact — or N/A