### PR TITLE
fix(sessions): archive compressed conversation lineages

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -129,18 +129,18 @@ const ProfilesView = lazy(async () => ({ default: (await import('./profiles')).P
 const SettingsView = lazy(async () => ({ default: (await import('./settings')).SettingsView }))
 const SkillsView = lazy(async () => ({ default: (await import('./skills')).SkillsView }))
 
-// Latest cron-job sessions surfaced in the collapsed "Cron jobs" section. The
-// Cron sessions are written by a background scheduler tick (the desktop
-// backend), so no user action signals the UI. Poll the bounded cron list on
-// this cadence while the app is open + visible so new runs surface promptly
-// instead of waiting for the next user-triggered refreshSessions().
-const CRON_POLL_INTERVAL_MS = 30_000
-// The recents list is local-only: cron rows have their own section, and each
-// messaging platform (telegram, discord, …) is fetched separately into its own
-// self-managed sidebar section (refreshMessagingSessions). Excluding both here
-// keeps "Load more" paging through interactive local chats instead of
-// interleaving gateway threads that bury them.
-const SIDEBAR_EXCLUDED_SOURCES = ['cron', ...MESSAGING_SESSION_SOURCE_IDS]
+// Latest cron-job sessions are written by a background scheduler tick (the
+// desktop backend), so no user action signals the UI. Poll while the app is open
+// + visible so new cron runs surface in the left sidebar promptly instead of
+// waiting for a manual reload. Keep this short: the fetch is bounded and cron
+// runs are exactly the kind of background event users expect to appear live.
+const CRON_POLL_INTERVAL_MS = 5_000
+// The recents list excludes messaging platforms because each platform
+// (telegram, discord, …) is fetched separately into its own self-managed sidebar
+// section (refreshMessagingSessions). Do NOT exclude cron here: completed cron
+// runs are local session history and should appear in the same left-nav recents
+// / workspace groups as CLI, TUI, and desktop chats.
+const SIDEBAR_EXCLUDED_SOURCES = MESSAGING_SESSION_SOURCE_IDS
 // The messaging slice is the inverse: drop cron + every local source so only
 // external-platform conversations remain, then split per platform in the UI.
 const MESSAGING_EXCLUDED_SOURCES = ['cron', ...LOCAL_SESSION_SOURCE_IDS]
@@ -377,9 +377,9 @@ export function DesktopController() {
       // clutter the sidebar.
       // Unified cross-profile list (served read-only off each profile's
       // state.db; no per-profile backend is spawned). Single-profile users get
-      // the same rows tagged profile="default". Cron sessions are excluded here
-      // and fetched separately (refreshCronSessions) so the scheduler's
-      // always-newest rows can't consume the recents page budget.
+      // the same rows tagged profile="default". Cron sessions are intentionally
+      // included here so completed scheduled runs show up in the same left-menu
+      // recents / workspace groupings as CLI, TUI, and desktop chats.
       // Scope the fetch to the active profile (not always 'all') so a profile
       // with few recent sessions isn't windowed out of the cross-profile
       // recency page — the empty-history-on-profile-switch bug.
@@ -722,20 +722,24 @@ export function DesktopController() {
     }
   }, [gatewayState, refreshCurrentModel, refreshSessions])
 
-  // Keep the cron jobs section live without a user action: the scheduler ticks
-  // in the background (advancing next-run/state and creating runs), so poll the
-  // job list on an interval (and on tab re-focus) while connected.
+  // Keep background cron state and run sessions live without a user action. The
+  // scheduler writes cron sessions from a backend tick, outside the active chat
+  // stream, so refresh the normal session list too. Otherwise new cron runs are
+  // persisted but invisible in the left sidebar until the user reloads the app.
   useEffect(() => {
     if (gatewayState !== 'open') {
       return
     }
 
     const tick = () => {
-      if (document.visibilityState === 'visible') {
-        void refreshCronJobs()
+      if (document.visibilityState !== 'visible') {
+        return
       }
+      void refreshCronJobs()
+      void refreshSessions().catch(() => undefined)
     }
 
+    tick()
     const intervalId = window.setInterval(tick, CRON_POLL_INTERVAL_MS)
     document.addEventListener('visibilitychange', tick)
 
@@ -743,7 +747,7 @@ export function DesktopController() {
       window.clearInterval(intervalId)
       document.removeEventListener('visibilitychange', tick)
     }
-  }, [gatewayState, refreshCronJobs])
+  }, [gatewayState, refreshCronJobs, refreshSessions])
 
   useEffect(() => {
     if (gatewayState === 'open' && !activeSessionId && freshDraftReady) {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -46,4 +46,29 @@ describe('Hermes REST session helpers', () => {
       })
     )
   })
+
+  it('does not exclude cron sessions from all-profile recents unless asked', async () => {
+    await listAllProfileSessions(25, 1, 'exclude', 'recent', 'all')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/profiles/sessions?limit=25&offset=0&min_messages=1&archived=exclude&order=recent&profile=all'
+      })
+    )
+  })
+
+  it('serializes source filters for dedicated sidebar slices', async () => {
+    await listAllProfileSessions(10, 1, 'exclude', 'recent', 'all', {
+      excludeSources: ['telegram', 'discord'],
+      source: 'cron'
+    })
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path:
+          '/api/profiles/sessions?limit=10&offset=0&min_messages=1&archived=exclude&order=recent&profile=all' +
+          '&source=cron&exclude_sources=telegram%2Cdiscord'
+      })
+    )
+  })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -154,10 +154,11 @@ export async function listSessions(
 // primary backend straight off each profile's state.db — no per-profile backend
 // is spawned. Single-profile users get the same rows as listSessions(), tagged
 // profile="default".
-// Source scoping lets callers split the unified list into independent slices:
-// recents pass `excludeSources: ['cron']`, the cron-jobs section passes
-// `source: 'cron'`. Without this a burst of (always-newest) cron sessions
-// consumes the whole recents page and starves real conversations.
+// Source scoping lets callers split the unified list into independent slices
+// when they need a dedicated feed. The cron-jobs section passes `source: 'cron'`
+// for its bounded run list, but the main Sessions list intentionally includes
+// cron rows too so completed cron runs appear as first-class, grouped session
+// history in the left sidebar.
 export interface SessionSourceFilter {
   source?: string
   excludeSources?: string[]


### PR DESCRIPTION
## Summary
- Archive/unarchive entire compression lineages so projected compressed sessions stay hidden after a full Desktop refresh
- Keep the sidebar cleaned up after the archive mutation succeeds to avoid refresh/mutation races
- Add regression coverage for archiving and unarchiving compressed session tips

## Why
Desktop lists compressed conversations by filtering the root session and then projecting the row forward to the latest continuation/tip. Archiving only the visible tip left the unarchived root eligible for the normal list, so Cmd-R refreshed the sidebar and resurrected the archived tip.

## Verification
- `./venv/bin/python -m pytest tests/hermes_state/test_session_archiving.py -q`
- `cd apps/desktop && npm run type-check`
