### PR TITLE
fix(media): add code file extensions to MEDIA_DELIVERY_EXTS (#42206)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1193,6 +1193,8 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".epub",
     # Spreadsheets / data
     ".xlsx", ".xls", ".ods", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml",
+    # Code / scripts (uploaded as file attachments)
+    ".py", ".js", ".ts", ".sh", ".rb", ".go", ".rs", ".java", ".c", ".cpp", ".h",
     # Presentations
     ".pptx", ".ppt", ".odp", ".key",
     # Archives

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -696,10 +696,10 @@ _AUTO_APPEND_MEDIA_TOOL_NAMES = {"text_to_speech", "text_to_speech_tool"}
 # auto-appended. Kept local to the auto-append path; the producer-tool allowlist
 # below is the primary guard, this is the secondary precision guard.
 _TOOL_MEDIA_RE = re.compile(
-    r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
+    r'MEDIA:((?:[A-Za-z]:[/\\\\]|/|~\\/)\\S+\\.(?:png|jpe?g|gif|webp|'
     r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
     r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-    r'txt|csv|apk|ipa))',
+    r'txt|csv|apk|ipa|py|js|ts|sh|rb|go|rs|java|c|cpp|h))',
     re.IGNORECASE,
 )
 
@@ -13847,11 +13847,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _hc = _hm.get("content", "")
                     if "MEDIA:" in _hc:
                         _TOOL_MEDIA_RE = re.compile(
-                            r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
+                            r'MEDIA:((?:[A-Za-z]:[/\\\\]|/|~\\/)\\S+\\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                             r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
-                            re.IGNORECASE
+                            r'txt|csv|apk|ipa|py|js|ts|sh|rb|go|rs|java|c|cpp|h))',
+                            re.IGNORECASE,
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):
                             _p = _match.group(1).strip().rstrip('",}')


### PR DESCRIPTION
Fixes #42206. Add .py, .js, .ts, .sh, .rb, .go, .rs, .java, .c, .cpp, .h to MEDIA_DELIVERY_EXTS so MEDIA:/path/to/file.py tags are matched and delivered as native attachments. Also update _TOOL_MEDIA_RE in gateway/run.py to include the new extensions.