### PR TITLE
fix(plugins): guard _get_middleware_callbacks against PluginManager missing _middleware

### DIFF
--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -234,7 +234,7 @@ def _has_middleware(kind: str) -> bool:
 def _get_middleware_callbacks(kind: str) -> List[Callable]:
     from hermes_cli.plugins import get_plugin_manager
 
-    return list(get_plugin_manager()._middleware.get(kind, []))
+    return list(getattr(get_plugin_manager(), "_middleware", {}).get(kind, []))
 
 
 def _run_execution_chain(

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -170,6 +170,20 @@ class TestPluginDiscovery:
         assert run_tool_execution_middleware("terminal", args, lambda payload: payload) is args
         assert has_middleware("tool_request") is False
 
+    def test_execution_middleware_tolerates_manager_without_middleware_attr(self, monkeypatch):
+        """Execution middleware should fail open for manager-shaped test doubles.
+
+        The real PluginManager initializes ``_middleware``, but several paths
+        treat the singleton as an interface and substitute lightweight manager
+        objects. Request middleware already handles that shape through
+        ``has_middleware``; execution middleware needs the same fallback.
+        """
+        manager = types.SimpleNamespace()
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        args = {"command": "printf ok"}
+        assert run_tool_execution_middleware("terminal", args, lambda payload: payload) is args
+
     def test_request_middleware_changed_tracks_trace_not_deep_equality(self, monkeypatch):
         def same_payload_middleware(**kwargs):
             return {"args": kwargs["args"], "source": "same-payload"}


### PR DESCRIPTION
## Summary

In production we hit a hard crash in the agent loop on every API call:

```
AttributeError: 'PluginManager' object has no attribute '_middleware'
```

The crash burns 3 retries and then surfaces as a canned error to the user — gateway is up, the model is reachable, but every conversation turn fails.

## Root cause

`hermes_cli/middleware.py:237` reads `get_plugin_manager()._middleware` directly:

```python
def _get_middleware_callbacks(kind: str) -> List[Callable]:
    from hermes_cli.plugins import get_plugin_manager
    return list(get_plugin_manager()._middleware.get(kind, []))
```

The matching helper at `hermes_cli/plugins.py:1737` already does this defensively:

```python
return bool(getattr(manager, "_middleware", {}).get(kind))
```

The real `PluginManager` class always initializes `_middleware`, but the existing test suite and several plugin paths already treat `get_plugin_manager()` as returning manager-shaped substitutes/wrappers, and the request-side path (`has_middleware`) was already defensive against that. Execution middleware was the last outlier reading the private dict directly. When any of those paths fire — test doubles, plugin overrides, lazy-init races — the whole conversation loop dies.

## Fix

Match the defensive pattern in `plugins.py` so execution middleware fails open instead of crashing the agent loop:

```python
return list(getattr(get_plugin_manager(), "_middleware", {}).get(kind, []))
```

## Test

Added regression test in `tests/hermes_cli/test_plugins.py`: `run_tool_execution_middleware` is invoked with a `SimpleNamespace` standing in for the manager and passes through to `next_call` without raising. Without the fix this test raises `AttributeError`.

## Production context

Verified on a downstream deployment running an agent on `anthropic/claude-opus-4-7`: pre-fix, 100% of agent API calls failed; hot-patching this one line on the running host restored normal operation immediately.