### PR TITLE
feat(skills): add bundled/hub-installed guard to all skill mutation operations

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -957,3 +957,87 @@ class TestPinnedGuard:
                        side_effect=RuntimeError("sidecar broken")):
                 result = _delete_skill("my-skill")
         assert result["success"] is True
+
+# ---------------------------------------------------------------------------
+# Bundled/hub-installed skill guard — ALL mutations are refused on skills
+# that are NOT agent-created (i.e., bundled or hub-installed).
+# ---------------------------------------------------------------------------
+
+class TestBundledGuard:
+    """All mutation actions are refused on bundled/hub-installed skills."""
+
+    @staticmethod
+    def _mark_bundled(name: str):
+        """Return a patch context that marks *name* as bundled (not agent-created)."""
+        def _fake_is_agent_created(skill_name, _name=name):
+            return skill_name != _name  # False for bundled skill, True for others
+        return patch("tools.skill_usage.is_agent_created", side_effect=_fake_is_agent_created)
+
+    def test_edit_refuses_bundled(self, tmp_path):
+        """Edit is refused on bundled skills."""
+        with _skill_dir(tmp_path):
+            _create_skill("bundled-skill", VALID_SKILL_CONTENT)
+            with self._mark_bundled("bundled-skill"):
+                result = _edit_skill("bundled-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+
+    def test_patch_refuses_bundled(self, tmp_path):
+        """Patch is refused on bundled skills."""
+        with _skill_dir(tmp_path):
+            _create_skill("bundled-skill", VALID_SKILL_CONTENT)
+            with self._mark_bundled("bundled-skill"):
+                result = _patch_skill("bundled-skill", "Do the thing.", "Do the new thing.")
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+
+    def test_delete_refuses_bundled(self, tmp_path):
+        """Delete is refused on bundled skills."""
+        with _skill_dir(tmp_path):
+            _create_skill("bundled-skill", VALID_SKILL_CONTENT)
+            with self._mark_bundled("bundled-skill"):
+                result = _delete_skill("bundled-skill")
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+        # Skill still exists
+        assert (tmp_path / "bundled-skill" / "SKILL.md").exists()
+
+    def test_write_file_refuses_bundled(self, tmp_path):
+        """write_file is refused on bundled skills."""
+        with _skill_dir(tmp_path):
+            _create_skill("bundled-skill", VALID_SKILL_CONTENT)
+            with self._mark_bundled("bundled-skill"):
+                result = _write_file("bundled-skill", "references/api.md", "content")
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+
+    def test_remove_file_refuses_bundled(self, tmp_path):
+        """remove_file is refused on bundled skills."""
+        with _skill_dir(tmp_path):
+            _create_skill("bundled-skill", VALID_SKILL_CONTENT)
+            _write_file("bundled-skill", "references/api.md", "content")
+            with self._mark_bundled("bundled-skill"):
+                result = _remove_file("bundled-skill", "references/api.md")
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+
+    def test_agent_created_skills_still_mutable(self, tmp_path):
+        """Agent-created skills are not blocked by the bundled guard."""
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            with self._mark_bundled("other-skill"):
+                result = _edit_skill("my-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is True, result
+
+    def test_bundled_guard_fails_open(self, tmp_path):
+        """If is_agent_created raises, we allow mutations through.
+
+        Rationale: a broken manifest shouldn't lock the agent out
+        of skills it would otherwise be allowed to touch.
+        """
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            with patch("tools.skill_usage.is_agent_created",
+                       side_effect=RuntimeError("manifest broken")):
+                result = _edit_skill("my-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is True

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -161,6 +161,34 @@ def _pinned_guard(name: str) -> Optional[str]:
     return None
 
 
+def _bundled_guard(name: str) -> Optional[str]:
+    """Return a refusal message if *name* is bundled or hub-installed.
+
+    Bundled and hub-installed skills carry upstream-maintained content.
+    Allowing the agent to mutate them silently diverges local state from
+    the upstream source and breaks reproducibility across machines.
+
+    Only agent-created skills (created via ``skill_manage(action="create")``)
+    may be freely mutated.
+
+    Best-effort: if the lookup fails we let the mutation through rather
+    than block on a broken manifest.
+    """
+    try:
+        from tools.skill_usage import is_agent_created
+        if not is_agent_created(name):
+            return (
+                f"Skill '{name}' is a bundled or hub-installed skill and "
+                f"cannot be modified by skill_manage. "
+                f"Only agent-created skills can be mutated. "
+                f"To customize, fork the skill with action='create' "
+                f"under a different name."
+            )
+    except Exception:
+        logger.debug("bundled-guard lookup failed for %s", name, exc_info=True)
+    return None
+
+
 MAX_SKILL_CONTENT_CHARS = 100_000   # ~36k tokens at 2.75 chars/token
 MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
 
@@ -553,6 +581,10 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
 
+    bundled_err = _bundled_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
+
     skill_md = existing["path"] / "SKILL.md"
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
@@ -592,6 +624,10 @@ def _patch_skill(
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
+
+    bundled_err = _bundled_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
 
     skill_dir = existing["path"]
 
@@ -686,6 +722,10 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if pinned_err:
         return {"success": False, "error": pinned_err}
 
+    bundled_err = _bundled_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
+
     # Validate absorbed_into target when declared non-empty
     if absorbed_into is not None and isinstance(absorbed_into, str) and absorbed_into.strip():
         target_name = absorbed_into.strip()
@@ -751,6 +791,10 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name, " Create it first with action='create'.")}
 
+    bundled_err = _bundled_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
+
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
@@ -784,6 +828,10 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
+
+    bundled_err = _bundled_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
 
     skill_dir = existing["path"]
 


### PR DESCRIPTION
## Summary

Adds a deterministic, tool-level guard that prevents the agent from modifying or deleting **bundled** and **hub-installed** skills via `skill_manage` tool calls. This closes the protection gap identified in #27997 where `_delete_skill()` had no `is_agent_created()` check and `_edit_skill()`, `_patch_skill()`, `_write_file()`, `_remove_file()` had zero protection checks at the tool-execution layer.

## Problem

Skill protection rules were **only enforced at the prompt level** (background review prompts tell the LLM not to touch bundled skills). The tool-execution layer in `skill_manager_tool.py` had no `is_agent_created()` guard — an agent could call `skill_manage(action="delete", name="some-bundled-skill")` and succeed.

Evidence from source:
- `_delete_skill()` only checked `_pinned_guard()` (deletion-only protection)
- `_edit_skill()`, `_patch_skill()`, `_write_file()`, `_remove_file()` had **no protection checks at all**

## What Changed

| File | Change |
|------|--------|
| `tools/skill_manager_tool.py` | Added `_bundled_guard()` function + guard calls in all 5 mutation actions |
| `tests/tools/test_skill_manager_tool.py` | 7 new tests: all 5 mutations refused on bundled skills, agent-created skills still work, fail-open on broken manifest |

## Design Decisions

- **`is_agent_created()` check** — uses the existing `tools.skill_usage.is_agent_created()` which checks both bundled manifest and hub-installed registry
- **Fail-open** — if `is_agent_created()` raises (broken manifest), the guard returns None and allows the mutation through, consistent with `_pinned_guard()` behavior
- **Separate from `pinned` guard** — `_pinned_guard` blocks delete only; `_bundled_guard` blocks all mutations (edit, patch, write_file, remove_file, delete)
- **Guard ordering** — in `_delete_skill()`, `_bundled_guard` runs after `_pinned_guard` (both must pass)

## Test Coverage

```
tests/tools/test_skill_manager_tool.py::TestBundledGuard
  test_edit_refuses_bundled      — edit blocked on bundled skill
  test_patch_refuses_bundled     — patch blocked on bundled skill
  test_delete_refuses_bundled    — delete blocked on bundled skill
  test_write_file_refuses_bundled — write_file blocked on bundled skill
  test_remove_file_refuses_bundled — remove_file blocked on bundled skill
  test_agent_created_skills_still_mutable — agent-created skills not affected
  test_bundled_guard_fails_open  — broken manifest allows mutation through
```

All 97 tests in `test_skill_manager_tool.py` pass (90 existing + 7 new).

Closes #27997
