### PR TITLE
chore(release): add mnajafian-nv to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -69,6 +69,7 @@ AUTHOR_MAP = {
     "ted.malone@outlook.com": "temalo",
     "adityamalik2833@gmail.com": "alarcritty",
     "islam666@users.noreply.github.com": "islam666",
+    "mnajafian@nvidia.com": "mnajafian-nv",
     "25539605+lsaether@users.noreply.github.com": "lsaether",
     "30080538+JimStenstrom@users.noreply.github.com": "JimStenstrom",
     "rod.boev@gmail.com": "rodboev",


### PR DESCRIPTION
Adds `mnajafian@nvidia.com` -> `mnajafian-nv` to `AUTHOR_MAP` in `scripts/release.py`.

Unblocks the contributor-attribution check on #41551 (currently failing: `mnajafian@nvidia.com (mnajafian-nv)` not in AUTHOR_MAP). One-line infra change; should land before #41551 so its attribution check passes.

## Type of Change
- [x] Chore (no functional code change)