### PR TITLE
fix(desktop): detect stale builds and surface rebuildNeeded in update UI

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -198,6 +198,7 @@ import {
   sandboxPreflight
 } from './update-relaunch'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
+import { bundleNeedsRebuild } from './update-stamp'
 import { spawnUpdaterProcess } from './updater-process'
 import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
@@ -2542,11 +2543,19 @@ async function checkUpdates() {
 
   const commits = behind > 0 ? await readCommitLog(updateRoot, branch) : []
 
+  // Detect if the running app bundle is stale relative to the source checkout.
+  // `runningAppBundle()` currently resolves only packaged macOS .app bundles;
+  // Linux/Windows/dev launches return null and simply skip this hint. The
+  // helper is best-effort, so malformed or missing stamps never break update
+  // checks.
+  const rebuildNeeded = bundleNeedsRebuild(runningAppBundle(), currentSha)
+
   return {
     supported: true,
     branch,
     currentBranch,
     behind,
+    rebuildNeeded,
     currentSha,
     targetSha,
     commits,

--- a/apps/desktop/electron/update-stamp.test.ts
+++ b/apps/desktop/electron/update-stamp.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { bundleNeedsRebuild, readInstallStamp } from './update-stamp'
+
+function withBundle(fn) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-update-stamp-'))
+  const resources = path.join(root, 'Contents', 'Resources')
+  fs.mkdirSync(resources, { recursive: true })
+  try {
+    return fn({ root, stampPath: path.join(resources, 'install-stamp.json') })
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test('readInstallStamp returns null when the bundle or stamp is missing', () => {
+  assert.equal(readInstallStamp(null), null)
+  withBundle(({ root }) => {
+    assert.equal(readInstallStamp(root), null)
+  })
+})
+
+test('bundleNeedsRebuild is true when the baked stamp differs from HEAD', () => {
+  withBundle(({ root, stampPath }) => {
+    fs.writeFileSync(stampPath, JSON.stringify({ commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }))
+
+    assert.equal(bundleNeedsRebuild(root, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'), true)
+  })
+})
+
+test('bundleNeedsRebuild is false when the baked stamp matches HEAD', () => {
+  withBundle(({ root, stampPath }) => {
+    fs.writeFileSync(stampPath, JSON.stringify({ commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }))
+
+    assert.equal(bundleNeedsRebuild(root, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), false)
+  })
+})
+
+test('bundleNeedsRebuild treats malformed stamps as non-fatal', () => {
+  withBundle(({ root, stampPath }) => {
+    fs.writeFileSync(stampPath, '{bad json')
+
+    assert.equal(bundleNeedsRebuild(root, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'), false)
+  })
+})

--- a/apps/desktop/electron/update-stamp.ts
+++ b/apps/desktop/electron/update-stamp.ts
@@ -1,0 +1,29 @@
+/**
+ * Helpers for comparing the running desktop bundle's install stamp against
+ * the source checkout. Kept outside main.ts so the stamp path stays covered
+ * by node --test without booting Electron.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+export function readInstallStamp(bundlePath, fsImpl = fs) {
+  if (!bundlePath) return null
+
+  const stampPath = path.join(bundlePath, 'Contents', 'Resources', 'install-stamp.json')
+  if (!fsImpl.existsSync(stampPath)) return null
+
+  return JSON.parse(fsImpl.readFileSync(stampPath, 'utf8'))
+}
+
+export function bundleNeedsRebuild(bundlePath, currentSha, fsImpl = fs) {
+  if (!bundlePath || !currentSha) return false
+
+  try {
+    const stamp = readInstallStamp(bundlePath, fsImpl)
+    const stampCommit = String(stamp?.commit || '').trim()
+    return Boolean(stampCommit && stampCommit !== currentSha)
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -65,6 +65,7 @@ export function AboutSettings() {
   const behind = status?.behind ?? 0
   const supported = status?.supported !== false
   const applying = apply.applying || apply.stage === 'restart'
+  const rebuildNeeded = status?.rebuildNeeded === true
 
   const handleCheck = async () => {
     setJustChecked(false)
@@ -86,6 +87,9 @@ export function AboutSettings() {
     statusTone = 'available'
   } else if (behind > 0) {
     statusLine = a.updateReady(behind)
+    statusTone = 'available'
+  } else if (rebuildNeeded) {
+    statusLine = a.rebuildNeeded
     statusTone = 'available'
   } else if (status) {
     statusLine = a.onLatest
@@ -151,6 +155,12 @@ export function AboutSettings() {
                   {a.seeWhatsNew}
                 </Button>
               </>
+            )}
+
+            {rebuildNeeded && supported && !applying && (
+              <Button onClick={() => openUpdatesWindow()} size="sm">
+                {a.rebuildNow}
+              </Button>
             )}
 
             <Button asChild className="ml-auto" size="sm" variant="text">

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -220,6 +220,9 @@ export function useStatusbarItems({
 
   const clientVersionItem = useMemo<StatusbarItem>(() => {
     const applying = updateApply.applying || updateApply.stage === 'restart'
+    // A stale bundle needs a rebuild even when the checkout is up to date, so
+    // the hint rides alongside the shared version status rather than inside it.
+    const rebuildNeeded = !applying && updateStatus?.rebuildNeeded === true
 
     const status = resolveVersionStatus({
       applying,
@@ -234,18 +237,23 @@ export function useStatusbarItems({
       version: desktopVersion?.appVersion
     })
 
+    const label = rebuildNeeded ? `${status.label} (+rebuild)` : status.label
+    const tooltip = rebuildNeeded
+      ? [status.tooltip, copy.rebuildNeeded].filter(Boolean).join(' · ')
+      : status.tooltip
+
     return {
-      className: status.hasUpdate ? 'text-primary hover:text-primary' : undefined,
+      className: status.hasUpdate || rebuildNeeded ? 'text-primary hover:text-primary' : undefined,
       detail: status.detail,
       hidden: status.unknown,
       icon: applying ? <Loader2 className="size-3 animate-spin" /> : <Hash className="size-3" />,
       id: 'version-client',
-      label: status.label,
+      label,
       // Update state is not a preference: hiding it is how a user misses that
       // their client is behind. Listed in the menu, but locked on.
       lockedVisible: true,
       onSelect: () => openUpdateOverlayFor('client'),
-      title: status.tooltip,
+      title: tooltip,
       toggleLabel: copy.toggleVersion,
       variant: 'action'
     }
@@ -258,7 +266,8 @@ export function useStatusbarItems({
     updateApply.stage,
     updateStatus?.behind,
     updateStatus?.branch,
-    updateStatus?.currentSha
+    updateStatus?.currentSha,
+    updateStatus?.rebuildNeeded
   ])
 
   const backendVersionItem = useMemo<StatusbarItem | null>(() => {

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -161,6 +161,7 @@ function IdleView({
 }) {
   const { t } = useI18n()
   const u = t.updates
+  const rebuildNeeded = status?.rebuildNeeded === true
 
   if (!status && checking) {
     return (
@@ -210,13 +211,37 @@ function IdleView({
     )
   }
 
-  if (!updateAvailable) {
+  if (!updateAvailable && !rebuildNeeded) {
     return (
       <CenteredStatus
         body={target === 'backend' ? u.latestBodyBackend : u.latestBody}
         icon={<BrandMark className="size-12" />}
         title={u.allSetTitle}
       />
+    )
+  }
+
+  // When a checkout is both behind and stale, show the commit list first. The
+  // pull/rebuild flow supersedes the local stale-bundle nudge.
+  if (behind === 0 && rebuildNeeded) {
+    return (
+      <div className="grid gap-5 px-6 pb-6 pt-7 pr-8">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <BrandMark className="size-16" />
+          <DialogTitle className="text-center text-xl">{u.rebuildTitle}</DialogTitle>
+          <DialogDescription className="text-center text-sm">
+            {u.rebuildBody}
+          </DialogDescription>
+        </div>
+        <div className="grid gap-2">
+          <Button className="font-semibold" onClick={onInstall} size="lg">
+            {u.updateNow}
+          </Button>
+          <Button className="font-medium" onClick={onLater} type="button" variant="text">
+            {u.maybeLater}
+          </Button>
+        </div>
+      </div>
     )
   }
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -376,6 +376,10 @@ export interface DesktopUpdateStatus {
   message?: string
   error?: string
   behind?: number
+  /** True when source code changed (merge, local edit) but the running .app
+   *  hasn't been rebuilt yet. The update flow should offer a rebuild even
+   *  though there are no new git commits to pull. */
+  rebuildNeeded?: boolean
   currentSha?: string
   /** Backend only: the version string the backend reports for itself. */
   currentVersion?: string

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2,6 +2,8 @@ import { FIELD_DESCRIPTIONS, FIELD_LABELS } from '@/app/settings/constants'
 
 import type { Translations } from './types'
 
+const REBUILD_NEEDED = 'Source code changed — rebuild to apply local changes.'
+
 export const en: Translations = {
   common: {
     apply: 'Apply',
@@ -522,6 +524,8 @@ export const en: Translations = {
       cantReach: "We couldn't reach the update server.",
       tapCheck: 'Tap "Check now" to look for updates.',
       updateReady: count => `A new update is ready (${count} change${count === 1 ? '' : 's'} included).`,
+      rebuildNeeded: REBUILD_NEEDED,
+      rebuildNow: 'Rebuild now',
       lastChecked: age => `Last checked ${age}`,
       justNowSuffix: ' · just now',
       automaticUpdates: 'Automatic updates',
@@ -2144,6 +2148,8 @@ export const en: Translations = {
     allSetTitle: 'You’re all set',
     availableTitle: 'New update available',
     availableBody: 'A new version of Hermes is ready to install.',
+    rebuildTitle: 'Source code changed',
+    rebuildBody: 'The Hermes source has changed since the last build. Rebuild to apply local changes.',
     availableTitleBackend: 'Backend update available',
     availableBodyBackend: 'A newer version of the connected Hermes backend is ready to install.',
     availableBodyNoChangelog: 'A newer version is ready. Release notes aren’t available for this install type.',
@@ -2409,6 +2415,7 @@ export const en: Translations = {
       update: 'update',
       updateInProgress: 'Update in progress',
       commitsBehind: (count, branch) => `${count} commit${count === 1 ? '' : 's'} behind ${branch}`,
+      rebuildNeeded: REBUILD_NEEDED,
       desktopVersion: version => `Hermes Desktop v${version}`,
       backendVersion: version => `Backend v${version}`,
       clientLabel: version => `client v${version}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -428,6 +428,8 @@ export interface Translations {
       cantReach: string
       tapCheck: string
       updateReady: (count: number) => string
+      rebuildNeeded: string
+      rebuildNow: string
       lastChecked: (age: string) => string
       justNowSuffix: string
       automaticUpdates: string
@@ -1782,6 +1784,8 @@ export interface Translations {
     allSetTitle: string
     availableTitle: string
     availableBody: string
+    rebuildTitle: string
+    rebuildBody: string
     availableTitleBackend: string
     availableBodyBackend: string
     availableBodyNoChangelog: string
@@ -2014,6 +2018,7 @@ export interface Translations {
       update: string
       updateInProgress: string
       commitsBehind: (count: number, branch: string) => string
+      rebuildNeeded: string
       desktopVersion: (version: string) => string
       backendVersion: (version: string) => string
       clientLabel: (version: string) => string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2,6 +2,8 @@ import { defineFieldCopy } from '@/app/settings/field-copy'
 
 import type { Translations } from './types'
 
+const REBUILD_NEEDED = '源代码已更改 — 重建以应用本地更改。'
+
 export const zh: Translations = {
   common: {
     apply: '应用',
@@ -733,6 +735,8 @@ export const zh: Translations = {
       cantReach: '无法连接更新服务器。',
       tapCheck: '点击"立即检查"以查找更新。',
       updateReady: count => `已准备好新更新 (包含 ${count} 项更改)。`,
+      rebuildNeeded: REBUILD_NEEDED,
+      rebuildNow: '立即重建',
       lastChecked: age => `上次检查:${age}`,
       justNowSuffix: ' · 刚刚',
       automaticUpdates: '自动更新',
@@ -2336,6 +2340,8 @@ export const zh: Translations = {
     allSetTitle: '已是最新',
     availableTitle: '有可用更新',
     availableBody: '新版 Hermes 已可安装。',
+    rebuildTitle: '源代码已更改',
+    rebuildBody: 'Hermes 源代码自上次构建以来已更改。重建以应用本地更改。',
     availableTitleBackend: '后端有可用更新',
     availableBodyBackend: '已连接的 Hermes 后端有新版本可安装。',
     availableBodyNoChangelog: '已有新版本可用。此安装方式无法显示更新日志。',
@@ -2590,6 +2596,7 @@ export const zh: Translations = {
       update: '更新',
       updateInProgress: '正在更新',
       commitsBehind: (count, branch) => `落后 ${branch} ${count} 个提交`,
+      rebuildNeeded: REBUILD_NEEDED,
       desktopVersion: version => `Hermes Desktop v${version}`,
       backendVersion: version => `后端 v${version}`,
       clientLabel: version => `客户端 v${version}`,


### PR DESCRIPTION
## Summary

When source changes (merge, local edits) leave the running `.app` behind,
the update UI now shows an actionable "rebuild needed" state instead of
"all set". The `checkUpdates` IPC handler compares the embedded
`install-stamp.json` commit (baked into the `.app` at build time) against
git HEAD. When they differ, it sets `rebuildNeeded: true`, which the UI
surfaces as a rebuild prompt with the same "Update now" button flow.

## Changes

- **`main.cjs`**: Compare running app stamp vs git HEAD in `checkUpdates()`
- **`global.d.ts`**: Add `rebuildNeeded?` to `DesktopUpdateStatus`
- **`i18n/types.ts` / `en.ts` / `zh.ts`**: New i18n strings + type defs
- **`updates-overlay.tsx`**: Show rebuild prompt when `behind=0` & `rebuildNeeded`
- **`about-settings.tsx`**: Show "Source code changed — rebuild needed" + "Rebuild now" button
- **`use-statusbar-items.tsx`**: Highlight version badge and show hint for stale build

## Testing

`npm run build` passes clean in the desktop app.