### PR TITLE
fix(cron): add explicit utf-8 encoding for subprocess stdout capture

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1049,6 +1049,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=script_timeout,
             cwd=str(path.parent),
             env=run_env,


### PR DESCRIPTION
## What does this PR do?

`no_agent` cron scripts that print multi-byte UTF-8 (emoji, CJK, etc.) to stdout on Windows are silently dropped when the gateway runs under `pythonw.exe`. The cron runner reports `last_status: ok` and `Status: silent (empty output)`, with no delivery and no error.

Root cause: `_run_job_script` in `cron/scheduler.py` calls `subprocess.run(...)` with `text=True` but no explicit `encoding=`, deferring to the parent process's `locale.getpreferredencoding()`. Under `pythonw.exe` on Windows (no console attached), this encoding silently corrupts multi-byte UTF-8 output.

Fix: add `encoding="utf-8"` and `errors="replace"` to the `subprocess.run()` call. The change is harmless on Linux/macOS (UTF-8 is the default locale) and fixes the silent failure on Windows.

## Related Issue

Fixes #42384

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Added `encoding="utf-8"` and `errors="replace"` to the `_run_job_script` subprocess call at line 1051.

## How to Test

1. Create a `no_agent=true` cron job with a script that prints emoji to stdout, e.g. `print("📊 hello")`
2. Run it under Windows `pythonw.exe` gateway
3. Before the fix: output is silently empty
4. After the fix: emoji-containing output is captured and delivered correctly
5. On Linux/macOS: existing cron tests continue to pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/ -q` — 401/403 passed (2 pre-existing failures unrelated to this change)
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — Windows-specific encoding issue, test runner not available on Linux
- [x] I've tested on my platform: Docker/Linux

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
