### PR TITLE
fix(gateway): remove LimitLoadToSessionType from launchd plist to fix macOS 26.5+ bootstrap

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3251,12 +3251,6 @@ def generate_launchd_plist() -> str:
         <string>{hermes_home}</string>
     </dict>
 
-    <key>LimitLoadToSessionType</key>
-    <array>
-        <string>Aqua</string>
-        <string>Background</string>
-    </array>
-    
     <key>RunAtLoad</key>
     <true/>
     

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1790,13 +1790,12 @@ class TestProfileArg:
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
 
-    def test_launchd_plist_supports_aqua_and_background_sessions(self):
-        # macOS 26+ only loads the agent in non-Aqua sessions when the plist
-        # opts into Background as well (issue #23387).
+    def test_launchd_plist_omits_limit_load_to_session_type(self):
+        # LimitLoadToSessionType breaks launchctl bootstrap on macOS 26.5+
+        # with exit code 5 (issue #42376).  User-domain LaunchAgents load
+        # correctly without it.
         plist = gateway_cli.generate_launchd_plist()
-        assert "<key>LimitLoadToSessionType</key>" in plist
-        assert "<string>Aqua</string>" in plist
-        assert "<string>Background</string>" in plist
+        assert "<key>LimitLoadToSessionType</key>" not in plist
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"


### PR DESCRIPTION
## Problem

`hermes gateway restart` and `hermes gateway install --force` generate a launchd plist containing:

```xml
<key>LimitLoadToSessionType</key>
<array>
    <string>Aqua</string>
    <string>Background</string>
</array>
```

On macOS 26.5+, this key causes `launchctl bootstrap gui/$(id -u)` to fail with exit code 5 (`Input/output error`). The gateway falls back to an unmanaged background process, losing launchd supervision (no auto-restart on crash, no `RunAtLoad` behavior).

The key was added in 360630733 to support Background sessions on macOS 26, but the user domain (`gui/<uid>`) works correctly without it.

## Fix

Remove the `LimitLoadToSessionType` key from the plist template. User-domain LaunchAgents don't need this key — `launchctl bootstrap gui/<uid>` loads the agent in the correct session automatically.

## Changes

- `hermes_cli/gateway.py`: Remove `LimitLoadToSessionType` XML block from `generate_launchd_plist()`
- `tests/hermes_cli/test_gateway_service.py`: Update `test_launchd_plist_supports_aqua_and_background_sessions` to assert the key is absent

Fixes #42376
