### PR TITLE
fix(desktop): stream the transcript while the window is backgrounded

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -119,6 +119,20 @@ if (REMOTE_DISPLAY_REASON) {
     `[hermes] remote display detected (${REMOTE_DISPLAY_REASON}); disabling GPU hardware acceleration to prevent flicker`
   )
 }
+
+// Keep the renderer running at full speed while the window is in the background
+// or occluded. The chat transcript streams to screen through a
+// requestAnimationFrame-gated flush; Chromium pauses rAF (and clamps timers)
+// for backgrounded/occluded renderers, so without these the live answer stalls
+// whenever the window loses focus (switching to your editor mid-turn, detached
+// devtools, another window covering it) and only paints on refocus or refresh.
+// `backgroundThrottling: false` on the BrowserWindow covers the blurred case;
+// these process-level switches additionally stop Chromium from backgrounding or
+// occlusion-throttling the renderer. Must run before app `ready`.
+app.commandLine.appendSwitch('disable-renderer-backgrounding')
+app.commandLine.appendSwitch('disable-backgrounding-occluded-windows')
+app.commandLine.appendSwitch('disable-background-timer-throttling')
+
 const SOURCE_REPO_ROOT = path.resolve(APP_ROOT, '../..')
 
 // Build-time install stamp -- the git ref this .exe was built against.
@@ -4689,7 +4703,16 @@ function createWindow() {
       webviewTag: true,
       sandbox: true,
       nodeIntegration: false,
-      devTools: true
+      devTools: true,
+      // Keep timers + requestAnimationFrame running at full speed when the
+      // window is blurred/occluded. The chat transcript streams to the screen
+      // through a requestAnimationFrame-gated flush (useSessionStateCache),
+      // so with Chromium's default background throttling the live answer
+      // stalls whenever this window isn't focused (e.g. you switch to your
+      // editor mid-turn, or open detached devtools) and only appears once you
+      // refocus or refresh. A streaming chat app must render in the
+      // background, so opt out — matching the secondary windows above.
+      backgroundThrottling: false
     }
   })
 


### PR DESCRIPTION
## Summary

The desktop chat transcript reaches the screen through a `requestAnimationFrame`-gated flush (`useSessionStateCache`). The main `BrowserWindow` never set `backgroundThrottling`, so Chromium **paused rAF and clamped timers whenever the window was blurred or occluded** — the live answer stalled until the window regained focus or the user refreshed.

In practice this bit any time Hermes wasn't the focused window mid-turn (typing in your editor while the agent replies, detached devtools, another window covering it), presenting as the recurring **"thinking, no text, have to refresh"** report. It resolves the instant you tab back, because rAF resumes on focus.

This is **latent since the desktop app first landed (#20059)** — not a regression from any recent PR. Backend event emission and renderer event routing were both verified correct (headless RPC probe + in-renderer event trace); the only broken hop was the final paint, throttled by Chromium.

## Changes

`apps/desktop/electron/main.cjs`:
- `backgroundThrottling: false` on the main window — matches the secondary windows in this same file that already set it.
- Process-level switches for the occlusion path: `disable-renderer-backgrounding`, `disable-backgrounding-occluded-windows`, `disable-background-timer-throttling`.

## Test plan

- [x] `npm run type-check` clean
- [ ] Full restart of the app (Electron main-process change — HMR does not pick it up)
- [ ] `Cmd+N`, send a prompt, immediately click into another window; the reply streams in live while Hermes is unfocused (no refresh, no tab-back)