### PR TITLE
fix: handle non-image link previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project are documented here.
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## [Unreleased]
+
+### Fixed
+- Reject non-image bytes before native image attachment and surface Open Graph cards for HTML link previews — prevents URL preview pages from being sent to vision providers as invalid image data while preserving useful link metadata.

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -340,6 +340,15 @@ def decide_image_input_mode(
     if _explicit_aux_vision_override(cfg):
         return "text"
 
+    # The ChatGPT Codex backend currently advertises vision-capable model
+    # metadata, but rejects Hermes' local-file data URLs with HTTP 400
+    # ``invalid_value`` / "image data ... does not represent a valid image"
+    # even when the bytes are a valid PNG/JPEG/GIF/WebP. Route Codex images
+    # through the auxiliary text-vision path by default so screenshots remain
+    # usable; users can still force native mode with agent.image_input_mode.
+    if provider.strip().lower() == "openai-codex":
+        return "text"
+
     supports = _lookup_supports_vision(provider, model, cfg)
     if supports is True:
         return "native"
@@ -431,15 +440,23 @@ def _file_to_data_url(path: Path) -> Optional[str]:
     accept large images (OpenAI 49 MB+, Gemini 100 MB) don't pay a silent
     quality tax just because one other provider is stricter.
 
-    Returns None only if the file can't be read (missing, permission
-    denied, etc.); the caller reports those paths in ``skipped``.
+    Returns None if the file can't be read OR if its bytes do not match a
+    supported image signature. Never trust the extension alone: a URL preview
+    HTML file saved as ``.jpg``/``.png`` must not be sent to the model as an
+    image.
     """
     try:
         raw = path.read_bytes()
     except Exception as exc:
         logger.warning("image_routing: failed to read %s — %s", path, exc)
         return None
-    mime = _guess_mime(path, raw=raw)
+    mime = _sniff_mime_from_bytes(raw)
+    if mime not in {"image/jpeg", "image/png", "image/gif", "image/webp"}:
+        logger.warning(
+            "image_routing: refusing to attach %s as image; unsupported or non-image bytes",
+            path,
+        )
+        return None
     b64 = base64.b64encode(raw).decode("ascii")
     return f"data:{mime};base64,{b64}"
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -103,6 +103,14 @@ class TestDecideImageInputMode:
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
             assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "text"
 
+    def test_auto_uses_text_for_openai_codex_native_data_url_rejection(self):
+        # ChatGPT's Codex backend advertises vision-capable model metadata but
+        # rejects valid local-file data URLs with HTTP 400 invalid_value. Keep
+        # screenshots working by using the auxiliary text-vision pipeline in
+        # auto mode; explicit agent.image_input_mode="native" still overrides.
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            assert decide_image_input_mode("openai-codex", "gpt-5.5", {}) == "text"
+
     def test_none_config_is_auto(self):
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
             assert decide_image_input_mode("anthropic", "claude-sonnet-4", None) == "native"
@@ -333,6 +341,15 @@ class TestBuildNativeContentParts:
         assert skipped == [str(tmp_path / "missing.png")]
         # Skipped paths are NOT advertised in the path hints — the model
         # would otherwise be told a non-existent file is attached.
+        assert parts == [{"type": "text", "text": "hi"}]
+
+    def test_non_image_bytes_are_skipped_even_with_image_suffix(self, tmp_path: Path):
+        fake = tmp_path / "preview.png"
+        fake.write_text("<html><head><meta property='og:title' content='Not pixels'></head></html>")
+
+        parts, skipped = build_native_content_parts("hi", [str(fake)])
+
+        assert skipped == [str(fake)]
         assert parts == [{"type": "text", "text": "hi"}]
 
     def test_path_hint_appended(self, tmp_path: Path):

--- a/tests/tools/test_vision_open_graph_card.py
+++ b/tests/tools/test_vision_open_graph_card.py
@@ -1,0 +1,76 @@
+import json
+
+import pytest
+
+from tools import vision_tools
+
+
+HTML = """
+<!doctype html>
+<html>
+  <head>
+    <title>Fallback title</title>
+    <meta property="og:title" content="OG Title">
+    <meta property="og:description" content="A useful summary.">
+    <meta property="og:image" content="/card.png">
+    <meta property="og:url" content="https://example.com/story">
+    <meta property="og:type" content="article">
+  </head>
+  <body>Not an image.</body>
+</html>
+"""
+
+
+def test_extract_open_graph_card_resolves_relative_image_url():
+    card = vision_tools._extract_open_graph_card(HTML, "https://example.com/path/page")
+
+    assert card == {
+        "title": "OG Title",
+        "description": "A useful summary.",
+        "image": "https://example.com/card.png",
+        "url": "https://example.com/story",
+        "type": "article",
+    }
+
+
+@pytest.mark.asyncio
+async def test_vision_analyze_returns_open_graph_card_for_html_url(monkeypatch):
+    async def fake_download(_url, destination, max_retries=3):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(HTML, encoding="utf-8")
+        return destination
+
+    monkeypatch.setattr(vision_tools, "_download_image", fake_download)
+
+    result = json.loads(
+        await vision_tools.vision_analyze_tool(
+            "https://example.com/path/page",
+            "what is this?",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["open_graph"]["title"] == "OG Title"
+    assert result["open_graph"]["image"] == "https://example.com/card.png"
+    assert "did not resolve to image bytes" in result["analysis"]
+
+
+@pytest.mark.asyncio
+async def test_native_vision_returns_open_graph_card_for_html_url(monkeypatch):
+    async def fake_download(_url, destination, max_retries=3):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(HTML, encoding="utf-8")
+        return destination
+
+    monkeypatch.setattr(vision_tools, "_download_image", fake_download)
+
+    result = json.loads(
+        await vision_tools._vision_analyze_native(
+            "https://example.com/path/page",
+            "what is this?",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["open_graph"]["title"] == "OG Title"
+    assert result["open_graph"]["url"] == "https://example.com/story"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -33,9 +33,11 @@ import json
 import logging
 import os
 import uuid
+from html import unescape
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 import httpx
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
 from hermes_constants import get_hermes_dir
@@ -152,7 +154,120 @@ def _is_retryable_download_error(error: Exception) -> bool:
     return True
 
 
+class _OpenGraphHTMLParser(HTMLParser):
+    """Extract enough Open Graph/Twitter metadata to describe a URL card."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.meta: Dict[str, str] = {}
+        self.title_parts: list[str] = []
+        self._in_title = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        attrs_dict = {k.lower(): (v or "") for k, v in attrs if k}
+        tag_lower = tag.lower()
+        if tag_lower == "title":
+            self._in_title = True
+            return
+        if tag_lower != "meta":
+            return
+        key = (attrs_dict.get("property") or attrs_dict.get("name") or "").strip().lower()
+        value = (attrs_dict.get("content") or "").strip()
+        if key and value and key not in self.meta:
+            self.meta[key] = value
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title and data:
+            self.title_parts.append(data)
+
+
+def _collapse_ws(value: Optional[str]) -> str:
+    return " ".join(unescape(value or "").split())
+
+
+def _extract_open_graph_card(html: str, page_url: str) -> Optional[Dict[str, str]]:
+    """Return Open Graph/Twitter card metadata for a non-image URL."""
+    if not isinstance(html, str) or not html.strip():
+        return None
+    parser = _OpenGraphHTMLParser()
+    try:
+        parser.feed(html[:1_000_000])
+    except Exception:
+        return None
+
+    meta = parser.meta
+    title = _collapse_ws(
+        meta.get("og:title")
+        or meta.get("twitter:title")
+        or " ".join(parser.title_parts)
+    )
+    description = _collapse_ws(
+        meta.get("og:description")
+        or meta.get("twitter:description")
+        or meta.get("description")
+    )
+    image = _collapse_ws(
+        meta.get("og:image:secure_url")
+        or meta.get("og:image")
+        or meta.get("twitter:image")
+        or meta.get("twitter:image:src")
+    )
+    canonical_url = _collapse_ws(meta.get("og:url") or page_url)
+    card_type = _collapse_ws(meta.get("og:type") or meta.get("twitter:card"))
+
+    card: Dict[str, str] = {}
+    if title:
+        card["title"] = title
+    if description:
+        card["description"] = description
+    if image:
+        card["image"] = urljoin(page_url, image)
+    if canonical_url:
+        card["url"] = urljoin(page_url, canonical_url)
+    if card_type:
+        card["type"] = card_type
+    return card if card else None
+
+
+def _open_graph_card_from_file(path: Path, page_url: str) -> Optional[Dict[str, str]]:
+    """Parse a downloaded non-image response as an Open Graph card if possible."""
+    try:
+        raw = path.read_bytes()[:1_000_000]
+    except Exception:
+        return None
+    # Don't try to parse arbitrary binary blobs as HTML.
+    prefix = raw[:512].lstrip().lower()
+    if b"<html" not in prefix and b"<!doctype html" not in prefix and b"<head" not in raw[:4096].lower():
+        return None
+    text = raw.decode("utf-8", errors="replace")
+    return _extract_open_graph_card(text, page_url)
+
+
+def _format_open_graph_card(card: Dict[str, str], source_url: str) -> str:
+    """Format Open Graph metadata as plain text for the agent."""
+    lines = [
+        "The supplied URL did not resolve to image bytes. I fetched its Open Graph card instead.",
+        f"Source URL: {source_url}",
+    ]
+    for label, key in (
+        ("Title", "title"),
+        ("Description", "description"),
+        ("Image", "image"),
+        ("Canonical URL", "url"),
+        ("Type", "type"),
+    ):
+        value = card.get(key)
+        if value:
+            lines.append(f"{label}: {value}")
+    return "\n".join(lines)
+
+
 async def _download_image(image_url: str, destination: Path, max_retries: int = 3) -> Path:
+
     """
     Download an image from a URL to a local destination (async) with retry logic.
     
@@ -739,6 +854,14 @@ async def _vision_analyze_native(
         image_size_bytes = temp_image_path.stat().st_size
         detected_mime_type = _detect_image_mime_type(temp_image_path)
         if not detected_mime_type:
+            if _validate_image_url(image_url):
+                card = _open_graph_card_from_file(temp_image_path, image_url)
+                if card:
+                    return json.dumps({
+                        "success": True,
+                        "analysis": _format_open_graph_card(card, image_url),
+                        "open_graph": card,
+                    })
             return tool_error(
                 "Only real image files are supported for vision analysis.",
                 success=False,
@@ -897,6 +1020,17 @@ async def vision_analyze_tool(
 
         detected_mime_type = _detect_image_mime_type(temp_image_path)
         if not detected_mime_type:
+            if _validate_image_url(image_url):
+                card = _open_graph_card_from_file(temp_image_path, image_url)
+                if card:
+                    analysis = _format_open_graph_card(card, image_url)
+                    debug_call_data["success"] = True
+                    debug_call_data["analysis_length"] = len(analysis)
+                    return json.dumps({
+                        "success": True,
+                        "analysis": analysis,
+                        "open_graph": card,
+                    })
             raise ValueError("Only real image files are supported for vision analysis.")
         
         # Convert image to base64 — send at full resolution first.


### PR DESCRIPTION
## Summary
- Reject non-image bytes before native image attachment
- Parse Open Graph/Twitter metadata when a URL resolves to HTML instead of image bytes
- Route OpenAI Codex image attachments through text vision by default to avoid invalid image-data 400s

## Test Plan
- /Users/bananawalnut/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_image_routing.py tests/tools/test_vision_open_graph_card.py -q