### PR TITLE
fix(curator): allow eligible built-in skill pinning

### DIFF
--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -233,11 +233,12 @@ def _cmd_resume(args) -> int:
 
 def _cmd_pin(args) -> int:
     from tools import skill_usage
-    if not skill_usage.is_agent_created(args.skill):
-        print(
-            f"curator: '{args.skill}' is bundled or hub-installed — cannot pin "
-            "(only agent-created skills participate in curation)"
-        )
+    if not skill_usage.is_curation_eligible(args.skill):
+        if skill_usage.is_hub_installed(args.skill):
+            reason = "hub-installed skills are never curator-managed"
+        else:
+            reason = "bundled built-ins require curator.prune_builtins=true"
+        print(f"curator: '{args.skill}' cannot be pinned ({reason})")
         return 1
     skill_usage.set_pinned(args.skill, True)
     print(f"curator: pinned '{args.skill}' (will bypass auto-transitions)")
@@ -246,11 +247,12 @@ def _cmd_pin(args) -> int:
 
 def _cmd_unpin(args) -> int:
     from tools import skill_usage
-    if not skill_usage.is_agent_created(args.skill):
-        print(
-            f"curator: '{args.skill}' is bundled or hub-installed — "
-            "there's nothing to unpin (curator only tracks agent-created skills)"
-        )
+    if not skill_usage.is_curation_eligible(args.skill):
+        if skill_usage.is_hub_installed(args.skill):
+            reason = "hub-installed skills are never curator-managed"
+        else:
+            reason = "bundled built-ins require curator.prune_builtins=true"
+        print(f"curator: '{args.skill}' cannot be unpinned ({reason})")
         return 1
     skill_usage.set_pinned(args.skill, False)
     print(f"curator: unpinned '{args.skill}'")

--- a/tests/hermes_cli/test_curator_status.py
+++ b/tests/hermes_cli/test_curator_status.py
@@ -109,6 +109,40 @@ def _capture_status(curator_cli) -> str:
     return buf.getvalue()
 
 
+def test_pin_and_unpin_allow_bundled_when_prune_builtins_enabled(curator_status_env, monkeypatch, capsys):
+    env = curator_status_env
+    env["make_skill"]("bundled-one")
+    (env["skills"] / ".bundled_manifest").write_text(
+        "bundled-one:abc\n", encoding="utf-8",
+    )
+    monkeypatch.setattr(env["skill_usage"], "_prune_builtins_enabled", lambda: True)
+
+    assert env["curator_cli"]._cmd_pin(Namespace(skill="bundled-one")) == 0
+    assert env["skill_usage"].get_record("bundled-one")["pinned"] is True
+    assert "pinned 'bundled-one'" in capsys.readouterr().out
+
+    assert env["curator_cli"]._cmd_unpin(Namespace(skill="bundled-one")) == 0
+    assert env["skill_usage"].get_record("bundled-one")["pinned"] is False
+    assert "unpinned 'bundled-one'" in capsys.readouterr().out
+
+
+def test_pin_still_refuses_hub_skill_even_when_prune_builtins_enabled(curator_status_env, monkeypatch, capsys):
+    env = curator_status_env
+    env["make_skill"]("hub-one")
+    hub = env["skills"] / ".hub"
+    hub.mkdir()
+    (hub / "lock.json").write_text(
+        '{"installed": {"hub-one": {}}}', encoding="utf-8",
+    )
+    monkeypatch.setattr(env["skill_usage"], "_prune_builtins_enabled", lambda: True)
+
+    assert env["curator_cli"]._cmd_pin(Namespace(skill="hub-one")) == 1
+    assert env["skill_usage"].load_usage() == {}
+    out = capsys.readouterr().out
+    assert "hub-one" in out
+    assert "hub-installed skills are never curator-managed" in out
+
+
 def test_status_shows_most_and_least_used_sections(curator_status_env):
     env = curator_status_env
     env["make_skill"]("top-dog")


### PR DESCRIPTION
## Summary
- allow `hermes curator pin/unpin` to operate on bundled built-in skills when `curator.prune_builtins=true`
- keep hub-installed skills refused because they have an external upstream owner
- add direct CLI coverage for bundled pin/unpin and hub refusal

## Test Plan
- `./scripts/run_tests.sh -j 2 tests/hermes_cli/test_curator_status.py tests/tools/test_skill_usage.py`
- `python -m ruff check hermes_cli/curator.py tests/hermes_cli/test_curator_status.py`
- `python -m py_compile hermes_cli/curator.py tests/hermes_cli/test_curator_status.py`
