### PR TITLE
feat(agent): add memory.background_review_writes config to decouple review fork write scope

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -467,26 +467,50 @@ def _run_review_in_thread(
                 clear_thread_tool_whitelist,
             )
 
+            # Check if memory writes are allowed in the background review fork.
+            # When memory.background_review_writes is False, the fork can only
+            # use skill tools — built-in memory (MEMORY.md / USER.md) stays
+            # curated and untouched by autonomous review.  See issue #42388.
+            _allow_memory_writes = True
+            try:
+                from hermes_cli.config import load_config
+                _mem_cfg = load_config().get("memory", {})
+                if isinstance(_mem_cfg, dict):
+                    _allow_memory_writes = bool(
+                        _mem_cfg.get("background_review_writes", True)
+                    )
+            except Exception:
+                pass
+
+            _review_toolsets = ["skills"]
+            if _allow_memory_writes:
+                _review_toolsets = ["memory", "skills"]
+
             review_whitelist = {
                 t["function"]["name"]
                 for t in get_tool_definitions(
-                    enabled_toolsets=["memory", "skills"],
+                    enabled_toolsets=_review_toolsets,
                     quiet_mode=True,
                 )
             }
+            _tool_desc = (
+                "memory and skill management tools"
+                if _allow_memory_writes
+                else "skill management tools only (memory writes disabled by config)"
+            )
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(
                     "Background review denied non-whitelisted tool: "
-                    "{tool_name}. Only memory/skill tools are allowed."
+                    "{tool_name}. Only " + _tool_desc + " are allowed."
                 ),
             )
             try:
                 review_agent.run_conversation(
                     user_message=(
                         prompt
-                        + "\n\nYou can only call memory and skill "
-                        "management tools. Other tools will be denied "
+                        + "\n\nYou can only call " + _tool_desc + ". "
+                        "Other tools will be denied "
                         "at runtime — do not attempt them."
                     ),
                     conversation_history=messages_snapshot,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1656,6 +1656,12 @@ DEFAULT_CONFIG = {
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        # When False, the background-review fork (skill self-improvement)
+        # cannot write to built-in memory (MEMORY.md / USER.md).  This
+        # decouples the fork's *write scope* from its *spawn triggers* so
+        # users who want curated memory + autonomous skill improvement
+        # can get that combination.  Default True preserves current behavior.
+        "background_review_writes": True,
     },
 
     # Subagent delegation — override the provider:model used by delegate_task

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -189,6 +189,7 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("display", "skin"),
         ("display", "show_reasoning"),
         ("privacy", "redact_pii"),
+        ("memory", "background_review_writes"),
         ("tts", "provider"),
     ]
 

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -156,3 +156,140 @@ def test_background_review_agent_tools_are_limited():
     assert "delegate_task" not in expected_tools
     assert "web_search" not in expected_tools
     assert "execute_code" not in expected_tools
+
+
+def test_background_review_whitelist_excludes_memory_when_config_disabled():
+    """When memory.background_review_writes is False, the review fork's
+    whitelist must NOT include the memory tool — only skill tools.
+
+    This is the core contract of issue #42388: decouple the fork's write
+    scope from its spawn triggers so curated memory stays untouched.
+    """
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        captured["deny_msg_fmt"] = deny_msg_fmt
+        raise RuntimeError("stop after capturing whitelist")
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    mock_config = {"memory": {"background_review_writes": False}}
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("threading.Thread", _SyncThread), \
+         patch("hermes_cli.config.load_config", return_value=mock_config):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=False,
+            review_skills=True,
+        )
+
+    assert "whitelist" in captured, "set_thread_tool_whitelist was not called"
+    whitelist = captured["whitelist"]
+    # memory tool must NOT be in the whitelist
+    assert "memory" not in whitelist, (
+        "memory tool should be excluded when background_review_writes is False"
+    )
+    # skill tools must still be allowed
+    assert "skill_manage" in whitelist
+    assert "skill_view" in whitelist
+    assert "skills_list" in whitelist
+    # dangerous tools still excluded
+    assert "terminal" not in whitelist
+    assert "send_message" not in whitelist
+
+
+def test_background_review_whitelist_includes_memory_when_config_enabled():
+    """When memory.background_review_writes is True (default), the review
+    fork's whitelist must include both memory and skill tools.
+
+    This preserves the existing behavior — the default is True.
+    """
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        raise RuntimeError("stop after capturing whitelist")
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    # Explicitly set to True (same as default)
+    mock_config = {"memory": {"background_review_writes": True}}
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("threading.Thread", _SyncThread), \
+         patch("hermes_cli.config.load_config", return_value=mock_config):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert "whitelist" in captured
+    whitelist = captured["whitelist"]
+    # memory tool must be in the whitelist (default behavior)
+    assert "memory" in whitelist
+    assert "skill_manage" in whitelist
+
+
+def test_background_review_prompt_adapts_when_memory_disabled():
+    """When memory writes are disabled, the run_conversation prompt must
+    mention 'skill management tools only', not 'memory and skill'.
+    """
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["deny_msg_fmt"] = deny_msg_fmt
+        # Don't raise — let execution continue to run_conversation
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    def _capture_run_conv(self, user_message=None, **kwargs):
+        captured["user_message"] = user_message
+        raise RuntimeError("stop after capturing prompt")
+
+    mock_config = {"memory": {"background_review_writes": False}}
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch.object(run_agent.AIAgent, "run_conversation", _capture_run_conv), \
+         patch("threading.Thread", _SyncThread), \
+         patch("hermes_cli.config.load_config", return_value=mock_config):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=False,
+            review_skills=True,
+        )
+
+    assert "user_message" in captured
+    msg = captured["user_message"]
+    assert "skill management tools only" in msg, (
+        f"Prompt should mention skill-only tools, got: {msg[:200]}"
+    )
+    assert "memory and skill" not in msg, (
+        f"Prompt should NOT mention memory tools when disabled, got: {msg[:200]}"
+    )
+    # deny_msg_fmt should also reflect the restriction
+    fmt = captured.get("deny_msg_fmt", "")
+    assert "skill management tools only" in fmt


### PR DESCRIPTION
## Problem

Setting `memory.nudge_interval: 0` does **not** stop autonomous writes to `MEMORY.md` / `USER.md`. The post-turn background-review fork is spawned whenever **either** the memory-review gate **or** the skill-review gate fires, and the fork inherits the built-in `memory` tool regardless of which gate spawned it. So a user who disables memory review to keep a *curated* memory still gets autonomous memory writes through the skill-review path.

The only config-level way to stop them today is to **also** disable skill self-improvement (`skills.creation_nudge_interval: 0`) — which throws out a feature users want to keep.

## Solution

Add a new config key `memory.background_review_writes` (default `True`) that controls whether the background-review fork has access to the built-in `memory` tool.

When set to `False`:
- The review fork's tool whitelist excludes memory tools — only skill tools are allowed
- The fork's prompt and deny message reflect the restriction
- Built-in memory (`MEMORY.md` / `USER.md`) stays curated and untouched by autonomous review
- Skill self-improvement continues to work normally

This yields a clean, independently controllable matrix:

| | memory writes ON | memory writes OFF |
|---|---|---|
| **skill self-improvement ON** | current default | **new: the missing cell** |
| **skill self-improvement OFF** | possible today | possible today |

## Usage

```yaml
# ~/.hermes/config.yaml
memory:
  background_review_writes: false  # default: true
```

## Changes

- `hermes_cli/config.py` — Add `background_review_writes` key to `memory` config section
- `hermes_cli/dump.py` — Add to `interesting_paths` for `hermes config display`
- `agent/background_review.py` — Read config and conditionally exclude memory from fork's toolset whitelist
- `tests/run_agent/test_background_review_toolset_restriction.py` — 3 new tests covering disabled, enabled, and prompt adaptation

## Testing

All 22 background review tests pass (6 in toolset restriction file including 3 new ones, 5 in main file, 2 in summary, 6 in cache parity, 3 in other files).

```
tests/run_agent/test_background_review_toolset_restriction.py::test_background_review_whitelist_excludes_memory_when_config_disabled PASSED
tests/run_agent/test_background_review_toolset_restriction.py::test_background_review_whitelist_includes_memory_when_config_enabled PASSED
tests/run_agent/test_background_review_toolset_restriction.py::test_background_review_prompt_adapts_when_memory_disabled PASSED
```
