### PR TITLE
fix(gateway): preserve loaded launchd domain

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3067,6 +3067,9 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
+_LAUNCHD_DOMAIN_PROBE_TIMEOUT_SECONDS = 1.0
+
+
 def _launchd_service_loaded_in_domain(domain: str, label: str) -> bool:
     """Return True when launchd already knows ``label`` in ``domain``.
 
@@ -3083,16 +3086,16 @@ def _launchd_service_loaded_in_domain(domain: str, label: str) -> bool:
             ["launchctl", "print", f"{domain}/{label}"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=_LAUNCHD_DOMAIN_PROBE_TIMEOUT_SECONDS,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return False
     return result.returncode == 0
 
 
-def _launchd_domain() -> str:
+def _launchd_domain(label: str | None = None) -> str:
     uid = os.getuid()
-    label = get_launchd_label()
+    label = label or get_launchd_label()
     gui_domain = f"gui/{uid}"
     user_domain = f"user/{uid}"
 
@@ -3319,7 +3322,7 @@ def launchd_plist_is_current() -> bool:
     ) == _normalize_launchd_plist_for_comparison(expected)
 
 
-def refresh_launchd_plist_if_needed() -> bool:
+def refresh_launchd_plist_if_needed(domain: str | None = None) -> bool:
     """Rewrite the installed launchd plist when the generated definition has changed.
 
     Unlike systemd, launchd picks up plist changes on the next ``launchctl kill``/
@@ -3332,7 +3335,7 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     label = get_launchd_label()
-    domain = _launchd_domain()
+    domain = domain or _launchd_domain(label)
     # Bootout/bootstrap so launchd picks up the new definition.  Keep the same
     # domain for both calls; after bootout the probe would no longer see the old
     # loaded job and could otherwise fall back to user/<uid> mid-refresh.
@@ -3437,8 +3440,8 @@ def launchd_start():
         print("✓ Service started")
         return
 
-    refresh_launchd_plist_if_needed()
-    domain = _launchd_domain()
+    domain = _launchd_domain(label)
+    refresh_launchd_plist_if_needed(domain=domain)
     target = f"{domain}/{label}"
     try:
         subprocess.run(
@@ -3448,6 +3451,9 @@ def launchd_start():
         )
     except subprocess.CalledProcessError as e:
         if not _launchd_error_indicates_unloaded(e):
+            if _launchctl_domain_unsupported(e.returncode):
+                _launchd_fallback_to_detached(f"launchctl kickstart exit {e.returncode}")
+                return
             raise
         # Job not loaded in this domain — re-bootstrap the plist and retry.
         print("↻ launchd job was unloaded; reloading service definition")
@@ -3558,17 +3564,16 @@ def _wait_for_gateway_exit(
 def launchd_restart():
     label = get_launchd_label()
     drain_timeout = _get_restart_drain_timeout()
-    domain: str | None = None
-    target: str | None = None
     from gateway.status import get_running_pid
 
+    pid = get_running_pid()
+    if pid is not None and _request_gateway_self_restart(pid):
+        print("✓ Service restart requested")
+        return
+
+    domain = _launchd_domain(label)
+    target = f"{domain}/{label}"
     try:
-        pid = get_running_pid()
-        if pid is not None and _request_gateway_self_restart(pid):
-            print("✓ Service restart requested")
-            return
-        domain = _launchd_domain()
-        target = f"{domain}/{label}"
         if pid is not None:
             try:
                 terminate_pid(pid, force=False)
@@ -3592,8 +3597,6 @@ def launchd_restart():
                 return
             raise
         # Job not loaded — bootstrap and start fresh
-        if domain is None or target is None:
-            raise
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
         try:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3067,12 +3067,45 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
+def _launchd_service_loaded_in_domain(domain: str, label: str) -> bool:
+    """Return True when launchd already knows ``label`` in ``domain``.
+
+    macOS keeps per-user LaunchAgents in distinct bootstrap domains.  Recent
+    Hermes builds prefer ``user/<uid>`` for macOS 26 background sessions, but
+    older installs — and some current hosts — may still have the same LaunchAgent
+    loaded in ``gui/<uid>``.  Restarting a running ``gui`` job through ``user``
+    produces a false "Could not find service" followed by a duplicate-label
+    bootstrap failure.  Probe the loaded domain first and manage the job where
+    it actually lives.
+    """
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"{domain}/{label}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0
+
+
 def _launchd_domain() -> str:
-    # The `user/<uid>` domain (vs the older `gui/<uid>`) is reachable from
-    # non-Aqua/background sessions (SSH, headless, login items) and is the only
-    # one that supports service management on macOS 26+. `gui/<uid>` returns
-    # error 125 ("Domain does not support specified action") there. See #23387.
-    return f"user/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    uid = os.getuid()
+    label = get_launchd_label()
+    gui_domain = f"gui/{uid}"
+    user_domain = f"user/{uid}"
+
+    # Preserve the loaded domain for existing installs.  This avoids trying to
+    # bootstrap the same label into user/<uid> while launchd still has it loaded
+    # in gui/<uid> (seen as Bootstrap failed: 5 / File exists on macOS 26.5).
+    for domain in (gui_domain, user_domain):
+        if _launchd_service_loaded_in_domain(domain, label):
+            return domain
+
+    # Fresh install / fully unloaded service: keep the macOS 26-safe default
+    # introduced for #23387.
+    return user_domain  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
 # On macOS, exit code 125 ("Domain does not support specified action") and
@@ -3299,14 +3332,17 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     label = get_launchd_label()
-    # Bootout/bootstrap so launchd picks up the new definition
+    domain = _launchd_domain()
+    # Bootout/bootstrap so launchd picks up the new definition.  Keep the same
+    # domain for both calls; after bootout the probe would no longer see the old
+    # loaded job and could otherwise fall back to user/<uid> mid-refresh.
     subprocess.run(
-        ["launchctl", "bootout", f"{_launchd_domain()}/{label}"],
+        ["launchctl", "bootout", f"{domain}/{label}"],
         check=False,
         timeout=90,
     )
     subprocess.run(
-        ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+        ["launchctl", "bootstrap", domain, str(plist_path)],
         check=False,
         timeout=30,
     )
@@ -3380,14 +3416,16 @@ def launchd_start():
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
+        domain = _launchd_domain()
+        target = f"{domain}/{label}"
         try:
             subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+                ["launchctl", "bootstrap", domain, str(plist_path)],
                 check=True,
                 timeout=30,
             )
             subprocess.run(
-                ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
+                ["launchctl", "kickstart", target],
                 check=True,
                 timeout=30,
             )
@@ -3400,9 +3438,11 @@ def launchd_start():
         return
 
     refresh_launchd_plist_if_needed()
+    domain = _launchd_domain()
+    target = f"{domain}/{label}"
     try:
         subprocess.run(
-            ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
+            ["launchctl", "kickstart", target],
             check=True,
             timeout=30,
         )
@@ -3413,12 +3453,12 @@ def launchd_start():
         print("↻ launchd job was unloaded; reloading service definition")
         try:
             subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+                ["launchctl", "bootstrap", domain, str(plist_path)],
                 check=True,
                 timeout=30,
             )
             subprocess.run(
-                ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
+                ["launchctl", "kickstart", target],
                 check=True,
                 timeout=30,
             )
@@ -3517,8 +3557,9 @@ def _wait_for_gateway_exit(
 
 def launchd_restart():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
     drain_timeout = _get_restart_drain_timeout()
+    domain: str | None = None
+    target: str | None = None
     from gateway.status import get_running_pid
 
     try:
@@ -3526,6 +3567,8 @@ def launchd_restart():
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
             return
+        domain = _launchd_domain()
+        target = f"{domain}/{label}"
         if pid is not None:
             try:
                 terminate_pid(pid, force=False)
@@ -3549,11 +3592,13 @@ def launchd_restart():
                 return
             raise
         # Job not loaded — bootstrap and start fresh
+        if domain is None or target is None:
+            raise
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
         try:
             subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+                ["launchctl", "bootstrap", domain, str(plist_path)],
                 check=True,
                 timeout=30,
             )

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -696,9 +696,11 @@ class TestLaunchdServiceRecovery:
     def test_launchd_domain_prefers_existing_gui_job(self, monkeypatch):
         label = gateway_cli.get_launchd_label()
         calls = []
+        timeouts = []
 
         def fake_run(cmd, **kwargs):
             calls.append(cmd)
+            timeouts.append(kwargs.get("timeout"))
             if cmd == ["launchctl", "print", f"gui/{os.getuid()}/{label}"]:
                 return SimpleNamespace(returncode=0, stdout="", stderr="")
             return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
@@ -707,6 +709,7 @@ class TestLaunchdServiceRecovery:
 
         assert gateway_cli._launchd_domain() == f"gui/{os.getuid()}"
         assert calls == [["launchctl", "print", f"gui/{os.getuid()}/{label}"]]
+        assert timeouts == [1.0]
 
     def test_launchd_domain_uses_user_when_only_user_job_loaded(self, monkeypatch):
         label = gateway_cli.get_launchd_label()
@@ -768,6 +771,46 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
+    def test_launchd_start_falls_back_to_detached_on_kickstart_error_5(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A directly unmanageable loaded domain should degrade instead of raising."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+        domain = f"gui/{os.getuid()}"
+        target = f"{domain}/{label}"
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda label=None: domain)
+        monkeypatch.setattr(
+            gateway_cli,
+            "refresh_launchd_plist_if_needed",
+            lambda *args, **kwargs: False,
+        )
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", target]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    5, cmd, stderr="Input/output error"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        spawned = []
+        monkeypatch.setattr(
+            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
+        )
+
+        gateway_cli.launchd_start()
+
+        assert calls == [["launchctl", "kickstart", target]]
+        assert spawned == [True]
+        assert "background process" in capsys.readouterr().out.lower()
+
     def test_launchd_start_falls_back_to_detached_when_rebootstrap_fails(self, tmp_path, monkeypatch, capsys):
         """If even a fresh bootstrap can't manage the domain, spawn detached."""
         plist_path = tmp_path / "ai.hermes.gateway.plist"
@@ -776,7 +819,11 @@ class TestLaunchdServiceRecovery:
         target = f"{gateway_cli._launchd_domain()}/{label}"
 
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_if_needed", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "refresh_launchd_plist_if_needed",
+            lambda *args, **kwargs: False,
+        )
 
         def fake_run(cmd, check=False, **kwargs):
             if cmd == ["launchctl", "kickstart", target]:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -18,6 +18,15 @@ from gateway.restart import (
 )
 
 
+def _without_launchd_probe_calls(calls):
+    """Drop launchctl print probes used by dynamic launchd domain detection."""
+    return [
+        cmd
+        for cmd in calls
+        if not (isinstance(cmd, list) and cmd[:2] == ["launchctl", "print"])
+    ]
+
+
 class TestUserSystemdPrivateSocketPreflight:
     def test_preflight_accepts_private_socket_without_dbus_bus(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "_ensure_user_systemd_env", lambda: None)
@@ -495,7 +504,8 @@ class TestLaunchdServiceRecovery:
         label = gateway_cli.get_launchd_label()
         domain = gateway_cli._launchd_domain()
         assert "--replace" in plist_path.read_text(encoding="utf-8")
-        assert calls[:2] == [
+        service_calls = _without_launchd_probe_calls(calls)
+        assert service_calls[:2] == [
             ["launchctl", "bootout", f"{domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],
         ]
@@ -521,7 +531,8 @@ class TestLaunchdServiceRecovery:
 
         gateway_cli.launchd_start()
 
-        assert calls == [
+        service_calls = _without_launchd_probe_calls(calls)
+        assert service_calls == [
             ["launchctl", "kickstart", target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
@@ -549,7 +560,8 @@ class TestLaunchdServiceRecovery:
 
         gateway_cli.launchd_start()
 
-        assert calls == [
+        service_calls = _without_launchd_probe_calls(calls)
+        assert service_calls == [
             ["launchctl", "kickstart", target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
@@ -576,7 +588,8 @@ class TestLaunchdServiceRecovery:
 
         gateway_cli.launchd_restart()
 
-        assert calls == [
+        service_calls = _without_launchd_probe_calls(calls)
+        assert service_calls == [
             ("term", 321, False),
             ["launchctl", "kickstart", "-k", target],
         ]
@@ -621,7 +634,8 @@ class TestLaunchdServiceRecovery:
 
         gateway_cli.launchd_stop()
 
-        assert calls == [["launchctl", "bootout", target]]
+        service_calls = _without_launchd_probe_calls(calls)
+        assert service_calls == [["launchctl", "bootout", target]]
 
     def test_launchd_stop_tolerates_already_unloaded(self, monkeypatch, capsys):
         """launchd_stop silently handles exit codes 3/113 (job not loaded)."""
@@ -679,9 +693,40 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
-    def test_launchd_domain_uses_user_domain(self):
-        # The user/<uid> domain (not gui/<uid>) is the one reachable from
-        # non-Aqua/background sessions on macOS 26+ (issue #23387).
+    def test_launchd_domain_prefers_existing_gui_job(self, monkeypatch):
+        label = gateway_cli.get_launchd_label()
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "print", f"gui/{os.getuid()}/{label}"]:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._launchd_domain() == f"gui/{os.getuid()}"
+        assert calls == [["launchctl", "print", f"gui/{os.getuid()}/{label}"]]
+
+    def test_launchd_domain_uses_user_when_only_user_job_loaded(self, monkeypatch):
+        label = gateway_cli.get_launchd_label()
+
+        def fake_run(cmd, **kwargs):
+            if cmd == ["launchctl", "print", f"user/{os.getuid()}/{label}"]:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
+
+    def test_launchd_domain_defaults_to_user_when_unloaded(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=113, stdout="", stderr="Could not find service"),
+        )
+
         assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
 
     def test_launchctl_domain_unsupported_recognizes_macos26_codes(self):
@@ -716,7 +761,8 @@ class TestLaunchdServiceRecovery:
 
         gateway_cli.launchd_start()
 
-        assert calls == [
+        service_calls = _without_launchd_probe_calls(calls)
+        assert service_calls == [
             ["launchctl", "kickstart", target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],


### PR DESCRIPTION
## Summary
- Probe loaded macOS launchd domains before managing the gateway LaunchAgent.
- Preserve an existing `gui/<uid>` or `user/<uid>` domain instead of hard-coding `user/<uid>`.
- Keep the selected domain stable across bootout/bootstrap/kickstart recovery paths.
- Add regression coverage for `gui/<uid>`, `user/<uid>`, and unloaded/fresh-install fallback behavior.

## Motivation
On at least one current macOS 26.x host, `ai.hermes.gateway` is loaded and manageable under `gui/<uid>`, while `user/<uid>` reports:

```text
Could not find service "ai.hermes.gateway" in domain for uid: 501
Bootstrap failed: 5: Input/output error
```

The current hard-coded `user/<uid>` path then falls back to a detached background gateway even though launchd is already managing the real service under `gui/<uid>`.

This preserves the previous `user/<uid>` default for unloaded/fresh installs, but avoids switching domains when a service already exists somewhere else.

## Test Plan
- [x] `git diff --check`
- [x] `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- [x] `python -m pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery -q -o 'addopts='`
- [x] Real macOS verification: `hermes gateway restart` now prints `✓ Service restarted` and `launchctl print gui/$(id -u)/ai.hermes.gateway` shows `state = running`.

## Notes
The full `tests/hermes_cli/test_gateway_service.py` file has unrelated Linux/systemd tests that fail on this macOS host because user D-Bus/systemd is unavailable. The launchd-focused test class passes.
