### PR TITLE
fix(docker): pre-install matrix deps in Docker image (#30399)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # hermes process, the dashboard, and per-profile gateways.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    ca-certificates curl iputils-ping python3 python-is-python3 ripgrep ffmpeg gcc python3-dev python3-venv libffi-dev libolm-dev procps git openssh-client docker-cli xz-utils && \
+    ca-certificates curl iputils-ping python3 python-is-python3 ripgrep ffmpeg gcc g++ make cmake python3-dev python3-venv libffi-dev libolm-dev procps git openssh-client docker-cli xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
 # ---------- s6-overlay install ----------
@@ -164,10 +164,17 @@ RUN npm install --prefer-offline --no-audit && \
 # image update and recall/retain then fails with
 # `ModuleNotFoundError: No module named 'hindsight_client'` (#38128).
 #
+# The Matrix gateway's deps ([matrix] extra) are baked in because
+# python-olm (transitive via mautrix[encryption]) builds from source on
+# Python/image combinations without usable wheels.  The Docker image is
+# Linux-only, so keeping the native libolm/build-toolchain packages here
+# avoids the cross-platform failures that kept [matrix] out of [all]
+# while still making Matrix work in the published container. Fixes #30399.
+#
 # The editable link is created after the source copy below.
 COPY pyproject.toml uv.lock ./
 RUN touch ./README.md
-RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra anthropic --extra bedrock --extra azure-identity --extra hindsight
+RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra anthropic --extra bedrock --extra azure-identity --extra hindsight --extra matrix
 
 # ---------- Source code ----------
 # .dockerignore excludes node_modules, so the installs above survive.

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -172,6 +172,31 @@ def test_dockerfile_preinstalls_gateway_messaging_dependencies(dockerfile_text):
     )
 
 
+def test_dockerfile_preinstalls_matrix_dependencies(dockerfile_text):
+    sync_steps = [
+        step for step in _run_steps(dockerfile_text)
+        if "uv sync" in step and "--no-install-project" in step
+    ]
+
+    assert sync_steps, "Dockerfile must install Python dependencies with uv sync"
+    assert any("--extra matrix" in step for step in sync_steps), (
+        "Published Docker images must preload the [matrix] extra so the "
+        "Matrix gateway has mautrix[encryption]/python-olm available at "
+        "runtime instead of relying on first-boot lazy installation into "
+        "the container venv (#30399)."
+    )
+
+
+def test_dockerfile_installs_matrix_native_build_dependencies(dockerfile_text):
+    instructions = _instruction_text(dockerfile_text)
+
+    for package in ("libolm-dev", "cmake", "g++", "make"):
+        assert package in instructions, (
+            "Docker image must include native build dependencies needed by "
+            f"python-olm when preinstalling the [matrix] extra (#30399): {package}"
+        )
+
+
 def test_dockerfile_preinstalls_hindsight_memory_dependency(dockerfile_text):
     sync_steps = [
         step for step in _run_steps(dockerfile_text)


### PR DESCRIPTION
## Summary

- Pre-install the Docker image's Matrix gateway dependencies by adding `--extra matrix` to the cached `uv sync` layer.
- Install the native build tools needed by `python-olm` in the Docker image (`cmake`, `g++`, `make`, alongside existing `libolm-dev`).
- Keep this Docker-only rather than restoring Matrix to `[all]`, preserving the cross-platform package policy while making the Linux container work out of the box.
- Add Dockerfile contract regression tests so published images continue baking the Matrix extra and its native build prerequisites instead of falling back to runtime lazy installation.

## Why

Issue #30399 reports that the Matrix gateway tries to lazy-install `mautrix[encryption]` / `python-olm` inside the Docker image, which fails for read-only root filesystems and immutable image-layer venvs. The Docker image should install these at build time, where Linux-only native dependencies are acceptable.

## Verification

- RED on upstream/main with the new regression test:
  - `tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_preinstalls_matrix_dependencies` failed because the Dockerfile did not include `--extra matrix`.
- GREEN after the fix:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/tools/test_dockerfile_pid1_reaping.py -v -o "addopts=" --tb=short`
  - Result: `10 passed in 0.07s`
- CI feedback after first push caught the missing native build tools (`cmake` / `make`); I force-pushed this revision adding those build dependencies plus a regression assertion for them.

## Competitor / duplicate check

- No open PRs referencing `#30399`.
- No open same-author PRs for `fix/30399*`.
- Keyword search for Matrix Docker dependency competitors returned no direct competitor PRs.

Auto-published by Moonsong via Path B automated pipeline.
