### PR TITLE
fix(desktop): convert epoch seconds to ms in artifact timestamp rendering

### DIFF
--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
-import { collectArtifactsForSession } from './index'
+import { collectArtifactsForSession, formatArtifactTime } from './index'
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -58,5 +58,28 @@ describe('collectArtifactsForSession', () => {
       kind: 'link',
       value: 'https://example.com/changelog/latest'
     })
+  })
+})
+
+describe('formatArtifactTime', () => {
+  it('treats small values as epoch seconds and converts to ms', () => {
+    // 1780936770 = 2026-06-08 ~19:39 UTC (epoch seconds)
+    const result = formatArtifactTime(1780936770)
+    // Should NOT be Jan 1970 — should contain a June date
+    expect(result).not.toMatch(/Jan/)
+    expect(result).toMatch(/Jun/)
+  })
+
+  it('passes through values already in milliseconds', () => {
+    // 1781036951103 = epoch milliseconds (already > 1e12)
+    const result = formatArtifactTime(1781036951103)
+    expect(result).not.toMatch(/Jan/)
+    expect(result).toMatch(/Jun/)
+  })
+
+  it('handles fractional epoch seconds', () => {
+    // 1780936770.62 — Python time.time() returns floats
+    const result = formatArtifactTime(1780936770.62)
+    expect(result).toMatch(/Jun/)
   })
 })

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -309,8 +309,11 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
   return Array.from(found.values())
 }
 
-function formatArtifactTime(timestamp: number): string {
-  return ARTIFACT_TIME_FMT.format(new Date(timestamp))
+export function formatArtifactTime(timestamp: number): string {
+  // Backend stores timestamps as epoch seconds (Python time.time()), but
+  // Date() expects milliseconds.  Values >= 1e12 are already in ms (from
+  // Date.now() or similar); smaller values are seconds and need conversion.
+  return ARTIFACT_TIME_FMT.format(new Date(timestamp < 1e12 ? timestamp * 1000 : timestamp))
 }
 
 function pageRangeLabel(total: number, page: number, pageSize: number, a: Translations['artifacts']): string {


### PR DESCRIPTION
## What does this PR do?

Fixes artifact timestamps in the Desktop "Artifacts" view rendering as January 1970. The backend stores timestamps as epoch **seconds** (Python `time.time()`), but `formatArtifactTime()` passed them directly to `new Date()` which expects **milliseconds**, causing a ~1000× misread that collapsed all dates to 1970.

## Related Issue

Fixes #42409

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/artifacts/index.tsx`: Added `< 1e12` guard in `formatArtifactTime()` to detect epoch-seconds values and multiply by 1000 before constructing the `Date`. Exported the function for testability.
- `apps/desktop/src/app/artifacts/index.test.ts`: Added 3 regression tests — epoch seconds, epoch milliseconds (passthrough), and fractional seconds.

## How to Test

1. Open the Desktop app and navigate to the Artifacts tab (Links / Files / Images)
2. Verify that timestamps show the actual session date (e.g., "Jun 8, 7:39 PM") instead of "Jan 21, 5:42 PM"
3. Run `cd apps/desktop && npx vitest run src/app/artifacts/index.test.ts` — all 5 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `formatArtifactTime` (callers: 2 in ArtifactsView component)
- Blast radius: LOW — pure display formatting, no data mutation
- Related patterns: Backend timestamps are epoch seconds throughout SessionDB; `Date.now()` fallback is already in milliseconds (handled by the `< 1e12` guard)
