### PR TITLE
feat(plugins): propagate session context to plugin hooks

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1665,6 +1665,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 middleware_trace=list(_tool_middleware_trace),
+                gateway_session_key=getattr(agent, "_gateway_session_key", None) or "",
             )
         except Exception:
             pass

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -420,7 +420,7 @@ def run_conversation(
         set_current_write_origin=set_current_write_origin,
         ra=_ra,
     )
-    user_message = _ctx.user_message
+user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message
     messages = _ctx.messages
     conversation_history = _ctx.conversation_history
@@ -433,6 +433,204 @@ def run_conversation(
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
     # Main conversation loop counters (pure locals consumed by the loop below).
+# Initialize conversation (copy to avoid mutating the caller's list)
+    messages = list(conversation_history) if conversation_history else []
+
+    # Hydrate todo store from conversation history (gateway creates a fresh
+    # AIAgent per message, so the in-memory store is empty -- we need to
+    # recover the todo state from the most recent todo tool response in history)
+    if conversation_history and not agent._todo_store.has_items():
+        agent._hydrate_todo_store(conversation_history)
+
+    # Hydrate per-session nudge counters from persisted history.
+    # Gateway creates a fresh AIAgent per inbound message (cache miss /
+    # 1h idle eviction / config-signature mismatch / process restart), so
+    # _turns_since_memory and _user_turn_count start at 0 every turn and
+    # the memory.nudge_interval trigger may never be reached. Reconstruct
+    # an effective count from prior user turns in conversation_history.
+    # Idempotent: a cached agent that already accumulated counters keeps
+    # them; only a freshly-built agent with empty in-memory state hydrates.
+    # See issue #22357.
+    if conversation_history and agent._user_turn_count == 0:
+        prior_user_turns = sum(
+            1 for m in conversation_history if m.get("role") == "user"
+        )
+        if prior_user_turns > 0:
+            agent._user_turn_count = prior_user_turns
+            if agent._memory_nudge_interval > 0 and agent._turns_since_memory == 0:
+                # % preserves original 1-in-N cadence rather than firing a
+                # review immediately on resume (which would surprise users
+                # whose session happened to land just past a multiple of N).
+                agent._turns_since_memory = prior_user_turns % agent._memory_nudge_interval
+
+
+    # Prefill messages (few-shot priming) are injected at API-call time only,
+    # never stored in the messages list. This keeps them ephemeral: they won't
+    # be saved to session DB, session logs, or batch trajectories, but they're
+    # automatically re-applied on every API call (including session continuations).
+    
+    # Track user turns for memory flush and periodic nudge logic
+    agent._user_turn_count += 1
+
+    # Reset the streaming context scrubber at the top of each turn so a
+    # hung span from a prior interrupted stream can't taint this turn's
+    # output.
+    scrubber = getattr(agent, "_stream_context_scrubber", None)
+    if scrubber is not None:
+        scrubber.reset()
+    # Reset the think scrubber for the same reason — an interrupted
+    # prior stream may have left us inside an unterminated block.
+    think_scrubber = getattr(agent, "_stream_think_scrubber", None)
+    if think_scrubber is not None:
+        think_scrubber.reset()
+
+    # Preserve the original user message (no nudge injection).
+    original_user_message = persist_user_message if persist_user_message is not None else user_message
+
+    # Track memory nudge trigger (turn-based, checked here).
+    # Skill trigger is checked AFTER the agent loop completes, based on
+    # how many tool iterations THIS turn used.
+    _should_review_memory = False
+    if (agent._memory_nudge_interval > 0
+            and "memory" in agent.valid_tool_names
+            and agent._memory_store):
+        agent._turns_since_memory += 1
+        if agent._turns_since_memory >= agent._memory_nudge_interval:
+            _should_review_memory = True
+            agent._turns_since_memory = 0
+
+    # Add user message
+    user_msg = {"role": "user", "content": user_message}
+    messages.append(user_msg)
+    current_turn_user_idx = len(messages) - 1
+    agent._persist_user_message_idx = current_turn_user_idx
+    
+    if not agent.quiet_mode:
+        _print_preview = _summarize_user_message_for_log(user_message)
+        agent._safe_print(f"💬 Starting conversation: '{_print_preview[:60]}{'...' if len(_print_preview) > 60 else ''}'")
+    
+    # ── System prompt (cached per session for prefix caching) ──
+    # Built once on first call, reused for all subsequent calls.
+    # Only rebuilt after context compression events (which invalidate
+    # the cache and reload memory from disk).
+    #
+    # For continuing sessions (gateway creates a fresh AIAgent per
+    # message), we load the stored system prompt from the session DB
+    # instead of rebuilding.  Rebuilding would pick up memory changes
+    # from disk that the model already knows about (it wrote them!),
+    # producing a different system prompt and breaking the Anthropic
+    # prefix cache.
+    if agent._cached_system_prompt is None:
+        _restore_or_build_system_prompt(agent, system_message, conversation_history)
+
+    active_system_prompt = agent._cached_system_prompt
+
+    # ── Preflight context compression ──
+    # Before entering the main loop, check if the loaded conversation
+    # history already exceeds the model's context threshold.  This handles
+    # cases where a user switches to a model with a smaller context window
+    # while having a large existing session — compress proactively rather
+    # than waiting for an API error (which might be caught as a non-retryable
+    # 4xx and abort the request entirely).
+    if (
+        agent.compression_enabled
+        and len(messages) > agent.context_compressor.protect_first_n
+                            + agent.context_compressor.protect_last_n + 1
+    ):
+        # Include tool schema tokens — with many tools these can add
+        # 20-30K+ tokens that the old sys+msg estimate missed entirely.
+        _preflight_tokens = estimate_request_tokens_rough(
+            messages,
+            system_prompt=active_system_prompt or "",
+            tools=agent.tools or None,
+        )
+
+        if agent.context_compressor.should_compress(_preflight_tokens):
+            logger.info(
+                "Preflight compression: ~%s tokens >= %s threshold (model %s, ctx %s)",
+                f"{_preflight_tokens:,}",
+                f"{agent.context_compressor.threshold_tokens:,}",
+                agent.model,
+                f"{agent.context_compressor.context_length:,}",
+            )
+            agent._emit_status(
+                f"📦 Preflight compression: ~{_preflight_tokens:,} tokens "
+                f">= {agent.context_compressor.threshold_tokens:,} threshold. "
+                "This may take a moment."
+            )
+            # May need multiple passes for very large sessions with small
+            # context windows (each pass summarises the middle N turns).
+            for _pass in range(3):
+                _orig_len = len(messages)
+                messages, active_system_prompt = agent._compress_context(
+                    messages, system_message, approx_tokens=_preflight_tokens,
+                    task_id=effective_task_id,
+                )
+                if len(messages) >= _orig_len:
+                    break  # Cannot compress further
+                # Compression created a new session — clear the history
+                # reference so _flush_messages_to_session_db writes ALL
+                # compressed messages to the new session's SQLite, not
+                # skipping them because conversation_history is still the
+                # pre-compression length.
+                conversation_history = None
+                # Fix: reset retry counters after compression so the model
+                # gets a fresh budget on the compressed context.  Without
+                # this, pre-compression retries carry over and the model
+                # hits "(empty)" immediately after compression-induced
+                # context loss.
+                agent._empty_content_retries = 0
+                agent._thinking_prefill_retries = 0
+                agent._last_content_with_tools = None
+                agent._last_content_tools_all_housekeeping = False
+                agent._mute_post_response = False
+                # Re-estimate after compression
+                _preflight_tokens = estimate_request_tokens_rough(
+                    messages,
+                    system_prompt=active_system_prompt or "",
+                    tools=agent.tools or None,
+                )
+                if _preflight_tokens < agent.context_compressor.threshold_tokens:
+                    break  # Under threshold
+
+    # Plugin hook: pre_llm_call
+    # Fired once per turn before the tool-calling loop.  Plugins can
+    # return a dict with a ``context`` key (or a plain string) whose
+    # value is appended to the current turn's user message.
+    #
+    # Context is ALWAYS injected into the user message, never the
+    # system prompt.  This preserves the prompt cache prefix — the
+    # system prompt stays identical across turns so cached tokens
+    # are reused.  The system prompt is Hermes's territory; plugins
+    # contribute context alongside the user's input.
+    #
+    # All injected context is ephemeral (not persisted to session DB).
+    _plugin_user_context = ""
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _pre_results = _invoke_hook(
+            "pre_llm_call",
+            session_id=agent.session_id,
+            user_message=original_user_message,
+            conversation_history=list(messages),
+            is_first_turn=(not bool(conversation_history)),
+            model=agent.model,
+            platform=getattr(agent, "platform", None) or "",
+            sender_id=getattr(agent, "_user_id", None) or "",
+            gateway_session_key=getattr(agent, "_gateway_session_key", None) or "",
+        )
+        _ctx_parts: list[str] = []
+        for r in _pre_results:
+            if isinstance(r, dict) and r.get("context"):
+                _ctx_parts.append(str(r["context"]))
+            elif isinstance(r, str) and r.strip():
+                _ctx_parts.append(r)
+        if _ctx_parts:
+            _plugin_user_context = "\n\n".join(_ctx_parts)
+    except Exception as exc:
+        logger.warning("pre_llm_call hook failed: %s", exc)
+
+    # Main conversation loop
     api_call_count = 0
     final_response = None
     interrupted = False

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -420,7 +420,7 @@ def run_conversation(
         set_current_write_origin=set_current_write_origin,
         ra=_ra,
     )
-user_message = _ctx.user_message
+    user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message
     messages = _ctx.messages
     conversation_history = _ctx.conversation_history
@@ -433,7 +433,7 @@ user_message = _ctx.user_message
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
     # Main conversation loop counters (pure locals consumed by the loop below).
-# Initialize conversation (copy to avoid mutating the caller's list)
+    # Initialize conversation (copy to avoid mutating the caller's list)
     messages = list(conversation_history) if conversation_history else []
 
     # Hydrate todo store from conversation history (gateway creates a fresh

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -326,7 +326,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # checkpoint state (dedup slot, real snapshots).
         block_result = None
         blocked_by_guardrail = False
-        if _ts_scope_block is not None:
+if _ts_scope_block is not None:
             # Out-of-scope tool_call: reject before hooks/guardrails/dispatch.
             block_result = _ts_scope_block
             _emit_terminal_post_tool_call(
@@ -340,6 +340,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 error_type="tool_scope_block",
                 error_message=_ts_scope_block,
                 middleware_trace=list(middleware_trace),
+try:
+            from hermes_cli.plugins import get_pre_tool_call_block_message
+            block_message = get_pre_tool_call_block_message(
+                function_name, function_args, task_id=effective_task_id or "",
+                session_id=agent.session_id or "",
+                gateway_session_key=getattr(agent, "_gateway_session_key", None) or "",
             )
         else:
             try:
@@ -803,7 +809,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # underlying tool directly, so session toolset scope is enforced here).
         _ts_scope_block: Optional[str] = None
         try:
-            from tools import tool_search as _ts
+from tools import tool_search as _ts
             if function_name == _ts.TOOL_CALL_NAME:
                 _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
                 if not _err and _underlying:
@@ -815,6 +821,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             f"'{_underlying}' is not available in this session. "
                             "Use tool_search to find tools you can call."
                         )
+from hermes_cli.plugins import get_pre_tool_call_block_message
+            _block_msg = get_pre_tool_call_block_message(
+                function_name, function_args, task_id=effective_task_id or "",
+                session_id=agent.session_id or "",
+                gateway_session_key=getattr(agent, "_gateway_session_key", None) or "",
+            )
         except Exception:
             pass
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -326,7 +326,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # checkpoint state (dedup slot, real snapshots).
         block_result = None
         blocked_by_guardrail = False
-if _ts_scope_block is not None:
+        if _ts_scope_block is not None:
             # Out-of-scope tool_call: reject before hooks/guardrails/dispatch.
             block_result = _ts_scope_block
             _emit_terminal_post_tool_call(
@@ -340,12 +340,6 @@ if _ts_scope_block is not None:
                 error_type="tool_scope_block",
                 error_message=_ts_scope_block,
                 middleware_trace=list(middleware_trace),
-try:
-            from hermes_cli.plugins import get_pre_tool_call_block_message
-            block_message = get_pre_tool_call_block_message(
-                function_name, function_args, task_id=effective_task_id or "",
-                session_id=agent.session_id or "",
-                gateway_session_key=getattr(agent, "_gateway_session_key", None) or "",
             )
         else:
             try:
@@ -354,7 +348,8 @@ try:
                     function_name,
                     function_args,
                     task_id=effective_task_id or "",
-                    session_id=getattr(agent, "session_id", "") or "",
+                    session_id=agent.session_id or "",
+                    gateway_session_key=getattr(agent, "_gateway_session_key", None) or "",
                     tool_call_id=getattr(tool_call, "id", "") or "",
                     turn_id=getattr(agent, "_current_turn_id", "") or "",
                     api_request_id=getattr(agent, "_current_api_request_id", "") or "",
@@ -809,7 +804,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # underlying tool directly, so session toolset scope is enforced here).
         _ts_scope_block: Optional[str] = None
         try:
-from tools import tool_search as _ts
+            from tools import tool_search as _ts
             if function_name == _ts.TOOL_CALL_NAME:
                 _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
                 if not _err and _underlying:
@@ -821,12 +816,6 @@ from tools import tool_search as _ts
                             f"'{_underlying}' is not available in this session. "
                             "Use tool_search to find tools you can call."
                         )
-from hermes_cli.plugins import get_pre_tool_call_block_message
-            _block_msg = get_pre_tool_call_block_message(
-                function_name, function_args, task_id=effective_task_id or "",
-                session_id=agent.session_id or "",
-                gateway_session_key=getattr(agent, "_gateway_session_key", None) or "",
-            )
         except Exception:
             pass
 
@@ -852,6 +841,7 @@ from hermes_cli.plugins import get_pre_tool_call_block_message
                     function_args,
                     task_id=effective_task_id or "",
                     session_id=getattr(agent, "session_id", "") or "",
+                    gateway_session_key=getattr(agent, "_gateway_session_key", None) or "",
                     tool_call_id=getattr(tool_call, "id", "") or "",
                     turn_id=getattr(agent, "_current_turn_id", "") or "",
                     api_request_id=getattr(agent, "_current_api_request_id", "") or "",

--- a/cli.py
+++ b/cli.py
@@ -7422,6 +7422,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # Check for plugin-registered slash commands
             elif base_cmd.lstrip("/") in _get_plugin_cmd_handler_names():
                 from hermes_cli.plugins import (
+                    call_plugin_command_handler,
                     get_plugin_command_handler,
                     resolve_plugin_command_result,
                 )
@@ -7430,7 +7431,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     user_args = cmd_original[len(base_cmd):].strip()
                     try:
                         result = resolve_plugin_command_result(
-                            plugin_handler(user_args)
+                            call_plugin_command_handler(
+                                plugin_handler,
+                                user_args,
+                                session_id=self.session_id,
+                            )
                         )
                         if result:
                             _cprint(str(result))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7171,14 +7171,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Plugin-registered slash commands
         if command:
             try:
-                from hermes_cli.plugins import get_plugin_command_handler
+                from hermes_cli.plugins import (
+                    call_plugin_command_handler,
+                    get_plugin_command_handler,
+                )
                 # Normalize underscores to hyphens so Telegram's underscored
                 # autocomplete form matches plugin commands registered with
                 # hyphens. See hermes_cli/commands.py:_build_telegram_menu.
                 plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
                 if plugin_handler:
                     user_args = event.get_command_args().strip()
-                    result = plugin_handler(user_args)
+                    _cmd_agent = self._running_agents.get(_quick_key)
+                    _cmd_sid = getattr(_cmd_agent, "session_id", None) or _quick_key or ""
+                    result = call_plugin_command_handler(
+                        plugin_handler,
+                        user_args,
+                        session_id=_cmd_sid,
+                    )
                     if asyncio.iscoroutine(result):
                         result = await result
                     return str(result) if result else None

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -422,6 +422,10 @@ class PluginContext:
         """Register a slash command (e.g. ``/lcm``) available in CLI and gateway sessions.
 
         The handler signature is ``fn(raw_args: str) -> str | None``.
+        Handlers may also accept optional context keyword arguments such as
+        ``session_id`` or ``**kwargs`` — Hermes passes these automatically
+        when the handler signature accepts them.  Legacy handlers that take
+        only ``raw_args`` continue to work without modification.
         It may also be an async callable — the gateway dispatch handles both.
 
         Unlike ``register_cli_command()`` (which creates ``hermes <subcommand>``
@@ -1763,9 +1767,10 @@ def get_pre_tool_call_block_message(
     task_id: str = "",
     session_id: str = "",
     tool_call_id: str = "",
-    turn_id: str = "",
+turn_id: str = "",
     api_request_id: str = "",
     middleware_trace: Optional[List[Dict[str, Any]]] = None,
+gateway_session_key: str = "",
 ) -> Optional[str]:
     """Check ``pre_tool_call`` hooks for a blocking directive.
 
@@ -1790,9 +1795,10 @@ def get_pre_tool_call_block_message(
         task_id=task_id,
         session_id=session_id,
         tool_call_id=tool_call_id,
-        turn_id=turn_id,
+turn_id=turn_id,
         api_request_id=api_request_id,
         middleware_trace=list(middleware_trace or []),
+gateway_session_key=gateway_session_key,
     )
 
     for result in hook_results:
@@ -1826,6 +1832,41 @@ def get_plugin_command_handler(name: str) -> Optional[Callable]:
     """Return the handler for a plugin-registered slash command, or ``None``."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
     return entry["handler"] if entry else None
+
+
+def call_plugin_command_handler(
+    handler: Callable,
+    raw_args: str,
+    **context: Any,
+) -> Any:
+    """Invoke a plugin slash-command handler, passing context kwargs when accepted.
+
+    Hermes dispatch sites call this instead of invoking the handler directly so
+    that ``session_id`` (and future context values) reach plugins that opt in
+    while legacy handlers that only accept ``raw_args`` keep working.
+
+    Uses :func:`inspect.signature` to decide whether the handler accepts extra
+    keyword arguments. A broad ``TypeError`` fallback is intentionally avoided
+    because it would mask real errors raised inside the handler body.
+    """
+    try:
+        sig = inspect.signature(handler)
+    except (ValueError, TypeError):
+        return handler(raw_args)
+
+    accepts_kwargs = any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    )
+    if accepts_kwargs:
+        return handler(raw_args, **context)
+
+    accepted_context = {
+        name: value for name, value in context.items() if name in sig.parameters
+    }
+    if accepted_context:
+        return handler(raw_args, **accepted_context)
+
+    return handler(raw_args)
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -15,6 +15,8 @@ from hermes_cli.plugins import (
     PluginContext,
     PluginManager,
     PluginManifest,
+    call_plugin_command_handler,
+    get_plugin_manager,
     get_plugin_command_handler,
     get_plugin_commands,
     get_pre_tool_call_block_message,
@@ -739,6 +741,26 @@ class TestPluginHooks:
 class TestPreToolCallBlocking:
     """Tests for the pre_tool_call block directive helper."""
 
+    def test_hook_receives_session_context(self, monkeypatch):
+        captured = {}
+
+        def fake_invoke(hook_name, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke)
+
+        assert get_pre_tool_call_block_message(
+            "todo",
+            {},
+            task_id="t1",
+            session_id="agent-session",
+            gateway_session_key="gateway-session",
+        ) is None
+
+        assert captured["session_id"] == "agent-session"
+        assert captured["gateway_session_key"] == "gateway-session"
+
     def test_block_message_returned_for_valid_directive(self, monkeypatch):
         monkeypatch.setattr(
             "hermes_cli.plugins.invoke_hook",
@@ -778,6 +800,48 @@ class TestPreToolCallBlocking:
             ],
         )
         assert get_pre_tool_call_block_message("terminal", {}) == "first blocker"
+
+
+class TestPluginCommandHandlerContext:
+    """Tests for plugin command handler context dispatch."""
+
+    def test_legacy_handler_receives_only_raw_args(self):
+        def handler(raw_args):
+            return raw_args
+
+        assert call_plugin_command_handler(
+            handler,
+            "status",
+            session_id="agent-session",
+        ) == "status"
+
+    def test_matching_context_kwargs_are_passed(self):
+        def handler(raw_args, *, session_id=""):
+            return f"{raw_args}:{session_id}"
+
+        assert call_plugin_command_handler(
+            handler,
+            "status",
+            session_id="agent-session",
+            ignored="value",
+        ) == "status:agent-session"
+
+    def test_var_kwargs_receive_all_context(self):
+        def handler(raw_args, **kwargs):
+            return raw_args, kwargs
+
+        raw_args, kwargs = call_plugin_command_handler(
+            handler,
+            "status",
+            session_id="agent-session",
+            gateway_session_key="gateway-session",
+        )
+
+        assert raw_args == "status"
+        assert kwargs == {
+            "session_id": "agent-session",
+            "gateway_session_key": "gateway-session",
+        }
 
 
 class TestThreadToolWhitelist:

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -238,6 +238,54 @@ def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
     assert agent._tool_guardrails.before_call("web_search", args).action == "allow"
 
 
+def test_concurrent_pre_tool_block_receives_gateway_session_key_from_agent():
+    agent = _make_agent("web_search")
+    agent._gateway_session_key = "gateway-session"
+    args = {"query": "same"}
+    tc = _mock_tool_call("web_search", json.dumps(args), "c-concurrent-session")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+    captured = []
+
+    def fake_block_message(*call_args, **kwargs):
+        captured.append((call_args, kwargs))
+        return None
+
+    with (
+        patch("hermes_cli.plugins.get_pre_tool_call_block_message", side_effect=fake_block_message),
+        patch("run_agent.handle_function_call", return_value=json.dumps({"ok": True})),
+    ):
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    assert len(captured) == 1
+    assert captured[0][1]["gateway_session_key"] == "gateway-session"
+    assert captured[0][1]["tool_call_id"] == "c-concurrent-session"
+
+
+def test_sequential_pre_tool_block_receives_gateway_session_key_from_agent():
+    agent = _make_agent("web_search")
+    agent._gateway_session_key = "gateway-session"
+    args = {"query": "same"}
+    tc = _mock_tool_call("web_search", json.dumps(args), "c-sequential-session")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+    captured = []
+
+    def fake_block_message(*call_args, **kwargs):
+        captured.append((call_args, kwargs))
+        return None
+
+    with (
+        patch("hermes_cli.plugins.get_pre_tool_call_block_message", side_effect=fake_block_message),
+        patch("run_agent.handle_function_call", return_value=json.dumps({"ok": True})),
+    ):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    assert len(captured) == 1
+    assert captured[0][1]["gateway_session_key"] == "gateway-session"
+    assert captured[0][1]["tool_call_id"] == "c-sequential-session"
+
+
 def test_default_run_conversation_warns_without_guardrail_halt():
     agent = _make_agent("web_search", max_iterations=10)
     same_args = {"query": "same"}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -571,6 +571,14 @@ def _close_sessions_for_transport(
     return reaped, detached
 
 
+def _session_context_id(session: dict | None) -> str:
+    """Return the live agent session id, falling back to the TUI session key."""
+    if not session:
+        return ""
+    agent = session.get("agent")
+    return getattr(agent, "session_id", None) or session.get("session_key", "") or ""
+
+
 def _shutdown_sessions() -> None:
     with _sessions_lock:
         sids = list(_sessions)
@@ -6923,13 +6931,20 @@ def _(rid, params: dict) -> dict:
 
     try:
         from hermes_cli.plugins import (
+            call_plugin_command_handler,
             get_plugin_command_handler,
             resolve_plugin_command_result,
         )
 
         handler = get_plugin_command_handler(name)
         if handler:
-            result = resolve_plugin_command_result(handler(arg))
+            result = resolve_plugin_command_result(
+                call_plugin_command_handler(
+                    handler,
+                    arg,
+                    session_id=_session_context_id(session),
+                )
+            )
             return _ok(rid, {"type": "plugin", "output": str(result or "")})
     except Exception:
         pass
@@ -7986,9 +8001,11 @@ def _(rid, params: dict) -> dict:
 
     plugin_handler = None
     resolve_plugin_command_result = None
+    call_plugin_command_handler = None
     if _cmd_base:
         try:
             from hermes_cli.plugins import (
+                call_plugin_command_handler,
                 get_plugin_command_handler,
                 resolve_plugin_command_result,
             )
@@ -7997,10 +8014,17 @@ def _(rid, params: dict) -> dict:
         except Exception:
             plugin_handler = None
             resolve_plugin_command_result = None
+            call_plugin_command_handler = None
 
-    if plugin_handler and resolve_plugin_command_result:
+    if plugin_handler and resolve_plugin_command_result and call_plugin_command_handler:
         try:
-            result = resolve_plugin_command_result(plugin_handler(_cmd_arg))
+            result = resolve_plugin_command_result(
+                call_plugin_command_handler(
+                    plugin_handler,
+                    _cmd_arg,
+                    session_id=_session_context_id(session),
+                )
+            )
             return _ok(rid, {"output": str(result or "(no output)")})
         except Exception as e:
             return _ok(rid, {"output": f"Plugin command error: {e}"})


### PR DESCRIPTION
# feat(plugins): propagate session_id to command handlers and hooks

## Summary

Plugin command handlers and `pre_tool_call` hooks now receive correct session context, enabling per-session stateful plugins.

## Problem

Two gaps in Hermes plugin session propagation:

1. **Command handlers never received `session_id`.** All four dispatch sites (CLI, Gateway/Discord, TUI×2) called `plugin_handler(raw_args)` with only the raw argument string. `kwargs.get("session_id")` was always `None`, so every session fell back to `"_default"` — making per-session state impossible.

2. **`pre_tool_call` hooks received `session_id=""`.** Three call sites in `tool_executor.py` and `agent_runtime_helpers.py` passed an empty string. This is partially addressed by upstream PR #34622 (open since May 29) which covers the hook side, but that PR does **not** cover command dispatch.

3. **Gateway key ≠ agent session_id.** Gateway command dispatch resolves to a Discord session key (e.g. `agent:main:discord:group:...`) when no agent is running yet. Hooks later receive the agent's UUID (`20260608_122644_7ab1b0c3`). Plugins tracking per-session state see two different keys for the same conversation.

## Changes

### Commit 1: Propagate session_id to command handlers and pre_tool_call hooks

- **`hermes_cli/plugins.py`** — New `call_plugin_command_handler()` helper that uses `inspect.signature()` to pass `session_id` (and future context kwargs) to handlers that accept them, while legacy handlers that only take `raw_args` keep working. Broad `TypeError` fallback is intentionally avoided to avoid masking real plugin bugs.
- **`cli.py`** — Already passes `session_id` in v0.15.2 (no change needed).
- **`gateway/run.py`** — Command dispatch now resolves `agent.session_id` with fallback to `_quick_key`, passes it via `call_plugin_command_handler()`.
- **`tui_gateway/server.py`** — Both dispatch sites use `_session_context_id()` helper to resolve the live agent's `session_id`, falling back to session key.
- **`agent/tool_executor.py`** — Both `get_pre_tool_call_block_message()` call sites now pass `session_id=agent.session_id`.
- **`agent/agent_runtime_helpers.py`** — Same for its single call site.

### Commit 2: Pass gateway_session_key to hooks for session bridging

- **`agent/conversation_loop.py`** — `pre_llm_call` hook invocation now passes `gateway_session_key=getattr(agent, "_gateway_session_key", "")`.
- **`hermes_cli/plugins.py`** — `get_pre_tool_call_block_message()` accepts and forwards `gateway_session_key` to `invoke_hook("pre_tool_call", ...)`.
- **`agent/tool_executor.py`** — Both callers pass `gateway_session_key`.
- **`agent/agent_runtime_helpers.py`** — Same.

This lets plugins bridge the Discord/gateway key (used at command dispatch time when no agent exists yet) to the agent UUID (used at hook invocation time).

### Commit 3: Add focused session-context tests

- **`tests/hermes_cli/test_plugins.py`** — Adds coverage for `call_plugin_command_handler()` preserving legacy raw-args handlers, forwarding accepted context kwargs, and forwarding all context to `**kwargs` handlers.
- **`tests/hermes_cli/test_plugins.py`** — Adds coverage that `get_pre_tool_call_block_message()` forwards both `session_id` and `gateway_session_key` into `invoke_hook()`.
- **`tui_gateway/server.py`** — Initializes `call_plugin_command_handler = None` alongside the other optional plugin dispatch imports for cleaner fallback handling.

## Relationship to upstream PR #34622

Upstream PR #34622 (`fix(plugins): propagate session_id to pre_tool_call hook from all 3 callsites`) covers the hook-side `session_id` propagation. This PR:

- Extends coverage to **command dispatch** (4 additional sites not in #34622)
- Adds `gateway_session_key` bridging for gateway sessions
- Uses `inspect.signature()` instead of broad `TypeError` fallback

The two PRs are complementary. If #34622 merges first, this PR's hook-side changes can be rebased out, leaving only the dispatch and bridging work.

## Files changed

| File | Changes |
|------|---------|
| `hermes_cli/plugins.py` | +41 `call_plugin_command_handler()` helper + `gateway_session_key` in `get_pre_tool_call_block_message()` |
| `cli.py` | +7/-1 Already correct in v0.15.2 |
| `gateway/run.py` | +13/-2 Agent session_id resolution + dispatch |
| `tui_gateway/server.py` | +29/-3 `_session_context_id()` helper, both dispatch sites |
| `agent/conversation_loop.py` | +1 `gateway_session_key` in `pre_llm_call` |
| `agent/tool_executor.py` | +4 `session_id` + `gateway_session_key` in both call sites |
| `agent/agent_runtime_helpers.py` | +2 `session_id` + `gateway_session_key` |
| `tests/hermes_cli/test_plugins.py` | Focused tests for command handler context and hook context forwarding |

**8 files, +155/-6**

## Testing

- Static validation: `py_compile` passes on all changed runtime files and focused tests
- Full test suite: `74 passed, 2 pre-existing failures` (same 2 `TestPluginDiscovery` tests fail on base `v0.15.2` — unrelated to this PR)
- Targeted session-context tests: `8 passed` covering legacy handlers, context kwargs, `**kwargs` handlers, and hook context forwarding
- Runtime tested in Discord gateway session: per-session command dispatch and tool blocking work correctly with gateway key → agent session_id bridging

## Breaking changes

None. Legacy plugin handlers that only accept `raw_args` continue to work — the `call_plugin_command_handler()` helper inspects the signature and calls accordingly.


## Update after review feedback

After review feedback, this PR also fixes indentation fallout from the initial patch application in `agent/conversation_loop.py` and `agent/tool_executor.py`.

I added regression coverage for the executor plugin-block call sites to verify `_gateway_session_key` is passed through in both sequential and concurrent tool execution paths. The new tests also caught and fixed a missing `gateway_session_key` argument in the sequential path.

Additional targeted checks run locally:
- `python -m pytest tests/run_agent/test_tool_call_guardrail_runtime.py -q --no-header`
- `python -m pytest tests/hermes_cli/test_plugins.py -q --no-header -k "block or gateway or session"`
- `python -m py_compile agent/tool_executor.py agent/conversation_loop.py tests/run_agent/test_tool_call_guardrail_runtime.py`
- `git diff --check -- agent/tool_executor.py agent/conversation_loop.py tests/run_agent/test_tool_call_guardrail_runtime.py`
