### PR TITLE
fix(memory): return current entries on replace/remove zero-match to break retry loop

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -326,6 +326,10 @@ class TestMemoryStoreReplace:
         store.add("memory", "fact A")
         result = store.replace("memory", "nonexistent", "new")
         assert result["success"] is False
+        assert "No entry matched" in result["error"]
+        # Zero-match branch must return current entries so the agent can self-correct
+        assert result["current_entries"] == ["fact A"]
+        assert result["entry_previews"] == ["fact A"]
 
     def test_replace_ambiguous_match(self, store):
         store.add("memory", "server A runs nginx")
@@ -357,8 +361,12 @@ class TestMemoryStoreRemove:
         assert len(store.memory_entries) == 0
 
     def test_remove_no_match(self, store):
+        store.add("memory", "fact A")
         result = store.remove("memory", "nonexistent")
         assert result["success"] is False
+        # Zero-match branch must return current entries so the agent can self-correct
+        assert result["current_entries"] == ["fact A"]
+        assert result["entry_previews"] == ["fact A"]
 
     def test_remove_empty_old_text(self, store):
         result = store.remove("memory", "  ")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -369,7 +369,13 @@ class MemoryStore:
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
 
             if not matches:
-                return {"success": False, "error": f"No entry matched '{old_text}'."}
+                previews = [e[:80] + ("..." if len(e) > 80 else "") for e in entries]
+                return {
+                    "success": False,
+                    "error": f"No entry matched '{old_text}'.",
+                    "current_entries": entries,
+                    "entry_previews": previews,
+                }
 
             if len(matches) > 1:
                 # If all matches are identical (exact duplicates), operate on the first one
@@ -426,7 +432,13 @@ class MemoryStore:
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
 
             if not matches:
-                return {"success": False, "error": f"No entry matched '{old_text}'."}
+                previews = [e[:80] + ("..." if len(e) > 80 else "") for e in entries]
+                return {
+                    "success": False,
+                    "error": f"No entry matched '{old_text}'.",
+                    "current_entries": entries,
+                    "entry_previews": previews,
+                }
 
             if len(matches) > 1:
                 # If all matches are identical (exact duplicates), remove the first one


### PR DESCRIPTION
## What does this PR do?

Fixes a silent hang when `memory replace` fails to find a substring match. The zero-match error response now includes `current_entries` and `entry_previews`, giving the agent visibility into stored entries so it can self-correct instead of retrying blindly until the iteration budget is exhausted.

## Related Issue

Fixes #42405

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py`: Added `current_entries` and `entry_previews` to the zero-match error response in both `replace()` and `remove()` methods, matching the existing pattern used by `add()` on the limit error.
- `tests/tools/test_memory_tool.py`: Updated `test_replace_no_match` and `test_remove_no_match` to verify the new fields are returned.

## How to Test

1. Fill `USER.md` or `MEMORY.md` to near its character limit with several entries
2. Prompt the agent to save a new memory — it will hit the limit, attempt `replace` with an inexact quote
3. Previously: agent loops silently with "No entry matched" until turn ends with no response
4. Now: agent receives current entries and can retry with a correct substring
5. Run `python -m pytest tests/tools/test_memory_tool.py -v` — all 69 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `MemoryStore.replace()`, `MemoryStore.remove()` (callers: agent tool dispatch via `memory` tool)
- Blast radius: LOW — adds fields to error responses, no behavior change on success paths
- Related patterns: `add()` already returns `current_entries` on limit error (line 337); `replace()` multi-match branch returns `matches: previews` (line 380). This fix aligns the zero-match branch with both existing patterns.
