### PR TITLE
feat(google-workspace): add Google Tasks support

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -286,6 +286,42 @@ $GAPI docs create --title "Draft" --body "First paragraph..."
 $GAPI docs append DOC_ID --text "Additional content to append"
 ```
 
+### Tasks
+
+```bash
+# List task lists
+$GAPI tasks tasklists list
+
+# Create / rename / delete a task list
+$GAPI tasks tasklists create --title "Work"
+$GAPI tasks tasklists update TASKLIST_ID --title "Work Projects"
+$GAPI tasks tasklists delete TASKLIST_ID
+
+# List tasks in a task list
+$GAPI tasks tasks list TASKLIST_ID --max 50
+$GAPI tasks tasks list TASKLIST_ID --show-completed --due-min 2026-06-01T00:00:00Z
+
+# Create a task or subtask
+$GAPI tasks tasks create TASKLIST_ID --title "Buy milk" --notes "2%"
+$GAPI tasks tasks create TASKLIST_ID --title "Draft slides" --parent PARENT_TASK_ID
+
+# Update / move / delete / clear completed tasks
+$GAPI tasks tasks update TASKLIST_ID TASK_ID --status completed --completed 2026-06-10T18:05:00Z
+$GAPI tasks tasks move TASKLIST_ID TASK_ID --previous OTHER_TASK_ID
+$GAPI tasks tasks delete TASKLIST_ID TASK_ID
+$GAPI tasks tasks clear TASKLIST_ID
+```
+
+### How this relates to Hermes task management
+
+Hermes already has its own built-in task systems:
+
+- `todo` — session-local planning for the current conversation
+- `cronjob` — scheduled reminders and recurring jobs
+- `kanban` — durable multi-agent work queues
+
+Google Tasks is separate: this skill lets Hermes read and modify your actual Google Tasks lists through the Google Tasks API. It does **not** automatically sync the built-in `todo` tool with Google Tasks.
+
 ## Output Format
 
 All commands return JSON. Parse with `jq` or read directly. Key fields:
@@ -307,14 +343,18 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 - **Sheets create**: `{status: "created", spreadsheetId, title, spreadsheetUrl}`
 - **Docs create**: `{status: "created", documentId, title, url}`
 - **Docs append**: `{status: "appended", documentId, inserted_at, characters}`
+- **Tasks tasklists list**: `[{id, title, updated, selfLink}]`
+- **Tasks tasks list**: `[{id, title, status, notes, due, completed, updated, deleted, hidden, position, parent, selfLink}]`
+- **Tasks writes**: `{status, tasklist? | task?}`
 
 ## Rules
 
-1. **Never send email, create/delete calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, file IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
+1. **Never send email, create/delete calendar events, delete Drive files, share files, modify Docs/Sheets, or change Google Tasks without confirming with the user first.** Show what will be done (recipients, file IDs, task IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
 2. **Check auth before first use** — run `setup.py --check`. If it fails, guide the user through setup.
 3. **Use the Gmail search syntax reference** for complex queries — load it with `skill_view("google-workspace", file_path="references/gmail-search-syntax.md")`.
 4. **Calendar times must include timezone** — always use ISO 8601 with offset (e.g., `2026-03-01T10:00:00-06:00`) or UTC (`Z`).
-5. **Respect rate limits** — avoid rapid-fire sequential API calls. Batch reads when possible.
+5. **Tasks due/completed timestamps should also use ISO 8601** — preferably UTC (`Z`) or an explicit offset.
+6. **Respect rate limits** — avoid rapid-fire sequential API calls. Batch reads when possible.
 
 ## Troubleshooting
 
@@ -323,7 +363,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 | `NOT_AUTHENTICATED` | Run setup Steps 2-5 above |
 | `REFRESH_FAILED` | Token revoked or expired — redo Steps 3-5 |
 | `HttpError 403: Insufficient Permission` | Missing API scope — `$GSETUP --revoke` then redo Steps 3-5 |
-| `AUTHENTICATED (partial)` or "Token missing scopes" | New write capabilities (Drive write/delete, Docs create/edit) require re-authorization. `$GSETUP --revoke` then redo Steps 3-5 to grant the upgraded scopes. |
+| `AUTHENTICATED (partial)` or "Token missing scopes" | New write capabilities (Drive write/delete, Docs create/edit, Google Tasks) require re-authorization. `$GSETUP --revoke` then redo Steps 3-5 to grant the upgraded scopes. |
 | `HttpError 403: Access Not Configured` | API not enabled — user needs to enable it in Google Cloud Console |
 | `ModuleNotFoundError` | Run `$GSETUP --install-deps` |
 | Advanced Protection blocks auth | Workspace admin must allowlist the OAuth client ID |

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -58,6 +58,12 @@ SCOPES = [
     "https://www.googleapis.com/auth/tasks.readonly",
 ]
 
+_SCOPE_IMPLICATIONS = {
+    "https://www.googleapis.com/auth/tasks": {
+        "https://www.googleapis.com/auth/tasks.readonly",
+    },
+}
+
 
 def _normalize_authorized_user_payload(payload: dict) -> dict:
     normalized = dict(payload)
@@ -73,15 +79,68 @@ def _ensure_authenticated():
         sys.exit(1)
 
 
-def _stored_token_scopes() -> list[str]:
+def _scope_list(raw) -> list[str]:
+    if not raw:
+        return []
+    values = raw.split() if isinstance(raw, str) else raw
+    return [s.strip() for s in values if isinstance(s, str) and s.strip()]
+
+
+def _expand_granted_scopes(scopes: list[str]) -> set[str]:
+    expanded = set(scopes)
+    for scope in list(expanded):
+        expanded.update(_SCOPE_IMPLICATIONS.get(scope, set()))
+    return expanded
+
+
+def _stored_token_payload() -> dict:
     try:
-        data = json.loads(TOKEN_PATH.read_text())
+        return json.loads(TOKEN_PATH.read_text())
     except Exception:
-        return list(SCOPES)
-    scopes = data.get("scopes")
-    if isinstance(scopes, list) and scopes:
-        return scopes
+        return {}
+
+
+def _stored_token_scope_list() -> list[str]:
+    data = _stored_token_payload()
+    scopes = data.get("scopes") or data.get("scope")
+    if scopes:
+        return _scope_list(scopes)
     return list(SCOPES)
+
+
+def _stored_token_scopes() -> list[str]:
+    return _stored_token_scope_list()
+
+
+def _normalized_scope_payload_for_save(creds, *, existing_payload: dict | None = None) -> dict:
+    token_payload = _normalize_authorized_user_payload(json.loads(creds.to_json()))
+    actually_granted = []
+    if hasattr(creds, "granted_scopes") and creds.granted_scopes:
+        actually_granted = _scope_list(list(creds.granted_scopes))
+    if actually_granted:
+        token_payload["scopes"] = actually_granted
+        return token_payload
+
+    existing_scopes = _scope_list((existing_payload or {}).get("scopes") or (existing_payload or {}).get("scope"))
+    if existing_scopes:
+        token_payload["scopes"] = existing_scopes
+    return token_payload
+
+
+def _require_scopes(required_scopes: list[str]):
+    granted = _expand_granted_scopes(_stored_token_scope_list())
+    missing = [scope for scope in required_scopes if scope not in granted]
+    if missing:
+        joined = ", ".join(missing)
+        print(
+            f"ERROR: Token missing required Google Workspace scopes for this operation: {joined}",
+            file=sys.stderr,
+        )
+        print(
+            f"Re-run: python {Path(__file__).parent / 'setup.py'} --revoke && python {Path(__file__).parent / 'setup.py'} --auth-url",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 def _gws_binary() -> str | None:
@@ -195,7 +254,7 @@ def get_credentials():
         creds.refresh(Request())
         TOKEN_PATH.write_text(
             json.dumps(
-                _normalize_authorized_user_payload(json.loads(creds.to_json())),
+                _normalized_scope_payload_for_save(creds, existing_payload=_stored_token_payload()),
                 indent=2,
             )
         )
@@ -1083,6 +1142,7 @@ def _docs_insert_text(doc_id: str, text: str, index: int) -> None:
 
 
 def tasks_tasklists_list(args):
+    _require_scopes(["https://www.googleapis.com/auth/tasks.readonly"])
     service = build_service("tasks", "v1")
     result = service.tasklists().list(maxResults=args.max).execute()
     tasklists = [_normalize_tasklist_resource(tl) for tl in result.get("items", [])]
@@ -1090,6 +1150,7 @@ def tasks_tasklists_list(args):
 
 
 def tasks_tasklists_create(args):
+    _require_scopes(["https://www.googleapis.com/auth/tasks"])
     service = build_service("tasks", "v1")
     result = service.tasklists().insert(body={"title": args.title}).execute()
     print(json.dumps({
@@ -1099,6 +1160,7 @@ def tasks_tasklists_create(args):
 
 
 def tasks_tasklists_update(args):
+    _require_scopes(["https://www.googleapis.com/auth/tasks"])
     service = build_service("tasks", "v1")
     result = service.tasklists().patch(
         tasklist=args.tasklist_id,
@@ -1111,6 +1173,7 @@ def tasks_tasklists_update(args):
 
 
 def tasks_tasklists_delete(args):
+    _require_scopes(["https://www.googleapis.com/auth/tasks"])
     service = build_service("tasks", "v1")
     service.tasklists().delete(tasklist=args.tasklist_id).execute()
     print(json.dumps({
@@ -1120,6 +1183,7 @@ def tasks_tasklists_delete(args):
 
 
 def tasks_tasks_list(args):
+    _require_scopes(["https://www.googleapis.com/auth/tasks.readonly"])
     service = build_service("tasks", "v1")
     params = {
         "tasklist": args.tasklist_id,
@@ -1138,6 +1202,7 @@ def tasks_tasks_list(args):
 
 
 def tasks_tasks_create(args):
+    _require_scopes(["https://www.googleapis.com/auth/tasks"])
     service = build_service("tasks", "v1")
     body = {"title": args.title}
     if args.notes:
@@ -1159,6 +1224,7 @@ def tasks_tasks_create(args):
 
 
 def tasks_tasks_update(args):
+    _require_scopes(["https://www.googleapis.com/auth/tasks"])
     service = build_service("tasks", "v1")
     body = {}
     if args.title:
@@ -1192,6 +1258,7 @@ def tasks_tasks_update(args):
 
 
 def tasks_tasks_delete(args):
+    _require_scopes(["https://www.googleapis.com/auth/tasks"])
     service = build_service("tasks", "v1")
     service.tasks().delete(tasklist=args.tasklist_id, task=args.task_id).execute()
     print(json.dumps({
@@ -1202,6 +1269,7 @@ def tasks_tasks_delete(args):
 
 
 def tasks_tasks_move(args):
+    _require_scopes(["https://www.googleapis.com/auth/tasks"])
     service = build_service("tasks", "v1")
     params = {"tasklist": args.tasklist_id, "task": args.task_id}
     if args.parent:
@@ -1216,6 +1284,7 @@ def tasks_tasks_move(args):
 
 
 def tasks_tasks_clear(args):
+    _require_scopes(["https://www.googleapis.com/auth/tasks"])
     service = build_service("tasks", "v1")
     service.tasks().clear(tasklist=args.tasklist_id).execute()
     print(json.dumps({

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -18,6 +18,9 @@ Usage:
   python google_api.py sheets update SHEET_ID RANGE --values '[[...]]'
   python google_api.py sheets append SHEET_ID RANGE --values '[[...]]'
   python google_api.py docs get DOC_ID
+  python google_api.py tasks tasklists list [--max 20]
+  python google_api.py tasks tasks list TASKLIST_ID [--max 50]
+  python google_api.py tasks tasks create TASKLIST_ID --title "Buy milk"
 """
 
 import argparse
@@ -51,6 +54,8 @@ SCOPES = [
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/tasks",
+    "https://www.googleapis.com/auth/tasks.readonly",
 ]
 
 
@@ -204,6 +209,32 @@ def build_service(api, version):
     from googleapiclient.discovery import build
 
     return build(api, version, credentials=get_credentials())
+
+
+def _normalize_task_resource(task: dict) -> dict:
+    return {
+        "id": task.get("id", ""),
+        "title": task.get("title", ""),
+        "status": task.get("status", ""),
+        "notes": task.get("notes", ""),
+        "due": task.get("due", ""),
+        "completed": task.get("completed", ""),
+        "updated": task.get("updated", ""),
+        "deleted": bool(task.get("deleted", False)),
+        "hidden": bool(task.get("hidden", False)),
+        "position": task.get("position", ""),
+        "parent": task.get("parent", ""),
+        "selfLink": task.get("selfLink", ""),
+    }
+
+
+def _normalize_tasklist_resource(tasklist: dict) -> dict:
+    return {
+        "id": tasklist.get("id", ""),
+        "title": tasklist.get("title", ""),
+        "updated": tasklist.get("updated", ""),
+        "selfLink": tasklist.get("selfLink", ""),
+    }
 
 
 # =========================================================================
@@ -1047,6 +1078,153 @@ def _docs_insert_text(doc_id: str, text: str, index: int) -> None:
 
 
 # =========================================================================
+# Tasks
+# =========================================================================
+
+
+def tasks_tasklists_list(args):
+    service = build_service("tasks", "v1")
+    result = service.tasklists().list(maxResults=args.max).execute()
+    tasklists = [_normalize_tasklist_resource(tl) for tl in result.get("items", [])]
+    print(json.dumps(tasklists, indent=2, ensure_ascii=False))
+
+
+def tasks_tasklists_create(args):
+    service = build_service("tasks", "v1")
+    result = service.tasklists().insert(body={"title": args.title}).execute()
+    print(json.dumps({
+        "status": "created",
+        "tasklist": _normalize_tasklist_resource(result),
+    }, indent=2, ensure_ascii=False))
+
+
+def tasks_tasklists_update(args):
+    service = build_service("tasks", "v1")
+    result = service.tasklists().patch(
+        tasklist=args.tasklist_id,
+        body={"title": args.title},
+    ).execute()
+    print(json.dumps({
+        "status": "updated",
+        "tasklist": _normalize_tasklist_resource(result),
+    }, indent=2, ensure_ascii=False))
+
+
+def tasks_tasklists_delete(args):
+    service = build_service("tasks", "v1")
+    service.tasklists().delete(tasklist=args.tasklist_id).execute()
+    print(json.dumps({
+        "status": "deleted",
+        "tasklistId": args.tasklist_id,
+    }, indent=2, ensure_ascii=False))
+
+
+def tasks_tasks_list(args):
+    service = build_service("tasks", "v1")
+    params = {
+        "tasklist": args.tasklist_id,
+        "maxResults": args.max,
+        "showCompleted": args.show_completed,
+        "showHidden": args.show_hidden,
+        "showDeleted": args.show_deleted,
+    }
+    if args.due_min:
+        params["dueMin"] = _datetime_with_timezone(args.due_min)
+    if args.due_max:
+        params["dueMax"] = _datetime_with_timezone(args.due_max)
+    result = service.tasks().list(**params).execute()
+    tasks = [_normalize_task_resource(task) for task in result.get("items", [])]
+    print(json.dumps(tasks, indent=2, ensure_ascii=False))
+
+
+def tasks_tasks_create(args):
+    service = build_service("tasks", "v1")
+    body = {"title": args.title}
+    if args.notes:
+        body["notes"] = args.notes
+    if args.due:
+        body["due"] = _datetime_with_timezone(args.due)
+
+    params = {"tasklist": args.tasklist_id, "body": body}
+    if args.parent:
+        params["parent"] = args.parent
+    if args.previous:
+        params["previous"] = args.previous
+
+    result = service.tasks().insert(**params).execute()
+    print(json.dumps({
+        "status": "created",
+        "task": _normalize_task_resource(result),
+    }, indent=2, ensure_ascii=False))
+
+
+def tasks_tasks_update(args):
+    service = build_service("tasks", "v1")
+    body = {}
+    if args.title:
+        body["title"] = args.title
+    if args.notes:
+        body["notes"] = args.notes
+    if args.due:
+        body["due"] = _datetime_with_timezone(args.due)
+    if args.clear_due:
+        body["due"] = None
+    if args.status:
+        body["status"] = args.status
+    if args.completed:
+        body["completed"] = _datetime_with_timezone(args.completed)
+    if args.clear_completed:
+        body["completed"] = None
+    if args.deleted is not None:
+        body["deleted"] = args.deleted
+    if args.hidden is not None:
+        body["hidden"] = args.hidden
+
+    result = service.tasks().patch(
+        tasklist=args.tasklist_id,
+        task=args.task_id,
+        body=body,
+    ).execute()
+    print(json.dumps({
+        "status": "updated",
+        "task": _normalize_task_resource(result),
+    }, indent=2, ensure_ascii=False))
+
+
+def tasks_tasks_delete(args):
+    service = build_service("tasks", "v1")
+    service.tasks().delete(tasklist=args.tasklist_id, task=args.task_id).execute()
+    print(json.dumps({
+        "status": "deleted",
+        "taskId": args.task_id,
+        "tasklistId": args.tasklist_id,
+    }, indent=2, ensure_ascii=False))
+
+
+def tasks_tasks_move(args):
+    service = build_service("tasks", "v1")
+    params = {"tasklist": args.tasklist_id, "task": args.task_id}
+    if args.parent:
+        params["parent"] = args.parent
+    if args.previous:
+        params["previous"] = args.previous
+    result = service.tasks().move(**params).execute()
+    print(json.dumps({
+        "status": "moved",
+        "task": _normalize_task_resource(result),
+    }, indent=2, ensure_ascii=False))
+
+
+def tasks_tasks_clear(args):
+    service = build_service("tasks", "v1")
+    service.tasks().clear(tasklist=args.tasklist_id).execute()
+    print(json.dumps({
+        "status": "cleared",
+        "tasklistId": args.tasklist_id,
+    }, indent=2, ensure_ascii=False))
+
+
+# =========================================================================
 # CLI parser
 # =========================================================================
 
@@ -1216,6 +1394,84 @@ def main():
     p.add_argument("doc_id")
     p.add_argument("--text", required=True, help="Text to append to the end of the document")
     p.set_defaults(func=docs_append)
+
+    # --- Tasks ---
+    tasks = sub.add_parser("tasks")
+    tasks_sub = tasks.add_subparsers(dest="resource", required=True)
+
+    tasklists = tasks_sub.add_parser("tasklists")
+    tasklists_sub = tasklists.add_subparsers(dest="action", required=True)
+
+    p = tasklists_sub.add_parser("list")
+    p.add_argument("--max", type=int, default=20)
+    p.set_defaults(func=tasks_tasklists_list)
+
+    p = tasklists_sub.add_parser("create")
+    p.add_argument("--title", required=True, help="Task list title")
+    p.set_defaults(func=tasks_tasklists_create)
+
+    p = tasklists_sub.add_parser("update")
+    p.add_argument("tasklist_id")
+    p.add_argument("--title", required=True, help="New task list title")
+    p.set_defaults(func=tasks_tasklists_update)
+
+    p = tasklists_sub.add_parser("delete")
+    p.add_argument("tasklist_id")
+    p.set_defaults(func=tasks_tasklists_delete)
+
+    task_items = tasks_sub.add_parser("tasks")
+    task_items_sub = task_items.add_subparsers(dest="action", required=True)
+
+    p = task_items_sub.add_parser("list")
+    p.add_argument("tasklist_id")
+    p.add_argument("--max", type=int, default=50)
+    p.add_argument("--show-completed", action="store_true")
+    p.add_argument("--show-hidden", action="store_true")
+    p.add_argument("--show-deleted", action="store_true")
+    p.add_argument("--due-min", default="", help="Only tasks due on or after this ISO 8601 timestamp")
+    p.add_argument("--due-max", default="", help="Only tasks due on or before this ISO 8601 timestamp")
+    p.set_defaults(func=tasks_tasks_list)
+
+    p = task_items_sub.add_parser("create")
+    p.add_argument("tasklist_id")
+    p.add_argument("--title", required=True)
+    p.add_argument("--notes", default="")
+    p.add_argument("--due", default="", help="Due time (ISO 8601)")
+    p.add_argument("--parent", default="", help="Parent task ID for subtasks")
+    p.add_argument("--previous", default="", help="Insert after this sibling task ID")
+    p.set_defaults(func=tasks_tasks_create)
+
+    p = task_items_sub.add_parser("update")
+    p.add_argument("tasklist_id")
+    p.add_argument("task_id")
+    p.add_argument("--title", default="")
+    p.add_argument("--notes", default="")
+    p.add_argument("--due", default="", help="Due time (ISO 8601)")
+    p.add_argument("--clear-due", action="store_true", help="Clear the due timestamp")
+    p.add_argument("--status", choices=["needsAction", "completed"], default="")
+    p.add_argument("--completed", default="", help="Completion timestamp (ISO 8601)")
+    p.add_argument("--clear-completed", action="store_true", help="Clear the completed timestamp")
+    p.add_argument("--deleted", dest="deleted", action="store_true", default=None)
+    p.add_argument("--not-deleted", dest="deleted", action="store_false")
+    p.add_argument("--hidden", dest="hidden", action="store_true", default=None)
+    p.add_argument("--not-hidden", dest="hidden", action="store_false")
+    p.set_defaults(func=tasks_tasks_update)
+
+    p = task_items_sub.add_parser("delete")
+    p.add_argument("tasklist_id")
+    p.add_argument("task_id")
+    p.set_defaults(func=tasks_tasks_delete)
+
+    p = task_items_sub.add_parser("move")
+    p.add_argument("tasklist_id")
+    p.add_argument("task_id")
+    p.add_argument("--parent", default="", help="New parent task ID")
+    p.add_argument("--previous", default="", help="Insert after this sibling task ID")
+    p.set_defaults(func=tasks_tasks_move)
+
+    p = task_items_sub.add_parser("clear")
+    p.add_argument("tasklist_id")
+    p.set_defaults(func=tasks_tasks_clear)
 
     args = parser.parse_args()
     args.func(args)

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -56,6 +56,12 @@ SCOPES = [
     "https://www.googleapis.com/auth/tasks.readonly",
 ]
 
+_SCOPE_IMPLICATIONS = {
+    "https://www.googleapis.com/auth/tasks": {
+        "https://www.googleapis.com/auth/tasks.readonly",
+    },
+}
+
 REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]
 
 # OAuth redirect for "out of band" manual code copy flow.
@@ -78,12 +84,46 @@ def _load_token_payload(path: Path = TOKEN_PATH) -> dict:
         return {}
 
 
+def _scope_list(raw) -> list[str]:
+    if not raw:
+        return []
+    values = raw.split() if isinstance(raw, str) else raw
+    return [s.strip() for s in values if isinstance(s, str) and s.strip()]
+
+
+def _expand_granted_scopes(scopes: list[str]) -> set[str]:
+    expanded = set(scopes)
+    for scope in list(expanded):
+        expanded.update(_SCOPE_IMPLICATIONS.get(scope, set()))
+    return expanded
+
+
 def _missing_scopes_from_payload(payload: dict) -> list[str]:
     raw = payload.get("scopes") or payload.get("scope")
     if not raw:
         return []
-    granted = {s.strip() for s in (raw.split() if isinstance(raw, str) else raw) if s.strip()}
+    granted = _expand_granted_scopes(_scope_list(raw))
     return sorted(scope for scope in SCOPES if scope not in granted)
+
+
+def _normalized_scope_payload_for_save(creds, *, existing_payload: dict | None = None, fallback_scopes=None) -> dict:
+    token_payload = _normalize_authorized_user_payload(json.loads(creds.to_json()))
+    actually_granted = []
+    if hasattr(creds, "granted_scopes") and creds.granted_scopes:
+        actually_granted = _scope_list(list(creds.granted_scopes))
+    if actually_granted:
+        token_payload["scopes"] = actually_granted
+        return token_payload
+
+    existing_scopes = _scope_list((existing_payload or {}).get("scopes") or (existing_payload or {}).get("scope"))
+    if existing_scopes:
+        token_payload["scopes"] = existing_scopes
+        return token_payload
+
+    fallback = _scope_list(fallback_scopes)
+    if fallback:
+        token_payload["scopes"] = fallback
+    return token_payload
 
 
 def _format_missing_scopes(missing_scopes: list[str]) -> str:
@@ -220,7 +260,7 @@ def check_auth(quiet: bool = False):
             creds.refresh(Request())
             TOKEN_PATH.write_text(
                 json.dumps(
-                    _normalize_authorized_user_payload(json.loads(creds.to_json())),
+                    _normalized_scope_payload_for_save(creds, existing_payload=payload),
                     indent=2,
                 )
             )
@@ -395,17 +435,10 @@ def exchange_auth_code(code: str):
         sys.exit(1)
 
     creds = flow.credentials
-    token_payload = _normalize_authorized_user_payload(json.loads(creds.to_json()))
-
-    # Store only the scopes actually granted by the user, not what was requested.
-    # creds.to_json() writes the requested scopes, which causes refresh to fail
-    # with invalid_scope if the user only authorized a subset.
-    actually_granted = list(creds.granted_scopes or []) if hasattr(creds, "granted_scopes") and creds.granted_scopes else []
-    if actually_granted:
-        token_payload["scopes"] = actually_granted
-    elif granted_scopes != SCOPES:
-        # granted_scopes was extracted from the callback URL
-        token_payload["scopes"] = granted_scopes
+    token_payload = _normalized_scope_payload_for_save(
+        creds,
+        fallback_scopes=granted_scopes if granted_scopes != SCOPES else None,
+    )
 
     missing_scopes = _missing_scopes_from_payload(token_payload)
     if missing_scopes:

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -52,6 +52,8 @@ SCOPES = [
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/tasks",
+    "https://www.googleapis.com/auth/tasks.readonly",
 ]
 
 REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -258,6 +258,81 @@ class TestExchangeAuthCode:
         assert not setup_module.PENDING_AUTH_PATH.exists()
 
 
+class TestScopeHandling:
+    def test_missing_scopes_treats_tasks_scope_as_covering_tasks_readonly(self, setup_module):
+        granted = [
+            scope
+            for scope in setup_module.SCOPES
+            if scope != "https://www.googleapis.com/auth/tasks.readonly"
+        ]
+
+        missing = setup_module._missing_scopes_from_payload({"scopes": granted})
+
+        assert missing == []
+
+    def test_check_auth_refresh_preserves_existing_scope_list(self, setup_module, monkeypatch):
+        tasks_scope = "https://www.googleapis.com/auth/tasks"
+        setup_module.TOKEN_PATH.write_text(
+            json.dumps(
+                {
+                    "token": "old-token",
+                    "refresh_token": "refresh-token",
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "scopes": [tasks_scope],
+                }
+            )
+        )
+
+        class FakeCredentials:
+            valid = False
+            expired = True
+            refresh_token = "refresh-token"
+            granted_scopes = None
+
+            def refresh(self, request):
+                self.valid = True
+                self.expired = False
+
+            def to_json(self):
+                return json.dumps(
+                    {
+                        "token": "refreshed-token",
+                        "refresh_token": "refresh-token",
+                        "client_id": "client-id",
+                        "client_secret": "client-secret",
+                        "token_uri": "https://oauth2.googleapis.com/token",
+                    }
+                )
+
+        class FakeCredentialsModule:
+            @staticmethod
+            def from_authorized_user_file(filename):
+                assert filename == str(setup_module.TOKEN_PATH)
+                return FakeCredentials()
+
+        google_module = types.ModuleType("google")
+        oauth2_module = types.ModuleType("google.oauth2")
+        credentials_module = types.ModuleType("google.oauth2.credentials")
+        credentials_module.Credentials = FakeCredentialsModule
+        transport_module = types.ModuleType("google.auth.transport")
+        requests_module = types.ModuleType("google.auth.transport.requests")
+        requests_module.Request = lambda: object()
+
+        monkeypatch.setitem(sys.modules, "google", google_module)
+        monkeypatch.setitem(sys.modules, "google.oauth2", oauth2_module)
+        monkeypatch.setitem(sys.modules, "google.oauth2.credentials", credentials_module)
+        monkeypatch.setitem(sys.modules, "google.auth.transport", transport_module)
+        monkeypatch.setitem(sys.modules, "google.auth.transport.requests", requests_module)
+
+        assert setup_module.check_auth(quiet=True) is True
+
+        saved = json.loads(setup_module.TOKEN_PATH.read_text())
+        assert saved["token"] == "refreshed-token"
+        assert saved["scopes"] == [tasks_scope]
+
+
 class TestHermesConstantsFallback:
     """Tests for _hermes_home.py fallback when hermes_constants is unavailable."""
 

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -484,3 +484,216 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+def test_api_scopes_include_google_tasks(api_module):
+    assert "https://www.googleapis.com/auth/tasks" in api_module.SCOPES
+    assert "https://www.googleapis.com/auth/tasks.readonly" in api_module.SCOPES
+
+
+def test_api_tasks_tasklists_list_uses_python_service_even_when_gws_is_present(api_module, capsys):
+    captured = {}
+
+    class FakeTasklistsResource:
+        def list(self, **kwargs):
+            captured["kwargs"] = kwargs
+            return types.SimpleNamespace(execute=lambda: {
+                "items": [
+                    {"id": "tl-1", "title": "Personal", "updated": "2026-06-09T10:00:00.000Z"},
+                ]
+            })
+
+    class FakeTasksService:
+        def tasklists(self):
+            return FakeTasklistsResource()
+
+    api_module.build_service = lambda api, version: FakeTasksService()
+    args = api_module.argparse.Namespace(max=25, func=api_module.tasks_tasklists_list)
+
+    api_module.tasks_tasklists_list(args)
+
+    assert captured["kwargs"] == {"maxResults": 25}
+    result = json.loads(capsys.readouterr().out)
+    assert result == [
+        {"id": "tl-1", "title": "Personal", "updated": "2026-06-09T10:00:00.000Z", "selfLink": ""}
+    ]
+
+
+def test_api_tasks_list_returns_normalized_items(api_module, capsys):
+    captured = {}
+
+    class FakeTasksResource:
+        def list(self, **kwargs):
+            captured["kwargs"] = kwargs
+            return types.SimpleNamespace(execute=lambda: {
+                "items": [
+                    {
+                        "id": "task-1",
+                        "title": "Buy milk",
+                        "status": "needsAction",
+                        "notes": "2%",
+                        "due": "2026-06-10T18:00:00.000Z",
+                        "updated": "2026-06-09T10:00:00.000Z",
+                        "position": "0001",
+                        "parent": "parent-1",
+                    }
+                ]
+            })
+
+    class FakeTasksService:
+        def tasks(self):
+            return FakeTasksResource()
+
+    api_module.build_service = lambda api, version: FakeTasksService()
+    args = api_module.argparse.Namespace(
+        tasklist_id="tl-1",
+        max=50,
+        show_completed=False,
+        show_hidden=False,
+        show_deleted=False,
+        due_min="",
+        due_max="",
+        func=api_module.tasks_tasks_list,
+    )
+
+    api_module.tasks_tasks_list(args)
+
+    assert captured["kwargs"] == {
+        "tasklist": "tl-1",
+        "maxResults": 50,
+        "showCompleted": False,
+        "showHidden": False,
+        "showDeleted": False,
+    }
+    result = json.loads(capsys.readouterr().out)
+    assert result == [
+        {
+            "id": "task-1",
+            "title": "Buy milk",
+            "status": "needsAction",
+            "notes": "2%",
+            "due": "2026-06-10T18:00:00.000Z",
+            "completed": "",
+            "updated": "2026-06-09T10:00:00.000Z",
+            "deleted": False,
+            "hidden": False,
+            "position": "0001",
+            "parent": "parent-1",
+            "selfLink": "",
+        }
+    ]
+
+
+def test_api_tasks_create_passes_due_and_parent(api_module, capsys):
+    captured = {}
+
+    class FakeTasksResource:
+        def insert(self, **kwargs):
+            captured["kwargs"] = kwargs
+            return types.SimpleNamespace(execute=lambda: {
+                "id": "task-1",
+                "title": "Buy milk",
+                "status": "needsAction",
+            })
+
+    class FakeTasksService:
+        def tasks(self):
+            return FakeTasksResource()
+
+    api_module.build_service = lambda api, version: FakeTasksService()
+    args = api_module.argparse.Namespace(
+        tasklist_id="tl-1",
+        title="Buy milk",
+        notes="2%",
+        due="2026-06-10T18:00:00Z",
+        parent="parent-1",
+        previous="prev-1",
+        func=api_module.tasks_tasks_create,
+    )
+
+    api_module.tasks_tasks_create(args)
+
+    assert captured["kwargs"] == {
+        "tasklist": "tl-1",
+        "parent": "parent-1",
+        "previous": "prev-1",
+        "body": {
+            "title": "Buy milk",
+            "notes": "2%",
+            "due": "2026-06-10T18:00:00Z",
+        },
+    }
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "created"
+    assert result["task"]["id"] == "task-1"
+
+
+def test_api_tasks_update_only_sends_fields_the_user_provided(api_module, capsys):
+    captured = {}
+
+    class FakeTasksResource:
+        def patch(self, **kwargs):
+            captured["kwargs"] = kwargs
+            return types.SimpleNamespace(execute=lambda: {
+                "id": "task-1",
+                "title": "Buy oat milk",
+                "status": "completed",
+                "completed": "2026-06-10T18:05:00.000Z",
+            })
+
+    class FakeTasksService:
+        def tasks(self):
+            return FakeTasksResource()
+
+    api_module.build_service = lambda api, version: FakeTasksService()
+    args = api_module.argparse.Namespace(
+        tasklist_id="tl-1",
+        task_id="task-1",
+        title="Buy oat milk",
+        notes="",
+        due="",
+        clear_due=False,
+        status="completed",
+        completed="2026-06-10T18:05:00Z",
+        clear_completed=False,
+        deleted=None,
+        hidden=None,
+        func=api_module.tasks_tasks_update,
+    )
+
+    api_module.tasks_tasks_update(args)
+
+    assert captured["kwargs"] == {
+        "tasklist": "tl-1",
+        "task": "task-1",
+        "body": {
+            "title": "Buy oat milk",
+            "status": "completed",
+            "completed": "2026-06-10T18:05:00Z",
+        },
+    }
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "updated"
+    assert result["task"]["status"] == "completed"
+
+
+def test_api_tasks_delete_calls_python_service(api_module, capsys):
+    captured = {}
+
+    class FakeTasksResource:
+        def delete(self, **kwargs):
+            captured["kwargs"] = kwargs
+            return types.SimpleNamespace(execute=lambda: None)
+
+    class FakeTasksService:
+        def tasks(self):
+            return FakeTasksResource()
+
+    api_module.build_service = lambda api, version: FakeTasksService()
+    args = api_module.argparse.Namespace(tasklist_id="tl-1", task_id="task-1", func=api_module.tasks_tasks_delete)
+
+    api_module.tasks_tasks_delete(args)
+
+    assert captured["kwargs"] == {"tasklist": "tl-1", "task": "task-1"}
+    result = json.loads(capsys.readouterr().out)
+    assert result == {"status": "deleted", "taskId": "task-1", "tasklistId": "tl-1"}

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -486,9 +486,101 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert saved["type"] == "authorized_user"
 
 
+def test_api_get_credentials_refresh_preserves_existing_scopes(api_module, monkeypatch):
+    token_path = api_module.TOKEN_PATH
+    _write_token(
+        token_path,
+        token="ya29.old",
+        scopes=["https://www.googleapis.com/auth/tasks"],
+    )
+
+    class FakeCredentials:
+        def __init__(self):
+            self.expired = True
+            self.refresh_token = "1//refresh"
+            self.valid = True
+            self.granted_scopes = None
+
+        def refresh(self, request):
+            self.expired = False
+
+        def to_json(self):
+            return json.dumps({
+                "token": "ya29.refreshed",
+                "refresh_token": "1//refresh",
+                "client_id": "123.apps.googleusercontent.com",
+                "client_secret": "secret",
+                "token_uri": "https://oauth2.googleapis.com/token",
+            })
+
+    class FakeCredentialsModule:
+        @staticmethod
+        def from_authorized_user_file(filename, scopes):
+            assert filename == str(token_path)
+            assert scopes == ["https://www.googleapis.com/auth/tasks"]
+            return FakeCredentials()
+
+    google_module = types.ModuleType("google")
+    oauth2_module = types.ModuleType("google.oauth2")
+    credentials_module = types.ModuleType("google.oauth2.credentials")
+    credentials_module.Credentials = FakeCredentialsModule
+    transport_module = types.ModuleType("google.auth.transport")
+    requests_module = types.ModuleType("google.auth.transport.requests")
+    requests_module.Request = lambda: object()
+
+    monkeypatch.setitem(sys.modules, "google", google_module)
+    monkeypatch.setitem(sys.modules, "google.oauth2", oauth2_module)
+    monkeypatch.setitem(sys.modules, "google.oauth2.credentials", credentials_module)
+    monkeypatch.setitem(sys.modules, "google.auth.transport", transport_module)
+    monkeypatch.setitem(sys.modules, "google.auth.transport.requests", requests_module)
+
+    api_module.get_credentials()
+
+    saved = json.loads(token_path.read_text())
+    assert saved["token"] == "ya29.refreshed"
+    assert saved["scopes"] == ["https://www.googleapis.com/auth/tasks"]
+
+
 def test_api_scopes_include_google_tasks(api_module):
     assert "https://www.googleapis.com/auth/tasks" in api_module.SCOPES
     assert "https://www.googleapis.com/auth/tasks.readonly" in api_module.SCOPES
+
+
+def test_api_tasks_create_rejects_readonly_token(api_module, monkeypatch, capsys):
+    api_module.TOKEN_PATH.write_text(
+        json.dumps(
+            {
+                "token": "ya29.test",
+                "scopes": ["https://www.googleapis.com/auth/tasks.readonly"],
+            }
+        )
+    )
+
+    called = {"build_service": False}
+
+    def fail_if_called(*args, **kwargs):
+        called["build_service"] = True
+        raise AssertionError("build_service should not be called when scopes are insufficient")
+
+    api_module.build_service = fail_if_called
+    args = api_module.argparse.Namespace(
+        tasklist_id="tl-1",
+        title="Buy milk",
+        notes="",
+        due="",
+        parent="",
+        previous="",
+        func=api_module.tasks_tasks_create,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        api_module.tasks_tasks_create(args)
+
+    assert exc_info.value.code == 1
+    assert called["build_service"] is False
+    err = capsys.readouterr().err
+    assert "missing required google workspace scopes" in err.lower()
+    assert "https://www.googleapis.com/auth/tasks" in err
 
 
 def test_api_tasks_tasklists_list_uses_python_service_even_when_gws_is_present(api_module, capsys):

--- a/website/docs/user-guide/skills/google-workspace.md
+++ b/website/docs/user-guide/skills/google-workspace.md
@@ -159,6 +159,39 @@ $GAPI docs get DOC_ID
 
 Returns the document title and full text content.
 
+## Tasks
+
+```bash
+# List task lists
+$GAPI tasks tasklists list
+
+# Create / rename / delete a task list
+$GAPI tasks tasklists create --title "Work"
+$GAPI tasks tasklists update TASKLIST_ID --title "Work Projects"
+$GAPI tasks tasklists delete TASKLIST_ID
+
+# List tasks in a task list
+$GAPI tasks tasks list TASKLIST_ID --max 50
+$GAPI tasks tasks list TASKLIST_ID --show-completed --due-min 2026-06-01T00:00:00Z
+
+# Create / update / move / delete tasks
+$GAPI tasks tasks create TASKLIST_ID --title "Buy milk" --notes "2%"
+$GAPI tasks tasks update TASKLIST_ID TASK_ID --status completed --completed 2026-06-10T18:05:00Z
+$GAPI tasks tasks move TASKLIST_ID TASK_ID --previous OTHER_TASK_ID
+$GAPI tasks tasks delete TASKLIST_ID TASK_ID
+$GAPI tasks tasks clear TASKLIST_ID
+```
+
+## How this relates to Hermes task management
+
+Hermes also has built-in task systems:
+
+- `todo` — session-local planning
+- `cronjob` — scheduled reminders and recurring jobs
+- `kanban` — durable multi-agent work queues
+
+Google Tasks is separate. This skill manages your actual Google Tasks lists via the Google Tasks API, but it does **not** automatically sync the built-in `todo` tool to Google Tasks.
+
 ## Contacts
 
 ```bash
@@ -179,6 +212,8 @@ All commands return JSON. Key fields per service:
 | `drive search` | `id`, `name`, `mimeType`, `modifiedTime`, `webViewLink` |
 | `contacts list` | `name`, `emails`, `phones` |
 | `sheets get` | 2D array of cell values |
+| `tasks tasklists list` | `id`, `title`, `updated`, `selfLink` |
+| `tasks tasks list` | `id`, `title`, `status`, `notes`, `due`, `completed`, `updated`, `deleted`, `hidden`, `position`, `parent`, `selfLink` |
 
 ## Troubleshooting
 
@@ -187,5 +222,6 @@ All commands return JSON. Key fields per service:
 | `NOT_AUTHENTICATED` | Run setup (ask Hermes to set up Google Workspace) |
 | `REFRESH_FAILED` | Token revoked — re-run authorization steps |
 | `HttpError 403: Insufficient Permission` | Missing scope — revoke and re-authorize with the right services |
+| `AUTHENTICATED (partial)` or `Token missing scopes` | New write capabilities (Drive write/delete, Docs create/edit, Google Tasks) require re-authorization |
 | `HttpError 403: Access Not Configured` | API not enabled in Google Cloud Console |
 | `ModuleNotFoundError` | Run setup script with `--install-deps` |


### PR DESCRIPTION
## Summary
- add Google Tasks support to the Google Workspace skill, including tasklists and task CRUD/move/clear operations
- extend OAuth setup and token handling so partial scope grants and refreshes remain stable and give clear errors
- document the new Tasks commands and add focused test coverage for API behavior and auth edge cases

## Testing
- python3 -m pytest tests/skills/test_google_workspace_api.py tests/skills/test_google_oauth_setup.py
- live auth check with `setup.py --check`
- live Tasks check with `google_api.py tasks tasklists list`

## Notes
- Google Tasks remains separate from Hermes' internal `todo` tool; this PR only adds Google Tasks support to the Google Workspace skill
- verified locally against an authenticated token after the scope-handling fixes
