### PR TITLE
fix(gateway): apply MarkdownV2 formatting on Telegram progress message edits

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -181,6 +181,8 @@ def _strip_mdv2(text: str) -> str:
     """
     # Remove escape backslashes before special characters
     cleaned = re.sub(r'\\([_*\[\]()~`>#\+\-=|{}.!\\])', r'\1', text)
+    # Remove standard markdown bold (**text** → text) BEFORE MarkdownV2 bold
+    cleaned = re.sub(r'\*\*([^*]+)\*\*', r'\1', cleaned)
     # Remove MarkdownV2 bold markers that format_message converted from **bold**
     cleaned = re.sub(r'\*([^*]+)\*', r'\1', cleaned)
     # Remove MarkdownV2 italic markers that format_message converted from *italic*
@@ -2208,11 +2210,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
                     return SendResult(success=True, message_id=message_id)
-                # Fallback: retry without markdown formatting
+                # Fallback: strip MarkdownV2 escapes and retry as clean plain text
+                logger.warning(
+                    "[%s] MarkdownV2 edit failed, falling back to plain text: %s",
+                    self.name,
+                    fmt_err,
+                )
+                _plain = _strip_mdv2(content) if content else content
                 await self._bot.edit_message_text(
                     chat_id=int(chat_id),
                     message_id=int(message_id),
-                    text=content,
+                    text=_plain,
                 )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13130,6 +13130,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "message_id": message_id,
                     "content": content,
                 }
+                if getattr(adapter, "REQUIRES_EDIT_FINALIZE", False):
+                    kwargs["finalize"] = True
                 if _edit_accepts_metadata:
                     kwargs["metadata"] = _progress_metadata
                 return await adapter.edit_message(**kwargs)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1241,6 +1241,7 @@ AUTHOR_MAP = {
     "charliekerfoot@gmail.com": "CharlieKerfoot",  # PR #18951
     # Debug share upload-time redaction (May 2026)
     "dhuysamen@gmail.com": "GodsBoy",  # PR #19318
+    "github@nadyahermes.anonaddy.com": "ruangraung",  # PR #42308
     "mrcoferland@gmail.com": "mrcoferland",  # PR #19023
     "chenlinfeng@ruije.com.cn": "noOne-list",  # PR #19050
     "briansu@Mac-mini.attlocal.net": "likejudy",  # PR #19052

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -835,7 +835,7 @@ class TestEditMessageStreamingSafety:
         assert second_call == {
             "chat_id": 123,
             "message_id": 456,
-            "text": "final **bold**",
+            "text": "final bold",
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Telegram tool-progress bubble *edits* now re-apply MarkdownV2 formatting instead of leaving raw markdown visible, and the MarkdownV2 edit fallback degrades to clean plain text instead of dumping escape sequences.

Root cause: progress edits call `edit_message()` with `finalize=False` (the default), which takes the plain-text branch and skips `format_message()`. The initial `send()` formats correctly; subsequent edits did not — so markdown in a progress bubble rendered raw after the first tool update.

## Changes
- `gateway/run.py`: `_edit_progress_message` now passes `finalize=True` for adapters with `REQUIRES_EDIT_FINALIZE` (Telegram, DingTalk), routing edits through the same MarkdownV2 pipeline as the initial send. Zero effect on other platforms (flag defaults False).
- `gateway/platforms/telegram.py`: MarkdownV2 edit-failure fallback now strips markdown via `_strip_mdv2()` (so users see clean text, not `\n`/`##`/`**`) and logs the parse error; `_strip_mdv2()` also strips standard `**bold**`.
- `scripts/release.py`: AUTHOR_MAP entry for @ruangraung.

## Validation
| | Before | After |
|---|---|---|
| Progress edit on Telegram | raw markdown shown (`finalize=False`) | `format_message()` applied, `parse_mode=MARKDOWN_V2` |
| MarkdownV2 parse failure | raw escapes dumped to chat | stripped to clean plain text + logged |
| `tests/gateway/test_telegram_format.py` | — | 101/101 pass |
| E2E (real `edit_message`) | — | finalize=True → escaped + parse_mode; finalize=False → plain; `_strip_mdv2('a **bold** b')` → `a bold b` |

Refs #41955, #41732. Complementary to #42420 (which restores truncated previews for terminal commands in default modes) — this fix keeps progress *edits* formatting-correct for verbose mode and any markdown progress content. Salvaged from #42308 onto current main; @ruangraung's commit authorship preserved.

## Infographic

![gateway-progress-rendering-two-fixes](https://v3b.fal.media/files/b/0a9d86bb/GY-Oj98kX4GJujDxKiVdl_bEun2jKg.png)
