### PR TITLE
fix(profiles): bound alias wrapper scanning

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -316,6 +316,23 @@ def profile_exists(name: str) -> bool:
 # Alias / wrapper script management
 # ---------------------------------------------------------------------------
 
+_MAX_WRAPPER_SCRIPT_BYTES = 4096
+
+
+def _read_wrapper_script(path: Path) -> Optional[str]:
+    """Return a small Hermes wrapper script's text, or None for anything else."""
+    try:
+        if path.is_symlink():
+            return None
+        if not path.is_file():
+            return None
+        if path.stat().st_size > _MAX_WRAPPER_SCRIPT_BYTES:
+            return None
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
 def check_alias_collision(name: str) -> Optional[str]:
     """Return a human-readable collision message, or None if the name is safe.
 
@@ -340,12 +357,9 @@ def check_alias_collision(name: str) -> Optional[str]:
             # Allow overwriting our own wrappers
             expected = wrapper_dir / (f"{canon}.bat" if is_windows else canon)
             if existing_path == str(expected):
-                try:
-                    content = expected.read_text()
-                    if "hermes -p" in content:
-                        return None  # it's our wrapper, safe to overwrite
-                except Exception:
-                    pass
+                content = _read_wrapper_script(expected)
+                if content and "hermes -p" in content:
+                    return None  # it's our wrapper, safe to overwrite
             return f"'{canon}' conflicts with an existing command ({existing_path})"
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
@@ -411,14 +425,14 @@ def remove_wrapper_script(name: str) -> bool:
 
     for wrapper_path in candidates:
         if wrapper_path.exists():
-            try:
-                # Verify it's our wrapper before removing
-                content = wrapper_path.read_text()
-                if "hermes -p" in content:
+            # Verify it's our wrapper before removing
+            content = _read_wrapper_script(wrapper_path)
+            if content and "hermes -p" in content:
+                try:
                     wrapper_path.unlink()
                     return True
-            except Exception:
-                pass
+                except OSError:
+                    pass
     return False
 
 
@@ -445,16 +459,13 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
     custom: Optional[str] = None
     profile_named: Optional[str] = None
     for entry in sorted(wrapper_dir.iterdir()):
-        if not entry.is_file():
-            continue
         # Only our own wrappers are named with the alias and (on Windows) .bat.
         if is_windows and entry.suffix != ".bat":
             continue
         if not is_windows and entry.suffix:
             continue
-        try:
-            content = entry.read_text()
-        except (OSError, UnicodeDecodeError):
+        content = _read_wrapper_script(entry)
+        if content is None:
             continue
         if needle not in content:
             continue

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -744,6 +744,30 @@ class TestFindAliasForProfile:
         (wrapper_dir / "pip").write_text("#!/bin/sh\nexec python -m pip \"$@\"\n")
         assert find_alias_for_profile("steve") is None
 
+    def test_large_unrelated_commands_do_not_block_alias_lookup(self, profile_env, monkeypatch):
+        monkeypatch.setattr("sys.platform", "darwin")
+        from hermes_cli.profiles import (
+            _get_wrapper_dir,
+            create_wrapper_script,
+            find_alias_for_profile,
+        )
+
+        wrapper_dir = _get_wrapper_dir()
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        large_tool = wrapper_dir / "large-tool"
+        large_tool.write_bytes(b"\0" * 8192)
+        create_wrapper_script("qiaobusi", target="steve")
+
+        original_read_text = Path.read_text
+
+        def fail_if_large_tool_read(path, *args, **kwargs):
+            if path == large_tool:
+                raise AssertionError("large unrelated command should not be read")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", fail_if_large_tool_read)
+        assert find_alias_for_profile("steve") == "qiaobusi"
+
     def test_custom_alias_on_windows(self, profile_env, monkeypatch):
         monkeypatch.setattr("sys.platform", "win32")
         from hermes_cli.profiles import create_wrapper_script, find_alias_for_profile


### PR DESCRIPTION
## What
- Add a bounded wrapper-script reader for Hermes profile aliases.
- Skip symlinks, non-files, and files larger than a tiny wrapper script before reading from `~/.local/bin`.
- Reuse the helper for alias collision, alias removal, and profile alias lookup.
- Add a regression test proving a large unrelated extensionless command does not block resolving a real profile alias.

## Why
`find_alias_for_profile()` scanned every extensionless file in `~/.local/bin` and read each one as text. On systems where that directory contains large extensionless binaries, `/api/profiles` can hang long enough to break dashboard/desktop startup. Hermes-created profile wrappers are tiny scripts, so bounding wrapper reads avoids unrelated binaries while preserving alias detection.

## How to test
- `scripts/run_tests.sh tests/hermes_cli/test_profiles.py`
- `python3 scripts/check-windows-footguns.py hermes_cli/profiles.py tests/hermes_cli/test_profiles.py`
- `uv run --extra dev ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py`

## Platforms tested
- macOS local checkout
- Linux VPS runtime path with `/api/profiles` returning successfully after the fix
