### PR TITLE
fix(tui): use default import for signal-exit (not named export)

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -7,7 +7,7 @@ import throttle from 'lodash-es/throttle.js'
 import React, { type ReactNode } from 'react'
 import type { FiberRoot } from 'react-reconciler'
 import { ConcurrentRoot } from 'react-reconciler/constants.js'
-import { onExit } from 'signal-exit'
+import onExit from 'signal-exit'
 
 import { flushInteractionTime } from '../bootstrap/state.js'
 import { getYogaCounters } from '../native-ts/yoga-layout/index.js'


### PR DESCRIPTION
## What changes:
Fix `ui-tui/packages/hermes-ink/src/ink/ink.tsx`: use default import for `signal-exit`.

## Why would it change:
`signal-exit` is a CJS module exported as a single function via `module.exports`.

The current prebuilt `dist/entry.js` accesses the module correctly via `.default` at three callsites (lines 43321, 53327, 54299). But the TypeScript source uses a named import `{ onExit }` which would resolve to `undefined` on the next esbuild rebuild, breaking the TUI on any environment — not just the npm-broken one.

Discovered during a separate debugging effort (PR #40694). Confirmed by the actual runtime error: `TypeError: (0, import_signal_exit.onExit) is not a function`.

## How to verify:
The fix has no behavioral change — it corrects the import to match the module's actual export shape. The esbuild `__toESM` wrapper sets `.default` to `module.exports`, so `import onExit from 'signal-exit'` resolves correctly.

## Tests:
Build-time correctness fix — the module's export shape doesn't change at runtime. The existing prebuilt bundle already uses `.default` access and works. The fix prevents a regression on the next rebuild.

## Platforms tested:
- Rocky Linux 9.7 (kernel 5.14, glibc 2.34)

## Related:
- [PR #40694](https://github.com/NousResearch/hermes-agent/pull/40694) — TUI launcher prebuilt-fallback fix where this import error was discovered.
