### PR TITLE
feat(gateway): inject Slack channel name and metadata into agent prompt

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -325,6 +325,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._handler: Optional[Any] = None
         self._bot_user_id: Optional[str] = None
         self._user_name_cache: Dict[str, str] = {}  # user_id → display name
+        self._channel_info_cache: Dict[str, Dict[str, Any]] = {}  # channel_id → {name, is_private}
         self._socket_mode_task: Optional[asyncio.Task] = None
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}  # team_id → WebClient
@@ -1707,6 +1708,28 @@ class SlackAdapter(BasePlatformAdapter):
             self._user_name_cache[user_id] = user_id
             return user_id
 
+    async def _resolve_channel_info(self, channel_id: str, team_id: str = "") -> Dict[str, Any]:
+        """Resolve a Slack channel ID to its name and privacy flag, with caching."""
+        if channel_id in self._channel_info_cache:
+            return self._channel_info_cache[channel_id]
+        default: Dict[str, Any] = {"name": channel_id, "is_private": False}
+        if not channel_id or not self._app:
+            return default
+        try:
+            client = self._get_client(team_id) if team_id else self._app.client
+            result = await client.conversations_info(channel=channel_id)
+            ch = result.get("channel", {})
+            info: Dict[str, Any] = {
+                "name": ch.get("name") or channel_id,
+                "is_private": bool(ch.get("is_private")),
+            }
+            self._channel_info_cache[channel_id] = info
+            return info
+        except Exception as e:
+            logger.debug("[Slack] conversations.info failed for %s: %s", channel_id, e)
+            self._channel_info_cache[channel_id] = default
+            return default
+
     async def send_image_file(
         self,
         chat_id: str,
@@ -2279,6 +2302,14 @@ class SlackAdapter(BasePlatformAdapter):
             channel_type = "im"
         is_dm = channel_type in {"im", "mpim"}  # Both 1:1 and group DMs
 
+        # Resolve channel name and privacy flag (skip for DMs — channel_id is the DM ID)
+        channel_name = channel_id
+        channel_is_private = False
+        if not is_dm:
+            _ch_info = await self._resolve_channel_info(channel_id, team_id)
+            channel_name = _ch_info["name"]
+            channel_is_private = _ch_info["is_private"]
+
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a
         #   new thread/session (the bot always replies in a thread).
@@ -2604,10 +2635,25 @@ class SlackAdapter(BasePlatformAdapter):
         # Resolve user display name (cached after first lookup)
         user_name = await self._resolve_user_name(user_id, chat_id=channel_id)
 
+        # Inject Slack channel context so the agent can infer project/client from channel name.
+        # Only for channel messages — DMs have no meaningful channel name to surface.
+        if not is_dm:
+            _ctx_lines = [
+                "[Slack context]",
+                "- source_platform: slack",
+                f"- channel_id: {channel_id}",
+                f"- channel_name: {channel_name}",
+                f"- channel_is_private: {str(channel_is_private).lower()}",
+            ]
+            if thread_ts:
+                _ctx_lines.append(f"- thread_ts: {thread_ts}")
+            _ctx_lines.append(f"- message_ts: {ts}")
+            text = "\n".join(_ctx_lines) + "\n\n" + text
+
         # Build source
         source = self.build_source(
             chat_id=channel_id,
-            chat_name=channel_id,  # Will be resolved later if needed
+            chat_name=channel_name,
             chat_type="dm" if is_dm else "group",
             user_id=user_id,
             user_name=user_name,

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1709,12 +1709,19 @@ class SlackAdapter(BasePlatformAdapter):
             return user_id
 
     async def _resolve_channel_info(self, channel_id: str, team_id: str = "") -> Dict[str, Any]:
-        """Resolve a Slack channel ID to its name and privacy flag, with caching."""
+        """Resolve a Slack channel ID to its name and privacy flag, with caching.
+
+        Cache is capped at 100 entries; oldest 50 are evicted when full so stale
+        channel renames eventually cycle out without requiring a restart.
+        """
         if channel_id in self._channel_info_cache:
             return self._channel_info_cache[channel_id]
         default: Dict[str, Any] = {"name": channel_id, "is_private": False}
         if not channel_id or not self._app:
             return default
+        if len(self._channel_info_cache) >= 100:
+            for k in list(self._channel_info_cache)[:50]:
+                del self._channel_info_cache[k]
         try:
             client = self._get_client(team_id) if team_id else self._app.client
             result = await client.conversations_info(channel=channel_id)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1714,8 +1714,8 @@ class TestMessageRouting:
         }
         await adapter._handle_slack_message(event)
         msg_event = adapter.handle_message.call_args[0][0]
-        assert msg_event.text == "what's the weather?"
         assert "<@U_BOT>" not in msg_event.text
+        assert msg_event.text.endswith("what's the weather?")
 
     @pytest.mark.asyncio
     async def test_bot_messages_ignored(self, adapter):
@@ -2570,9 +2570,10 @@ class TestThreadReplyHandling:
         await adapter_with_session_store._handle_slack_message(event)
         adapter_with_session_store.handle_message.assert_called_once()
 
-        # Verify the text is passed through unchanged (no mention stripping needed)
+        # Verify the user text is passed through unchanged (no mention stripping needed).
+        # Note: msg_event.text is prefixed with a [Slack context] block.
         msg_event = adapter_with_session_store.handle_message.call_args[0][0]
-        assert msg_event.text == "Follow-up question"
+        assert msg_event.text.endswith("Follow-up question")
 
     @pytest.mark.asyncio
     async def test_thread_reply_with_mention_strips_bot_id(
@@ -2597,7 +2598,7 @@ class TestThreadReplyHandling:
 
         msg_event = adapter_with_session_store.handle_message.call_args[0][0]
         assert "<@U_BOT>" not in msg_event.text
-        assert msg_event.text == "thanks for the help"
+        assert msg_event.text.endswith("thanks for the help")
 
     @pytest.mark.asyncio
     async def test_top_level_message_requires_mention_even_with_session(


### PR DESCRIPTION
## What does this PR do?

The Slack adapter currently passes only message text and thread history to the agent — it has no awareness of which channel a message originated from. This means agents cannot infer context from channel naming conventions.

This PR adds channel metadata injection: for every non-DM Slack message, a [Slack context] block is prepended to the message text containing the resolved channel name, channel ID, privacy flag, thread timestamp, and message timestamp.

Before:
The agent receives only the user's message text with no channel context.

After:
[Slack context]
- source_platform: slack
- channel_id: C0AQWDLHY9M
- channel_name: proj-example-channel
- channel_is_private: false
- thread_ts: 1749123456.000100
- message_ts: 1749123789.000200

<user message here>

The channel name is also now passed as chat_name in SessionSource instead of the raw channel ID.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- gateway/platforms/slack.py — Added _resolve_channel_info(): a cached async helper that calls conversations.info to resolve a channel ID to its human-readable name and privacy flag. Results are cached per channel ID to avoid redundant API calls.
- gateway/platforms/slack.py — In _handle_slack_message(): resolves channel info after is_dm is determined, builds and prepends the [Slack context] block to message text (channel messages only), and passes the resolved channel_name to build_source() instead of the raw channel ID.
- tests/gateway/test_slack.py — Updated 3 assertions that checked exact msg_event.text equality to use endswith(), accounting for the new context prefix.

## How to Test

1. Configure a Slack bot in a channel with a descriptive name
2. @mention the bot and ask "what channel are we in?"
3. The agent should correctly identify the channel name
4. Verify DMs are unaffected (no [Slack context] block injected)
5. Verify thread replies in a channel still include the parent channel name

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run pytest tests/gateway/ and all tests pass (7 pre-existing failures in test_slack_channel_session_scope.py exist on unmodified upstream main and are unrelated to this change)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've considered cross-platform impact — N/A (gateway code, no OS-level calls)

### Slack App Manifest — Required Scope Changes

Deployments must add the following OAuth scopes to their Slack app for conversations.info to work:

| Scope | Required for |
|---|---|
| `channels:read` | Resolving public channel names |
| `groups:read` | Resolving private channel names |

Without these scopes, _resolve_channel_info() will fall back gracefully to using the raw channel ID — the agent will still function, just without the resolved channel name.

---