### PR TITLE
fix(auth): preserve independent Codex OAuth profiles

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -600,6 +600,14 @@ class CredentialPool:
                 state = _load_provider_state(auth_store, "openai-codex")
             if not isinstance(state, dict):
                 return entry
+            state_label = state.get("label") if isinstance(state.get("label"), str) else None
+            if state_label and entry.label and state_label != entry.label:
+                logger.debug(
+                    "Pool entry %s: refusing Codex auth.json sync for mismatched label %r",
+                    entry.id,
+                    state_label,
+                )
+                return entry
             tokens = state.get("tokens")
             if not isinstance(tokens, dict):
                 return entry
@@ -1891,22 +1899,37 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # existing Codex CLI credentials get a one-time, explicit prompt
         # via `hermes auth openai-codex`.
         if isinstance(tokens, dict) and tokens.get("access_token"):
+            access_token = str(tokens.get("access_token") or "")
             active_sources.add("device_code")
             custom_label = str(state.get("label") or "").strip()
-            changed |= _upsert_entry(
-                entries,
-                provider,
-                "device_code",
-                {
-                    "source": "device_code",
-                    "auth_type": AUTH_TYPE_OAUTH,
-                    "access_token": tokens.get("access_token", ""),
-                    "refresh_token": tokens.get("refresh_token"),
-                    "base_url": "https://chatgpt.com/backend-api/codex",
-                    "last_refresh": state.get("last_refresh"),
-                    "label": custom_label or label_from_token(tokens.get("access_token", ""), "device_code"),
-                },
-            )
+            existing_device_code = next((entry for entry in entries if entry.source == "device_code"), None)
+            if (
+                custom_label
+                and existing_device_code is not None
+                and existing_device_code.label
+                and existing_device_code.label != custom_label
+            ):
+                logger.debug(
+                    "Refusing to seed Codex singleton label %r over device_code entry %s labelled %r",
+                    custom_label,
+                    existing_device_code.id,
+                    existing_device_code.label,
+                )
+            else:
+                changed |= _upsert_entry(
+                    entries,
+                    provider,
+                    "device_code",
+                    {
+                        "source": "device_code",
+                        "auth_type": AUTH_TYPE_OAUTH,
+                        "access_token": access_token,
+                        "refresh_token": tokens.get("refresh_token"),
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                        "last_refresh": state.get("last_refresh"),
+                        "label": custom_label or label_from_token(access_token, "device_code"),
+                    },
+                )
 
     elif provider == "xai-oauth":
         # When the user logs in via ``hermes model`` -> xAI Grok OAuth,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3369,70 +3369,139 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     }
 
 
+def _codex_pool_entries(auth_store: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
+    pool = auth_store.get("credential_pool")
+    if not isinstance(pool, dict):
+        return None
+    entries = pool.get("openai-codex")
+    if not isinstance(entries, list):
+        return None
+    return entries
+
+
+def _apply_codex_tokens_to_pool_entry(
+    entry: Dict[str, Any],
+    tokens: Dict[str, str],
+    last_refresh: Optional[str],
+) -> None:
+    access_token = tokens.get("access_token")
+    if not access_token:
+        return
+    refresh_token = tokens.get("refresh_token")
+    entry["access_token"] = access_token
+    if refresh_token:
+        entry["refresh_token"] = refresh_token
+    if last_refresh:
+        entry["last_refresh"] = last_refresh
+    entry["last_status"] = None
+    entry["last_status_at"] = None
+    entry["last_error_code"] = None
+    entry["last_error_reason"] = None
+    entry["last_error_message"] = None
+    entry["last_error_reset_at"] = None
+
+
+def _codex_non_target_snapshot(
+    entries: Optional[List[Dict[str, Any]]],
+    target_label: Optional[str],
+) -> List[tuple]:
+    if not entries:
+        return []
+    snapshot = []
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            continue
+        if target_label and entry.get("label") == target_label:
+            continue
+        snapshot.append((
+            index,
+            entry.get("id"),
+            entry.get("label"),
+            entry.get("source"),
+            entry.get("access_token"),
+            entry.get("refresh_token"),
+            entry.get("last_status"),
+            entry.get("last_status_at"),
+            entry.get("last_error_code"),
+            entry.get("last_error_reason"),
+            entry.get("last_error_message"),
+            entry.get("last_error_reset_at"),
+        ))
+    return snapshot
+
+
+def _assert_codex_non_targets_unchanged(
+    before: List[tuple],
+    entries: Optional[List[Dict[str, Any]]],
+    target_label: Optional[str],
+) -> None:
+    after = _codex_non_target_snapshot(entries, target_label)
+    if after != before:
+        raise AuthError(
+            "safety_guard_non_target_codex_profiles_changed: refusing to write auth.json",
+            provider="openai-codex",
+            code="codex_non_target_profiles_changed",
+        )
+
+
 def _sync_codex_pool_entries(
     auth_store: Dict[str, Any],
     tokens: Dict[str, str],
     last_refresh: Optional[str],
     previous_singleton_tokens: Optional[Dict[str, str]] = None,
+    label: Optional[str] = None,
+    singleton_label: Optional[str] = None,
 ) -> None:
-    """Mirror a fresh Codex re-auth into the credential_pool OAuth entries.
+    """Mirror fresh Codex OAuth tokens into the intended pool entry.
 
-    The runtime selects credentials from ``credential_pool.openai-codex``, not
-    from ``providers.openai-codex.tokens``.  A re-auth invalidates the prior
-    OAuth pair server-side, but pool entries keep holding the now-consumed
-    refresh token plus any stale error markers — so the next request spends a
-    dead token and gets a 401 ``token_invalidated``.
+    Labelled Codex auth is a profile-targeted operation: ``--label profile-two``
+    updates only the pool entry whose label is ``profile-two``.  It must not
+    rewrite sibling ``manual:device_code`` entries, because those entries can be
+    independent ChatGPT accounts with separate quota and refresh-token state.
 
-    What gets refreshed:
-
-    * ``device_code`` — the singleton-seeded entry written by the device-code
-      OAuth flow when the user logged in via ``hermes setup`` / the model
-      picker.  Always synced with the fresh tokens.
-    * ``manual:device_code`` — entries created by ``hermes auth add openai-codex``
-      that use the same device-code OAuth mechanism.  ONLY synced if the
-      entry's existing access_token matches the *previous* singleton
-      access_token (i.e. the entry is a legacy singleton-alias from the
-      #33000 workaround era).  Manual entries whose tokens never matched the
-      singleton represent INDEPENDENT accounts added via
-      ``hermes auth add openai-codex`` and must not be overwritten by a
-      re-auth that targeted a different account (regression for #39236).
-
-      The original #33538 fix refreshed every ``manual:device_code`` entry
-      unconditionally.  That worked when ``manual:device_code`` only meant
-      "legacy alias of the singleton", but the same source string is now
-      also produced by independent-account additions, and the broad sync
-      silently clobbered distinct accounts with the latest-authenticated
-      token pair.  The access_token-match check distinguishes the two cases
-      without changing the source-string contract.
-
-    What does NOT get refreshed:
-
-    * ``manual:api_key`` and any other non-device-code manual sources — those
-      are independent credentials (an explicit API key, a different ChatGPT
-      account, etc.) and must not be overwritten by a single re-auth.
-    * ``manual:device_code`` entries whose access_token does NOT match the
-      previous singleton — see above; these are independent accounts.
-
-    Error markers (``last_status``, ``last_error_*``) are cleared ONLY on
-    entries that actually had their tokens rewritten by this re-auth.
-    Independent entries keep their own error state (their 401/429 markers
-    belong to that account's own auth flow, not this re-auth).
+    Unlabelled singleton refreshes keep the legacy behavior when the singleton
+    has no label: refresh the ``device_code`` mirror and true legacy aliases
+    whose token material matched the previous singleton token.  If the provider
+    singleton has a label, the refresh is scoped to the matching labelled pool
+    entry instead of blindly updating the first ``device_code`` row.
     """
     access_token = tokens.get("access_token")
     if not access_token:
         return
-    refresh_token = tokens.get("refresh_token")
-    pool = auth_store.get("credential_pool")
-    if not isinstance(pool, dict):
+    entries = _codex_pool_entries(auth_store)
+    if entries is None:
         return
-    entries = pool.get("openai-codex")
-    if not isinstance(entries, list):
+
+    target_label = str(label or singleton_label or "").strip() or None
+    if target_label:
+        matches = [entry for entry in entries if isinstance(entry, dict) and entry.get("label") == target_label]
+        if len(matches) > 1:
+            raise AuthError(
+                "duplicate Codex profile label; refusing to write auth.json",
+                provider="openai-codex",
+                code="codex_duplicate_profile_label",
+            )
+        if matches:
+            _apply_codex_tokens_to_pool_entry(matches[0], tokens, last_refresh)
+            return
+        entries.append({
+            "id": uuid.uuid4().hex[:12],
+            "label": target_label,
+            "source": "manual:device_code",
+            "auth_type": "oauth",
+            "priority": len(entries),
+            "access_token": tokens.get("access_token"),
+            "refresh_token": tokens.get("refresh_token"),
+            "last_refresh": last_refresh,
+            "last_status": None,
+            "last_status_at": None,
+            "last_error_code": None,
+            "last_error_reason": None,
+            "last_error_message": None,
+            "last_error_reset_at": None,
+        })
         return
-    # Previous singleton access_token (before this re-auth overwrote it) —
-    # used to distinguish legacy singleton-aliases from independent accounts.
-    # When None or empty, no manual entry can be treated as an alias (which
-    # is the right default for first-ever-save or a freshly initialized
-    # auth.json).
+
     prev_at = None
     if isinstance(previous_singleton_tokens, dict):
         prev_at = previous_singleton_tokens.get("access_token") or None
@@ -3441,33 +3510,13 @@ def _sync_codex_pool_entries(
             continue
         source = entry.get("source")
         if source == "device_code":
-            # Singleton-seeded mirror — always refresh.
             refresh_this_entry = True
         elif source == "manual:device_code":
-            # Refresh only if this entry's existing access_token matches the
-            # previous singleton access_token (i.e. it is a true alias of the
-            # singleton from the #33000 workaround era).  An entry with its
-            # own distinct token material is an independent account and must
-            # be left alone (#39236).
-            refresh_this_entry = bool(
-                prev_at and entry.get("access_token") == prev_at
-            )
+            refresh_this_entry = bool(prev_at and entry.get("access_token") == prev_at)
         else:
-            # ``manual:api_key`` and any future non-device-code sources.
             refresh_this_entry = False
-        if not refresh_this_entry:
-            continue
-        entry["access_token"] = access_token
-        if refresh_token:
-            entry["refresh_token"] = refresh_token
-        if last_refresh:
-            entry["last_refresh"] = last_refresh
-        entry["last_status"] = None
-        entry["last_status_at"] = None
-        entry["last_error_code"] = None
-        entry["last_error_reason"] = None
-        entry["last_error_message"] = None
-        entry["last_error_reset_at"] = None
+        if refresh_this_entry:
+            _apply_codex_tokens_to_pool_entry(entry, tokens, last_refresh)
 
 
 def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
@@ -3477,12 +3526,25 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
     with _auth_store_lock():
         auth_store = _load_auth_store()
         state = _load_provider_state(auth_store, "openai-codex") or {}
-        # Capture the previous singleton tokens BEFORE overwriting them.  The
-        # pool-sync step uses this to distinguish legacy singleton-aliases
-        # (which should be refreshed) from independent accounts that
-        # ``hermes auth add openai-codex`` created (which must not be
-        # overwritten — see #39236).
         previous_singleton_tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else None
+        singleton_label = state.get("label") if isinstance(state.get("label"), str) else None
+        target_label = str(label or singleton_label or "").strip() or None
+        entries = _codex_pool_entries(auth_store)
+        before_non_targets = (
+            _codex_non_target_snapshot(entries, target_label) if target_label else []
+        )
+
+        # Validate ambiguous target labels before mutating provider singleton state,
+        # so duplicate-label auth stores fail closed with auth.json unchanged.
+        if target_label and entries is not None:
+            matches = [entry for entry in entries if isinstance(entry, dict) and entry.get("label") == target_label]
+            if len(matches) > 1:
+                raise AuthError(
+                    "duplicate Codex profile label; refusing to write auth.json",
+                    provider="openai-codex",
+                    code="codex_duplicate_profile_label",
+                )
+
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = "chatgpt"
@@ -3494,9 +3556,12 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
             tokens,
             last_refresh,
             previous_singleton_tokens=previous_singleton_tokens,
+            label=label,
+            singleton_label=singleton_label,
         )
+        if target_label:
+            _assert_codex_non_targets_unchanged(before_non_targets, entries, target_label)
         _save_auth_store(auth_store)
-
 
 def refresh_codex_oauth_pure(
     access_token: str,

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2998,3 +2998,48 @@ def test_codex_oauth_nonterminal_refresh_does_not_quarantine(tmp_path, monkeypat
     tokens = auth_payload["providers"]["openai-codex"].get("tokens", {})
     assert tokens.get("access_token") == "old-access-token"
     assert tokens.get("refresh_token") == "old-refresh-token"
+
+
+def test_codex_device_code_sync_respects_provider_label(tmp_path, monkeypatch):
+    """A provider singleton for one profile must not overwrite another profile row."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "label": "profile-two",
+                    "tokens": {"access_token": "profile-two-at", "refresh_token": "profile-two-rt"},
+                    "last_refresh": "2026-06-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                },
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "entry-one",
+                        "label": "profile-one",
+                        "auth_type": "oauth",
+                        "source": "device_code",
+                        "access_token": "profile-one-at",
+                        "refresh_token": "profile-one-rt",
+                        "last_status": "exhausted",
+                        "last_error_code": 429,
+                    },
+                ],
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.entries()[0]
+    synced = pool._sync_codex_entry_from_auth_store(entry)
+
+    assert synced.access_token == "profile-one-at"
+    assert synced.refresh_token == "profile-one-rt"
+    assert synced.last_status == "exhausted"
+    assert synced.last_error_code == 429
+    assert pool.entries()[0].access_token == "profile-one-at"

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -817,6 +817,157 @@ def _patch_httpx(monkeypatch, response):
     monkeypatch.setattr("hermes_cli.auth.httpx.Client", _factory)
 
 
+
+def test_save_codex_tokens_with_label_updates_matching_profile_only(tmp_path, monkeypatch):
+    """A labelled Codex re-auth must not mutate sibling OAuth profiles."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    original = {
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "label": "profile-two",
+                "tokens": {"access_token": "profile-two-at", "refresh_token": "profile-two-rt"},
+                "last_refresh": "2026-01-01T00:00:00Z",
+                "auth_mode": "chatgpt",
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "entry-one", "label": "profile-one", "source": "device_code",
+                    "auth_type": "oauth", "priority": 0,
+                    "access_token": "profile-one-at", "refresh_token": "profile-one-rt",
+                    "last_status": "exhausted", "last_error_code": 429,
+                    "last_error_reason": "usage_limit_reached",
+                },
+                {
+                    "id": "entry-two", "label": "profile-two", "source": "manual:device_code",
+                    "auth_type": "oauth", "priority": 1,
+                    "access_token": "profile-two-at", "refresh_token": "profile-two-rt",
+                    "last_status": "ok",
+                },
+                {
+                    "id": "entry-three", "label": "profile-three", "source": "manual:device_code",
+                    "auth_type": "oauth", "priority": 2,
+                    "access_token": "profile-three-at", "refresh_token": "profile-three-rt",
+                    "last_status": "exhausted", "last_error_code": 429,
+                    "last_error_reason": "usage_limit_reached",
+                },
+            ],
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(original))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_codex_tokens(
+        {"access_token": "fresh-profile-two-at", "refresh_token": "fresh-profile-two-rt"},
+        last_refresh="2026-06-01T00:00:00Z",
+        label="profile-two",
+    )
+
+    auth = json.loads((hermes_home / "auth.json").read_text())
+    entries = {entry["id"]: entry for entry in auth["credential_pool"]["openai-codex"]}
+    assert entries["entry-one"] == original["credential_pool"]["openai-codex"][0]
+    assert entries["entry-three"] == original["credential_pool"]["openai-codex"][2]
+    updated = entries["entry-two"]
+    assert updated["label"] == "profile-two"
+    assert updated["source"] == "manual:device_code"
+    assert updated["priority"] == 1
+    assert updated["access_token"] == "fresh-profile-two-at"
+    assert updated["refresh_token"] == "fresh-profile-two-rt"
+    assert updated["last_refresh"] == "2026-06-01T00:00:00Z"
+    assert updated["last_status"] is None
+    assert updated["last_error_code"] is None
+
+
+def test_save_codex_tokens_with_label_refuses_duplicate_profile_labels(tmp_path, monkeypatch):
+    """Ambiguous target labels must fail closed before writing auth.json."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    original = {
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "label": "profile-one",
+                "tokens": {"access_token": "old-at", "refresh_token": "old-rt"},
+                "last_refresh": "2026-01-01T00:00:00Z",
+                "auth_mode": "chatgpt",
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "entry-one-a", "label": "profile-one", "source": "device_code",
+                    "auth_type": "oauth", "access_token": "profile-one-a-at",
+                    "refresh_token": "profile-one-a-rt",
+                },
+                {
+                    "id": "entry-one-b", "label": "profile-one", "source": "manual:device_code",
+                    "auth_type": "oauth", "access_token": "profile-one-b-at",
+                    "refresh_token": "profile-one-b-rt",
+                },
+            ],
+        },
+    }
+    auth_file = hermes_home / "auth.json"
+    auth_file.write_text(json.dumps(original, indent=2))
+    before = auth_file.read_text()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError, match="duplicate Codex profile label"):
+        _save_codex_tokens(
+            {"access_token": "fresh-at", "refresh_token": "fresh-rt"},
+            last_refresh="2026-06-01T00:00:00Z",
+            label="profile-one",
+        )
+
+    assert auth_file.read_text() == before
+
+
+def test_save_codex_tokens_without_label_uses_provider_singleton_label(tmp_path, monkeypatch):
+    """Unlabelled refresh should not blindly update the first device_code row."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    original = {
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "label": "profile-three",
+                "tokens": {"access_token": "profile-three-at", "refresh_token": "profile-three-rt"},
+                "last_refresh": "2026-01-01T00:00:00Z",
+                "auth_mode": "chatgpt",
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "entry-one", "label": "profile-one", "source": "device_code",
+                    "auth_type": "oauth", "access_token": "profile-one-at",
+                    "refresh_token": "profile-one-rt",
+                },
+                {
+                    "id": "entry-three", "label": "profile-three", "source": "manual:device_code",
+                    "auth_type": "oauth", "access_token": "profile-three-at",
+                    "refresh_token": "profile-three-rt",
+                },
+            ],
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(original))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_codex_tokens(
+        {"access_token": "fresh-profile-three-at", "refresh_token": "fresh-profile-three-rt"},
+        last_refresh="2026-06-01T00:00:00Z",
+    )
+
+    auth = json.loads((hermes_home / "auth.json").read_text())
+    entries = {entry["id"]: entry for entry in auth["credential_pool"]["openai-codex"]}
+    assert entries["entry-one"] == original["credential_pool"]["openai-codex"][0]
+    assert entries["entry-three"]["access_token"] == "fresh-profile-three-at"
+    assert entries["entry-three"]["refresh_token"] == "fresh-profile-three-rt"
+
 def test_refresh_parses_openai_nested_error_shape_refresh_token_reused(monkeypatch):
     """OpenAI returns {"error": {"code": "refresh_token_reused", "message": "..."}}
     — parser must surface relogin_required and the dedicated message.


### PR DESCRIPTION
## What does this PR do?

Fixes Codex OAuth credential-pool isolation for multi-profile/multi-account setups.

A labelled Codex OAuth re-auth now updates only the intended profile entry and does not rewrite, relabel, or clear status on non-target Codex profiles. Unlabelled singleton refreshes keep the existing legacy-alias behavior, but when the provider singleton has a label, the refresh is scoped to that matching labelled pool entry instead of blindly updating the first `device_code` row.

This also prevents provider-singleton sync/seed paths from overwriting a `device_code` pool entry when the singleton label belongs to a different profile.

## Related Issue

Refs #42102
Refs #39236
Complements #42110

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/auth.py`: labelled Codex token saves now target only the matching pool label; duplicate labels fail closed; labelled writes guard non-target entries against accidental mutation.
- `agent/credential_pool.py`: Codex provider singleton sync/seed paths now respect label mismatches before adopting token material.
- `tests/hermes_cli/test_auth_codex_provider.py`: added regressions for generic profile isolation, duplicate-label fail-closed behavior, and unlabelled refresh targeting.
- `tests/agent/test_credential_pool.py`: added regression for provider singleton label mismatch.

## How to Test

Focused pytest:

```bash
python -m pytest -q -o addopts='' tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py tests/hermes_cli/test_auth_commands.py
```

Canonical per-file runner for touched suites:

```bash
scripts/run_tests.sh tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py tests/hermes_cli/test_auth_commands.py
```

Static checks:

```bash
python -m py_compile hermes_cli/auth.py agent/credential_pool.py
git diff --check
python -m ruff check hermes_cli/auth.py agent/credential_pool.py tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My code follows the project's style guidelines
- [x] I've performed a self-review of my code
- [x] Code comments N/A: the changed logic is covered by names, structure, and regression tests without adding explanatory comments
- [x] My changes generate no new warnings
- [x] I've added tests that prove my fix is effective
- [x] New and existing focused tests pass locally

### Documentation

- [x] Documentation N/A: behavior is covered by regression tests; no user-facing config or CLI docs changed
- [x] cli-config.yaml.example N/A: no config keys changed
- [x] CONTRIBUTING.md / AGENTS.md N/A: no contributor workflow changes

### Testing

- [x] Focused pytest suite passed locally: 161 passed
- [x] Canonical per-file runner passed locally for touched suites: 161 passed
- [x] Ruff check passed for changed Python files
- [x] `git diff --check` passed

### Security / Privacy

- [x] Tests use synthetic generic profile labels only (`profile-one`, `profile-two`, `profile-three`)
- [x] No real tokens, refresh tokens, credential fingerprints, account names, or user-specific paths are included
- [x] No auth store, backup file, or runtime log output is included

## Screenshots / Logs

Not applicable. This is a credential-store behavior fix covered by regression tests with synthetic generic credential data only.