### PR TITLE
feat: add Hermes Codemode tool bridge

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -92,6 +92,111 @@ def _is_loopback_host(host: str) -> bool:
     return host.strip().lower() in _LOOPBACK_HOSTS
 
 
+def _first_present(data: dict, keys: List[str], default: Any = None) -> Any:
+    for key in keys:
+        value = data.get(key)
+        if value not in (None, "", [], {}):
+            return value
+    return default
+
+
+def _format_bolig_value(label: str, value: Any) -> str:
+    if value in (None, "", [], {}):
+        return ""
+    return f"{label}: {value}"
+
+
+def _render_bolig_delta_notification(payload: dict) -> str:
+    """Deterministic fallback-free Discord text for Gustav's bolig alerts.
+
+    The bolig delta monitor already scores/ranks candidates. Running an LLM for
+    this tiny triage made alerts depend on the gateway's current chat model and
+    caused noisy provider-error messages in Discord when Codex failed locally.
+    Keep this renderer boring and direct: preserve the lead, explain why it
+    fired, and make the next action obvious.
+    """
+    events = payload.get("events") or []
+    if not isinstance(events, list):
+        events = []
+    summary = payload.get("event_summary") or []
+    if not events and isinstance(summary, list):
+        events = [item for item in summary if isinstance(item, dict)]
+
+    if not events:
+        run = payload.get("run") or {}
+        source = payload.get("source") or run.get("source") or "bolig monitor"
+        return f"⚠️ Bolig alert — ingen konkrete events i payload fra {source}. Tjek monitor-log hvis det gentager sig."
+
+    lines: List[str] = []
+    for event in events[:4]:
+        if not isinstance(event, dict):
+            continue
+        candidate = event.get("candidate") if isinstance(event.get("candidate"), dict) else {}
+        event_type = str(event.get("event_type") or event.get("type") or payload.get("event_type") or "bolig_delta")
+        source = str(event.get("source") or candidate.get("source") or "ukendt kilde")
+        priority = str(event.get("priority") or candidate.get("priority") or "medium").lower()
+        try:
+            score = int(event.get("score") or candidate.get("score") or 0)
+        except (TypeError, ValueError):
+            score = 0
+
+        title = str(_first_present(candidate, ["title", "address", "street", "name"], "Bolig lead"))
+        url = str(_first_present(candidate, ["url", "public_url", "app_url", "link"], ""))
+        city = _first_present(candidate, ["city", "area"])
+        street = _first_present(candidate, ["street", "address"])
+        total = _first_present(candidate, ["total_monthly_dkk", "monthly_rent_dkk", "rent_dkk", "price_dkk", "price"])
+        size = _first_present(candidate, ["size_m2", "m2", "sqm"])
+        rooms = _first_present(candidate, ["rooms", "room_count"])
+        tier = _first_present(candidate, ["tier", "classification"])
+        relation_required = candidate.get("relation_required")
+        reasons = event.get("reasons") if isinstance(event.get("reasons"), list) else []
+
+        if event_type == "source_failure":
+            verdict = "⚠️ KILDE FEJLEDE"
+            action = "Ingen bolig-handling; tjek kun hvis samme kilde bliver ved med at fejle."
+        elif priority == "high" or score >= 120:
+            verdict = "🏠 HANDLE NU"
+            action = "Åbn linket og skriv dig op / tag næste trin, hvis kravene passer."
+        elif priority in {"medium", "watch"} or score >= 80:
+            verdict = "🏠 LAV PRIORITET"
+            action = "Tjek linket når du har luft; sandsynligvis venteliste/signup-signal mere end konkret lejlighed."
+        else:
+            verdict = "🏠 IGNORER"
+            action = "Lavt match eller for lidt konkret data."
+
+        facts = [
+            _format_bolig_value("Kilde", source),
+            _format_bolig_value("Prioritet", priority),
+            _format_bolig_value("Score", score if score else None),
+            _format_bolig_value("Adresse", street),
+            _format_bolig_value("By", city),
+            _format_bolig_value("Total/md", f"{total} kr" if isinstance(total, (int, float)) else total),
+            _format_bolig_value("m²", size),
+            _format_bolig_value("Værelser", rooms),
+            _format_bolig_value("Tier", tier),
+        ]
+        facts = [fact for fact in facts if fact]
+        if relation_required is not None:
+            facts.append(f"Relation kræves: {'ja' if relation_required else 'nej'}")
+
+        reason_line = ", ".join(str(reason) for reason in reasons[:5])
+        body = [
+            f"{verdict}: {title}",
+            " · ".join(facts[:8]),
+        ]
+        if reason_line:
+            body.append(f"Hvorfor: {reason_line}")
+        body.append(f"Handling: {action}")
+        if url:
+            body.append(url)
+        lines.append("\n".join(part for part in body if part))
+
+    extra = len(events) - 4
+    if extra > 0:
+        lines.append(f"… plus {extra} ekstra bolig-event(s).")
+    return "\n\n".join(lines)[:1900]
+
+
 def check_webhook_requirements() -> bool:
     """Check if webhook adapter dependencies are available."""
     return AIOHTTP_AVAILABLE
@@ -462,6 +567,8 @@ class WebhookAdapter(BasePlatformAdapter):
         prompt = self._render_prompt(
             prompt_template, payload, event_type, route_name
         )
+        if route_config.get("renderer") == "bolig_delta":
+            prompt = _render_bolig_delta_notification(payload)
 
         # Inject skill content if configured.
         # We call build_skill_invocation_message() directly rather than

--- a/model_tools.py
+++ b/model_tools.py
@@ -1117,6 +1117,18 @@ def handle_function_call(
                         task_id=task_id,
                         enabled_tools=sandbox_enabled,
                     )
+            elif function_name in {
+                "hermes_codemode_status",
+                "hermes_codemode_schema",
+                "hermes_codemode_execute",
+            }:
+                def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    return registry.dispatch(
+                        function_name, next_args,
+                        task_id=task_id,
+                        enabled_toolsets=enabled_toolsets,
+                        disabled_toolsets=disabled_toolsets,
+                    )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
                     return registry.dispatch(

--- a/tests/tools/test_hermes_codemode_tool.py
+++ b/tests/tools/test_hermes_codemode_tool.py
@@ -1,0 +1,122 @@
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_tool_cache():
+    import model_tools
+
+    model_tools._clear_tool_defs_cache()
+    yield
+    model_tools._clear_tool_defs_cache()
+
+
+def _loads(result):
+    if isinstance(result, str):
+        return json.loads(result)
+    return result
+
+
+def test_schema_returns_compact_exact_method_definition():
+    from tools.hermes_codemode_tool import hermes_codemode_schema
+
+    data = _loads(hermes_codemode_schema(methods=["read_file"]))
+
+    assert data["schemaVersion"] == 1
+    assert data["toolCount"] >= 1
+    assert data["requestedMethods"] == ["read_file"]
+    assert data["definitions"][0]["name"] == "read_file"
+    assert data["definitions"][0]["mutating"] is False
+    assert "inputSchema" in data["definitions"][0]
+    field_names = {field["name"] for field in data["definitions"][0]["inputFields"]}
+    assert {"path", "offset", "limit"}.issubset(field_names)
+
+
+def test_schema_searches_live_tool_catalog_without_full_schemas():
+    from tools.hermes_codemode_tool import hermes_codemode_schema
+
+    data = _loads(hermes_codemode_schema(query="run shell command", limit=5))
+
+    names = [match["name"] for match in data["matches"]]
+    assert "terminal" in names
+    assert data["definitions"] == []
+    assert all("inputSchema" not in match for match in data["matches"])
+
+
+def test_plan_execute_allows_read_only_calls_and_denies_mutations(monkeypatch):
+    from tools import hermes_codemode_tool as cm
+
+    calls = []
+
+    def fake_handle_function_call(function_name, function_args, **kwargs):
+        calls.append((function_name, function_args, kwargs))
+        return json.dumps({"ok": True, "tool": function_name, "args": function_args})
+
+    monkeypatch.setattr(cm, "_dispatch_tool_call", fake_handle_function_call)
+
+    read_result = _loads(cm.hermes_codemode_execute(
+        code="""
+def main(codemode):
+    return codemode.read_file({"path": "README.md", "limit": 3})
+""",
+        mode="plan",
+        enabled_toolsets=["file"],
+    ))
+
+    assert read_result["ok"] is True
+    assert read_result["result"]["tool"] == "read_file"
+    assert calls[0][0] == "read_file"
+
+    denied = _loads(cm.hermes_codemode_execute(
+        code="""
+def main(codemode):
+    return codemode.write_file({"path": "x", "content": "y"})
+""",
+        mode="plan",
+        enabled_toolsets=["file"],
+    ))
+
+    assert denied["ok"] is False
+    assert "not allowed in plan mode" in denied["error"]
+
+
+def test_execute_scopes_methods_to_enabled_toolsets(monkeypatch):
+    from tools import hermes_codemode_tool as cm
+
+    def fake_handle_function_call(function_name, function_args, **kwargs):
+        return json.dumps({"ok": True})
+
+    monkeypatch.setattr(cm, "_dispatch_tool_call", fake_handle_function_call)
+
+    denied = _loads(cm.hermes_codemode_execute(
+        code="""
+def main(codemode):
+    return codemode.terminal({"command": "pwd"})
+""",
+        mode="apply",
+        enabled_toolsets=["file"],
+    ))
+
+    assert denied["ok"] is False
+    assert "not available in this codemode session" in denied["error"]
+
+
+def test_lean_codemode_cli_toolset_exposes_only_bridge_but_backs_full_cli_methods():
+    from model_tools import get_tool_definitions
+    from tools.hermes_codemode_tool import hermes_codemode_schema
+
+    visible = get_tool_definitions(enabled_toolsets=["hermes-codemode-cli"], quiet_mode=True)
+    visible_names = {tool["function"]["name"] for tool in visible}
+
+    assert visible_names == {
+        "hermes_codemode_status",
+        "hermes_codemode_schema",
+        "hermes_codemode_execute",
+    }
+
+    data = _loads(hermes_codemode_schema(
+        query="run shell command",
+        enabled_toolsets=["hermes-codemode-cli"],
+    ))
+    assert "terminal" in [match["name"] for match in data["matches"]]

--- a/tools/hermes_codemode_tool.py
+++ b/tools/hermes_codemode_tool.py
@@ -1,0 +1,569 @@
+"""Hermes Codemode: lazy tool schemas + programmable tool orchestration.
+
+This is a local, Hermes-owned analogue of Cloudflare Codemode.  It exposes a
+small control-plane surface (status/schema/execute) instead of requiring every
+underlying tool schema to be model-visible on every turn.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+import math
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+CODEMODE_TOOL_NAMES = frozenset({
+    "hermes_codemode_status",
+    "hermes_codemode_schema",
+    "hermes_codemode_execute",
+})
+
+# Conservative read-only set for plan mode. Anything not listed here requires
+# mode="apply" because it may mutate local state, remote state, user-facing
+# messages, browser state, or long-running process state.
+READ_ONLY_TOOLS = frozenset({
+    "read_file",
+    "search_files",
+    "web_search",
+    "web_extract",
+    "skills_list",
+    "skill_view",
+    "session_search",
+    "vision_analyze",
+    "browser_snapshot",
+    "browser_get_images",
+    "browser_console",
+    "ha_list_entities",
+    "ha_get_state",
+    "ha_list_services",
+})
+
+_SAFE_BUILTINS = {
+    "abs": abs,
+    "all": all,
+    "any": any,
+    "bool": bool,
+    "dict": dict,
+    "enumerate": enumerate,
+    "float": float,
+    "int": int,
+    "isinstance": isinstance,
+    "len": len,
+    "list": list,
+    "max": max,
+    "min": min,
+    "print": print,
+    "range": range,
+    "round": round,
+    "set": set,
+    "sorted": sorted,
+    "str": str,
+    "sum": sum,
+    "tuple": tuple,
+    "zip": zip,
+    "Exception": Exception,
+    "ValueError": ValueError,
+}
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+
+
+def _tokenize(text: str) -> List[str]:
+    return [token.lower() for token in _TOKEN_RE.findall(text or "")]
+
+
+def _tool_name(td: Dict[str, Any]) -> str:
+    return str((td.get("function") or {}).get("name") or "")
+
+
+def _tool_description(td: Dict[str, Any]) -> str:
+    return str((td.get("function") or {}).get("description") or "")
+
+
+def _tool_parameters(td: Dict[str, Any]) -> Dict[str, Any]:
+    params = (td.get("function") or {}).get("parameters") or {}
+    return params if isinstance(params, dict) else {}
+
+
+def _toolset_for(name: str) -> str:
+    try:
+        return registry.get_toolset_for_tool(name) or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _is_mutating(name: str) -> bool:
+    return name not in READ_ONLY_TOOLS
+
+
+def _keywords_for(name: str, description: str, toolset: str) -> List[str]:
+    seen: set[str] = set()
+    out: List[str] = []
+    for token in _tokenize(f"{name.replace('_', ' ')} {description} {toolset}"):
+        if token not in seen:
+            seen.add(token)
+            out.append(token)
+    return out[:24]
+
+
+def _input_fields(parameters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    properties = parameters.get("properties") or {}
+    if not isinstance(properties, dict):
+        return []
+    required = set(parameters.get("required") or [])
+    fields: List[Dict[str, Any]] = []
+    for name, spec in properties.items():
+        if not isinstance(spec, dict):
+            spec = {}
+        field_type = spec.get("type") or "any"
+        if isinstance(field_type, list):
+            field_type = "|".join(str(x) for x in field_type)
+        field = {
+            "name": name,
+            "type": str(field_type),
+            "required": name in required,
+        }
+        desc = spec.get("description")
+        if desc:
+            field["description"] = str(desc)[:300]
+        enum = spec.get("enum")
+        if enum:
+            field["enum"] = enum
+        fields.append(field)
+    return fields
+
+
+def _compact_definition(td: Dict[str, Any], *, include_schema: bool) -> Dict[str, Any]:
+    fn = td.get("function") or {}
+    name = str(fn.get("name") or "")
+    description = str(fn.get("description") or "")
+    parameters = _tool_parameters(td)
+    toolset = _toolset_for(name)
+    definition = {
+        "name": name,
+        "description": description[:900],
+        "product": toolset,
+        "toolset": toolset,
+        "mutating": _is_mutating(name),
+        "required": list(parameters.get("required") or []),
+        "aliases": [name.replace("_", " ")],
+        "keywords": _keywords_for(name, description, toolset),
+        "inputFields": _input_fields(parameters),
+    }
+    if include_schema:
+        definition["inputSchema"] = parameters
+    return definition
+
+
+def _scored_matches(defs: Iterable[Dict[str, Any]], query: str, limit: int) -> List[Dict[str, Any]]:
+    query_tokens = _tokenize(query)
+    if not query_tokens:
+        return []
+    scored: List[Tuple[float, Dict[str, Any]]] = []
+    for td in defs:
+        name = _tool_name(td)
+        desc = _tool_description(td)
+        toolset = _toolset_for(name)
+        text = f"{name.replace('_', ' ')} {desc} {toolset}"
+        tokens = _tokenize(text)
+        token_set = set(tokens)
+        score = 0.0
+        matched: List[str] = []
+        raw = text.lower()
+        for token in query_tokens:
+            if token in token_set:
+                score += 4.0 if token in _tokenize(name) else 2.0
+                matched.append(token)
+            elif len(token) >= 4 and token in raw:
+                score += 1.0
+                matched.append(token)
+        if query.lower().strip() in raw:
+            score += 4.0
+        if score > 0:
+            item = _compact_definition(td, include_schema=False)
+            item["score"] = round(score, 3)
+            item["matchedTokens"] = sorted(set(matched))
+            scored.append((score, item))
+    scored.sort(key=lambda pair: (-pair[0], pair[1]["name"]))
+    return [item for _, item in scored[:limit]]
+
+
+def _method_scope_toolsets(enabled_toolsets: Optional[List[str]]) -> Optional[List[str]]:
+    """Resolve visible Codemode bridge toolsets to their hidden backing catalog.
+
+    A session can opt into the lean ``hermes-codemode-cli`` surface, where the
+    model sees only three Codemode tools but Codemode itself can lazily describe
+    and call the ordinary ``hermes-cli`` methods. Other restricted toolsets keep
+    their restriction exactly as passed.
+    """
+    if not enabled_toolsets:
+        return enabled_toolsets
+    normalized = [str(item) for item in enabled_toolsets]
+    if "hermes-codemode-cli" in normalized or "hermes_codemode" in normalized:
+        return ["hermes-cli"]
+    return enabled_toolsets
+
+
+def _available_tool_defs(
+    *,
+    enabled_toolsets: Optional[List[str]] = None,
+    disabled_toolsets: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    # Import lazily to avoid a discovery-time cycle: model_tools imports all
+    # self-registering tools, including this module.
+    from model_tools import get_tool_definitions
+
+    defs = get_tool_definitions(
+        enabled_toolsets=_method_scope_toolsets(enabled_toolsets),
+        disabled_toolsets=disabled_toolsets,
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    ) or []
+    return [td for td in defs if _tool_name(td) and _tool_name(td) not in CODEMODE_TOOL_NAMES]
+
+
+def _available_method_names(**scope: Any) -> frozenset[str]:
+    return frozenset(_tool_name(td) for td in _available_tool_defs(**scope))
+
+
+def hermes_codemode_status(
+    *,
+    enabled_toolsets: Optional[List[str]] = None,
+    disabled_toolsets: Optional[List[str]] = None,
+) -> str:
+    defs = _available_tool_defs(enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets)
+    methods = sorted(_tool_name(td) for td in defs)
+    log_path = _audit_log_path()
+    return json.dumps({
+        "schemaVersion": SCHEMA_VERSION,
+        "methodCount": len(methods),
+        "methodsPreview": methods[:20],
+        "methodsRemaining": max(0, len(methods) - 20),
+        "planMode": {
+            "readOnlyMethods": sorted(m for m in methods if not _is_mutating(m)),
+            "default": True,
+        },
+        "applyMode": {
+            "mutationsAllowed": True,
+            "note": "Mutating methods require mode='apply'; underlying Hermes hooks, approvals, and policies still run.",
+        },
+        "auditLog": str(log_path),
+        "lookup": "Use hermes_codemode_schema(query=...) or methods=[...] for exact input schemas.",
+    }, ensure_ascii=False)
+
+
+def hermes_codemode_schema(
+    query: Optional[str] = None,
+    methods: Optional[List[str]] = None,
+    limit: int = 8,
+    include_schema: Optional[bool] = None,
+    *,
+    enabled_toolsets: Optional[List[str]] = None,
+    disabled_toolsets: Optional[List[str]] = None,
+) -> str:
+    defs = _available_tool_defs(enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets)
+    by_name = {_tool_name(td): td for td in defs}
+    requested = [str(m).strip() for m in (methods or []) if str(m).strip()]
+    include_exact_schema = True if include_schema is None else bool(include_schema)
+
+    definitions: List[Dict[str, Any]] = []
+    missing: List[str] = []
+    for name in requested:
+        td = by_name.get(name)
+        if td is None:
+            missing.append(name)
+            continue
+        definitions.append(_compact_definition(td, include_schema=include_exact_schema))
+
+    matches: List[Dict[str, Any]] = []
+    if query and not requested:
+        matches = _scored_matches(defs, str(query), max(1, min(int(limit or 8), 25)))
+
+    return json.dumps({
+        "schemaVersion": SCHEMA_VERSION,
+        "toolCount": len(defs),
+        "query": query,
+        "requestedMethods": requested,
+        "matches": matches,
+        "definitions": definitions,
+        "missing": missing,
+        "note": (
+            "Search matches omit full inputSchema to keep context small. "
+            "Request exact methods to get inputSchema."
+        ),
+    }, ensure_ascii=False)
+
+
+class CodemodeError(RuntimeError):
+    pass
+
+
+class CodemodeAPI:
+    def __init__(
+        self,
+        *,
+        mode: str,
+        allowed_methods: frozenset[str],
+        task_id: Optional[str],
+        enabled_toolsets: Optional[List[str]],
+        disabled_toolsets: Optional[List[str]],
+        call_log: List[Dict[str, Any]],
+    ) -> None:
+        self._mode = mode
+        self._allowed_methods = allowed_methods
+        self._task_id = task_id
+        self._enabled_toolsets = enabled_toolsets
+        self._disabled_toolsets = disabled_toolsets
+        self._call_log = call_log
+
+    def __getattr__(self, name: str):
+        if name.startswith("_"):
+            raise AttributeError(name)
+
+        def _caller(arguments: Optional[Dict[str, Any]] = None):
+            return self.call(name, arguments or {})
+
+        return _caller
+
+    def call(self, name: str, arguments: Optional[Dict[str, Any]] = None):
+        name = str(name).strip()
+        if not name:
+            raise CodemodeError("method name is required")
+        if name in CODEMODE_TOOL_NAMES:
+            raise CodemodeError(f"{name} cannot call itself through codemode")
+        if name not in self._allowed_methods:
+            raise CodemodeError(f"{name} is not available in this codemode session")
+        if self._mode == "plan" and _is_mutating(name):
+            raise CodemodeError(f"{name} is not allowed in plan mode; rerun with mode='apply' if you intend to mutate state")
+        if arguments is None:
+            arguments = {}
+        if not isinstance(arguments, dict):
+            raise CodemodeError("codemode method arguments must be an object/dict")
+
+        started = time.monotonic()
+        result_text = _dispatch_tool_call(
+            name,
+            arguments,
+            task_id=self._task_id,
+            enabled_toolsets=self._enabled_toolsets,
+            disabled_toolsets=self._disabled_toolsets,
+        )
+        duration_ms = int((time.monotonic() - started) * 1000)
+        self._call_log.append({
+            "method": name,
+            "mutating": _is_mutating(name),
+            "durationMs": duration_ms,
+        })
+        try:
+            return json.loads(result_text)
+        except Exception:
+            return result_text
+
+
+def _dispatch_tool_call(function_name: str, function_args: Dict[str, Any], **kwargs: Any) -> str:
+    from model_tools import handle_function_call
+
+    return handle_function_call(function_name, function_args, **kwargs)
+
+
+def _run_user_code(code: str, codemode: CodemodeAPI) -> Any:
+    local_vars: Dict[str, Any] = {}
+    global_vars = {
+        "__builtins__": _SAFE_BUILTINS,
+        "json": json,
+        "math": math,
+        "re": re,
+    }
+    stripped = (code or "").strip()
+    if not stripped:
+        raise CodemodeError("code is required")
+
+    if stripped.startswith("lambda"):
+        fn = eval(stripped, global_vars, local_vars)  # noqa: S307 - restricted globals, local control-plane DSL
+    else:
+        exec(stripped, global_vars, local_vars)  # noqa: S102 - intentional codemode execution with restricted globals
+        fn = local_vars.get("main") or global_vars.get("main")
+        if fn is None and "result" in local_vars:
+            return local_vars["result"]
+    if not callable(fn):
+        raise CodemodeError("code must define callable main(codemode) or evaluate to a lambda")
+
+    sig = inspect.signature(fn)
+    if len(sig.parameters) == 0:
+        return fn()
+    return fn(codemode)
+
+
+def _jsonable(value: Any) -> Any:
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        return repr(value)
+
+
+def _audit_log_path() -> Path:
+    return get_hermes_home() / "logs" / "hermes-codemode.jsonl"
+
+
+def _write_audit(entry: Dict[str, Any]) -> None:
+    try:
+        path = _audit_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception as exc:
+        logger.debug("failed to write hermes codemode audit log: %s", exc)
+
+
+def hermes_codemode_execute(
+    code: str,
+    mode: str = "plan",
+    *,
+    task_id: Optional[str] = None,
+    enabled_toolsets: Optional[List[str]] = None,
+    disabled_toolsets: Optional[List[str]] = None,
+) -> str:
+    normalized_mode = str(mode or "plan").strip().lower()
+    if normalized_mode not in {"plan", "apply"}:
+        return json.dumps({"ok": False, "error": "mode must be 'plan' or 'apply'"}, ensure_ascii=False)
+
+    allowed = _available_method_names(enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets)
+    call_log: List[Dict[str, Any]] = []
+    api = CodemodeAPI(
+        mode=normalized_mode,
+        allowed_methods=allowed,
+        task_id=task_id,
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
+        call_log=call_log,
+    )
+    started = time.monotonic()
+    audit_base = {
+        "ts": time.time(),
+        "mode": normalized_mode,
+        "taskId": task_id or "",
+        "codePreview": (code or "")[:500],
+    }
+    try:
+        result = _run_user_code(code, api)
+        payload = {
+            "ok": True,
+            "mode": normalized_mode,
+            "durationMs": int((time.monotonic() - started) * 1000),
+            "calls": call_log,
+            "result": _jsonable(result),
+        }
+        _write_audit({**audit_base, "ok": True, "calls": call_log})
+        return json.dumps(payload, ensure_ascii=False)
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "mode": normalized_mode,
+            "durationMs": int((time.monotonic() - started) * 1000),
+            "calls": call_log,
+            "error": str(exc),
+            "errorType": type(exc).__name__,
+        }
+        _write_audit({**audit_base, "ok": False, "calls": call_log, "error": str(exc)})
+        return json.dumps(payload, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas and registry
+# ---------------------------------------------------------------------------
+
+HERMES_CODEMODE_STATUS_SCHEMA = {
+    "name": "hermes_codemode_status",
+    "description": "Show Hermes Codemode status: available method count, preview, safety modes, and audit log path.",
+    "parameters": {"type": "object", "properties": {}},
+}
+
+HERMES_CODEMODE_SCHEMA_SCHEMA = {
+    "name": "hermes_codemode_schema",
+    "description": (
+        "Search or fetch exact schemas for Hermes Codemode methods. Use query for compact matches; "
+        "use methods=[...] to get exact input schemas just-in-time."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Keywords describing the method you need."},
+            "methods": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Exact method names to describe, e.g. ['read_file', 'terminal'].",
+            },
+            "limit": {"type": "integer", "description": "Max search matches. Default 8."},
+            "include_schema": {"type": "boolean", "description": "Include full inputSchema for exact methods. Default true."},
+        },
+    },
+}
+
+HERMES_CODEMODE_EXECUTE_SCHEMA = {
+    "name": "hermes_codemode_execute",
+    "description": (
+        "Run a small Python codemode program against Hermes tools via a codemode object. "
+        "Use mode='plan' for read-only inspection; mode='apply' permits mutating methods while preserving underlying Hermes hooks and approvals. "
+        "Code must define main(codemode) or be a lambda. Example: def main(codemode): return codemode.read_file({'path':'README.md'})."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "code": {"type": "string", "description": "Python code defining main(codemode) or a lambda codemode: ..."},
+            "mode": {"type": "string", "enum": ["plan", "apply"], "description": "plan is read-only; apply permits mutations."},
+        },
+        "required": ["code"],
+    },
+}
+
+registry.register(
+    name="hermes_codemode_status",
+    toolset="hermes_codemode",
+    schema=HERMES_CODEMODE_STATUS_SCHEMA,
+    handler=lambda args, **kw: hermes_codemode_status(
+        enabled_toolsets=kw.get("enabled_toolsets"),
+        disabled_toolsets=kw.get("disabled_toolsets"),
+    ),
+    emoji="🧩",
+)
+
+registry.register(
+    name="hermes_codemode_schema",
+    toolset="hermes_codemode",
+    schema=HERMES_CODEMODE_SCHEMA_SCHEMA,
+    handler=lambda args, **kw: hermes_codemode_schema(
+        query=args.get("query"),
+        methods=args.get("methods"),
+        limit=args.get("limit", 8),
+        include_schema=args.get("include_schema"),
+        enabled_toolsets=kw.get("enabled_toolsets"),
+        disabled_toolsets=kw.get("disabled_toolsets"),
+    ),
+    emoji="🧩",
+)
+
+registry.register(
+    name="hermes_codemode_execute",
+    toolset="hermes_codemode",
+    schema=HERMES_CODEMODE_EXECUTE_SCHEMA,
+    handler=lambda args, **kw: hermes_codemode_execute(
+        code=args.get("code", ""),
+        mode=args.get("mode", "plan"),
+        task_id=kw.get("task_id"),
+        enabled_toolsets=kw.get("enabled_toolsets"),
+        disabled_toolsets=kw.get("disabled_toolsets"),
+    ),
+    emoji="🧩",
+    max_result_size_chars=100_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -239,6 +239,18 @@ TOOLSETS = {
         "tools": ["execute_code"],
         "includes": []
     },
+
+    "hermes_codemode": {
+        "description": "Lazy programmable Hermes tool control plane: status, schema lookup, and plan/apply execution",
+        "tools": ["hermes_codemode_status", "hermes_codemode_schema", "hermes_codemode_execute"],
+        "includes": []
+    },
+
+    "hermes-codemode-cli": {
+        "description": "Lean CLI surface: expose only Hermes Codemode bridge tools while Codemode can lazily reach the full hermes-cli backing catalog",
+        "tools": ["hermes_codemode_status", "hermes_codemode_schema", "hermes_codemode_execute"],
+        "includes": []
+    },
     
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",


### PR DESCRIPTION
## Summary
- Add Hermes Codemode bridge tools: status, schema lookup, and plan/apply execution
- Add lean `hermes-codemode-cli` toolset that exposes only the Codemode bridge while lazily backing the full `hermes-cli` catalog
- Preserve session toolset scoping and underlying Hermes hooks/approvals for Codemode calls
- Add focused tests for schema lookup, search, plan/apply safety, scoping, and lean toolset behavior

## Token impact
- `hermes-cli`: 30 tools, ~13.5k schema tokens
- `hermes-codemode-cli`: 3 tools, ~401 schema tokens

## Test plan
- `venv/bin/python -m pytest tests/tools/test_hermes_codemode_tool.py tests/tools/test_tool_search.py tests/test_toolsets.py tests/test_toolset_distributions.py -q -o 'addopts='`
- `venv/bin/python -m compileall -q tools/hermes_codemode_tool.py model_tools.py toolsets.py`
