### PR TITLE
fix: route email intake approvals to Discord

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -922,6 +922,23 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                # Generic platform extras that should work when users place
+                # them directly under ``platforms.<name>`` instead of nesting
+                # under ``extra``.  This keeps adapter-specific runtime knobs
+                # (for example email approval routing) from being silently
+                # dropped by PlatformConfig.from_dict().
+                for _extra_key in (
+                    "suppress_home_notice",
+                    "suppress_home_channel_notice",
+                    "response_delivery",
+                    "approval_discord_channel",
+                    "approval_discord_thread",
+                    "approval_discord_thread_id",
+                    "approval_policy_note",
+                    "skip_attachments",
+                ):
+                    if _extra_key in platform_cfg:
+                        bridged[_extra_key] = platform_cfg[_extra_key]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -18,12 +18,15 @@ Environment variables:
 import asyncio
 import email as email_lib
 import imaplib
+import json
 import logging
 import os
 import re
 import smtplib
 import ssl
 import uuid
+import urllib.error
+import urllib.request
 from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -262,6 +265,23 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         extra = config.extra or {}
         self._skip_attachments = extra.get("skip_attachments", False)
+        self._response_delivery = str(
+            extra.get("response_delivery")
+            or os.getenv("EMAIL_RESPONSE_DELIVERY")
+            or "email"
+        ).strip().lower()
+        self._approval_discord_channel = str(
+            extra.get("approval_discord_channel")
+            or os.getenv("EMAIL_APPROVAL_DISCORD_CHANNEL")
+            or os.getenv("DISCORD_HOME_CHANNEL")
+            or ""
+        ).strip()
+        self._approval_discord_thread = str(
+            extra.get("approval_discord_thread")
+            or os.getenv("EMAIL_APPROVAL_DISCORD_THREAD_ID")
+            or os.getenv("DISCORD_HOME_CHANNEL_THREAD_ID")
+            or ""
+        ).strip()
 
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
@@ -517,6 +537,85 @@ class EmailAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[Email] Send failed to %s: %s", chat_id, e)
             return SendResult(success=False, error=str(e))
+
+    async def _send_with_retry(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Any = None,
+        max_retries: int = 2,
+        base_delay: float = 2.0,
+    ) -> SendResult:
+        """Deliver the gateway's automatic response to an inbound email.
+
+        The stock Email adapter replies by email.  For approval-gated email
+        intake, email is an input surface only: the response/approval card must
+        go to Discord, and explicit outbound email remains possible only via an
+        approved send/reply action that calls ``send`` directly.
+        """
+        if self._response_delivery not in {"discord", "discord_home", "approval_discord"}:
+            return await super()._send_with_retry(
+                chat_id=chat_id,
+                content=content,
+                reply_to=reply_to,
+                metadata=metadata,
+                max_retries=max_retries,
+                base_delay=base_delay,
+            )
+
+        result = await asyncio.to_thread(self._send_discord_approval_message, content)
+        if not result.success:
+            logger.error(
+                "[Email] Discord approval delivery failed; suppressing email fallback: %s",
+                result.error,
+            )
+        return result
+
+    def _send_discord_approval_message(self, content: str) -> SendResult:
+        """Send an email-intake response to the configured Discord channel."""
+        token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+        channel_id = self._approval_discord_thread or self._approval_discord_channel
+        if not token:
+            return SendResult(success=False, error="DISCORD_BOT_TOKEN is not configured")
+        if not channel_id:
+            return SendResult(success=False, error="No Discord approval channel configured")
+
+        chunks = []
+        text = content or ""
+        while text:
+            chunks.append(text[:1900])
+            text = text[1900:]
+        if not chunks:
+            chunks = ["(empty email-intake response)"]
+
+        last_message_id = None
+        for idx, chunk in enumerate(chunks, start=1):
+            if len(chunks) > 1:
+                chunk = f"{chunk}\n\n({idx}/{len(chunks)})"
+            payload = json.dumps({"content": chunk}).encode("utf-8")
+            req = urllib.request.Request(
+                f"https://discord.com/api/v10/channels/{channel_id}/messages",
+                data=payload,
+                headers={
+                    "Authorization": f"Bot {token}",
+                    "Content-Type": "application/json",
+                    "User-Agent": "HermesEmailApprovalRelay/1.0",
+                },
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=20) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    last_message_id = str(data.get("id") or "") or last_message_id
+            except urllib.error.HTTPError as e:
+                detail = e.read().decode("utf-8", errors="replace")[:500]
+                return SendResult(success=False, error=f"Discord HTTP {e.code}: {detail}")
+            except Exception as e:
+                return SendResult(success=False, error=str(e))
+
+        logger.info("[Email] Routed inbound-email response to Discord channel %s", channel_id)
+        return SendResult(success=True, message_id=last_message_id)
 
     def _send_email(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -841,6 +841,22 @@ def _home_thread_env_var(platform_name: str) -> str:
     return f"{_home_target_env_var(platform_name)}_THREAD_ID"
 
 
+def _suppress_home_channel_notice(platform_name: str) -> bool:
+    """Return True when a platform opts out of the first-run /sethome notice."""
+    try:
+        cfg = _load_gateway_config()
+        platforms = cfg.get("platforms") or {}
+        platform_cfg = platforms.get(platform_name) or {}
+        if not isinstance(platform_cfg, dict):
+            return False
+        return bool(
+            platform_cfg.get("suppress_home_notice")
+            or platform_cfg.get("suppress_home_channel_notice")
+        )
+    except Exception:
+        return False
+
+
 def _restart_notification_pending() -> bool:
     """Return True when a /restart completion marker is waiting to be delivered."""
     return (_hermes_home / ".restart_notify.json").exists()
@@ -9486,7 +9502,7 @@ class GatewayRunner:
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
-            if not os.getenv(env_key):
+            if not os.getenv(env_key) and not _suppress_home_channel_notice(platform_name):
                 # Slack dispatches all Hermes commands through a single
                 # parent slash command `/hermes`; bare `/sethome` is not
                 # registered and would fail with "app did not respond".

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -233,6 +233,98 @@ class TestExtractAttachments(unittest.TestCase):
         mock_cache.assert_called_once()
 
 
+class TestEmailResponseDelivery(unittest.TestCase):
+    """Test approval-first response routing for inbound email."""
+
+    def test_yaml_platform_keys_are_bridged_into_email_extra(self):
+        from pathlib import Path
+        import tempfile
+        import yaml
+        from unittest.mock import patch
+
+        from gateway.config import Platform, load_gateway_config
+
+        with tempfile.TemporaryDirectory() as td:
+            Path(td, "config.yaml").write_text(yaml.safe_dump({
+                "platforms": {
+                    "email": {
+                        "response_delivery": "discord",
+                        "approval_discord_channel": "12345",
+                        "approval_discord_thread": "67890",
+                        "suppress_home_notice": True,
+                        "skip_attachments": True,
+                    }
+                }
+            }))
+            with patch.dict(os.environ, {
+                "HERMES_HOME": td,
+                "EMAIL_ADDRESS": "hermes@test.com",
+                "EMAIL_PASSWORD": "secret",
+                "EMAIL_IMAP_HOST": "imap.test.com",
+                "EMAIL_SMTP_HOST": "smtp.test.com",
+            }, clear=False):
+                cfg = load_gateway_config()
+
+        extra = cfg.platforms[Platform.EMAIL].extra
+        self.assertEqual(extra["response_delivery"], "discord")
+        self.assertEqual(extra["approval_discord_channel"], "12345")
+        self.assertEqual(extra["approval_discord_thread"], "67890")
+        self.assertTrue(extra["suppress_home_notice"])
+        self.assertTrue(extra["skip_attachments"])
+
+    def test_discord_response_delivery_does_not_call_smtp_send(self):
+        import asyncio
+        from gateway.config import PlatformConfig
+        from gateway.platforms.email import EmailAdapter
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "DISCORD_BOT_TOKEN": "token",
+            "DISCORD_HOME_CHANNEL": "12345",
+        }, clear=False):
+            adapter = EmailAdapter(PlatformConfig(
+                enabled=True,
+                extra={"response_delivery": "discord"},
+            ))
+
+        adapter._send_email = MagicMock(return_value="email-message-id")
+        adapter._send_discord_approval_message = MagicMock(
+            return_value=SendResult(success=True, message_id="discord-message-id")
+        )
+
+        result = asyncio.run(adapter._send_with_retry("rob@example.com", "approval card"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "discord-message-id")
+        adapter._send_discord_approval_message.assert_called_once_with("approval card")
+        adapter._send_email.assert_not_called()
+
+    def test_default_response_delivery_still_uses_email_send_path(self):
+        import asyncio
+        from gateway.config import PlatformConfig
+        from gateway.platforms.email import EmailAdapter
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_RESPONSE_DELIVERY": "",
+        }, clear=False):
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="email-message-id"))
+
+        result = asyncio.run(adapter._send_with_retry("rob@example.com", "normal reply"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "email-message-id")
+        adapter.send.assert_awaited_once()
+
+
 class TestDispatchMessage(unittest.TestCase):
     """Test email message dispatch logic."""
 


### PR DESCRIPTION
## Summary\n- add email adapter response delivery mode that routes automatic inbound-email responses to a configured Discord approval channel instead of replying by SMTP\n- add suppress_home_notice so email intake does not send no-home-channel setup emails\n- bridge top-level platforms.email routing keys into platform extra config\n\n## Tests\n- PYTHONPATH=$PWD ~/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_email.py::TestEmailResponseDelivery tests/gateway/test_restart_notification.py -q -o 'addopts='\n