### PR TITLE
fix(desktop): persist composer draft across non-overlay route changes

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -8,6 +8,7 @@ import {
   type DragEvent as ReactDragEvent,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState
@@ -23,7 +24,7 @@ import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
-import { $composerAttachments, clearComposerAttachments, type ComposerAttachment } from '@/store/composer'
+import { $composerAttachments, $composerDraft, clearComposerAttachments, type ComposerAttachment } from '@/store/composer'
 import {
   browseBackward,
   browseForward,
@@ -302,6 +303,37 @@ export function ChatBar({
       renderComposerContents(editor, draft)
     }
   }, [draft])
+
+  // Persist unsent draft across route changes that unmount ChatView (e.g.
+  // navigating to Skills, Messaging, or Artifacts).  The assistant-ui composer
+  // state is ephemeral — it dies when the <AssistantRuntimeProvider> tree
+  // unmounts.  Saving to the nanostore lets us restore the text when the user
+  // navigates back to the chat.
+  useEffect(() => {
+    return () => {
+      const text = draftRef.current
+
+      if (text.trim()) {
+        $composerDraft.set(text)
+      }
+    }
+    // Mount/unmount only — draftRef.current is read at cleanup time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Restore a persisted draft on mount (navigated back from a non-overlay
+  // route).  useLayoutEffect prevents a visible flash of empty composer.
+  useLayoutEffect(() => {
+    const saved = $composerDraft.get()
+
+    if (saved.trim()) {
+      aui.composer().setText(saved)
+      draftRef.current = saved
+      $composerDraft.set('')
+    }
+    // Mount-only — read the store once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     if (urlOpen) {

--- a/apps/desktop/src/store/composer-persistence.test.ts
+++ b/apps/desktop/src/store/composer-persistence.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { $composerDraft } from './composer'
+
+describe('$composerDraft cross-navigation persistence', () => {
+  it('stores and retrieves a non-empty draft', () => {
+    $composerDraft.set('hello world')
+    expect($composerDraft.get()).toBe('hello world')
+    $composerDraft.set('')
+  })
+
+  it('returns empty string by default', () => {
+    expect($composerDraft.get()).toBe('')
+  })
+
+  it('round-trips multiline text', () => {
+    const text = 'line one\n\nline two'
+    $composerDraft.set(text)
+    expect($composerDraft.get()).toBe(text)
+    $composerDraft.set('')
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Preserves unsent composer draft text when navigating away from the chat view to non-overlay routes (Skills, Messaging, Artifacts) in the desktop app. Previously, the draft was lost because the assistant-ui composer state is ephemeral and dies when `ChatView` unmounts.

## Related Issue

Fixes #42401

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx`: Added `useEffect` cleanup to save `draftRef.current` to the `$composerDraft` nanostore on unmount, and `useLayoutEffect` to restore it on mount (preventing a visible flash). The store is cleared after restore so stale text doesn't leak into subsequent submits or fresh-session actions.
- `apps/desktop/src/store/composer-persistence.test.ts`: Unit tests verifying `$composerDraft` round-trips non-empty and multiline text correctly.

## How to Test

1. Open the desktop app and type a multi-line prompt in the composer (do not send it)
2. Navigate to the Skills page (or Messaging / Artifacts)
3. Navigate back to the chat view
4. Verify the previously typed prompt text is restored in the composer
5. Verify that starting a new session (sidebar + button) correctly gives an empty composer
6. Verify that submitting a prompt and then navigating away/back does not restore the old text

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `apps/desktop/src/app/chat/composer/index.tsx` (callers: ChatView renders ChatBar; draft state managed by assistant-ui `useAuiState`)
- Blast radius: LOW — additive only (two new effects), no existing behavior changed
- Related patterns: `$composerDraft` nanostore atom already existed but was unused by the composer; `clearComposerDraft()` on submit/new-session already clears it
