### PR TITLE
fix(desktop): show script field in Cron detail when prompt is empty

### DIFF
--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -85,6 +85,10 @@ function jobPrompt(job: CronJob): string {
   return asText(job.prompt)
 }
 
+function jobDescription(job: CronJob): string {
+  return asText(job.prompt) || asText(job.script)
+}
+
 function jobScheduleDisplay(job: CronJob): string {
   return asText(job.schedule_display) || asText(job.schedule?.display) || asText(job.schedule?.expr) || '—'
 }
@@ -545,7 +549,7 @@ function CronJobDetail({
   const state = jobState(job)
   const isPaused = state === 'paused'
   const deliver = jobDeliver(job)
-  const prompt = jobPrompt(job)
+  const description = jobDescription(job)
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -559,6 +563,9 @@ function CronJobDetail({
                   <StatePill tone={STATE_TONE[state] ?? 'muted'}>{c.states[state] ?? state}</StatePill>
                   {deliver && deliver !== DEFAULT_DELIVER && (
                     <StatePill tone="muted">{c.deliveryLabels[deliver] ?? deliver}</StatePill>
+                  )}
+                  {!jobPrompt(job) && asText(job.script) && (
+                    <StatePill tone="muted">script</StatePill>
                   )}
                 </div>
                 <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[0.7rem] text-muted-foreground">
@@ -598,7 +605,7 @@ function CronJobDetail({
               </div>
             </div>
 
-            {prompt && <p className="line-clamp-3 text-xs text-muted-foreground">{prompt}</p>}
+            {description && <p className="line-clamp-3 text-xs text-muted-foreground">{description}</p>}
             {job.last_error && (
               <p className="inline-flex items-start gap-1 text-[0.7rem] text-destructive">
                 <AlertTriangle className="mt-px size-3 shrink-0" />


### PR DESCRIPTION
## What does this PR do?

Shows the `script` field in the Desktop Cron detail view when `prompt` is empty (script/no_agent jobs). Adds a muted "script" badge to distinguish script-based jobs from prompt-based ones.

## Related Issue

Fixes #42433

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/cron/index.tsx`: Added `jobDescription()` helper that returns `prompt || script`, updated `CronJobDetail` to use it instead of raw `prompt`, added a muted "script" badge for script-based jobs.

## How to Test

1. Create a script-based cron job via CLI: `hermes cron add --name "test" --schedule "0 * * * *" --script "echo hello" --no-agent`
2. Open the Desktop app and navigate to the Cron page
3. Select the script job — the detail view should now show the script content in the description area
4. Verify the "script" badge appears next to the job title

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes — or N/A (TSX rendering change, no testable business logic)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `CronJobDetail` in `cron/index.tsx` (single file change)
- Blast radius: LOW
- Related patterns: `jobTitle()` in `job-state.ts` already falls back to script; `jobDescription()` mirrors the same pattern for the description area
