### PR TITLE
fix(gateway): clear session store mapping on hard delete to prevent resurrection

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -997,6 +997,23 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("SessionDB unavailable for API server: %s", e)
         return self._session_db
 
+    def _get_sessions_dir(self) -> "Optional[Path]":
+        """Return the sessions directory for transcript file cleanup."""
+        try:
+            from hermes_constants import get_hermes_home
+            return get_hermes_home() / "sessions"
+        except Exception:
+            return None
+
+    def _clear_session_store_mapping(self, session_id: str) -> None:
+        """Remove the channel→session mapping from the gateway SessionStore."""
+        try:
+            store = getattr(self, "_session_store", None)
+            if store is not None and hasattr(store, "remove_by_session_id"):
+                store.remove_by_session_id(session_id)
+        except Exception as exc:
+            logger.debug("Could not clear session store mapping for %s: %s", session_id, exc)
+
     # ------------------------------------------------------------------
     # Agent creation helper
     # ------------------------------------------------------------------
@@ -1467,7 +1484,13 @@ class APIServerAdapter(BasePlatformAdapter):
         if err:
             return err
         db = self._ensure_session_db()
-        deleted = db.delete_session(session_id)
+        # Pass sessions_dir so transcript files are also removed
+        sessions_dir = self._get_sessions_dir()
+        deleted = db.delete_session(session_id, sessions_dir=sessions_dir)
+        # Clear the gateway's durable channel→session mapping so the
+        # session is not resurrected by the next inbound message.
+        if deleted:
+            self._clear_session_store_mapping(session_id)
         return web.json_response({"object": "hermes.session.deleted", "id": session_id, "deleted": bool(deleted)})
 
     async def _handle_session_messages(self, request: "web.Request") -> "web.Response":

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1050,6 +1050,33 @@ class SessionStore:
             self._save()
             return True
 
+    def remove_by_session_id(self, session_id: str) -> bool:
+        """Remove the session_key → session_id mapping for a deleted session.
+
+        When a session is hard-deleted (e.g. via ``DELETE /api/sessions/<id>``),
+        the durable mapping in ``sessions.json`` must also be cleared so that
+        subsequent messages from the same channel create a fresh session instead
+        of resurrecting the deleted one.
+
+        Returns True if an entry was found and removed.
+        """
+        with self._lock:
+            self._ensure_loaded_locked()
+            removed_key = None
+            for key, entry in self._entries.items():
+                if entry.session_id == session_id:
+                    removed_key = key
+                    break
+            if removed_key is not None:
+                self._entries.pop(removed_key, None)
+                self._save()
+                logger.info(
+                    "SessionStore removed mapping for deleted session %s (key=%s)",
+                    session_id, removed_key,
+                )
+                return True
+        return False
+
     def prune_old_entries(self, max_age_days: int) -> int:
         """Drop SessionEntry records older than max_age_days.
 


### PR DESCRIPTION
## What does this PR do?

Prevents deleted gateway-sourced sessions (e.g. Discord) from being resurrected by clearing the durable `session_key → session_id` mapping and removing transcript files during hard delete.

## Related Issue

Fixes #42422

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py`: Added `SessionStore.remove_by_session_id()` method that clears the `sessions.json` mapping for a deleted session, preventing resurrection on the next inbound message.
- `gateway/platforms/api_server.py`: Updated `_handle_delete_session` to pass `sessions_dir` (so transcript files are removed) and call `remove_by_session_id()` after successful deletion. Added `_get_sessions_dir()` and `_clear_session_store_mapping()` helpers.

## How to Test

1. Start the gateway with a Discord source: `hermes gateway --start`
2. Send a message from Discord to create a session
3. Open the Desktop app and delete the session (trash icon)
4. Send another message from Discord — it should create a **new** session, not resurrect the deleted one
5. Verify `sessions.json` no longer contains the deleted session's key

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes — or N/A (integration test requires live gateway; helper methods are defensive with try/except)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `SessionStore._entries` dict (session_key → SessionEntry), `delete_session()` in `hermes_state.py`, `_handle_delete_session` in `api_server.py`
- Blast radius: LOW — new method only called on explicit DELETE; gateway adapters unaffected
- Related patterns: `prune_old_entries()` uses the same `_lock` + `_ensure_loaded_locked` + `_save` pattern
