### PR TITLE
feat(telegram): adaptive clarify buttons — show label text when short enough

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2808,11 +2808,23 @@ class TelegramAdapter(BasePlatformAdapter):
             text = f"❓ {_html.escape(question)}"
             thread_id = self._metadata_thread_id(metadata)
 
-            if choices:
-                # Render full option text in the message body so mobile
-                # users can read long choices that would be truncated in
-                # inline button labels.  Buttons keep short numeric labels
-                # (1, 2, …, Other) to avoid Telegram truncation.
+            # Adaptive button rendering: if ALL choice labels fit within
+            # _CLARIFY_BUTTON_LABEL_MAX chars, render the label text
+            # directly on each button and skip the numbered list in the
+            # body.  Otherwise fall back to the classic numeric buttons
+            # + full option list so mobile users aren't hurt by truncation.
+            _CLARIFY_BUTTON_LABEL_MAX = 24
+            use_text_buttons = (
+                choices
+                and all(len(str(c)) <= _CLARIFY_BUTTON_LABEL_MAX for c in choices)
+            )
+
+            if choices and not use_text_buttons:
+                # Long labels: render full option text in the message body
+                # so mobile users can read long choices that would be
+                # truncated in inline button labels.  Buttons keep short
+                # numeric labels (1, 2, …, Other) to avoid Telegram
+                # truncation.
                 option_lines = "\n".join(
                     f"{i + 1}. {_html.escape(str(c))}"
                     for i, c in enumerate(choices)
@@ -2830,10 +2842,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>"
                 # short.
                 rows = []
-                for idx in range(len(choices)):
+                for idx, choice in enumerate(choices):
+                    label = str(choice) if use_text_buttons else str(idx + 1)
                     rows.append([
                         InlineKeyboardButton(
-                            str(idx + 1),
+                            label,
                             callback_data=f"cl:{clarify_id}:{idx}",
                         )
                     ])

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -98,10 +98,8 @@ class TestTelegramSendClarify:
         kwargs = adapter._bot.send_message.call_args[1]
         assert kwargs["chat_id"] == 12345
         assert "Which option?" in kwargs["text"]
-        # Full option text rendered in the message body (not just buttons)
-        assert "1. alpha" in kwargs["text"]
-        assert "2. beta" in kwargs["text"]
-        assert "3. gamma" in kwargs["text"]
+        # Short labels (≤24 chars) → text buttons, no numbered list in body
+        assert "1. alpha" not in kwargs["text"]
         # InlineKeyboardMarkup with N+1 buttons (3 choices + Other)
         markup = kwargs["reply_markup"]
         assert markup is not None
@@ -188,6 +186,71 @@ class TestTelegramSendClarify:
         # Must NOT contain raw <script> — html.escape should have neutralized
         assert "<script>" not in kwargs["text"]
         assert "&lt;script&gt;" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_short_labels_use_text_buttons(self):
+        """When ALL choice labels are ≤ 24 chars, buttons show label text
+        directly and the message body has no numbered list."""
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 200
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send_clarify(
+            chat_id="12345",
+            question="Pick one",
+            choices=["🌱 Plant rescue", "✈️ Travel parser", "🎨 Art gen"],
+            clarify_id="cid-short",
+            session_key="sk-short",
+        )
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        # No numbered list in body for short labels
+        assert "1. " not in kwargs["text"]
+        assert "2. " not in kwargs["text"]
+        assert "Pick one" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_labels_use_numeric_buttons(self):
+        """When ANY choice label exceeds 24 chars, fall back to numeric
+        buttons and render the numbered list in the body."""
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 201
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send_clarify(
+            chat_id="12345",
+            question="Pick one",
+            choices=["short", "x" * 25, "tiny"],
+            clarify_id="cid-mixed",
+            session_key="sk-mixed",
+        )
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        # Numbered list in body for long labels
+        assert "1. short" in kwargs["text"]
+        assert "2. " in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_exactly_24_char_label_uses_text_buttons(self):
+        """Labels exactly at the 24-char boundary use text buttons."""
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 202
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send_clarify(
+            chat_id="12345",
+            question="Choose",
+            choices=["a" * 24],
+            clarify_id="cid-exact",
+            session_key="sk-exact",
+        )
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        # Exactly 24 chars → text buttons, no numbered list
+        assert "1. " not in kwargs["text"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Problem

When the `clarify` tool renders choices on Telegram, inline buttons always show bare numbers (`1`, `2`, `3`, …). Users must visually map numbers to the option list in the message body before every tap. For short labels (e.g. `🌱 Plant rescue`, `✈️ Travel parser`), this indirection is unnecessary — Telegram buttons comfortably fit ~25-30 chars on mobile.

Closes #40259

## Solution

Adaptive rendering in `send_clarify()`:

- If **all** choice labels are ≤ 24 chars → render the label text directly on each button and **omit** the numbered list from the message body (buttons are self-describing)
- If **any** label exceeds 24 chars → fall back to the classic behavior (numbered list in body + numeric buttons)

The 24-char threshold is chosen conservatively to stay well within Telegram's button label display limits on mobile devices.

## Changes

- `gateway/platforms/telegram.py` — Add `_CLARIFY_BUTTON_LABEL_MAX` constant and `use_text_buttons` adaptive flag in `send_clarify()`. When enabled, button labels show choice text instead of numbers, and the numbered list is omitted from the message body.
- `tests/gateway/test_telegram_clarify_buttons.py` — Update existing test to match new short-label behavior. Add 3 new tests: short labels use text buttons, mixed (any long) labels use numeric fallback, boundary case at exactly 24 chars.

## Testing

```
tests/gateway/test_telegram_clarify_buttons.py — 15/15 passed
```

New tests:
- `test_short_labels_use_text_buttons` — all short → text buttons, no numbered list
- `test_mixed_labels_use_numeric_buttons` — any long → numeric fallback with numbered list
- `test_exactly_24_char_label_uses_text_buttons` — boundary: exactly 24 chars uses text buttons
