### PR TITLE
fix(agent): deepcopy plugin context engine to prevent parent corruption

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1489,7 +1489,8 @@ def init_agent(
                 from hermes_cli.plugins import get_plugin_context_engine
                 _candidate = get_plugin_context_engine()
                 if _candidate and _candidate.name == _engine_name:
-                    _selected_engine = _candidate
+                    import copy as _copy
+                    _selected_engine = _copy.deepcopy(_candidate)
             except Exception:
                 pass
 

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -248,3 +248,52 @@ class TestPluginContextEngineSlot:
             assert get_plugin_context_engine() is engine
         finally:
             plugins_mod._plugin_manager = old_mgr
+
+
+
+class TestPluginContextEngineDeepCopy:
+    """Verify that the plugin context engine singleton is deep-copied before
+    mutation in agent_init — regression test for #42449."""
+
+    def test_deepcopy_prevents_shared_mutation(self):
+        """Deep-copied engine should not propagate mutations back to the singleton."""
+        import copy
+        engine = StubEngine(context_length=1_000_000, threshold_pct=0.20)
+        clone = copy.deepcopy(engine)
+
+        # Mutate the clone (simulating child agent's update_model)
+        clone.context_length = 204800
+        clone.threshold_tokens = 40960
+
+        # Original must be unaffected
+        assert engine.context_length == 1_000_000
+        assert engine.threshold_tokens == 200000  # 1M * 0.20
+        assert clone is not engine
+
+    def test_deepcopy_preserves_engine_name(self):
+        """Deep-copied engine retains its identity (name property)."""
+        import copy
+        engine = StubEngine(context_length=500000)
+        clone = copy.deepcopy(engine)
+        assert clone.name == engine.name == "stub"
+
+    def test_deepcopy_preserves_compressor_state(self):
+        """Deep-copied engine starts with the same token counters."""
+        import copy
+        engine = StubEngine(context_length=500000)
+        engine.last_prompt_tokens = 1000
+        engine.last_total_tokens = 1500
+        engine.compression_count = 3
+
+        clone = copy.deepcopy(engine)
+        assert clone.last_prompt_tokens == 1000
+        assert clone.last_total_tokens == 1500
+        assert clone.compression_count == 3
+        assert clone is not engine
+
+    def test_no_deepcopy_direct_assignment_would_share_state(self):
+        """Baseline: without deepcopy, both variables point to the same object."""
+        engine = StubEngine(context_length=1_000_000)
+        direct = engine  # no deepcopy — the bug path
+        direct.context_length = 204800
+        assert engine.context_length == 204800  # bug: parent corrupted!


### PR DESCRIPTION
## What does this PR do?

Deep-copies the plugin context engine singleton before assigning it to a child agent in `agent_init.py`, preventing the child's `update_model()` from mutating the parent's compression threshold.

## Related Issue

Fixes #42449

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py`: Use `copy.deepcopy()` on the plugin context engine before assignment, so each agent gets an independent copy
- `tests/agent/test_context_engine.py`: Add 4 regression tests verifying deepcopy isolation and state preservation

## How to Test

1. Install a context engine plugin (e.g., chat-compressor)
2. Configure a parent agent with a high-context model (e.g., deepseek-v4, 1M context)
3. Use `delegate_task` with a low-context model (e.g., MiniMax-M2.7, 204K context)
4. After delegation completes, verify the parent's compression threshold is still based on 1M context, not 204K
5. Run tests: `pytest tests/agent/test_context_engine.py::TestPluginContextEngineDeepCopy -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/agent_init.py:1488-1493` (get_plugin_context_engine singleton path)
- Callers of `get_plugin_context_engine()`: 2 production sites (agent_init.py, plugins_cmd.py)
- Blast radius: LOW — only affects the plugin context engine fallback path; built-in ContextCompressor is unaffected
- Related patterns: singleton shared-mutation class of bugs; deepcopy is safe (ContextEngine has no locks/sockets)
