### PR TITLE
fix(desktop): honor HERMES_GIT_BASH_PATH in Git Bash preflight

### DIFF
--- a/apps/desktop/electron/bootstrap-platform.cjs
+++ b/apps/desktop/electron/bootstrap-platform.cjs
@@ -1,4 +1,5 @@
 const fs = require('node:fs')
+const path = require('node:path')
 
 function isWslEnvironment(env = process.env, platform = process.platform, kernelRelease = null) {
   if (platform !== 'linux') return false
@@ -83,9 +84,45 @@ function detectRemoteDisplay(options = {}) {
   return null
 }
 
+function resolveGitBash(options = {}) {
+  const env = options.env ?? process.env
+  const platform = options.platform ?? process.platform
+  const fileExists = options.fileExists ?? fs.existsSync
+  const findOnPath = options.findOnPath ?? (() => null)
+
+  if (platform !== 'win32') {
+    return findOnPath('bash')
+  }
+
+  const pathModule = options.pathModule ?? path.win32
+
+  const custom = String(env.HERMES_GIT_BASH_PATH || '').trim()
+  if (custom && fileExists(custom)) return custom
+
+  const localAppData = env.LOCALAPPDATA || ''
+  const candidates = []
+  if (localAppData) {
+    candidates.push(pathModule.join(localAppData, 'hermes', 'git', 'bin', 'bash.exe'))
+    candidates.push(pathModule.join(localAppData, 'hermes', 'git', 'usr', 'bin', 'bash.exe'))
+  }
+
+  candidates.push(pathModule.join(env.ProgramFiles || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'))
+  candidates.push(pathModule.join(env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'))
+  if (localAppData) {
+    candidates.push(pathModule.join(localAppData, 'Programs', 'Git', 'bin', 'bash.exe'))
+  }
+
+  for (const candidate of candidates) {
+    if (fileExists(candidate)) return candidate
+  }
+
+  return findOnPath('bash')
+}
+
 module.exports = {
   bundledRuntimeImportCheck,
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
-  isWslEnvironment
+  isWslEnvironment,
+  resolveGitBash
 }

--- a/apps/desktop/electron/bootstrap-platform.test.cjs
+++ b/apps/desktop/electron/bootstrap-platform.test.cjs
@@ -7,7 +7,8 @@ const {
   bundledRuntimeImportCheck,
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
-  isWslEnvironment
+  isWslEnvironment,
+  resolveGitBash
 } = require('./bootstrap-platform.cjs')
 
 test('isWslEnvironment detects WSL2 env vars on linux', () => {
@@ -108,4 +109,68 @@ test('packaged electron entrypoints do not require unpackaged npm modules', () =
 
     assert.deepEqual(bareRequires, [], `${entrypoint} has unpackaged runtime requires`)
   }
+})
+
+test('resolveGitBash honors HERMES_GIT_BASH_PATH before probing defaults', () => {
+  const explicit = 'F:\\Git\\bin\\bash.exe'
+  const systemPath = 'C:\\Program Files\\Git\\bin\\bash.exe'
+  const seen = []
+  const result = resolveGitBash({
+    platform: 'win32',
+    env: {
+      HERMES_GIT_BASH_PATH: explicit,
+      ProgramFiles: 'C:\\Program Files'
+    },
+    fileExists(candidate) {
+      seen.push(candidate)
+      return candidate === explicit || candidate === systemPath
+    },
+    findOnPath() {
+      throw new Error('PATH fallback should not run when explicit override exists')
+    }
+  })
+
+  assert.equal(result, explicit)
+  assert.deepEqual(seen, [explicit])
+})
+
+test('resolveGitBash checks installer-managed and standard Windows locations before PATH', () => {
+  const portable = 'C:\\Users\\alice\\AppData\\Local\\hermes\\git\\usr\\bin\\bash.exe'
+  const result = resolveGitBash({
+    platform: 'win32',
+    env: {
+      LOCALAPPDATA: 'C:\\Users\\alice\\AppData\\Local',
+      ProgramFiles: 'C:\\Program Files',
+      'ProgramFiles(x86)': 'C:\\Program Files (x86)'
+    },
+    fileExists(candidate) {
+      return candidate === portable
+    },
+    findOnPath() {
+      throw new Error('PATH fallback should not run when a probed location exists')
+    }
+  })
+
+  assert.equal(result, portable)
+})
+
+test('resolveGitBash falls back to PATH when no known Windows location exists', () => {
+  const pathBash = 'D:\\Tools\\bash.exe'
+  const result = resolveGitBash({
+    platform: 'win32',
+    env: {
+      LOCALAPPDATA: 'C:\\Users\\alice\\AppData\\Local',
+      ProgramFiles: 'C:\\Program Files',
+      'ProgramFiles(x86)': 'C:\\Program Files (x86)'
+    },
+    fileExists() {
+      return false
+    },
+    findOnPath(command) {
+      assert.equal(command, 'bash')
+      return pathBash
+    }
+  })
+
+  assert.equal(result, pathBash)
 })

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -24,7 +24,7 @@ const net = require('node:net')
 const path = require('node:path')
 const { fileURLToPath, pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
-const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = require('./bootstrap-platform.cjs')
+const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment, resolveGitBash } = require('./bootstrap-platform.cjs')
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
@@ -1165,35 +1165,12 @@ function findSystemPython() {
 // On non-Windows hosts bash is part of the OS and this just returns the
 // first bash on PATH.
 function findGitBash() {
-  if (!IS_WINDOWS) {
-    return findOnPath('bash')
-  }
-
-  // install.ps1 drops PortableGit at %LOCALAPPDATA%\hermes\git\... — checked
-  // first so users who installed via install.ps1 are detected before we
-  // start probing system-wide locations.
-  const localAppData = process.env.LOCALAPPDATA || ''
-  const candidates = []
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'bin', 'bash.exe'))
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'usr', 'bin', 'bash.exe'))
-  }
-
-  // Standard Git for Windows install locations.
-  candidates.push(path.join(process.env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'))
-  candidates.push(path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'))
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'Programs', 'Git', 'bin', 'bash.exe'))
-  }
-
-  for (const candidate of candidates) {
-    if (fileExists(candidate)) return candidate
-  }
-
-  // Last resort — bash on PATH (covers WSL bash, MSYS2, custom installs).
-  // On WSL hosts findOnPath itself filters out Windows-binary paths via
-  // isWindowsBinaryPathInWsl, so we won't hand back a wsl.exe shim either.
-  return findOnPath('bash')
+  return resolveGitBash({
+    env: process.env,
+    platform: process.platform,
+    fileExists,
+    findOnPath
+  })
 }
 
 function getVenvPython(venvRoot) {


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows desktop boot preflight so it uses `HERMES_GIT_BASH_PATH` first when locating `bash.exe`. This matches the runtime terminal environment and the Windows docs, and fixes installs where Git Bash lives outside the default `C:\Program Files\Git` locations, such as custom drive installs that worked before an upgrade but fail on relaunch.

## Related Issue

Fixes #38963

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/bootstrap-platform.cjs`: added a shared `resolveGitBash()` helper that checks `HERMES_GIT_BASH_PATH` first, then Hermes-managed PortableGit/system locations, then PATH.
- `apps/desktop/electron/main.cjs`: switched desktop boot preflight to use the shared resolver instead of a separate hardcoded probe list.
- `apps/desktop/electron/bootstrap-platform.test.cjs`: added coverage for env-override precedence, installer-managed fallback, and PATH fallback on Windows.

## How to Test

1. On Windows, set `HERMES_GIT_BASH_PATH` to a valid `bash.exe` outside the default Git-for-Windows install path.
2. Launch Hermes Desktop and verify the backend boot no longer fails with `Git for Windows is required for Hermes on Windows`.
3. Run `node --test apps/desktop/electron/bootstrap-platform.test.cjs`.
4. Run `npm --prefix apps/desktop run test:desktop:platforms`.

## What platforms tested on

- macOS 15 arm64 (local)
- Windows behavior covered via Electron unit tests that simulate Win32 resolution order

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 arm64; Win32 resolution behavior covered by Electron tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Broad `pytest tests/ -q -x --timeout=60` did not complete locally because collection stopped early on an unrelated environment error: `ModuleNotFoundError: No module named 'fastapi'` in `tests/hermes_cli/test_dashboard_auth_401_reauth.py`.
- Covering subset passed: `node --test apps/desktop/electron/bootstrap-platform.test.cjs` and `npm --prefix apps/desktop run test:desktop:platforms`.

<!-- autocontrib:worker-id=issue-new-437c208e kind=pr-open -->