### PR TITLE
Fix Claude worker auth, Desktop recency, update safety, and MCP discovery wait

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -103,9 +103,62 @@ def _resolve_home_dir() -> str:
     return "/tmp"
 
 
-def _build_subprocess_env() -> dict[str, str]:
-    env = os.environ.copy()
+_ACP_ENV_ALLOWLIST = frozenset({
+    "HOME",
+    "PATH",
+    "LANG",
+    "TERM",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "HERMES_HOME",
+    "HERMES_PROFILE",
+})
+_ACP_ENV_PREFIX_ALLOWLIST = ("LC_",)
+_ACP_DEFAULT_PATH = "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin"
+_CLAUDE_CODE_OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
+
+
+def _is_truthy_config_value(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _claude_code_oauth_token_passthrough_enabled() -> bool:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        delegation = cfg.get("delegation") or {}
+        return _is_truthy_config_value(delegation.get("claude_code_pass_oauth_token", False))
+    except Exception:
+        return False
+
+
+def _is_claude_acp_command(command: str | None) -> bool:
+    basename = os.path.basename((command or "").strip().strip('"\''))
+    return basename in {"claude", "claude.exe"}
+
+
+def _build_subprocess_env(command: str | None = None) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for key, value in os.environ.items():
+        if key in _ACP_ENV_ALLOWLIST or key.startswith(_ACP_ENV_PREFIX_ALLOWLIST):
+            env[key] = value
+
     env["HOME"] = _resolve_home_dir()
+    if not env.get("PATH"):
+        env["PATH"] = _ACP_DEFAULT_PATH
+
+    token = os.environ.get(_CLAUDE_CODE_OAUTH_TOKEN_ENV, "").strip()
+    if token and _is_claude_acp_command(command) and _claude_code_oauth_token_passthrough_enabled():
+        env[_CLAUDE_CODE_OAUTH_TOKEN_ENV] = token
+
     return env
 
 
@@ -445,7 +498,7 @@ class CopilotACPClient:
                 text=True,
                 bufsize=1,
                 cwd=self._acp_cwd,
-                env=_build_subprocess_env(),
+                env=_build_subprocess_env(self._acp_command),
             )
         except FileNotFoundError as exc:
             raise RuntimeError(

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -66,7 +66,8 @@ import {
   dragHasAttachments,
   droppedFileInlineRef,
   type InlineRefInput,
-  insertInlineRefsIntoEditor
+  insertInlineRefsIntoEditor,
+  splitDroppedFilesForComposer
 } from './inline-refs'
 import { QueuePanel } from './queue-panel'
 import {
@@ -171,10 +172,12 @@ export function ChatBar({
   const canSubmit = busy || hasComposerPayload
   const editingQueuedPrompt = queueEdit ? (queuedPrompts.find(entry => entry.id === queueEdit.entryId) ?? null) : null
   const busyAction = busy && hasComposerPayload ? 'queue' : 'stop'
+
   // Steer only makes sense mid-turn, text-only (the gateway can't carry images
   // into a tool result) and never for a slash command (those execute inline).
   const canSteer =
     busy && !!onSteer && attachments.length === 0 && trimmedDraft.length > 0 && !SLASH_COMMAND_RE.test(trimmedDraft)
+
   const showHelpHint = draft === '?'
 
   const { t } = useI18n()
@@ -919,19 +922,21 @@ export function ChatBar({
       return
     }
 
-    if (Array.from(event.dataTransfer.types || []).includes(HERMES_PATHS_MIME)) {
-      const refs = candidates
-        .map(candidate => droppedFileInlineRef(candidate, cwd))
-        .filter((ref): ref is string => Boolean(ref))
+    const { attachmentCandidates, inlineRefCandidates } = splitDroppedFilesForComposer(candidates)
 
-      if (insertInlineRefs(refs)) {
-        triggerHaptic('selection')
-      }
+    const refs = inlineRefCandidates
+      .map(candidate => droppedFileInlineRef(candidate, cwd))
+      .filter((ref): ref is string => Boolean(ref))
 
+    if (refs.length && insertInlineRefs(refs)) {
+      triggerHaptic('selection')
+    }
+
+    if (!attachmentCandidates.length) {
       return
     }
 
-    void Promise.resolve(onAttachDroppedItems(candidates)).then(attached => {
+    void Promise.resolve(onAttachDroppedItems(attachmentCandidates)).then(attached => {
       if (attached) {
         triggerHaptic('selection')
         requestMainFocus()
@@ -955,12 +960,13 @@ export function ChatBar({
     }
 
     const candidates = extractDroppedFiles(event.dataTransfer)
+    const { attachmentCandidates, inlineRefCandidates } = splitDroppedFilesForComposer(candidates)
 
-    const refs = candidates
+    const refs = inlineRefCandidates
       .map(candidate => droppedFileInlineRef(candidate, cwd))
       .filter((ref): ref is string => Boolean(ref))
 
-    if (!refs.length) {
+    if (!refs.length && (!onAttachDroppedItems || !attachmentCandidates.length)) {
       return
     }
 
@@ -968,9 +974,20 @@ export function ChatBar({
     event.stopPropagation()
     resetDragState()
 
-    if (insertInlineRefs(refs)) {
+    if (refs.length && insertInlineRefs(refs)) {
       triggerHaptic('selection')
     }
+
+    if (!onAttachDroppedItems || !attachmentCandidates.length) {
+      return
+    }
+
+    void Promise.resolve(onAttachDroppedItems(attachmentCandidates)).then(attached => {
+      if (attached) {
+        triggerHaptic('selection')
+        requestMainFocus()
+      }
+    })
   }
 
   const clearDraft = useCallback(() => {

--- a/apps/desktop/src/app/chat/composer/inline-refs.test.ts
+++ b/apps/desktop/src/app/chat/composer/inline-refs.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { droppedFileInlineRef, splitDroppedFilesForComposer } from './inline-refs'
+
+describe('splitDroppedFilesForComposer', () => {
+  it('routes native OS image drops to attachments instead of inline @file refs', () => {
+    const drop = {
+      file: new File(['png'], 'screenshot.png', { type: 'image/png' }),
+      path: '/Users/seiyeong/Library/Containers/me.damir.dropover-mac/Data/tmp/Screenshots/screenshot.png'
+    }
+
+    const { attachmentCandidates, inlineRefCandidates } = splitDroppedFilesForComposer([drop])
+
+    expect(attachmentCandidates).toEqual([drop])
+    expect(inlineRefCandidates).toEqual([])
+    expect(inlineRefCandidates.map(candidate => droppedFileInlineRef(candidate, '/Users/seiyeong/sywork'))).toEqual([])
+  })
+
+  it('keeps in-app path drags as inline context refs', () => {
+    const drop = {
+      path: '/Users/seiyeong/sywork/10-projects/spec.md'
+    }
+
+    const { attachmentCandidates, inlineRefCandidates } = splitDroppedFilesForComposer([drop])
+
+    expect(attachmentCandidates).toEqual([])
+    expect(inlineRefCandidates).toEqual([drop])
+    expect(inlineRefCandidates.map(candidate => droppedFileInlineRef(candidate, '/Users/seiyeong/sywork'))).toEqual([
+      '@file:10-projects/spec.md'
+    ])
+  })
+})

--- a/apps/desktop/src/app/chat/composer/inline-refs.ts
+++ b/apps/desktop/src/app/chat/composer/inline-refs.ts
@@ -83,6 +83,21 @@ export function droppedFileInlineRef(candidate: DroppedFile, cwd: string | null 
   return `@${kind}:${formatRefValue(rel)}`
 }
 
+export function splitDroppedFilesForComposer(candidates: readonly DroppedFile[]) {
+  const attachmentCandidates: DroppedFile[] = []
+  const inlineRefCandidates: DroppedFile[] = []
+
+  for (const candidate of candidates) {
+    if (candidate.file) {
+      attachmentCandidates.push(candidate)
+    } else {
+      inlineRefCandidates.push(candidate)
+    }
+  }
+
+  return { attachmentCandidates, inlineRefCandidates }
+}
+
 export function insertInlineRefsIntoEditor(editor: HTMLDivElement, refs: readonly InlineRefInput[]) {
   if (!refs.length) {
     return null

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -8,7 +8,6 @@ import {
   useSensors
 } from '@dnd-kit/core'
 import {
-  arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
   useSortable,
@@ -52,8 +51,6 @@ import {
   $sidebarOverlayMounted,
   $sidebarPinsOpen,
   $sidebarRecentsOpen,
-  $sidebarSessionOrderIds,
-  $sidebarWorkspaceOrderIds,
   pinSession,
   reorderPinnedSession,
   SESSION_SEARCH_FOCUS_EVENT,
@@ -61,8 +58,6 @@ import {
   setSidebarCronOpen,
   setSidebarPinsOpen,
   setSidebarRecentsOpen,
-  setSidebarSessionOrderIds,
-  setSidebarWorkspaceOrderIds,
   SIDEBAR_SESSIONS_PAGE_SIZE,
   unpinSession
 } from '@/store/layout'
@@ -91,6 +86,7 @@ import type { SidebarNavItem } from '../../types'
 
 import { SidebarCronJobsSection } from './cron-jobs-section'
 import { ProfileRail } from './profile-switcher'
+import { freshestSessionId, topRecentSessions } from './session-order'
 import { SidebarSessionRow } from './session-row'
 import { VirtualSessionList } from './virtual-session-list'
 
@@ -128,65 +124,8 @@ const LOCAL_SESSION_SOURCES = new Set(['cli', 'desktop', 'local', 'tui'])
 
 const groupDndId = (id: string) => `${GROUP_DND_ID_PREFIX}${id}`
 
-const parseGroupDndId = (id: string) =>
-  id.startsWith(GROUP_DND_ID_PREFIX) ? id.slice(GROUP_DND_ID_PREFIX.length) : null
-
 const countLabel = (loaded: number, total: number) => (total > loaded ? `${loaded}/${total}` : String(loaded))
 const sessionTime = (s: SessionInfo) => s.last_active || s.started_at || 0
-
-function orderByIds<T>(items: T[], getId: (item: T) => string, orderIds: string[]): T[] {
-  if (!orderIds.length) {
-    return items
-  }
-
-  const byId = new Map(items.map(item => [getId(item), item]))
-  const seen = new Set<string>()
-  const out: T[] = []
-
-  for (const id of orderIds) {
-    const item = byId.get(id)
-
-    if (item) {
-      out.push(item)
-      seen.add(id)
-    }
-  }
-
-  for (const item of items) {
-    if (!seen.has(getId(item))) {
-      out.push(item)
-    }
-  }
-
-  return out
-}
-
-function reconcileOrderIds(currentIds: string[], orderIds: string[]): string[] {
-  if (!currentIds.length) {
-    return []
-  }
-
-  if (!orderIds.length) {
-    return currentIds
-  }
-
-  const current = new Set(currentIds)
-  const next = orderIds.filter(id => current.has(id))
-  const known = new Set(next)
-
-  for (const id of currentIds) {
-    if (!known.has(id)) {
-      next.push(id)
-      known.add(id)
-    }
-  }
-
-  return next
-}
-
-function sameIds(left: string[], right: string[]) {
-  return left.length === right.length && left.every((item, index) => item === right[index])
-}
 
 const baseName = (path: string) =>
   path
@@ -194,6 +133,12 @@ const baseName = (path: string) =>
     .split(/[/\\]/)
     .filter(Boolean)
     .pop()
+
+const workspaceDisplayName = (path: string) => {
+  const name = baseName(path) || path
+
+  return name.replace(/^\d{2}(?:\.\d{2})?[-_\s]+/, '')
+}
 
 // FTS results cover sessions that aren't in the loaded page; synthesize a
 // minimal SessionInfo so they render in the same row component (resume works
@@ -231,7 +176,7 @@ function workspaceGroupsFor(
   for (const session of sessions) {
     const path = session.cwd?.trim() || ''
     const id = path || '__no_workspace__'
-    const label = baseName(path) || path || noWorkspaceLabel
+    const label = workspaceDisplayName(path) || path || noWorkspaceLabel
 
     const group = groups.get(id) ?? { id, label, path: path || null, sessions: [] }
     group.sessions.push(session)
@@ -358,11 +303,12 @@ export function ChatSidebar({
   // profile while scope is still ALL (persisted), the rail is hidden and they'd
   // otherwise be stuck in the grouped view with no way out.
   const showAllProfiles = multiProfile && profileScope === ALL_PROFILES
-  const agentOrderIds = useStore($sidebarSessionOrderIds)
-  const workspaceOrderIds = useStore($sidebarWorkspaceOrderIds)
   const [searchQuery, setSearchQuery] = useState('')
   const [serverMatches, setServerMatches] = useState<SessionSearchResult[]>([])
   const [newSessionKbdFlash, setNewSessionKbdFlash] = useState(false)
+  // The "Recent" quick section is a lightweight, session-local collapse — no
+  // need to persist it like the recents/pins sections.
+  const [quickRecentOpen, setQuickRecentOpen] = useState(true)
   const [profileLoadMorePending, setProfileLoadMorePending] = useState<Record<string, boolean>>({})
   const searchInputRef = useRef<HTMLInputElement>(null)
   const trimmedQuery = searchQuery.trim()
@@ -508,25 +454,27 @@ export function ChatSidebar({
     return [...out.values()]
   }, [trimmedQuery, sortedSessions, serverMatches, sessionByAnyId])
 
-  const unpinnedAgentSessions = useMemo(
+  // Recents are pure activity order: `sortedSessions` is already recency-sorted
+  // (newest first), so the freshest session always floats to the top. Manual
+  // drag order now applies only to the Pinned section — never to recents or the
+  // workspace/source groups below.
+  const agentSessions = useMemo(
     () => sortedSessions.filter(s => !pinnedRealIdSet.has(s.id)),
     [sortedSessions, pinnedRealIdSet]
   )
 
-  useEffect(() => {
-    const next = reconcileOrderIds(
-      unpinnedAgentSessions.map(s => s.id),
-      agentOrderIds
-    )
+  // The single most-recently-active session across loaded recents + cron runs.
+  // Badged 'Live' in the row so the newest is obvious at a glance.
+  const liveSessionId = useMemo(
+    () => freshestSessionId([visibleSessions, cronSessions], session => session.id, sessionTime),
+    [visibleSessions, cronSessions]
+  )
 
-    if (!sameIds(next, agentOrderIds)) {
-      setSidebarSessionOrderIds(next)
-    }
-  }, [agentOrderIds, unpinnedAgentSessions])
-
-  const agentSessions = useMemo(
-    () => orderByIds(unpinnedAgentSessions, s => s.id, agentOrderIds),
-    [unpinnedAgentSessions, agentOrderIds]
+  // Top 5 most-recently-worked sessions spanning local, external-source, and
+  // cron runs — a quick-access shortcut above the fuller recents list.
+  const recentQuickSessions = useMemo(
+    () => topRecentSessions([visibleSessions, cronSessions], session => session.id, sessionTime, 5),
+    [visibleSessions, cronSessions]
   )
 
   const { localSessions: localAgentSessions, sourceGroups } = useMemo(
@@ -534,19 +482,9 @@ export function ChatSidebar({
     [agentSessions]
   )
 
-  const orderedSourceGroups = useMemo(
-    () => orderByIds(sourceGroups, g => g.id, workspaceOrderIds),
-    [sourceGroups, workspaceOrderIds]
-  )
-
   const agentGroups = useMemo(
-    () =>
-      orderByIds(
-        workspaceGroupsFor(localAgentSessions, s.noWorkspace, { preserveSessionOrder: sourceGroups.length > 0 }),
-        g => g.id,
-        workspaceOrderIds
-      ),
-    [localAgentSessions, s.noWorkspace, sourceGroups.length, workspaceOrderIds]
+    () => workspaceGroupsFor(localAgentSessions, s.noWorkspace, { preserveSessionOrder: true }),
+    [localAgentSessions, s.noWorkspace]
   )
 
   const loadMoreForProfileGroup = useCallback(
@@ -613,7 +551,7 @@ export function ChatSidebar({
   const displayAgentSessions = sourceGroups.length ? localAgentSessions : agentSessions
 
   const displayAgentGroups = useMemo(() => {
-    if (orderedSourceGroups.length) {
+    if (sourceGroups.length) {
       const localGroups = agentsGrouped
         ? agentGroups
         : localAgentSessions.length
@@ -628,7 +566,7 @@ export function ChatSidebar({
             ]
           : []
 
-      return orderByIds([...orderedSourceGroups, ...localGroups], g => g.id, workspaceOrderIds)
+      return [...localGroups, ...sourceGroups]
     }
 
     return showAllProfiles ? profileGroups : agentsGrouped ? agentGroups : undefined
@@ -636,26 +574,10 @@ export function ChatSidebar({
     agentGroups,
     agentsGrouped,
     localAgentSessions,
-    orderedSourceGroups,
     profileGroups,
     showAllProfiles,
-    workspaceOrderIds
+    sourceGroups
   ])
-
-  useEffect(() => {
-    if (!displayAgentGroups?.length || showAllProfiles) {
-      return
-    }
-
-    const next = reconcileOrderIds(
-      displayAgentGroups.map(g => g.id),
-      workspaceOrderIds
-    )
-
-    if (!sameIds(next, workspaceOrderIds)) {
-      setSidebarWorkspaceOrderIds(next)
-    }
-  }, [displayAgentGroups, showAllProfiles, workspaceOrderIds])
 
   const showSessionSkeletons = sessionsLoading && sortedSessions.length === 0
 
@@ -697,43 +619,6 @@ export function ChatSidebar({
     reorderPinnedSession(dragged ? sessionPinId(dragged) : String(active.id), newIndex)
   }
 
-  const handleAgentDragEnd = ({ active, over }: DragEndEvent) => {
-    if (!over || active.id === over.id) {
-      return
-    }
-
-    const activeId = String(active.id)
-    const overId = String(over.id)
-    const activeGroup = parseGroupDndId(activeId)
-    const overGroup = parseGroupDndId(overId)
-
-    if (activeGroup && overGroup) {
-      const groups = displayAgentGroups ?? []
-      const oldIdx = groups.findIndex(g => g.id === activeGroup)
-      const newIdx = groups.findIndex(g => g.id === overGroup)
-
-      if (oldIdx < 0 || newIdx < 0) {
-        return
-      }
-
-      setSidebarWorkspaceOrderIds(arrayMove(groups, oldIdx, newIdx).map(g => g.id))
-
-      return
-    }
-
-    if (activeGroup || overGroup) {
-      return
-    }
-
-    const oldIdx = agentSessions.findIndex(s => s.id === activeId)
-    const newIdx = agentSessions.findIndex(s => s.id === overId)
-
-    if (oldIdx < 0 || newIdx < 0) {
-      return
-    }
-
-    setSidebarSessionOrderIds(arrayMove(agentSessions, oldIdx, newIdx).map(s => s.id))
-  }
 
   return (
     <Sidebar
@@ -834,6 +719,7 @@ export function ChatSidebar({
             }
             label={s.results}
             labelMeta={String(searchResults.length)}
+            liveSessionId={liveSessionId}
             onArchiveSession={onArchiveSession}
             onDeleteSession={onDeleteSession}
             onResumeSession={onResumeSession}
@@ -847,6 +733,27 @@ export function ChatSidebar({
           />
         )}
 
+        {contentVisible && showSessionSections && !trimmedQuery && recentQuickSessions.length > 0 && (
+          <SidebarSessionsSection
+            activeSessionId={activeSidebarSessionId}
+            contentClassName="flex max-h-40 shrink-0 flex-col gap-px overflow-y-auto overscroll-contain pb-1.75"
+            emptyState={null}
+            label="Recent 5"
+            labelMeta={String(recentQuickSessions.length)}
+            liveSessionId={liveSessionId}
+            onArchiveSession={onArchiveSession}
+            onDeleteSession={onDeleteSession}
+            onResumeSession={onResumeSession}
+            onToggle={() => setQuickRecentOpen(!quickRecentOpen)}
+            onTogglePin={pinSession}
+            open={quickRecentOpen}
+            pinned={false}
+            rootClassName="shrink-0 p-0 pb-1"
+            sessions={recentQuickSessions}
+            workingSessionIdSet={workingSessionIdSet}
+          />
+        )}
+
         {contentVisible && showSessionSections && !trimmedQuery && (
           <SidebarSessionsSection
             activeSessionId={activeSidebarSessionId}
@@ -854,6 +761,7 @@ export function ChatSidebar({
             dndSensors={dndSensors}
             emptyState={<SidebarPinnedEmptyState />}
             label={s.pinned}
+            liveSessionId={liveSessionId}
             onArchiveSession={onArchiveSession}
             onDeleteSession={onDeleteSession}
             onReorder={handlePinnedDragEnd}
@@ -926,10 +834,10 @@ export function ChatSidebar({
             }
             label={s.sessions}
             labelMeta={recentsMeta}
+            liveSessionId={liveSessionId}
             onArchiveSession={onArchiveSession}
             onDeleteSession={onDeleteSession}
             onNewSessionInWorkspace={showAllProfiles ? undefined : onNewSessionInWorkspace}
-            onReorder={showAllProfiles ? undefined : handleAgentDragEnd}
             onResumeSession={onResumeSession}
             onToggle={() => setSidebarRecentsOpen(!agentsOpen)}
             onTogglePin={pinSession}
@@ -937,7 +845,6 @@ export function ChatSidebar({
             pinned={false}
             rootClassName="min-h-0 flex-1 p-0"
             sessions={displayAgentSessions}
-            sortable={!showAllProfiles && agentSessions.length > 1}
             workingSessionIdSet={workingSessionIdSet}
           />
         )}
@@ -1065,6 +972,7 @@ interface SidebarSessionsSectionProps {
   footer?: React.ReactNode
   groups?: SidebarSessionGroup[]
   labelMeta?: React.ReactNode
+  liveSessionId?: null | string
   sortable?: boolean
   onReorder?: (event: DragEndEvent) => void
   dndSensors?: ReturnType<typeof useSensors>
@@ -1091,6 +999,7 @@ function SidebarSessionsSection({
   footer,
   groups,
   labelMeta,
+  liveSessionId = null,
   sortable = false,
   onReorder,
   dndSensors
@@ -1102,6 +1011,7 @@ function SidebarSessionsSection({
   const renderRow = (session: SessionInfo) => {
     const rowProps = {
       isPinned: pinned,
+      isLive: session.id === liveSessionId,
       isSelected: session.id === activeSessionId,
       isWorking: workingSessionIdSet.has(session.id),
       onArchive: () => onArchiveSession(session.id),
@@ -1181,6 +1091,7 @@ function SidebarSessionsSection({
     inner = (
       <VirtualSessionList
         activeSessionId={activeSessionId}
+        liveSessionId={liveSessionId}
         onArchiveSession={onArchiveSession}
         onDeleteSession={onDeleteSession}
         onResumeSession={onResumeSession}
@@ -1387,6 +1298,7 @@ function SidebarCount({ children }: { children: React.ReactNode }) {
 interface SortableSessionRowProps {
   session: SessionInfo
   isPinned: boolean
+  isLive: boolean
   isSelected: boolean
   isWorking: boolean
   onArchive: () => void

--- a/apps/desktop/src/app/chat/sidebar/session-order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-order.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { freshestSessionId, topRecentSessions } from './session-order'
+
+interface TimedRow {
+  id: string
+  t: number
+}
+
+const timed = (...specs: Array<[string, number]>): TimedRow[] => specs.map(([id, t]) => ({ id, t }))
+const timedId = (item: TimedRow) => item.id
+const timedTime = (item: TimedRow) => item.t
+const timedIds = (items: TimedRow[]) => items.map(item => item.id)
+
+describe('topRecentSessions', () => {
+  it('merges several lists, sorts newest-first, and caps at n', () => {
+    const local = timed(['a', 10], ['b', 30])
+    const slack = timed(['s', 45])
+    const cron = timed(['c', 20], ['d', 5])
+
+    expect(timedIds(topRecentSessions([local, slack, cron], timedId, timedTime, 3))).toEqual(['s', 'b', 'c'])
+  })
+
+  it('dedupes by id, keeping the freshest timestamp on collision', () => {
+    const loaded = timed(['x', 10], ['y', 40])
+    const cron = timed(['x', 99]) // same session id, but fresher
+
+    expect(timedIds(topRecentSessions([loaded, cron], timedId, timedTime, 5))).toEqual(['x', 'y'])
+  })
+
+  it('returns an empty list for n <= 0 or no input', () => {
+    expect(topRecentSessions([], timedId, timedTime, 5)).toEqual([])
+    expect(topRecentSessions([timed(['a', 1])], timedId, timedTime, 0)).toEqual([])
+  })
+})
+
+describe('freshestSessionId', () => {
+  it('returns the id of the single newest session across lists', () => {
+    expect(freshestSessionId([timed(['a', 10]), timed(['b', 50], ['c', 5])], timedId, timedTime)).toBe('b')
+  })
+
+  it('returns null when there are no sessions', () => {
+    expect(freshestSessionId([], timedId, timedTime)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-order.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-order.ts
@@ -1,0 +1,47 @@
+// Ordering helpers for sidebar recents.
+//
+// The sidebar's unpinned session lists are for finding recent work, so they must
+// stay activity-ordered. Manual ordering belongs to the Pinned section only.
+
+// Merge several session lists into one newest-first list, deduped by id (the
+// freshest timestamp wins on collision), capped at `n`. Powers the "Recent N"
+// quick-access section, which spans local, external-source, and cron sessions —
+// the same session can appear in more than one source list, so dedup matters.
+export function topRecentSessions<T>(
+  lists: T[][],
+  getId: (item: T) => string,
+  getTime: (item: T) => number,
+  n: number
+): T[] {
+  if (n <= 0) {
+    return []
+  }
+
+  const best = new Map<string, T>()
+
+  for (const list of lists) {
+    for (const item of list) {
+      const id = getId(item)
+      const existing = best.get(id)
+
+      if (!existing || getTime(item) > getTime(existing)) {
+        best.set(id, item)
+      }
+    }
+  }
+
+  return Array.from(best.values()).sort((a, b) => getTime(b) - getTime(a)).slice(0, n)
+}
+
+// Id of the single most-recently-active session across the given lists, or null
+// when there are none. Used to badge the newest session 'Live' so it reads as
+// the freshest at a glance.
+export function freshestSessionId<T>(
+  lists: T[][],
+  getId: (item: T) => string,
+  getTime: (item: T) => number
+): null | string {
+  const [top] = topRecentSessions(lists, getId, getTime, 1)
+
+  return top ? getId(top) : null
+}

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -16,6 +16,7 @@ import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
   session: SessionInfo
   isPinned: boolean
+  isLive?: boolean
   isSelected: boolean
   isWorking: boolean
   onArchive: () => void
@@ -48,6 +49,7 @@ function formatAge(seconds: number, r: Translations['sidebar']['row']): string {
 export function SidebarSessionRow({
   session,
   isPinned,
+  isLive = false,
   isSelected,
   isWorking,
   onArchive,
@@ -182,9 +184,17 @@ export function SidebarSessionRow({
           <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-normal text-(--ui-text-secondary) group-hover:text-foreground group-data-[working=true]:text-foreground/90">
             {title}
           </span>
+          {isLive && (
+            <span
+              className="shrink-0 rounded-[4px] border border-(--ui-stroke-tertiary) bg-(--ui-control-active-background) px-1 py-px text-[0.5625rem] font-semibold uppercase tracking-[0.08em] text-(--ui-accent)"
+              title="Live"
+            >
+              Live
+            </span>
+          )}
         </button>
         <div className="relative z-2 grid w-[1.375rem] place-items-center">
-          {!isWorking && (
+          {!isWorking && !isLive && (
             <span className="pointer-events-none absolute right-6 top-1/2 min-w-6 -translate-y-1/2 text-right text-[0.625rem] leading-none text-(--ui-text-tertiary) opacity-0 transition-opacity group-hover:opacity-100">
               {age}
             </span>

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -11,6 +11,7 @@ import { SidebarSessionRow } from './session-row'
 
 interface SessionRowCommonProps {
   isPinned: boolean
+  isLive: boolean
   isSelected: boolean
   isWorking: boolean
   onArchive: () => void
@@ -27,6 +28,7 @@ interface VirtualSessionListProps {
   onResumeSession: (sessionId: string) => void
   onTogglePin: (sessionId: string) => void
   pinned: boolean
+  liveSessionId?: null | string
   sessions: SessionInfo[]
   sortable: boolean
   workingSessionIdSet: Set<string>
@@ -43,6 +45,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   onResumeSession,
   onTogglePin,
   pinned,
+  liveSessionId = null,
   sessions,
   sortable,
   workingSessionIdSet
@@ -74,6 +77,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
 
     const commonProps: SessionRowCommonProps = {
       isPinned: pinned,
+      isLive: session.id === liveSessionId,
       isSelected: session.id === activeSessionId,
       isWorking: workingSessionIdSet.has(session.id),
       onArchive: () => onArchiveSession(session.id),

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { $commandPaletteOpen, closeCommandPalette, setCommandPaletteOpen } from '@/store/command-palette'
+import { $attentionSessionIds, $workingSessionIds } from '@/store/session'
 import { type ThemeMode, useTheme } from '@/themes/context'
 
 import {
@@ -149,6 +150,8 @@ const THEME_MODES: ReadonlyArray<{ icon: IconComponent; mode: ThemeMode }> = [
 export function CommandPalette() {
   const { t } = useI18n()
   const open = useStore($commandPaletteOpen)
+  const attentionSessionIds = useStore($attentionSessionIds)
+  const workingSessionIds = useStore($workingSessionIds)
   const navigate = useNavigate()
   const { availableThemes, mode, resolvedMode, setMode, setTheme, themeName } = useTheme()
   const [search, setSearch] = useState('')
@@ -184,6 +187,7 @@ export function CommandPalette() {
 
   const sessions = useMemo(() => (sessionsQuery.data?.sessions ?? []).map(toSessionEntry), [sessionsQuery.data])
   const archivedSessions = useMemo(() => (archivedQuery.data?.sessions ?? []).map(toSessionEntry), [archivedQuery.data])
+  const sessionById = useMemo(() => new Map(sessions.map(session => [session.id, session])), [sessions])
 
   // Reset the query/sub-page on close so it reopens clean.
   useEffect(() => {
@@ -194,10 +198,62 @@ export function CommandPalette() {
   }, [open])
 
   const go = useCallback((path: string) => () => navigate(path), [navigate])
+
+  const recentSessionItems = useMemo<PaletteItem[]>(
+    () =>
+      sessions.slice(0, 5).map((session, index) => ({
+        icon: index === 0 ? Zap : Clock,
+        id: `recent-session-${session.id}`,
+        keywords: ['recent', 'latest', 'live', 'chat', 'session', ...(session.preview ? [session.preview] : [])],
+        label: index === 0 ? `Live: ${session.title}` : session.title,
+        run: go(sessionRoute(session.id))
+      })),
+    [go, sessions]
+  )
+
+  const sessionShortcutItems = useMemo<PaletteItem[]>(() => {
+    const latestSession = sessions[0]
+    const runningSession = workingSessionIds.map(id => sessionById.get(id)).find(Boolean)
+    const inputSession = attentionSessionIds.map(id => sessionById.get(id)).find(Boolean)
+
+    const items: (PaletteItem | null)[] = [
+      latestSession
+        ? {
+            icon: Clock,
+            id: 'session-shortcut-recent-work',
+            keywords: ['recent work', 'latest', '최근 작업'],
+            label: `Recent work: ${latestSession.title}`,
+            run: go(sessionRoute(latestSession.id))
+          }
+        : null,
+      runningSession
+        ? {
+            icon: Activity,
+            id: 'session-shortcut-running-now',
+            keywords: ['running now', 'working', 'live', '현재 실행 중'],
+            label: `Running now: ${runningSession.title}`,
+            run: go(sessionRoute(runningSession.id))
+          }
+        : null,
+      inputSession
+        ? {
+            icon: Info,
+            id: 'session-shortcut-needs-input',
+            keywords: ['needs input', 'waiting', 'clarify', '입력 대기 중'],
+            label: `Needs input: ${inputSession.title}`,
+            run: go(sessionRoute(inputSession.id))
+          }
+        : null
+    ]
+
+    return items.filter((item): item is PaletteItem => item !== null)
+  }, [attentionSessionIds, go, sessionById, sessions, workingSessionIds])
+
   const settingsSectionLabel = useCallback(
     (section: (typeof SECTIONS)[number]) => t.settings.sections[section.id] ?? section.label,
     [t.settings.sections]
   )
+
   const configFieldLabel = useCallback(
     (key: string) =>
       fieldCopyForSchemaKey(t.settings.fieldLabels, key) ??
@@ -230,6 +286,22 @@ export function CommandPalette() {
           { icon: Cpu, id: 'nav-agents', label: t.agents.title, run: go(AGENTS_ROUTE) }
         ]
       },
+      ...(sessionShortcutItems.length > 0
+        ? [
+            {
+              heading: 'Session shortcuts',
+              items: sessionShortcutItems
+            }
+          ]
+        : []),
+      ...(recentSessionItems.length > 0
+        ? [
+            {
+              heading: 'Recent sessions',
+              items: recentSessionItems
+            }
+          ]
+        : []),
       {
         heading: cc.commandCenter,
         items: [
@@ -298,7 +370,7 @@ export function CommandPalette() {
         ]
       }
     ]
-  }, [go, settingsSectionLabel, t])
+  }, [go, recentSessionItems, sessionShortcutItems, settingsSectionLabel, t])
 
   // The long, granular lists (settings fields, API keys, MCP servers, archived
   // chats) only surface once the user types — otherwise they'd bury the

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.tsx
@@ -1,0 +1,62 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $currentCwd, setCurrentCwd } from '@/store/session'
+
+import { useHermesConfig } from './use-hermes-config'
+
+vi.mock('@/hermes', () => ({
+  getHermesConfig: vi.fn(),
+  getHermesConfigDefaults: vi.fn()
+}))
+
+import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
+
+function Probe({ refreshProjectBranch }: { refreshProjectBranch: (cwd: string) => Promise<void> }) {
+  const { refreshHermesConfig } = useHermesConfig({
+    activeSessionIdRef: { current: null },
+    refreshProjectBranch
+  })
+
+  return <button onClick={() => void refreshHermesConfig()}>refresh</button>
+}
+
+describe('useHermesConfig workspace defaults', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    setCurrentCwd('')
+    vi.mocked(getHermesConfig).mockResolvedValue({})
+    vi.mocked(getHermesConfigDefaults).mockResolvedValue({})
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        settings: {
+          getDefaultProjectDir: vi.fn().mockResolvedValue({
+            defaultLabel: '/Users/test/fallback',
+            dir: '/Users/test/sywork'
+          })
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+    setCurrentCwd('')
+    Reflect.deleteProperty(window, 'hermesDesktop')
+    vi.clearAllMocks()
+  })
+
+  it('seeds new chats from the desktop default project directory when config cwd is empty', async () => {
+    const refreshProjectBranch = vi.fn().mockResolvedValue(undefined)
+    const { getByRole } = render(<Probe refreshProjectBranch={refreshProjectBranch} />)
+
+    await act(async () => {
+      getByRole('button', { name: 'refresh' }).click()
+    })
+
+    await waitFor(() => expect($currentCwd.get()).toBe('/Users/test/sywork'))
+    expect(refreshProjectBranch).toHaveBeenCalledWith('/Users/test/sywork')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -54,6 +54,16 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
       if (cwd && cwd !== '.') {
         setCurrentCwd(prev => prev || cwd)
         void refreshProjectBranch($currentCwd.get() || cwd)
+      } else if (!$currentCwd.get().trim()) {
+        const desktopDefault = await window.hermesDesktop?.settings
+          ?.getDefaultProjectDir?.()
+          .then(result => result.dir?.trim() || '')
+          .catch(() => '')
+
+        if (desktopDefault) {
+          setCurrentCwd(prev => prev || desktopDefault)
+          void refreshProjectBranch($currentCwd.get() || desktopDefault)
+        }
       }
 
       const reasoning = (config.agent?.reasoning_effort ?? '').trim()

--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -1,7 +1,14 @@
-import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import {
+  AssistantRuntimeProvider,
+  ExportedMessageRepository,
+  type ThreadMessage,
+  useExternalStoreRuntime
+} from '@assistant-ui/react'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
 
 import { Thread } from './thread'
 
@@ -43,11 +50,14 @@ class TestResizeObserver {
   }
 }
 
+const requestAnimationFrameStub = (callback: FrameRequestCallback) => window.setTimeout(() => callback(performance.now()), 0)
+const cancelAnimationFrameStub = (id: number) => window.clearTimeout(id)
+
 vi.stubGlobal('ResizeObserver', TestResizeObserver)
-vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
-  window.setTimeout(() => callback(performance.now()), 0)
-)
-vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('requestAnimationFrame', requestAnimationFrameStub)
+vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameStub)
+Object.defineProperty(window, 'requestAnimationFrame', { configurable: true, value: requestAnimationFrameStub })
+Object.defineProperty(window, 'cancelAnimationFrame', { configurable: true, value: cancelAnimationFrameStub })
 
 Element.prototype.scrollTo = function scrollTo() {}
 
@@ -277,6 +287,28 @@ function StaticThreadHarness() {
   )
 }
 
+function EditableResetHarness() {
+  const [messages, setMessages] = useState<ThreadMessage[]>([userMessage()])
+  const messageRepository = useMemo(() => ExportedMessageRepository.fromArray(messages), [messages])
+
+  const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
+    messageRepository,
+    isRunning: false,
+    onEdit: async () => {},
+    onNew: async () => {},
+    setMessages: () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <button onClick={() => setMessages([])} type="button">
+        clear messages
+      </button>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
 function TodoHarness({ message }: { message: ThreadMessage }) {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
     messages: [message],
@@ -410,6 +442,27 @@ describe('assistant-ui streaming renderer', () => {
     const { container } = render(<IntroHarness />)
 
     expect(container.querySelector('[data-slot="aui_composer-clearance"]')).toBeNull()
+  })
+
+  it('does not throw when a message edit composer is mounted and the thread resets empty', async () => {
+    const { container } = render(<EditableResetHarness />)
+    const ui = within(container)
+
+    fireEvent.click(ui.getByRole('button', { name: /edit message/i }))
+    await waitFor(() => {
+      expect(ui.getByRole('textbox', { name: /edit message/i })).toBeTruthy()
+    })
+
+    // The edit composer uses a custom contentEditable editor. Mounting the
+    // hidden Assistant UI primitive input creates a second message-scoped
+    // composer subscriber; during empty-thread/session resets that subscriber
+    // can read `thread().message({ index: 0 }).composer()` after the message
+    // client lookup has been cleared.
+    expect(container.querySelector('[data-slot="aui_edit-composer-root"] textarea.sr-only')).toBeNull()
+
+    expect(() => {
+      fireEvent.click(ui.getByRole('button', { name: /clear messages/i }))
+    }).not.toThrow(/tapClientLookup/)
   })
 
   it('renders assistant provider errors inline', () => {
@@ -640,23 +693,20 @@ describe('assistant-ui streaming renderer', () => {
 
     await waitFor(() => {
       expect(container.querySelector('[data-slot="code-card"]')).toBeTruthy()
+      expect(container.textContent).toContain('const answer = 42')
     })
 
-    expect(container.textContent).toContain('const answer = 42')
     expect(container.textContent).not.toContain('```ts')
   })
 
   it('renders an incomplete streaming reasoning fenced code block as a code card', async () => {
     const { container } = render(<RunningReasoningHarness />)
-    const ui = within(container)
-
-    fireEvent.click(ui.getByRole('button', { name: /thinking/i }))
 
     await waitFor(() => {
       expect(container.querySelector('[data-slot="code-card"]')).toBeTruthy()
+      expect(container.querySelector('[data-slot="aui_reasoning-text"]')?.textContent).toContain('const answer = 42')
     })
 
-    expect(container.querySelector('[data-slot="aui_reasoning-text"]')?.textContent).toContain('const answer = 42')
     expect(container.textContent).not.toContain('```ts')
   })
 

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -1444,7 +1444,6 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
               role="textbox"
               suppressContentEditableWarning
             />
-            <ComposerPrimitive.Input className="sr-only" tabIndex={-1} unstable_focusOnScrollToBottom={false} />
             <button
               aria-label={copy.sendEdited}
               className={cn('absolute right-2 bottom-2 size-5', USER_ACTION_ICON_BUTTON_CLASS)}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1703,6 +1703,11 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+        # OFF by default. When true, Hermes may pass CLAUDE_CODE_OAUTH_TOKEN
+        # only to direct Claude Code worker subprocesses (`claude -p` / ACP
+        # command basename `claude`). General terminal/provider secret
+        # blocklists remain intact.
+        "claude_code_pass_oauth_token": False,
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
@@ -5998,8 +6003,19 @@ def set_config_value(key: str, value: str):
         'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
         'GITHUB_TOKEN', 'HONCHO_API_KEY',
     ]
-    
-    if key.upper() in api_keys or key.upper().endswith(('_API_KEY', '_TOKEN')) or key.upper().startswith('TERMINAL_SSH'):
+
+    config_key_exceptions = {
+        "delegation.claude_code_pass_oauth_token",
+    }
+
+    if (
+        key.lower() not in config_key_exceptions
+        and (
+            key.upper() in api_keys
+            or key.upper().endswith(('_API_KEY', '_TOKEN'))
+            or key.upper().startswith('TERMINAL_SSH')
+        )
+    ):
         save_env_value(key.upper(), value)
         print(f"✓ Set {key} in {get_env_path()}")
         return

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4240,6 +4240,49 @@ def _capture_head_sha(git_cmd, cwd) -> str | None:
         return None
 
 
+def _count_git_commits(git_cmd, cwd, rev_range: str) -> int | None:
+    """Return ``git rev-list <range> --count`` as an int, or None on failure."""
+    result = subprocess.run(
+        git_cmd + ["rev-list", rev_range, "--count"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        return int(result.stdout.strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _create_update_safety_branch(git_cmd, cwd, branch: str) -> str | None:
+    """Create a best-effort branch pointing at pre-update HEAD.
+
+    When a managed install carries local commits, ``hermes update`` may need to
+    rebase them onto the fetched upstream branch. A safety branch gives the user
+    a stable recovery handle even if the rebase hits conflicts or the working
+    tree is later cleaned up.
+    """
+    safe_branch = "".join(ch if ch.isalnum() or ch in "._-" else "-" for ch in branch)
+    name = f"backup/update-preserve-{safe_branch}-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+    result = subprocess.run(
+        git_cmd + ["branch", name, "HEAD"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        print(f"  ✓ Safety branch for local commits: {name}")
+        return name
+
+    stderr = result.stderr.strip()
+    print("  ⚠ Could not create a safety branch for local commits.")
+    if stderr:
+        print(f"    {stderr.splitlines()[0]}")
+    return None
+
+
 def _validate_critical_files_syntax(root) -> tuple[bool, str | None, str | None]:
     """Compile each file in ``_UPDATE_CRITICAL_FILES`` to catch SyntaxErrors.
 
@@ -8174,26 +8217,68 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True,
             )
             if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                # ff-only failed — local and remote have diverged. Managed
+                # installs can also carry intentional local commits (Desktop UX
+                # fixes, private automations). Preserve those by rebasing them
+                # onto the fetched branch before falling back to a hard reset.
+                local_commit_count = _count_git_commits(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    f"origin/{branch}..HEAD",
                 )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
+                if local_commit_count and local_commit_count > 0:
                     print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        f"  ⚠ Fast-forward not possible; preserving {local_commit_count} local commit(s) by rebasing onto origin/{branch}..."
                     )
-                    sys.exit(1)
+                    safety_branch = _create_update_safety_branch(git_cmd, PROJECT_ROOT, branch)
+                    rebase_result = subprocess.run(
+                        git_cmd + ["rebase", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if rebase_result.returncode == 0:
+                        print("  ✓ Local commits preserved after update rebase.")
+                    else:
+                        print("✗ Could not rebase local commits onto the update.")
+                        stderr = rebase_result.stderr.strip()
+                        if stderr:
+                            print(f"  {stderr.splitlines()[0]}")
+                        abort_result = subprocess.run(
+                            git_cmd + ["rebase", "--abort"],
+                            cwd=PROJECT_ROOT,
+                            capture_output=True,
+                            text=True,
+                        )
+                        if abort_result.returncode == 0:
+                            print("  ✓ Rebase aborted — local commits remain on the current branch.")
+                        elif safety_branch:
+                            print(
+                                f"  ⚠ Rebase abort failed; recover local commits with: git reset --hard {safety_branch}"
+                            )
+                        print("  Update stopped so your local Desktop changes are not discarded.")
+                        sys.exit(1)
+                else:
+                    # No local commits to preserve (or we couldn't count them),
+                    # so keep the previous self-healing behavior for truly
+                    # diverged/force-pushed histories.
+                    print(
+                        "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    )
+                    reset_result = subprocess.run(
+                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if reset_result.returncode != 0:
+                        print(f"✗ Failed to reset to origin/{branch}.")
+                        if reset_result.stderr.strip():
+                            print(f"  {reset_result.stderr.strip()}")
+                        print(
+                            f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        )
+                        sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8226,7 +8226,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     PROJECT_ROOT,
                     f"origin/{branch}..HEAD",
                 )
-                if local_commit_count and local_commit_count > 0:
+                if local_commit_count is None:
+                    print(
+                        "✗ Fast-forward not possible, and Hermes could not determine whether local commits exist."
+                    )
+                    print("  Update stopped so local commits are not discarded by a hard reset.")
+                    print(
+                        f"  Inspect manually: git fetch origin && git log --oneline origin/{branch}..HEAD"
+                    )
+                    sys.exit(1)
+
+                if local_commit_count > 0:
                     print(
                         f"  ⚠ Fast-forward not possible; preserving {local_commit_count} local commit(s) by rebasing onto origin/{branch}..."
                     )
@@ -8259,9 +8269,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         print("  Update stopped so your local Desktop changes are not discarded.")
                         sys.exit(1)
                 else:
-                    # No local commits to preserve (or we couldn't count them),
-                    # so keep the previous self-healing behavior for truly
-                    # diverged/force-pushed histories.
+                    # No local commits to preserve, so keep the previous
+                    # self-healing behavior for truly diverged/force-pushed
+                    # histories.
                     print(
                         "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
                     )

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -51,8 +51,16 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         thread.start()
 
 
-def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
-    """Briefly wait for background MCP discovery before the first tool snapshot."""
+def wait_for_mcp_discovery(timeout: float = 5.0) -> None:
+    """Boundedly wait for background MCP discovery before the first tool snapshot.
+
+    Discovery stays off the startup path, but the agent snapshots its tool list
+    once at build time.  Some healthy OAuth-backed HTTP MCPs (notably Notion)
+    take a couple of seconds to connect; a sub-second default lets the first
+    one-shot chat miss those tools for the entire session.  Keep the wait
+    bounded so a dead server cannot hang startup, while giving reachable servers
+    enough time to land before tool selection.
+    """
     thread = _mcp_discovery_thread
     if thread is None or not thread.is_alive():
         return

--- a/scripts/smoke_claude_worker_injection.py
+++ b/scripts/smoke_claude_worker_injection.py
@@ -267,6 +267,7 @@ def check_local_injection_with_shim() -> None:
         try:
             allowed = env.execute(f"{shim} -p 'Reply exactly: ok'", timeout=20)
             denied = env.execute(f"{shim} -p hi & env", timeout=20)
+            env_hijack = env.execute(f"env PATH={tmp} claude -p hi", timeout=20)
             non_claude = env.execute("env", timeout=20)
             subsequent = env.execute("env", timeout=20)
         finally:
@@ -283,6 +284,12 @@ def check_local_injection_with_shim() -> None:
             _ok("`claude -p ... & env` leak form did NOT receive the token")
         else:
             _fail("shell-control wrapper leaked the token")
+
+        # 4a.1: env-prefixed PATH/loader overrides must NOT receive the token.
+        if "TOKEN_PRESENT" not in env_hijack["output"]:
+            _ok("`env PATH=... claude -p` hijack form did NOT receive the token")
+        else:
+            _fail("env-prefixed command leaked the token")
 
         # 4b: plain non-claude command must not see it.
         if "CLAUDE_CODE_OAUTH_TOKEN" not in non_claude["output"]:

--- a/scripts/smoke_claude_worker_injection.py
+++ b/scripts/smoke_claude_worker_injection.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Smoke test for scoped Claude Code OAuth token injection.
+
+Verifies the narrow, opt-in passthrough of ``CLAUDE_CODE_OAUTH_TOKEN`` to
+direct ``claude -p`` worker subprocesses without globally unblocking secrets.
+
+This is a *diagnostic*, not a pytest. Run it by hand on a machine where the
+Claude CLI is installed to confirm worker auth reliability end to end:
+
+    venv/bin/python scripts/smoke_claude_worker_injection.py
+
+What it checks
+--------------
+  1. Config paths + terminal backend are resolvable.
+  2. The ``delegation.claude_code_pass_oauth_token`` flag value.
+  3. A direct LocalEnvironment ``claude -p`` worker receives an injected
+     **fake** token (via a shim ``claude`` on PATH).
+  4. Non-Claude commands do NOT receive the token.
+  5. A fake token actually reaches the *real* Claude CLI — the CLI rejects it
+     with a 401 / "invalid bearer token" rather than "not logged in" (proving
+     the token is delivered, not stripped).
+  6. A real PONG round-trips when real CLI auth / token is available.
+
+Safety
+------
+  - Never prints token values or OAuth URLs/codes; all sensitive strings are
+    masked before display.
+  - Forces the passthrough flag ON only in-process (monkeypatching the config
+    loader); it never writes to the user's real config.
+  - Steps 5 and 6 are SKIPPED when the real ``claude`` binary is absent.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Make the repo importable when run directly.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _maybe_reexec_with_repo_python() -> None:
+    """When launched as an executable, switch to a repo venv with deps.
+
+    The diagnostic imports Hermes modules, which depend on PyYAML. macOS/system
+    Python often lacks those deps, while the repo venv has them. `python
+    scripts/...` already uses the caller's interpreter; this only improves the
+    shebang path (`scripts/smoke_claude_worker_injection.py`).
+    """
+    if os.environ.get("HERMES_SMOKE_NO_VENV_REEXEC"):
+        return
+    try:
+        import yaml  # noqa: F401
+        return
+    except Exception:
+        pass
+
+    current = Path(sys.executable).resolve()
+    for rel in ("venv/bin/python", ".venv/bin/python"):
+        # Keep the venv symlink path intact. Resolving it jumps to the base
+        # Python binary and drops the venv's site-packages from sys.path.
+        candidate = _REPO_ROOT / rel
+        if not candidate.exists() or candidate.resolve() == current:
+            continue
+        probe = subprocess.run(
+            [str(candidate), "-c", "import yaml"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if probe.returncode == 0:
+            env = os.environ.copy()
+            env["HERMES_SMOKE_NO_VENV_REEXEC"] = "1"
+            os.execve(str(candidate), [str(candidate), *sys.argv], env)
+
+
+_maybe_reexec_with_repo_python()
+
+FAKE_TOKEN = "cc-worker-FAKE-do-not-use-0000000000000000"
+_SENSITIVE = [FAKE_TOKEN]
+
+
+# ── output helpers ────────────────────────────────────────────────────────
+
+class _Tally:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+        self.skipped = 0
+
+
+TALLY = _Tally()
+
+
+def _register_secret(value: str | None) -> None:
+    if value and value.strip() and value not in _SENSITIVE:
+        _SENSITIVE.append(value)
+
+
+def _mask(text: str) -> str:
+    """Redact any known sensitive substrings before display."""
+    out = text or ""
+    for secret in _SENSITIVE:
+        if secret:
+            out = out.replace(secret, "***REDACTED***")
+    # Belt-and-suspenders: blank out anything that looks like an oauth token
+    # or an authorize URL/code we might not have registered.
+    out = re.sub(r"(CLAUDE_CODE_OAUTH_TOKEN=)\S+", r"\1***REDACTED***", out)
+    out = re.sub(r"https://\S*oauth\S*", "https://***REDACTED-OAUTH-URL***", out)
+    return out
+
+
+def _section(title: str) -> None:
+    print(f"\n=== {title} ===")
+
+
+def _ok(msg: str) -> None:
+    TALLY.passed += 1
+    print(f"  PASS  {_mask(msg)}")
+
+
+def _fail(msg: str) -> None:
+    TALLY.failed += 1
+    print(f"  FAIL  {_mask(msg)}")
+
+
+def _skip(msg: str) -> None:
+    TALLY.skipped += 1
+    print(f"  SKIP  {_mask(msg)}")
+
+
+def _info(msg: str) -> None:
+    print(f"  ..    {_mask(msg)}")
+
+
+# ── token-source / auth-error classification ──────────────────────────────
+
+def _looks_like_not_logged_in(text: str) -> bool:
+    low = (text or "").lower()
+    return any(
+        marker in low
+        for marker in (
+            "not logged in",
+            "please run /login",
+            "run `claude /login`",
+            "no api key",
+            "no authentication",
+        )
+    )
+
+
+def _looks_like_bad_bearer(text: str) -> bool:
+    low = (text or "").lower()
+    return any(
+        marker in low
+        for marker in (
+            "401",
+            "invalid bearer token",
+            "invalid_bearer",
+            "unauthorized",
+            "authentication_error",
+            "invalid api key",
+            "oauth token has expired",
+        )
+    )
+
+
+# ── check 1: config paths + backend ───────────────────────────────────────
+
+def check_config_paths() -> None:
+    _section("1. Config paths + terminal backend")
+    try:
+        from hermes_cli.config import get_config_path, get_env_path, load_config
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+        cfg_path = get_config_path()
+        env_path = get_env_path()
+        _info(f"HERMES_HOME : {home}")
+        _info(f"config.yaml : {cfg_path} (exists={cfg_path.exists()})")
+        _info(f".env        : {env_path} (exists={env_path.exists()})")
+
+        cfg = load_config() or {}
+        backend = ((cfg.get("terminal") or {}).get("backend")) or "local"
+        _info(f"terminal.backend : {backend}")
+        if backend != "local":
+            _info(
+                "backend is not 'local' — token injection only applies to the "
+                "LocalEnvironment path; remote backends are out of scope."
+            )
+        _ok("config paths and terminal backend resolved")
+    except Exception as exc:  # pragma: no cover - diagnostic
+        _fail(f"could not resolve config: {exc!r}")
+
+
+# ── check 2: flag value ───────────────────────────────────────────────────
+
+def check_flag_value() -> None:
+    _section("2. delegation.claude_code_pass_oauth_token")
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        delegation = cfg.get("delegation") or {}
+        value = delegation.get("claude_code_pass_oauth_token", False)
+        _info(f"configured value : {value!r}")
+        if value:
+            _ok("passthrough is ENABLED in real config")
+        else:
+            _ok(
+                "passthrough is DISABLED in real config (default-safe). "
+                "Injection checks below force it on in-process only."
+            )
+    except Exception as exc:  # pragma: no cover - diagnostic
+        _fail(f"could not read flag: {exc!r}")
+
+
+# ── shared: force flag on in-process, point PATH at a shim claude ──────────
+
+def _write_shim_claude(dir_path: Path) -> Path:
+    """A fake `claude` that reports whether the token reached its env."""
+    shim = dir_path / "claude"
+    shim.write_text(
+        "#!/bin/sh\n"
+        'if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then\n'
+        "  echo TOKEN_PRESENT\n"
+        "else\n"
+        "  echo TOKEN_ABSENT\n"
+        "fi\n"
+    )
+    shim.chmod(0o755)
+    return shim
+
+
+def _force_flag_on() -> None:
+    import hermes_cli.config as cfg_mod
+
+    cfg_mod.load_config = lambda: {  # type: ignore[assignment]
+        "delegation": {"claude_code_pass_oauth_token": True}
+    }
+
+
+# ── check 3 + 4: shim worker receives token; non-claude does not ──────────
+
+def check_local_injection_with_shim() -> None:
+    _section("3+4. LocalEnvironment injection (fake token, shim claude)")
+    os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = FAKE_TOKEN
+    _register_secret(FAKE_TOKEN)
+    _force_flag_on()
+
+    try:
+        from tools.environments.local import LocalEnvironment
+    except Exception as exc:  # pragma: no cover
+        _fail(f"could not import LocalEnvironment: {exc!r}")
+        return
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        shim = _write_shim_claude(tmp)
+        env = LocalEnvironment(cwd=str(tmp), timeout=20)
+        try:
+            allowed = env.execute(f"{shim} -p 'Reply exactly: ok'", timeout=20)
+            denied = env.execute(f"{shim} -p hi & env", timeout=20)
+            non_claude = env.execute("env", timeout=20)
+            subsequent = env.execute("env", timeout=20)
+        finally:
+            env.cleanup()
+
+        # 3: direct worker gets the token.
+        if "TOKEN_PRESENT" in allowed["output"]:
+            _ok("direct `claude -p` worker received the injected token")
+        else:
+            _fail(f"worker did not receive token (output: {allowed['output'].strip()!r})")
+
+        # 4a: shell-control wrapper must NOT receive the token.
+        if "TOKEN_PRESENT" not in denied["output"]:
+            _ok("`claude -p ... & env` leak form did NOT receive the token")
+        else:
+            _fail("shell-control wrapper leaked the token")
+
+        # 4b: plain non-claude command must not see it.
+        if "CLAUDE_CODE_OAUTH_TOKEN" not in non_claude["output"]:
+            _ok("non-claude `env` command did not receive the token")
+        else:
+            _fail("non-claude command saw CLAUDE_CODE_OAUTH_TOKEN")
+
+        # 4c: token must not persist into the session snapshot.
+        if "CLAUDE_CODE_OAUTH_TOKEN" not in subsequent["output"]:
+            _ok("token did not persist into the session env snapshot")
+        else:
+            _fail("token leaked into a subsequent command via the snapshot")
+
+
+# ── check 5: fake token reaches the real Claude CLI → 401, not "logged out" ─
+
+def check_real_cli_rejects_fake_token() -> None:
+    _section("5. Real Claude CLI rejects the fake token (401, not logged-out)")
+    claude = shutil.which("claude")
+    if not claude:
+        _skip("`claude` binary not on PATH")
+        return
+
+    os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = FAKE_TOKEN
+    _register_secret(FAKE_TOKEN)
+    _force_flag_on()
+
+    from tools.environments.local import LocalEnvironment
+
+    env = LocalEnvironment(cwd=tempfile.gettempdir(), timeout=60)
+    try:
+        result = env.execute("claude -p 'Return exactly PONG'", timeout=60)
+    finally:
+        env.cleanup()
+
+    out = result["output"]
+    _info(f"exit={result['returncode']} output={out.strip()[:300]!r}")
+
+    if "PONG" in out and not _looks_like_bad_bearer(out):
+        _skip(
+            "real CLI returned PONG with a FAKE token — a valid stored login "
+            "took precedence over the env token, so token delivery can't be "
+            "isolated here. Re-run after `claude /logout` to assert the 401 path."
+        )
+        return
+    if _looks_like_not_logged_in(out) and not _looks_like_bad_bearer(out):
+        _fail(
+            "CLI reports 'not logged in' — the fake token did NOT reach the CLI "
+            "(it was stripped before exec)"
+        )
+        return
+    if _looks_like_bad_bearer(out):
+        _ok(
+            "CLI rejected the fake token with an auth/401 error — token IS being "
+            "delivered to the real CLI"
+        )
+        return
+    _skip(
+        "CLI produced an unrecognized response; inspect masked output above "
+        "to classify manually"
+    )
+
+
+# ── check 6: real PONG when genuine auth is available ─────────────────────
+
+def check_real_pong() -> None:
+    _section("6. Real PONG round-trip (genuine CLI auth)")
+    claude = shutil.which("claude")
+    if not claude:
+        _skip("`claude` binary not on PATH")
+        return
+
+    # Use the real stored login / real token, NOT the fake one.
+    os.environ.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+    real_token = os.environ.get("_HERMES_SMOKE_REAL_OAUTH_TOKEN", "").strip()
+    if real_token:
+        _register_secret(real_token)
+
+    import subprocess
+
+    sub_env = os.environ.copy()
+    sub_env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+    if real_token:
+        sub_env["CLAUDE_CODE_OAUTH_TOKEN"] = real_token
+        _info("using real token from _HERMES_SMOKE_REAL_OAUTH_TOKEN")
+    else:
+        _info("no explicit real token; relying on stored CLI login")
+
+    try:
+        proc = subprocess.run(
+            [claude, "-p", "Return exactly PONG"],
+            env=sub_env,
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+    except subprocess.TimeoutExpired:
+        _fail("real claude CLI timed out")
+        return
+
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    _info(f"exit={proc.returncode} output={combined.strip()[:300]!r}")
+
+    if "PONG" in combined:
+        _ok("real Claude CLI returned PONG — worker auth is healthy")
+    elif _looks_like_not_logged_in(combined) or _looks_like_bad_bearer(combined):
+        _skip(
+            "no valid CLI auth available in this environment — run "
+            "`claude /login` (or set _HERMES_SMOKE_REAL_OAUTH_TOKEN) to exercise"
+        )
+    else:
+        _fail("real CLI did not return PONG; inspect masked output above")
+
+
+# ── main ──────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    print("Claude Code worker OAuth-token injection smoke test")
+    print("(no token values or OAuth URLs are printed)")
+
+    check_config_paths()
+    check_flag_value()
+    check_local_injection_with_shim()
+    check_real_cli_rejects_fake_token()
+    check_real_pong()
+
+    _section("Summary")
+    print(f"  passed={TALLY.passed} failed={TALLY.failed} skipped={TALLY.skipped}")
+    return 1 if TALLY.failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -205,3 +205,71 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+# ── Claude Code OAuth worker env gate ─────────────────────────────────────
+
+def _delegation_flag(enabled: bool):
+    return {"delegation": {"claude_code_pass_oauth_token": enabled}}
+
+
+def test_acp_env_does_not_copy_collateral_secrets(monkeypatch, tmp_path):
+    from agent import copilot_acp_client as acp
+
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "anthropic-token")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+    monkeypatch.setenv("SLACK_APP_TOKEN", "slack-secret")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: _delegation_flag(False))
+
+    env = acp._build_subprocess_env("copilot")
+
+    assert env["HOME"]
+    assert env["PATH"] == "/usr/bin:/bin"
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+    assert "ANTHROPIC_TOKEN" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert "SLACK_APP_TOKEN" not in env
+
+
+def test_acp_env_passes_claude_oauth_only_for_claude_command_with_flag(monkeypatch, tmp_path):
+    from agent import copilot_acp_client as acp
+
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "anthropic-token")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: _delegation_flag(True))
+
+    env = acp._build_subprocess_env("/opt/homebrew/bin/claude")
+
+    assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "cc-worker-token"
+    assert "ANTHROPIC_TOKEN" not in env
+    assert "OPENAI_API_KEY" not in env
+
+
+def test_acp_env_does_not_pass_claude_oauth_to_non_claude_commands(monkeypatch, tmp_path):
+    from agent import copilot_acp_client as acp
+
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: _delegation_flag(True))
+
+    env = acp._build_subprocess_env("copilot")
+
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+
+
+def test_acp_env_does_not_pass_whitespace_only_claude_oauth(monkeypatch, tmp_path):
+    from agent import copilot_acp_client as acp
+
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "   ")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: _delegation_flag(True))
+
+    env = acp._build_subprocess_env("claude")
+
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in env

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -140,6 +140,43 @@ def test_cli_get_tool_definitions_briefly_waits_for_fast_mcp_thread(monkeypatch)
     assert not thread.is_alive()
 
 
+def test_default_wait_covers_slow_reachable_mcp_thread():
+    """A reachable-but-slow server (e.g. Notion's ~2.6s OAuth handshake) must
+    land in the first tool snapshot.  The DEFAULT wait — no explicit timeout —
+    has to outlast such a thread, so a thread that finishes at ~1.1s is joined
+    to completion rather than abandoned mid-connect (regression: the old 0.75s
+    default snapshotted before Notion connected, hiding all 14 of its tools)."""
+    thread = threading.Thread(target=lambda: time.sleep(1.1), daemon=True)
+    thread.start()
+    mcp_startup._mcp_discovery_thread = thread
+
+    start = time.monotonic()
+    mcp_startup.wait_for_mcp_discovery()  # default timeout, no override
+    elapsed = time.monotonic() - start
+
+    assert not thread.is_alive()  # default wait outlasted the slow connect
+    assert elapsed >= 1.0
+
+
+def test_explicit_short_timeout_still_bounds_hung_mcp_thread():
+    """A raised default must NOT remove the override: passing an explicit short
+    timeout for a hung/dead server still returns near that bound, never the
+    (now larger) default — startup stays non-blocking on dead servers."""
+    stop = threading.Event()
+    thread = threading.Thread(target=stop.wait, daemon=True)
+    thread.start()
+    mcp_startup._mcp_discovery_thread = thread
+
+    try:
+        start = time.monotonic()
+        mcp_startup.wait_for_mcp_discovery(timeout=0.3)
+        elapsed = time.monotonic() - start
+        assert 0.25 <= elapsed < 1.0  # bounded by the explicit override
+        assert thread.is_alive()  # we did not block on the hung thread
+    finally:
+        stop.set()
+
+
 def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):
     waited = {"done": False}
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -124,6 +124,14 @@ class TestConfigYamlRouting:
             or "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=True" in env_content
         )
 
+    def test_delegation_claude_oauth_flag_goes_to_config_despite_token_suffix(self, _isolated_hermes_home):
+        set_config_value("delegation.claude_code_pass_oauth_token", "true")
+
+        config = _read_config(_isolated_hermes_home)
+        env_content = _read_env(_isolated_hermes_home)
+        assert "claude_code_pass_oauth_token: true" in config
+        assert "CLAUDE_CODE_PASS_OAUTH_TOKEN" not in env_content
+
 
 # ---------------------------------------------------------------------------
 # Empty / falsy values — regression tests for #4277

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -496,6 +496,8 @@ def _make_update_side_effect(
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-list" in joined:
             if "origin/main..HEAD" in joined:
+                if local_commit_count is None:
+                    return SimpleNamespace(stdout="", stderr="fatal: bad revision\n", returncode=128)
                 return SimpleNamespace(stdout=f"{local_commit_count}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout=f"{commit_count}\n", stderr="", returncode=0)
         if "--ff-only" in joined:
@@ -539,6 +541,26 @@ def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path
 
     out = capsys.readouterr().out
     assert "Fast-forward not possible" in out
+
+
+def test_cmd_update_stops_when_local_commit_count_is_unknown(monkeypatch, tmp_path, capsys):
+    """If local commits cannot be counted, fail safe instead of hard-resetting."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True,
+        local_commit_count=None,
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    assert [c for c in recorded if "reset" in c and "--hard" in c] == []
+    out = capsys.readouterr().out
+    assert "could not determine whether local commits exist" in out
+    assert "not discarded" in out
 
 
 def test_cmd_update_rebases_local_commits_when_ff_only_fails(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -474,6 +474,8 @@ def _make_update_side_effect(
     current_branch="main",
     commit_count="3",
     ff_only_fails=False,
+    local_commit_count="0",
+    rebase_fails=False,
     reset_fails=False,
     fetch_fails=False,
     fetch_stderr="",
@@ -493,6 +495,8 @@ def _make_update_side_effect(
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-list" in joined:
+            if "origin/main..HEAD" in joined:
+                return SimpleNamespace(stdout=f"{local_commit_count}\n", stderr="", returncode=0)
             return SimpleNamespace(stdout=f"{commit_count}\n", stderr="", returncode=0)
         if "--ff-only" in joined:
             if ff_only_fails:
@@ -502,6 +506,14 @@ def _make_update_side_effect(
                     returncode=128,
                 )
             return SimpleNamespace(stdout="Updating abc..def\n", stderr="", returncode=0)
+        if "branch" in joined and "backup/update-preserve-main" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd[1:3] == ["rebase", "origin/main"]:
+            if rebase_fails:
+                return SimpleNamespace(stdout="", stderr="CONFLICT (content): file\n", returncode=1)
+            return SimpleNamespace(stdout="Successfully rebased\n", stderr="", returncode=0)
+        if cmd[1:3] == ["rebase", "--abort"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "reset" in joined and "--hard" in joined:
             if reset_fails:
                 return SimpleNamespace(stdout="", stderr="error: unable to write\n", returncode=1)
@@ -512,7 +524,7 @@ def _make_update_side_effect(
 
 
 def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path, capsys):
-    """When --ff-only fails (diverged history), update resets to origin/{branch}."""
+    """When --ff-only fails without local commits, update resets to origin/{branch}."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
@@ -527,6 +539,55 @@ def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path
 
     out = capsys.readouterr().out
     assert "Fast-forward not possible" in out
+
+
+def test_cmd_update_rebases_local_commits_when_ff_only_fails(monkeypatch, tmp_path, capsys):
+    """When a managed install carries local commits, update preserves them."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True,
+        local_commit_count="2",
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    branch_calls = [c for c in recorded if c[1:2] == ["branch"] and c[2].startswith("backup/update-preserve-main-")]
+    rebase_calls = [c for c in recorded if c[1:3] == ["rebase", "origin/main"]]
+    reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
+    assert len(branch_calls) == 1
+    assert rebase_calls == [["git", "rebase", "origin/main"]]
+    assert reset_calls == []
+
+    out = capsys.readouterr().out
+    assert "preserving 2 local commit" in out
+    assert "Local commits preserved" in out
+
+
+def test_cmd_update_stops_without_reset_when_local_commit_rebase_fails(monkeypatch, tmp_path, capsys):
+    """A rebase conflict aborts the update instead of discarding local commits."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True,
+        local_commit_count="2",
+        rebase_fails=True,
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    assert [c for c in recorded if c[1:3] == ["rebase", "--abort"]] == [["git", "rebase", "--abort"]]
+    assert [c for c in recorded if "reset" in c and "--hard" in c] == []
+
+    out = capsys.readouterr().out
+    assert "Could not rebase local commits" in out
+    assert "local commits remain" in out
+    assert "not discarded" in out
 
 
 def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -213,6 +213,188 @@ class TestProviderEnvBlocklist:
         assert result_env["MY_CUSTOM_VAR"] == "keep-this"
 
 
+class TestClaudeCodeWorkerTokenGate:
+    """Claude Code worker auth gets a narrow opt-in, not a global unblock."""
+
+    def _flag(self, enabled: bool):
+        return {"delegation": {"claude_code_pass_oauth_token": enabled}}
+
+    def test_flag_off_keeps_claude_oauth_token_stripped(self, monkeypatch):
+        from tools.environments import local as local_env
+
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: self._flag(False))
+
+        result_env = local_env._make_run_env({}, command="claude -p 'Reply exactly: ok'")
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in result_env
+
+    def test_flag_on_passes_only_token_for_direct_claude_print_worker(self, monkeypatch):
+        from tools.environments import local as local_env
+
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "anthropic-token")
+        monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+        monkeypatch.setenv("SLACK_APP_TOKEN", "slack-secret")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: self._flag(True))
+
+        result_env = local_env._make_run_env({}, command="claude -p 'Reply exactly: ok'")
+
+        assert result_env["CLAUDE_CODE_OAUTH_TOKEN"] == "cc-worker-token"
+        assert "ANTHROPIC_TOKEN" not in result_env
+        assert "OPENAI_API_KEY" not in result_env
+        assert "SLACK_APP_TOKEN" not in result_env
+
+    def test_flag_on_does_not_pass_token_to_non_claude_command(self, monkeypatch):
+        from tools.environments import local as local_env
+
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: self._flag(True))
+
+        result_env = local_env._make_run_env({}, command="echo claude -p not-a-worker")
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in result_env
+
+    def test_real_local_wrapper_eval_is_detected(self):
+        from tools.environments.local import _is_direct_claude_worker_command
+
+        wrapped = "\n".join([
+            "source /tmp/hermes-snap-123.sh >/dev/null 2>&1 || true",
+            "builtin cd -- /tmp || exit 126",
+            "eval 'claude -p '\''Reply exactly: ok'\'''",
+            "__hermes_ec=$?",
+        ])
+
+        assert _is_direct_claude_worker_command(wrapped)
+
+    def test_arbitrary_shell_wrappers_are_rejected(self):
+        from tools.environments.local import _is_direct_claude_worker_command
+
+        assert not _is_direct_claude_worker_command("bash -lc 'claude -p hi'")
+
+    def test_multiline_commands_with_extra_user_steps_are_rejected(self):
+        from tools.environments.local import _is_direct_claude_worker_command
+
+        assert not _is_direct_claude_worker_command("claude -p hi\nprintf \"$CLAUDE_CODE_OAUTH_TOKEN\"")
+
+    def test_wrapped_eval_with_extra_user_steps_is_rejected(self):
+        from tools.environments.local import _is_direct_claude_worker_command
+
+        wrapped = "\n".join([
+            "source /tmp/hermes-snap-123.sh >/dev/null 2>&1 || true",
+            "builtin cd -- /tmp || exit 126",
+            "eval 'claude -p hi'\''; printf \"$CLAUDE_CODE_OAUTH_TOKEN\"'",
+            "__hermes_ec=$?",
+        ])
+
+        assert not _is_direct_claude_worker_command(wrapped)
+
+    def test_whitespace_only_oauth_token_is_not_injected(self, monkeypatch):
+        from tools.environments import local as local_env
+
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "   ")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: self._flag(True))
+
+        result_env = local_env._make_run_env({}, command="claude -p 'Reply exactly: ok'")
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in result_env
+
+    def test_shell_control_and_expansion_forms_are_rejected(self):
+        from tools.environments.local import _is_direct_claude_worker_command
+
+        dangerous_commands = [
+            "claude -p hi & env",
+            "claude -p \"$(env)\"",
+            "claude -p `env`",
+            "claude -p hi > /tmp/out",
+        ]
+        for command in dangerous_commands:
+            assert not _is_direct_claude_worker_command(command)
+
+    def test_shell_control_forms_do_not_receive_token(self, monkeypatch):
+        from tools.environments import local as local_env
+
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: self._flag(True))
+
+        result_env = local_env._make_run_env({}, command="claude -p hi & env")
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in result_env
+
+    def test_local_environment_rejects_background_leak_command(self, monkeypatch, tmp_path):
+        fake_claude = tmp_path / "claude"
+        fake_claude.write_text(
+            "#!/bin/sh\n"
+            "if [ -n \"${CLAUDE_CODE_OAUTH_TOKEN:-}\" ]; then\n"
+            "  echo TOKEN_PRESENT\n"
+            "else\n"
+            "  echo TOKEN_ABSENT\n"
+            "fi\n"
+        )
+        fake_claude.chmod(0o755)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: self._flag(True))
+
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        try:
+            result = env.execute(f"{fake_claude} -p hi & env", timeout=10)
+        finally:
+            env.cleanup()
+
+        assert "TOKEN_PRESENT" not in result["output"]
+        assert "CLAUDE_CODE_OAUTH_TOKEN=cc-worker-token" not in result["output"]
+
+    def test_local_environment_execute_injects_token_through_real_wrapper(self, monkeypatch, tmp_path):
+        fake_claude = tmp_path / "claude"
+        fake_claude.write_text(
+            "#!/bin/sh\n"
+            "if [ -n \"${CLAUDE_CODE_OAUTH_TOKEN:-}\" ]; then\n"
+            "  echo TOKEN_PRESENT\n"
+            "else\n"
+            "  echo TOKEN_ABSENT\n"
+            "fi\n"
+        )
+        fake_claude.chmod(0o755)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: self._flag(True))
+
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        try:
+            result = env.execute(f"{fake_claude} -p 'Reply exactly: ok'", timeout=10)
+        finally:
+            env.cleanup()
+
+        assert result["returncode"] == 0
+        assert "TOKEN_PRESENT" in result["output"]
+
+    def test_injected_oauth_token_does_not_persist_to_local_snapshot(self, monkeypatch, tmp_path):
+        fake_claude = tmp_path / "claude"
+        fake_claude.write_text(
+            "#!/bin/sh\n"
+            "if [ -n \"${CLAUDE_CODE_OAUTH_TOKEN:-}\" ]; then\n"
+            "  echo TOKEN_PRESENT\n"
+            "else\n"
+            "  echo TOKEN_ABSENT\n"
+            "fi\n"
+        )
+        fake_claude.chmod(0o755)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: self._flag(True))
+
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        try:
+            allowed = env.execute(f"{fake_claude} -p 'Reply exactly: ok'", timeout=10)
+            subsequent_env = env.execute("env", timeout=10)
+            rejected = env.execute(f"{fake_claude} -p hi & env", timeout=10)
+        finally:
+            env.cleanup()
+
+        assert "TOKEN_PRESENT" in allowed["output"]
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in subsequent_env["output"]
+        assert "TOKEN_PRESENT" not in rejected["output"]
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in rejected["output"]
+
+
 class TestForceEnvOptIn:
     """Callers can opt in to passing a blocked var via _HERMES_FORCE_ prefix."""
 

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -321,6 +321,52 @@ class TestClaudeCodeWorkerTokenGate:
 
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in result_env
 
+    def test_env_prefix_forms_are_rejected(self):
+        from tools.environments.local import _is_direct_claude_worker_command
+
+        dangerous_commands = [
+            "env PATH=/tmp/evil claude -p hi",
+            "env NODE_OPTIONS=--require=/tmp/evil.js claude -p hi",
+            "env LD_PRELOAD=/tmp/evil.so claude -p hi",
+            "env DYLD_INSERT_LIBRARIES=/tmp/evil.dylib claude -p hi",
+            "env BASH_ENV=/tmp/evil.sh claude -p hi",
+        ]
+        for command in dangerous_commands:
+            assert not _is_direct_claude_worker_command(command)
+
+    def test_env_prefix_forms_do_not_receive_token(self, monkeypatch):
+        from tools.environments import local as local_env
+
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: self._flag(True))
+
+        result_env = local_env._make_run_env({}, command="env PATH=/tmp/evil claude -p hi")
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in result_env
+
+    def test_local_environment_rejects_env_path_hijack(self, monkeypatch, tmp_path):
+        fake_claude = tmp_path / "claude"
+        fake_claude.write_text(
+            "#!/bin/sh\n"
+            "if [ -n \"${CLAUDE_CODE_OAUTH_TOKEN:-}\" ]; then\n"
+            "  echo TOKEN_PRESENT\n"
+            "else\n"
+            "  echo TOKEN_ABSENT\n"
+            "fi\n"
+        )
+        fake_claude.chmod(0o755)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-worker-token")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: self._flag(True))
+
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        try:
+            result = env.execute(f"env PATH={tmp_path} claude -p hi", timeout=10)
+        finally:
+            env.cleanup()
+
+        assert "TOKEN_PRESENT" not in result["output"]
+        assert "CLAUDE_CODE_OAUTH_TOKEN=cc-worker-token" not in result["output"]
+
     def test_local_environment_rejects_background_leak_command(self, monkeypatch, tmp_path):
         fake_claude = tmp_path / "claude"
         fake_claude.write_text(

--- a/tests/tui_gateway/test_wait_for_mcp_discovery.py
+++ b/tests/tui_gateway/test_wait_for_mcp_discovery.py
@@ -59,6 +59,25 @@ def test_fast_thread_is_joined():
         _restore_thread_slot(saved)
 
 
+def test_default_wait_covers_slow_reachable_thread():
+    """The DEFAULT wait (no explicit timeout) must outlast a reachable-but-slow
+    server such as Notion's ~2.6s OAuth handshake.  A thread finishing at ~1.1s
+    is joined to completion under the default — regression against the old 0.75s
+    default that snapshotted tools before Notion connected, hiding its tools."""
+    saved = entry._mcp_discovery_thread
+    try:
+        t = threading.Thread(target=lambda: time.sleep(1.1), daemon=True)
+        t.start()
+        entry._mcp_discovery_thread = t
+        start = time.monotonic()
+        entry.wait_for_mcp_discovery()  # default timeout, no override
+        elapsed = time.monotonic() - start
+        assert not t.is_alive()  # default wait outlasted the slow connect
+        assert elapsed >= 1.0
+    finally:
+        _restore_thread_slot(saved)
+
+
 def test_hung_thread_is_bounded_by_timeout():
     """A slow/dead server must NOT re-introduce the startup hang — the join is
     bounded by the timeout and returns even though the thread is still alive."""

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -280,6 +280,12 @@ def _cwd_marker(session_id: str) -> str:
     return f"__HERMES_CWD_{session_id}__"
 
 
+def _shell_safe_env_name(name: str) -> bool:
+    if not name or not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(ch.isalnum() or ch == "_" for ch in name)
+
+
 # ---------------------------------------------------------------------------
 # BaseEnvironment
 # ---------------------------------------------------------------------------
@@ -307,6 +313,10 @@ class BaseEnvironment(ABC):
         may be missing and ``TMPDIR`` is the portable writable location.
         """
         return "/tmp"
+
+    def _snapshot_env_excludes(self) -> tuple[str, ...]:
+        """Environment variable names that must not persist into snapshots."""
+        return ()
 
     def __init__(self, cwd: str, timeout: int, env: dict = None):
         self.cwd = cwd
@@ -451,6 +461,9 @@ class BaseEnvironment(ABC):
 
         # Re-dump env vars to snapshot (last-writer-wins for concurrent calls)
         if self._snapshot_ready:
+            for name in self._snapshot_env_excludes():
+                if _shell_safe_env_name(name):
+                    parts.append(f"unset {name}")
             parts.append(f"export -p > {_quoted_snap} 2>/dev/null || true")
 
         # Write CWD to file (local reads this) and stdout marker (remote parses this)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -4,6 +4,7 @@ import logging
 import os
 import platform
 import re
+import shlex
 import shutil
 import signal
 import subprocess
@@ -203,6 +204,151 @@ def _inject_context_hermes_home(env: dict) -> None:
         pass
 
 
+_CLAUDE_CODE_OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
+
+
+def _is_truthy_config_value(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _claude_code_oauth_token_passthrough_enabled() -> bool:
+    """Return whether config explicitly opts into Claude worker token passing."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        delegation = cfg.get("delegation") or {}
+        return _is_truthy_config_value(delegation.get("claude_code_pass_oauth_token", False))
+    except Exception:
+        return False
+
+
+def _is_claude_executable(token: str) -> bool:
+    basename = os.path.basename((token or "").strip().strip('"\''))
+    return basename in {"claude", "claude.exe"}
+
+
+def _looks_like_env_assignment(token: str) -> bool:
+    return bool(re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", token or ""))
+
+
+def _has_shell_active_chars(command: str) -> bool:
+    # The token is injected into a bash wrapper env. Any shell control,
+    # expansion, substitution, or redirection syntax can run collateral code
+    # before/alongside Claude and must fail safe.
+    return any(ch in command for ch in ("$", "`", "&", ";", "|", "<", ">"))
+
+
+def _tokens_are_direct_claude_print_command(tokens: list[str]) -> bool:
+    """Conservative detector for `claude -p` / `env FOO=bar claude -p`."""
+    if not tokens:
+        return False
+
+    if any(token in {";", "&&", "||", "|"} or any(op in token for op in (";", "&&", "||", "|")) for token in tokens):
+        return False
+
+    index = 0
+    if os.path.basename(tokens[index]) in {"env", "env.exe"}:
+        index += 1
+        while index < len(tokens) and _looks_like_env_assignment(tokens[index]):
+            index += 1
+        if index >= len(tokens):
+            return False
+
+    if not _is_claude_executable(tokens[index]):
+        return False
+
+    return any(token in {"-p", "--print"} for token in tokens[index + 1:])
+
+
+def _shlex_split(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return []
+
+
+def _is_benign_hermes_wrapper_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return True
+    if stripped.startswith("source "):
+        return "hermes-snap-" in stripped and ">/dev/null 2>&1 || true" in stripped
+    if stripped.startswith("builtin cd "):
+        return stripped.endswith("|| exit 126")
+    if stripped == "__hermes_ec=$?":
+        return True
+    if stripped.startswith("export -p > "):
+        return "hermes-snap-" in stripped and stripped.endswith("2>/dev/null || true")
+    if stripped.startswith("pwd -P > "):
+        return "hermes-cwd-" in stripped and stripped.endswith("2>/dev/null || true")
+    if stripped.startswith("printf '\\n__HERMES_CWD_"):
+        return "$(pwd -P)" in stripped
+    if stripped == "exit $__hermes_ec":
+        return True
+    if stripped == f"unset {_CLAUDE_CODE_OAUTH_TOKEN_ENV}":
+        return True
+    return False
+
+
+def _is_direct_claude_worker_command(command: str | None, *, _depth: int = 0) -> bool:
+    """True only for direct Claude Code print-mode worker commands.
+
+    This intentionally accepts Hermes' own multi-line wrapper (`eval '<cmd>'`)
+    but rejects arbitrary shell wrappers such as `bash -lc 'claude -p ...'`.
+    """
+    if not command or _depth > 3:
+        return False
+    command = str(command).strip()
+    if not command:
+        return False
+
+    if "\n" not in command:
+        if _has_shell_active_chars(command):
+            return False
+        if _tokens_are_direct_claude_print_command(_shlex_split(command)):
+            return True
+
+    found_worker_line = False
+    for raw_line in command.splitlines():
+        line = raw_line.strip()
+        if _is_benign_hermes_wrapper_line(line):
+            continue
+
+        tokens = _shlex_split(line)
+        if tokens and tokens[0] == "eval":
+            candidate = " ".join(tokens[1:])
+            if candidate and _is_direct_claude_worker_command(candidate, _depth=_depth + 1):
+                found_worker_line = True
+                continue
+            return False
+
+        if _tokens_are_direct_claude_print_command(tokens):
+            found_worker_line = True
+            continue
+
+        return False
+
+    return found_worker_line
+
+
+def _maybe_inject_claude_code_oauth_token(run_env: dict[str, str], command: str | None) -> None:
+    token = os.environ.get(_CLAUDE_CODE_OAUTH_TOKEN_ENV, "").strip()
+    if not token:
+        return
+    if not _claude_code_oauth_token_passthrough_enabled():
+        return
+    if not _is_direct_claude_worker_command(command):
+        return
+    run_env[_CLAUDE_CODE_OAUTH_TOKEN_ENV] = token
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -300,7 +446,7 @@ _SANE_PATH = (
 )
 
 
-def _make_run_env(env: dict) -> dict:
+def _make_run_env(env: dict, command: str | None = None) -> dict:
     """Build a run environment with a sane PATH and provider-var stripping."""
     try:
         from tools.env_passthrough import is_env_passthrough as _is_passthrough
@@ -347,6 +493,8 @@ def _make_run_env(env: dict) -> dict:
                 run_env[var_name] = value
     except Exception:
         pass
+
+    _maybe_inject_claude_code_oauth_token(run_env, command)
 
     return run_env
 
@@ -448,6 +596,9 @@ class LocalEnvironment(BaseEnvironment):
         super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
         self.init_session()
 
+    def _snapshot_env_excludes(self) -> tuple[str, ...]:
+        return (_CLAUDE_CODE_OAUTH_TOKEN_ENV,)
+
     def get_temp_dir(self) -> str:
         """Return a shell-safe writable temp dir for local execution.
 
@@ -511,7 +662,7 @@ class LocalEnvironment(BaseEnvironment):
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
-        run_env = _make_run_env(self.env)
+        run_env = _make_run_env(self.env, command=cmd_string)
 
         # Recover when the cwd has been deleted out from under us — usually by
         # a previous tool call that ran ``rm -rf`` on its own working dir

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -234,10 +234,6 @@ def _is_claude_executable(token: str) -> bool:
     return basename in {"claude", "claude.exe"}
 
 
-def _looks_like_env_assignment(token: str) -> bool:
-    return bool(re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", token or ""))
-
-
 def _has_shell_active_chars(command: str) -> bool:
     # The token is injected into a bash wrapper env. Any shell control,
     # expansion, substitution, or redirection syntax can run collateral code
@@ -246,25 +242,26 @@ def _has_shell_active_chars(command: str) -> bool:
 
 
 def _tokens_are_direct_claude_print_command(tokens: list[str]) -> bool:
-    """Conservative detector for `claude -p` / `env FOO=bar claude -p`."""
+    """Conservative detector for a bare `claude -p` / `claude --print` command.
+
+    Do not accept `env FOO=bar claude -p ...` forms. Even apparently simple
+    assignments can alter PATH, loader hooks, startup files, or Node/Python
+    behavior before Claude starts, causing the narrowly-scoped OAuth token to be
+    exposed to collateral code.
+    """
     if not tokens:
         return False
 
     if any(token in {";", "&&", "||", "|"} or any(op in token for op in (";", "&&", "||", "|")) for token in tokens):
         return False
 
-    index = 0
-    if os.path.basename(tokens[index]) in {"env", "env.exe"}:
-        index += 1
-        while index < len(tokens) and _looks_like_env_assignment(tokens[index]):
-            index += 1
-        if index >= len(tokens):
-            return False
-
-    if not _is_claude_executable(tokens[index]):
+    if os.path.basename(tokens[0]) in {"env", "env.exe"}:
         return False
 
-    return any(token in {"-p", "--print"} for token in tokens[index + 1:])
+    if not _is_claude_executable(tokens[0]):
+        return False
+
+    return any(token in {"-p", "--print"} for token in tokens[1:])
 
 
 def _shlex_split(command: str) -> list[str]:

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -192,15 +192,16 @@ def _log_exit(reason: str) -> None:
     print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
 
 
-def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
+def wait_for_mcp_discovery(timeout: float = 5.0) -> None:
     """Briefly block until background MCP discovery finishes, up to ``timeout``.
 
     MCP discovery runs in a daemon thread spawned at startup (see main()) so a
     slow/dead server can't freeze ``gateway.ready``.  But the agent snapshots
     its tool list ONCE at build time and never re-reads it, so a reachable-but-
     slow server that finishes connecting *after* the first prompt would be
-    invisible for the whole session.  Joining with a short bounded timeout
-    before the first agent build lets already-spawning fast servers land
+    invisible for the whole session.  Joining with a bounded timeout before the
+    first agent build lets already-spawning reachable servers land (including
+    OAuth-backed HTTP servers that can take a couple of seconds)
     without re-introducing the startup hang: a dead server simply isn't waited
     on beyond ``timeout``.  No-op when no discovery thread was started.
     """


### PR DESCRIPTION
## Summary
- Preserve and harden Claude worker OAuth token injection with command-scoped passthrough and env-prefixed hijack rejection.
- Preserve local Desktop/update commits during `hermes update`; fail safe when local commit count is unknown.
- Improve Desktop session activity switching / live recency behavior.
- Wait longer for reachable MCP discovery so first tool snapshots do not miss slow OAuth-backed MCP tools.

## Local verification
- `./venv/bin/pytest -o 'addopts=' tests/tools/test_local_env_blocklist.py tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_mcp_startup.py tests/tui_gateway/test_wait_for_mcp_discovery.py -q` → 83 passed
- `./venv/bin/python scripts/smoke_claude_worker_injection.py` → passed=8 failed=0 skipped=1
- Desktop Vitest targeted suite → 25 passed
- Desktop `npm run type-check` → passed
- Desktop targeted eslint → passed
- Clean detached worktree Desktop build/package (`npm run build && npm run builder -- --dir`) → passed
- Claude Code final review → PASS

Note: the installed checkout had unrelated live Desktop archive/lineage edits appearing in the working tree during packaging, so packaging was verified in a clean detached worktree at this PR HEAD.

## Commits
```text
8ff3d2a41 fix(mcp): wait longer for reachable discovery
2035e48ff fix(update): fail safe when local commits cannot be counted
62e41374c fix(terminal): reject env-prefixed claude token injection
ccd5ed203 fix(update): preserve local commits during desktop updates
ae5d3dff3 feat(desktop): improve session activity switching
008bb5bda fix: scope Claude worker OAuth token injection
```
