### PR TITLE
fix: clarify tool crashes with KeyboardInterrupt in non-interactive mode (-q)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9902,8 +9902,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # by the Enter key binding (routed to the clarify response queue),
             # so we skip interrupt processing to avoid stealing that input.
             interrupt_msg = None
+            # In single-query / non-interactive mode, _interrupt_queue has no
+            # producer (prompt_toolkit event loop isn't running). Polling an
+            # empty queue in this mode and treating SIGINT during the wait as
+            # a KeyboardInterrupt causes crashes when the agent blocks on
+            # interactive tools (e.g., clarify). Fall through to the simple
+            # join path instead.
+            _interactive = (
+                hasattr(self, '_interrupt_queue')
+                and self._app is not None
+            )
             while agent_thread.is_alive():
-                if hasattr(self, '_interrupt_queue'):
+                if _interactive:
                     try:
                         interrupt_msg = self._interrupt_queue.get(timeout=0.1)
                         if interrupt_msg:


### PR DESCRIPTION
### Description

The `clarify` tool causes a `KeyboardInterrupt` crash when Hermes is invoked in non-interactive mode (`hermes chat -q "prompt"`). The tool itself is innocent — it correctly identifies that user input is needed. The crash originates in `cli.py`, where `_interrupt_queue.get(timeout=0.1)` has no producer in `-q` mode, and `_signal_handler_q` converts the queue timeout into a `KeyboardInterrupt`.

This is an architectural gap: `-q` mode has no mechanism to resolve any tool that requires user interaction. Fixing it in `cli.py` protects all current and future interactive tools at once.

### Steps to reproduce

```bash
hermes chat -q "configure a test service for me" -m <any-model>
```

The agent reasons that "test service" is ambiguous, attempts to use the `clarify` tool, and crashes.

### Expected behavior

In non-interactive mode, the session should end gracefully — with the agent's last text response as the output, not a crash.

### Actual behavior

```
╭─ ⚕ Hermes ───────────────────────────────────────╮
    I need more detail. What kind of test service?
╰────────────────────────────────────────────────────╯
  ❓ preparing clarify…
Traceback (most recent call last):
  File "hermes_cli/main.py", line 11567, in main
  File "hermes_cli/main.py", line 2210, in cmd_chat
  File "cli.py", line 13540, in main
  File "cli.py", line 9908, in chat
    interrupt_msg = self._interrupt_queue.get(timeout=0.1)
  File "queue.py", line 180, in get
  File "threading.py", line 331, in wait
  File "cli.py", line 13314, in _signal_handler_q
    raise KeyboardInterrupt()
KeyboardInterrupt
```

### Root cause

In `cli.py`, `HermesCLI.__init__` always creates `_interrupt_queue` (line 3417). In `chat()`, the post-response loop checks `hasattr(self, '_interrupt_queue')` — which is always `True`. The intended fallback for non-interactive mode at line 9939-9941 ("Fallback for non-interactive mode (e.g., single-query)") was **dead code** — unreachable because the `hasattr()` guard always passes.

In interactive mode, `_interrupt_queue` is fed by the prompt_toolkit event loop. In single-query mode, no producer exists — the queue sits empty. `_signal_handler_q` interprets the SIGINT during the blocking wait as a `KeyboardInterrupt`.

### Fix

Use `self._app` (the prompt_toolkit `Application` instance) to distinguish interactive vs. non-interactive mode. `_app` is `None` in single-query `chat()`, and set to the Application in interactive `run()` (line 12433). This is already the canonical signal — line 3410 initializes `_app = None` with the comment "prompt_toolkit Application (set in run())".

The change (10 lines added, 1 changed):

```python
# Before:
while agent_thread.is_alive():
    if hasattr(self, '_interrupt_queue'):
        try:
            interrupt_msg = self._interrupt_queue.get(timeout=0.1)
            ...

# After:
_interactive = (
    hasattr(self, '_interrupt_queue')
    and not self._app is None
)
while agent_thread.is_alive():
    if _interactive:
        try:
            interrupt_msg = self._interrupt_queue.get(timeout=0.1)
            ...
```

When not interactive, the existing join path handles the wait — exactly as the original comment at line 9950 intended.

### Environment

- **Hermes version:** v0.16.0 (upstream `b5f8996c`)
- **OS:** Linux Mint 22.3, kernel 6.17.0
- **Python:** 3.11.15 (uv-managed)
- **Reproduced with:** deepseek-v4-pro, deepseek-v4-flash (OpenRouter)

### Impact

- **Consistent reproduction:** 100% of `-q` sessions where the agent reaches for `clarify`
- **Affected use cases:** Automated testing, cron jobs, scripted agent invocations, CI pipelines, single-query API usage
- **Workaround:** None — `-q` is the intended mechanism for non-interactive use
- **Regression risk:** Minimal — the change only affects non-interactive mode; interactive behavior is unchanged
- **Future-proof:** Protects any tool that requires user interaction, not just `clarify`