### PR TITLE
Scope Runs API by session key

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -791,6 +791,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # Owner session key for each run_id.  API clients can intentionally
+        # share one bearer token while using X-Hermes-Session-Key as the
+        # per-user/channel boundary; run follow-up endpoints must preserve it.
+        self._run_session_keys: Dict[str, Optional[str]] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         # Concurrency cap shared across all agent-serving endpoints
         # (/v1/chat/completions, /v1/responses, /v1/runs). Read from
@@ -3792,6 +3796,25 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_statuses[run_id] = current
         return current
 
+    def _authorize_run_session_key(
+        self,
+        request: "web.Request",
+        run_id: str,
+    ) -> Optional["web.Response"]:
+        """Return 404 when a keyed caller reaches across a run boundary."""
+        caller_key, key_err = self._parse_session_key_header(request)
+        if key_err is not None:
+            return key_err
+        if run_id not in self._run_session_keys:
+            return None
+        owner_key = self._run_session_keys.get(run_id)
+        if owner_key == caller_key:
+            return None
+        return web.json_response(
+            _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+            status=404,
+        )
+
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
         def _push(event: Dict[str, Any]) -> None:
@@ -3925,6 +3948,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_streams[run_id] = q
         self._run_streams_created[run_id] = created_at
         self._run_approval_sessions[run_id] = approval_session_key
+        self._run_session_keys[run_id] = gateway_session_key
 
         event_cb = self._make_run_event_callback(run_id, loop)
 
@@ -4121,6 +4145,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                self._run_session_keys.pop(run_id, None)
 
         task = asyncio.create_task(_run_and_close())
         self._active_run_tasks[run_id] = task
@@ -4153,6 +4178,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 _openai_error(f"Run not found: {run_id}", code="run_not_found"),
                 status=404,
             )
+        key_err = self._authorize_run_session_key(request, run_id)
+        if key_err is not None:
+            return key_err
         return web.json_response(status)
 
     async def _handle_run_events(self, request: "web.Request") -> "web.StreamResponse":
@@ -4170,6 +4198,10 @@ class APIServerAdapter(BasePlatformAdapter):
             await asyncio.sleep(0.05)
         else:
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+
+        key_err = self._authorize_run_session_key(request, run_id)
+        if key_err is not None:
+            return key_err
 
         q = self._run_streams[run_id]
 
@@ -4218,6 +4250,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 _openai_error(f"Run not found: {run_id}", code="run_not_found"),
                 status=404,
             )
+        key_err = self._authorize_run_session_key(request, run_id)
+        if key_err is not None:
+            return key_err
 
         try:
             body = await request.json()
@@ -4305,6 +4340,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         if agent is None and task is None:
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+        key_err = self._authorize_run_session_key(request, run_id)
+        if key_err is not None:
+            return key_err
 
         self._set_run_status(run_id, "stopping", last_event="run.stopping")
 
@@ -4358,6 +4396,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                self._run_session_keys.pop(run_id, None)
 
             stale_statuses = [
                 run_id
@@ -4367,6 +4406,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ]
             for run_id in stale_statuses:
                 self._run_statuses.pop(run_id, None)
+                self._run_session_keys.pop(run_id, None)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -269,6 +269,46 @@ class TestRunStatus:
             resp = await cli.get("/v1/runs/run_any")
         assert resp.status == 401
 
+    @pytest.mark.asyncio
+    async def test_status_denies_different_session_key(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                mock_agent, agent_ready, interrupted = _make_slow_agent()
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "alpha",
+                    },
+                )
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+                agent_ready.wait(timeout=3.0)
+
+                wrong = await cli.get(
+                    f"/v1/runs/{run_id}",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "beta",
+                    },
+                )
+                assert wrong.status == 404
+
+                right = await cli.get(
+                    f"/v1/runs/{run_id}",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "alpha",
+                    },
+                )
+                assert right.status == 200
+
+                interrupted.set()
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id}/events — SSE event stream
@@ -356,6 +396,28 @@ class TestRunEvents:
         )
 
     @pytest.mark.asyncio
+    async def test_approval_denies_different_session_key(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        run_id = "run_approval_owner"
+        auth_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_approval"}
+        auth_adapter._run_approval_sessions[run_id] = "approval-session"
+        auth_adapter._run_session_keys[run_id] = "alpha"
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                resp = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json={"choice": "once"},
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "beta",
+                    },
+                )
+
+        assert resp.status == 404
+        mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_events_not_found_returns_404(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -368,6 +430,24 @@ class TestRunEvents:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/v1/runs/run_any/events")
         assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_events_denies_different_session_key(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        run_id = "run_events_owner"
+        auth_adapter._run_streams[run_id] = asyncio.Queue()
+        auth_adapter._run_streams_created[run_id] = 0.0
+        auth_adapter._run_session_keys[run_id] = "alpha"
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                f"/v1/runs/{run_id}/events",
+                headers={
+                    "Authorization": "Bearer sk-secret",
+                    "X-Hermes-Session-Key": "beta",
+                },
+            )
+        assert resp.status == 404
 
 
 # ---------------------------------------------------------------------------
@@ -431,6 +511,38 @@ class TestStopRun:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post("/v1/runs/run_any/stop")
         assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_stop_denies_different_session_key(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                mock_agent, agent_ready, interrupted = _make_slow_agent()
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "alpha",
+                    },
+                )
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+                agent_ready.wait(timeout=3.0)
+
+                wrong = await cli.post(
+                    f"/v1/runs/{run_id}/stop",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "beta",
+                    },
+                )
+                assert wrong.status == 404
+                mock_agent.interrupt.assert_not_called()
+
+                interrupted.set()
 
     @pytest.mark.asyncio
     async def test_stop_already_completed_run_returns_404(self, adapter):


### PR DESCRIPTION
This stores the creating request's `X-Hermes-Session-Key` for each `/v1/runs` run and enforces that owner key on the run follow-up endpoints.

## Why

The API server allows multiple clients to share one `API_SERVER_KEY` while using `X-Hermes-Session-Key` as the per-user/channel boundary. `POST /v1/runs` already parses and forwards that key, but the follow-up endpoints only checked the bearer token and `run_id`. A caller with the same API key and a different session key could read another run's status, attach to events, resolve approvals, or stop the run if it knew the `run_id`.

Wrong-key requests now return 404 so the run's existence is not disclosed.

## Changes

- Add a `run_id -> X-Hermes-Session-Key` owner map for API runs.
- Check the owner key in:
  - `GET /v1/runs/{run_id}`
  - `GET /v1/runs/{run_id}/events`
  - `POST /v1/runs/{run_id}/approval`
  - `POST /v1/runs/{run_id}/stop`
- Clean up the owner map with the existing run lifecycle cleanup.
- Add regression coverage for wrong-key status, events, approval, and stop attempts.

## Tests

```text
python -m pytest tests/gateway/test_api_server_runs.py -k "session_key or RunStatus or RunEvents or StopRun" -q --timeout-method=thread
19 passed, 7 deselected
```