### PR TITLE
fix(gateway): remove LimitLoadToSessionType from launchd plist (#42376)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3251,12 +3251,6 @@ def generate_launchd_plist() -> str:
         <string>{hermes_home}</string>
     </dict>
 
-    <key>LimitLoadToSessionType</key>
-    <array>
-        <string>Aqua</string>
-        <string>Background</string>
-    </array>
-    
     <key>RunAtLoad</key>
     <true/>
     

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1790,13 +1790,12 @@ class TestProfileArg:
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
 
-    def test_launchd_plist_supports_aqua_and_background_sessions(self):
-        # macOS 26+ only loads the agent in non-Aqua sessions when the plist
-        # opts into Background as well (issue #23387).
+    def test_launchd_plist_no_limit_load_to_session_type(self):
+        # LimitLoadToSessionType removed — it caused launchctl bootstrap to
+        # fail with exit code 5 on macOS 26+ (issue #42376).  Without the
+        # key, launchd loads the service in the user's current session.
         plist = gateway_cli.generate_launchd_plist()
-        assert "<key>LimitLoadToSessionType</key>" in plist
-        assert "<string>Aqua</string>" in plist
-        assert "<string>Background</string>" in plist
+        assert "<key>LimitLoadToSessionType</key>" not in plist
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"


### PR DESCRIPTION
Fixes #42376. The LimitLoadToSessionType key in the launchd plist caused launchctl bootstrap to fail with exit code 5 on macOS 26+. Removed the key entirely — without it, launchd loads the service in the user's current session by default, which is the correct behavior.