### PR TITLE
fix(feishu): serialize card.data to JSON string for approval/update-prompt responses

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2636,7 +2636,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            card.data = json.dumps(
+                self._build_resolved_approval_card(choice=choice, user_name=user_name),
+                ensure_ascii=False,
+            )
             response.card = card
         return response
 
@@ -2693,7 +2696,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_update_prompt_card(answer=answer, user_name=user_name)
+            card.data = json.dumps(
+                self._build_resolved_update_prompt_card(answer=answer, user_name=user_name),
+                ensure_ascii=False,
+            )
             response.card = card
         return response
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -497,7 +497,8 @@ class TestCardActionCallbackResponse:
         assert response is not None
         assert response.card is not None
         assert response.card.type == "raw"
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert card["header"]["template"] == "green"
         assert "Approved once" in card["header"]["title"]["content"]
         assert "Bob" in card["elements"][0]["content"]
@@ -520,7 +521,8 @@ class TestCardActionCallbackResponse:
             response = adapter._on_card_action_trigger(data)
 
         assert response.card is not None
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert card["header"]["template"] == "red"
         assert "Denied" in card["header"]["title"]["content"]
 
@@ -567,7 +569,8 @@ class TestCardActionCallbackResponse:
         with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
             response = adapter._on_card_action_trigger(data)
 
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert "ou_unknown" in card["elements"][0]["content"]
 
     def test_ignores_expired_cached_name(self, _patch_callback_card_types):
@@ -589,7 +592,8 @@ class TestCardActionCallbackResponse:
         with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
             response = adapter._on_card_action_trigger(data)
 
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert "Old Name" not in card["elements"][0]["content"]
         assert "ou_expired" in card["elements"][0]["content"]
 
@@ -659,7 +663,8 @@ class TestCardActionCallbackResponse:
 
         assert response is not None
         assert response.card is not None
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert card["header"]["template"] == "green"
         assert "answered: Yes" in card["header"]["title"]["content"]
         assert "Bob" in card["elements"][0]["content"]
@@ -683,7 +688,8 @@ class TestCardActionCallbackResponse:
 
         assert response is not None
         assert response.card is not None
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert card["header"]["template"] == "red"
         assert "answered: No" in card["header"]["title"]["content"]
 


### PR DESCRIPTION
## What does this PR do?

Serializes `card.data` to a JSON string in both `_handle_approval_card_action` and `_handle_update_prompt_card_action` callbacks. The Feishu API requires `card.data` to be a JSON string, but both handlers were passing raw Python dicts, causing error 200340 when users click approval or update-prompt buttons on interactive cards.

## Related Issue

Fixes #38305, Fixes #10251, Fixes #10073, Fixes #8246, Fixes #13924

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/feishu.py`: Wrap `card.data` assignments in `_handle_approval_card_action` (line 2639) and `_handle_update_prompt_card_action` (line 2696) with `json.dumps(ensure_ascii=False)` so the Feishu API receives a JSON string instead of a Python dict.
- `tests/gateway/test_feishu_approval_buttons.py`: Update 6 test assertions to verify `card.data` is a `str` (via `isinstance` check) and parse it with `json.loads()` before accessing dict keys.

## How to Test

1. `pytest tests/gateway/test_feishu_approval_buttons.py -v` — all 38 tests pass
2. On a live Feishu bot: trigger an exec approval → click "Approve" or "Deny" → card should update without error 200340
3. Trigger a `/update` prompt → click "Yes" or "No" → card should update without error 200340

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_feishu_approval_buttons.py -v` and all 38 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (Feishu platform adapter, no OS-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/feishu.py` → `_handle_approval_card_action`, `_handle_update_prompt_card_action`, `_build_resolved_approval_card`, `_build_resolved_update_prompt_card`
- Callers of `_build_resolved_approval_card`: 1 (line 2639)
- Callers of `_build_resolved_update_prompt_card`: 1 (line 2696)
- Blast radius: LOW — only affects Feishu card callback responses, no other callers
- Related patterns: PR #10256 attempted the same fix but targeted stale line numbers (line 1909 vs current 2639). This PR applies the fix to the current codebase and also covers the `_handle_update_prompt_card_action` handler that #10256 missed.