### PR TITLE
fix(agent): deepcopy plugin context engine to prevent parent corruption on delegate_task

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1489,7 +1489,8 @@ def init_agent(
                 from hermes_cli.plugins import get_plugin_context_engine
                 _candidate = get_plugin_context_engine()
                 if _candidate and _candidate.name == _engine_name:
-                    _selected_engine = _candidate
+                    import copy
+                    _selected_engine = copy.deepcopy(_candidate)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary

When `delegate_task` spawns a child agent with a different model/provider, the child's `agent_init` overwrites the parent's context engine via a shared global singleton — corrupting the parent's context_length and compression threshold.

## Motivation

Fixes #42449

## Implementation

The fix adds `copy.deepcopy()` when assigning the global plugin context engine singleton to the child agent. Previously both parent and child shared the same object reference; `update_model()` called during child init would mutate the parent's compressor state (e.g., DeepSeek 1M → 204800 tokens).

The `ContextCompressor` and `ChatCompressor` have no locks, sockets, or non-copyable state — `deepcopy` is safe here.

## Test Plan

- Ran `tests/run_agent/test_plugin_context_engine_init.py` — 3/3 passed
- Ran `tests/agent/test_context_engine.py` — 20/20 passed
- Ran `tests/agent/test_context_engine_host_contract.py` — 8/8 passed
- Ran `tests/gateway/test_compress_plugin_engine.py` — 2/2 passed
- Ran `tests/run_agent/test_commit_memory_session_context_engine.py` — 6/6 passed

## Screenshots

N/A