### PR TITLE
fix(desktop): stop event propagation on nested DropdownMenu in session row

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -183,7 +183,11 @@ export function SidebarSessionRow({
             {title}
           </span>
         </button>
-        <div className="relative z-2 grid w-[1.375rem] place-items-center">
+        <div
+          className="relative z-2 grid w-[1.375rem] place-items-center"
+          onContextMenu={e => e.stopPropagation()}
+          onPointerDown={e => e.stopPropagation()}
+        >
           {!isWorking && (
             <span className="pointer-events-none absolute right-6 top-1/2 min-w-6 -translate-y-1/2 text-right text-[0.625rem] leading-none text-(--ui-text-tertiary) opacity-0 transition-opacity group-hover:opacity-100">
               {age}


### PR DESCRIPTION
## Problem

In the sidebar session list, clicking menu items in the `SessionActionsMenu` dropdown ("Copy ID", "Export", "Rename", etc.) has no effect. The `onSelect` handler never fires.

**Root cause:** Nested Radix UI menu conflict. The `SessionContextMenu` (ContextMenu, right-click) wraps the entire session row, and the `SessionActionsMenu` (DropdownMenu, "..." button) is nested inside it. Radix's ContextMenu intercepts pointer events from the inner DropdownMenu, preventing `onSelect` from firing on `DropdownMenuItem`.

Verified via runtime interception — `writeClipboard` is never called when "Copy ID" is clicked, confirming the event is swallowed before reaching the handler.

## Fix

Add `onPointerDown` and `onContextMenu` `stopPropagation()` on the `<div>` wrapper that contains the `SessionActionsMenu`. This prevents the parent `SessionContextMenu` from capturing events intended for the inner dropdown.

**Before:** The ContextMenu's pointer-down listener fires first and prevents the DropdownMenu from opening/handling events.

**After:** Events on the actions button area are contained, allowing the DropdownMenu to function independently while the ContextMenu still works on the rest of the row.

## Changes

- `apps/desktop/src/app/chat/sidebar/session-row.tsx` — Add event propagation stopping on the DropdownMenu wrapper div (+5 lines)

Fixes #42468