### PR TITLE
fix(photon): repair outbound — pinned spectrum-ts ^0.1.0 targets a decommissioned host

### DIFF
--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -71,17 +71,17 @@ const app = await Spectrum({
   providers: [imessage.config()],
 });
 
-// Drain the inbound stream — Photon's webhook is the canonical inbound
-// path, but we still consume `app.messages` so spectrum-ts' internal
-// reconnect/heartbeat logic keeps running.  Each event is logged at
-// debug level; everything else is a no-op here.
+// Drain the inbound stream — Photon's webhook is the canonical inbound path,
+// but we still consume `app.messages` so spectrum-ts' reconnect/heartbeat logic
+// keeps running.  We also cache each live Space here: spectrum-ts removed the
+// `app.space(id)` lookup, so outbound replies resolve their Space from this
+// cache (an outbound reply always follows an inbound that populated it).
+const spaceCache = new Map();
 (async () => {
   try {
-    for await (const [, message] of app.messages) {
-      console.error(
-        `photon-sidecar: drained inbound from ${message.platform} ` +
-          `space=${message.space?.id}`
-      );
+    for await (const [space, message] of app.messages) {
+      if (space?.id) spaceCache.set(space.id, space);
+      if (message?.space?.id && space) spaceCache.set(message.space.id, space);
     }
   } catch (e) {
     console.error(
@@ -130,26 +130,47 @@ function ok(res, data) {
   res.end(JSON.stringify({ ok: true, ...data }));
 }
 
-async function resolveSpace(spaceId) {
-  // spectrum-ts exposes the same Space methods via `app.space(spaceId)` /
-  // narrowed helpers; we fall back through a few accessor shapes to
-  // tolerate small SDK API drift.
-  if (typeof app.space === "function") {
-    return await app.space(spaceId);
-  }
-  if (app.spaces && typeof app.spaces.get === "function") {
-    return await app.spaces.get(spaceId);
-  }
-  // Last resort — the platform-narrowed helper.
-  if (imessage) {
-    const im = imessage(app);
-    if (typeof im.space === "function") {
-      try {
-        return await im.space({ id: spaceId });
-      } catch {
-        /* fall through */
-      }
+// Outbound sends occasionally race a gRPC channel that idled out while the
+// agent was thinking; Photon surfaces this as a one-off `Connection dropped` /
+// gRPC UNAVAILABLE. The next call re-establishes the channel, so retry such
+// transient failures with capped exponential backoff + jitter (the idiomatic
+// gRPC mitigation), and only for retryable codes — never for permanent ones
+// like PERMISSION_DENIED ("Target not allowed for this project").
+const _RETRYABLE_GRPC = new Set([14, 4, 8]); // UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED
+const _RETRYABLE_MSG =
+  /connection dropped|unavailable|deadline exceeded|resource exhausted|econnreset|socket hang up|goaway/i;
+const isTransient = (e) =>
+  _RETRYABLE_GRPC.has(e?.grpcCode) || _RETRYABLE_MSG.test(e?.message || "");
+
+async function withRetry(fn, { tries = 4, baseMs = 250, capMs = 4000 } = {}) {
+  let lastErr;
+  for (let i = 0; i < tries; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastErr = e;
+      if (i >= tries - 1 || !isTransient(e)) throw e;
+      const backoff = Math.min(baseMs * 2 ** i, capMs);
+      await new Promise((r) => setTimeout(r, backoff + Math.random() * backoff * 0.2));
     }
+  }
+  throw lastErr;
+}
+
+async function resolveSpace(spaceId) {
+  // spectrum-ts dropped the `app.space(id)` lookup, and `space.send()` needs a
+  // real resolved Space. Prefer the live Space cached from the inbound stream
+  // (an outbound reply always follows an inbound that populated the cache).
+  // Fall back for DMs by rebuilding the Space from the phone embedded in the id
+  // (iMessage DM ids are `any;-;+E164`).
+  const cached = spaceCache.get(spaceId);
+  if (cached) return cached;
+  const dm = spaceId.match(/;-;(\+\d+)/);
+  if (dm) {
+    const im = imessage(app);
+    const space = await im.space(await im.user({ phone: dm[1] }));
+    spaceCache.set(spaceId, space);
+    return space;
   }
   throw new Error(`unable to resolve space id ${spaceId}`);
 }
@@ -173,19 +194,20 @@ const server = http.createServer(async (req, res) => {
     }
     const body = await readBody(req);
     if (req.url === "/send") {
-      const { spaceId, text, replyTo } = body || {};
+      const { spaceId, text } = body || {};
       if (!spaceId || typeof text !== "string") {
         return badRequest(res, "spaceId and text are required");
       }
       const space = await resolveSpace(spaceId);
-      const result = replyTo
-        ? await space.send(text, { replyTo })
-        : await space.send(text);
+      // spectrum-ts send() is variadic-content: a positional options object is
+      // treated as a second content item and throws `c.build is not a function`.
+      // Threaded replies in 1.x need the reply() builder + the original Message,
+      // which the adapter doesn't hand us, so replyTo is not forwarded here.
+      const result = await withRetry(() => space.send(text));
       return ok(res, { messageId: result?.id || result?.messageId || null });
     }
     if (req.url === "/send-attachment") {
-      const { spaceId, path, name, mimeType, caption, kind, replyTo } =
-        body || {};
+      const { spaceId, path, name, mimeType, caption, kind } = body || {};
       if (!spaceId || typeof path !== "string" || !path) {
         return badRequest(res, "spaceId and path are required");
       }
@@ -202,16 +224,13 @@ const server = http.createServer(async (req, res) => {
           ? voice(path, Object.keys(opts).length ? opts : undefined)
           : attachment(path, Object.keys(opts).length ? opts : undefined);
 
-      const sendOpts = replyTo ? { replyTo } : undefined;
-      const result = sendOpts
-        ? await space.send(builder, sendOpts)
-        : await space.send(builder);
+      const result = await withRetry(() => space.send(builder));
 
       // iMessage delivers the caption as a separate bubble; send it
       // after the media so the attachment renders first.
       if (caption && typeof caption === "string") {
         try {
-          await space.send(caption);
+          await withRetry(() => space.send(caption));
         } catch (e) {
           console.error(
             "photon-sidecar: attachment sent but caption failed: " +

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -9,9 +9,9 @@
     "start": "node index.mjs"
   },
   "engines": {
-    "node": ">=18.17"
+    "node": ">=20"
   },
   "dependencies": {
-    "spectrum-ts": "^0.1.0"
+    "spectrum-ts": "^1.18.0"
   }
 }


### PR DESCRIPTION
## What does this PR do?

Repairs **Photon (iMessage) outbound**, which is broken on `main` for every fresh setup.

The sidecar pins `spectrum-ts: "^0.1.0"` → `0.1.2`, and that SDK connects to **`spectrum-cloud.photon.codes`** — a host that no longer resolves (`NXDOMAIN` on both Google and Cloudflare DNS). The sidecar exits on connect with `TypeError: fetch failed … getaddrinfo ENOTFOUND spectrum-cloud.photon.codes`, so the gateway can neither send nor reply over iMessage.

This bumps `spectrum-ts` to the maintained `^1.18.0` (which targets the live `spectrum.photon.codes`) and adapts the Node sidecar to the 1.x API. Independently diagnosed and reproduced on Linux; same root cause as the report in #42454.

## Related Issue

Related to #42454 (same root cause, independently reproduced on a different platform). Credit to @UOD317 for the parallel diagnosis — including the `space.send()` `replyTo` regression noted below.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ♻️ Robustness (retry on transient gRPC failure)

## Changes Made

- `plugins/platforms/photon/sidecar/package.json`
  - `spectrum-ts` `^0.1.0` → `^1.18.0` (the dead host is baked into 0.1.x; no `0.x` keeps both the old API and a live host).
  - `engines.node` `>=18.17` → `>=20` (spectrum-ts 1.x requires Node ≥ 20).
- `plugins/platforms/photon/sidecar/index.mjs`
  - `resolveSpace()`: 1.x removed the `app.space(id)` lookup. Resolve outbound replies from a cache of the live `Space` objects populated by the `app.messages` drain the sidecar **already runs** (caching the live `Space` is the SDK's canonical reply pattern — an outbound reply always follows an inbound that fills the cache). DM fallback rebuilds the `Space` from the phone embedded in the id.
  - `space.send()`: drop the positional `{ replyTo }` — 1.x `send()` is variadic-content, so a positional options object is treated as a second content item and throws `c.build is not a function` (both `/send` and `/send-attachment`).
  - Wrap sends in **capped exponential-backoff-with-jitter retry, gated on retryable gRPC codes** (`UNAVAILABLE`/`DEADLINE_EXCEEDED`/`RESOURCE_EXHAUSTED`). The transient `ConnectionError: [upstream] Connection dropped` shows up when the gRPC channel idles out while the agent is thinking (~15s between inbound and reply). Permanent codes (e.g. `PERMISSION_DENIED`) are never retried.

Out of scope (deferred to #42454): inbound attachment retrieval via `imessage(app).getAttachment(...)` — a feature addition needing a live media round-trip to validate, already covered there.

## How to Test

1. `cd plugins/platforms/photon/sidecar && rm -rf node_modules && npm install` (pulls spectrum-ts 1.18.x; needs Node ≥ 20).
2. Configure a Photon project (`PHOTON_PROJECT_ID` / `PHOTON_PROJECT_SECRET`), enable the photon platform, start the gateway.
3. **Before:** the sidecar exits with `fetch failed … ENOTFOUND spectrum-cloud.photon.codes`; outbound never works.
4. **After:** `[spectrum.lifecycle] Spectrum started`; texting the line gets an agent reply. Verified end-to-end on **Ubuntu 24.04 / Node v24** against a live free-tier project — inbound + outbound both ways, including real agent replies, with the transient `Connection dropped` recovered by the retry (0 send failures after the fix).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (linked the related issue #42454)
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/plugins/platforms/photon -q` — 48 passed (the change is in the Node sidecar; Python side unaffected)
- [ ] Tests for the change — the sidecar is plain Node with no JS test harness in-repo; verified end-to-end manually (repro + fix proof above). Happy to add a node test if you'd like one wired up.
- [x] I've tested on my platform: Ubuntu 24.04, Node v24.15.0

### Documentation & Housekeeping

- [x] Docs — N/A (no user-facing API/config change)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — the dead-host repro is platform-independent; bumping `engines.node` to `>=20` surfaces the real runtime requirement on all platforms
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Before (fresh setup, 0.1.2): `failed to start Photon sidecar … exited with code 1` → `TypeError: fetch failed … ENOTFOUND spectrum-cloud.photon.codes`.

After (1.18.0 + this patch): `[spectrum.lifecycle] Spectrum started` → inbound forwarded → agent reply delivered; transient `Connection dropped` retried and succeeds.
