### PR TITLE
fix(agent): deepcopy plugin context engine singleton to prevent parent corruption via delegate_task

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1489,7 +1489,8 @@ def init_agent(
                 from hermes_cli.plugins import get_plugin_context_engine
                 _candidate = get_plugin_context_engine()
                 if _candidate and _candidate.name == _engine_name:
-                    _selected_engine = _candidate
+                    import copy
+                    _selected_engine = copy.deepcopy(_candidate)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Description

When `delegate_task` spawns a child agent with a different model/provider, the child's `agent_init` overwrites the **parent's** `ChatCompressor` context_length via a shared global singleton returned by `get_plugin_context_engine()`.

### Root Cause

In `agent/agent_init.py` lines 1489-1492, the fallback path for loading a context engine retrieves the **global singleton** from the plugin manager. The child agent then calls `update_model()` on this shared instance with its own model info, **mutating the parent's compressor**.

### Fix

Deep-copy the candidate engine before assigning it to `_selected_engine`, so each agent gets its own independent context engine instance. `ContextCompressor` and `ChatCompressor` have no locks, sockets, or non-copyable state — `deepcopy` is safe here.

### Impact

- Fixes context corruption where DeepSeek V4 context drops from 1,000,000 → 204,800 tokens after any `delegate_task` with a different model
- Compression threshold no longer incorrectly drops from 200K → 40K
- Any model switch via delegation no longer corrupts the parent session's context window

### Testing

- 156 delegate-related tests pass (1 pre-existing flaky timing test skipped)
- Minimal change: +2 lines, -1 line

Fixes #42449