### PR TITLE
fix(cron): drain memory provider before agent close to prevent Hindsight retain race

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1993,6 +1993,16 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
+        # Drain memory-provider queues (e.g. Hindsight's async retain
+        # writer) while the worker-thread event loop is still alive.
+        # Without this, the ThreadPoolExecutor's cancel_futures=True
+        # destroys the loop before the writer can flush, producing
+        # "cannot schedule new futures after interpreter shutdown".  (#42466)
+        try:
+            if agent is not None:
+                agent.shutdown_memory_provider()
+        except (Exception, KeyboardInterrupt) as e:
+            logger.debug("Job '%s': failed to shutdown memory provider: %s", job_id, e)
         # Release subprocesses, terminal sandboxes, browser daemons, and the
         # main OpenAI/httpx client held by this ephemeral cron agent. Without
         # this, a gateway that ticks cron every N minutes leaks fds per job

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -1020,6 +1020,81 @@ class TestRunJobSessionPersistence:
 
         assert success is True
         cleanup_mock.assert_called_once()
+
+    def test_run_job_shuts_down_memory_provider_before_close(self, tmp_path):
+        # Regression: Hindsight's async retain writer uses the worker-thread
+        # event loop.  If agent.close() runs without first draining the
+        # memory provider, the ThreadPoolExecutor's cancel_futures=True
+        # destroys the loop mid-flush → "cannot schedule new futures after
+        # interpreter shutdown".  (#42466)
+        job = {
+            "id": "mem-shutdown-job",
+            "name": "mem-shutdown",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, _final_response, _error = run_job(job)
+
+        assert success is True
+        mock_agent.shutdown_memory_provider.assert_called_once()
+        # shutdown_memory_provider must be called BEFORE close.
+        mock_agent.assert_has_calls([
+            call.shutdown_memory_provider(),
+            call.close(),
+        ])
+
+    def test_run_job_shuts_down_memory_provider_on_failure(self, tmp_path):
+        # Even when run_conversation raises, the memory provider must still
+        # be drained before the agent is closed.
+        job = {
+            "id": "mem-shutdown-fail-job",
+            "name": "mem-shutdown-fail",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.side_effect = RuntimeError("pool died")
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, _final_response, _error = run_job(job)
+
+        assert success is False
+        mock_agent.shutdown_memory_provider.assert_called_once()
+        mock_agent.close.assert_called_once()
 
     def _make_run_job_patches(self, tmp_path):
         """Common patches for run_job tests."""


### PR DESCRIPTION
## What does this PR do?

Drains the memory provider's async retain queue before closing the ephemeral cron agent, preventing a race condition where the ThreadPoolExecutor's event loop is destroyed mid-flush.

## Related Issue

Fixes #42466

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Added `agent.shutdown_memory_provider()` call before `agent.close()` in the `_run_job_impl()` finally block, giving memory providers (e.g. Hindsight) a chance to drain their retain queues while the worker-thread event loop is still alive.
- `tests/cron/test_scheduler.py`: Added 2 regression tests verifying `shutdown_memory_provider()` is called before `close()` on both success and failure paths.

## How to Test

1. Configure Hindsight as the active memory provider (`memory.provider: hindsight`)
2. Create a cron job with `no_agent: false` and a simple prompt
3. Let the scheduler tick the job — it should complete without "cannot schedule new futures" errors
4. Run `pytest tests/cron/test_scheduler.py -k shutdown_memory -v` to verify the new regression tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/test_scheduler.py -q` and all tests pass (1 pre-existing failure unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (threading/memory lifecycle is platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cron/scheduler.py::_run_job_impl` (callers: 1 via `tick()`)
- Related: `run_agent.py::shutdown_memory_provider` (calls `_memory_manager.on_session_end()` + `_memory_manager.shutdown_all()`)
- Related: `plugins/memory/hindsight/__init__.py::shutdown` (drains retain queue via sentinel + 10s join)
- Blast radius: LOW — additive call in error-guarded try/except, no control flow change
