### PR TITLE
fix(desktop): use in-app updater on macOS

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1411,6 +1411,11 @@ let updateInFlight = false
 // updater isn't staged (e.g. a dev/source run that never went through the
 // installer); callers degrade gracefully.
 function resolveUpdaterBinary() {
+  if (IS_MAC) {
+    rememberLog('[updates] macOS using in-app updater; ignoring staged hermes-setup helper')
+    return null
+  }
+
   const name = IS_WINDOWS ? 'hermes-setup.exe' : 'hermes-setup'
   const candidate = path.join(HERMES_HOME, name)
   return fileExists(candidate) ? candidate : null


### PR DESCRIPTION
## Summary
- route macOS Desktop updates through the existing in-app updater path instead of the staged `hermes-setup` helper
- keep the staged helper path for Windows/Linux behavior
- add an update log marker when macOS bypasses the helper

## Why
On macOS I reproduced a stale helper handoff where Desktop launched `~/.hermes/hermes-setup --update`, the backend checkout updated, but `/Applications/Hermes.app` remained stale and Desktop relaunched into the old bundle. The existing POSIX in-app path already runs `hermes update`, rebuilds the Desktop app, swaps the `.app` bundle, clears quarantine, and relaunches, so macOS can avoid the stale helper entirely.

## Verification
- `node --check apps/desktop/electron/main.cjs`
- live local validation: rebuilt Desktop with `hermes desktop --build-only`, installed `/Applications/Hermes.app`, confirmed embedded install stamp at current commit, and confirmed `hermes update --yes` still completes with local changes autostashed/restored

## Related
- Follow-up to local macOS Desktop update lockup investigation; also related to existing updater relaunch work in #40832.