### PR TITLE
fix(kanban): force cli mode for dispatched workers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6810,6 +6810,10 @@ def _default_spawn(
         cmd.extend(["-m", task.model_override])
     cmd.extend([
         "chat",
+        # Workers are detached, non-TTY subprocesses. Scope --cli to the chat
+        # subcommand so TUI-default configs do not try to start hermes-tui and
+        # fail with "hermes-tui: no TTY" before reaching kanban tools.
+        "--cli",
         "-q", prompt,
     ])
     # Redirect output to a per-task log under <board-root>/logs/.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2856,6 +2856,44 @@ def test_migrate_add_optional_columns_tolerates_concurrent_migration(kanban_home
 # ---------------------------------------------------------------------------
 
 
+def test_default_spawn_scopes_cli_flag_to_chat_subcommand(
+    kanban_home, monkeypatch, tmp_path
+):
+    """Kanban workers are non-TTY children, so ``--cli`` must be scoped to chat.
+
+    Regression for detached dispatcher workers under TUI-default configs:
+    ``hermes chat -q`` can select TUI and write ``hermes-tui: no TTY`` before
+    reaching kanban tools. A global ``hermes --cli chat -q`` wrapper is not
+    sufficient; the working launch shape is ``hermes ... chat --cli -q``.
+    """
+    captured: dict[str, object] = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return FakeProc()
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["/bin/hermes"])
+    monkeypatch.setattr(kb.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda home: False)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="worker", assignee="default")
+        task = kb.get_task(conn, tid)
+    assert task is not None
+
+    pid = kb._default_spawn(task, str(tmp_path), board="default")
+
+    assert pid == 4242
+    cmd = captured["cmd"]
+    assert isinstance(cmd, list)
+    chat_index = cmd.index("chat")
+    assert cmd[chat_index : chat_index + 4] == ["chat", "--cli", "-q", f"work kanban task {tid}"]
+
+
 def test_resolve_hermes_argv_prefers_path_shim(monkeypatch):
     """When `hermes` is on PATH, use the shim — preserves familiar ps output."""
     import shutil


### PR DESCRIPTION
## What does this PR do?

Fixes Kanban dispatcher worker startup in TUI-default/headless environments by spawning workers as:

```bash
hermes ... chat --cli -q "work kanban task <id>"
```

instead of:

```bash
hermes ... chat -q "work kanban task <id>"
```

Dispatcher workers are detached, non-TTY subprocesses. Without a subcommand-scoped `--cli`, TUI-default configurations can try to initialize `hermes-tui` and fail with `hermes-tui: no TTY` before the worker reaches Kanban lifecycle tools.

This is intentionally a focused dispatcher-side fix: keep the existing `chat -q` worker flow, but make the launch shape explicit and non-TTY-safe.

## Related Issue

No public issue number. Related prior/overlapping work:

- Related: #35629 (`chat -q` headless fallback)
- Related: #23851 (closed earlier Kanban worker headless-spawn attempt)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`
  - Add `--cli` after the `chat` subcommand in `_default_spawn()`.
- `tests/hermes_cli/test_kanban_db.py`
  - Add regression coverage that pins the dispatcher argv shape to `chat --cli -q`.

## How to Test

1. Run the Kanban DB/dispatcher test module:

   ```bash
   uv run python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='
   ```

2. Expected result from this branch on macOS:

   ```text
   215 passed
   ```

3. For manual verification, configure Hermes to prefer TUI, create a Kanban task assigned to a worker profile, and dispatch it from a non-TTY context. The worker command should include `chat --cli -q` and should not fail at startup with `hermes-tui: no TTY`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, bug fix covered by code comment + regression test
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
uv run python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='
215 passed
```