### PR TITLE
fix(web_server): auto-migrate lagging profile DBs in /api/profiles/sessions

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15,9 +15,9 @@ import asyncio
 import atexit
 import base64
 import binascii
-import concurrent.futures
-import functools
+import sqlite3
 from dataclasses import dataclass
+import functools
 from datetime import datetime, timezone
 import hashlib
 import hmac
@@ -4182,6 +4182,57 @@ def get_profiles_sessions(
                 archived_only=archived_only,
                 order_by_last_active=order == "recent",
                 # Same SQL-level blob skip as /api/sessions (see above).
+                compact_rows=not full,
+            )
+            profile_total = db.session_count(
+                source=source_filter,
+                exclude_sources=exclude_list or None,
+                min_message_count=min_message_count,
+                include_archived=include_archived,
+                archived_only=archived_only,
+                exclude_children=True,
+            )
+            total += profile_total
+            profile_totals[name] = profile_total
+            for s in rows:
+                s["profile"] = name
+                s["is_default_profile"] = name == "default"
+                s["is_active"] = (
+                    s.get("ended_at") is None
+                    and (now - s.get("last_active", s.get("started_at", 0))) < 300
+                )
+                s["archived"] = bool(s.get("archived"))
+                merged.append(s)
+        except sqlite3.OperationalError as exc:
+            # Schema mismatch — profile DB was last written under an older
+            # Hermes release and is missing columns added since. Only
+            # recover on verified missing-column errors; lock/contention and
+            # other operational errors are left uncaught to preserve the
+            # read-only path's no-write-lock purpose.
+            exc_msg = str(exc)
+            if "no such column" not in exc_msg.lower():
+                # Non-schema error — let it be caught by the outer handler.
+                raise
+            # One-time migration: open the profile DB read-write to trigger
+            # _init_schema(), then re-open read-only and retry the query.
+            db.close()
+            try:
+                migrate_db = SessionDB(db_path=db_path, read_only=False)
+                migrate_db.close()
+            except Exception:
+                # Migration failed — report the original schema error.
+                errors.append({"profile": name, "error": exc_msg})
+                continue
+            db = SessionDB(db_path=db_path, read_only=True)
+            rows = db.list_sessions_rich(
+                source=source_filter,
+                exclude_sources=exclude_list or None,
+                limit=per_profile,
+                offset=0,
+                min_message_count=min_message_count,
+                include_archived=include_archived,
+                archived_only=archived_only,
+                order_by_last_active=order == "recent",
                 compact_rows=not full,
             )
             profile_total = db.session_count(

--- a/tests/hermes_cli/test_profile_schema_migration.py
+++ b/tests/hermes_cli/test_profile_schema_migration.py
@@ -1,0 +1,140 @@
+"""Test schema migration on GET /api/profiles/sessions."""
+import sqlite3
+import pytest
+
+
+class TestProfileSessionSchemaMigration:
+    """Verify that lagging profile DBs are auto-migrated instead of
+    silently returning zero sessions.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup_test_client(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        self.monkeypatch = monkeypatch
+        self.hermes_home = get_hermes_home()
+
+    def _create_lagging_db(self, db_path):
+        """Create a state.db whose sessions table lacks the ``archived``
+        column, simulating a profile DB from before the feature was added.
+
+        Strategy: create the DB with full schema via SessionDB, add a session,
+        then DROP the archived column.
+        """
+        from hermes_state import SessionDB
+
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = SessionDB(db_path=db_path, read_only=False)
+        try:
+            db.create_session(session_id="laggy-session-1", source="cli")
+            db.append_message(
+                session_id="laggy-session-1", role="user", content="hello from laggy"
+            )
+        finally:
+            db.close()
+
+        # Drop the archived column to simulate an older schema
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("ALTER TABLE sessions DROP COLUMN archived")
+        conn.commit()
+        conn.close()
+
+    def test_profiles_sessions_auto_migrates_lagging_schema(self):
+        """When a profile DB is missing the ``archived`` column, the
+        cross-profile endpoint auto-migrates it instead of silently
+        returning zero sessions for that profile.
+        """
+        from hermes_cli import profiles as profiles_mod
+
+        # Create a fake "laggy" profile with an outdated DB
+        profile_dir = self.hermes_home / "profiles" / "laggy"
+        db_path = profile_dir / "state.db"
+        self._create_lagging_db(db_path)
+
+        # Monkeypatch list_profiles to include our laggy profile
+        self.monkeypatch.setattr(
+            profiles_mod,
+            "list_profiles",
+            lambda: [
+                profiles_mod.ProfileInfo(
+                    name="default",
+                    path=self.hermes_home,
+                    is_default=True,
+                    gateway_running=False,
+                ),
+                profiles_mod.ProfileInfo(
+                    name="laggy",
+                    path=profile_dir,
+                    is_default=False,
+                    gateway_running=False,
+                ),
+            ],
+        )
+
+        # Call the endpoint — should trigger migration and return the session
+        resp = self.client.get("/api/profiles/sessions?limit=20&min_messages=0")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # No errors for the laggy profile
+        laggy_errors = [
+            e for e in data.get("errors", []) if e.get("profile") == "laggy"
+        ]
+        assert len(laggy_errors) == 0, f"Unexpected errors: {laggy_errors}"
+
+        # The laggy profile's session should appear (migration happened)
+        sessions = data["sessions"]
+        laggy = [s for s in sessions if s.get("profile") == "laggy"]
+        assert len(laggy) == 1
+        assert laggy[0]["id"] == "laggy-session-1"
+
+    def test_profiles_sessions_migration_is_idempotent(self):
+        """Second call to the endpoint should work without re-migrating."""
+        from hermes_cli import profiles as profiles_mod
+
+        profile_dir = self.hermes_home / "profiles" / "laggy3"
+        db_path = profile_dir / "state.db"
+        self._create_lagging_db(db_path)
+
+        self.monkeypatch.setattr(
+            profiles_mod,
+            "list_profiles",
+            lambda: [
+                profiles_mod.ProfileInfo(
+                    name="default",
+                    path=self.hermes_home,
+                    is_default=True,
+                    gateway_running=False,
+                ),
+                profiles_mod.ProfileInfo(
+                    name="laggy3",
+                    path=profile_dir,
+                    is_default=False,
+                    gateway_running=False,
+                ),
+            ],
+        )
+
+        # First call triggers migration
+        resp1 = self.client.get("/api/profiles/sessions?limit=20&min_messages=0")
+        assert resp1.status_code == 200
+
+        # Second call should also work (no re-migration needed)
+        resp2 = self.client.get("/api/profiles/sessions?limit=20&min_messages=0")
+        assert resp2.status_code == 200
+        data2 = resp2.json()
+        laggy = [s for s in data2["sessions"] if s.get("profile") == "laggy3"]
+        assert len(laggy) == 1
+        assert len(data2.get("errors", [])) == 0


### PR DESCRIPTION
## Problem

On a multi-profile install, the Desktop sidebar shows **no sessions for a profile** when that profile's `state.db` schema lags the default DB's schema. This happens after an update bumps the SessionDB schema — the default DB is migrated on gateway startup, but per-profile DBs are only ever opened read-only by the `/api/profiles/sessions` aggregation endpoint.

When `list_sessions_rich` queries `s.archived` against a DB missing that column, it raises `sqlite3.OperationalError`. The endpoint silently swallows the error into `errors[]`, contributing zero sessions for that profile — the Desktop renders an empty sidebar with no indication of what went wrong.

Closes #42467

## Solution

Catch `sqlite3.OperationalError` from the read-only query path. When a schema mismatch is detected:

1. Close the read-only connection
2. Open the DB read-write to trigger `_init_schema()` → `_reconcile_columns()` (adds missing columns via `ALTER TABLE ADD COLUMN`)
3. Close the read-write connection
4. Re-open read-only and retry the query

This is a one-time cost per lagging profile. After migration, the read-only path works normally. The write lock is brief (column reconciliation only) and only happens when the schema is actually outdated.

## Changes

- `hermes_cli/web_server.py` — Wrap `list_sessions_rich`/`session_count` calls in an inner try/except for `sqlite3.OperationalError`; on schema mismatch, open read-write to trigger migration, then retry
- `tests/hermes_cli/test_profile_schema_migration.py` — 2 new tests:
  - `test_profiles_sessions_auto_migrates_lagging_schema` — verifies a lagging profile DB returns sessions after auto-migration
  - `test_profiles_sessions_migration_is_idempotent` — verifies second call works without re-migration

## Testing

```
$ python -m pytest tests/hermes_cli/test_profile_schema_migration.py -xvs
2 passed

$ python -m pytest tests/hermes_cli/test_web_server.py -k "profile" -x
27 passed
```
