### PR TITLE
fix: add timeout to subprocess.run() calls in managed_uv.py

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -117,6 +117,7 @@ def _ensure_uv_path() -> Optional[str]:
             capture_output=True,
             text=True,
             check=False,
+            timeout=10,
         ).stdout.strip()
         print(f"  ✓ Managed uv installed ({version})")
     else:
@@ -172,6 +173,7 @@ def update_managed_uv() -> Optional[str]:
         capture_output=True,
         text=True,
         check=False,
+        timeout=120,
     )
     if result.returncode == 0:
         version = subprocess.run(
@@ -179,6 +181,7 @@ def update_managed_uv() -> Optional[str]:
             capture_output=True,
             text=True,
             check=False,
+            timeout=10,
         ).stdout.strip()
         print(f"  ✓ Managed uv updated ({version})")
     else:
@@ -224,12 +227,14 @@ def _install_uv_posix(env: dict[str, str]) -> None:
             ["curl", "-LsSf", "https://astral.sh/uv/install.sh", "-o", installer_path],
             check=True,
             capture_output=True,
+            timeout=60,
         )
         subprocess.run(
             ["sh", installer_path],
             env=env,
             check=True,
             capture_output=True,
+            timeout=120,
         )
     finally:
         try:
@@ -248,6 +253,7 @@ def _install_uv_windows(env: dict[str, str]) -> None:
         env=env,
         check=True,
         capture_output=True,
+        timeout=120,
     )
 
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:


### PR DESCRIPTION
## Summary

All 6 `subprocess.run()` calls in `hermes_cli/managed_uv.py` lacked a `timeout` parameter. If `uv`, `curl`, or the installer hangs (network issue, DNS stall, unresponsive mirror), the CLI blocks indefinitely with no way for the user to recover except killing the process.

## Changes

| Call | Timeout | Rationale |
|------|---------|-----------|
| `uv --version` | 10s | Quick local binary invocation |
| `uv self update` | 120s | Network download of new binary |
| `curl` download of `install.sh` | 60s | Single HTTP GET |
| `sh` installer | 120s | Download + extract + write |
| `powershell` installer | 120s | Download + extract + write |

## Impact

- Prevents indefinite hangs when uv bootstrap/update runs on unreliable networks
- Users get a clear `subprocess.TimeoutExpired` error instead of a frozen terminal
- No behavioral change under normal operation (all operations complete well within the timeout)
