### PR TITLE
feat(setup): auto-set web.extract_backend when Tavily is selected as web backend

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2752,6 +2752,9 @@ def _write_provider_config(provider: dict, config: dict, *, managed_feature) -> 
         web_cfg = config.setdefault("web", {})
         web_cfg["backend"] = provider["web_backend"]
         web_cfg["use_gateway"] = bool(managed_feature)
+        # Auto-set extract_backend to match when Tavily is selected
+        if provider["web_backend"] == "tavily" and not web_cfg.get("extract_backend"):
+            web_cfg["extract_backend"] = "tavily"
 
     # For tools without a specific config key (e.g. image_gen), still
     # track use_gateway so the runtime knows the user's intent.
@@ -3261,6 +3264,9 @@ def _reconfigure_provider(
         web_cfg = config.setdefault("web", {})
         web_cfg["backend"] = provider["web_backend"]
         web_cfg["use_gateway"] = bool(managed_feature)
+        # Auto-set extract_backend to match when Tavily is selected
+        if provider["web_backend"] == "tavily" and not web_cfg.get("extract_backend"):
+            web_cfg["extract_backend"] = "tavily"
         _print_success(f"  Web backend set to: {provider['web_backend']}")
 
     if managed_feature and managed_feature not in {"web", "tts", "browser"}:


### PR DESCRIPTION
## What does this PR do?

When Tavily is selected as the web search backend (via `hermes tools`), `web.extract_backend` stays empty. The built-in Hermes extractor (trafilatura + auxiliary LLM) is then used for `web_extract` calls, taking ~28s for heavy pages. Tavily Extract API does the same job in ~0.5s — roughly 50x faster.

This PR auto-sets `web.extract_backend: tavily` when Tavily is chosen, in both config write paths (`_write_provider_config` and `_reconfigure_provider`). Users can still override to empty string if they prefer the built-in extractor.

## Related Issue

Fixes #42483

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/tools_config.py` — Two locations (`_write_provider_config` at ~L2754 and `_reconfigure_provider` at ~L3266): when `web.backend` is being set to `tavily` and `web.extract_backend` is not already explicitly configured, also set `web.extract_backend` to `tavily`.

## How to Test

1. Run `hermes tools` and select Tavily as web search backend
2. Verify `config.yaml` contains `web.extract_backend: tavily` alongside `web.backend: tavily`
3. Or verify via Python:

```python
from hermes_cli.tools_config import _write_provider_config

config = {}
provider = {'web_backend': 'tavily'}
_write_provider_config(provider, config, managed_feature=None)
assert config['web']['backend'] == 'tavily'
assert config['web']['extract_backend'] == 'tavily'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: Docker/Linux

## Verification

The config-write logic was verified with Python covering 6 scenarios:

```
Test 1: Tavily selected -> extract_backend auto-set               PASS
Test 2: Existing extract_backend preserved (not overridden)       PASS
Test 3: Firecrawl selected -> extract_backend NOT set             PASS
Test 4: _reconfigure_provider path -> Tavily sets extract_backend PASS
Test 5: _reconfigure_provider path -> existing preserved          PASS
Test 6: _reconfigure_provider path -> non-Tavily not set          PASS
```
