### PR TITLE
fix(desktop): skip remote session cwd in Files panel to prevent ENOENT

### DIFF
--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { setCurrentSessionPreviewTarget } from '@/store/preview'
-import { $currentBranch, $currentCwd } from '@/store/session'
+import { $connection, $currentBranch, $currentCwd } from '@/store/session'
 
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
@@ -47,6 +47,12 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
   const currentBranch = useStore($currentBranch).trim()
   const currentCwd = useStore($currentCwd).trim()
   const hasCwd = currentCwd.length > 0
+  const isRemote = $connection.get()?.mode === 'remote'
+  // In remote mode the session cwd is a path on the remote host that does
+  // not exist locally. Use empty string so the Files panel shows "No folder
+  // selected" instead of an unreadable remote path.
+  const filesCwd = isRemote ? '' : currentCwd
+  const filesHasCwd = isRemote ? false : hasCwd
 
   const cwdName = hasCwd
     ? (currentCwd
@@ -65,7 +71,7 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
     rootError,
     rootLoading,
     setNodeOpen
-  } = useProjectTree(currentCwd)
+  } = useProjectTree(filesCwd)
 
   const canCollapse = Object.values(openState).some(Boolean)
   const effectiveTab: RightSidebarTabId = terminalTakeover ? 'files' : activeTab
@@ -117,11 +123,13 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder, onChangeCwd
         <FilesystemTab
           canCollapse={canCollapse}
           collapseNonce={collapseNonce}
-          cwd={currentCwd}
+          cwd={filesCwd}
           cwdName={cwdName}
           data={data}
           error={rootError}
-          hasCwd={hasCwd}
+          hasCwd={filesHasCwd}
+          isRemote={isRemote}
+          remoteCwd={isRemote ? currentCwd : undefined}
           loading={rootLoading}
           onActivateFile={onActivateFile}
           onActivateFolder={onActivateFolder}
@@ -192,9 +200,13 @@ interface FilesystemTabProps extends FileTreeBodyProps {
   canCollapse: boolean
   cwdName: string
   hasCwd: boolean
+  /** True when the Desktop is connected to a remote backend. */
+  isRemote?: boolean
   onChangeFolder: () => Promise<void> | void
   onCollapseAll: () => void
   onRefresh: () => void
+  /** The remote session's cwd, shown in the info banner. */
+  remoteCwd?: string
 }
 
 // Sidebar-specific color/hover treatment only — size, radius, cursor and the
@@ -213,6 +225,7 @@ function FilesystemTab({
   data,
   error,
   hasCwd,
+  isRemote,
   loading,
   onActivateFile,
   onActivateFolder,
@@ -222,13 +235,20 @@ function FilesystemTab({
   onNodeOpenChange,
   onPreviewFile,
   onRefresh,
-  openState
+  openState,
+  remoteCwd
 }: FilesystemTabProps) {
   const { t } = useI18n()
   const r = t.rightSidebar
 
   return (
     <div className="group/project-header flex min-h-0 flex-1 flex-col">
+      {isRemote && (
+        <div className="flex items-center gap-1.5 px-2.5 py-1 text-[0.6875rem] text-(--ui-text-tertiary)" title={remoteCwd ? r.remoteLocalFilesTip(remoteCwd) : undefined}>
+          <Codicon className="shrink-0" name="cloud" size="0.75rem" />
+          <span>{r.remoteLocalFiles}</span>
+        </div>
+      )}
       <RightSidebarSectionHeader>
         <Tip label={hasCwd ? r.folderTip(cwd) : r.openFolder}>
           <button

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1517,7 +1517,9 @@ export const en: Translations = {
     loadingFiles: 'Loading files',
     terminalFocus: 'Focus terminal view',
     terminalSplit: 'Return to split view',
-    addToChat: 'Add to chat'
+    addToChat: 'Add to chat',
+    remoteLocalFiles: 'Browsing local files',
+    remoteLocalFilesTip: cwd => `The remote session's cwd (${cwd}) is not accessible locally. Select a local folder to browse.`
   },
 
   preview: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1660,7 +1660,9 @@ export const ja = defineLocale({
     loadingFiles: 'ファイルを読み込み中',
     terminalFocus: 'ターミナルビューにフォーカス',
     terminalSplit: '分割ビューに戻る',
-    addToChat: 'チャットに追加'
+    addToChat: 'チャットに追加',
+    remoteLocalFiles: 'ローカルファイルを参照',
+    remoteLocalFilesTip: cwd => `リモートセッションの作業ディレクトリ (${cwd}) はローカルでは利用できません。ローカルフォルダを選択してください。`
   },
 
   preview: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1190,6 +1190,8 @@ export interface Translations {
     terminalFocus: string
     terminalSplit: string
     addToChat: string
+    remoteLocalFiles: string
+    remoteLocalFilesTip: (cwd: string) => string
   }
 
   preview: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1621,7 +1621,9 @@ export const zhHant = defineLocale({
     loadingFiles: '正在載入檔案',
     terminalFocus: '聚焦終端機檢視',
     terminalSplit: '返回分割檢視',
-    addToChat: '新增至聊天'
+    addToChat: '新增至聊天',
+    remoteLocalFiles: '瀏覽本地檔案',
+    remoteLocalFilesTip: cwd => `遠端會話的工作目錄 (${cwd}) 在本機不可用。選擇本機資料夾瀏覽。`
   },
 
   preview: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1698,7 +1698,9 @@ export const zh: Translations = {
     loadingFiles: '正在加载文件',
     terminalFocus: '聚焦终端视图',
     terminalSplit: '返回分栏视图',
-    addToChat: '添加到对话'
+    addToChat: '添加到对话',
+    remoteLocalFiles: '浏览本地文件',
+    remoteLocalFilesTip: cwd => `远程会话的工作目录 (${cwd}) 在本地不可用。选择本地文件夹浏览。`
   },
 
   preview: {


### PR DESCRIPTION
## Problem

In remote mode (`connection.json` `mode: "remote"`), the Desktop Files panel inherits the remote session's `cwd` (e.g. `/home/user/.hermes`) and tries to read it via the local Electron `fs`. Since the remote path doesn't exist on the local machine, the panel always shows **"Unreadable — ENOENT"**.

The "Change folder" button opens a local macOS picker, but the default state is permanently broken — there's no way to see the panel work without manually selecting a local folder every time.

## Fix

When `$connection.mode === 'remote'`, pass an empty `cwd` to the Files panel so it shows **"No folder selected"** instead of trying to read a non-existent remote path. A subtle **"Browsing local files"** banner with a cloud icon appears to inform the user that the panel is browsing local files, not the remote session's filesystem.

The "Change folder" button still opens the local file picker as before — once the user selects a local folder, it works normally.

## Changes

- `apps/desktop/src/app/right-sidebar/index.tsx` — Detect remote mode, skip remote cwd for Files panel, pass `isRemote`/`remoteCwd` props to `FilesystemTab`, render info banner
- `apps/desktop/src/i18n/types.ts` — Add `remoteLocalFiles` and `remoteLocalFilesTip` type definitions
- `apps/desktop/src/i18n/en.ts`, `zh.ts`, `zh-hant.ts`, `ja.ts` — Add localized strings

## Testing

- `npx tsc --noEmit` — zero errors
- `npx vitest run --environment jsdom src/app/right-sidebar` — 10/10 tests pass
- Manual: In remote mode, Files panel shows "No folder selected" + "Browsing local files" banner instead of ENOENT

Closes #42431
