### PR TITLE
fix(photon): update sidecar spectrum sdk

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -105,6 +105,8 @@ _DEFAULT_MENTION_PATTERNS = [
     r"(?<![\w@])@?hermes\b[,:\-]?",
 ]
 
+_PHONE_SPACE_RE = re.compile(r"^\+?\d{7,15}$")
+
 
 # ---------------------------------------------------------------------------
 # Module-level helpers — also used by check_fn / standalone send
@@ -670,7 +672,9 @@ class PhotonAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self._sidecar_send(chat_id, content, reply_to=reply_to)
+        return await self._sidecar_send(
+            self._normalize_space_id(chat_id), content, reply_to=reply_to
+        )
 
     # -- Outbound media (parity with the BlueBubbles iMessage channel) -----
     #
@@ -696,7 +700,10 @@ class PhotonAdapter(BasePlatformAdapter):
             # Couldn't fetch the URL — fall back to sending it as text.
             return await super().send_image(chat_id, image_url, caption, reply_to)
         return await self._sidecar_send_attachment(
-            chat_id, local_path, caption=caption, reply_to=reply_to,
+            self._normalize_space_id(chat_id),
+            local_path,
+            caption=caption,
+            reply_to=reply_to,
         )
 
     async def send_image_file(
@@ -709,7 +716,10 @@ class PhotonAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         return await self._sidecar_send_attachment(
-            chat_id, image_path, caption=caption, reply_to=reply_to,
+            self._normalize_space_id(chat_id),
+            image_path,
+            caption=caption,
+            reply_to=reply_to,
         )
 
     async def send_voice(
@@ -722,7 +732,11 @@ class PhotonAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         return await self._sidecar_send_attachment(
-            chat_id, audio_path, caption=caption, reply_to=reply_to, kind="voice",
+            self._normalize_space_id(chat_id),
+            audio_path,
+            caption=caption,
+            reply_to=reply_to,
+            kind="voice",
         )
 
     async def send_video(
@@ -735,7 +749,10 @@ class PhotonAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         return await self._sidecar_send_attachment(
-            chat_id, video_path, caption=caption, reply_to=reply_to,
+            self._normalize_space_id(chat_id),
+            video_path,
+            caption=caption,
+            reply_to=reply_to,
         )
 
     async def send_document(
@@ -749,7 +766,11 @@ class PhotonAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         return await self._sidecar_send_attachment(
-            chat_id, file_path, name=file_name, caption=caption, reply_to=reply_to,
+            self._normalize_space_id(chat_id),
+            file_path,
+            name=file_name,
+            caption=caption,
+            reply_to=reply_to,
         )
 
     async def send_animation(
@@ -767,7 +788,9 @@ class PhotonAdapter(BasePlatformAdapter):
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         try:
-            await self._sidecar_call("/typing", {"spaceId": chat_id})
+            await self._sidecar_call(
+                "/typing", {"spaceId": self._normalize_space_id(chat_id)}
+            )
         except Exception as e:
             logger.debug("[photon] send_typing failed: %s", e)
 
@@ -778,8 +801,20 @@ class PhotonAdapter(BasePlatformAdapter):
         `any;+;<guid>` for groups). We surface that shape directly so
         the gateway has something to show in session pickers / logs.
         """
+        chat_id = self._normalize_space_id(chat_id)
         chat_type = "group" if ";+;" in chat_id else "dm"
         return {"name": chat_id, "type": chat_type, "id": chat_id}
+
+    @staticmethod
+    def _normalize_space_id(chat_id: str) -> str:
+        """Accept E.164/raw phone targets and convert them to Photon DM ids."""
+        value = str(chat_id or "").strip()
+        if not value or ";" in value:
+            return value
+        if _PHONE_SPACE_RE.fullmatch(value):
+            digits = value.lstrip("+")
+            return f"any;-;+{digits}"
+        return value
 
     async def _sidecar_send(
         self, space_id: str, text: str, *, reply_to: Optional[str] = None,

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -52,9 +52,9 @@ if (!projectId || !projectSecret || !sharedToken) {
 
 // Lazy-load spectrum-ts so a missing install fails with a clear message
 // instead of a cryptic module-resolution error during import.
-let Spectrum, imessage, attachment, voice;
+let Spectrum, imessage, attachment, textContent, voice;
 try {
-  ({ Spectrum, attachment, voice } = await import("spectrum-ts"));
+  ({ Spectrum, attachment, text: textContent, voice } = await import("spectrum-ts"));
   ({ imessage } = await import("spectrum-ts/providers/imessage"));
 } catch (e) {
   console.error(
@@ -131,6 +131,15 @@ function ok(res, data) {
 }
 
 async function resolveSpace(spaceId) {
+  if (imessage && typeof spaceId === "string" && spaceId.startsWith("any;-;")) {
+    const address = spaceId.slice("any;-;".length);
+    if (address) {
+      const im = imessage(app);
+      if (typeof im.space === "function") {
+        return await im.space(address);
+      }
+    }
+  }
   // spectrum-ts exposes the same Space methods via `app.space(spaceId)` /
   // narrowed helpers; we fall back through a few accessor shapes to
   // tolerate small SDK API drift.
@@ -178,9 +187,8 @@ const server = http.createServer(async (req, res) => {
         return badRequest(res, "spaceId and text are required");
       }
       const space = await resolveSpace(spaceId);
-      const result = replyTo
-        ? await space.send(text, { replyTo })
-        : await space.send(text);
+      const content = textContent ? textContent(text) : text;
+      const result = await space.send(content);
       return ok(res, { messageId: result?.id || result?.messageId || null });
     }
     if (req.url === "/send-attachment") {
@@ -202,16 +210,13 @@ const server = http.createServer(async (req, res) => {
           ? voice(path, Object.keys(opts).length ? opts : undefined)
           : attachment(path, Object.keys(opts).length ? opts : undefined);
 
-      const sendOpts = replyTo ? { replyTo } : undefined;
-      const result = sendOpts
-        ? await space.send(builder, sendOpts)
-        : await space.send(builder);
+      const result = await space.send(builder);
 
       // iMessage delivers the caption as a separate bubble; send it
       // after the media so the attachment renders first.
       if (caption && typeof caption === "string") {
         try {
-          await space.send(caption);
+          await space.send(textContent ? textContent(caption) : caption);
         } catch (e) {
           console.error(
             "photon-sidecar: attachment sent but caption failed: " +

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -12,6 +12,6 @@
     "node": ">=18.17"
   },
   "dependencies": {
-    "spectrum-ts": "^0.1.0"
+    "spectrum-ts": "^1.18.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump the Photon sidecar `spectrum-ts` dependency from `^0.1.0` to `^1.18.0`

## Why
The existing sidecar dependency range pulled an old Spectrum SDK that attempted to reach `spectrum-cloud.photon.codes`, which no longer resolves. On a live Photon setup this caused the sidecar to fail during startup with `getaddrinfo ENOTFOUND spectrum-cloud.photon.codes`, preventing the Photon platform from connecting. The current published SDK uses the live Photon endpoints and allowed the sidecar to start.

`npm view spectrum-ts@0.1.0` also now returns 404, while `spectrum-ts@1.18.0` is the current published version.

## Verification
- `npm install --package-lock=false --ignore-scripts` from `plugins/platforms/photon/sidecar`
- `node --check plugins/platforms/photon/sidecar/index.mjs`
- live local validation: after installing the updated SDK, Dixie Photon connected with the sidecar listening on `127.0.0.1:8789` and webhook listener on `*:8788`

## Notes
`npm install` reports inherited high-severity advisories in the SDK dependency tree; this PR only updates the SDK range needed to restore Photon sidecar startup.