### PR TITLE
fix(xai): avoid Responses web_search function-name collision

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -234,8 +234,21 @@ def _derive_responses_function_call_id(
 # Schema conversion
 # ---------------------------------------------------------------------------
 
-def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
-    """Convert chat-completions tool schemas to Responses function-tool schemas."""
+def _responses_tools(
+    tools: Optional[List[Dict[str, Any]]] = None,
+    *,
+    name_aliases: Optional[Dict[str, str]] = None,
+) -> Optional[List[Dict[str, Any]]]:
+    """Convert chat-completions tool schemas to Responses function-tool schemas.
+
+    ``name_aliases`` lets a backend receive a provider-safe function name while
+    Hermes keeps dispatching the canonical registry name. xAI Responses/Grok
+    Composer currently treats ``web_search`` specially enough that requests
+    asking it to call that function can return reasoning-only/incomplete turns
+    without a structured function_call. Exposing the same tool as
+    ``hermes_web_search`` avoids that provider-side collision; normalization
+    maps the call back before dispatch.
+    """
     if not tools:
         return None
 
@@ -245,9 +258,10 @@ def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[L
         name = fn.get("name")
         if not isinstance(name, str) or not name.strip():
             continue
+        exposed_name = name_aliases.get(name, name) if name_aliases else name
         converted.append({
             "type": "function",
-            "name": name,
+            "name": exposed_name,
             "description": fn.get("description", ""),
             "strict": False,
             "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
@@ -1153,6 +1167,8 @@ def _normalize_codex_response(
             if item_status in {"queued", "in_progress", "incomplete"}:
                 continue
             fn_name = getattr(item, "name", "") or ""
+            if fn_name == "hermes_web_search":
+                fn_name = "web_search"
             arguments = getattr(item, "arguments", "{}")
             if not isinstance(arguments, str):
                 arguments = json.dumps(arguments, ensure_ascii=False)
@@ -1174,6 +1190,8 @@ def _normalize_codex_response(
             ))
         elif item_type == "custom_tool_call":
             fn_name = getattr(item, "name", "") or ""
+            if fn_name == "hermes_web_search":
+                fn_name = "web_search"
             arguments = getattr(item, "input", "{}")
             if not isinstance(arguments, str):
                 arguments = json.dumps(arguments, ensure_ascii=False)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -127,7 +127,8 @@ class ResponsesApiTransport(ProviderTransport):
         _effort_clamp = {"minimal": "low"}
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
-        response_tools = _responses_tools(tools)
+        name_aliases = {"web_search": "hermes_web_search"} if is_xai_responses else None
+        response_tools = _responses_tools(tools, name_aliases=name_aliases)
         # ``tools`` MUST be omitted entirely when there are no functions to
         # expose: the openai SDK's ``responses.stream()`` / ``responses.parse()``
         # eagerly call ``_make_tools(tools)`` which does ``for tool in tools``

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -138,6 +138,39 @@ class TestCodexBuildKwargs:
         assert eb.get("prompt_cache_key") == "caller-override"
         assert eb.get("other_field") == 42
 
+    def test_xai_aliases_web_search_tool_name(self, transport):
+        """Expose web_search under a provider-safe alias on xAI Responses.
+
+        Grok Composer can return reasoning-only/incomplete responses when asked
+        to call a custom Responses function literally named ``web_search``. The
+        transport should alias only xAI's exposed schema name; other providers
+        keep the canonical Hermes name.
+        """
+        messages = [{"role": "user", "content": "Search the web"}]
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search the web",
+                "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+            },
+        }]
+        kw = transport.build_kwargs(
+            model="grok-composer-2.5-fast",
+            messages=messages,
+            tools=tools,
+            is_xai_responses=True,
+        )
+        assert kw["tools"][0]["name"] == "hermes_web_search"
+
+        kw_non_xai = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=tools,
+            is_xai_responses=False,
+        )
+        assert kw_non_xai["tools"][0]["name"] == "web_search"
+
     def test_max_tokens(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
@@ -452,6 +485,30 @@ class TestCodexNormalizeResponse:
         tc = nr.tool_calls[0]
         assert tc.name == "terminal"
         assert '"command"' in tc.arguments
+
+    def test_xai_web_search_alias_normalizes_back_to_canonical_name(self, transport):
+        """Function calls returned under the xAI-safe alias dispatch as web_search."""
+        r = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="function_call",
+                    call_id="call_search123",
+                    name="hermes_web_search",
+                    arguments=json.dumps({"query": "Hermes Agent docs"}),
+                    id="fc_search123",
+                    status="completed",
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=20,
+                                  input_tokens_details=None, output_tokens_details=None),
+        )
+        nr = transport.normalize_response(r)
+        assert nr.finish_reason == "tool_calls"
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "web_search"
+        assert '"query"' in nr.tool_calls[0].arguments
 
 
 


### PR DESCRIPTION
## Summary
- expose Hermes' local `web_search` function as `hermes_web_search` on xAI/Grok Responses requests
- normalize returned `hermes_web_search` calls back to canonical `web_search` before dispatch
- add regression coverage for the aliasing path in the Codex/Responses transport

## Problem
xAI/Grok Responses models can treat a function named `web_search` specially. When Hermes exposes its local function tool with that exact name, the provider/model may produce reasoning-only or otherwise non-dispatchable output instead of a normal function call. This is separate from xAI's server-side search provider; it affects Hermes' local `web_search` tool when routed through the Responses transport.

## Fix
For xAI Responses requests only, rename the local function tool on the wire to `hermes_web_search`. When parsing response output, map `hermes_web_search` back to `web_search` so the rest of Hermes dispatch remains unchanged.

## Tests
- `python -m pytest tests/agent/transports/test_codex_transport.py -q -o 'addopts='`
