### PR TITLE
feat(photon): full bidirectional iMessage media + interactions (completes #42454)

### DIFF
--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -104,20 +104,51 @@ All env vars are documented in `plugin.yaml`. The most important are:
 | `PHOTON_HOME_CHANNEL`    | (unset)            | Default space ID for cron delivery     |
 | `PHOTON_ALLOWED_USERS`   | (unset)            | Comma-separated E.164 allowlist        |
 
-## Limitations (current Photon API)
+## Capability coverage
 
-- **Inbound attachments are metadata only.** Inbound webhooks include the
-  filename + MIME type but no download URL. The plugin surfaces a
-  text marker (`[Photon attachment received: …]`) so the agent knows
-  something arrived, but cannot read the bytes.  Photon's docs note
-  an attachment retrieval endpoint is on the roadmap.
-- **Outbound attachments are supported.** Images, voice notes, video,
-  and documents are sent via `space.send(attachment(...))` /
-  `space.send(voice(...))` through the sidecar's `/send-attachment`
-  endpoint. A caption is delivered as a separate text bubble after the
-  media.
-- **Reactions, message effects, polls** — not exposed yet; the
-  `spectrum-ts` SDK supports them, and the sidecar is the natural
-  place to add them when the agent has reason to use them.
+This plugin exposes the **full reachable surface** of the `spectrum-ts`
+iMessage provider — the layer Photon's managed (incl. free shared-line)
+service makes available. Mapped against the SDK:
+
+**Covered (in / out, end to end):**
+
+| Capability | How |
+|---|---|
+| Send text (+ native link previews) | `/send` → `space.send(text)` |
+| Screen/bubble effects | `/send` `effect` → `space.send(effect(...))` |
+| Send image / GIF / video / voice / sticker / document | `/send-attachment` → `space.send(attachment()/voice())`; documents use an `application/octet-stream` MIME fallback |
+| Multiple attachments (paced) | `/send-attachments` |
+| Bot → user tapbacks (👀/✅/❌ acks) | `/react` → `space.send(reaction(...))` |
+| Typing indicator (tracks compute) | `/typing` → `space.send(typing(...))` |
+| Read receipts | auto on every inbound → `space.read(message)` |
+| Inbound text | gRPC stream → adapter |
+| Inbound photo → vision | `attachments.downloadStream` → temp file → `media_urls` |
+| Inbound video → keyframes + audio transcript | ffmpeg keyframes + WAV → vision routing + STT |
+| Inbound voice memo → transcription | `.caf` → `.wav` transcode → STT |
+| Inbound reactions (observe) | gRPC stream (unreliable on the free shared line) |
+
+Outbound text is markdown-stripped and split into paragraph bubbles
+(BlueBubbles-parity); attachments over `PHOTON_MAX_ATTACHMENT_MB` forward
+a note instead of blocking.
+
+**Reliability:** `spectrum-ts` tracks a cursor and runs
+`catchUpThenConsumeLive()` internally, so the live `app.messages` stream
+replays missed events on a gRPC reconnect — no message loss within a
+process. The stream takes no resume cursor, so messages during a full
+sidecar *restart* (a brief window) aren't recovered.
+
+**Not reachable from this layer.** `edit`, `unsend`, threaded `reply`,
+`sendMultipart`, `placeSticker`, `listRecent` (history), `polls`,
+`groups`, `addresses` (`isIMessageAvailable`), `getEmbeddedMedia`,
+`locations`, and `chats.create` (proactive cold-start DM to a new
+handle) live on the lower `@photon-ai/advanced-imessage` client, which
+`spectrum-ts` holds as internal context (`client: AdvancedIMessage`) and
+does **not** expose — the provider only surfaces `getAttachment`,
+`getMessage`, `read`, `background`. Reaching them would require a
+*separate* direct advanced-imessage connection (its own auth, likely a
+paid/dedicated line, not the free shared tier). When that's wired, the
+SOTA exposure is a few **semantic** agent tools (send / manage-message /
+manage-chat / history) with capability-gating and confirmation for
+destructive ops (`unsend`, group changes) — not raw 1:1 endpoints.
 
 [photon]: https://photon.codes/

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -39,7 +39,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 try:
     import httpx
@@ -512,18 +512,35 @@ class PhotonAdapter(BasePlatformAdapter):
         except ValueError:
             timestamp = datetime.now(tz=timezone.utc)
 
-        # Content normalization.  Spectrum is a discriminated union;
-        # text vs attachment metadata.  Attachments are metadata-only
-        # today (no download URL) — log + carry the name so the agent
-        # at least knows something was sent.
+        # Content normalization.  Spectrum is a discriminated union of
+        # text / attachment / reaction. For attachments the sidecar has
+        # already streamed the bytes to a temp file (the SDK's read()/stream()
+        # closures can't survive JSON serialization), so we surface the local
+        # path via media_urls — mirroring the BlueBubbles iMessage channel.
+        media_urls: List[str] = []
+        media_types: List[str] = []
         if content.get("type") == "text":
             text = content.get("text") or ""
             mtype = MessageType.TEXT
         elif content.get("type") == "attachment":
             name = content.get("name") or "(unnamed)"
-            mime = content.get("mimeType") or ""
-            text = f"[Photon attachment received: {name} ({mime}) — no download URL yet]"
+            mime = (content.get("mimeType") or "").lower()
+            local_path = content.get("localPath")
             mtype = _attachment_message_type(mime)
+            if local_path and os.path.isfile(local_path):
+                media_urls.append(local_path)
+                media_types.append(mime)
+                text = ""  # attachments usually arrive without caption text
+            else:
+                text = (
+                    f"[Photon attachment received: {name} ({mime}) "
+                    "— download unavailable]"
+                )
+        elif content.get("type") == "reaction":
+            emoji = content.get("emoji") or ""
+            target = content.get("target") or ""
+            text = f"[Reaction {emoji} on {target}]" if emoji else "[Reaction]"
+            mtype = MessageType.TEXT
         else:
             text = f"[Photon content type not handled: {content.get('type')}]"
             mtype = MessageType.TEXT
@@ -555,6 +572,8 @@ class PhotonAdapter(BasePlatformAdapter):
             message_id=msg.get("id"),
             raw_message=payload,
             timestamp=timestamp,
+            media_urls=media_urls,
+            media_types=media_types,
         )
         await self.handle_message(event)
 

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -815,6 +815,25 @@ class PhotonAdapter(BasePlatformAdapter):
             chat_id, video_path, caption=caption, reply_to=reply_to,
         )
 
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        # iMessage sends documents/PDFs the same way as any other attachment —
+        # raw bytes + a name (mirrors the BlueBubbles channel). The explicit
+        # MIME (with an application/octet-stream fallback in
+        # _sidecar_send_attachment) is what keeps spectrum-ts' attachment()
+        # builder from throwing on types it can't infer.
+        return await self._sidecar_send_attachment(
+            chat_id, file_path, name=file_name, caption=caption, reply_to=reply_to,
+        )
+
     async def send_animation(
         self,
         chat_id: str,
@@ -979,8 +998,12 @@ class PhotonAdapter(BasePlatformAdapter):
         if not mime_type:
             import mimetypes
 
-            guessed, _ = mimetypes.guess_type(safe_path)
-            mime_type = guessed or None
+            guessed, _ = mimetypes.guess_type(name or safe_path)
+            # spectrum-ts' attachment() builder THROWS when it can't resolve a
+            # MIME type, so always pass one — mirroring the BlueBubbles channel,
+            # which uploads every attachment as application/octet-stream when the
+            # type is unknown. This is what makes documents/PDFs sendable.
+            mime_type = guessed or "application/octet-stream"
         body: Dict[str, Any] = {
             "spaceId": space_id,
             "path": safe_path,

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -528,6 +528,12 @@ class PhotonAdapter(BasePlatformAdapter):
             name = content.get("name") or "(unnamed)"
             mime = (content.get("mimeType") or "").lower()
             local_path = content.get("localPath")
+            if local_path and not _is_within_download_dir(local_path):
+                # Defence-in-depth against a forged loopback webhook.
+                logger.warning(
+                    "[photon] rejecting out-of-scope localPath: %r", local_path
+                )
+                local_path = None
             mtype = _attachment_message_type(mime)
             # iMessage voice memos are .caf and often arrive WITHOUT an audio/*
             # mime (so the mime-only check above types them DOCUMENT, which the
@@ -1036,6 +1042,26 @@ def _attachment_message_type(mime: str) -> MessageType:
 
 _FFMPEG = shutil.which("ffmpeg")
 _FFPROBE = shutil.which("ffprobe")
+
+# The sidecar downloads inbound attachments into this directory (same default,
+# overridable via PHOTON_DOWNLOAD_DIR on both sides). The forwarded `localPath`
+# is only trusted if it resolves inside it — otherwise a forged loopback webhook
+# could point the agent at an arbitrary file (/etc/shadow, ~/.ssh/id_rsa, …) and
+# exfiltrate it via media_urls.
+def _download_dir() -> str:
+    return os.path.realpath(
+        os.environ.get("PHOTON_DOWNLOAD_DIR")
+        or os.path.join(tempfile.gettempdir(), "photon-attachments")
+    )
+
+
+def _is_within_download_dir(p: str) -> bool:
+    try:
+        base = _download_dir()
+        rp = os.path.realpath(p)
+        return rp == base or rp.startswith(base + os.sep)
+    except Exception:
+        return False
 
 # Voice-memo file extensions — iMessage records voice messages as CoreAudio
 # (.caf); these should always route to STT even when the mime is non-audio.

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -79,7 +79,13 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_WEBHOOK_PORT = 8788
 _DEFAULT_WEBHOOK_PATH = "/photon/webhook"
-_DEFAULT_WEBHOOK_BIND = "0.0.0.0"
+# Bind the inbound webhook receiver to loopback by default. The sidecar bridges
+# inbound over the gRPC stream and POSTs to 127.0.0.1, so loopback is all that's
+# needed — and binding 0.0.0.0 would expose the receiver to the network, where
+# (with no PHOTON_WEBHOOK_SECRET) an attacker could inject forged inbound
+# messages. The public Photon-cloud webhook path is opt-in: set
+# PHOTON_WEBHOOK_BIND=0.0.0.0 *and* a signing secret.
+_DEFAULT_WEBHOOK_BIND = "127.0.0.1"
 
 _DEFAULT_SIDECAR_PORT = 8789
 _DEFAULT_SIDECAR_BIND = "127.0.0.1"
@@ -457,6 +463,17 @@ class PhotonAdapter(BasePlatformAdapter):
         app = web.Application(client_max_size=2 * 1024 * 1024)
         app.router.add_post(self._webhook_path, self._handle_webhook)
         app.router.add_get("/healthz", lambda _: web.Response(text="ok"))
+        # Fail loud if the receiver is exposed beyond loopback without a signing
+        # secret — that combination accepts forged inbound from any network peer.
+        if self._webhook_bind not in ("127.0.0.1", "::1", "localhost") and (
+            not self._webhook_secret
+        ):
+            logger.warning(
+                "[photon] webhook bound to %s with NO PHOTON_WEBHOOK_SECRET — "
+                "this accepts UNSIGNED inbound from the network. Set a signing "
+                "secret, or bind to 127.0.0.1 (the default).",
+                self._webhook_bind,
+            )
         self._runner = web.AppRunner(app)
         await self._runner.setup()
         site = web.TCPSite(self._runner, self._webhook_bind, self._webhook_port)
@@ -1231,6 +1248,11 @@ async def _run_quiet(args: List[str], timeout: float = 45.0) -> int:
         await asyncio.wait_for(proc.wait(), timeout=timeout)
     except asyncio.TimeoutError:
         proc.kill()
+        # Reap the killed process so it doesn't linger as a zombie.
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        except (asyncio.TimeoutError, ProcessLookupError):
+            pass
         return 1
     return proc.returncode or 0
 

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -785,10 +785,21 @@ class PhotonAdapter(BasePlatformAdapter):
         )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
+        # The gateway's _keep_typing loop calls this on a cadence while the agent
+        # computes; the sidecar re-sends typing("start") each tick (iMessage
+        # indicators auto-expire) so the bubble tracks Hermes' actual status.
         try:
-            await self._sidecar_call("/typing", {"spaceId": chat_id})
+            await self._sidecar_call("/typing", {"spaceId": chat_id, "state": "start"})
         except Exception as e:
             logger.debug("[photon] send_typing failed: %s", e)
+
+    async def stop_typing(self, chat_id: str, metadata=None) -> None:
+        # Clear the indicator the moment the agent stops computing, instead of
+        # waiting for iMessage's auto-expire — keeps the bubble in sync.
+        try:
+            await self._sidecar_call("/typing", {"spaceId": chat_id, "state": "stop"})
+        except Exception as e:
+            logger.debug("[photon] stop_typing failed: %s", e)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return whatever we know about a Spectrum space id.

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -64,6 +64,7 @@ from gateway.platforms.base import (
     ProcessingOutcome,
     SendResult,
 )
+from gateway.platforms.helpers import strip_markdown
 
 from .auth import (
     DEFAULT_SPECTRUM_HOST,
@@ -740,6 +741,21 @@ class PhotonAdapter(BasePlatformAdapter):
 
     # -- Outbound ----------------------------------------------------------
 
+    def format_message(self, content: str) -> str:
+        # iMessage renders plain text — markdown syntax (**bold**, # headings,
+        # `code`, links) shows up as literal characters. Strip it, mirroring the
+        # BlueBubbles iMessage channel.
+        return strip_markdown(content)
+
+    @staticmethod
+    def truncate_message(
+        content: str, max_length: int = _MAX_MESSAGE_LENGTH
+    ) -> List[str]:
+        # Use the base splitter but drop "(1/3)" pagination suffixes — iMessage
+        # bubbles flow naturally without them (parity with BlueBubbles).
+        chunks = BasePlatformAdapter.truncate_message(content, max_length)
+        return [re.sub(r"\s*\(\d+/\d+\)$", "", c) for c in chunks]
+
     async def send(
         self,
         chat_id: str,
@@ -747,7 +763,33 @@ class PhotonAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self._sidecar_send(chat_id, content, reply_to=reply_to)
+        text = self.format_message(content)
+        if not text:
+            return SendResult(success=False, error="Photon send requires text")
+        # Split on paragraph breaks so each thought becomes its own iMessage
+        # bubble, then chunk any paragraph that's still too long (parity with
+        # the BlueBubbles channel — natural bubble flow, no hard mid-sentence
+        # cut).
+        paragraphs = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+        chunks: List[str] = []
+        for para in paragraphs or [text]:
+            if len(para) <= self.MAX_MESSAGE_LENGTH:
+                chunks.append(para)
+            else:
+                chunks.extend(
+                    self.truncate_message(para, max_length=self.MAX_MESSAGE_LENGTH)
+                )
+        last = SendResult(success=True)
+        for chunk in chunks:
+            last = await self._sidecar_send(chat_id, chunk, reply_to=reply_to)
+            if not last.success:
+                return last
+        return last
+
+    # NOTE: no explicit mark_read() — the sidecar already sends a read receipt
+    # for every inbound message it handles (markRead on receipt), so the whole
+    # conversation is always marked read without an on-demand call. This is
+    # broader coverage than the BlueBubbles channel's manual mark_read.
 
     # -- Outbound media (parity with the BlueBubbles iMessage channel) -----
     #
@@ -875,6 +917,13 @@ class PhotonAdapter(BasePlatformAdapter):
 
     def _reactions_enabled(self, event: "MessageEvent" = None) -> bool:
         if os.getenv("PHOTON_REACTIONS", "true").lower() in {"false", "0", "no"}:
+            return False
+        # Never ack a reaction event: the shared line can echo the bot's own
+        # tapback back as an inbound reaction, and acking that would loop. (The
+        # SDK already drops own *messages*; only reactions leak.)
+        if event is not None and ":reaction:" in str(
+            getattr(event, "message_id", "") or ""
+        ):
             return False
         # Only react to allowlisted senders so a stranger never sees the bot
         # acknowledge (the reaction fires before run.py's auth gate). Read the

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -575,6 +575,14 @@ class PhotonAdapter(BasePlatformAdapter):
                     media_urls.append(local_path)
                     media_types.append(mime)
                 text = ""  # attachments usually arrive without caption text
+            elif content.get("tooLarge"):
+                _mb = (content.get("size") or 0) / (1024 * 1024)
+                text = (
+                    f'[The user sent a {mime or "media"} attachment "{name}" '
+                    f"(~{_mb:.0f} MB) that is too large to download and analyze "
+                    "here. Acknowledge it and suggest a shorter clip or a "
+                    "screenshot.]"
+                )
             else:
                 text = (
                     f"[Photon attachment received: {name} ({mime}) "

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -36,6 +36,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -60,6 +61,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     SendResult,
 )
 
@@ -527,9 +529,51 @@ class PhotonAdapter(BasePlatformAdapter):
             mime = (content.get("mimeType") or "").lower()
             local_path = content.get("localPath")
             mtype = _attachment_message_type(mime)
+            # iMessage voice memos are .caf and often arrive WITHOUT an audio/*
+            # mime (so the mime-only check above types them DOCUMENT, which the
+            # gateway excludes from STT). Type by extension too, like the
+            # BlueBubbles channel's `uti.endswith("caf")` check, so voice memos
+            # always reach transcription.
+            _ext = os.path.splitext(name)[1].lower()
+            if _ext in _VOICE_EXTS and mtype is not MessageType.VOICE:
+                mtype = MessageType.VOICE
+            logger.debug(
+                "[photon] inbound attachment name=%r mime=%r ext=%r -> %s",
+                name, mime, _ext, mtype,
+            )
             if local_path and os.path.isfile(local_path):
-                media_urls.append(local_path)
-                media_types.append(mime)
+                if mime.startswith("video/"):
+                    # Hermes has no native inbound-video path, so normalize the
+                    # clip into keyframes (→ the capability-aware vision routing
+                    # in agent/image_routing.py: native pixels if the model is
+                    # vision-capable, else vision_analyze) plus the audio track
+                    # (→ the existing STT path). Model-agnostic — no per-model
+                    # branching here. Falls back to the raw video on failure.
+                    frames, audio = await _extract_video_media(
+                        local_path, _video_frame_count()
+                    )
+                    for f in frames:
+                        media_urls.append(f)
+                        media_types.append("image/jpeg")
+                    if audio:
+                        media_urls.append(audio)
+                        media_types.append("audio/wav")
+                    if not frames and not audio:
+                        media_urls.append(local_path)
+                        media_types.append(mime)
+                elif mtype is MessageType.VOICE and _ext not in _STT_OK_EXTS:
+                    # iMessage voice memos (.caf) aren't an STT-accepted format;
+                    # transcode to .wav so the gateway's transcription works.
+                    wav = await _transcode_audio_to_wav(local_path)
+                    if wav:
+                        media_urls.append(wav)
+                        media_types.append("audio/wav")
+                    else:
+                        media_urls.append(local_path)
+                        media_types.append(mime)
+                else:
+                    media_urls.append(local_path)
+                    media_types.append(mime)
                 text = ""  # attachments usually arrive without caption text
             else:
                 text = (
@@ -757,20 +801,6 @@ class PhotonAdapter(BasePlatformAdapter):
             chat_id, video_path, caption=caption, reply_to=reply_to,
         )
 
-    async def send_document(
-        self,
-        chat_id: str,
-        file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        **kwargs,
-    ) -> SendResult:
-        return await self._sidecar_send_attachment(
-            chat_id, file_path, name=file_name, caption=caption, reply_to=reply_to,
-        )
-
     async def send_animation(
         self,
         chat_id: str,
@@ -800,6 +830,82 @@ class PhotonAdapter(BasePlatformAdapter):
             await self._sidecar_call("/typing", {"spaceId": chat_id, "state": "stop"})
         except Exception as e:
             logger.debug("[photon] stop_typing failed: %s", e)
+
+    # -- Tapback reactions (bot -> user) -----------------------------------
+    #
+    # iMessage tapbacks are sent via spectrum-ts' `reaction(emoji, target)`
+    # builder (resolves to `messages.setReaction(...)`). Native tapbacks
+    # (❤️👍👎😂‼️❓) map to Apple's tapback kinds; any other emoji is delivered
+    # as an emoji reaction (iOS 18+). Used by the on_processing_* hooks to
+    # acknowledge a message with 👀 (received) → ✅/❌ (done), matching the
+    # Signal/Telegram channels.
+
+    def _reactions_enabled(self, event: "MessageEvent" = None) -> bool:
+        if os.getenv("PHOTON_REACTIONS", "true").lower() in {"false", "0", "no"}:
+            return False
+        # Only react to allowlisted senders so a stranger never sees the bot
+        # acknowledge (the reaction fires before run.py's auth gate). Read the
+        # allowlist straight from env — the same source the sidecar uses.
+        allow = {
+            u.strip()
+            for u in os.getenv("PHOTON_ALLOWED_USERS", "").split(",")
+            if u.strip()
+        }
+        if event is not None and allow:
+            sender = getattr(getattr(event, "source", None), "user_id", None)
+            if sender and sender not in allow:
+                return False
+        return True
+
+    def _extract_reaction_target(self, event: "MessageEvent"):
+        mid = getattr(event, "message_id", None)
+        return (mid,) if mid else None
+
+    async def send_reaction(
+        self, chat_id: str, emoji: str, target_message_id: str
+    ) -> bool:
+        try:
+            await self._sidecar_call(
+                "/react",
+                {
+                    "spaceId": chat_id,
+                    "targetMessageId": target_message_id,
+                    "reaction": emoji,
+                },
+            )
+            return True
+        except Exception as e:
+            logger.debug("[photon] send_reaction failed: %s", e)
+            return False
+
+    async def remove_reaction(self, chat_id: str, target_message_id: str) -> None:
+        # spectrum-ts' high-level `reaction()` builder only *adds* a tapback;
+        # clearing one (setReaction isSet=false) isn't exposed, so removal is a
+        # no-op. The completion reaction is simply added alongside the 👀.
+        return None
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        if not self._reactions_enabled(event):
+            return
+        target = self._extract_reaction_target(event)
+        if target:
+            await self.send_reaction(event.source.chat_id, "👀", *target)
+
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
+        # CANCELLED: leave 👀 in place — no terminal outcome yet.
+        if not self._reactions_enabled(event) or outcome == ProcessingOutcome.CANCELLED:
+            return
+        target = self._extract_reaction_target(event)
+        if not target:
+            return
+        chat_id = event.source.chat_id
+        await self.remove_reaction(chat_id, *target)
+        if outcome == ProcessingOutcome.SUCCESS:
+            await self.send_reaction(chat_id, "✅", *target)
+        elif outcome == ProcessingOutcome.FAILURE:
+            await self.send_reaction(chat_id, "❌", *target)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return whatever we know about a Spectrum space id.
@@ -911,10 +1017,130 @@ def _attachment_message_type(mime: str) -> MessageType:
     if mime.startswith("video/"):
         return MessageType.VIDEO
     if mime.startswith("audio/"):
-        return MessageType.AUDIO
+        # iMessage voice memos arrive as audio attachments; map to VOICE so
+        # the gateway's STT path transcribes them (MessageType.AUDIO is the
+        # "never transcribe" file-attachment bucket — see gateway/run.py).
+        return MessageType.VOICE
     if mime.startswith("application/"):
         return MessageType.DOCUMENT
     return MessageType.DOCUMENT
+
+
+_FFMPEG = shutil.which("ffmpeg")
+_FFPROBE = shutil.which("ffprobe")
+
+# Voice-memo file extensions — iMessage records voice messages as CoreAudio
+# (.caf); these should always route to STT even when the mime is non-audio.
+_VOICE_EXTS = frozenset({".caf", ".amr", ".opus"})
+
+# Audio container formats Hermes' STT pipeline (tools.transcription_tools)
+# accepts. iMessage's .caf is NOT here, so voice memos must be transcoded to
+# .wav before they reach transcription.
+_STT_OK_EXTS = frozenset(
+    {".aac", ".flac", ".m4a", ".mp3", ".mp4", ".mpeg", ".mpga", ".ogg", ".wav", ".webm"}
+)
+
+
+async def _transcode_audio_to_wav(src: str) -> Optional[str]:
+    """Transcode an audio file to 16 kHz mono WAV (the canonical STT input).
+    Returns the new path, or None on failure (caller falls back to the original).
+    """
+    if not _FFMPEG:
+        return None
+    try:
+        workdir = tempfile.mkdtemp(prefix="photon-aud-")
+        out = os.path.join(workdir, "voice.wav")
+        rc = await _run_quiet(
+            [_FFMPEG, "-y", "-i", src, "-ac", "1", "-ar", "16000", out]
+        )
+        if rc == 0 and os.path.exists(out) and os.path.getsize(out) > 256:
+            return out
+    except Exception as e:
+        logger.debug("[photon] audio transcode failed: %s", e)
+    return None
+
+
+def _video_frame_count() -> int:
+    """How many keyframes to sample from an inbound video (configurable, not
+    hardcoded). Anyone running Hermes can tune PHOTON_VIDEO_FRAMES."""
+    try:
+        return max(1, min(32, int(os.getenv("PHOTON_VIDEO_FRAMES", "6"))))
+    except ValueError:
+        return 6
+
+
+async def _run_quiet(args: List[str], timeout: float = 45.0) -> int:
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        return 1
+    return proc.returncode or 0
+
+
+async def _video_duration(path: str) -> float:
+    if not _FFPROBE:
+        return 0.0
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            _FFPROBE, "-v", "error", "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1", path,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+        return float(out.decode().strip())
+    except Exception:
+        return 0.0
+
+
+async def _extract_video_media(video_path: str, max_frames: int):
+    """Normalize an inbound video into model-digestible media: evenly-spaced
+    keyframes (JPEG, for the capability-aware vision pipeline) + the audio track
+    as 16 kHz mono WAV (for STT). Returns ``(frame_paths, audio_path)``.
+
+    Best-effort: returns ``([], None)`` when ffmpeg is missing or extraction
+    fails, so the caller falls back to handing over the raw video path.
+    """
+    if not _FFMPEG:
+        return [], None
+    workdir = tempfile.mkdtemp(prefix="photon-vid-")
+    frames: List[str] = []
+    audio_path: Optional[str] = None
+    try:
+        duration = await _video_duration(video_path)
+        # fps that yields ~max_frames across the whole clip; default to 1 fps for
+        # very short / unknown-duration clips, capped by -frames:v.
+        fps = "1"
+        if duration > 0:
+            fps = f"{max_frames}/{duration:.3f}"
+        frame_tmpl = os.path.join(workdir, "frame_%03d.jpg")
+        rc = await _run_quiet([
+            _FFMPEG, "-y", "-i", video_path,
+            "-vf", f"fps={fps},scale='min(1024,iw)':-2",
+            "-frames:v", str(max_frames), frame_tmpl,
+        ])
+        if rc == 0:
+            frames = sorted(
+                os.path.join(workdir, f)
+                for f in os.listdir(workdir)
+                if f.startswith("frame_") and f.endswith(".jpg")
+            )[:max_frames]
+        # Audio track (silent videos simply won't produce a usable file).
+        wav = os.path.join(workdir, "audio.wav")
+        rc2 = await _run_quiet([
+            _FFMPEG, "-y", "-i", video_path, "-vn",
+            "-ac", "1", "-ar", "16000", wav,
+        ])
+        if rc2 == 0 and os.path.exists(wav) and os.path.getsize(wav) > 1024:
+            audio_path = wav
+    except Exception as e:
+        logger.debug("[photon] video extraction failed: %s", e)
+    return frames, audio_path
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -265,6 +265,7 @@ class PhotonAdapter(BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._sidecar_proc: Optional[subprocess.Popen] = None
         self._sidecar_supervisor_task: Optional[asyncio.Task] = None
+        self._media_sweeper_task: Optional[asyncio.Task] = None
         self._http_client: Optional["httpx.AsyncClient"] = None
         # Lightweight in-memory dedup. Photon's at-least-once guarantee
         # means we WILL see the same message.id more than once.
@@ -397,6 +398,7 @@ class PhotonAdapter(BasePlatformAdapter):
             logger.info("[photon] sidecar autostart disabled — outbound will fail")
 
         self._http_client = httpx.AsyncClient(timeout=30.0)
+        self._media_sweeper_task = asyncio.create_task(self._sweep_media_temp())
         self._mark_connected()
         logger.info(
             "[photon] connected — webhook at %s:%d%s, sidecar on %s:%d",
@@ -405,7 +407,37 @@ class PhotonAdapter(BasePlatformAdapter):
         )
         return True
 
+    async def _sweep_media_temp(self) -> None:
+        """Periodically delete orphaned media temp dirs (ffmpeg keyframes +
+        .caf→.wav transcodes) and any stale sidecar downloads. They're consumed
+        by the agent within seconds, so an age TTL is safe and bounds disk use
+        (the OS tmp reaper is only a backstop)."""
+        import glob
+
+        ttl = float(os.getenv("PHOTON_MEDIA_TTL_SECONDS", "3600"))  # 1h
+        tmp = tempfile.gettempdir()
+        while True:
+            try:
+                now = time.time()
+                targets = glob.glob(os.path.join(tmp, "photon-vid-*")) + glob.glob(
+                    os.path.join(tmp, "photon-aud-*")
+                )
+                for d in targets:
+                    try:
+                        if now - os.path.getmtime(d) > ttl:
+                            shutil.rmtree(d, ignore_errors=True)
+                    except OSError:
+                        pass
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.debug("[photon] media sweep error: %s", e)
+            await asyncio.sleep(600)  # every 10 min
+
     async def disconnect(self) -> None:
+        if self._media_sweeper_task is not None:
+            self._media_sweeper_task.cancel()
+            self._media_sweeper_task = None
         await self._stop_sidecar()
         await self._stop_webhook_server()
         if self._http_client is not None:
@@ -419,7 +451,10 @@ class PhotonAdapter(BasePlatformAdapter):
     # -- Webhook server ----------------------------------------------------
 
     async def _start_webhook_server(self) -> None:
-        app = web.Application()
+        # Cap the inbound webhook body — control/metadata messages are tiny, so
+        # 2 MiB is generous headroom while preventing a compromised local peer
+        # from OOMing the receiver (defence-in-depth on the loopback channel).
+        app = web.Application(client_max_size=2 * 1024 * 1024)
         app.router.add_post(self._webhook_path, self._handle_webhook)
         app.router.add_get("/healthz", lambda _: web.Response(text="ok"))
         self._runner = web.AppRunner(app)
@@ -1115,6 +1150,16 @@ def _attachment_message_type(mime: str) -> MessageType:
 _FFMPEG = shutil.which("ffmpeg")
 _FFPROBE = shutil.which("ffprobe")
 
+# Hardening flags for running ffmpeg/ffprobe on UNTRUSTED iMessage media:
+#   -nostdin              never block on / read from stdin
+#   -loglevel error -nostats  quiet, no log-injection surface
+#   -threads 1            bound CPU per job (DoS guard; clips are small)
+#   -protocol_whitelist file,pipe  no network protocols — a crafted container
+#                         can't make ffmpeg fetch a URL (SSRF/exfil guard)
+# (input is also size-capped at 32MB upstream and each run has a wall-timeout.)
+_FFMPEG_HARDEN = ["-nostdin", "-loglevel", "error", "-nostats", "-threads", "1"]
+_FFMPEG_INPUT_GUARD = ["-protocol_whitelist", "file,pipe"]
+
 # The sidecar downloads inbound attachments into this directory (same default,
 # overridable via PHOTON_DOWNLOAD_DIR on both sides). The forwarded `localPath`
 # is only trusted if it resolves inside it — otherwise a forged loopback webhook
@@ -1157,7 +1202,8 @@ async def _transcode_audio_to_wav(src: str) -> Optional[str]:
         workdir = tempfile.mkdtemp(prefix="photon-aud-")
         out = os.path.join(workdir, "voice.wav")
         rc = await _run_quiet(
-            [_FFMPEG, "-y", "-i", src, "-ac", "1", "-ar", "16000", out]
+            [_FFMPEG, *_FFMPEG_HARDEN, "-y", *_FFMPEG_INPUT_GUARD,
+             "-i", src, "-ac", "1", "-ar", "16000", out]
         )
         if rc == 0 and os.path.exists(out) and os.path.getsize(out) > 256:
             return out
@@ -1194,7 +1240,8 @@ async def _video_duration(path: str) -> float:
         return 0.0
     try:
         proc = await asyncio.create_subprocess_exec(
-            _FFPROBE, "-v", "error", "-show_entries", "format=duration",
+            _FFPROBE, "-v", "error", *_FFMPEG_INPUT_GUARD,
+            "-show_entries", "format=duration",
             "-of", "default=noprint_wrappers=1:nokey=1", path,
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
         )
@@ -1226,7 +1273,7 @@ async def _extract_video_media(video_path: str, max_frames: int):
             fps = f"{max_frames}/{duration:.3f}"
         frame_tmpl = os.path.join(workdir, "frame_%03d.jpg")
         rc = await _run_quiet([
-            _FFMPEG, "-y", "-i", video_path,
+            _FFMPEG, *_FFMPEG_HARDEN, "-y", *_FFMPEG_INPUT_GUARD, "-i", video_path,
             "-vf", f"fps={fps},scale='min(1024,iw)':-2",
             "-frames:v", str(max_frames), frame_tmpl,
         ])
@@ -1239,8 +1286,8 @@ async def _extract_video_media(video_path: str, max_frames: int):
         # Audio track (silent videos simply won't produce a usable file).
         wav = os.path.join(workdir, "audio.wav")
         rc2 = await _run_quiet([
-            _FFMPEG, "-y", "-i", video_path, "-vn",
-            "-ac", "1", "-ar", "16000", wav,
+            _FFMPEG, *_FFMPEG_HARDEN, "-y", *_FFMPEG_INPUT_GUARD, "-i", video_path,
+            "-vn", "-ac", "1", "-ar", "16000", wav,
         ])
         if rc2 == 0 and os.path.exists(wav) and os.path.getsize(wav) > 1024:
             audio_path = wav

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -443,6 +443,12 @@ class PhotonAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         if self._media_sweeper_task is not None:
             self._media_sweeper_task.cancel()
+            # Await the cancellation so the task's exception (if any) is
+            # retrieved — avoids "Task exception was never retrieved".
+            try:
+                await self._media_sweeper_task
+            except asyncio.CancelledError:
+                pass
             self._media_sweeper_task = None
         await self._stop_sidecar()
         await self._stop_webhook_server()
@@ -533,14 +539,19 @@ class PhotonAdapter(BasePlatformAdapter):
 
     def _is_duplicate(self, msg_id: str) -> bool:
         now = time.time()
-        if len(self._seen_messages) > _DEDUP_MAX_SIZE:
-            cutoff = now - _DEDUP_WINDOW_SECONDS
-            self._seen_messages = {
-                k: v for k, v in self._seen_messages.items() if v > cutoff
-            }
-        if msg_id in self._seen_messages:
-            return True
-        self._seen_messages[msg_id] = now
+        seen = self._seen_messages
+        t = seen.get(msg_id)
+        if t is not None and now - t < _DEDUP_WINDOW_SECONDS:
+            return True  # seen, unexpired
+        # New or expired: record and enforce a HARD size bound (evict oldest,
+        # insertion-order) so a burst of unique ids within the window can't grow
+        # the dict without limit — not just the expired-only prune.
+        if msg_id in seen:
+            del seen[msg_id]  # refresh insertion order
+        seen[msg_id] = now
+        if len(seen) > _DEDUP_MAX_SIZE:
+            for old in list(seen.keys())[: len(seen) - _DEDUP_MAX_SIZE]:
+                del seen[old]
         return False
 
     async def _dispatch_inbound(self, payload: Dict[str, Any]) -> None:

--- a/plugins/platforms/photon/plugin.yaml
+++ b/plugins/platforms/photon/plugin.yaml
@@ -42,7 +42,7 @@ optional_env:
     prompt: "Webhook receiver path"
     password: false
   - name: PHOTON_WEBHOOK_BIND
-    description: "Bind address for the webhook receiver (default 0.0.0.0)"
+    description: "Bind address for the webhook receiver (default 127.0.0.1; set 0.0.0.0 only for the public Photon-cloud webhook path, and only with a signing secret)"
     prompt: "Webhook bind address"
     password: false
   - name: PHOTON_SIDECAR_PORT

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -133,6 +133,16 @@ async function markRead(space, message) {
 // `app.space(id)`).
 // ---------------------------------------------------------------------------
 const spaceCache = new Map();
+const _SPACE_CACHE_MAX = 1000;
+function setSpace(id, space) {
+  if (!id || !space) return;
+  // Bound the cache so a long-running process with many conversations can't
+  // grow it without limit (evict oldest, insertion-order).
+  if (spaceCache.size >= _SPACE_CACHE_MAX && !spaceCache.has(id)) {
+    spaceCache.delete(spaceCache.keys().next().value);
+  }
+  spaceCache.set(id, space);
+}
 
 const WEBHOOK_HOST = "127.0.0.1"; // sidecar -> adapter is always loopback
 const WEBHOOK_PORT = parseInt(process.env.PHOTON_WEBHOOK_PORT || "8788", 10);
@@ -144,7 +154,8 @@ const ALLOW = new Set(
     .map((s) => s.trim())
     .filter(Boolean)
 );
-const DOWNLOAD_DIR = path.join(os.tmpdir(), "photon-attachments");
+const DOWNLOAD_DIR =
+  process.env.PHOTON_DOWNLOAD_DIR || path.join(os.tmpdir(), "photon-attachments");
 // Cap inbound attachment downloads so a large video (downloaded over a slow
 // gRPC stream) can't block the message — and the agent's ack/reply — for
 // minutes. Oversized attachments forward as metadata-only with a note.
@@ -219,9 +230,13 @@ function pump() {
 // rename into place. Partial files are unlinked on any failure.
 async function downloadAttachmentToFile(content) {
   await fsp.mkdir(DOWNLOAD_DIR, { recursive: true });
-  const guid = content.id || crypto.randomUUID();
-  const safeName = String(content.name || guid).replace(/[^\w.\-]+/g, "_");
-  const finalPath = path.join(DOWNLOAD_DIR, `${guid}-${safeName}`);
+  // Sanitize BOTH the guid and the name before they reach the filesystem path —
+  // `content.id` is attacker-controlled, so an unsanitized `../` could escape
+  // DOWNLOAD_DIR via path.join. The allowlist regex keeps the path a basename.
+  const safeGuid =
+    String(content.id || "").replace(/[^\w.\-]+/g, "_") || crypto.randomUUID();
+  const safeName = String(content.name || safeGuid).replace(/[^\w.\-]+/g, "_");
+  const finalPath = path.join(DOWNLOAD_DIR, `${safeGuid}-${safeName}`);
   const partPath = `${finalPath}.part`;
   let received = 0;
   const ac = new AbortController();
@@ -232,6 +247,9 @@ async function downloadAttachmentToFile(content) {
     const nodeReadable = Readable.fromWeb(webStream);
     nodeReadable.on("data", (c) => {
       received += c.length;
+      // Streaming cap: a sender can under-declare `size`, so enforce the
+      // ceiling on actual bytes too — abort before exhausting disk.
+      if (received > MAX_ATTACH_BYTES) ac.abort();
     });
     await pipeline(nodeReadable, fs.createWriteStream(partPath), {
       signal: ac.signal,
@@ -352,8 +370,8 @@ async function handleInbound(space, message) {
 (async () => {
   try {
     for await (const [space, message] of app.messages) {
-      if (space?.id) spaceCache.set(space.id, space);
-      if (message?.space?.id && space) spaceCache.set(message.space.id, space);
+      if (space?.id) setSpace(space.id, space);
+      if (message?.space?.id && space) setSpace(message.space.id, space);
       schedule(() => handleInbound(space, message));
     }
   } catch (e) {
@@ -441,7 +459,7 @@ async function resolveSpace(spaceId) {
   const dm = spaceId.match(/;-;(\+\d+)/);
   if (dm) {
     const space = await provider.space(await provider.user({ phone: dm[1] }));
-    spaceCache.set(spaceId, space);
+    setSpace(spaceId, space);
     return space;
   }
   throw new Error(`unable to resolve space id ${spaceId}`);
@@ -599,7 +617,12 @@ const server = http.createServer(async (req, res) => {
       // `messages.setReaction(...)`; native tapbacks (❤️👍👎😂‼️❓) map to
       // Apple's tapback kinds, any other emoji is sent as an emoji reaction
       // (iOS 18+). `targetMessageId` is the guid of the message to react to.
-      const { spaceId, targetMessageId, reaction: emoji } = body || {};
+      const { spaceId, targetMessageId, reaction: rawEmoji } = body || {};
+      // Strip control characters and cap length on the reaction.
+      const emoji =
+        typeof rawEmoji === "string"
+          ? rawEmoji.replace(/\p{Cc}/gu, "").slice(0, 16)
+          : "";
       if (!spaceId || !targetMessageId || !emoji) {
         return badRequest(
           res,

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -24,7 +24,7 @@
 //       body: {"spaceId": "...", "paths": ["...", ...],
 //              "caption": "..." | null, "pacingMs": 600 | null}
 //   - POST /typing                      -> {"ok": true}
-//       body: {"spaceId": "..."}
+//       body: {"spaceId": "...", "state": "start" | "stop"}
 //   - POST /shutdown                    -> {"ok": true}; then process exits
 //
 // On SIGINT/SIGTERM the sidecar calls `app.stop()` (3s graceful) before
@@ -66,9 +66,9 @@ if (!projectId || !projectSecret || !sharedToken) {
 
 // Lazy-load spectrum-ts so a missing install fails with a clear message
 // instead of a cryptic module-resolution error during import.
-let Spectrum, imessage, attachment, voice, effect;
+let Spectrum, imessage, attachment, voice, effect, typing;
 try {
-  ({ Spectrum, attachment, voice } = await import("spectrum-ts"));
+  ({ Spectrum, attachment, voice, typing } = await import("spectrum-ts"));
   ({ imessage, effect } = await import("spectrum-ts/providers/imessage"));
 } catch (e) {
   console.error(
@@ -95,9 +95,19 @@ const SEND_READ_RECEIPTS =
   (process.env.PHOTON_READ_RECEIPTS || "true").toLowerCase() !== "false";
 
 async function markRead(space, message) {
-  if (!SEND_READ_RECEIPTS || typeof provider.read !== "function") return;
+  if (!SEND_READ_RECEIPTS) return;
   try {
-    await provider.read(space, message);
+    // The read receipt is a Space/Message *sugar* — `space.read(message)`
+    // (sends `read(message)` through the space). It lives on the live Space and
+    // Message objects from the inbound stream, NOT on the provider, so call it
+    // there (prefer the space; fall back to the message's own `read()`).
+    if (space && typeof space.read === "function") {
+      await space.read(message);
+    } else if (message && typeof message.read === "function") {
+      await message.read();
+    } else {
+      console.error("photon-sidecar: no read() on space/message — receipt skipped");
+    }
   } catch (e) {
     // Best-effort — SMS/some services don't support read receipts.
     console.error(
@@ -520,13 +530,23 @@ const server = http.createServer(async (req, res) => {
       return ok(res, { messageIds });
     }
     if (req.url === "/typing") {
-      const { spaceId } = body || {};
+      const { spaceId, state } = body || {};
       if (!spaceId) return badRequest(res, "spaceId is required");
       const space = await resolveSpace(spaceId);
-      if (typeof space.typing === "function") {
-        await space.typing();
-      } else if (typeof space.setTyping === "function") {
-        await space.setTyping(true);
+      // spectrum-ts 1.x has no `space.typing()` method — the typing indicator
+      // is content: `space.send(typing("start" | "stop"))`. The gateway's
+      // _keep_typing loop re-sends "start" on a cadence (iMessage indicators
+      // auto-expire), and stop_typing sends "stop" when the agent is done — so
+      // the bubble tracks Hermes' actual compute status. Best-effort: a missed
+      // typing tick must never fail the turn.
+      const sig = state === "stop" ? "stop" : "start";
+      try {
+        if (typeof typing === "function") await space.send(typing(sig));
+      } catch (e) {
+        console.error(
+          "photon-sidecar: typing(" + sig + ") failed: " +
+            (e && e.message ? e.message : e)
+        );
       }
       return ok(res, {});
     }

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -118,6 +118,20 @@ async function markRead(space, message) {
   }
 }
 
+// Bound concurrent read receipts. markRead is fire-and-forget (not awaited by
+// handleInbound), so a burst could otherwise spawn unbounded in-flight promises
+// that bypass the inbound scheduler's cap. Receipts are non-critical, so simply
+// skip when at capacity.
+const MAX_READ_INFLIGHT = 8;
+let _readActive = 0;
+function markReadBounded(space, message) {
+  if (!SEND_READ_RECEIPTS || _readActive >= MAX_READ_INFLIGHT) return;
+  _readActive += 1;
+  Promise.resolve(markRead(space, message)).finally(() => {
+    _readActive -= 1;
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Inbound bridge (sidecar -> adapter).
 //
@@ -182,11 +196,13 @@ const _DEDUP_MAX = 5000;
 const _DEDUP_TTL_MS = 10 * 60 * 1000;
 function isDuplicate(id) {
   const now = Date.now();
-  if (_seen.size > _DEDUP_MAX) {
-    for (const [k, t] of _seen) if (now - t > _DEDUP_TTL_MS) _seen.delete(k);
-  }
-  if (_seen.has(id)) return true;
+  const t = _seen.get(id);
+  if (t !== undefined && now - t < _DEDUP_TTL_MS) return true; // seen, unexpired
+  // New or expired: record and enforce a HARD size bound (LRU evict-oldest), so
+  // a burst of unique ids within the TTL can't grow the map without limit.
+  _seen.delete(id); // refresh insertion order if re-seen after expiry
   _seen.set(id, now);
+  if (_seen.size > _DEDUP_MAX) _seen.delete(_seen.keys().next().value);
   return false;
 }
 
@@ -321,8 +337,8 @@ async function handleInbound(space, message) {
     );
     return;
   }
-  // Fire-and-forget read receipt (handles its own errors); don't delay forward.
-  markRead(space, message);
+  // Fire-and-forget read receipt (bounded; handles its own errors).
+  markReadBounded(space, message);
   cacheMessage(message); // so /react can resolve this as a tapback target
   const content = message?.content || {};
 
@@ -381,18 +397,31 @@ async function handleInbound(space, message) {
   return forwardInbound(message);
 }
 
+// spectrum-ts handles in-session gRPC reconnects internally, but if the async
+// iterator itself throws or ends, the consumer would stop forever. Wrap it in a
+// re-subscribe loop with capped exponential backoff + jitter so inbound always
+// recovers (dedup makes any catch-up replay idempotent).
 (async () => {
-  try {
-    for await (const [space, message] of app.messages) {
-      if (space?.id) setSpace(space.id, space);
-      if (message?.space?.id && space) setSpace(message.space.id, space);
-      schedule(() => handleInbound(space, message));
+  let backoff = 1000;
+  for (;;) {
+    try {
+      for await (const [space, message] of app.messages) {
+        backoff = 1000; // healthy traffic — reset
+        if (space?.id) setSpace(space.id, space);
+        if (message?.space?.id && space) setSpace(message.space.id, space);
+        schedule(() => handleInbound(space, message));
+      }
+      console.error("photon-sidecar: inbound stream ended — re-subscribing");
+    } catch (e) {
+      console.error(
+        "photon-sidecar: inbound stream errored — restarting: " +
+          (e && e.message ? e.message : String(e))
+      );
     }
-  } catch (e) {
-    console.error(
-      "photon-sidecar: inbound stream errored: " +
-        (e && e.stack ? e.stack : String(e))
+    await new Promise((r) =>
+      setTimeout(r, backoff + Math.random() * backoff * 0.2)
     );
+    backoff = Math.min(backoff * 2, 30000);
   }
 })();
 

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -85,6 +85,27 @@ const app = await Spectrum({
   providers: [imessage.config()],
 });
 
+// The spectrum-ts iMessage provider instance bound to this app. Exposes the
+// high-level actions we use: space()/user() resolution and read receipts.
+const provider = imessage(app);
+
+// Send read receipts for inbound messages we handle (so the human sees
+// Delivered → Read). On by default; set PHOTON_READ_RECEIPTS=false to disable.
+const SEND_READ_RECEIPTS =
+  (process.env.PHOTON_READ_RECEIPTS || "true").toLowerCase() !== "false";
+
+async function markRead(space, message) {
+  if (!SEND_READ_RECEIPTS || typeof provider.read !== "function") return;
+  try {
+    await provider.read(space, message);
+  } catch (e) {
+    // Best-effort — SMS/some services don't support read receipts.
+    console.error(
+      "photon-sidecar: read receipt failed: " + (e && e.message ? e.message : e)
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Inbound bridge (sidecar -> adapter).
 //
@@ -229,6 +250,8 @@ async function handleInbound(space, message) {
     console.error(`photon-sidecar: drop non-allowlisted sender ${from}`);
     return;
   }
+  // Fire-and-forget read receipt (handles its own errors); don't delay forward.
+  markRead(space, message);
   const content = message?.content || {};
 
   if (content.type === "attachment" && typeof content.stream === "function") {
@@ -364,8 +387,7 @@ async function resolveSpace(spaceId) {
   if (cached) return cached;
   const dm = spaceId.match(/;-;(\+\d+)/);
   if (dm) {
-    const im = imessage(app);
-    const space = await im.space(await im.user({ phone: dm[1] }));
+    const space = await provider.space(await provider.user({ phone: dm[1] }));
     spaceCache.set(spaceId, space);
     return space;
   }

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -1,10 +1,13 @@
 // Hermes Agent — Photon Spectrum sidecar
 //
-// Spawned by `plugins/platforms/photon/adapter.py` to bridge outbound
-// messaging to Photon's Spectrum platform. Inbound messages go directly
-// from Photon's webhook to Hermes' Python aiohttp receiver — this
-// sidecar handles ONLY outbound calls (which require the spectrum-ts
-// SDK because Photon has no public HTTP send endpoint today).
+// Spawned by `plugins/platforms/photon/adapter.py` to bridge messaging to
+// Photon's Spectrum platform. Outbound calls require the spectrum-ts SDK
+// (Photon has no public HTTP send endpoint today). Inbound is bridged here too:
+// the sidecar consumes spectrum-ts' `app.messages` gRPC stream and forwards
+// each message to the adapter's loopback webhook — necessary because attachment
+// bytes are only reachable from this Node process (the SDK's read()/stream()
+// closures are lost on JSON serialization), so the sidecar downloads them to a
+// temp file and forwards the local path.
 //
 // Protocol:
 //   - The sidecar listens on http://127.0.0.1:${PORT} (loopback only)
@@ -35,6 +38,13 @@
 //                         honours it)
 
 import http from "node:http";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
 
 const projectId = process.env.PHOTON_PROJECT_ID;
 const projectSecret = process.env.PHOTON_PROJECT_SECRET;
@@ -71,17 +81,200 @@ const app = await Spectrum({
   providers: [imessage.config()],
 });
 
-// Drain the inbound stream — Photon's webhook is the canonical inbound path,
-// but we still consume `app.messages` so spectrum-ts' reconnect/heartbeat logic
-// keeps running.  We also cache each live Space here: spectrum-ts removed the
-// `app.space(id)` lookup, so outbound replies resolve their Space from this
-// cache (an outbound reply always follows an inbound that populated it).
+// ---------------------------------------------------------------------------
+// Inbound bridge (sidecar -> adapter).
+//
+// We consume spectrum-ts' `app.messages` gRPC stream and forward each inbound
+// message to the adapter's loopback webhook in the `{event:"messages", message}`
+// shape it parses. We MUST do this here (not let Photon's cloud webhook deliver
+// inbound) for attachments: spectrum-ts hands attachment content as an
+// `asAttachment({ read(), stream() })` object whose byte-fetching closures are
+// LOST the moment the message is JSON-serialized. So the bytes are only
+// reachable from this Node process — we stream them to a temp file and forward
+// the local path. The same loop also caches each live Space so outbound replies
+// can resolve a real Space from just its id (spectrum-ts 1.x removed
+// `app.space(id)`).
+// ---------------------------------------------------------------------------
 const spaceCache = new Map();
+
+const WEBHOOK_HOST = "127.0.0.1"; // sidecar -> adapter is always loopback
+const WEBHOOK_PORT = parseInt(process.env.PHOTON_WEBHOOK_PORT || "8788", 10);
+const WEBHOOK_PATH = process.env.PHOTON_WEBHOOK_PATH || "/photon/webhook";
+const WEBHOOK_SECRET = process.env.PHOTON_WEBHOOK_SECRET || "";
+const ALLOW = new Set(
+  (process.env.PHOTON_ALLOWED_USERS || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+);
+const DOWNLOAD_DIR = path.join(os.tmpdir(), "photon-attachments");
+
+const senderId = (m) =>
+  typeof m?.sender?.id === "string"
+    ? m.sender.id
+    : m?.sender?.id?.phone || m?.sender?.phone || "";
+
+// In-memory dedup (the adapter dedups too; this is belt-and-suspenders and also
+// covers the spectrum reconnect/catch-up replay that re-emits recent messages).
+const _seen = new Map();
+const _DEDUP_MAX = 5000;
+const _DEDUP_TTL_MS = 10 * 60 * 1000;
+function isDuplicate(id) {
+  const now = Date.now();
+  if (_seen.size > _DEDUP_MAX) {
+    for (const [k, t] of _seen) if (now - t > _DEDUP_TTL_MS) _seen.delete(k);
+  }
+  if (_seen.has(id)) return true;
+  _seen.set(id, now);
+  return false;
+}
+
+// Bounded-concurrency scheduler so a slow attachment download (large video)
+// never head-of-line-blocks the message loop or other senders' messages.
+const MAX_INFLIGHT = 8;
+let _active = 0;
+const _queue = [];
+function schedule(fn) {
+  _queue.push(fn);
+  pump();
+}
+function pump() {
+  while (_active < MAX_INFLIGHT && _queue.length) {
+    const fn = _queue.shift();
+    _active++;
+    Promise.resolve()
+      .then(fn)
+      .catch((e) =>
+        console.error(
+          "photon-sidecar: inbound task error: " + (e && e.stack ? e.stack : e)
+        )
+      )
+      .finally(() => {
+        _active--;
+        pump();
+      });
+  }
+}
+
+// Stream an inbound attachment's bytes to a temp file: write to `<final>.part`,
+// verify the received byte count against the declared size, then atomically
+// rename into place. Partial files are unlinked on any failure.
+async function downloadAttachmentToFile(content) {
+  await fsp.mkdir(DOWNLOAD_DIR, { recursive: true });
+  const guid = content.id || crypto.randomUUID();
+  const safeName = String(content.name || guid).replace(/[^\w.\-]+/g, "_");
+  const finalPath = path.join(DOWNLOAD_DIR, `${guid}-${safeName}`);
+  const partPath = `${finalPath}.part`;
+  let received = 0;
+  try {
+    // `stream()` yields a WHATWG ReadableStream of the primaryChunk bytes.
+    const webStream = await content.stream();
+    const nodeReadable = Readable.fromWeb(webStream);
+    nodeReadable.on("data", (c) => {
+      received += c.length;
+    });
+    await pipeline(nodeReadable, fs.createWriteStream(partPath));
+    if (
+      typeof content.size === "number" &&
+      content.size > 0 &&
+      received !== content.size
+    ) {
+      throw new Error(
+        `byte-count mismatch: received ${received}, declared ${content.size}`
+      );
+    }
+    await fsp.rename(partPath, finalPath);
+    return { localPath: finalPath, bytes: received };
+  } catch (e) {
+    await fsp.rm(partPath, { force: true }).catch(() => {});
+    throw e;
+  }
+}
+
+async function forwardInbound(message) {
+  const url = `http://${WEBHOOK_HOST}:${WEBHOOK_PORT}${WEBHOOK_PATH}`;
+  const bodyStr = JSON.stringify({ event: "messages", message });
+  const headers = { "Content-Type": "application/json" };
+  // Sign when a webhook secret is configured so the adapter's verify_signature
+  // accepts the loopback delivery: v0=HMAC_SHA256(secret, "v0:{ts}:{body}").
+  if (WEBHOOK_SECRET) {
+    const ts = Math.floor(Date.now() / 1000).toString();
+    const sig =
+      "v0=" +
+      crypto
+        .createHmac("sha256", WEBHOOK_SECRET)
+        .update(`v0:${ts}:${bodyStr}`)
+        .digest("hex");
+    headers["X-Spectrum-Timestamp"] = ts;
+    headers["X-Spectrum-Signature"] = sig;
+  }
+  try {
+    await fetch(url, { method: "POST", headers, body: bodyStr });
+  } catch (e) {
+    console.error(
+      "photon-sidecar: inbound forward failed: " + (e && e.message ? e.message : e)
+    );
+  }
+}
+
+async function handleInbound(space, message) {
+  const id = message?.id;
+  if (!id || isDuplicate(id)) return;
+  const from = senderId(message);
+  if (ALLOW.size && from && !ALLOW.has(from)) {
+    console.error(`photon-sidecar: drop non-allowlisted sender ${from}`);
+    return;
+  }
+  const content = message?.content || {};
+
+  if (content.type === "attachment" && typeof content.stream === "function") {
+    // Download here — the read()/stream() closures cannot survive JSON.
+    let localPath = null;
+    let bytes = null;
+    try {
+      ({ localPath, bytes } = await downloadAttachmentToFile(content));
+    } catch (e) {
+      console.error(
+        `photon-sidecar: attachment download failed for ${id}: ` +
+          (e && e.message ? e.message : e)
+      );
+    }
+    return forwardInbound({
+      ...message,
+      content: {
+        type: "attachment",
+        id: content.id,
+        name: content.name,
+        mimeType: content.mimeType,
+        size: content.size,
+        localPath,
+        bytes,
+      },
+    });
+  }
+
+  if (content.type === "reaction") {
+    // Tapback / emoji reaction — forward so the adapter can surface it.
+    return forwardInbound({
+      ...message,
+      content: {
+        type: "reaction",
+        emoji: content.emoji,
+        target: content.target,
+      },
+    });
+  }
+
+  // text / other — JSON.stringify silently drops any non-serializable fields.
+  return forwardInbound(message);
+}
+
 (async () => {
   try {
     for await (const [space, message] of app.messages) {
       if (space?.id) spaceCache.set(space.id, space);
       if (message?.space?.id && space) spaceCache.set(message.space.id, space);
+      schedule(() => handleInbound(space, message));
     }
   } catch (e) {
     console.error(

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -25,6 +25,8 @@
 //              "caption": "..." | null, "pacingMs": 600 | null}
 //   - POST /typing                      -> {"ok": true}
 //       body: {"spaceId": "...", "state": "start" | "stop"}
+//   - POST /react                       -> {"ok": true}
+//       body: {"spaceId": "...", "targetMessageId": "...", "reaction": "👍"}
 //   - POST /shutdown                    -> {"ok": true}; then process exits
 //
 // On SIGINT/SIGTERM the sidecar calls `app.stop()` (3s graceful) before
@@ -66,9 +68,9 @@ if (!projectId || !projectSecret || !sharedToken) {
 
 // Lazy-load spectrum-ts so a missing install fails with a clear message
 // instead of a cryptic module-resolution error during import.
-let Spectrum, imessage, attachment, voice, effect, typing;
+let Spectrum, imessage, attachment, voice, effect, typing, reaction;
 try {
-  ({ Spectrum, attachment, voice, typing } = await import("spectrum-ts"));
+  ({ Spectrum, attachment, voice, typing, reaction } = await import("spectrum-ts"));
   ({ imessage, effect } = await import("spectrum-ts/providers/imessage"));
 } catch (e) {
   console.error(
@@ -162,6 +164,20 @@ function isDuplicate(id) {
   if (_seen.has(id)) return true;
   _seen.set(id, now);
   return false;
+}
+
+// Recent inbound messages by id. The reaction() builder needs the full target
+// Message (it validates `isMessage` and reads `target.content.type`), not just
+// an id — so /react resolves the message object from here (the ack flow always
+// reacts to a message we just received and cached).
+const _msgCache = new Map();
+const _MSG_CACHE_MAX = 500;
+function cacheMessage(message) {
+  if (!message?.id) return;
+  if (_msgCache.size >= _MSG_CACHE_MAX) {
+    _msgCache.delete(_msgCache.keys().next().value);
+  }
+  _msgCache.set(message.id, message);
 }
 
 // Bounded-concurrency scheduler so a slow attachment download (large video)
@@ -262,6 +278,7 @@ async function handleInbound(space, message) {
   }
   // Fire-and-forget read receipt (handles its own errors); don't delay forward.
   markRead(space, message);
+  cacheMessage(message); // so /react can resolve this as a tapback target
   const content = message?.content || {};
 
   if (content.type === "attachment" && typeof content.stream === "function") {
@@ -468,10 +485,11 @@ const server = http.createServer(async (req, res) => {
       const space = await resolveSpace(spaceId);
 
       // spectrum-ts infers name + MIME from the file extension; pass
-      // overrides only when Hermes supplied them so a known-good
-      // inference isn't clobbered with an empty string. Images/GIFs/videos and
-      // arbitrary files (PDFs, docs) all go through the same builder and render
-      // natively; a sticker is just a (sticker-sized) image attachment.
+      // overrides only when Hermes supplied them so a known-good inference
+      // isn't clobbered with an empty string. Images/GIFs/videos and voice
+      // (kind="voice") render natively; a sticker is just a (sticker-sized)
+      // image attachment. (Documents/PDFs aren't a reliable send over this
+      // line, so there's no send_document override on the adapter.)
       const opts = {};
       if (name) opts.name = name;
       if (mimeType) opts.mimeType = mimeType;
@@ -548,6 +566,38 @@ const server = http.createServer(async (req, res) => {
             (e && e.message ? e.message : e)
         );
       }
+      return ok(res, {});
+    }
+    if (req.url === "/react") {
+      // Bot -> user tapback. `reaction(emoji, target)` resolves to
+      // `messages.setReaction(...)`; native tapbacks (❤️👍👎😂‼️❓) map to
+      // Apple's tapback kinds, any other emoji is sent as an emoji reaction
+      // (iOS 18+). `targetMessageId` is the guid of the message to react to.
+      const { spaceId, targetMessageId, reaction: emoji } = body || {};
+      if (!spaceId || !targetMessageId || !emoji) {
+        return badRequest(
+          res,
+          "spaceId, targetMessageId and reaction are required"
+        );
+      }
+      const space = await resolveSpace(spaceId);
+      // reaction() needs the full target Message. Prefer the cached inbound
+      // message; fall back to fetching it by id from the provider.
+      let target = _msgCache.get(targetMessageId);
+      if (!target && typeof provider.getMessage === "function") {
+        try {
+          target = await provider.getMessage(space, targetMessageId);
+        } catch (e) {
+          console.error(
+            "photon-sidecar: getMessage(" + targetMessageId + ") failed: " +
+              (e && e.message ? e.message : e)
+          );
+        }
+      }
+      if (!target) {
+        return badRequest(res, "target message not found");
+      }
+      await withRetry(() => space.send(reaction(emoji, target)));
       return ok(res, {});
     }
     res.statusCode = 404;

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -291,7 +291,13 @@ async function forwardInbound(message) {
     headers["X-Spectrum-Signature"] = sig;
   }
   try {
-    await fetch(url, { method: "POST", headers, body: bodyStr });
+    // Bound the forward so a hung adapter webhook can't pin a concurrency slot.
+    await fetch(url, {
+      method: "POST",
+      headers,
+      body: bodyStr,
+      signal: AbortSignal.timeout(10000),
+    });
   } catch (e) {
     console.error(
       "photon-sidecar: inbound forward failed: " + (e && e.message ? e.message : e)
@@ -382,9 +388,21 @@ async function handleInbound(space, message) {
   }
 })();
 
+// Control/metadata messages are tiny; cap the body so a compromised local peer
+// can't OOM the sidecar by streaming an unbounded request (defence-in-depth on
+// the loopback channel).
+const MAX_BODY_BYTES = 2 * 1024 * 1024; // 2 MiB
 async function readBody(req) {
   const chunks = [];
-  for await (const chunk of req) chunks.push(chunk);
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > MAX_BODY_BYTES) {
+      req.destroy();
+      throw new Error("request body too large");
+    }
+    chunks.push(chunk);
+  }
   const raw = Buffer.concat(chunks).toString("utf-8");
   if (!raw) return {};
   try {
@@ -667,6 +685,39 @@ server.listen(port, bind, () => {
   console.error(`photon-sidecar: listening on ${bind}:${port}`);
 });
 
+// Age-based sweeper for downloaded attachments — they're consumed by the agent
+// within seconds, so anything older than the TTL is safe to delete. Keeps the
+// download dir from growing without bound (the OS tmp reaper is only a backstop).
+const ATTACH_TTL_MS = parseInt(
+  process.env.PHOTON_ATTACHMENT_TTL_MS || "3600000", // 1h
+  10
+);
+async function sweepDownloads() {
+  let names;
+  try {
+    names = await fsp.readdir(DOWNLOAD_DIR);
+  } catch {
+    return; // dir not created yet
+  }
+  const now = Date.now();
+  for (const name of names) {
+    const fp = path.join(DOWNLOAD_DIR, name);
+    try {
+      const st = await fsp.stat(fp);
+      if (now - st.mtimeMs > ATTACH_TTL_MS) {
+        await fsp.rm(fp, { force: true, recursive: true });
+      }
+    } catch {
+      /* raced with another delete / vanished — ignore */
+    }
+  }
+}
+setInterval(() => {
+  sweepDownloads().catch((e) =>
+    console.error("photon-sidecar: sweep error: " + (e && e.message ? e.message : e))
+  );
+}, 10 * 60 * 1000).unref(); // every 10 min, don't keep the process alive
+
 async function shutdown(signal) {
   console.error(`photon-sidecar: received ${signal}, stopping...`);
   try {
@@ -683,3 +734,13 @@ async function shutdown(signal) {
 
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));
+
+// Don't let a stray promise rejection take the process down silently — inbound
+// handlers already catch their own errors, so log and keep serving. (Python
+// supervises and restarts on a real fatal exit.)
+process.on("unhandledRejection", (reason) => {
+  console.error(
+    "photon-sidecar: unhandledRejection: " +
+      (reason && reason.stack ? reason.stack : String(reason))
+  );
+});

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -169,6 +169,12 @@ const senderId = (m) =>
     ? m.sender.id
     : m?.sender?.id?.phone || m?.sender?.phone || "";
 
+// Mask a phone/handle for logs — keep enough to debug, never the full PII.
+const maskHandle = (h) => {
+  const s = String(h || "");
+  return s.length <= 6 ? "***" : `${s.slice(0, 3)}***${s.slice(-2)}`;
+};
+
 // In-memory dedup (the adapter dedups too; this is belt-and-suspenders and also
 // covers the spectrum reconnect/catch-up replay that re-emits recent messages).
 const _seen = new Map();
@@ -310,7 +316,9 @@ async function handleInbound(space, message) {
   if (!id || isDuplicate(id)) return;
   const from = senderId(message);
   if (ALLOW.size && from && !ALLOW.has(from)) {
-    console.error(`photon-sidecar: drop non-allowlisted sender ${from}`);
+    console.error(
+      `photon-sidecar: drop non-allowlisted sender ${maskHandle(from)}`
+    );
     return;
   }
   // Fire-and-forget read receipt (handles its own errors); don't delay forward.

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -14,11 +14,15 @@
 //   - Each request must include `X-Hermes-Sidecar-Token: ${TOKEN}`
 //   - POST /healthz                     -> {"ok": true}
 //   - POST /send                        -> {"ok": true, "messageId": "..."}
-//       body: {"spaceId": "...", "text": "...", "replyTo": "..." | null}
+//       body: {"spaceId": "...", "text": "...", "effect": "confetti" | null}
+//       (a URL in `text` renders a native link preview automatically)
 //   - POST /send-attachment             -> {"ok": true, "messageId": "..."}
 //       body: {"spaceId": "...", "path": "...", "name": "..." | null,
 //              "mimeType": "..." | null, "caption": "..." | null,
-//              "kind": "attachment" | "voice", "replyTo": "..." | null}
+//              "kind": "attachment" | "voice", "effect": "slam" | null}
+//   - POST /send-attachments            -> {"ok": true, "messageIds": [...]}
+//       body: {"spaceId": "...", "paths": ["...", ...],
+//              "caption": "..." | null, "pacingMs": 600 | null}
 //   - POST /typing                      -> {"ok": true}
 //       body: {"spaceId": "..."}
 //   - POST /shutdown                    -> {"ok": true}; then process exits
@@ -62,10 +66,10 @@ if (!projectId || !projectSecret || !sharedToken) {
 
 // Lazy-load spectrum-ts so a missing install fails with a clear message
 // instead of a cryptic module-resolution error during import.
-let Spectrum, imessage, attachment, voice;
+let Spectrum, imessage, attachment, voice, effect;
 try {
   ({ Spectrum, attachment, voice } = await import("spectrum-ts"));
-  ({ imessage } = await import("spectrum-ts/providers/imessage"));
+  ({ imessage, effect } = await import("spectrum-ts/providers/imessage"));
 } catch (e) {
   console.error(
     "photon-sidecar: spectrum-ts is not installed. Run `npm install` " +
@@ -368,6 +372,25 @@ async function resolveSpace(spaceId) {
   throw new Error(`unable to resolve space id ${spaceId}`);
 }
 
+// Resolve a friendly screen/bubble effect name (e.g. "confetti", "slam",
+// "invisible") to Apple's reverse-DNS effect id. Names + ids come straight from
+// the provider's own effect map so we never hardcode the (long, churn-prone)
+// identifiers. Returns null for an unknown/empty name (send proceeds without
+// an effect rather than failing the message).
+function resolveEffect(name) {
+  if (!name) return null;
+  const map = (imessage && imessage.effect && imessage.effect.message) || {};
+  const id = map[String(name).trim().toLowerCase()];
+  if (!id) console.error(`photon-sidecar: unknown effect "${name}" — ignoring`);
+  return id || null;
+}
+
+// Wrap outgoing content with an effect when one was requested and resolved.
+function withEffect(content, effectName) {
+  const id = resolveEffect(effectName);
+  return id && typeof effect === "function" ? effect(content, id) : content;
+}
+
 const server = http.createServer(async (req, res) => {
   if (req.headers["x-hermes-sidecar-token"] !== sharedToken) {
     return unauthorized(res);
@@ -387,7 +410,7 @@ const server = http.createServer(async (req, res) => {
     }
     const body = await readBody(req);
     if (req.url === "/send") {
-      const { spaceId, text } = body || {};
+      const { spaceId, text, effect: effectName } = body || {};
       if (!spaceId || typeof text !== "string") {
         return badRequest(res, "spaceId and text are required");
       }
@@ -396,11 +419,17 @@ const server = http.createServer(async (req, res) => {
       // treated as a second content item and throws `c.build is not a function`.
       // Threaded replies in 1.x need the reply() builder + the original Message,
       // which the adapter doesn't hand us, so replyTo is not forwarded here.
-      const result = await withRetry(() => space.send(text));
+      //
+      // Plain URLs in `text` get native iMessage link previews automatically
+      // (Apple's client renders the Open Graph card), so no special handling is
+      // needed for rich links. An optional `effect` applies a screen/bubble
+      // effect (confetti, slam, invisible ink, …).
+      const result = await withRetry(() => space.send(withEffect(text, effectName)));
       return ok(res, { messageId: result?.id || result?.messageId || null });
     }
     if (req.url === "/send-attachment") {
-      const { spaceId, path, name, mimeType, caption, kind } = body || {};
+      const { spaceId, path, name, mimeType, caption, kind, effect: effectName } =
+        body || {};
       if (!spaceId || typeof path !== "string" || !path) {
         return badRequest(res, "spaceId and path are required");
       }
@@ -408,7 +437,9 @@ const server = http.createServer(async (req, res) => {
 
       // spectrum-ts infers name + MIME from the file extension; pass
       // overrides only when Hermes supplied them so a known-good
-      // inference isn't clobbered with an empty string.
+      // inference isn't clobbered with an empty string. Images/GIFs/videos and
+      // arbitrary files (PDFs, docs) all go through the same builder and render
+      // natively; a sticker is just a (sticker-sized) image attachment.
       const opts = {};
       if (name) opts.name = name;
       if (mimeType) opts.mimeType = mimeType;
@@ -417,7 +448,7 @@ const server = http.createServer(async (req, res) => {
           ? voice(path, Object.keys(opts).length ? opts : undefined)
           : attachment(path, Object.keys(opts).length ? opts : undefined);
 
-      const result = await withRetry(() => space.send(builder));
+      const result = await withRetry(() => space.send(withEffect(builder, effectName)));
 
       // iMessage delivers the caption as a separate bubble; send it
       // after the media so the attachment renders first.
@@ -432,6 +463,39 @@ const server = http.createServer(async (req, res) => {
         }
       }
       return ok(res, { messageId: result?.id || result?.messageId || null });
+    }
+    if (req.url === "/send-attachments") {
+      // Multiple files in one logical send. iMessage has no atomic multi-file
+      // bubble over this path, so we send them sequentially with a short pace
+      // between each (back-to-back sends can arrive out of order or get
+      // coalesced); `pacingMs` overrides the default.
+      const { spaceId, paths, caption, pacingMs } = body || {};
+      if (!spaceId || !Array.isArray(paths) || paths.length === 0) {
+        return badRequest(res, "spaceId and a non-empty paths[] are required");
+      }
+      const space = await resolveSpace(spaceId);
+      const delay = Number.isFinite(pacingMs) ? Math.max(0, pacingMs) : 600;
+      const messageIds = [];
+      for (let i = 0; i < paths.length; i++) {
+        const p = paths[i];
+        if (typeof p !== "string" || !p) continue;
+        const r = await withRetry(() => space.send(attachment(p)));
+        messageIds.push(r?.id || r?.messageId || null);
+        if (i < paths.length - 1 && delay) {
+          await new Promise((rs) => setTimeout(rs, delay));
+        }
+      }
+      if (caption && typeof caption === "string") {
+        try {
+          await withRetry(() => space.send(caption));
+        } catch (e) {
+          console.error(
+            "photon-sidecar: multi-attachment caption failed: " +
+              (e && e.stack ? e.stack : String(e))
+          );
+        }
+      }
+      return ok(res, { messageIds });
     }
     if (req.url === "/typing") {
       const { spaceId } = body || {};

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -510,8 +510,18 @@ function withEffect(content, effectName) {
   return id && typeof effect === "function" ? effect(content, id) : content;
 }
 
+// Constant-time token comparison (don't leak the token via `!==` timing).
+const _tokenBuf = Buffer.from(sharedToken);
+function tokenOk(header) {
+  if (typeof header !== "string") return false;
+  const h = Buffer.from(header);
+  // Length check first — timingSafeEqual throws on length mismatch; the token
+  // length is not secret.
+  return h.length === _tokenBuf.length && crypto.timingSafeEqual(h, _tokenBuf);
+}
+
 const server = http.createServer(async (req, res) => {
-  if (req.headers["x-hermes-sidecar-token"] !== sharedToken) {
+  if (!tokenOk(req.headers["x-hermes-sidecar-token"])) {
     return unauthorized(res);
   }
   if (req.method !== "POST") {

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -145,6 +145,13 @@ const ALLOW = new Set(
     .filter(Boolean)
 );
 const DOWNLOAD_DIR = path.join(os.tmpdir(), "photon-attachments");
+// Cap inbound attachment downloads so a large video (downloaded over a slow
+// gRPC stream) can't block the message — and the agent's ack/reply — for
+// minutes. Oversized attachments forward as metadata-only with a note.
+const MAX_ATTACH_BYTES =
+  parseInt(process.env.PHOTON_MAX_ATTACHMENT_MB || "32", 10) * 1024 * 1024;
+const DOWNLOAD_TIMEOUT_MS =
+  parseInt(process.env.PHOTON_DOWNLOAD_TIMEOUT_MS || "120000", 10);
 
 const senderId = (m) =>
   typeof m?.sender?.id === "string"
@@ -217,6 +224,8 @@ async function downloadAttachmentToFile(content) {
   const finalPath = path.join(DOWNLOAD_DIR, `${guid}-${safeName}`);
   const partPath = `${finalPath}.part`;
   let received = 0;
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), DOWNLOAD_TIMEOUT_MS);
   try {
     // `stream()` yields a WHATWG ReadableStream of the primaryChunk bytes.
     const webStream = await content.stream();
@@ -224,7 +233,9 @@ async function downloadAttachmentToFile(content) {
     nodeReadable.on("data", (c) => {
       received += c.length;
     });
-    await pipeline(nodeReadable, fs.createWriteStream(partPath));
+    await pipeline(nodeReadable, fs.createWriteStream(partPath), {
+      signal: ac.signal,
+    });
     if (
       typeof content.size === "number" &&
       content.size > 0 &&
@@ -239,6 +250,8 @@ async function downloadAttachmentToFile(content) {
   } catch (e) {
     await fsp.rm(partPath, { force: true }).catch(() => {});
     throw e;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -285,13 +298,25 @@ async function handleInbound(space, message) {
     // Download here — the read()/stream() closures cannot survive JSON.
     let localPath = null;
     let bytes = null;
-    try {
-      ({ localPath, bytes } = await downloadAttachmentToFile(content));
-    } catch (e) {
+    let tooLarge = false;
+    if (typeof content.size === "number" && content.size > MAX_ATTACH_BYTES) {
+      // Skip the download entirely so a huge clip never blocks the agent's
+      // ack/reply; forward metadata-only with a flag so the user still gets a
+      // prompt response.
+      tooLarge = true;
       console.error(
-        `photon-sidecar: attachment download failed for ${id}: ` +
-          (e && e.message ? e.message : e)
+        `photon-sidecar: attachment ${id} too large ` +
+          `(${content.size} > ${MAX_ATTACH_BYTES}) — forwarding metadata only`
       );
+    } else {
+      try {
+        ({ localPath, bytes } = await downloadAttachmentToFile(content));
+      } catch (e) {
+        console.error(
+          `photon-sidecar: attachment download failed for ${id}: ` +
+            (e && e.message ? e.message : e)
+        );
+      }
     }
     return forwardInbound({
       ...message,
@@ -303,6 +328,7 @@ async function handleInbound(space, message) {
         size: content.size,
         localPath,
         bytes,
+        tooLarge,
       },
     });
   }

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -71,17 +71,17 @@ const app = await Spectrum({
   providers: [imessage.config()],
 });
 
-// Drain the inbound stream — Photon's webhook is the canonical inbound
-// path, but we still consume `app.messages` so spectrum-ts' internal
-// reconnect/heartbeat logic keeps running.  Each event is logged at
-// debug level; everything else is a no-op here.
+// Drain the inbound stream — Photon's webhook is the canonical inbound path,
+// but we still consume `app.messages` so spectrum-ts' reconnect/heartbeat logic
+// keeps running.  We also cache each live Space here: spectrum-ts removed the
+// `app.space(id)` lookup, so outbound replies resolve their Space from this
+// cache (an outbound reply always follows an inbound that populated it).
+const spaceCache = new Map();
 (async () => {
   try {
-    for await (const [, message] of app.messages) {
-      console.error(
-        `photon-sidecar: drained inbound from ${message.platform} ` +
-          `space=${message.space?.id}`
-      );
+    for await (const [space, message] of app.messages) {
+      if (space?.id) spaceCache.set(space.id, space);
+      if (message?.space?.id && space) spaceCache.set(message.space.id, space);
     }
   } catch (e) {
     console.error(
@@ -130,26 +130,47 @@ function ok(res, data) {
   res.end(JSON.stringify({ ok: true, ...data }));
 }
 
-async function resolveSpace(spaceId) {
-  // spectrum-ts exposes the same Space methods via `app.space(spaceId)` /
-  // narrowed helpers; we fall back through a few accessor shapes to
-  // tolerate small SDK API drift.
-  if (typeof app.space === "function") {
-    return await app.space(spaceId);
-  }
-  if (app.spaces && typeof app.spaces.get === "function") {
-    return await app.spaces.get(spaceId);
-  }
-  // Last resort — the platform-narrowed helper.
-  if (imessage) {
-    const im = imessage(app);
-    if (typeof im.space === "function") {
-      try {
-        return await im.space({ id: spaceId });
-      } catch {
-        /* fall through */
-      }
+// Outbound sends occasionally race a gRPC channel that idled out while the
+// agent was thinking; Photon surfaces this as a one-off `Connection dropped` /
+// gRPC UNAVAILABLE. The next call re-establishes the channel, so retry such
+// transient failures with capped exponential backoff + jitter (the idiomatic
+// gRPC mitigation), and only for retryable codes — never for permanent ones
+// like PERMISSION_DENIED ("Target not allowed for this project").
+const _RETRYABLE_GRPC = new Set([14, 4, 8]); // UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED
+const _RETRYABLE_MSG =
+  /connection dropped|unavailable|deadline exceeded|resource exhausted|econnreset|socket hang up|goaway/i;
+const isTransient = (e) =>
+  _RETRYABLE_GRPC.has(e?.grpcCode) || _RETRYABLE_MSG.test(e?.message || "");
+
+async function withRetry(fn, { tries = 4, baseMs = 250, capMs = 4000 } = {}) {
+  let lastErr;
+  for (let i = 0; i < tries; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastErr = e;
+      if (i >= tries - 1 || !isTransient(e)) throw e;
+      const backoff = Math.min(baseMs * 2 ** i, capMs);
+      await new Promise((r) => setTimeout(r, backoff + Math.random() * backoff * 0.2));
     }
+  }
+  throw lastErr;
+}
+
+async function resolveSpace(spaceId) {
+  // spectrum-ts dropped the `app.space(id)` lookup, and `space.send()` needs a
+  // real resolved Space. Prefer the live Space cached from the inbound stream
+  // (an outbound reply always follows an inbound that populated the cache).
+  // Fall back for DMs by rebuilding the Space from the phone embedded in the id
+  // (iMessage DM ids are `any;-;+E164`).
+  const cached = spaceCache.get(spaceId);
+  if (cached) return cached;
+  const dm = spaceId.match(/;-;(\+\d+)/);
+  if (dm) {
+    const im = imessage(app);
+    const space = await im.space(await im.user({ phone: dm[1] }));
+    spaceCache.set(spaceId, space);
+    return space;
   }
   throw new Error(`unable to resolve space id ${spaceId}`);
 }
@@ -173,19 +194,20 @@ const server = http.createServer(async (req, res) => {
     }
     const body = await readBody(req);
     if (req.url === "/send") {
-      const { spaceId, text, replyTo } = body || {};
+      const { spaceId, text } = body || {};
       if (!spaceId || typeof text !== "string") {
         return badRequest(res, "spaceId and text are required");
       }
       const space = await resolveSpace(spaceId);
-      const result = replyTo
-        ? await space.send(text, { replyTo })
-        : await space.send(text);
+      // spectrum-ts send() is variadic-content: a positional options object is
+      // treated as a second content item and throws `c.build is not a function`.
+      // Threaded replies in 1.x need the reply() builder + the original Message,
+      // which the adapter doesn't hand us, so replyTo is not forwarded here.
+      const result = await withRetry(() => space.send(text));
       return ok(res, { messageId: result?.id || result?.messageId || null });
     }
     if (req.url === "/send-attachment") {
-      const { spaceId, path, name, mimeType, caption, kind, replyTo } =
-        body || {};
+      const { spaceId, path, name, mimeType, caption, kind } = body || {};
       if (!spaceId || typeof path !== "string" || !path) {
         return badRequest(res, "spaceId and path are required");
       }
@@ -202,16 +224,13 @@ const server = http.createServer(async (req, res) => {
           ? voice(path, Object.keys(opts).length ? opts : undefined)
           : attachment(path, Object.keys(opts).length ? opts : undefined);
 
-      const sendOpts = replyTo ? { replyTo } : undefined;
-      const result = sendOpts
-        ? await space.send(builder, sendOpts)
-        : await space.send(builder);
+      const result = await withRetry(() => space.send(builder));
 
       // iMessage delivers the caption as a separate bubble; send it
       // after the media so the attachment renders first.
       if (caption && typeof caption === "string") {
         try {
-          await space.send(caption);
+          await withRetry(() => space.send(caption));
         } catch (e) {
           console.error(
             "photon-sidecar: attachment sent but caption failed: " +

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -1,0 +1,1451 @@
+{
+  "name": "@hermes-agent/photon-sidecar",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@hermes-agent/photon-sidecar",
+      "version": "0.1.0",
+      "dependencies": {
+        "spectrum-ts": "^1.18.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.216.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.7.1",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/sdk-logs": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.216.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.216.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@parseaple/bplist": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@parseaple/typedstream": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@parseaple/bplist": "1.0.1"
+      }
+    },
+    "node_modules/@photon-ai/advanced-imessage": {
+      "version": "0.11.2",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.11.0",
+        "@grpc/grpc-js": "^1.12.6",
+        "nice-grpc": "^2.1.11",
+        "nice-grpc-common": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@photon-ai/imessage-kit": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@parseaple/typedstream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "better-sqlite3": "^12.5.0"
+      }
+    },
+    "node_modules/@photon-ai/otel": {
+      "version": "0.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/api-logs": "^0.216.0",
+        "@opentelemetry/context-async-hooks": "^2.7.1",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.216.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
+        "@opentelemetry/resources": "^2.7.1",
+        "@opentelemetry/sdk-logs": "^0.216.0",
+        "@opentelemetry/sdk-trace-base": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5 || ^6.0.0"
+      }
+    },
+    "node_modules/@photon-ai/proto": {
+      "version": "0.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "nice-grpc-common": "^2.0.3"
+      }
+    },
+    "node_modules/@photon-ai/slack": {
+      "version": "0.2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@grpc/grpc-js": "^1.14.3",
+        "nice-grpc": "^2.1.15",
+        "nice-grpc-common": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@photon-ai/whatsapp-business": {
+      "version": "0.1.1",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "long": "^5.3.2",
+        "nice-grpc": "^2.1.15",
+        "nice-grpc-common": "^2.0.3",
+        "protobufjs": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@repeaterjs/repeater": {
+      "version": "3.1.0",
+      "license": "MIT"
+    },
+    "node_modules/abort-controller-x": {
+      "version": "0.5.0",
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/better-grpc": {
+      "version": "0.3.2",
+      "license": "MIT",
+      "dependencies": {
+        "@msgpack/msgpack": "^3.1.2",
+        "async-mutex": "^0.5.0",
+        "it-pushable": "^3.2.3",
+        "nice-grpc": "^2.1.13",
+        "zod": "^4.1.12"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "license": "ISC"
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "license": "MIT"
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/foldline": {
+      "version": "1.1.0",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/it-pushable": {
+      "version": "3.2.4",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nice-grpc": {
+      "version": "2.1.16",
+      "license": "MIT",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.0",
+        "abort-controller-x": "^0.5.0",
+        "nice-grpc-common": "^2.0.3"
+      }
+    },
+    "node_modules/nice-grpc-common": {
+      "version": "2.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "ts-error": "^1.0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open-graph-scraper": {
+      "version": "6.11.0",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "cheerio": "^1.1.2",
+        "iconv-lite": "^0.7.0",
+        "undici": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
+      "integrity": "sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==",
+      "dependencies": {
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.3",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/spectrum-ts": {
+      "version": "1.18.0",
+      "license": "MIT",
+      "dependencies": {
+        "@photon-ai/advanced-imessage": "^0.11.0",
+        "@photon-ai/imessage-kit": "^3.0.0",
+        "@photon-ai/otel": "^0.1.1",
+        "@photon-ai/proto": "^0.2.4",
+        "@photon-ai/slack": "^0.2.0",
+        "@photon-ai/whatsapp-business": "^0.1.1",
+        "@repeaterjs/repeater": "^3.0.6",
+        "better-grpc": "^0.3.2",
+        "lru-cache": "^11.0.0",
+        "mime-types": "^3.0.1",
+        "nice-grpc": "^2.1.16",
+        "nice-grpc-common": "^2.0.2",
+        "open-graph-scraper": "^6.11.0",
+        "type-fest": "^5.4.1",
+        "vcf": "^2.1.2",
+        "zod": "^4.2.1"
+      },
+      "peerDependencies": {
+        "ffmpeg-static": "^5",
+        "typescript": "^5 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ffmpeg-static": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ts-error": {
+      "version": "1.0.6",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.7.0",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.27.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/vcf": {
+      "version": "2.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "foldline": "^1.1.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -13,5 +13,12 @@
   },
   "dependencies": {
     "spectrum-ts": "^1.18.0"
+  },
+  "overrides": {
+    "protobufjs": "8.6.1",
+    "@opentelemetry/otlp-transformer": "0.218.0",
+    "@opentelemetry/otlp-exporter-base": "0.218.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.218.0",
+    "@opentelemetry/exporter-logs-otlp-http": "0.218.0"
   }
 }

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -9,9 +9,9 @@
     "start": "node index.mjs"
   },
   "engines": {
-    "node": ">=18.17"
+    "node": ">=20"
   },
   "dependencies": {
-    "spectrum-ts": "^0.1.0"
+    "spectrum-ts": "^1.18.0"
   }
 }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "philipadsouza@gmail.com": "PhilipAD",
     "raysun12142006@gmail.com": "yanxue06",
     "alberto.regalado@ymail.com": "ARegalado1",
     "alchemistchaos@protonmail.com": "AlchemistChaos",  # co-author only

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -130,6 +130,7 @@ async def test_dispatch_attachment_with_local_path(
     """When the sidecar has downloaded the bytes and forwarded ``localPath``,
     the adapter surfaces the real file via ``media_urls`` (vision-tool access)
     instead of the metadata-only marker."""
+    monkeypatch.setenv("PHOTON_DOWNLOAD_DIR", str(tmp_path))
     adapter = _make_adapter(monkeypatch)
     captured: List[MessageEvent] = []
 
@@ -240,6 +241,7 @@ async def test_inbound_audio_maps_to_voice(
 ) -> None:
     """A voice memo (audio/*) must map to VOICE so the gateway transcribes it
     (AUDIO is the never-STT bucket)."""
+    monkeypatch.setenv("PHOTON_DOWNLOAD_DIR", str(tmp_path))
     adapter = _make_adapter(monkeypatch)
     captured: List[MessageEvent] = []
 
@@ -292,6 +294,7 @@ async def test_inbound_caf_voice_transcoded_to_wav(
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True,
     )
 
+    monkeypatch.setenv("PHOTON_DOWNLOAD_DIR", str(tmp_path))
     adapter = _make_adapter(monkeypatch)
     captured: List[MessageEvent] = []
 
@@ -347,6 +350,7 @@ async def test_inbound_video_extracts_frames_and_audio(
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True,
     )
 
+    monkeypatch.setenv("PHOTON_DOWNLOAD_DIR", str(tmp_path))
     adapter = _make_adapter(monkeypatch)
     captured: List[MessageEvent] = []
 
@@ -417,6 +421,42 @@ async def test_inbound_too_large_attachment_note(
     assert event.media_urls == []
     assert "too large" in event.text.lower()
     assert "60 MB" in event.text
+
+
+@pytest.mark.asyncio
+async def test_inbound_rejects_out_of_scope_localpath(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A forged localPath outside the sidecar download dir must NOT be handed to
+    the agent (no arbitrary-file read via media_urls)."""
+    adapter = _make_adapter(monkeypatch)
+    captured: List[MessageEvent] = []
+
+    async def fake_handle(event: MessageEvent) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+
+    payload = {
+        "event": "messages",
+        "message": {
+            "id": "spc-msg-evil",
+            "timestamp": "2026-05-14T19:06:32.000Z",
+            "sender": {"id": "+15551234567"},
+            "space": {"id": "any;-;+15551234567"},
+            "content": {
+                "type": "attachment",
+                "name": "passwd",
+                "mimeType": "text/plain",
+                "size": 100,
+                "localPath": "/etc/passwd",
+            },
+        },
+    }
+    await adapter._dispatch_inbound(payload)
+    event = captured[0]
+    assert event.media_urls == []
+    assert "/etc/passwd" not in (event.text or "")
 
 
 def test_is_duplicate_window(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -473,3 +473,11 @@ def test_check_requirements_without_node(monkeypatch: pytest.MonkeyPatch) -> Non
 
     monkeypatch.setattr(adapter_mod.shutil, "which", lambda _name: None)
     assert adapter_mod.check_requirements() is False
+
+
+def test_webhook_binds_loopback_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Secure-by-default: the inbound receiver must not be exposed to the network
+    # unless the operator explicitly opts in (the sidecar bridges over loopback).
+    monkeypatch.delenv("PHOTON_WEBHOOK_BIND", raising=False)
+    adapter = _make_adapter(monkeypatch)
+    assert adapter._webhook_bind == "127.0.0.1"

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -123,6 +123,117 @@ async def test_dispatch_attachment_surfaces_marker(
     assert event.message_type == MessageType.PHOTO
 
 
+@pytest.mark.asyncio
+async def test_dispatch_attachment_with_local_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """When the sidecar has downloaded the bytes and forwarded ``localPath``,
+    the adapter surfaces the real file via ``media_urls`` (vision-tool access)
+    instead of the metadata-only marker."""
+    adapter = _make_adapter(monkeypatch)
+    captured: List[MessageEvent] = []
+
+    async def fake_handle(event: MessageEvent) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+
+    img = tmp_path / "IMG_4127.jpg"
+    img.write_bytes(b"\xff\xd8\xff\xe0 jpeg bytes")
+
+    payload = {
+        "event": "messages",
+        "message": {
+            "id": "spc-msg-att-dl",
+            "timestamp": "2026-05-14T19:06:32.000Z",
+            "sender": {"id": "+15551234567"},
+            "space": {"id": "any;-;+15551234567"},
+            "content": {
+                "type": "attachment",
+                "name": "IMG_4127.jpg",
+                "mimeType": "image/jpeg",
+                "size": 12,
+                "localPath": str(img),
+            },
+        },
+    }
+    await adapter._dispatch_inbound(payload)
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.media_urls == [str(img)]
+    assert event.media_types == ["image/jpeg"]
+    assert event.message_type == MessageType.PHOTO
+    # No metadata marker once the real file is available.
+    assert "Photon attachment received" not in event.text
+
+
+@pytest.mark.asyncio
+async def test_dispatch_attachment_missing_local_path_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-existent ``localPath`` (download failed in the sidecar) falls back
+    to the metadata marker rather than handing the agent a dead path."""
+    adapter = _make_adapter(monkeypatch)
+    captured: List[MessageEvent] = []
+
+    async def fake_handle(event: MessageEvent) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+
+    payload = {
+        "event": "messages",
+        "message": {
+            "id": "spc-msg-att-fail",
+            "timestamp": "2026-05-14T19:06:32.000Z",
+            "sender": {"id": "+15551234567"},
+            "space": {"id": "any;-;+15551234567"},
+            "content": {
+                "type": "attachment",
+                "name": "IMG_4127.jpg",
+                "mimeType": "image/jpeg",
+                "size": 12,
+                "localPath": "/tmp/does-not-exist-xyz.jpg",
+            },
+        },
+    }
+    await adapter._dispatch_inbound(payload)
+    event = captured[0]
+    assert event.media_urls == []
+    assert "Photon attachment received" in event.text
+
+
+@pytest.mark.asyncio
+async def test_dispatch_reaction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tapback / emoji reactions arrive on the same stream and are surfaced."""
+    adapter = _make_adapter(monkeypatch)
+    captured: List[MessageEvent] = []
+
+    async def fake_handle(event: MessageEvent) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+
+    payload = {
+        "event": "messages",
+        "message": {
+            "id": "spc-msg-react",
+            "timestamp": "2026-05-14T19:06:32.000Z",
+            "sender": {"id": "+15551234567"},
+            "space": {"id": "any;-;+15551234567"},
+            "content": {
+                "type": "reaction",
+                "emoji": "❤️",
+                "target": "spc-msg-abc",
+            },
+        },
+    }
+    await adapter._dispatch_inbound(payload)
+    event = captured[0]
+    assert "❤️" in event.text
+    assert event.message_type == MessageType.TEXT
+
+
 def test_is_duplicate_window(monkeypatch: pytest.MonkeyPatch) -> None:
     adapter = _make_adapter(monkeypatch)
     assert adapter._is_duplicate("id-1") is False

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -234,6 +234,152 @@ async def test_dispatch_reaction(monkeypatch: pytest.MonkeyPatch) -> None:
     assert event.message_type == MessageType.TEXT
 
 
+@pytest.mark.asyncio
+async def test_inbound_audio_maps_to_voice(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """A voice memo (audio/*) must map to VOICE so the gateway transcribes it
+    (AUDIO is the never-STT bucket)."""
+    adapter = _make_adapter(monkeypatch)
+    captured: List[MessageEvent] = []
+
+    async def fake_handle(event: MessageEvent) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+
+    memo = tmp_path / "memo.caf"
+    memo.write_bytes(b"caf fake audio")
+    payload = {
+        "event": "messages",
+        "message": {
+            "id": "spc-msg-voice",
+            "timestamp": "2026-05-14T19:06:32.000Z",
+            "sender": {"id": "+15551234567"},
+            "space": {"id": "any;-;+15551234567"},
+            "content": {
+                "type": "attachment",
+                "name": "memo.caf",
+                "mimeType": "audio/x-caf",
+                "size": 14,
+                "localPath": str(memo),
+            },
+        },
+    }
+    await adapter._dispatch_inbound(payload)
+    event = captured[0]
+    assert event.message_type == MessageType.VOICE
+    assert event.media_urls == [str(memo)]
+
+
+@pytest.mark.asyncio
+async def test_inbound_caf_voice_transcoded_to_wav(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """An iMessage .caf voice memo (which arrives as application/octet-stream
+    and isn't an STT-accepted format) is typed VOICE and transcoded to .wav so
+    the gateway's transcription pipeline accepts it."""
+    import shutil
+    import subprocess
+
+    if not shutil.which("ffmpeg"):
+        pytest.skip("ffmpeg not available")
+
+    caf = tmp_path / "Audio Message.caf"
+    subprocess.run(
+        ["ffmpeg", "-y", "-f", "lavfi", "-i", "sine=frequency=440:duration=1",
+         str(caf)],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True,
+    )
+
+    adapter = _make_adapter(monkeypatch)
+    captured: List[MessageEvent] = []
+
+    async def fake_handle(event: MessageEvent) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+
+    payload = {
+        "event": "messages",
+        "message": {
+            "id": "spc-msg-caf",
+            "timestamp": "2026-05-14T19:06:32.000Z",
+            "sender": {"id": "+15551234567"},
+            "space": {"id": "any;-;+15551234567"},
+            "content": {
+                "type": "attachment",
+                "name": "Audio Message.caf",
+                "mimeType": "application/octet-stream",  # how iMessage delivers it
+                "size": caf.stat().st_size,
+                "localPath": str(caf),
+            },
+        },
+    }
+    await adapter._dispatch_inbound(payload)
+    event = captured[0]
+    assert event.message_type == MessageType.VOICE
+    assert len(event.media_urls) == 1
+    assert event.media_urls[0].endswith(".wav")
+    assert event.media_types == ["audio/wav"]
+
+
+@pytest.mark.asyncio
+async def test_inbound_video_extracts_frames_and_audio(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """An inbound video is normalized into keyframes (image/*) + audio track
+    (audio/*) so the existing vision + STT pipelines can consume it."""
+    import shutil
+    import subprocess
+
+    if not shutil.which("ffmpeg"):
+        pytest.skip("ffmpeg not available")
+
+    clip = tmp_path / "clip.mp4"
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-f", "lavfi",
+            "-i", "testsrc=duration=2:size=320x240:rate=10",
+            "-f", "lavfi", "-i", "sine=frequency=440:duration=2",
+            "-c:v", "libx264", "-c:a", "aac", "-shortest", str(clip),
+        ],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True,
+    )
+
+    adapter = _make_adapter(monkeypatch)
+    captured: List[MessageEvent] = []
+
+    async def fake_handle(event: MessageEvent) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+
+    payload = {
+        "event": "messages",
+        "message": {
+            "id": "spc-msg-video",
+            "timestamp": "2026-05-14T19:06:32.000Z",
+            "sender": {"id": "+15551234567"},
+            "space": {"id": "any;-;+15551234567"},
+            "content": {
+                "type": "attachment",
+                "name": "clip.mp4",
+                "mimeType": "video/mp4",
+                "size": clip.stat().st_size,
+                "localPath": str(clip),
+            },
+        },
+    }
+    await adapter._dispatch_inbound(payload)
+    event = captured[0]
+    # Frames (image/jpeg) for vision + audio track (audio/wav) for STT.
+    assert any(t == "image/jpeg" for t in event.media_types)
+    assert any(t.startswith("audio/") for t in event.media_types)
+    # No raw .mp4 left in the media set — it was normalized.
+    assert not any(u.endswith(".mp4") for u in event.media_urls)
+
+
 def test_is_duplicate_window(monkeypatch: pytest.MonkeyPatch) -> None:
     adapter = _make_adapter(monkeypatch)
     assert adapter._is_duplicate("id-1") is False

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -380,6 +380,45 @@ async def test_inbound_video_extracts_frames_and_audio(
     assert not any(u.endswith(".mp4") for u in event.media_urls)
 
 
+@pytest.mark.asyncio
+async def test_inbound_too_large_attachment_note(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An oversized attachment (sidecar skipped the download, tooLarge=True)
+    surfaces an actionable note so the agent replies promptly instead of the
+    message blocking on a huge download."""
+    adapter = _make_adapter(monkeypatch)
+    captured: List[MessageEvent] = []
+
+    async def fake_handle(event: MessageEvent) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+
+    payload = {
+        "event": "messages",
+        "message": {
+            "id": "spc-msg-big",
+            "timestamp": "2026-05-14T19:06:32.000Z",
+            "sender": {"id": "+15551234567"},
+            "space": {"id": "any;-;+15551234567"},
+            "content": {
+                "type": "attachment",
+                "name": "ScreenRecording.mov",
+                "mimeType": "video/quicktime",
+                "size": 60 * 1024 * 1024,
+                "localPath": None,
+                "tooLarge": True,
+            },
+        },
+    }
+    await adapter._dispatch_inbound(payload)
+    event = captured[0]
+    assert event.media_urls == []
+    assert "too large" in event.text.lower()
+    assert "60 MB" in event.text
+
+
 def test_is_duplicate_window(monkeypatch: pytest.MonkeyPatch) -> None:
     adapter = _make_adapter(monkeypatch)
     assert adapter._is_duplicate("id-1") is False

--- a/tests/plugins/platforms/photon/test_outbound_media.py
+++ b/tests/plugins/platforms/photon/test_outbound_media.py
@@ -96,10 +96,41 @@ async def test_send_voice_marks_kind_voice(
     assert body["kind"] == "voice"
 
 
-def test_no_send_document_override() -> None:
-    # Documents/PDFs aren't a reliable send over the Photon iMessage line, so
-    # the adapter must NOT override send_document (it falls back to base).
-    assert "send_document" not in vars(PhotonAdapter)
+@pytest.mark.asyncio
+async def test_send_document_passes_mime_and_name(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # Documents/PDFs send like any other attachment, with an explicit MIME so
+    # spectrum-ts' attachment() builder never throws on type resolution.
+    _patch_safe_path(monkeypatch)
+    doc = tmp_path / "report.pdf"
+    doc.write_bytes(b"%PDF-1.4 fake")
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    await adapter.send_document("any;-;+1", str(doc), file_name="Q3.pdf")
+
+    _, body = calls[0]
+    assert body["kind"] == "attachment"
+    assert body["name"] == "Q3.pdf"
+    assert body["mimeType"] == "application/pdf"
+
+
+@pytest.mark.asyncio
+async def test_send_document_unknown_type_falls_back_to_octet_stream(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # An unknown extension must still send (octet-stream), not raise/skip.
+    _patch_safe_path(monkeypatch)
+    blob = tmp_path / "data.weirdext"
+    blob.write_bytes(b"\x00\x01\x02")
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    await adapter.send_document("any;-;+1", str(blob))
+
+    _, body = calls[0]
+    assert body["mimeType"] == "application/octet-stream"
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/photon/test_outbound_media.py
+++ b/tests/plugins/platforms/photon/test_outbound_media.py
@@ -96,22 +96,66 @@ async def test_send_voice_marks_kind_voice(
     assert body["kind"] == "voice"
 
 
+def test_no_send_document_override() -> None:
+    # Documents/PDFs aren't a reliable send over the Photon iMessage line, so
+    # the adapter must NOT override send_document (it falls back to base).
+    assert "send_document" not in vars(PhotonAdapter)
+
+
 @pytest.mark.asyncio
-async def test_send_document_passes_filename(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-) -> None:
-    _patch_safe_path(monkeypatch)
-    doc = tmp_path / "report.pdf"
-    doc.write_bytes(b"%PDF-1.4 fake")
+async def test_reaction_ack_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 👀 on processing start, ✅ on success — bot tapbacks the user's message.
+    from gateway.platforms.base import (
+        MessageEvent,
+        MessageType,
+        ProcessingOutcome,
+    )
+
+    monkeypatch.setenv("PHOTON_ALLOWED_USERS", "+15551234567")
     adapter = _make_adapter(monkeypatch)
     calls = _capture_sidecar(adapter)
 
-    await adapter.send_document("any;-;+1", str(doc), file_name="Q3.pdf")
+    src = adapter.build_source(
+        chat_id="any;-;+15551234567",
+        chat_name="any;-;+15551234567",
+        chat_type="dm",
+        user_id="+15551234567",
+        user_name=None,
+    )
+    ev = MessageEvent(
+        text="hi", message_type=MessageType.TEXT, source=src, message_id="m1"
+    )
 
-    _, body = calls[0]
-    assert body["kind"] == "attachment"
-    assert body["name"] == "Q3.pdf"
-    assert body["mimeType"] == "application/pdf"
+    await adapter.on_processing_start(ev)
+    await adapter.on_processing_complete(ev, ProcessingOutcome.SUCCESS)
+
+    reacts = [body for path, body in calls if path == "/react"]
+    assert len(reacts) == 2
+    assert reacts[0]["reaction"] == "👀"
+    assert reacts[0]["targetMessageId"] == "m1"
+    assert reacts[0]["spaceId"] == "any;-;+15551234567"
+    assert reacts[1]["reaction"] == "✅"
+
+
+@pytest.mark.asyncio
+async def test_reaction_skips_non_allowlisted(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    monkeypatch.setenv("PHOTON_ALLOWED_USERS", "+15550000000")  # different number
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+    src = adapter.build_source(
+        chat_id="any;-;+15551234567",
+        chat_name="any;-;+15551234567",
+        chat_type="dm",
+        user_id="+15551234567",
+        user_name=None,
+    )
+    ev = MessageEvent(
+        text="hi", message_type=MessageType.TEXT, source=src, message_id="m1"
+    )
+    await adapter.on_processing_start(ev)
+    assert [b for p, b in calls if p == "/react"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/platforms/photon/test_outbound_media.py
+++ b/tests/plugins/platforms/photon/test_outbound_media.py
@@ -328,3 +328,49 @@ async def test_standalone_send_text_then_attachments(
     assert posted[1][1]["path"] == str(img)
     assert posted[1][1]["kind"] == "attachment"
     assert posted[1][1]["mimeType"] == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_send_strips_markdown_and_splits_into_bubbles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # iMessage renders plain text: markdown is stripped, and paragraphs become
+    # separate bubbles (parity with BlueBubbles).
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    await adapter.send("any;-;+1", "**Bold** title\n\nSecond _paragraph_ here.")
+
+    sends = [b for p, b in calls if p == "/send"]
+    assert len(sends) == 2  # two paragraphs → two bubbles
+    joined = " ".join(b["text"] for b in sends)
+    assert "**" not in joined and "_" not in joined
+    assert "Bold title" in sends[0]["text"]
+    assert "Second paragraph here." in sends[1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_no_ack_reaction_on_reaction_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The bot must not 👀-ack an inbound reaction event (echo-loop guard).
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    monkeypatch.setenv("PHOTON_ALLOWED_USERS", "+15551234567")
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+    src = adapter.build_source(
+        chat_id="any;-;+15551234567",
+        chat_name="any;-;+15551234567",
+        chat_type="dm",
+        user_id="+15551234567",
+        user_name=None,
+    )
+    ev = MessageEvent(
+        text="[Reaction 👀]",
+        message_type=MessageType.TEXT,
+        source=src,
+        message_id="spc-msg-abc:reaction:7",
+    )
+    await adapter.on_processing_start(ev)
+    assert [b for p, b in calls if p == "/react"] == []


### PR DESCRIPTION
## What does this PR do?

Completes inbound attachment retrieval deferred from #42472 (tracked in #42454), then builds out the iMessage interaction surface bidirectionally — media in/out, voice memos, video, tapbacks, read receipts, typing, effects.

**Stacked on #42472** (`fix/photon-spectrum-ts-dead-host`). Its dead-host fix is the first commit here and drops out once #42472 merges/rebases. The six `feat(photon)`/`fix(photon)` commits are this PR.

## Why inbound media needed a sidecar bridge

spectrum-ts hands inbound attachment content as `asAttachment({ read(), stream() })` — the byte-fetching is a closure, lost the moment the message is JSON-serialized, so Photon's cloud webhook can only deliver attachment *metadata*. The fix bridges inbound through the sidecar's own `app.messages` gRPC stream and downloads bytes in-process (atomic temp-write + byte-count verify, bounded concurrency, allowlist + dedup, size cap + timeout) before forwarding to the adapter's loopback webhook.

## Feature matrix

| Capability | Status |
|---|---|
| Inbound photo → agent (vision) | ✅ verified (real iPhone photo → complete JPEG → media_urls) |
| Inbound video → agent | ✅ normalized to keyframes (→ capability-aware vision routing) + audio-track transcript (→ STT) |
| Inbound voice memo → agent | ✅ `.caf` typed VOICE + transcoded to `.wav` (Hermes STT rejects `.caf`); transcript verified end-to-end |
| Inbound file download | ✅ |
| Large-attachment handling | ✅ size cap + download timeout so a huge clip never blocks the ack/reply; oversized → prompt actionable note |
| Read receipts (Delivered → Read) | ✅ `space.read(message)` |
| Typing indicator tracks compute status | ✅ `space.send(typing("start"/"stop"))` + stop_typing |
| Bot → user tapbacks (👀 → ✅/❌ acks) | ✅ `/react` + `reaction()` builder, via on_processing_* hooks |
| Outbound image / GIF / video / voice / sticker | ✅ |
| Multiple files with pacing | ✅ `/send-attachments` |
| Screen/bubble effects | ✅ `effect` param (ids from the provider's map) |
| Rich link previews | ✅ native (URL in text) |
| Markdown → plain text + paragraph bubbles | ✅ strip markdown, split paragraphs into separate bubbles, clean chunking (the existing iMessage channel parity) |
| Reaction echo-loop guard | ✅ never ack a reaction event (shared line can echo the bot's own tapback) |
| Inbound reaction/tapback **observe** | ⚠️ implemented; delivery of reaction events is inconsistent on the free shared line (the SDK drops reactions it can't attribute to a non-account sender) |
| Document/PDF **send** | ✅ uniform attachment send + `application/octet-stream` MIME fallback |

## Model-agnostic by design

Inbound video/voice reuse Hermes' existing capability-aware routing rather than hardcoding any model: keyframes go through `agent/image_routing.py` (native pixels if `supports_vision`, else `vision_analyze`); audio goes through the configured STT provider.

## Tunables (env)

| Var | Default | Purpose |
|---|---|---|
| `PHOTON_VIDEO_FRAMES` | 6 | keyframes sampled from an inbound video |
| `PHOTON_MAX_ATTACHMENT_MB` | 32 | skip download above this (matches gateway `max_attachment_bytes`) |
| `PHOTON_DOWNLOAD_TIMEOUT_MS` | 120000 | abort a slow/stalled download |
| `PHOTON_REACTIONS` | true | bot→user tapback acks |
| `PHOTON_READ_RECEIPTS` | true | send read receipts |

## How it was tested

- **Live, end-to-end** on a real iPhone + free Photon line: photo (complete 5712×4284 JPEG), video (complete .mov → keyframes + audio), voice memo (`.caf` → `.wav` → transcript `"One times ten."` reaching the agent cleanly, 0 STT errors), outbound text/link/effect/image/multi-image (all delivered), typing + read receipts; large screen-recording surfaced the blocking bug fixed by the size cap.
- `pytest tests/plugins/platforms/photon -q` → **57 passed** (new: localPath→media_urls, missing-path fallback, reaction-ack lifecycle + allowlist gating, audio→VOICE, `.caf`→`.wav` transcode, video→frames+audio, oversized-attachment note, no-send_document).
- Node smoke tests for the download algorithm, effect resolver.

## Capability coverage vs the spectrum-ts SDK

This plugin exposes the **full reachable surface** of the `spectrum-ts` iMessage provider (the layer Photon's managed / free shared-line service makes available). Full map in `plugins/platforms/photon/README.md`.

**Reliability — handled by the SDK.** `spectrum-ts` runs `catchUpThenConsumeLive(lastCursor)` + `replayMissed()` + cursor tracking internally, so the live `app.messages` stream replays missed events on a gRPC reconnect (no in-process loss). The stream takes no resume cursor, so a full sidecar *restart* has a brief unrecovered window.

**Not reachable from this layer** (and why): `edit`, `unsend`, threaded `reply`, `sendMultipart`, `placeSticker`, `listRecent` (history), `polls`, `groups`, `addresses` (`isIMessageAvailable`), `getEmbeddedMedia`, `locations`, and `chats.create` (proactive cold-start DM to a new handle) live on the lower `@photon-ai/advanced-imessage` client, which spectrum-ts holds as internal context (`client: AdvancedIMessage`) and does **not** expose — the provider only surfaces `getAttachment` / `getMessage` / `read` / `background`. Reaching them needs a *separate* direct advanced-imessage connection (own auth, likely a paid/dedicated line, not the free shared tier); the recommended exposure there is a few semantic, capability-gated, confirmation-guarded agent tools — not raw endpoints. Documented rather than half-built.

## Production hardening & security audit

A recursive, per-file audit (validated against current best practices) drove each part to two consecutive clean passes. Summary of what the later commits address:

**Security**
- Webhook receiver now binds **127.0.0.1 by default** (was 0.0.0.0) — with no signing secret, 0.0.0.0 accepted forged unsigned inbound from the network; the sidecar bridges over loopback, so the public Photon-cloud path is now explicit opt-in (+ a warning if exposed without a secret).
- Sidecar control-token comparison is now **constant-time** (`timingSafeEqual`), matching the webhook's `hmac.compare_digest`.
- `localPath` containment (no arbitrary-file read), `content.id` path-traversal sanitisation, streaming size cap, reaction/emoji sanitisation, phone numbers masked in sidecar logs.
- ffmpeg on untrusted media: `-nostdin -threads 1 -loglevel error -nostats -protocol_whitelist file,pipe` (the whitelist blocks a crafted container from making ffmpeg fetch a URL).

**Supply chain**
- Commit the sidecar **`package-lock.json`** (was the only node sub-project without one) and `overrides` to pin patched transitive deps (protobufjs 8.6.1, `@opentelemetry/*` 0.218.0) — clears 7 high-severity CVEs **without** downgrading `spectrum-ts` (npm's suggested fix would reintroduce #42472). `npm audit` → 0.

**Resource lifecycle / robustness**
- TTL sweepers for the download dir and ffmpeg/transcode temp dirs (were leaking); request-body caps (Node + aiohttp); bounded `spaceCache`/`_msgCache`/dedup; `unhandledRejection` handler; bounded inbound-forward fetch; ffmpeg zombie reaping.

All tunable via env (`PHOTON_ATTACHMENT_TTL_MS`, `PHOTON_MEDIA_TTL_SECONDS`, `PHOTON_MAX_ATTACHMENT_MB`, `PHOTON_DOWNLOAD_TIMEOUT_MS`, …). 62 plugin tests pass; `npm audit` clean.

## Notes for reviewers

- Inbound reaction-observe and document-send limits are line/SDK constraints, documented above rather than papered over.
- `.caf` voice-memo support is a genuine ingest fix (Hermes' STT whitelist excludes `.caf`); any platform delivering CoreAudio benefits from the transcode approach.
- Documents/PDFs send like any attachment (the earlier failure was spectrum-ts' attachment() builder throwing on unresolved MIME — fixed with an octet-stream fallback, matching the existing iMessage channel).
- The size cap intentionally aligns with the gateway's existing 32MB `max_attachment_bytes`, so nothing downloadable is wasted on an attachment the gateway would reject anyway.

- Outbound-rendering pass: adopted `format_message` (strip_markdown), paragraph-bubble splitting, pagination-free `truncate_message`, and document/PDF send. and it adds bot→user tapback acks the existing iMessage channel doesn't have. Remaining gap: proactive cold-start DMs to a *new* handle  aren't supported — the free shared line rejects sends to non-allowlisted targets, so replies use the live Space cached from an inbound.


