### PR TITLE
fix(agent): recover from 413 caused by oversized inline image

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2620,6 +2620,36 @@ def run_conversation(
                     classified.reason == FailoverReason.payload_too_large
                 )
 
+                # 413 image-shrink recovery: a 413 (Request Entity Too Large)
+                # classifies as payload_too_large and normally drives
+                # *conversation* compression.  But when the oversized payload is
+                # an inline native image (Copilot / GitHub Copilot enforce a
+                # tighter request-size ceiling than Anthropic-direct), shrinking
+                # text history does nothing — the image bytes are the floor, and
+                # the loop burns every compression attempt then dies with
+                # "cannot compress further."  Attempt the same image-shrink the
+                # 400 image_too_large path uses BEFORE compressing text.  If an
+                # oversized data: URL image part was actually shrunk, retry
+                # immediately.  If there's no shrinkable image, fall through to
+                # normal compression — text really is the problem.
+                if (
+                    is_payload_too_large
+                    and not _retry.payload_image_shrink_attempted
+                ):
+                    _retry.payload_image_shrink_attempted = True
+                    if agent._try_shrink_image_parts_in_messages(api_messages):
+                        agent._vprint(
+                            f"{agent.log_prefix}📐 Request too large (413) — shrank "
+                            f"oversized inline image(s) and retrying...",
+                            force=True,
+                        )
+                        continue
+                    else:
+                        logger.info(
+                            "413 image-shrink recovery: no oversized data-URL image "
+                            "parts to shrink; falling through to context compression."
+                        )
+
                 # Actionable hint for GitHub Models (Azure) 413 errors.
                 # The free tier enforces a hard 8K token cap per request,
                 # which Hermes' system prompt + tool schemas alone exceed.

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -50,6 +50,13 @@ class TurnRetryState:
     thinking_sig_retry_attempted: bool = False
     invalid_encrypted_content_retry_attempted: bool = False
     image_shrink_retry_attempted: bool = False
+    # 413 (payload-too-large) image-shrink guard. Distinct from
+    # image_shrink_retry_attempted because a 413 classifies as
+    # payload_too_large (not image_too_large) yet may still be caused by an
+    # oversized inline image on a provider with a tight request ceiling
+    # (Copilot / GitHub Copilot). Fires the same shrink recovery once before
+    # the 413 path falls through to conversation compression.
+    payload_image_shrink_attempted: bool = False
     multimodal_tool_content_retry_attempted: bool = False
     oauth_1m_beta_retry_attempted: bool = False
     llama_cpp_grammar_retry_attempted: bool = False

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -22,6 +22,7 @@ EXPECTED_FIELDS = {
     "thinking_sig_retry_attempted",
     "invalid_encrypted_content_retry_attempted",
     "image_shrink_retry_attempted",
+    "payload_image_shrink_attempted",
     "multimodal_tool_content_retry_attempted",
     "oauth_1m_beta_retry_attempted",
     "llama_cpp_grammar_retry_attempted",

--- a/tests/run_agent/test_image_shrink_recovery.py
+++ b/tests/run_agent/test_image_shrink_recovery.py
@@ -321,3 +321,71 @@ class TestShrinkImagePartsHelper:
         assert msgs[0]["content"][0]["image_url"]["url"] == small
         # The unshrinkable one is left as-is (caller surfaces original error).
         assert msgs[0]["content"][1]["image_url"]["url"] == unshrinkable
+
+
+# ─── 413 payload-too-large → image-shrink wiring ─────────────────────────────
+
+
+class TestPayloadTooLarge413ImageShrink:
+    """A 413 (Request Entity Too Large) from a provider with a tight request
+    ceiling (Copilot / GitHub Copilot) must drive the SAME image-shrink
+    recovery the 400 image_too_large path uses, BEFORE falling through to
+    conversation compression.
+
+    Regression guard for the bug where an oversized inline screenshot 413'd,
+    Hermes compressed *text* history (which did nothing — the image bytes were
+    the floor), burned all compression attempts, and died with "cannot compress
+    further."  The loop wiring lives in agent/conversation_loop.py; here we lock
+    in the pieces it depends on: (1) 413 classifies as payload_too_large,
+    (2) the TurnRetryState carries a dedicated one-shot guard, and (3) the
+    shrink helper truthy-returns only when it actually reduced an oversized
+    inline image so the 413 branch retries iff there's an image to blame, else
+    falls through to text compression.
+    """
+
+    def test_413_classifies_as_payload_too_large(self):
+        """Copilot's bare '413 Request Entity Too Large' → payload_too_large."""
+        err = _FakeApiError(status_code=413, message="Request Entity Too Large")
+        result = classify_api_error(err, provider="copilot", model="claude-opus-4.8")
+        assert result.reason == FailoverReason.payload_too_large
+        assert result.retryable is True
+
+    def test_turn_retry_state_has_payload_image_shrink_guard(self):
+        """The 413 path needs its own one-shot guard, defaulting False, distinct
+        from the 400-path image_shrink_retry_attempted guard."""
+        from agent.turn_retry_state import TurnRetryState
+
+        st = TurnRetryState()
+        assert st.payload_image_shrink_attempted is False
+        # Independent of the 400-path guard — flipping one must not flip the other.
+        st.payload_image_shrink_attempted = True
+        assert st.image_shrink_retry_attempted is False
+
+    def test_413_shrinkable_image_returns_true(self, monkeypatch):
+        """An oversized inline data: URL image shrinks → True (loop retries)."""
+        agent = _make_agent()
+        big = _big_png_data_url(6000)  # ~6 MB, over the 4 MB target
+        small = "data:image/jpeg;base64," + "C" * 500
+
+        monkeypatch.setattr(
+            "tools.vision_tools._resize_image_for_vision",
+            lambda path, *a, **kw: small,
+            raising=False,
+        )
+        msgs = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look at this screenshot"},
+                {"type": "image_url", "image_url": {"url": big}},
+            ],
+        }]
+        assert agent._try_shrink_image_parts_in_messages(msgs) is True
+        assert msgs[0]["content"][1]["image_url"]["url"] == small
+
+    def test_413_no_image_returns_false_falls_through(self):
+        """A 413 with NO inline image → False, so the loop falls through to
+        text compression instead of falsely 'recovering'."""
+        agent = _make_agent()
+        msgs = [{"role": "user", "content": "huge text conversation, no image at all"}]
+        assert agent._try_shrink_image_parts_in_messages(msgs) is False
+


### PR DESCRIPTION
## Summary

A **413 (Request Entity Too Large)** caused by an **oversized inline image** is currently unrecoverable — the turn dies with `413 payload too large. Cannot compress further.` and the user loses the message.

### Root cause

A 413 classifies as `FailoverReason.payload_too_large`, which drives **conversation compression** (shrinking text history). That's correct when the conversation is genuinely too long — but when the oversized payload is a **native inline image**, the image bytes are the floor and compressing text accomplishes nothing. The loop burns all `max_compression_attempts`, then returns `compression_exhausted`.

This bites providers with a **tighter request-size ceiling than Anthropic-direct**. Anthropic returns a **400** "image exceeds 5 MB maximum" (already handled by the `image_too_large` shrink path). **Copilot / GitHub Copilot** instead reject an oversized request body with a **413**, which never reached the image-shrink recovery — so a full-resolution screenshot attached inline to a vision-capable model (e.g. `claude-opus-4.8` via the `copilot` provider) reliably kills the turn.

Observed in the wild: every 413 in the affected session fired 2–3s after an `Image routing: native … attached inline` log line.

### Fix

Wire the **existing** image-shrink recovery (`_try_shrink_image_parts_in_messages`, already used by the 400 `image_too_large` path) into the 413 path, **before** falling through to conversation compression:

- On `payload_too_large`, attempt to shrink oversized inline `data:` URL image parts.
- If an image was actually shrunk → retry immediately.
- If there's **no** shrinkable image → fall through to conversation compression unchanged (text really is the problem).

Guarded by a new one-shot `TurnRetryState.payload_image_shrink_attempted`, distinct from the 400-path `image_shrink_retry_attempted` so the two recoveries are independent.

The shrink helper already targets 4 MB with dimension capping and only returns truthy when it genuinely reduced an oversized part, so the fall-through behavior is precise — no false "recovered" on a 413 that wasn't image-caused.

## Changes

- `agent/turn_retry_state.py` — add `payload_image_shrink_attempted` one-shot guard.
- `agent/conversation_loop.py` — 413 image-shrink recovery block before the compression path (+30 lines).
- `tests/run_agent/test_image_shrink_recovery.py` — `TestPayloadTooLarge413ImageShrink` (4 tests).
- `tests/agent/test_turn_retry_state.py` — extend the field contract.

`+106 / -0` across 4 files. No behavior change for non-image 413s (still compress) or for the 400 `image_too_large` path.

## Test plan

- [x] `tests/run_agent/test_image_shrink_recovery.py` — new 413 class + existing 400 path
- [x] `tests/agent/test_error_classifier.py` — 413 → `payload_too_large` unchanged
- [x] `tests/agent/test_turn_retry_state.py` — field-contract + default-False guards
- [x] **177 passed** across the three suites
- [x] **Live verification against a real 25.8 MB inline PNG: 25.81 MB → 1.32 MB**, retries and succeeds; no-image 413 falls through to compression

## Notes

- Reactive (shrink-on-reject), consistent with the existing design choice documented in `agent/image_routing.py` — providers that accept large images pay no proactive quality tax; only a confirmed 413 triggers the one-time shrink.
- No new dependencies (Pillow is already a declared soft dep for the shrink path).
