### PR TITLE
fix(agent): close unclosed JSON delimiters in LIFO order when repairing truncated tool_call arguments

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -224,13 +224,38 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     fixed = raw_stripped
     # 1. Strip trailing commas before } or ]
     fixed = re.sub(r',\s*([}\]])', r'\1', fixed)
-    # 2. Close unclosed structures
-    open_curly = fixed.count('{') - fixed.count('}')
-    open_bracket = fixed.count('[') - fixed.count(']')
-    if open_curly > 0:
-        fixed += '}' * open_curly
-    if open_bracket > 0:
-        fixed += ']' * open_bracket
+    # 2. Close unclosed structures in LIFO nesting order.
+    # A plain count-and-append ('}' * n then ']' * m) closes in a fixed
+    # order that is wrong for nested payloads: '{"k": [1, 2' would become
+    # '{"k": [1, 2}]' (invalid) instead of '{"k": [1, 2]}'. Walk the text
+    # tracking string state — so braces/brackets inside string values are
+    # ignored — and append the closer for each still-open delimiter by
+    # popping the open-delimiter stack.
+    stack: list[str] = []
+    in_string = False
+    escaped = False
+    for ch in fixed:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == '\\':
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch in '{[':
+            stack.append(ch)
+        elif ch == '}':
+            if stack and stack[-1] == '{':
+                stack.pop()
+        elif ch == ']':
+            if stack and stack[-1] == '[':
+                stack.pop()
+    if stack:
+        closers = {'{': '}', '[': ']'}
+        fixed += ''.join(closers[opener] for opener in reversed(stack))
     # 3. Remove excess closing braces/brackets (bounded to 50 iterations)
     for _ in range(50):
         try:

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -54,10 +54,35 @@ class TestRepairToolCallArguments:
 
     def test_unclosed_bracket_and_brace(self):
         result = _repair_tool_call_arguments('{"a": [1, 2', "t")
-        # Bracket counting adds ']' then '}', producing {"a": [1, 2]}
-        # which is valid JSON.  But the naive count can't always recover
-        # complex nesting — verify we at least get valid JSON.
-        json.loads(result)
+        # The unclosed array must be closed before the object — ']' then
+        # '}', yielding {"a": [1, 2]}. A fixed '}'-then-']' order would
+        # produce the invalid {"a": [1, 2}] and lose the whole payload.
+        assert json.loads(result) == {"a": [1, 2]}
+
+    def test_unclosed_array_of_strings_recovers(self):
+        result = _repair_tool_call_arguments('{"files": ["a.py", "b.py"', "t")
+        assert json.loads(result) == {"files": ["a.py", "b.py"]}
+
+    def test_unclosed_nested_write_file_args_recovers(self):
+        raw = '{"path": "x.txt", "lines": ["one", "two"'
+        result = _repair_tool_call_arguments(raw, "write_file")
+        assert json.loads(result) == {"path": "x.txt", "lines": ["one", "two"]}
+
+    def test_unclosed_object_inside_array_closes_lifo(self):
+        # Stack is [ '{', '[', '{' ] → closers must be '}', ']', '}'.
+        result = _repair_tool_call_arguments('{"a": [{"b": 1', "t")
+        assert json.loads(result) == {"a": [{"b": 1}]}
+
+    def test_flat_object_still_recovers(self):
+        # Regression guard: the simple (already-working) case must not break.
+        result = _repair_tool_call_arguments('{"a": 1, "b": 2', "t")
+        assert json.loads(result) == {"a": 1, "b": 2}
+
+    def test_brace_inside_string_value_not_treated_as_delimiter(self):
+        # The '{' lives inside a string value and must not be counted as an
+        # open delimiter, so the only missing closer is the object's '}'.
+        result = _repair_tool_call_arguments('{"msg": "a { b"', "t")
+        assert json.loads(result) == {"msg": "a { b"}
 
     # -- Stage 5: excess closing delimiters --
 


### PR DESCRIPTION
## What does this PR do?

`_repair_tool_call_arguments` salvages malformed tool-call JSON from
local/quantized models. When closing unclosed structures it appended all
missing `}` first, then all missing `]` — a fixed order that is wrong for
nested payloads. `{"items": [1, 2` became `{"items": [1, 2}]` (invalid)
instead of `{"items": [1, 2]}`, every later repair pass then failed, and the
whole argument payload was silently dropped to `{}`. The tool then ran with
empty arguments.

The fix walks the text tracking string state (so braces/brackets inside
string values are ignored) and closes open delimiters in LIFO nesting order,
so nested truncations recover correctly. The flat-object case keeps working.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/message_sanitization.py` — replace the count-and-append delimiter
  close in `_repair_tool_call_arguments` with a string-aware, stack-based
  LIFO close. Trailing-comma strip and the excess-closer pass are unchanged.
- `tests/run_agent/test_repair_tool_call_arguments.py` — turn the misleading
  `test_unclosed_bracket_and_brace` (asserted only "valid JSON", so it passed
  on the dropped `{}`) into a real value assertion, plus 5 regression tests.

## How to Test

```
pytest tests/run_agent/test_repair_tool_call_arguments.py -q
pytest tests/run_agent/test_streaming_tool_call_repair.py -q
```

Results:

- `test_repair_tool_call_arguments.py` — 26 passed
- `test_streaming_tool_call_repair.py` (uses the same repair path) — 12 passed

Before the fix, `{"items": [1, 2` → `{}` (args lost); after, it recovers to
`{"items": [1, 2]}`.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] All tests pass
- [x] I've added tests for my changes
- [x] I've updated relevant documentation — N/A (internal helper)