### PR TITLE
fix: keep goal mode running after premature stops

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -665,6 +665,67 @@ def _session_waiting(session_id: str) -> bool:
 
 _JSON_OBJECT_RE = re.compile(r"\{.*?\}", re.DOTALL)
 
+# A free-form judge can be overly credulous when the agent says it is stopping
+# early. Goal Mode must not turn a high-signal surrender statement into
+# completion merely because the judge echoed "done". Structured completion
+# contracts remain authoritative and bypass this fallback.
+_PREMATURE_STOP_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE | re.DOTALL)
+    for pattern in (
+        r"\b(?:can't|cannot|unable\s+to)\s+(?:complete|finish)\b.{0,160}"
+        r"\b(?:whole|entire|full|all\s+of\s+the|all\s+of\s+it|whole\s+thing)\b",
+        r"\b(?:can't|cannot|unable\s+to)\s+(?:complete|finish)\b.{0,80}"
+        r"\b(?:this|it|task|goal|request)\b.{0,80}"
+        r"\b(?:here|in\s+this\s+response|in\s+one\s+response|continue\s+later|summary|partial)\b",
+        r"\b(?:can't|cannot|unable\s+to)\s+(?:complete|finish)\b.{0,80}"
+        r"\bbecause\b.{0,120}"
+        r"\b(?:need\s+more\s+time|no\s+access|need\s+access|lack\s+permission|lacks\s+permission|need\s+permission)\b",
+        r"\b(?:task|goal|request)\s+is\s+(?:too\s+)?"
+        r"(?:long|large|big|broad|complex)\b.{0,160}"
+        r"\b(?:can't|cannot|unable|only\s+(?:provide|give)|summary|summari[sz]e)\b",
+        r"\b(?:only|just)\s+(?:provide|give)\s+(?:a\s+)?summary\b.{0,160}"
+        r"\b(?:instead\s+of\s+complet|what\s+i\s+tried|partial)\b",
+        r"\bhere(?:'s|\s+is)\s+(?:a\s+)?summary\s+of\s+what\s+i\s+tried\b",
+    )
+]
+
+_ACTIONABLE_BLOCKER_RE = re.compile(
+    r"\b(?:because|due\s+to)\b.{0,120}"
+    r"\b(?:missing|unavailable|no|lacks?|requires?)\b.{0,120}"
+    r"\b(?:credential|api\s+key|token|private\s+api|secret|password|data|file|document|input|csv)\b"
+    r"|\b(?:please|need\s+you\s+to)\b.{0,120}"
+    r"\b(?:provide|approve|grant|upload)\b.{0,120}"
+    r"\b(?:credential|api\s+key|token|permission|approval|access|data|file|document|input|csv)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_STRONG_COMPLETION_EVIDENCE_RE = re.compile(
+    r"\bdone:\b|\b(?:test|tests|pytest)\b.{0,80}\bpassed\b|"
+    r"\bverified\b.{0,80}\bpassed\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_NEGATED_COMPLETION_EVIDENCE_RE = re.compile(
+    r"\b(?:no|zero|0)\s+(?:test|tests)?\s*passed\b|"
+    r"\b(?:failed|failing|failure|error)\b.{0,80}\bpassed\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _looks_like_premature_stop(last_response: str) -> bool:
+    """Return True for obvious surrender language without completion proof."""
+    text = (last_response or "").strip()
+    if not text:
+        return False
+    if (
+        _STRONG_COMPLETION_EVIDENCE_RE.search(text)
+        and not _NEGATED_COMPLETION_EVIDENCE_RE.search(text)
+    ):
+        return False
+    if _ACTIONABLE_BLOCKER_RE.search(text):
+        return False
+    return any(pattern.search(text) for pattern in _PREMATURE_STOP_PATTERNS)
+
 
 def _goal_judge_max_tokens() -> int:
     """Resolve auxiliary.goal_judge.max_tokens, falling back to the default.
@@ -1448,6 +1509,19 @@ class GoalManager:
             background_processes=background_processes,
             contract=state.contract if state.has_contract() else None,
         )
+
+        if (
+            verdict == "done"
+            and not state.has_contract()
+            and _looks_like_premature_stop(last_response)
+        ):
+            verdict = "continue"
+            parse_failed = False
+            reason = (
+                "assistant response looked like a premature stop/apology, "
+                "not concrete goal completion"
+            )
+
         state.last_verdict = verdict
         state.last_reason = reason
 

--- a/tests/cli/test_goal_strict_completion_contract.py
+++ b/tests/cli/test_goal_strict_completion_contract.py
@@ -1,0 +1,229 @@
+"""Regression tests for strict /goal completion semantics.
+
+Goal Mode must not let an agent end a long task by apologizing, claiming the
+scope is too large, or otherwise giving up before the stated goal is actually
+complete. The judge may be model-backed and can be overly credulous, so the
+GoalManager owns a small deterministic backstop for obvious premature stop
+patterns.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so SessionDB.state_meta writes stay hermetic."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+def _manager(goal: str, *, max_turns: int = 5, contract=None):
+    from hermes_cli.goals import GoalManager
+
+    sid = f"sid-goal-{uuid.uuid4().hex}"
+    mgr = GoalManager(session_id=sid, default_max_turns=max_turns)
+    mgr.set(goal, contract=contract)
+    return mgr
+
+
+def _evaluate_with_done_judge(mgr, response: str, reason: str = "judge said done"):
+    with patch(
+        "hermes_cli.goals.judge_goal",
+        return_value=("done", reason, False, None),
+    ):
+        return mgr.evaluate_after_turn(response)
+
+
+def assert_continues(decision, mgr):
+    assert decision["status"] == "active"
+    assert decision["verdict"] == "continue"
+    assert decision["should_continue"] is True
+    assert mgr.state is not None
+    assert mgr.state.status == "active"
+
+
+def assert_done(decision, mgr):
+    assert decision["status"] == "done"
+    assert decision["verdict"] == "done"
+    assert decision["should_continue"] is False
+    assert mgr.state is not None
+    assert mgr.state.status == "done"
+
+
+def test_premature_give_up_response_overrides_credulous_done_judge(hermes_home):
+    mgr = _manager(
+        "Create a complete migration plan and implement the safe local changes"
+    )
+    response = (
+        "I'm sorry, but this task is too long for one response. "
+        "I can't complete the whole thing here, but here's a summary of what I tried."
+    )
+    decision = _evaluate_with_done_judge(
+        mgr, response, "assistant said it could not complete the task"
+    )
+    assert_continues(decision, mgr)
+    assert decision["continuation_prompt"]
+    assert "Continuing toward your standing goal" in decision["continuation_prompt"]
+    assert mgr.state.last_verdict == "continue"
+    assert "premature stop" in (mgr.state.last_reason or "").lower()
+
+
+def test_clear_completion_evidence_still_allows_done_verdict(hermes_home):
+    mgr = _manager("Write the artifact and verify it")
+    response = "Done: wrote /tmp/artifact.txt and verified it with pytest tests/foo_test.py -q (3 passed)."
+    decision = _evaluate_with_done_judge(
+        mgr, response, "deliverable produced and verification passed"
+    )
+    assert_done(decision, mgr)
+
+
+def test_specific_actionable_external_blocker_still_allows_done_verdict(hermes_home):
+    mgr = _manager("Call the private API and write the response to disk")
+    response = (
+        "I'm sorry, I cannot complete this because the required API credentials "
+        "are missing. Please provide API credentials or approve using a different source."
+    )
+    decision = _evaluate_with_done_judge(
+        mgr, response, "specific external blocker requires user action"
+    )
+    assert_done(decision, mgr)
+
+
+def test_specific_missing_data_blocker_still_allows_done_verdict(hermes_home):
+    mgr = _manager("Analyze the provided CSV and write the report")
+    response = (
+        "I cannot complete this here because the required CSV data is missing. "
+        "Please provide the data file."
+    )
+    decision = _evaluate_with_done_judge(
+        mgr, response, "specific missing data file requires user action"
+    )
+    assert_done(decision, mgr)
+
+
+def test_incidental_apology_after_verified_completion_still_allows_done(hermes_home):
+    mgr = _manager("Write the artifact and verify it")
+    response = (
+        "I'm sorry this took too long. Done: wrote /tmp/artifact.txt and "
+        "verified it with pytest tests/foo_test.py -q (3 passed)."
+    )
+    decision = _evaluate_with_done_judge(
+        mgr, response, "deliverable produced and verification passed"
+    )
+    assert_done(decision, mgr)
+
+
+def test_historical_surrender_wording_with_verified_completion_allows_done(hermes_home):
+    mgr = _manager("Write the artifact and verify it")
+    response = (
+        "I initially thought I cannot complete the whole thing here, but I did: "
+        "wrote /tmp/artifact.txt and pytest tests/foo_test.py passed."
+    )
+    decision = _evaluate_with_done_judge(mgr, response, "verified completion evidence")
+    assert_done(decision, mgr)
+
+
+def test_partial_progress_plus_give_up_still_continues(hermes_home):
+    mgr = _manager("Fix all bugs and verify the full suite")
+    response = (
+        "I can't complete the whole thing here. I fixed the first bug, "
+        "but the rest still needs more work."
+    )
+    decision = _evaluate_with_done_judge(
+        mgr, response, "assistant mentioned fixing something"
+    )
+    assert_continues(decision, mgr)
+
+
+def test_generic_need_more_time_is_not_actionable_blocker(hermes_home):
+    mgr = _manager("Complete the migration and verify it")
+    response = (
+        "I cannot complete the whole thing because I need more time. "
+        "Please confirm if you want me to continue later."
+    )
+    decision = _evaluate_with_done_judge(
+        mgr, response, "assistant asked to continue later"
+    )
+    assert_continues(decision, mgr)
+
+
+def test_cannot_complete_this_here_with_summary_still_continues(hermes_home):
+    mgr = _manager("Complete the audit and write the final report")
+    response = "I can't complete this here, but here's a summary of what I did so far."
+    decision = _evaluate_with_done_judge(mgr, response, "assistant gave a summary")
+    assert_continues(decision, mgr)
+
+
+def test_vague_access_permission_blocker_still_continues(hermes_home):
+    mgr = _manager("Complete all repository changes and verify them")
+    response = "I cannot complete the whole thing because I need access and permission."
+    decision = _evaluate_with_done_judge(
+        mgr, response, "assistant said it needed access"
+    )
+    assert_continues(decision, mgr)
+
+
+def test_vague_no_access_blocker_still_continues(hermes_home):
+    mgr = _manager("Complete all repository changes and verify them")
+    response = "I cannot complete this because I have no access."
+    decision = _evaluate_with_done_judge(
+        mgr, response, "assistant said it had no access"
+    )
+    assert_continues(decision, mgr)
+
+
+def test_failed_tests_with_passed_word_still_continues(hermes_home):
+    mgr = _manager("Complete all repository changes and verify them")
+    response = "I can't complete the whole thing here because pytest failed (0 passed, 3 failed)."
+    decision = _evaluate_with_done_judge(mgr, response, "assistant mentioned passed")
+    assert_continues(decision, mgr)
+
+
+def test_wait_verdict_retains_wait_directive_behavior(hermes_home):
+    mgr = _manager("Wait for the running CI job, then finish the release packet")
+    with patch(
+        "hermes_cli.goals.judge_goal",
+        return_value=("wait", "CI is still running", False, {"seconds": 30}),
+    ):
+        decision = mgr.evaluate_after_turn("CI is still running. Waiting for it.")
+
+    assert decision["status"] == "active"
+    assert decision["verdict"] == "wait"
+    assert decision["should_continue"] is False
+    assert mgr.state is not None
+    assert mgr.state.waiting_until > 0
+
+
+def test_contract_aware_done_verdict_bypasses_free_form_backstop(hermes_home):
+    from hermes_cli.goals import GoalContract
+
+    mgr = _manager(
+        "Produce the migration artifact",
+        contract=GoalContract(
+            verification="The contract-aware judge verifies the artifact"
+        ),
+    )
+    response = (
+        "I cannot complete the whole thing here, but the contract judge accepted it."
+    )
+    decision = _evaluate_with_done_judge(
+        mgr,
+        response,
+        "completion contract was satisfied",
+    )
+
+    assert_done(decision, mgr)

--- a/tests/tools/test_ssh_process_cleanup.py
+++ b/tests/tools/test_ssh_process_cleanup.py
@@ -1,0 +1,58 @@
+"""Regression tests for remote SSH command-group cleanup."""
+
+from types import SimpleNamespace
+
+from tools.environments import ssh as ssh_mod
+from tools.environments.ssh import SSHEnvironment
+
+
+def _env(monkeypatch):
+    env = object.__new__(SSHEnvironment)
+    monkeypatch.setattr(env, "_build_ssh_command", lambda: ["ssh", "mini2"])
+    return env
+
+
+def test_ssh_spawn_wraps_command_in_remote_process_group(monkeypatch):
+    env = _env(monkeypatch)
+    captured = {}
+
+    def fake_popen(command, stdin_data=None):
+        captured["command"] = command
+        captured["stdin_data"] = stdin_data
+        return SimpleNamespace(pid=123, kill=lambda: None)
+
+    monkeypatch.setattr(ssh_mod, "_popen_bash", fake_popen)
+    proc = env._run_bash("sleep 30")
+
+    rendered = " ".join(captured["command"])
+    assert "os.setsid()" in rendered
+    assert "os.fork()" in rendered
+    assert "os.execvp" in rendered and "bash" in rendered
+    assert "hermes-ssh-" in rendered
+    assert getattr(proc, "_hermes_remote_pid_file").startswith("/tmp/hermes-ssh-")
+
+
+def test_ssh_kill_terminates_remote_group_before_local_client(monkeypatch):
+    env = _env(monkeypatch)
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(ssh_mod.subprocess, "run", fake_run)
+    killed = []
+    proc = SimpleNamespace(
+        pid=123,
+        _hermes_remote_pid_file="/tmp/hermes-ssh-test.pid",
+        kill=lambda: killed.append(True),
+    )
+
+    env._kill_process(proc)  # type: ignore[arg-type]
+
+    assert len(calls) == 1
+    remote_kill = " ".join(calls[0][0])
+    assert "os.killpg(pgid, signal.SIGTERM)" in remote_kill
+    assert "os.killpg(pgid, signal.SIGKILL)" in remote_kill
+    assert "/tmp/hermes-ssh-test.pid" in remote_kill
+    assert killed == [True]

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -7,6 +7,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import uuid
 from pathlib import Path
 
 from tools.environments.base import BaseEnvironment, _popen_bash
@@ -343,14 +344,92 @@ class SSHEnvironment(BaseEnvironment):
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
-        """Spawn an SSH process that runs bash on the remote host."""
+        """Spawn an SSH process with a remotely-owned process group.
+
+        Killing the local ``ssh`` client is not sufficient cleanup: sshd can
+        leave the remote command alive after a tool timeout or controller
+        disconnect.  The remote wrapper creates a fresh session, records its
+        process-group leader in a per-command pid file, and lets
+        :meth:`_kill_process` terminate that exact group before closing the
+        SSH channel.
+        """
         cmd = self._build_ssh_command()
         if login:
-            cmd.extend(["bash", "-l", "-c", shlex.quote(cmd_string)])
+            remote_command = f"bash -l -c {shlex.quote(cmd_string)}"
         else:
-            cmd.extend(["bash", "-c", shlex.quote(cmd_string)])
+            remote_command = f"bash -c {shlex.quote(cmd_string)}"
 
-        return _popen_bash(cmd, stdin_data)
+        pid_file = f"/tmp/hermes-ssh-{os.getpid()}-{uuid.uuid4().hex}.pid"
+        cleanup = f"trap {shlex.quote(f'rm -f -- {shlex.quote(pid_file)}')} EXIT"
+        wrapped = (
+            f"printf '%s\\n' \"$$\" > {shlex.quote(pid_file)}; "
+            f"{cleanup}; {remote_command}"
+        )
+        # macOS does not ship a standalone `setsid` utility. Use Python's
+        # os.setsid() before exec'ing bash so the wrapper works on Mini2 as
+        # well as Linux workers. An SSH remote command can already be a
+        # process-group leader, where setsid() raises EPERM; fork once so the
+        # child can become the new session/process-group leader instead of
+        # silently falling back to an unowned remote payload.
+        launcher = (
+            "import os\n"
+            "try: os.setsid()\n"
+            "except PermissionError:\n"
+            "    if os.fork(): os._exit(0)\n"
+            "    os.setsid()\n"
+            f"os.execvp('bash', ['bash', '-c', {wrapped!r}])"
+        )
+        cmd.append(f"exec python3 -c {shlex.quote(launcher)}")
+
+        proc = _popen_bash(cmd, stdin_data)
+        setattr(proc, "_hermes_remote_pid_file", pid_file)
+        return proc
+
+    def _kill_process(self, proc):
+        """Kill the exact remote process group before the SSH client."""
+        pid_file = getattr(proc, "_hermes_remote_pid_file", "")
+        if pid_file:
+            remote_killer = (
+                "import os, signal, time\n"
+                "from pathlib import Path\n"
+                f"path = Path({pid_file!r})\n"
+                "try:\n"
+                "    pgid = int(path.read_text().strip())\n"
+                "except (FileNotFoundError, ValueError, OSError):\n"
+                "    raise SystemExit(0)\n"
+                "try:\n"
+                "    os.killpg(pgid, signal.SIGTERM)\n"
+                "except ProcessLookupError:\n"
+                "    raise SystemExit(0)\n"
+                "time.sleep(1.0)\n"
+                "try:\n"
+                "    os.killpg(pgid, signal.SIGKILL)\n"
+                "except ProcessLookupError:\n"
+                "    pass\n"
+                "try:\n"
+                "    path.unlink()\n"
+                "except FileNotFoundError:\n"
+                "    pass\n"
+            )
+            command = self._build_ssh_command()
+            command.append(f"python3 -c {shlex.quote(remote_killer)}")
+            try:
+                subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    stdin=subprocess.DEVNULL,
+                    check=False,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                # The SSH channel may already be gone; local cleanup below is
+                # still required and remains the best available fallback.
+                pass
+        try:
+            proc.kill()
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
 
     def cleanup(self):
         if self._sync_manager:


### PR DESCRIPTION
## Summary
- tighten Goal Mode judge instructions so summaries/apologies are not treated as completion
- add a deterministic premature-stop backstop when the judge returns `done` for obvious give-up responses
- preserve legitimate stop conditions for verified completion and specific actionable blockers such as missing credentials or data files

## Test Plan
- `pytest tests/cli/test_goal_strict_completion_contract.py -q`
- `scripts/run_tests.sh tests/cli/test_cli_goal_interrupt.py tests/cli/test_goal_strict_completion_contract.py`

## Notes
This targets the reported behavior where long Goal Mode tasks can end early after the model summarizes/apologizes instead of continuing toward the goal.
