### PR TITLE
fix(agent): suppress bg review during active goal, inherit parent goal (#42391)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -146,20 +146,31 @@ def run_codex_app_server_turn(
 
     # Background review fork — same cadence + signature as the default
     # path (line ~15449). Only fires when a trigger actually tripped AND
-    # we have a real final response.
+    # we have a real final response.  Skip when a /goal is active so the
+    # goal continuation prompt gets the session next, not the review.
+    # (issue #42391)
     if (
         turn.final_text
         and not turn.interrupted
         and (should_review_memory or should_review_skills)
     ):
+        _goal_active = False
         try:
-            agent._spawn_background_review(
-                messages_snapshot=list(messages),
-                review_memory=should_review_memory,
-                review_skills=should_review_skills,
-            )
+            from hermes_cli.goals import load_goal as _load_goal_bg
+            _g = _load_goal_bg(agent.session_id or "")
+            if _g and _g.status == "active":
+                _goal_active = True
         except Exception:
-            logger.debug("background review spawn raised", exc_info=True)
+            pass
+        if not _goal_active:
+            try:
+                agent._spawn_background_review(
+                    messages_snapshot=list(messages),
+                    review_memory=should_review_memory,
+                    review_skills=should_review_skills,
+                )
+            except Exception:
+                logger.debug("background review spawn raised", exc_info=True)
 
     return {
         "final_response": turn.final_text,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -390,15 +390,28 @@ def finalize_turn(
 
     # Background memory/skill review — runs AFTER the response is delivered
     # so it never competes with the user's task for model attention.
+    # When a /goal is active, skip background review so it never races
+    # with the goal continuation prompt that will be submitted next.
+    # The goal loop needs the full session budget; the review can wait
+    # until the goal is done or paused.  (issue #42391)
+    _skip_bg_review_for_goal = False
     if final_response and not interrupted and (_should_review_memory or _should_review_skills):
         try:
-            agent._spawn_background_review(
-                messages_snapshot=list(messages),
-                review_memory=_should_review_memory,
-                review_skills=_should_review_skills,
-            )
+            from hermes_cli.goals import load_goal as _load_goal_for_skip
+            _active_goal = _load_goal_for_skip(agent.session_id or "")
+            if _active_goal and _active_goal.status == "active":
+                _skip_bg_review_for_goal = True
         except Exception:
-            pass  # Background review is best-effort
+            pass
+        if not _skip_bg_review_for_goal:
+            try:
+                agent._spawn_background_review(
+                    messages_snapshot=list(messages),
+                    review_memory=_should_review_memory,
+                    review_skills=_should_review_skills,
+                )
+            except Exception:
+                pass  # Background review is best-effort
 
     # Note: Memory provider on_session_end() + shutdown_all() are NOT
     # called here — run_conversation() is called once per user message in

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -236,8 +236,15 @@ def _get_session_db() -> Optional[Any]:
     return db
 
 
-def load_goal(session_id: str) -> Optional[GoalState]:
-    """Load the goal for a session, or None if none exists."""
+def load_goal(session_id: str, *, _visited: Optional[set] = None) -> Optional[GoalState]:
+    """Load the goal for a session, or None if none exists.
+
+    When the session has no direct goal, walks the ``parent_session_id``
+    chain (via SessionDB) to find the nearest active or paused goal.
+    This prevents goals set on a parent session from being silently lost
+    when the conversation rotates into a child session during compression
+    or resume.  (issue #42391)
+    """
     if not session_id:
         return None
     db = _get_session_db()
@@ -248,13 +255,33 @@ def load_goal(session_id: str) -> Optional[GoalState]:
     except Exception as exc:
         logger.debug("GoalManager: get_meta failed: %s", exc)
         return None
-    if not raw:
+    if raw:
+        try:
+            return GoalState.from_json(raw)
+        except Exception as exc:
+            logger.warning("GoalManager: could not parse stored goal for %s: %s", session_id, exc)
+            return None
+
+    # No goal on this session — walk the parent chain.
+    if _visited is None:
+        _visited = set()
+    if session_id in _visited:
         return None
+    _visited.add(session_id)
     try:
-        return GoalState.from_json(raw)
-    except Exception as exc:
-        logger.warning("GoalManager: could not parse stored goal for %s: %s", session_id, exc)
+        entry = db.get_session(session_id)
+    except Exception:
+        entry = None
+    if entry is None:
         return None
+    parent_id = entry.get("parent_session_id") or ""
+    if not parent_id:
+        return None
+    logger.debug(
+        "GoalManager: no goal for %s, walking to parent %s",
+        session_id, parent_id,
+    )
+    return load_goal(parent_id, _visited=_visited)
 
 
 def save_goal(session_id: str, state: GoalState) -> None:


### PR DESCRIPTION
Fixes #42391. Walk parent_session_id chain in load_goal() so child sessions (compression/resume) inherit active goals from their parents. Skip background memory/skill review while a /goal is active to prevent it from racing with the goal continuation prompt.