### PR TITLE
fix(desktop): keep natural sidebar order until manual drag

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -166,8 +166,11 @@ function reconcileOrderIds(currentIds: string[], orderIds: string[]): string[] {
     return []
   }
 
+  // No saved manual order means keep the natural API/recency order.
+  // Do not seed localStorage on app start, otherwise future new sessions
+  // are appended after the stale persisted list instead of appearing first.
   if (!orderIds.length) {
-    return currentIds
+    return []
   }
 
   const current = new Set(currentIds)


### PR DESCRIPTION
## Summary

- keep the Desktop sidebar in natural recency order when no manual order exists
- stop seeding `hermes.desktop.sessionOrder` during app startup
- allow new sessions to appear at the top until the user explicitly drags/reorders sessions

Fixes #42516

## Test plan

- `npm --workspace apps/desktop run build`
- Locally rebuilt Desktop and verified that changing the empty-order branch to return `[]` stops new sessions being appended below a stale persisted order after clearing `hermes.desktop.sessionOrder` once.
