### PR TITLE
fix(tools): return previews on zero-match in replace/remove (#42405)

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -327,6 +327,7 @@ class MemoryStore:
 
             if new_total > limit:
                 current = self._char_count(target)
+                previews = [e[:80] + ("..." if len(e) > 80 else "") for e in entries]
                 return {
                     "success": False,
                     "error": (
@@ -336,6 +337,7 @@ class MemoryStore:
                         f"shorter ones or 'remove' stale or less important entries (see "
                         f"current_entries below), then retry this add — all in this turn."
                     ),
+                    "previews": previews,
                     "current_entries": entries,
                     "usage": f"{current:,}/{limit:,}",
                 }
@@ -369,7 +371,13 @@ class MemoryStore:
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
 
             if not matches:
-                return {"success": False, "error": f"No entry matched '{old_text}'."}
+                previews = [e[:80] + ("..." if len(e) > 80 else "") for e in entries]
+                return {
+                    "success": False,
+                    "error": f"No entry matched '{old_text}'. Check the previews below and retry with the exact text of the entry you want to replace.",
+                    "previews": previews,
+                    "current_entries": entries,
+                }
 
             if len(matches) > 1:
                 # If all matches are identical (exact duplicates), operate on the first one
@@ -426,7 +434,13 @@ class MemoryStore:
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
 
             if not matches:
-                return {"success": False, "error": f"No entry matched '{old_text}'."}
+                previews = [e[:80] + ("..." if len(e) > 80 else "") for e in entries]
+                return {
+                    "success": False,
+                    "error": f"No entry matched '{old_text}'. Check the previews below and retry with the exact text of the entry you want to remove.",
+                    "previews": previews,
+                    "current_entries": entries,
+                }
 
             if len(matches) > 1:
                 # If all matches are identical (exact duplicates), remove the first one


### PR DESCRIPTION
Fixes #42405. replace() and remove() now return entry previews and current_entries when no entry matches old_text, matching the multi-match and add-limit error behavior. Agent can self-correct after a failed replace/remove instead of looping blindly until turn budget is exhausted with no user response.