### PR TITLE
fix(gateway): respect utf16 budget in _split_text_chunks no-newline fallback

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -754,7 +754,11 @@ class GatewayStreamConsumer:
             _cp_budget = _custom_unit_to_cp(remaining, limit, len_fn)
             split_at = remaining.rfind("\n", 0, _cp_budget)
             if split_at < limit // 2:
-                split_at = limit
+                # Hard split at the codepoint budget — NOT ``limit``, which is
+                # measured in ``len_fn`` units (e.g. UTF-16 for Telegram). Using
+                # ``limit`` as a codepoint index over-slices non-BMP text (emoji
+                # = 2 UTF-16 units each), producing chunks past the platform cap.
+                split_at = _cp_budget
             chunks.append(remaining[:split_at])
             remaining = remaining[split_at:].lstrip("\n")
         if remaining:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1908,3 +1908,70 @@ class TestUtf16OverflowDetection:
         # this file passing — they all use MagicMock adapters.
         assert consumer is not None
 
+
+class TestSplitTextChunksUtf16Budget:
+    """_split_text_chunks must keep every chunk within the len_fn budget.
+
+    The no-newline fallback used to hard-split at ``limit`` codepoints, but
+    ``limit`` is measured in ``len_fn`` units. With ``utf16_len`` (Telegram),
+    non-BMP characters (emoji = 2 UTF-16 units) made a fallback chunk up to
+    2x the budget, so Telegram rejected the over-long final message.
+    """
+
+    LIMIT = 4000
+
+    def test_emoji_without_newlines_stays_within_utf16_budget(self):
+        from gateway.platforms.base import utf16_len
+
+        text = "😀" * 5000  # 5000 codepoints, 10000 UTF-16 units, no newline
+        chunks = GatewayStreamConsumer._split_text_chunks(
+            text, self.LIMIT, len_fn=utf16_len,
+        )
+        assert all(utf16_len(c) <= self.LIMIT for c in chunks), (
+            [utf16_len(c) for c in chunks]
+        )
+        assert "".join(chunks) == text  # lossless (no newlines to strip)
+
+    def test_emoji_with_newlines_stays_within_utf16_budget(self):
+        from gateway.platforms.base import utf16_len
+
+        text = ("😀" * 100 + "\n") * 60
+        chunks = GatewayStreamConsumer._split_text_chunks(
+            text, self.LIMIT, len_fn=utf16_len,
+        )
+        assert all(utf16_len(c) <= self.LIMIT for c in chunks), (
+            [utf16_len(c) for c in chunks]
+        )
+
+    def test_cjk_bmp_stays_within_utf16_budget(self):
+        from gateway.platforms.base import utf16_len
+
+        # CJK BMP chars are 1 UTF-16 unit each — already fine; guards the
+        # root-cause boundary (only non-BMP diverges from codepoint count).
+        text = "中" * 5000
+        chunks = GatewayStreamConsumer._split_text_chunks(
+            text, self.LIMIT, len_fn=utf16_len,
+        )
+        assert all(utf16_len(c) <= self.LIMIT for c in chunks)
+
+    def test_plain_len_path_unchanged_and_within_budget(self):
+        # Regression guard: with the default len_fn, _cp_budget == limit, so
+        # the plain-codepoint behavior must be unchanged.
+        text = "a" * 5000
+        chunks = GatewayStreamConsumer._split_text_chunks(text, self.LIMIT)
+        assert all(len(c) <= self.LIMIT for c in chunks)
+        assert "".join(chunks) == text
+
+    def test_no_newline_fallback_does_not_drop_text(self):
+        from gateway.platforms.base import utf16_len
+
+        # A single long no-newline emoji run must be fully delivered across
+        # chunks (the bug produced one over-limit chunk that the platform
+        # would then reject, losing the message).
+        text = "🎉" * 3333
+        chunks = GatewayStreamConsumer._split_text_chunks(
+            text, self.LIMIT, len_fn=utf16_len,
+        )
+        assert "".join(chunks) == text
+        assert all(utf16_len(c) <= self.LIMIT for c in chunks)
+


### PR DESCRIPTION
## What does this PR do?

`GatewayStreamConsumer._split_text_chunks` splits the fallback final
message into platform-sized chunks. Its no-newline fallback hard-split at
`limit`, but `limit` is measured in `len_fn` units (UTF-16 code units for
Telegram) while it was used as a codepoint slice index. Non-BMP text
(emoji = 2 UTF-16 units each) produced chunks up to 2x the budget,
exceeding the platform cap — so the final fallback message was rejected
and lost.

The function already computes `_cp_budget` (the largest codepoint offset
within the unit budget) and uses it to bound the newline search; the fix
also uses it for the hard split. For the default `len_fn=len`,
`_cp_budget == limit`, so plain-text behavior is unchanged.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/stream_consumer.py` — in `_split_text_chunks`, hard-split at
  `_cp_budget` instead of `limit` so chunks respect the `len_fn` budget.
- `tests/gateway/test_stream_consumer.py` — add regression tests.

## How to Test

Run:

    pytest tests/gateway/test_stream_consumer.py -q

Added tests (all pass):

- emoji without newlines: every chunk `utf16_len(chunk) <= limit`
- emoji with newlines: stays within budget
- no-newline run is delivered losslessly across chunks
- CJK-BMP stays within budget (root-cause boundary)
- regression: default `len_fn` behavior unchanged

Before the fix, an emoji-only chunk reached `utf16_len = 8000` for a
4000-unit limit; after, all chunks are `<= limit`.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've updated relevant documentation — N/A (internal helper)