### PR TITLE
Crash-cause diagnostics on the gateway "back online" notification

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -859,6 +859,12 @@ def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
 
 
+def _gateway_lifecycle_path() -> Path:
+    # Records how each gateway run ended (running/clean) so crash-cause diagnostics only fire on an
+    # UNCLEAN exit and stay bounded to the prior run's window.
+    return _hermes_home / ".gateway_lifecycle.json"
+
+
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
@@ -1918,6 +1924,13 @@ class GatewayRunner:
         self._exit_cleanly = False
         self._exit_with_failure = False
         self._exit_reason: Optional[str] = None
+        # Record THIS run's start + capture how the PRIOR run ended (running=crashed / clean).
+        # crash-cause diagnostics use this so they only fire on an unclean exit, bounded to that run.
+        try:
+            from hermes_cli.crash_diagnostics import record_gateway_start
+            self._prior_run = record_gateway_start(_gateway_lifecycle_path())
+        except Exception:
+            self._prior_run = {}
         self._exit_code: Optional[int] = None
         self._draining = False
         self._restart_requested = False
@@ -2842,6 +2855,13 @@ class GatewayRunner:
     def _request_clean_exit(self, reason: str) -> None:
         self._exit_cleanly = True
         self._exit_reason = reason
+        # Hermes-owned lifecycle: this is a PLANNED exit → flip the marker to 'clean' so the next
+        # startup doesn't misread the shutdown (or any unrelated crash near it) as a gateway crash.
+        try:
+            from hermes_cli.crash_diagnostics import mark_gateway_clean_exit
+            mark_gateway_clean_exit(_gateway_lifecycle_path())
+        except Exception:
+            pass
         self._shutdown_event.set()
 
     def _running_agent_count(self) -> int:
@@ -15706,12 +15726,32 @@ class GatewayRunner:
         """
         delivered: set[tuple[str, str, Optional[str]]] = set()
         skipped = skip_targets or set()
-        # Append the crash *cause* when the previous run died unexpectedly — it rides along
-        # with the "back online" message users already get (best-effort, "" on a clean restart
-        # or any failure; gated below by gateway_restart_notification like the rest).
-        from hermes_cli.crash_diagnostics import restart_notice
+        # Crash-cause suffix on the "back online" message — but ONLY when the gateway's own
+        # lifecycle says the prior run exited uncleanly AND a home platform actually wants restart
+        # notices. Gate BEFORE the (subprocess) scan so its timeouts never run when disabled or on a
+        # planned restart; offload the scan off the event loop; and bound the crash search to the
+        # prior run's window so an unrelated crash near a planned restart is never misattributed.
+        notice = ""
+        try:
+            from hermes_cli.crash_diagnostics import prior_run_crashed
+            crashed, started_at = prior_run_crashed(getattr(self, "_prior_run", {}))
+            any_home_wants_notice = any(
+                (self.config.platforms.get(p) is None
+                 or self.config.platforms.get(p).gateway_restart_notification)
+                for p in self.adapters
+                if self.config.get_home_channel(p) and self.config.get_home_channel(p).chat_id
+            )
+            if crashed and any_home_wants_notice:
+                since_h = (
+                    max(0.05, min(24.0, (time.time() - started_at) / 3600.0))
+                    if started_at else 0.5
+                )
+                from hermes_cli.crash_diagnostics import restart_notice
+                notice = await asyncio.to_thread(restart_notice, since_hours=since_h)
+        except Exception:
+            notice = ""
 
-        message = "♻️ Gateway online — Hermes is back and ready." + restart_notice()
+        message = "♻️ Gateway online — Hermes is back and ready." + notice
 
         for platform, adapter in self.adapters.items():
             home = self.config.get_home_channel(platform)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15706,7 +15706,12 @@ class GatewayRunner:
         """
         delivered: set[tuple[str, str, Optional[str]]] = set()
         skipped = skip_targets or set()
-        message = "♻️ Gateway online — Hermes is back and ready."
+        # Append the crash *cause* when the previous run died unexpectedly — it rides along
+        # with the "back online" message users already get (best-effort, "" on a clean restart
+        # or any failure; gated below by gateway_restart_notification like the rest).
+        from hermes_cli.crash_diagnostics import restart_notice
+
+        message = "♻️ Gateway online — Hermes is back and ready." + restart_notice()
 
         for platform, adapter in self.adapters.items():
             home = self.config.get_home_channel(platform)

--- a/hermes_cli/crash_diagnostics.py
+++ b/hermes_cli/crash_diagnostics.py
@@ -51,6 +51,59 @@ def os_kind() -> str:
     return "unknown"
 
 
+# ─── Gateway lifecycle (clean-exit tracking) ─────────────────────────────────
+# So a crash is only ever reported when the gateway's OWN lifecycle says the prior run ended
+# UNCLEANLY — never for a planned restart, and the OS-crash search is bounded to that prior run's
+# window. The gateway records its start (status="running"); a clean shutdown flips it to "clean".
+# A run that never got flipped = it crashed. (Addresses the false-attribution + lifecycle review.)
+
+def read_run_state(state_path: "os.PathLike | str") -> dict:
+    """The persisted lifecycle marker (whatever the most recent run wrote), or ``{}``."""
+    try:
+        p = Path(state_path)
+        return json.loads(p.read_text()) if p.exists() else {}
+    except Exception:
+        return {}
+
+
+def record_gateway_start(state_path: "os.PathLike | str") -> dict:
+    """Call ONCE at gateway startup. Reads the PRIOR run's marker (returned so the caller can
+    decide whether to report a crash), then overwrites it with a fresh ``running`` marker for THIS
+    run. Best-effort — never raises."""
+    prior = read_run_state(state_path)
+    try:
+        p = Path(state_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"started_at": time.time(), "status": "running", "pid": os.getpid()}))
+    except Exception:
+        pass
+    return prior
+
+
+def mark_gateway_clean_exit(state_path: "os.PathLike | str") -> None:
+    """Call on a PLANNED shutdown/restart — flips this run's marker to ``clean`` so the next
+    startup knows the prior run ended on purpose (nothing to report). Best-effort."""
+    try:
+        data = read_run_state(state_path)
+        data["status"] = "clean"
+        data["exited_at"] = time.time()
+        Path(state_path).write_text(json.dumps(data))
+    except Exception:
+        pass
+
+
+def prior_run_crashed(prior: dict) -> tuple[bool, float]:
+    """From a prior-run marker → ``(crashed, started_at)``. A run recorded ``running`` that never
+    got flipped to ``clean`` = crashed. Unknown/empty/clean → ``(False, 0.0)`` so we never
+    misreport a planned restart or a first-ever start."""
+    if not prior or prior.get("status") != "running":
+        return (False, 0.0)
+    try:
+        return (True, float(prior.get("started_at") or 0.0))
+    except (TypeError, ValueError):
+        return (True, 0.0)
+
+
 def _infer_cause(signal: str, backtrace: list[str]) -> str:
     """Map a signal + faulting frames to a short, human-readable cause."""
     bt = " ".join(backtrace).lower()

--- a/hermes_cli/crash_diagnostics.py
+++ b/hermes_cli/crash_diagnostics.py
@@ -1,0 +1,261 @@
+"""Crash-cause diagnostics — parse *why* a Hermes process died, not just that it restarted.
+
+Hermes already notifies on restart ("gateway restarting / back online"). This is the
+complementary signal: when a process dies, read the OS's *own* crash record and surface a
+normalized, human-readable **cause** + faulting backtrace — so an unclean shutdown becomes
+``SIGABRT in libmlx (GPU memory pressure)`` instead of a silent restart.
+
+A native crash (a GPU OOM, a segfault in a C extension, the OOM-killer) never produces a
+Python traceback, so the app/Docker logs just show the process vanishing and coming back.
+Parsing the OS-level crash record is the only reliable, cross-platform way to recover the
+actual cause + faulting frames.
+
+Sources, per platform (best-effort, fully wrapped — never raises into the caller):
+
+* **macOS**   — ``~/Library/Logs/DiagnosticReports/*.ips`` (signal + triggered-thread backtrace)
+* **Linux**   — ``systemd-coredump`` via ``coredumpctl`` (signal + stack); ``journalctl`` fallback
+* **Windows** — Application event log / Windows Error Reporting via ``Get-WinEvent``
+
+GPU-aware (Metal/MLX on Apple, CUDA/NVIDIA on Linux/DGX). One call::
+
+    from hermes_cli.crash_diagnostics import recent_crashes, summarize
+    for c in recent_crashes(name_filter="python", since_hours=24):
+        print(summarize(c))
+
+Each record is a plain dict: ``{os, when, process, signal, cause, backtrace, source}``.
+
+Wired into the gateway's restart machinery: ``_send_home_channel_startup_notifications``
+appends the cause to the "gateway is back online" message after an *unexpected* restart
+(gated by the same ``gateway_restart_notification`` setting). Also surfaced on demand via
+the "Recent Crashes" section of ``hermes doctor`` (see :func:`doctor_section`).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def os_kind() -> str:
+    """Coarse platform bucket: ``macos`` / ``linux`` / ``windows`` / ``unknown``."""
+    p = sys.platform
+    if p == "darwin":
+        return "macos"
+    if p.startswith("linux"):
+        return "linux"
+    if p.startswith("win") or os.name == "nt":
+        return "windows"
+    return "unknown"
+
+
+def _infer_cause(signal: str, backtrace: list[str]) -> str:
+    """Map a signal + faulting frames to a short, human-readable cause."""
+    bt = " ".join(backtrace).lower()
+    sig = str(signal)
+    apple_gpu = any(k in bt for k in ("metal", "libmlx", "mtlcommand", "iogpu"))
+    nv_gpu = any(k in bt for k in ("cuda", "libcudart", "libcublas", "nvidia", "nvrtc"))
+    if apple_gpu or nv_gpu:
+        kind = "Metal/MLX" if apple_gpu else "CUDA/NVIDIA"
+        return f"GPU error ({kind}) → {sig or 'abort'} (often GPU memory pressure / OOM)"
+    if "out of memory" in bt or "oom" in bt:
+        return f"out-of-memory → {sig}"
+    if "SIGSEGV" in sig or "SEGV" in sig or "segfault" in bt:
+        return f"segmentation fault ({sig}) — bad memory access, usually a native extension"
+    if "SIGABRT" in sig or "Abort" in sig or "abort" in bt:
+        return f"aborted ({sig}) — uncaught native exception / assertion"
+    if "SIGKILL" in sig or sig == "9":
+        return f"killed ({sig}) — OOM-killer or manual kill"
+    return f"crashed ({sig or 'unknown signal'})"
+
+
+# ─── macOS (.ips DiagnosticReports) ──────────────────────────────────────────
+def _macos(name_filter: str, since_hours: float, limit: int) -> list[dict]:
+    reports = Path(os.path.expanduser("~/Library/Logs/DiagnosticReports"))
+    if not reports.exists():
+        return []
+    cutoff = time.time() - since_hours * 3600
+    out: list[dict] = []
+    files = [
+        p for p in reports.iterdir()
+        if p.suffix == ".ips" and p.stat().st_mtime >= cutoff
+        and (not name_filter or name_filter.lower() in p.name.lower())
+    ]
+    for p in sorted(files, key=lambda x: x.stat().st_mtime, reverse=True)[:limit]:
+        rec = {"os": "macos", "when": p.stat().st_mtime, "process": "?",
+               "signal": "?", "backtrace": [], "source": p.name}
+        try:
+            # .ips is a header line + a JSON body
+            body = json.loads(p.read_text(errors="replace").split("\n", 1)[1])
+            rec["process"] = body.get("procName", "?")
+            exc = body.get("exception", {}) or {}
+            term = body.get("termination", {}) or {}
+            rec["signal"] = exc.get("signal") or term.get("indicator") or "?"
+            images = body.get("usedImages", [])
+            for thread in body.get("threads", []) or []:
+                if thread.get("triggered"):
+                    for fr in (thread.get("frames") or [])[:14]:
+                        i = fr.get("imageIndex", -1)
+                        name = images[i].get("name", "?") if 0 <= i < len(images) else "?"
+                        sym = (fr.get("symbol") or "")[:54]
+                        rec["backtrace"].append(f"{name}: {sym}" if sym else name)
+                    break
+        except Exception:
+            pass
+        rec["cause"] = _infer_cause(rec["signal"], rec["backtrace"])
+        out.append(rec)
+    return out
+
+
+# ─── Linux (systemd-coredump / journald) ─────────────────────────────────────
+def _linux(name_filter: str, since_hours: float, limit: int) -> list[dict]:
+    out: list[dict] = []
+    try:  # preferred: systemd-coredump
+        r = subprocess.run(
+            ["coredumpctl", "list", "--json=short", "--no-pager"],
+            capture_output=True, text=True, timeout=4,   # short — must never block the restart path
+        )
+        entries = json.loads(r.stdout) if r.returncode == 0 and r.stdout.strip() else []
+        cutoff_us = (time.time() - since_hours * 3600) * 1e6
+        for e in reversed(entries):
+            exe = e.get("exe", "") or ""
+            if name_filter and name_filter.lower() not in exe.lower():
+                continue
+            if e.get("time", 0) and e["time"] < cutoff_us:
+                continue
+            rec = {"os": "linux", "when": (e.get("time", 0) or 0) / 1e6,
+                   "process": Path(exe).name or "?", "signal": str(e.get("sig", "?")),
+                   "backtrace": [], "source": "coredumpctl"}
+            try:
+                info = subprocess.run(
+                    ["coredumpctl", "info", str(e.get("pid", ""))],
+                    capture_output=True, text=True, timeout=4,   # short — must never block the restart path
+                ).stdout
+                grab = False
+                for line in info.splitlines():
+                    if line.strip().startswith("Stack trace"):
+                        grab = True
+                        continue
+                    if grab and line.startswith("    #"):
+                        rec["backtrace"].append(line.strip()[:80])
+            except Exception:
+                pass
+            rec["cause"] = _infer_cause(rec["signal"], rec["backtrace"])
+            out.append(rec)
+            if len(out) >= limit:
+                break
+    except Exception:
+        pass
+    if not out:  # fallback: kernel log segfault lines
+        try:
+            r = subprocess.run(
+                ["journalctl", "-k", "--no-pager", "-n", "200"],
+                capture_output=True, text=True, timeout=4,   # short — must never block the restart path
+            )
+            for line in reversed(r.stdout.splitlines()):
+                low = line.lower()
+                if ("segfault" in low or "core dumped" in low) and (
+                    not name_filter or name_filter.lower() in low
+                ):
+                    out.append({"os": "linux", "when": time.time(), "process": "?",
+                                "signal": "SIGSEGV", "backtrace": [line.strip()[:120]],
+                                "cause": "segfault (from kernel log)", "source": "journald"})
+                    if len(out) >= limit:
+                        break
+        except Exception:
+            pass
+    return out
+
+
+# ─── Windows (Application event log / WER) ───────────────────────────────────
+def _windows(name_filter: str, since_hours: float, limit: int) -> list[dict]:
+    out: list[dict] = []
+    ps = (
+        f"$s=(Get-Date).AddHours(-{since_hours}); "
+        "Get-WinEvent -FilterHashtable @{LogName='Application';"
+        "ProviderName='Application Error';StartTime=$s} "
+        f"-MaxEvents {max(limit, 10)} -ErrorAction SilentlyContinue | "
+        "ForEach-Object { [pscustomobject]@{ t=$_.TimeCreated.ToString('o'); m=$_.Message } } "
+        "| ConvertTo-Json -Compress"
+    )
+    try:
+        r = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", ps],
+            capture_output=True, text=True, timeout=5,   # short — must never block the restart path
+        )
+        data = json.loads(r.stdout) if r.stdout.strip() else []
+        if isinstance(data, dict):
+            data = [data]
+        for e in data:
+            msg = e.get("m") or ""
+            if name_filter and name_filter.lower() not in msg.lower():
+                continue
+            proc = "?"
+            for line in msg.splitlines():
+                if "Faulting application name" in line:
+                    proc = line.split(":", 1)[1].strip().split(",")[0]
+                    break
+            out.append({"os": "windows", "when": time.time(), "process": proc,
+                        "signal": "WER",
+                        "backtrace": [l.strip() for l in msg.splitlines() if "module" in l.lower()][:5],
+                        "cause": "application fault (Windows Error Reporting)", "source": "EventLog"})
+            if len(out) >= limit:
+                break
+    except Exception:
+        pass
+    return out
+
+
+def recent_crashes(name_filter: str = "", since_hours: float = 24, limit: int = 10) -> list[dict]:
+    """Most-recent crashes (newest first), normalized + human-readable, for THIS OS.
+
+    ``name_filter`` matches the crashing process/executable (e.g. ``"python"``).
+    Returns a list of ``{os, when, process, signal, cause, backtrace, source}`` dicts.
+    Best-effort: returns ``[]`` rather than raising if the platform tools are absent.
+    """
+    try:
+        fn = {"macos": _macos, "linux": _linux, "windows": _windows}.get(os_kind())
+        return fn(name_filter, since_hours, limit) if fn else []
+    except Exception:
+        return []
+
+
+def summarize(crash: dict) -> str:
+    """One-line (+ indented backtrace) human summary of a crash record."""
+    when = (
+        time.strftime("%Y-%m-%d %H:%M", time.localtime(crash.get("when", 0)))
+        if crash.get("when") else "?"
+    )
+    head = f"[{when}] {crash.get('process', '?')} ({crash.get('signal', '?')}) — {crash.get('cause', '?')}"
+    bt = crash.get("backtrace") or []
+    return head + (("\n   " + "\n   ".join(bt[:6])) if bt else "")
+
+
+def doctor_section(name_filter: str = "python", since_hours: float = 168) -> list[dict]:
+    """Return recent crashes for a ``hermes doctor`` 'Recent crashes' section
+    (default: last 7 days). Empty list = nothing to report (clean)."""
+    return recent_crashes(name_filter=name_filter, since_hours=since_hours, limit=5)
+
+
+def restart_notice(name_filter: str = "python", since_hours: float = 0.5) -> str:
+    """One-line crash-cause suffix for the gateway's 'back online' notification.
+
+    When the previous run died unexpectedly, returns a short ``"\\n\\n⚠️ …"`` string naming
+    the cause; a clean restart leaves no recent crash record, so this returns ``""``. Returns
+    ``""`` on ANY failure too — never raises, so it is safe to append directly to a message
+    and can never block the restart path. ``since_hours`` is intentionally small: a crash that
+    maps to *this* restart is seconds-to-minutes old, not hours.
+    """
+    try:
+        crashes = recent_crashes(name_filter=name_filter, since_hours=since_hours, limit=1)
+        if not crashes:
+            return ""
+        crash = crashes[0]
+        return (
+            "\n\n⚠️ The previous run ended unexpectedly: "
+            f"{crash.get('process', '?')} ({crash.get('signal', '?')}) — {crash.get('cause', '?')}"
+        )
+    except Exception:
+        return ""

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -991,6 +991,21 @@ def run_doctor(args):
     except Exception as _xai_check_err:
         check_warn("xAI retirement check skipped", f"({_xai_check_err})")
 
+    _section("Recent Crashes")
+
+    try:
+        from hermes_cli.crash_diagnostics import doctor_section, summarize
+
+        crashes = doctor_section()  # last 7 days, python processes
+        if not crashes:
+            check_ok("No crashes in the last 7 days")
+        else:
+            check_warn(f"{len(crashes)} crash(es) in the last 7 days — why each died:")
+            for crash in crashes:
+                check_info(summarize(crash).replace("\n", "\n      "))
+    except Exception as _crash_check_err:
+        check_warn("Crash diagnostics skipped", f"({_crash_check_err})")
+
     _section("Auth Providers")
 
     try:

--- a/tests/hermes_cli/test_crash_diagnostics.py
+++ b/tests/hermes_cli/test_crash_diagnostics.py
@@ -1,0 +1,91 @@
+"""Tests for crash-cause diagnostics (``hermes_cli.crash_diagnostics``).
+
+Pins the cause inference (signal + faulting backtrace → human-readable cause), the
+cross-platform dispatch (never raises into the caller), and the one-line summary format.
+The OS-specific readers (.ips / coredumpctl / WER) are exercised only through the
+graceful-degradation path here — they're integration-tested on their respective platforms.
+"""
+from __future__ import annotations
+
+from hermes_cli import crash_diagnostics as cd
+
+
+def test_infer_cause_gpu_metal():
+    cause = cd._infer_cause("SIGABRT", ["libmlx.dylib: x", "Metal: command buffer"])
+    assert "GPU error (Metal/MLX)" in cause
+
+
+def test_infer_cause_gpu_cuda():
+    cause = cd._infer_cause("SIGABRT", ["libcudart.so: cudaMalloc", "libtorch_cuda.so"])
+    assert "GPU error (CUDA/NVIDIA)" in cause
+
+
+def test_infer_cause_segfault():
+    assert "segmentation fault" in cd._infer_cause("SIGSEGV", ["libpython: PyEval"])
+
+
+def test_infer_cause_abort():
+    assert "aborted" in cd._infer_cause("SIGABRT", ["libc++abi: __abort_message"])
+
+
+def test_infer_cause_oom_killer():
+    assert "killed" in cd._infer_cause("SIGKILL", [])
+
+
+def test_recent_crashes_returns_list_and_never_raises():
+    # A bogus filter yields no matches on any platform; the call must still return a list,
+    # not raise, even when the platform's crash tools are missing.
+    out = cd.recent_crashes(name_filter="no-such-process-zzz", since_hours=1)
+    assert isinstance(out, list)
+
+
+def test_summarize_format():
+    rec = {
+        "when": 0, "process": "python", "signal": "SIGABRT",
+        "cause": "aborted (SIGABRT)", "backtrace": ["a.dylib: foo", "b.dylib: bar"],
+    }
+    summary = cd.summarize(rec)
+    assert "python (SIGABRT)" in summary
+    assert "aborted" in summary
+    assert "a.dylib: foo" in summary  # backtrace surfaced
+
+
+def test_summarize_no_backtrace_is_single_line():
+    rec = {"when": 0, "process": "node", "signal": "WER", "cause": "application fault", "backtrace": []}
+    assert "\n" not in cd.summarize(rec)
+
+
+def test_os_kind_is_known_bucket():
+    assert cd.os_kind() in ("macos", "linux", "windows", "unknown")
+
+
+def test_doctor_section_returns_list():
+    assert isinstance(cd.doctor_section(), list)
+
+
+# ── restart_notice: the suffix appended to the gateway "back online" message ──
+
+def test_restart_notice_empty_on_clean_restart(monkeypatch):
+    # No recent crash record (clean shutdown) → no suffix.
+    monkeypatch.setattr(cd, "recent_crashes", lambda **kw: [])
+    assert cd.restart_notice() == ""
+
+
+def test_restart_notice_names_the_cause_on_unclean_restart(monkeypatch):
+    monkeypatch.setattr(cd, "recent_crashes", lambda **kw: [
+        {"process": "python", "signal": "SIGABRT",
+         "cause": "GPU error (Metal/MLX) → SIGABRT (often GPU memory pressure / OOM)"}
+    ])
+    notice = cd.restart_notice()
+    assert notice.startswith("\n\n⚠️")
+    assert "previous run ended unexpectedly" in notice
+    assert "python (SIGABRT)" in notice
+    assert "GPU error (Metal/MLX)" in notice
+
+
+def test_restart_notice_swallows_errors(monkeypatch):
+    # Must never raise into the restart/notification path.
+    def boom(**kw):
+        raise RuntimeError("crash reader blew up")
+    monkeypatch.setattr(cd, "recent_crashes", boom)
+    assert cd.restart_notice() == ""

--- a/tests/hermes_cli/test_crash_diagnostics.py
+++ b/tests/hermes_cli/test_crash_diagnostics.py
@@ -89,3 +89,43 @@ def test_restart_notice_swallows_errors(monkeypatch):
         raise RuntimeError("crash reader blew up")
     monkeypatch.setattr(cd, "recent_crashes", boom)
     assert cd.restart_notice() == ""
+
+
+# ── Gateway lifecycle (clean-exit tracking) ──────────────────────────────────
+# A crash is only reported when the gateway's OWN lifecycle says the prior run ended uncleanly,
+# so a planned restart (or an unrelated crash near it) is never misattributed.
+
+def test_lifecycle_first_start_not_crashed(tmp_path):
+    prior = cd.record_gateway_start(tmp_path / ".gw.json")
+    assert cd.prior_run_crashed(prior) == (False, 0.0)
+
+
+def test_lifecycle_unclean_exit_detected(tmp_path):
+    p = tmp_path / ".gw.json"
+    cd.record_gateway_start(p)              # run 1 starts (marker: running)
+    prior = cd.record_gateway_start(p)      # run 2 starts, run 1 never exited cleanly → crashed
+    crashed, started_at = cd.prior_run_crashed(prior)
+    assert crashed is True and started_at > 0
+
+
+def test_lifecycle_clean_exit_not_crashed(tmp_path):
+    p = tmp_path / ".gw.json"
+    cd.record_gateway_start(p)              # run 1 starts
+    cd.mark_gateway_clean_exit(p)           # run 1 exits cleanly (planned)
+    prior = cd.record_gateway_start(p)      # run 2 starts → prior was clean
+    assert cd.prior_run_crashed(prior) == (False, 0.0)
+
+
+def test_prior_run_crashed_guards():
+    assert cd.prior_run_crashed({}) == (False, 0.0)
+    assert cd.prior_run_crashed({"status": "clean"}) == (False, 0.0)
+    # recorded running but no start time → still a crash, started_at defaults to 0.0
+    assert cd.prior_run_crashed({"status": "running"}) == (True, 0.0)
+
+
+def test_lifecycle_state_survives_bad_file(tmp_path):
+    p = tmp_path / ".gw.json"
+    p.write_text("{ not json")
+    assert cd.read_run_state(p) == {}       # malformed → empty, never raises
+    prior = cd.record_gateway_start(p)      # still records fine over the bad file
+    assert cd.prior_run_crashed(prior) == (False, 0.0)


### PR DESCRIPTION
Implements #41763.

When a process dies unexpectedly, this parses the OS's own crash record into a normalized **cause** + faulting backtrace and appends it to the existing "♻️ Gateway online — Hermes is back and ready" message (via `_send_home_channel_startup_notifications` in `gateway/run.py`), so an unclean restart shows *why* it died — e.g. `Python (SIGABRT) — GPU error (Metal/MLX)` — instead of a silent recovery.

### Addresses the review notes
- **Wired into the existing notification**, gated by the same `gateway_restart_notification` setting — not a standalone module. The cause rides along with the "back online" message users already get.
- **Best-effort and truly silent**: short subprocess timeouts (4–5s), bare-except boundaries, returns `[]` / `""` on missing tools, wrong platform, parse failure, or timeout. Never raises into, or blocks, the restart path.
- **Windows-safe**: `Get-WinEvent` only runs on Windows (via the `os_kind()` dispatch); non-Windows returns `[]`. Passes `scripts/check-windows-footguns.py`.
- **Stdlib only** (`subprocess`, `json`, `pathlib`).

### Sources
macOS `.ips` DiagnosticReports · Linux `coredumpctl` (journald fallback) · Windows WER (Application event log). GPU-aware (Metal/MLX on Apple, CUDA/NVIDIA on Linux/DGX).

### Secondary surface
A "Recent Crashes" section in `hermes doctor`.

### Tests
13 tests in `tests/hermes_cli/test_crash_diagnostics.py`, all passing — cause inference, graceful degradation (never raises), and the `restart_notice()` glue (empty on clean restart, names the cause on an unclean one, swallows errors).

Closes #41763