### PR TITLE
fix: use fallback model for custom provider fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3614,10 +3614,18 @@ def resolve_provider_client(
                     else (client, final_model))
         # Try custom first, then API-key providers (Codex excluded here:
         # falling through to Codex with no model is a stale-constant trap).
+        _first_try = True
         for try_fn in (_try_custom_endpoint, _resolve_api_key_provider):
             client, default = try_fn()
             if client is not None:
-                final_model = _normalize_resolved_model(model or default, provider)
+                # When falling back to a different provider (e.g. Gemini),
+                # use that provider's default model — not the original model
+                # meant for the custom endpoint. Otherwise we'd send
+                # "ark-code-latest" to Gemini's API and get a 404.
+                if _first_try:
+                    final_model = _normalize_resolved_model(model or default, provider)
+                else:
+                    final_model = _normalize_resolved_model(default, provider)
                 _cbase = str(getattr(client, "base_url", "") or "")
                 # ``client.api_key`` may be a callable (Azure Foundry Entra
                 # bearer provider). Pass empty string for the wrapper-detection
@@ -3627,6 +3635,7 @@ def resolve_provider_client(
                 client = _wrap_if_needed(client, final_model, _cbase, _ckey)
                 return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                         else (client, final_model))
+            _first_try = False
         logger.warning("resolve_provider_client: custom/main requested "
                        "but no endpoint credentials found")
         return None, None

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -949,6 +949,22 @@ class TestVisionClientFallback:
         assert client.__class__.__name__ == "AnthropicAuxiliaryClient"
         assert model == "claude-haiku-4-5-20251001"
 
+    def test_custom_provider_fallback_uses_fallback_provider_default_model(self):
+        """A failed custom endpoint must not leak its model into fallback providers."""
+        fallback_client = MagicMock()
+
+        with (
+            patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)),
+            patch(
+                "agent.auxiliary_client._resolve_api_key_provider",
+                return_value=(fallback_client, "gemini-2.0-flash"),
+            ),
+        ):
+            client, model = resolve_provider_client("custom", "ark-code-latest")
+
+        assert client is fallback_client
+        assert model == "gemini-2.0-flash"
+
 
 class TestAuxiliaryPoolAwareness:
     def test_try_nous_uses_pool_entry(self):


### PR DESCRIPTION
## Summary
- Fix custom provider fallback model selection so fallback providers use their own default model.
- Preserve explicit model behavior for the primary custom endpoint attempt.
- Add a regression test for the `custom` -> API-key provider fallback path.

## Root cause
When `resolve_provider_client("custom", model)` failed to build a custom endpoint client, it fell back to API-key providers such as Gemini. The fallback client/default model was resolved correctly, but the final model still preferred the original custom model via `model or default`. That could pair a Gemini client with a non-Gemini model such as `ark-code-latest`, causing Gemini 404 errors.

## Fix
Use the caller-provided model only for the first custom endpoint attempt. If that fails and the code falls back to another provider, use the fallback provider's default model.

## Tests
- `python -m pytest tests/agent/test_auxiliary_client.py::TestVisionClientFallback::test_custom_provider_fallback_uses_fallback_provider_default_model -v --tb=short -p no:timeout -o 'addopts='`
- `python -m pytest tests/agent/test_auxiliary_client.py -q -p no:timeout -o 'addopts='`

Result: `214 passed, 1 warning`