### PR TITLE
feat: add kanban workboard overview

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -86,27 +86,32 @@
     return body || raw;
   }
 
-  // Order matches BOARD_COLUMNS in plugin_api.py.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
+  // Order matches BOARD_COLUMNS in plugin_api.py. These backend statuses are
+  // labelled as Jose's Workboard workflow in the UI.
+  const COLUMN_ORDER = ["triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
   const FALLBACK_COLUMN_LABEL = {
-    triage: "Triage",
-    todo: "Todo",
+    triage: "Inbox",
+    todo: "Plan",
+    scheduled: "Scheduled",
     ready: "Ready",
     running: "In Progress",
     blocked: "Blocked",
-    done: "Done",
+    review: "Preview",
+    done: "Verified/Done",
     archived: "Archived",
   };
   const FALLBACK_COLUMN_HELP = {
-    triage: "Raw ideas — a specifier will flesh out the spec",
-    todo: "Waiting on dependencies or unassigned",
+    triage: "Chats and raw asks — 'pásalo al Kanban' lands here before spec",
+    todo: "Plan, owner, scope, acceptance criteria, and dependencies",
+    scheduled: "Waiting on a known time delay or follow-up window",
     ready: "Dependencies satisfied; assign a profile to dispatch",
-    running: "Claimed by a worker — in-flight",
-    blocked: "Worker asked for human input",
-    done: "Completed",
+    running: "Claimed by a worker — in-flight implementation",
+    blocked: "Worker asked for human input or hit a real blocker",
+    review: "Preview/evidence lane: URL, screenshots, tests, smoke, branch/PR",
+    done: "Verified by smoke/test/live evidence and ready to close",
     archived: "Archived",
   };
   const FALLBACK_DESTRUCTIVE = {
@@ -135,10 +140,19 @@
   };
 
   function getColumnLabel(t, status) {
-    return tx(t, "columnLabels." + status, FALLBACK_COLUMN_LABEL[status] || status);
+    // Jose's Workboard labels intentionally override the generic host i18n
+    // catalog (Triage/Todo/Done) so this plugin presents one consistent
+    // workflow even when the surrounding dashboard locale is English.
+    if (Object.prototype.hasOwnProperty.call(FALLBACK_COLUMN_LABEL, status)) {
+      return FALLBACK_COLUMN_LABEL[status];
+    }
+    return tx(t, "columnLabels." + status, status);
   }
   function getColumnHelp(t, status) {
-    return tx(t, "columnHelp." + status, FALLBACK_COLUMN_HELP[status] || "");
+    if (Object.prototype.hasOwnProperty.call(FALLBACK_COLUMN_HELP, status)) {
+      return FALLBACK_COLUMN_HELP[status];
+    }
+    return tx(t, "columnHelp." + status, "");
   }
   function getDestructiveConfirm(t, status) {
     const key = DESTRUCTIVE_KEYS[status];
@@ -154,9 +168,11 @@
   const COLUMN_DOT = {
     triage: "hermes-kanban-dot-triage",
     todo: "hermes-kanban-dot-todo",
+    scheduled: "hermes-kanban-dot-scheduled",
     ready: "hermes-kanban-dot-ready",
     running: "hermes-kanban-dot-running",
     blocked: "hermes-kanban-dot-blocked",
+    review: "hermes-kanban-dot-review",
     done: "hermes-kanban-dot-done",
     archived: "hermes-kanban-dot-archived",
   };
@@ -1005,6 +1021,7 @@
           boardData,
           onOpen: setSelectedTaskId,
         }),
+        h(WorkboardOverview, { boardData: filteredBoard }),
         h(BoardToolbar, {
           board: boardData,
           tenantFilter, setTenantFilter,
@@ -1056,6 +1073,42 @@
           assignees: (boardData && boardData.assignees) || [],
           eventTick: taskEventTick[selectedTaskId] || 0,
         }) : null,
+      ),
+    );
+  }
+
+  function WorkboardOverview(props) {
+    const board = props.boardData;
+    const columns = (board && board.columns) || [];
+    const counts = {};
+    let total = 0;
+    for (const col of columns) {
+      const n = (col.tasks || []).length;
+      counts[col.name] = n;
+      total += n;
+    }
+    const live = (counts.running || 0) + (counts.review || 0);
+    const waiting = (counts.triage || 0) + (counts.todo || 0) + (counts.scheduled || 0) + (counts.ready || 0);
+    return h("section", { className: "hermes-kanban-workboard", "aria-label": "Hermes Workboard overview" },
+      h("div", { className: "hermes-kanban-workboard-copy" },
+        h("div", { className: "hermes-kanban-eyebrow" }, "Hermes Workboard"),
+        h("h2", { className: "hermes-kanban-workboard-title" }, "Chats → Tasks → Previews → Verified evidence"),
+        h("p", { className: "hermes-kanban-workboard-text" },
+          "Usa este tablero como la superficie visual del trabajo: cuando Jose diga ‘pásalo al Kanban’, crea/actualiza una card con scope, owner, preview URL, screenshots, test/smoke output, branch/commit/PR y evidencia externa cuando aplique."),
+      ),
+      h("div", { className: "hermes-kanban-workboard-stats" },
+        h("div", { className: "hermes-kanban-workboard-stat" }, h("strong", null, total), h("span", null, "cards")),
+        h("div", { className: "hermes-kanban-workboard-stat" }, h("strong", null, waiting), h("span", null, "waiting")),
+        h("div", { className: "hermes-kanban-workboard-stat" }, h("strong", null, live), h("span", null, "active/review")),
+        h("div", { className: "hermes-kanban-workboard-stat" }, h("strong", null, counts.done || 0), h("span", null, "verified")),
+      ),
+      h("div", { className: "hermes-kanban-workboard-flow" },
+        ["Inbox", "Plan", "In Progress", "Preview", "Verified/Done"].map(function (label, idx) {
+          return h("span", { key: label, className: "hermes-kanban-workboard-step" },
+            idx > 0 ? h("span", { className: "hermes-kanban-workboard-arrow" }, "→") : null,
+            label,
+          );
+        }),
       ),
     );
   }
@@ -2267,6 +2320,34 @@
     );
   }
 
+  function emptyTitle(status) {
+    const map = {
+      triage: "No incoming asks",
+      todo: "No plans waiting",
+      scheduled: "No scheduled follow-ups",
+      ready: "Nothing ready to dispatch",
+      running: "No workers active",
+      blocked: "No blockers",
+      review: "No previews to verify",
+      done: "No verified work yet",
+    };
+    return map[status] || "No cards";
+  }
+
+  function emptyHint(status) {
+    const map = {
+      triage: "Drop rough chat asks here; the next step is scope + owner.",
+      todo: "Planned cards should include acceptance criteria and evidence needed.",
+      scheduled: "Time-based reminders and follow-ups appear here.",
+      ready: "Assign a Hermes profile, then nudge dispatcher.",
+      running: "Active workers will show owner lanes and live evidence.",
+      blocked: "Human-input blockers will surface here instead of disappearing.",
+      review: "Attach preview URL, screenshots, build/test/smoke output, commit/PR.",
+      done: "Only close after verification evidence is attached or summarized.",
+    };
+    return map[status] || "Create a card to start.";
+  }
+
   function Column(props) {
     const { t } = useI18n();
     const [dragOver, setDragOver] = useState(false);
@@ -2372,7 +2453,15 @@
       }) : null,
       h("div", { className: "hermes-kanban-column-body" },
         props.column.tasks.length === 0
-          ? h("div", { className: "hermes-kanban-empty" }, tx(t, "noTasks", "— no tasks —"))
+          ? h("div", { className: "hermes-kanban-empty" },
+              h("strong", null, emptyTitle(props.column.name)),
+              h("span", null, emptyHint(props.column.name)),
+              h("button", {
+                type: "button",
+                className: "hermes-kanban-empty-action",
+                onClick: function () { setShowCreate(true); },
+              }, props.column.name === "triage" ? "Pásalo al Kanban" : tx(t, "createTask", "Create task")),
+            )
           : lanes
             ? lanes.map(function (lane) {
                 return h("div", { key: lane.assignee, className: "hermes-kanban-lane" },
@@ -2568,6 +2657,9 @@
           ),
           h("div", { className: "hermes-kanban-card-title" },
             t.title || tx(i18n, "untitled", "(untitled)")),
+          t.latest_summary
+            ? h("div", { className: "hermes-kanban-card-summary", title: t.latest_summary }, t.latest_summary)
+            : null,
           h("div", { className: "hermes-kanban-card-row hermes-kanban-card-meta" },
             t.assignee
               ? h("span", { className: "hermes-kanban-assignee",
@@ -2580,6 +2672,14 @@
             t.comment_count > 0
               ? h("span", { className: "hermes-kanban-count",
                             title: `${t.comment_count} comment${t.comment_count === 1 ? "" : "s"} on this task` }, "💬 ", t.comment_count)
+              : null,
+            t.attachment_count > 0
+              ? h("span", { className: "hermes-kanban-count hermes-kanban-evidence-count",
+                            title: `${t.attachment_count} attached artifact${t.attachment_count === 1 ? "" : "s"}: screenshots, previews, test logs, files` }, "📎 ", t.attachment_count)
+              : null,
+            t.latest_summary
+              ? h("span", { className: "hermes-kanban-count hermes-kanban-evidence-count",
+                            title: "Latest worker summary is available in the card drawer" }, "✓ evidence")
               : null,
             t.link_counts && (t.link_counts.parents + t.link_counts.children) > 0
               ? h("span", { className: "hermes-kanban-count",

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -60,24 +60,102 @@
   color: var(--color-muted-foreground) !important;
 }
 
+
+/* ---- Jose Workboard overview ----------------------------------------- */
+
+.hermes-kanban-workboard {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(220px, 0.85fr);
+  gap: 0.9rem;
+  align-items: stretch;
+  border: 1px solid color-mix(in srgb, var(--color-border) 76%, transparent);
+  border-radius: calc(var(--radius) + 4px);
+  padding: 0.9rem;
+  background:
+    radial-gradient(circle at top left, color-mix(in srgb, var(--color-ring) 16%, transparent), transparent 38%),
+    color-mix(in srgb, var(--color-card) 82%, transparent);
+}
+.hermes-kanban-eyebrow {
+  color: var(--color-muted-foreground);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.65rem;
+  margin-bottom: 0.25rem;
+}
+.hermes-kanban-workboard-title {
+  margin: 0;
+  font-size: clamp(1.05rem, 2vw, 1.5rem);
+  line-height: 1.1;
+}
+.hermes-kanban-workboard-text {
+  margin: 0.45rem 0 0;
+  color: var(--color-muted-foreground);
+  font-size: 0.82rem;
+  max-width: 75ch;
+}
+.hermes-kanban-workboard-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+.hermes-kanban-workboard-stat {
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  border-radius: var(--radius-sm, 0.35rem);
+  padding: 0.55rem;
+  background: color-mix(in srgb, var(--color-background) 35%, transparent);
+}
+.hermes-kanban-workboard-stat strong {
+  display: block;
+  font-size: 1.05rem;
+}
+.hermes-kanban-workboard-stat span {
+  color: var(--color-muted-foreground);
+  font-size: 0.68rem;
+}
+.hermes-kanban-workboard-flow {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  color: var(--color-muted-foreground);
+  font-size: 0.72rem;
+}
+.hermes-kanban-workboard-step {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
+  border-radius: 999px;
+  padding: 0.18rem 0.5rem;
+  background: color-mix(in srgb, var(--color-card) 70%, transparent);
+}
+.hermes-kanban-workboard-arrow { color: var(--color-ring); }
+@media (max-width: 900px) {
+  .hermes-kanban-workboard { grid-template-columns: 1fr; }
+}
+
 /* ---- Columns layout -------------------------------------------------- */
 
 .hermes-kanban-columns {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65rem;
   align-items: start;
   overflow-x: auto;
+  padding-bottom: 0.35rem;
+  scroll-snap-type: x proximity;
 }
 
 .hermes-kanban-column {
-  flex: 0 0 280px;
+  flex: 0 0 clamp(220px, 16vw, 260px);
   display: flex;
   flex-direction: column;
   background: color-mix(in srgb, var(--color-card) 85%, transparent);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  padding: 0.5rem;
-  min-height: 200px;
+  padding: 0.48rem;
+  min-height: 220px;
+  scroll-snap-align: start;
   max-height: calc(100vh - 220px);
   transition: border-color 120ms ease, background-color 120ms ease;
 }
@@ -144,12 +222,34 @@
 }
 
 .hermes-kanban-empty {
-  padding: 1.5rem 0.5rem;
-  text-align: center;
+  padding: 1rem 0.6rem;
+  text-align: left;
   font-size: 0.75rem;
   color: var(--color-muted-foreground);
   border: 1px dashed color-mix(in srgb, var(--color-border) 70%, transparent);
   border-radius: var(--radius-sm, 0.25rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  min-height: 118px;
+}
+.hermes-kanban-empty strong {
+  color: var(--color-foreground);
+  font-size: 0.78rem;
+}
+.hermes-kanban-empty-action {
+  align-self: flex-start;
+  border: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-foreground) 5%, transparent);
+  color: var(--color-foreground);
+  border-radius: 999px;
+  padding: 0.22rem 0.55rem;
+  font-size: 0.68rem;
+  cursor: pointer;
+}
+.hermes-kanban-empty-action:hover {
+  border-color: var(--color-ring);
+  background: color-mix(in srgb, var(--color-ring) 12%, transparent);
 }
 
 /* ---- Status dots ----------------------------------------------------- */
@@ -163,9 +263,11 @@
 }
 .hermes-kanban-dot-triage   { background: #b47dd6; }  /* lilac — fresh/unspecified */
 .hermes-kanban-dot-todo     { background: var(--color-muted-foreground); }
+.hermes-kanban-dot-scheduled{ background: #c59a5b; }  /* warm queue */
 .hermes-kanban-dot-ready    { background: #d4b348; }  /* amber */
 .hermes-kanban-dot-running  { background: #3fb97d; }  /* green */
 .hermes-kanban-dot-blocked  { background: var(--color-destructive, #d14a4a); }
+.hermes-kanban-dot-review   { background: #7fb7ff; }  /* preview */
 .hermes-kanban-dot-done     { background: #4a8cd1; }  /* blue */
 .hermes-kanban-dot-archived { background: var(--color-border); }
 
@@ -254,6 +356,21 @@
   font-size: 0.65rem;
   color: var(--color-muted-foreground);
   letter-spacing: 0.03em;
+}
+
+.hermes-kanban-card-summary {
+  border-left: 2px solid color-mix(in srgb, var(--color-ring) 55%, transparent);
+  padding-left: 0.45rem;
+  color: var(--color-muted-foreground);
+  font-size: 0.72rem;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.hermes-kanban-evidence-count {
+  color: color-mix(in srgb, var(--color-ring) 70%, var(--color-foreground));
 }
 
 .hermes-kanban-card-title {

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -140,13 +140,14 @@ def _conn(board: Optional[str] = None):
 # ---------------------------------------------------------------------------
 
 # Columns shown by the dashboard, in left-to-right order. "archived" is
-# available via a filter toggle rather than a visible column.
+# available via a filter toggle rather than a visible column. The frontend
+# labels these statuses as Jose's Workboard workflow:
+# Inbox -> Plan -> Scheduled -> Ready -> In Progress -> Blocked -> Preview -> Verified/Done.
 #
 # Keep this in sync with kanban_db.VALID_STATUSES.  In particular,
-# ``scheduled`` is a first-class waiting column used for time-based follow-ups;
-# if it is omitted here, the board-level fallback below mis-buckets scheduled
-# tasks into ``todo`` and makes the dashboard look like the Scheduled column
-# disappeared.
+# ``scheduled`` and ``review`` are first-class columns: scheduled follow-ups
+# should not fall back to planning, and review is the preview/evidence lane
+# before Verified/Done.
 BOARD_COLUMNS: list[str] = [
     "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
 ]
@@ -418,11 +419,19 @@ def get_board(
                 "parents"
             ] += 1
 
-        # Comment + event counts (both cheap aggregates).
+        # Comment + attachment counts (cheap aggregates). Attachments are
+        # treated as Workboard evidence chips on cards (screenshots, preview
+        # files, smoke output, PR artifacts).
         comment_counts: dict[str, int] = {
             r["task_id"]: r["n"]
             for r in conn.execute(
                 "SELECT task_id, COUNT(*) AS n FROM task_comments GROUP BY task_id"
+            )
+        }
+        attachment_counts: dict[str, int] = {
+            r["task_id"]: r["n"]
+            for r in conn.execute(
+                "SELECT task_id, COUNT(*) AS n FROM task_attachments GROUP BY task_id"
             )
         }
 
@@ -467,6 +476,8 @@ def get_board(
             d = _task_dict(t, latest_summary=preview)
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
             d["comment_count"] = comment_counts.get(t.id, 0)
+            d["attachment_count"] = attachment_counts.get(t.id, 0)
+            d["evidence_count"] = d["comment_count"] + d["attachment_count"]
             d["progress"] = progress.get(t.id)  # None when the task has no children
             diags = diagnostics_per_task.get(t.id)
             if diags:

--- a/tests/plugins/test_kanban_workboard_api.py
+++ b/tests/plugins/test_kanban_workboard_api.py
@@ -1,0 +1,75 @@
+"""Workboard-facing Kanban dashboard API regression tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+
+
+def _load_plugin_router():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    mod_name = "hermes_dashboard_plugin_kanban_workboard_api_test"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name].router
+    spec = importlib.util.spec_from_file_location(mod_name, plugin_file)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod.router
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    return TestClient(app)
+
+
+def test_board_exposes_full_workboard_columns(client):
+    resp = client.get("/api/plugins/kanban/board")
+    assert resp.status_code == 200
+    columns = [c["name"] for c in resp.json()["columns"]]
+    assert columns == ["triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done"]
+
+
+def test_board_cards_include_attachment_and_evidence_counts(client):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="ship preview")
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (task_id,))
+        conn.execute(
+            "INSERT INTO task_attachments "
+            "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (task_id, "desktop.png", "/tmp/desktop.png", "image/png", 123, "test", int(time.time())),
+        )
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, ?, ?, ?)",
+            (task_id, "test", "smoke passed", int(time.time())),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    resp = client.get("/api/plugins/kanban/board")
+    assert resp.status_code == 200
+    review = next(c for c in resp.json()["columns"] if c["name"] == "review")
+    card = review["tasks"][0]
+    assert card["attachment_count"] == 1
+    assert card["comment_count"] == 1
+    assert card["evidence_count"] == 2


### PR DESCRIPTION
## Summary
- Adds a Hermes Workboard overview panel for the Kanban plugin with Jose's chat → task → preview → verified-evidence workflow.
- Relabels visible Kanban statuses into the Workboard lanes: Inbox, Plan, Scheduled, Ready, In Progress, Blocked, Preview, Verified/Done while preserving backend status names.
- Adds evidence signals on cards from attachments/latest summaries, richer empty states, denser horizontally-scrolled columns, and API regression coverage for workboard columns/evidence counts.

## Test Plan
- `node --check plugins/kanban/dashboard/dist/index.js`
- `python -m pytest tests/plugins/test_kanban_workboard_api.py tests/plugins/test_kanban_worker_runs.py -q`
- Live dashboard smoke at `http://100.99.61.87:9119/kanban`: verified Workboard panel, lane labels, internal column scroll, and authenticated plugin API via SDK fetch.
