### PR TITLE
fix(photon): unwrap dashboard project responses

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -147,7 +147,7 @@
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",
     "@vitejs/plugin-react": "^6.0.1",
-    "concurrently": "^10.0.3",
+    "concurrently": "^9.2.4",
     "cross-env": "^10.1.0",
     "electron": "40.10.2",
     "electron-builder": "^26.8.1",

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -98,6 +98,19 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     text = (error or "unknown error").strip()
     lower = text.lower()
 
+    # Script-only jobs never invoke an LLM provider. Preserve their actual
+    # local/script error instead of classifying any "timeout" substring as a
+    # provider/fallback-chain failure.
+    if job.get("no_agent"):
+        cleaned = re.sub(
+            r"^(RuntimeError|Exception|ValueError|HTTPStatusError):\s*",
+            "", text[:2000],
+        )
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        if len(cleaned) > 180:
+            cleaned = cleaned[:177].rstrip() + "..."
+        return f"⚠️ Cron '{job_name}' failed: {cleaned}"
+
     # Provider/API failures are the common noisy path. Keep these short.
     if "429" in text or "rate limit" in lower or "usage limit" in lower:
         reason = "rate limit"

--- a/docs/argus-dashboard-kit-spec.md
+++ b/docs/argus-dashboard-kit-spec.md
@@ -1,0 +1,440 @@
+# Argus Dashboard Kit Spec
+
+A concept/spec for lightweight, thesis-adjacent research dashboards in Argus.
+
+---
+
+## Purpose
+
+Argus dashboards are not meant to be full-blown web applications or generalized BI products. They are lightweight research artifacts that sit alongside a thesis note and help surface the most important evidence, visuals, and point-in-time context.
+
+The goal is to standardize the workflow and design philosophy without over-standardizing the output.
+
+This spec defines:
+- the role dashboards play inside Argus
+- the recommended project/folder shape
+- the lifecycle of a dashboard
+- the design philosophy Argus should follow
+- a lightweight publishing philosophy suitable for private hosting
+
+---
+
+## Core Idea
+
+Argus should support a shared dashboard kit plus per-dashboard instances.
+
+That means:
+- one reusable dashboard kit provides the visual language, rendering conventions, payload expectations, and workflow guidance
+- each dashboard remains a self-contained project instance tied to a single company, token, theme, or thesis
+- individual dashboards can be ephemeral, weird, or highly specific without needing to conform to a rigid component checklist
+
+This is deliberately a middle ground between:
+- one-off bespoke dashboard projects with no shared structure
+- a heavy production dashboard framework that is too expensive to build and maintain for ephemeral thesis work
+
+---
+
+## Product Philosophy
+
+Argus dashboards should be treated as research artifacts, not SaaS apps.
+
+They should optimize for:
+- speed of creation
+- clarity of thought
+- point-in-time usefulness
+- ease of refresh when worthwhile
+- low maintenance burden
+- portability
+
+They should not optimize for:
+- maximal abstraction
+- backend complexity
+- generic productization too early
+- polished enterprise software workflows
+
+A dashboard that is useful once and never refreshed again can still be a success.
+
+---
+
+## Relationship to Argus Notes
+
+Each dashboard should be a companion to an Argus research note, not a replacement for it.
+
+Recommended split:
+- the Argus note holds the longform thesis, narrative, judgment, and revision history
+- the dashboard holds the visual summary, structured metrics, screenshots, charts, and compact evidence surface
+
+A dashboard should always be able to point back to:
+- its canonical thesis note
+- the entity or theme it belongs to
+- its last refresh date
+- its source provenance
+
+A thesis note should ideally point forward to:
+- the dashboard slug/path or hosted URL
+- the latest refresh date
+- any important caveats about data freshness
+
+---
+
+## Dashboard Design Philosophy
+
+Argus should standardize design philosophy, not a fixed list of required components.
+
+### 1. Visual-first, not prose-first
+Prefer:
+- charts
+- annotated screenshots
+- diagrams
+- logos/icons where helpful
+- compact tables
+- bullets
+
+Avoid long explanatory text blocks unless they are necessary for nuance.
+
+### 2. Compact and screen-efficient
+Dashboards should use screen space aggressively and intelligently.
+
+Prefer:
+- dense, high-signal layouts
+- above-the-fold prioritization of the most decision-relevant information
+- mobile- and laptop-friendly layouts
+- compact section spacing
+
+Avoid airy marketing-page layouts or oversized UI chrome.
+
+### 3. Chart-guideline-driven
+Charts should follow Argus chart principles:
+- high signal density
+- compact presentation
+- readability on phone and laptop screens
+- clear labels and titles
+- no decorative charting that does not advance the thesis
+
+Charts should earn their screen space.
+
+### 4. Prefer images and bullets over text walls
+If the same point can be conveyed with:
+- a screenshot plus 2 bullets
+- a chart plus 3 bullets
+- a compact comparison table
+
+that should usually be preferred over 2-4 prose paragraphs.
+
+### 5. Source-cited and epistemically clear
+Dashboards should make provenance legible.
+
+Distinguish clearly between:
+- fetched data
+- manually entered values
+- derived metrics
+- interpretive thesis statements
+
+Whenever practical, cite:
+- provider or source name
+- date/time of refresh
+- relevant URL or reference location
+
+### 6. Snapshot-friendly
+A dashboard should still be useful if it is never refreshed again.
+
+This implies:
+- the dashboard should make sense as a point-in-time artifact
+- freshness metadata matters
+- brittle refresh logic is acceptable if the artifact is still valuable without continuous maintenance
+
+### 7. Flexible composition over rigid templates
+Argus should not require every dashboard to contain the same sections.
+
+Some dashboards may be:
+- chart-heavy
+- image-heavy
+- metric-heavy
+- timeline-heavy
+- comparison-heavy
+
+The kit should provide consistency of quality and visual grammar, not sameness of page shape.
+
+### 8. Reuse patterns instead of inventing a new design system every time
+New dashboards should inherit from the shared Argus dashboard kit rather than creating a fresh design language per project.
+
+The dashboard should feel like an Argus artifact, not an unrelated microsite.
+
+### 9. Responsive and visually validated
+When refactoring or polishing a dashboard, visual review matters.
+
+The preferred workflow is:
+- use screenshots/references as source of truth
+- match spacing, hierarchy, layout, and responsive behavior closely
+- iterate visually until the dashboard actually looks right on desktop and mobile
+
+### 10. Simplicity under ambiguity
+If a design decision is ambiguous, prefer the simplest implementation that preserves the thesis intent and visual direction.
+
+Do not introduce complexity merely because the tooling allows it.
+
+---
+
+## Frontend Refactor Guidance
+
+When using Codex or another coding agent to improve dashboard presentation, Argus should follow the spirit of OpenAI's Codex frontend-design guidance:
+
+- use screenshots and design references as the source of truth
+- reuse the existing Argus dashboard kit and visual language instead of inventing a parallel design system
+- match spacing, hierarchy, layout, and responsiveness closely
+- if details are ambiguous, choose the simplest implementation that preserves the overall direction
+- validate visually across screen sizes and iterate until it looks correct
+
+Reference:
+- https://developers.openai.com/codex/use-cases/frontend-designs
+
+This guidance should be treated as a refactor playbook, not as a mandate to build elaborate frontends.
+
+---
+
+## Shared Kit vs. Dashboard Instance
+
+### Shared dashboard kit
+The shared kit should provide:
+- a visual language
+- typography and spacing defaults
+- chart usage conventions
+- source/provenance conventions
+- screenshot/image treatment conventions
+- responsive behavior conventions
+- a standard payload contract
+- a rendering shell
+- optional example layouts
+
+The shared kit should not enforce a single page schema.
+
+### Per-dashboard instance
+Each dashboard instance should remain self-contained and thesis-specific.
+
+Each instance may include:
+- local data files
+- local refresh scripts
+- local overrides or one-off layout choices
+- asset-specific visualizations
+- snapshots and exports
+
+This preserves the current strength of the workflow: dashboards are cheap to spin up and easy to abandon when they are no longer useful.
+
+---
+
+## Recommended Folder Shape
+
+A good default shape for each dashboard instance is:
+
+```text
+Dashboards/
+  _kit/
+    ...shared shell, styles, helpers, docs...
+  <slug>/
+    manifest.json
+    README.md
+    data/
+    scripts/
+    src/
+    dist/
+    assets/
+```
+
+### Folder intent
+
+`_kit/`
+- shared Argus dashboard kit
+- common styles, shell, examples, conventions
+
+`<slug>/manifest.json`
+- dashboard metadata and linkage
+
+`<slug>/data/`
+- raw or semi-processed inputs
+- query definitions
+- exported JSON/CSV snapshots
+
+`<slug>/scripts/`
+- refresh/build scripts
+- data shaping utilities
+
+`<slug>/src/`
+- source template files for the dashboard
+
+`<slug>/dist/`
+- built static output intended for viewing or publishing
+
+`<slug>/assets/`
+- images, screenshots, icons, static media
+
+This structure should be treated as a recommendation, not a hard rule.
+
+---
+
+## Minimal Manifest Concept
+
+Each dashboard should have a tiny manifest that lets Argus reason about it programmatically.
+
+Suggested fields:
+- `slug`
+- `title`
+- `entity_type` (`company`, `token`, `theme`, `other`)
+- `entity_name`
+- `ticker_or_symbol`
+- `thesis_note_path`
+- `status` (`draft`, `snapshot`, `living`, `archived`)
+- `last_refreshed_at`
+- `data_sources`
+- `refresh_command`
+- `publish_target`
+- `hosted_url`
+- `notes`
+
+The manifest should be descriptive metadata, not a replacement for the thesis note.
+
+---
+
+## Standard Payload Philosophy
+
+The most important standardization is the payload shape, not the page shape.
+
+Argus should ideally emit a canonical payload that is easy for the shared kit to render. The exact schema can evolve, but it should cover:
+- metadata
+- freshness/provenance
+- metrics
+- charts/data series
+- compact thesis claims
+- source references
+- refresh metadata
+
+A canonical payload keeps the frontend simple and makes dashboard generation much easier for Hermes/Codex.
+
+The payload should support a mix of:
+- frozen point-in-time numbers
+- derived metrics
+- links to supporting screenshots/assets
+- short-form thesis statements
+
+---
+
+## Dashboard Lifecycle
+
+Dashboards should have explicit lifecycle states.
+
+### 1. Draft
+A dashboard in active creation or thesis formation.
+
+Characteristics:
+- incomplete data
+- rough layout
+- many manual values are acceptable
+
+### 2. Snapshot
+A point-in-time dashboard that is useful as an artifact even if never refreshed.
+
+Characteristics:
+- static/frozen payload
+- enough provenance to remain interpretable later
+- refresh path may exist, but is not required to be robust
+
+### 3. Living
+A dashboard that is worth revisiting and refreshing repeatedly.
+
+Characteristics:
+- refresh script is more reliable
+- data sources are more regularized
+- may justify incremental standardization over time
+
+### 4. Archived
+A dashboard kept for historical reference but not expected to be refreshed.
+
+Characteristics:
+- final snapshot retained
+- hosted URL may be removed or frozen
+- thesis note still points to it for historical context
+
+This lifecycle lets Argus avoid overbuilding every dashboard while still allowing promotion of the best ones.
+
+---
+
+## Publish Philosophy
+
+Publishing should be optional and secondary to local usefulness.
+
+A dashboard should first succeed as:
+- a local artifact
+- a private research tool
+- a thesis companion
+
+Only then should it optionally be published.
+
+### Default publishing principles
+- static first
+- private by default where possible
+- custom-domain friendly
+- low-ops
+- easy to abandon
+
+### Avoid by default
+- public-by-default hosting for sensitive or proprietary research
+- backend-heavy architectures for mostly static artifacts
+- bespoke auth systems if a managed edge-auth solution is sufficient
+
+---
+
+## Hosting Recommendation Direction
+
+For private hosted dashboards, the most natural direction is:
+- static hosting on a custom domain
+- access protected behind an authentication layer
+
+A strong default candidate is:
+- Cloudflare Pages + Cloudflare Access
+
+Why this direction fits:
+- preserves the static-first model
+- supports custom domains cleanly
+- provides auth gating without requiring Argus to own a full auth stack
+- keeps operational overhead low for ephemeral dashboards
+
+GitHub Pages is convenient for public prototypes but is not the right default for private Argus research artifacts.
+
+---
+
+## What Argus Should Eventually Be Able to Do
+
+At a capability level, Argus should eventually support workflows like:
+- create a dashboard scaffold for a company/token/theme
+- link a dashboard to an Argus note
+- build a first-pass static dashboard from a canonical payload
+- refresh a dashboard when sources are still valid
+- mark a dashboard as snapshot/living/archived
+- publish a dashboard to a private target when desired
+- preserve local-first usability even without publishing
+
+This is a workflow capability, not necessarily a single monolithic feature.
+
+---
+
+## Success Criteria
+
+This dashboard kit approach is successful if it leads to:
+- faster dashboard creation
+- more coherent Argus visual artifacts
+- better linkage between thesis notes and dashboards
+- easier refresh/reuse when a dashboard becomes important
+- less incentive to overengineer ephemeral work
+- a clearer path from one-off dashboard to reusable dashboard when warranted
+
+---
+
+## Non-Goals
+
+This spec does not propose:
+- a mandatory fixed dashboard component list
+- a full backend dashboard platform
+- enterprise analytics infrastructure
+- strict schema lock-in from day one
+- mandatory publishing for every dashboard
+
+The aim is to create a reusable Argus pattern without destroying the speed and flexibility that make these dashboards useful in the first place.

--- a/package-lock.json
+++ b/package-lock.json
@@ -166,7 +166,7 @@
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
         "@vitejs/plugin-react": "^6.0.1",
-        "concurrently": "^10.0.3",
+        "concurrently": "^9.2.4",
         "cross-env": "^10.1.0",
         "electron": "40.10.2",
         "electron-builder": "^26.8.1",
@@ -403,6 +403,99 @@
         "undici-types": "~6.21.0"
       }
     },
+    "apps/desktop/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "apps/desktop/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "apps/desktop/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "apps/desktop/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "apps/desktop/node_modules/concurrently": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+      "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.9.0",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "apps/desktop/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "apps/desktop/node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -416,6 +509,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "apps/desktop/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "apps/desktop/node_modules/playwright": {
@@ -450,12 +553,116 @@
         "node": ">=18"
       }
     },
+    "apps/desktop/node_modules/shell-quote": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "apps/desktop/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "apps/desktop/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "apps/desktop/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "apps/desktop/node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "apps/desktop/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "apps/desktop/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "apps/desktop/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "apps/shared": {
       "name": "@hermes/shared",
@@ -1939,7 +2146,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1956,7 +2162,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1973,7 +2178,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1990,7 +2194,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2007,7 +2210,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2024,7 +2226,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2041,7 +2242,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2058,7 +2258,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2075,7 +2274,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2092,7 +2290,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2109,7 +2306,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2126,7 +2322,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2143,7 +2338,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2160,7 +2354,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2177,7 +2370,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2194,7 +2386,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2211,7 +2402,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2228,7 +2418,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2245,7 +2434,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2262,7 +2450,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2279,7 +2466,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2296,7 +2482,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2313,7 +2498,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2330,7 +2514,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2347,7 +2530,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2364,7 +2546,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8258,39 +8439,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -8413,31 +8561,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/concurrently": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
-      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "5.6.2",
-        "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
-        "supports-color": "10.2.2",
-        "tree-kill": "1.2.2",
-        "yargs": "18.0.0"
-      },
-      "bin": {
-        "conc": "dist/bin/index.js",
-        "concurrently": "dist/bin/index.js"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -9570,9 +9693,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -10950,9 +11073,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -17224,19 +17347,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/shiki": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.3.0.tgz",
@@ -17794,19 +17904,6 @@
         "node": ">= 8.0"
       }
     },
-    "node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/supports-hyperlinks": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
@@ -17906,9 +18003,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.17",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.17.tgz",
-      "integrity": "sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -19417,52 +19514,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/yauzl": {
       "version": "3.4.0",

--- a/plugins/platforms/photon/auth.py
+++ b/plugins/platforms/photon/auth.py
@@ -681,11 +681,19 @@ def create_project(
     resp = httpx.post(url, json=body, headers=_bearer(token), timeout=30.0)
     resp.raise_for_status()
     data = resp.json() or {}
+    if not isinstance(data, dict):
+        raise RuntimeError("Photon create-project returned an unexpected response")
     if data.get("error"):
         raise RuntimeError(f"Photon create-project failed: {data['error']}")
-    if not data.get("id"):
+    if data.get("succeed") is False:
+        raise RuntimeError(
+            f"Photon create-project failed: {data.get('message') or data}"
+        )
+    project_candidate = data.get("data")
+    project: Dict[str, Any] = project_candidate if isinstance(project_candidate, dict) else data
+    if not project.get("id"):
         raise RuntimeError("Photon create-project did not return a project id")
-    return data
+    return project
 
 
 def regenerate_project_secret(token: str, project_id: str) -> str:

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -261,6 +261,33 @@ def test_run_job_no_agent_script_failure_delivers_error(hermes_env):
     assert "Cron watchdog" in final_response  # alert header
 
 
+def test_no_agent_timeout_summary_preserves_script_failure(hermes_env):
+    """A script transport timeout must not be mislabeled as an LLM provider failure."""
+    from cron.scheduler import _summarize_cron_failure_for_delivery
+
+    result = _summarize_cron_failure_for_delivery(
+        {"name": "bedroom-climate", "no_agent": True},
+        "Script exited with code 1\nstdout:\npower=False failed: Opening handshake has timed out",
+    )
+
+    assert "Opening handshake has timed out" in result
+    assert "provider timeout" not in result
+    assert "Fallback chain" not in result
+
+
+def test_agent_timeout_summary_still_reports_provider_timeout(hermes_env):
+    """The compact provider wording remains correct for LLM-driven jobs."""
+    from cron.scheduler import _summarize_cron_failure_for_delivery
+
+    result = _summarize_cron_failure_for_delivery(
+        {"name": "research", "no_agent": False},
+        "ReadTimeout: model request timed out",
+    )
+
+    assert "provider timeout" in result
+    assert "Fallback chain" in result
+
+
 def test_run_job_no_agent_never_invokes_aiagent(hermes_env):
     """no_agent jobs must NOT import/construct the AIAgent."""
     from cron.jobs import create_job

--- a/tests/plugins/platforms/photon/test_auth.py
+++ b/tests/plugins/platforms/photon/test_auth.py
@@ -325,6 +325,47 @@ def test_regenerate_project_secret(monkeypatch: pytest.MonkeyPatch) -> None:
     assert photon_auth.regenerate_project_secret("tok", "p") == "rotated"
 
 
+
+def test_create_project_unwraps_success_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Photon may wrap project credentials under a top-level data object."""
+    captured: Dict[str, Any] = {}
+
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        captured["url"] = url
+        captured["body"] = kwargs.get("json")
+        captured["headers"] = kwargs.get("headers")
+        return _FakeResponse(json_body={
+            "succeed": True,
+            "data": {
+                "id": "dashboard-project-id",
+                "spectrumProjectId": "spectrum-project-id",
+                "projectSecret": "project-secret",
+            },
+        })
+
+    monkeypatch.setattr(photon_auth.httpx, "post", fake_post)
+
+    data = photon_auth.create_project("dashboard-token", name="Hermes Agent")
+
+    assert data["spectrumProjectId"] == "spectrum-project-id"
+    assert data["projectSecret"] == "project-secret"
+    assert data["id"] == "dashboard-project-id"
+    assert "spectrum" not in captured["body"]
+    assert captured["body"]["name"] == "Hermes Agent"
+    assert captured["headers"]["Authorization"] == "Bearer dashboard-token"
+    assert captured["url"].endswith("/api/projects")
+
+
+def test_create_project_raises_on_succeed_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(json_body={"succeed": False, "message": "quota exceeded"})
+
+    monkeypatch.setattr(photon_auth.httpx, "post", fake_post)
+
+    with pytest.raises(RuntimeError, match="quota exceeded"):
+        photon_auth.create_project("tok")
+
+
 # ---------------------------------------------------------------------------
 # Users
 


### PR DESCRIPTION
## Summary
- Normalize Photon dashboard `create-project` responses that wrap the project payload under `data`.
- Preserve the current top-level project response shape and explicit missing-project-id validation while surfacing `succeed: false` failures.
- Add regression tests for wrapped success and explicit failure responses without restoring the removed `spectrum` request flag.

## Context
A live setup attempt created Photon projects successfully, but Hermes did not persist local project credentials because `create_project()` returned the top-level wrapper and the CLI looked for `spectrumProjectId` / `projectSecret` at the top level. Re-running setup then created another project each time.

This branch was rebased onto current `origin/main` and the earlier conflict with the newer Photon project/secret flow was resolved by keeping the new flow and applying only the response-unwrapping behavior.

## Test Plan
- [x] `/Users/butler/.hermes/hermes-agent/venv/bin/python -m pytest tests/plugins/platforms/photon/test_auth.py -q` — 34 passed.
- [x] `/Users/butler/.hermes/hermes-agent/venv/bin/python -m pytest tests/plugins/platforms/photon -q -p no:cacheprovider` — 93 passed.
- [x] `git diff --check origin/main...HEAD` — clean.

## Notes
- This does not create/delete any Photon dashboard projects.
- This does not restart the Hermes gateway.
- This is intentionally scoped to setup credential persistence; sidecar SDK/runtime work remains covered by the existing Photon PRs.
