### PR TITLE
feat(gateway): add /hermes ping command for inbound path liveness check

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8192,6 +8192,9 @@ class GatewayRunner:
         if canonical == "whoami":
             return await self._handle_whoami_command(event)
 
+        if canonical == "ping":
+            return await self._handle_ping_command(event)
+
         if canonical == "status":
             return await self._handle_status_command(event)
 
@@ -10326,6 +10329,20 @@ class GatewayRunner:
             f"Tier: user\n"
             f"Slash commands you can run: {runnable_str}"
         )
+
+    async def _handle_ping_command(self, event: MessageEvent) -> str:
+        """Handle /ping - reply 'pong' to verify the inbound path is alive.
+
+        Designed as a 30-second liveness check for the silent Slack
+        socket-mode drop case (2026-06-07): the gateway process and
+        socket-mode WebSocket both look healthy (``is_active() == True``)
+        but inbound message events stop being dispatched to the agent.
+        If a real user types /ping and gets a 'pong' back within 30s, the
+        inbound path is alive. If no reply arrives, the socket is
+        silently dead and the user can recover with /hermes restart.
+        """
+        from datetime import datetime as _dt
+        return f"pong - gateway received your message at {_dt.now().strftime('%Y-%m-%d %H:%M:%S')}"
 
 
     async def _handle_kanban_command(self, event: MessageEvent) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -111,6 +111,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[text | remove N | clear]"),
     CommandDef("status", "Show session info", "Session"),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
+    CommandDef("ping", "Reply with 'pong' - verifies the inbound path is alive (used to detect silent Slack socket-mode drops)", "Info"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),


### PR DESCRIPTION
## Problem

Slack socket mode can silently drop inbound events: the gateway process stays alive, `is_active()` returns `True`, but no message events reach the agent. Users have no way to distinguish "gateway is down" from "gateway is silently broken" without inspecting logs.

Observed 2026-06-07: zhizhe sent messages at 8:26 PM and 9:55 PM, both invisible to the agent for hours. Restarting the gateway cleared it, but users should not have to discover this manually.

## Solution

Add `/hermes ping` (and the standalone `/ping` slash auto-registered from `COMMAND_REGISTRY`). Reply:

```
pong - gateway received your message at 2026-06-09 10:36:55
```

If the reply arrives within 30s, the inbound path is alive. If not, the socket is silently dead — recover with `/hermes restart` (already exists in `COMMAND_REGISTRY`).

## Diff

Three small additions, no existing logic touched:
- `hermes_cli/commands.py`: `CommandDef("ping", ...)` in `COMMAND_REGISTRY`
- `gateway/run.py`: dispatch branch in the canonical-cmd if-chain (next to `whoami`)
- `gateway/run.py`: `_handle_ping_command` async method

`gateway_only=True` not set — `/ping` is also useful from the CLI, and exposing it doesn't cost anything (sync return, no agent run, no LLM cost).

## Verification

- Branch `feat/slack-ping-command`, commit 86506caa9
- Pushed to fork `zzhan111/hermes-agent`
- Smoke test from a real Slack user (zhizhe): 30s reply latency, no errors in `gateway.log`

## Not in this PR

- Watchdog cron / automated probe — the 2026-06-07 incident confirmed that `is_active()` is a false positive when the socket silently dies, so no out-of-band check can validate the inbound path. A user-initiated ping is the only reliable signal.
- A patch to `if connected is False` → `if not connected` in `_socket_watchdog_loop` — separate concern, separate PR if anyone wants it.