### PR TITLE
fix(zai): probe Coding Plan endpoints before generic to prevent silent wallet drain

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -614,10 +614,14 @@ def _resolve_api_key_provider_secret(
 
 ZAI_ENDPOINTS = [
     # (id, base_url, probe_models, label)
-    ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
-    ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
-    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
+    # Coding Plan endpoints probed first — Z.AI keys authenticate against both
+    # generic and coding endpoints, so the first 200 wins.  Coding Plan keys are
+    # now the common case; probing generic first silently routes to pay-as-you-go
+    # billing instead of the subscription quota.  See issue #42536.
     ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
+    ("coding-global", "https://api.z.ai/api/coding/paas/v4",         ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
+    ("cn",            "https://open.bigmodel.cn/api/paas/v4",        ["glm-5"],                              "China"),
+    ("global",        "https://api.z.ai/api/paas/v4",                ["glm-5"],                              "Global"),
 ]
 
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1296,3 +1296,31 @@ class TestMinimaxOAuthProvider:
             "doesn't fire the 'No auxiliary LLM provider configured' warning "
             "for every minimax-oauth session."
         )
+
+
+class TestZaiEndpointProbeOrder:
+    """Coding Plan endpoints must be probed before generic ones (issue #42536)."""
+
+    def test_coding_endpoints_before_generic(self):
+        """ZAI_ENDPOINTS must list coding-* entries before generic ones."""
+        from hermes_cli.auth import ZAI_ENDPOINTS
+
+        ids = [ep[0] for ep in ZAI_ENDPOINTS]
+        coding_indices = [i for i, ep_id in enumerate(ids) if ep_id.startswith("coding-")]
+        generic_indices = [i for i, ep_id in enumerate(ids) if not ep_id.startswith("coding-")]
+
+        assert coding_indices, "ZAI_ENDPOINTS must contain coding-* entries"
+        assert generic_indices, "ZAI_ENDPOINTS must contain generic entries"
+        assert max(coding_indices) < min(generic_indices), (
+            f"Coding endpoints must precede generic ones. "
+            f"Got coding at {coding_indices}, generic at {generic_indices}"
+        )
+
+    def test_coding_cn_before_coding_global(self):
+        """China coding endpoint should be probed before global (lower latency for CN users)."""
+        from hermes_cli.auth import ZAI_ENDPOINTS
+
+        ids = [ep[0] for ep in ZAI_ENDPOINTS]
+        assert ids.index("coding-cn") < ids.index("coding-global"), (
+            "coding-cn should precede coding-global for lower latency"
+        )


### PR DESCRIPTION
## What does this PR do?

Reorders `ZAI_ENDPOINTS` so Coding Plan endpoints (`coding-cn`, `coding-global`) are probed before generic ones (`cn`, `global`). This prevents Coding Plan keys from being silently routed to the pay-as-you-go billing endpoint.

## Related Issue

Fixes #42536

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py`: Reorder `ZAI_ENDPOINTS` list — coding endpoints first, generic as fallback. Added comment explaining the rationale and linking to issue #42536.
- `tests/hermes_cli/test_api_key_providers.py`: Add `TestZaiEndpointProbeOrder` with 2 tests verifying coding endpoints precede generic ones in the probe order.

## How to Test

1. `pytest tests/hermes_cli/test_api_key_providers.py::TestZaiEndpointProbeOrder -v` — verifies endpoint order invariant
2. With a Z.AI Coding Plan key: `hermes config set provider zai` → start a session → check Z.AI dashboard usage shows Coding Plan quota consumed (not wallet balance)
3. With a non-Coding-Plan Z.AI key: verify the probe still falls through to the generic endpoint correctly

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (list reorder, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `ZAI_ENDPOINTS` (callers: 1 — `detect_zai_endpoint`)
- Blast radius: LOW — only affects probe order for `zai` provider; no other providers affected
- Related patterns: `kimi-coding` (auth.py:248) uses prefix-based routing, not probe — verified no similar bug
