### PR TITLE
fix(cron): conditional MCP init and robust datetime parsing

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -314,6 +314,19 @@ def _ensure_aware(dt: datetime) -> datetime:
     return dt.astimezone(target_tz)
 
 
+def _parse_stored_datetime(value: str) -> datetime:
+    """Parse stored cron datetimes, accepting ISO UTC ``Z`` suffixes."""
+    if isinstance(value, str) and value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    if isinstance(value, str):
+        value = re.sub(
+            r"(\.\d{1,5})([+-]\d{2}:\d{2})$",
+            lambda match: match.group(1).ljust(7, "0") + match.group(2),
+            value,
+        )
+    return datetime.fromisoformat(value)
+
+
 def _recoverable_oneshot_run_at(
     schedule: Dict[str, Any],
     now: datetime,
@@ -1073,7 +1086,27 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                     needs_save = True
                     break
 
-        next_run_dt = _ensure_aware(datetime.fromisoformat(next_run))
+        try:
+            next_run_dt = _ensure_aware(_parse_stored_datetime(next_run))
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "Job '%s' has invalid next_run_at %r (%s); recomputing from schedule",
+                job.get("name", job.get("id")),
+                next_run,
+                exc,
+            )
+            schedule = job.get("schedule", {})
+            recovered_next = compute_next_run(schedule, now.isoformat())
+            if not recovered_next:
+                continue
+            job["next_run_at"] = recovered_next
+            next_run = recovered_next
+            for rj in raw_jobs:
+                if rj["id"] == job["id"]:
+                    rj["next_run_at"] = recovered_next
+                    needs_save = True
+                    break
+            next_run_dt = _ensure_aware(_parse_stored_datetime(next_run))
         if next_run_dt <= now:
             schedule = job.get("schedule", {})
             kind = schedule.get("kind")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -112,8 +112,25 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         )
         return None
 
+
+def _cron_toolsets_need_mcp(enabled_toolsets: list[str] | None) -> bool:
+    """Return whether a cron agent should eagerly initialize MCP servers.
+
+    ``enabled_toolsets=None`` means "legacy full tool access", so preserve the
+    old behavior there. Explicit job/platform toolsets are narrower: initialize
+    MCP only when they ask for an MCP toolset. This keeps broken remote MCP
+    auth (for example Composio) from slowing or polluting web/search-only jobs.
+    """
+    if enabled_toolsets is None:
+        return True
+    for raw_name in enabled_toolsets:
+        name = str(raw_name).strip().lower()
+        if name == "mcp" or name.startswith("mcp-"):
+            return True
+    return False
+
+
 # Valid delivery platforms — used to validate user-supplied platform names
-# in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "telegram", "discord", "slack", "whatsapp", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
@@ -1748,6 +1765,8 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             except Exception as e:
                 logger.debug("Job '%s': failed to load credential pool for %s: %s", job_id, runtime_provider, e)
 
+        enabled_toolsets = _resolve_cron_enabled_toolsets(job, _cfg)
+
         # Initialize MCP servers so configured mcp_servers are available to
         # the agent's tool registry before AIAgent is constructed. Without
         # this, cron jobs never saw any MCP tools — only the gateway / CLI
@@ -1755,19 +1774,20 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # ticks short-circuit on already-connected servers inside
         # register_mcp_servers(). Non-fatal on failure: a broken MCP server
         # shouldn't kill an otherwise-working cron job. See #4219.
-        try:
-            from tools.mcp_tool import discover_mcp_tools
-            _mcp_tools = discover_mcp_tools()
-            if _mcp_tools:
-                logger.info(
-                    "Job '%s': %d MCP tool(s) available",
-                    job_id, len(_mcp_tools),
+        if _cron_toolsets_need_mcp(enabled_toolsets):
+            try:
+                from tools.mcp_tool import discover_mcp_tools
+                _mcp_tools = discover_mcp_tools()
+                if _mcp_tools:
+                    logger.info(
+                        "Job '%s': %d MCP tool(s) available",
+                        job_id, len(_mcp_tools),
+                    )
+            except Exception as _mcp_exc:
+                logger.warning(
+                    "Job '%s': MCP initialization failed (non-fatal): %s",
+                    job_id, _mcp_exc,
                 )
-        except Exception as _mcp_exc:
-            logger.warning(
-                "Job '%s': MCP initialization failed (non-fatal): %s",
-                job_id, _mcp_exc,
-            )
 
         agent = AIAgent(
             model=model,


### PR DESCRIPTION
Summary

- Only initialize MCP servers when the cron job actually needs MCP toolsets (via the new _cron_toolsets_need_mcp() guard). This prevents broken remote MCP auth from slowing web/search-only cron jobs. Idempotent and non-fatal on failure — matches existing pattern for #4219.
- Add _parse_stored_datetime() helper that accepts ISO UTC "Z" suffixes and normalizes sub-microsecond precision for Python < 3.11 fromisoformat(). Falls back to recomputing next_run from schedule when parsing fails, making cron resilient against stale or malformed stored timestamps.

Local verification

- Verified against origin/main (e8811625). Two files: cron/jobs.py (+34/-1), cron/scheduler.py (+32/-14). AST clean, no credential/IP leakage. MCP init gate is opt-in per job toolset config.

Commits
text
0ce51432c fix(cron): conditional MCP init and robust datetime parsing
