### PR TITLE
fix(gateway): write planned-stop marker from systemd ExecStop

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7,6 +7,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 import asyncio
 import logging
 import os
+import shlex
 import shutil
 import signal
 import subprocess
@@ -2394,6 +2395,11 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         # _stable_service_working_dir() for the full rationale.
         working_dir = str(hermes_home) if hermes_home else _remap_path_for_user(working_dir, home_dir)
         venv_dir = _remap_path_for_user(venv_dir, home_dir)
+        python_path = _remap_path_for_user(python_path, home_dir)
+        planned_stop_exec = (
+            f"{shlex.quote(python_path)} -m hermes_cli.main "
+            "gateway planned-stop-helper --pid $MAINPID"
+        )
         path_entries = [_remap_path_for_user(p, home_dir) for p in path_entries]
         path_entries.extend(_build_user_local_paths(Path(home_dir), path_entries))
         path_entries.extend(_build_wsl_interop_paths(path_entries))
@@ -2422,6 +2428,7 @@ RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
+ExecStop={planned_stop_exec}
 ExecReload=/bin/kill -USR1 $MAINPID
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal
@@ -2433,6 +2440,10 @@ WantedBy=multi-user.target
 
     hermes_home = str(get_hermes_home().resolve())
     profile_arg = _profile_arg(hermes_home)
+    planned_stop_exec = (
+        f"{shlex.quote(python_path)} -m hermes_cli.main "
+        "gateway planned-stop-helper --pid $MAINPID"
+    )
     path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
     path_entries.extend(_build_wsl_interop_paths(path_entries))
     path_entries.extend(common_bin_paths)
@@ -2455,6 +2466,7 @@ RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
+ExecStop={planned_stop_exec}
 ExecReload=/bin/kill -USR1 $MAINPID
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal
@@ -2834,6 +2846,16 @@ def systemd_stop(system: bool = False):
         )
         return
     print(f"✓ {_service_scope_label(system).capitalize()} service stopped")
+
+
+def gateway_planned_stop_helper(pid: int) -> bool:
+    """Write the planned-stop marker for ``pid`` and return success."""
+    try:
+        from gateway.status import write_planned_stop_marker
+
+        return bool(write_planned_stop_marker(pid))
+    except Exception:
+        return False
 
 
 def systemd_restart(system: bool = False):
@@ -6506,6 +6528,17 @@ def _gateway_command_inner(args):
                     print("✗ No gateway running for this profile")
             else:
                 print(f"✓ Stopped {get_service_name()} service")
+
+    elif subcmd == "planned-stop-helper":
+        pid = int(getattr(args, "pid", 0) or 0)
+        if pid <= 0:
+            print("✗ --pid must be a positive integer")
+            sys.exit(1)
+        ok = gateway_planned_stop_helper(pid)
+        if not ok:
+            print("✗ Failed to write planned-stop marker")
+            sys.exit(1)
+        return
 
     elif subcmd == "restart":
         # Defense: refuse self-targeting gateway restart from inside the gateway.

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -89,6 +89,17 @@ def build_gateway_parser(subparsers, *, cmd_gateway: Callable, cmd_proxy: Callab
         help="Stop ALL gateway processes across all profiles",
     )
 
+    gateway_stop_helper = gateway_subparsers.add_parser(
+        "planned-stop-helper",
+        help=argparse.SUPPRESS,
+    )
+    gateway_stop_helper.add_argument(
+        "--pid",
+        type=int,
+        required=True,
+        help=argparse.SUPPRESS,
+    )
+
     # gateway restart
     gateway_restart = gateway_subparsers.add_parser(
         "restart", help="Restart gateway service"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -325,7 +325,9 @@ class TestGeneratedSystemdUnits:
         unit = gateway_cli.generate_systemd_unit(system=False)
 
         assert "ExecStart=" in unit
-        assert "ExecStop=" not in unit
+        assert "ExecStop=" in unit
+        assert "gateway planned-stop-helper --pid $MAINPID" in unit
+        assert "gateway stop" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
@@ -386,7 +388,9 @@ class TestGeneratedSystemdUnits:
         unit = gateway_cli.generate_systemd_unit(system=True)
 
         assert "ExecStart=" in unit
-        assert "ExecStop=" not in unit
+        assert "ExecStop=" in unit
+        assert "gateway planned-stop-helper --pid $MAINPID" in unit
+        assert "gateway stop" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
@@ -394,6 +398,30 @@ class TestGeneratedSystemdUnits:
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
         assert self._expected_timeout_stop_sec() in unit
         assert "WantedBy=multi-user.target" in unit
+
+    def test_planned_stop_helper_writes_marker_for_target_pid(self, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr(
+            gateway_cli,
+            "gateway_planned_stop_helper",
+            lambda pid: calls.append(pid) or True,
+        )
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="planned-stop-helper", pid=321))
+
+        assert calls == [321]
+
+    def test_planned_stop_helper_exits_nonzero_on_marker_failure(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "gateway_planned_stop_helper", lambda pid: False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            gateway_cli.gateway_command(
+                SimpleNamespace(gateway_command="planned-stop-helper", pid=321)
+            )
+
+        assert exc_info.value.code == 1
+        assert "Failed to write planned-stop marker" in capsys.readouterr().out
 
 
 class TestGatewayStopCleanup:


### PR DESCRIPTION
## What does this PR do?

Routes `systemctl stop` through the existing planned-stop marker path instead of trying to infer who sent `SIGTERM` inside the gateway.

The generated systemd unit now includes an `ExecStop` helper that writes the planned-stop marker for `$MAINPID` before systemd delivers `SIGTERM`. That keeps intentional service stops on the same clean-shutdown path already used by `hermes gateway stop`, while leaving unexpected external `SIGTERM` handling unchanged.

This follows the direction in #42517 and avoids the `INVOCATION_ID` / `under_systemd` inference problem discussed against #41642 and #41690.

## Related Issue

Fixes #42517

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added a hidden `hermes gateway planned-stop-helper --pid <pid>` subcommand for service-managed stop flows
- Updated generated systemd user/system units to include:
  - `ExecStop=<python> -m hermes_cli.main gateway planned-stop-helper --pid $MAINPID`
- Kept `ExecStop` non-recursive:
  - it writes the planned-stop marker only
  - it does not call `hermes gateway stop`
- Added regression coverage for:
  - `ExecStop` presence in generated units
  - helper wiring using `$MAINPID`
  - failure path when marker writing fails
  - no root/tmp path leakage in remapped system units

## How to Test

1. Generate/install the updated systemd gateway unit.
2. Verify the unit contains `ExecStop=... gateway planned-stop-helper --pid $MAINPID`.
3. Start the gateway service and stop it with `systemctl --user stop <service>` (or system scope as appropriate).
4. Confirm the gateway exits through the planned-stop path rather than relying on `INVOCATION_ID`-based signal-source inference.
5. Run the targeted regression tests below.

Targeted local validation:
```bash
pytest tests/hermes_cli/test_gateway_service.py -q -k 'planned_stop_helper or avoids_recursive_execstop or system_unit_has_no_root_paths or systemd_stop_marks_running_gateway_as_planned_stop'
pytest tests/hermes_cli/test_systemd_optional_directives.py -q
pytest tests/hermes_cli/test_gateway_service.py -q -k 'systemd_unit_uses_dot_venv_when_detected or systemd_unit_includes_profile or system_unit_includes_wsl_windows_interop_paths or user_unit_includes_resolved_node_directory_in_path'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (targeted unit-generation and regression tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
