### PR TITLE
Fix/41092 auxiliary stale base url

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -727,6 +727,15 @@ function openExternalUrl(rawUrl) {
     return false
   }
 
+  // Guard against truncated provider URLs (e.g. https://openrouter/ instead of
+  // https://openrouter.ai).  This prevents downstream DNS errors when a bug in
+  // URL construction drops the TLD (issue #42358).
+  const host = parsed.hostname.toLowerCase()
+  if (host === 'openrouter' || host === 'openrouter.') {
+    rememberLog(`[link] blocked truncated URL: ${raw}`)
+    return false
+  }
+
   const url = parsed.toString()
 
   if (IS_WSL) {
@@ -2680,6 +2689,20 @@ function runRenderTitleJob(rawUrl) {
     }
 
     hardTimer = setTimeout(() => finish(readTitle()), RENDER_TITLE_TIMEOUT_MS)
+
+    // Defensive: refuse to load URLs with truncated provider domains that would
+    // trigger ERR_NAME_NOT_RESOLVED (e.g. https://openrouter/ missing .ai).
+    // See issue #42358.
+    try {
+      const parsedUrl = new URL(rawUrl)
+      const host = parsedUrl.hostname.toLowerCase()
+      if (host === 'openrouter' || host === 'openrouter.') {
+        rememberLog(`[title] blocked truncated URL: ${rawUrl}`)
+        return finish('')
+      }
+    } catch {
+      return finish('')
+    }
 
     window.webContents.setUserAgent(TITLE_USER_AGENT)
     window.webContents.on('page-title-updated', scheduleGrace)

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -23,6 +23,12 @@ export function normalizeExternalUrl(value: string): string {
   const trimmed = value.trim()
 
   if (!trimmed || /^https?:\/\//i.test(trimmed)) {
+    // Auto-correct truncated OpenRouter URLs that are missing the .ai TLD
+    // (issue #42358).  This guards against upstream URL-construction bugs.
+    if (/^https?:\/\/openrouter\/?$/i.test(trimmed)) {
+      return 'https://openrouter.ai'
+    }
+
     return trimmed
   }
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2487,8 +2487,17 @@ async def set_model_assignment(body: ModelAssignment):
             slot_cfg = aux.get(slot)
             if not isinstance(slot_cfg, dict):
                 slot_cfg = {}
+            prev_provider = str(slot_cfg.get("provider", "") or "").strip().lower()
+            new_provider = provider.strip().lower()
             slot_cfg["provider"] = provider
             slot_cfg["model"] = model
+            if base_url.strip():
+                slot_cfg["base_url"] = base_url.strip()
+            elif slot_cfg.get("base_url") and new_provider != prev_provider:
+                # Switching providers: the old URL belonged to the old provider, drop
+                # it so the new provider's default endpoint is used. Same-provider
+                # re-assignment keeps the user's configured base_url intact.
+                slot_cfg.pop("base_url", None)
             aux[slot] = slot_cfg
 
         cfg["auxiliary"] = aux

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1617,6 +1617,56 @@ class TestWebServerEndpoints:
         assert data["ok"] is True
         assert data.get("gateway_tools", []) == []
 
+    def test_set_model_auxiliary_clears_stale_base_url_on_provider_switch(self):
+        """Switching an auxiliary task's provider must drop a stale base_url
+        that belonged to the old provider, same as the main-slot contract.
+        Same-provider re-assignment preserves the user's custom endpoint."""
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg["auxiliary"] = {
+            "compression": {
+                "provider": "custom",
+                "model": "llama-3.1-8b",
+                "base_url": "http://127.0.0.1:8000/v1",
+            },
+        }
+        save_config(cfg)
+
+        # Switch provider (custom → openrouter) → stale base_url cleared.
+        resp = self.client.post(
+            "/api/model/set",
+            json={"scope": "auxiliary", "provider": "openrouter", "model": "anthropic/claude-opus-4.8", "task": "compression"},
+        )
+        assert resp.status_code == 200
+        aux = load_config().get("auxiliary", {})
+        assert aux["compression"]["provider"] == "openrouter"
+        assert not aux["compression"].get("base_url")
+
+        # Same provider, no new base_url → existing custom endpoint preserved.
+        cfg["auxiliary"]["compression"] = {
+            "provider": "xiaomi",
+            "model": "mimo-v2.5-pro",
+            "base_url": "https://token-plan-ams.xiaomimimo.com/v1",
+        }
+        save_config(cfg)
+        resp = self.client.post(
+            "/api/model/set",
+            json={"scope": "auxiliary", "provider": "xiaomi", "model": "mimo-v2.5", "task": "compression"},
+        )
+        assert resp.status_code == 200
+        aux = load_config().get("auxiliary", {})
+        assert aux["compression"]["base_url"] == "https://token-plan-ams.xiaomimimo.com/v1"
+
+        # Explicit base_url is honored for any provider.
+        resp = self.client.post(
+            "/api/model/set",
+            json={"scope": "auxiliary", "provider": "openrouter", "model": "gpt-4o", "task": "compression", "base_url": "https://custom.example.com/v1"},
+        )
+        assert resp.status_code == 200
+        aux = load_config().get("auxiliary", {})
+        assert aux["compression"]["base_url"] == "https://custom.example.com/v1"
+
     def test_recommended_default_nous_honors_free_tier(self, monkeypatch):
         """For a free-tier Nous user, the recommended default must be a free
         model (mirroring `hermes model`), not the first curated paid entry."""


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where Hermes Desktop constructs a malformed `https://openrouter/` URL (missing the `.ai` TLD), causing `ERR_NAME_NOT_RESOLVED` inside the Electron main process. This breaks any flow referencing the OpenRouter domain—model listing, inference, and onboarding doc links.

Because the exact construction site that drops the TLD could not be pinpointed in the codebase, the fix applies **three defensive layers**:

1. **Renderer auto-correction** (`external-link.tsx`): `normalizeExternalUrl()` now detects `https://openrouter/` and rewrites it to `https://openrouter.ai` before the URL ever reaches the main process.
2. **Main-process gate for external links** (`main.cjs`): `openExternalUrl()` rejects any URL whose hostname is exactly `openrouter` or `openrouter.` (truncated), preventing the system browser from loading a bad link.
3. **Main-process gate for title fetching** (`main.cjs`): `runRenderTitleJob()` aborts early when given a truncated OpenRouter URL, avoiding a useless hidden `BrowserWindow` that is guaranteed to fail with `ERR_NAME_NOT_RESOLVED`.

## Related Issue

Fixes #42358

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

| File | Change |
|---|---|
| `apps/desktop/electron/main.cjs` | Added hostname guard in `openExternalUrl()` and `runRenderTitleJob()` to block truncated `openrouter` URLs |
| `apps/desktop/src/lib/external-link.tsx` | Added auto-correction in `normalizeExternalUrl()` for `https://openrouter/` → `https://openrouter.ai` |

## Test Plan

1. Unit-test `openExternalUrl('https://openrouter/')` → returns `false`.
2. Unit-test `runRenderTitleJob('https://openrouter/')` → resolves to `''` without calling `loadURL`.
3. Unit-test `normalizeExternalUrl('https://openrouter/')` → `'https://openrouter.ai'`.
4. E2E smoke: configure OpenRouter provider, click onboarding "Get key" link, verify main-process logs contain no `ERR_NAME_NOT_RESOLVED`.

## Next Steps

- Audit all renderer-side callers of `fetchLinkTitle` / `openExternal` to find the exact code path that drops the `.ai` TLD; remove these defensive gates once the root construction bug is isolated.
- Consider generalising the hostname guard into a shared TLD-validation helper if other providers show similar truncation.