### PR TITLE
fix(slack): ack reaction lifecycle events

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -885,6 +885,18 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_file_change(event, say):
                 pass
 
+            # Reactions are useful lightweight acknowledgements in Slack, but
+            # Hermes does not currently need to route them into the agent loop.
+            # Ack the events explicitly so high-traffic channels do not fill
+            # gateway.error.log with Slack Bolt "Unhandled request" warnings.
+            @self._app.event("reaction_added")
+            async def handle_reaction_added(event, say):
+                pass
+
+            @self._app.event("reaction_removed")
+            async def handle_reaction_removed(event, say):
+                pass
+
             @self._app.event("assistant_thread_started")
             async def handle_assistant_thread_started(event, say):
                 await self._handle_assistant_thread_lifecycle_event(event)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -234,6 +234,8 @@ class TestAppMentionHandler:
 
         assert "message" in registered_events
         assert "app_mention" in registered_events
+        assert "reaction_added" in registered_events
+        assert "reaction_removed" in registered_events
         assert "assistant_thread_started" in registered_events
         assert "assistant_thread_context_changed" in registered_events
         # Slack slash commands are registered via a single regex matcher


### PR DESCRIPTION
## Summary
- Add explicit no-op Slack handlers for `reaction_added` and `reaction_removed`
- Prevent Slack Bolt from logging `Unhandled request` / 404 warnings for reaction events Hermes does not consume
- Extend the Slack adapter registration test to cover the reaction lifecycle handlers

Fixes #6572

## Test plan
- `python -m pytest tests/gateway/test_slack.py -q -o 'addopts='`
- `gitleaks git --log-opts="origin/main..HEAD" --no-banner --redact`
