### PR TITLE
feat(stt): add local_http provider for HTTP-based local STT service

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -458,7 +458,7 @@ def save_jobs(jobs: List[Dict[str, Any]]):
     fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2, ensure_ascii=False)
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, JOBS_FILE)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -394,6 +394,7 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    reply_in_thread: bool = True
 
 
 @dataclass
@@ -1572,6 +1573,9 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            reply_in_thread=_to_boolean(
+                extra.get("reply_in_thread", os.getenv("FEISHU_REPLY_IN_THREAD", "true"))
+            ),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1604,6 +1608,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._reply_in_thread = settings.reply_in_thread
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -4391,7 +4396,9 @@ class FeishuAdapter(BasePlatformAdapter):
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
-        reply_in_thread = bool((metadata or {}).get("thread_id"))
+        reply_in_thread = self._reply_in_thread and bool(
+            (metadata or {}).get("thread_id")
+        )
         if effective_reply_to:
             body = self._build_reply_message_body(
                 content=payload,
@@ -4404,8 +4411,11 @@ class FeishuAdapter(BasePlatformAdapter):
 
         # For topic/thread messages that fell back from reply→create, use
         # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
-        _thread_id = (metadata or {}).get("thread_id")
+        # the main chat.  When reply_in_thread is false AND there's no
+        # thread_id, route to the main chat; when there IS a thread_id (user
+        # manually created it), follow it regardless of reply_in_thread.
+        has_thread_id = bool((metadata or {}).get("thread_id"))
+        _thread_id = (metadata or {}).get("thread_id") if has_thread_id else None
         if _thread_id:
             body = self._build_create_message_body(
                 receive_id=_thread_id,

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2049,15 +2049,61 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """Send audio to Feishu as a file attachment plus optional caption."""
-        return await self._send_uploaded_file_message(
-            chat_id=chat_id,
-            file_path=audio_path,
-            reply_to=reply_to,
-            metadata=metadata,
-            caption=caption,
-            outbound_message_type="audio",
-        )
+        """Send audio to Feishu as a native voice bubble.
+
+        Converts non-Opus/Ogg audio to Opus (16 kHz mono) so Feishu renders
+        it as a voice bubble rather than a file attachment.  Files that are
+        already Opus/Ogg are sent as-is.
+        """
+        if not os.path.exists(audio_path):
+            return SendResult(success=False, error=f"Audio file not found: {audio_path}")
+
+        ext = Path(audio_path).suffix.lower()
+        _temp_files: List[str] = []
+
+        try:
+            if ext not in _FEISHU_OPUS_UPLOAD_EXTENSIONS:
+                import subprocess as _subprocess
+                import tempfile as _tempfile
+                import uuid as _uuid
+
+                opus_path = os.path.join(
+                    _tempfile.gettempdir(), "hermes_voice",
+                    f"voice_{_uuid.uuid4().hex[:12]}.opus",
+                )
+                os.makedirs(os.path.dirname(opus_path), exist_ok=True)
+
+                _result = _subprocess.run(
+                    [
+                        "ffmpeg", "-y", "-i", audio_path,
+                        "-ar", "16000", "-ac", "1",
+                        "-c:a", "libopus", "-b:a", "24k",
+                        opus_path,
+                    ],
+                    capture_output=True, text=True, timeout=60,
+                )
+                if _result.returncode != 0:
+                    return SendResult(
+                        success=False,
+                        error=f"ffmpeg opus conversion failed: {_result.stderr}",
+                    )
+                _temp_files.append(opus_path)
+                audio_path = opus_path
+
+            return await self._send_uploaded_file_message(
+                chat_id=chat_id,
+                file_path=audio_path,
+                reply_to=reply_to,
+                metadata=metadata,
+                caption=caption,
+                outbound_message_type="audio",
+            )
+        finally:
+            for _p in _temp_files:
+                try:
+                    os.unlink(_p)
+                except OSError:
+                    pass
 
     async def send_document(
         self,
@@ -3620,7 +3666,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if preferred == "photo":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.PHOTO)
         if preferred == "audio":
-            return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.AUDIO)
+            # Feishu "audio" messages are real-time voice messages (Opus/OGG),
+            # not file attachments — map to VOICE so gateway/run.py sends
+            # them through the STT pipeline instead of treating them as
+            # audio file attachments (which would skip transcription).
+            return MessageType.VOICE
         if preferred == "document":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.DOCUMENT)
         return MessageType.TEXT
@@ -4372,10 +4422,24 @@ class FeishuAdapter(BasePlatformAdapter):
                     metadata=metadata,
                 )
             else:
+                payload_dict: Dict[str, Any] = {"file_key": file_key}
+                if resolved_message_type == "audio":
+                    try:
+                        import subprocess as _subprocess
+                        _result = _subprocess.run(
+                            ["ffprobe", "-v", "error", "-show_entries",
+                             "format=duration", "-of",
+                             "default=noprint_wrappers=1:nokey=1", file_path],
+                            capture_output=True, text=True, timeout=5,
+                        )
+                        _dur_s = float(_result.stdout.strip())
+                        payload_dict["duration"] = int(_dur_s * 1000)
+                    except Exception:
+                        pass
                 message_response = await self._feishu_send_with_retry(
                     chat_id=chat_id,
                     msg_type=resolved_message_type,
-                    payload=json.dumps({"file_key": file_key}, ensure_ascii=False),
+                    payload=json.dumps(payload_dict, ensure_ascii=False),
                     reply_to=reply_to,
                     metadata=metadata,
                 )

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4393,10 +4393,28 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         try:
             with open(file_path, "rb") as file_obj:
+                # For audio files, extract duration before upload so Feishu can
+                # register it properly during file creation.
+                upload_duration = None
+                if resolved_message_type == "audio":
+                    try:
+                        import subprocess as _subprocess
+                        _result = _subprocess.run(
+                            ["ffprobe", "-v", "error", "-show_entries",
+                             "format=duration", "-of",
+                             "default=noprint_wrappers=1:nokey=1", file_path],
+                            capture_output=True, text=True, timeout=5,
+                        )
+                        _dur_s = float(_result.stdout.strip())
+                        upload_duration = int(_dur_s * 1000)
+                    except Exception:
+                        pass
+
                 body = self._build_file_upload_body(
                     file_type=upload_file_type,
                     file_name=display_name,
                     file=file_obj,
+                    duration=upload_duration,
                 )
                 request = self._build_file_upload_request(body)
                 upload_response = await asyncio.to_thread(self._client.im.v1.file.create, request)
@@ -4832,16 +4850,24 @@ class FeishuAdapter(BasePlatformAdapter):
         return SimpleNamespace(request_body=request_body)
 
     @staticmethod
-    def _build_file_upload_body(*, file_type: str, file_name: str, file: Any) -> Any:
+    def _build_file_upload_body(*, file_type: str, file_name: str, file: Any, duration: Optional[int] = None) -> Any:
         if "CreateFileRequestBody" in globals():
-            return (
+            builder = (
                 CreateFileRequestBody.builder()
                 .file_type(file_type)
                 .file_name(file_name)
                 .file(file)
-                .build()
             )
-        return SimpleNamespace(file_type=file_type, file_name=file_name, file=file)
+            if duration is not None:
+                try:
+                    builder = builder.duration(duration)
+                except AttributeError:
+                    pass
+            return builder.build()
+        body = SimpleNamespace(file_type=file_type, file_name=file_name, file=file)
+        if duration is not None:
+            body.duration = duration
+        return body
 
     @staticmethod
     def _build_file_upload_request(request_body: Any) -> Any:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9359,7 +9359,12 @@ class GatewayRunner:
 
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
-            if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
+            # Use new_messages (this turn only) for dedup — not agent_messages
+            # (full history).  Prevents a text_to_speech call in a prior turn
+            # from blocking auto-TTS in the current turn.
+            _history_len = agent_result.get("history_offset", len(history)) if isinstance(agent_result, dict) else 0
+            _new_msgs_for_dedup = agent_messages[_history_len:] if len(agent_messages) > _history_len else []
+            if self._should_send_voice_reply(event, response, _new_msgs_for_dedup, already_sent=_already_sent):
                 await self._send_voice_reply(event, response)
 
             # If streaming already delivered the response, extract and
@@ -11678,10 +11683,12 @@ class GatewayRunner:
           runner must handle it.
         """
         if not response or response.startswith("Error:"):
+            logger.info("_should_send_voice_reply: False — response empty or Error: %r", response[:80] if response else None)
             return False
 
         chat_id = event.source.chat_id
-        voice_mode = self._voice_mode.get(self._voice_key(event.source.platform, chat_id), "off")
+        voice_key = self._voice_key(event.source.platform, chat_id)
+        voice_mode = self._voice_mode.get(voice_key, "off")
         is_voice_input = (event.message_type == MessageType.VOICE)
 
         should = (
@@ -11689,16 +11696,28 @@ class GatewayRunner:
             or (voice_mode == "voice_only" and is_voice_input)
         )
         if not should:
+            logger.info(
+                "_should_send_voice_reply: False — voice_mode=%r is_voice_input=%r key=%r",
+                voice_mode, is_voice_input, voice_key,
+            )
             return False
 
-        # Dedup: agent already called TTS tool
+        # Dedup: agent already called TTS tool in the *current turn*.
+        # Scanning ALL history is too aggressive — a text_to_speech call
+        # from 100 turns ago shouldn't block auto-TTS forever.
+        # Only check messages after the last user message (turn boundary).
+        _current_turn_start = 0
+        for _i in range(len(agent_messages) - 1, -1, -1):
+            if agent_messages[_i].get("role") == "user":
+                _current_turn_start = _i
+                break
         has_agent_tts = any(
             msg.get("role") == "assistant"
             and any(
                 tc.get("function", {}).get("name") == "text_to_speech"
                 for tc in (msg.get("tool_calls") or [])
             )
-            for msg in agent_messages
+            for msg in agent_messages[_current_turn_start:]
         )
         if has_agent_tts:
             return False
@@ -11709,8 +11728,10 @@ class GatewayRunner:
         # the base adapter will receive None and can't run auto-TTS,
         # so the runner must take over.
         if is_voice_input and not already_sent:
+            logger.info("_should_send_voice_reply: False — voice input and already_sent=%s", already_sent)
             return False
 
+        logger.info("_should_send_voice_reply: True — mode=%r key=%r is_voice=%r already_sent=%s", voice_mode, voice_key, is_voice_input, already_sent)
         return True
 
     async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -38,11 +38,7 @@ from urllib.parse import urljoin
 
 from utils import is_truthy_value
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
-from tools.tool_backend_helpers import (
-    managed_nous_tools_enabled,
-    nous_tool_gateway_unavailable_message,
-    resolve_openai_audio_api_key,
-)
+from tools.tool_backend_helpers import managed_nous_tools_enabled, resolve_openai_audio_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -221,519 +217,6 @@ def _try_lazy_install_stt() -> bool:
     return False
 
 
-# Names of the 6 STT providers with native handlers in this module.
-# Kept in sync with ``agent.transcription_registry._BUILTIN_NAMES`` —
-# a regression test fails if they drift. The plugin hook from
-# issue #30398-style follow-up rejects plugins registering under any
-# of these names; the dispatcher in ``transcribe_audio`` short-circuits
-# them defensively as well.
-BUILTIN_STT_PROVIDERS = frozenset({
-    "local",
-    "local_command",
-    "groq",
-    "openai",
-    "mistral",
-    "xai",
-})
-
-
-# ---------------------------------------------------------------------------
-# Command-provider registry (``stt.providers.<name>: type: command``)
-# ---------------------------------------------------------------------------
-#
-# Mirrors the TTS command-provider registry shipped in PR #17843 — same
-# placeholder grammar, same shell-quote-aware rendering, same process-tree
-# termination on timeout. Lets any whisper CLI / ASR CLI / curl pipeline
-# become an STT backend with zero Python.
-#
-# Resolution order:
-#   1. Built-in (``local``, ``local_command``, ``groq``, ``openai``,
-#      ``mistral``, ``xai``)              → native handler. **Always wins.**
-#   2. ``stt.providers.<name>: type: command``  → command-provider runner.
-#   3. Plugin-registered TranscriptionProvider  → plugin dispatch.
-#   4. No match                                 → "No STT provider available".
-#
-# The single-env-var ``HERMES_LOCAL_STT_COMMAND`` escape hatch is preserved
-# untouched via the built-in ``local_command`` path. Use the command-provider
-# registry when you want MULTIPLE shell-driven STT engines, or you want a
-# named provider you can pick via ``stt.provider`` in config.yaml.
-DEFAULT_COMMAND_STT_TIMEOUT_SECONDS = 300
-DEFAULT_COMMAND_STT_LANGUAGE = "en"
-DEFAULT_COMMAND_STT_OUTPUT_FORMAT = "txt"
-COMMAND_STT_OUTPUT_FORMATS = frozenset({"txt", "json", "srt", "vtt"})
-
-
-def _get_stt_section(stt_config: Dict[str, Any], name: str) -> Dict[str, Any]:
-    """Return an stt sub-section if it's a dict, else an empty dict."""
-    if not isinstance(stt_config, dict):
-        return {}
-    section = stt_config.get(name)
-    return section if isinstance(section, dict) else {}
-
-
-def _get_named_stt_provider_config(
-    stt_config: Dict[str, Any],
-    name: str,
-) -> Dict[str, Any]:
-    """Return the config dict for a user-declared STT command provider.
-
-    Looks up ``stt.providers.<name>`` first (the canonical location), and
-    falls back to ``stt.<name>`` so users who followed the built-in layout
-    still work. Returns an empty dict when the provider is not declared.
-
-    Built-in names are NOT special-cased here — the caller short-circuits
-    them before this is consulted, AND ``_is_command_stt_provider_config``
-    requires an explicit ``command:`` value, so a built-in section like
-    ``stt.openai`` (which has ``model``/``language`` but no ``command``)
-    can't accidentally be treated as a command provider.
-    """
-    providers = _get_stt_section(stt_config, "providers")
-    section = providers.get(name) if isinstance(providers, dict) else None
-    if isinstance(section, dict):
-        return section
-    # Back-compat: allow ``stt.<name>`` for user-declared providers too,
-    # but only when the name is not a built-in (so a user's ``stt.openai``
-    # block still means the OpenAI provider, not a custom command).
-    if name.lower() not in BUILTIN_STT_PROVIDERS:
-        legacy = _get_stt_section(stt_config, name)
-        if legacy:
-            return legacy
-    return {}
-
-
-def _is_command_stt_provider_config(config: Dict[str, Any]) -> bool:
-    """Return True when *config* declares a command-type STT provider."""
-    if not isinstance(config, dict):
-        return False
-    ptype = str(config.get("type") or "").strip().lower()
-    if ptype and ptype != "command":
-        return False
-    command = config.get("command")
-    return isinstance(command, str) and bool(command.strip())
-
-
-def _resolve_command_stt_provider_config(
-    provider: str,
-    stt_config: Dict[str, Any],
-) -> Optional[Dict[str, Any]]:
-    """Return the provider config if *provider* resolves to a command type.
-
-    Built-in provider names are rejected (they have native handlers).
-    Returns None when the name is a built-in, ``"none"``, unknown, or not
-    a command type.
-    """
-    if not provider:
-        return None
-    key = provider.lower().strip()
-    if key in BUILTIN_STT_PROVIDERS or key == "none":
-        return None
-    config = _get_named_stt_provider_config(stt_config, key)
-    if _is_command_stt_provider_config(config):
-        return config
-    return None
-
-
-def _iter_command_stt_providers(stt_config: Dict[str, Any]):
-    """Yield (name, config) pairs for every declared command-type STT provider."""
-    if not isinstance(stt_config, dict):
-        return
-    providers = _get_stt_section(stt_config, "providers")
-    for name, cfg in (providers or {}).items():
-        if isinstance(name, str) and name.lower() not in BUILTIN_STT_PROVIDERS:
-            if _is_command_stt_provider_config(cfg):
-                yield name, cfg
-
-
-def _has_any_command_stt_provider(stt_config: Optional[Dict[str, Any]] = None) -> bool:
-    """Return True when any command-type STT provider is configured."""
-    if stt_config is None:
-        stt_config = _load_stt_config()
-    for _name, _cfg in _iter_command_stt_providers(stt_config):
-        return True
-    return False
-
-
-def _get_command_stt_timeout(config: Dict[str, Any]) -> float:
-    """Return timeout in seconds, falling back when invalid."""
-    raw = config.get("timeout", config.get("timeout_seconds", DEFAULT_COMMAND_STT_TIMEOUT_SECONDS))
-    try:
-        value = float(raw)
-    except (TypeError, ValueError):
-        return float(DEFAULT_COMMAND_STT_TIMEOUT_SECONDS)
-    if value <= 0:
-        return float(DEFAULT_COMMAND_STT_TIMEOUT_SECONDS)
-    return value
-
-
-def _get_command_stt_output_format(config: Dict[str, Any]) -> str:
-    """Return the validated output format (txt/json/srt/vtt)."""
-    raw = (
-        config.get("format")
-        or config.get("output_format")
-        or DEFAULT_COMMAND_STT_OUTPUT_FORMAT
-    )
-    fmt = str(raw).lower().strip().lstrip(".")
-    return fmt if fmt in COMMAND_STT_OUTPUT_FORMATS else DEFAULT_COMMAND_STT_OUTPUT_FORMAT
-
-
-def _shell_quote_context_stt(command_template: str, position: int) -> Optional[str]:
-    """Return the shell quote character active right before *position*.
-
-    Mirrors ``tools.tts_tool._shell_quote_context`` — kept local to avoid
-    cross-module import of a private helper. Returns ``"'"`` / ``'"'`` when
-    inside a quoted region, ``None`` for bare context.
-    """
-    quote: Optional[str] = None
-    escaped = False
-    i = 0
-    while i < position:
-        char = command_template[i]
-        if quote == "'":
-            if char == "'":
-                quote = None
-        elif quote == '"':
-            if escaped:
-                escaped = False
-            elif char == "\\":
-                escaped = True
-            elif char == '"':
-                quote = None
-        elif char == "'":
-            quote = "'"
-        elif char == '"':
-            quote = '"'
-        elif char == "\\":
-            i += 1
-        i += 1
-    return quote
-
-
-def _quote_command_stt_placeholder(value: str, quote_context: Optional[str]) -> str:
-    """Quote a placeholder value for its position in a shell command template.
-
-    Mirrors ``tools.tts_tool._quote_command_tts_placeholder``.
-    """
-    if quote_context == "'":
-        return value.replace("'", r"'\''")
-    if quote_context == '"':
-        return (
-            value
-            .replace("\\", "\\\\")
-            .replace('"', r'\"')
-            .replace("$", r"\$")
-            .replace("`", r"\`")
-        )
-    if os.name == "nt":
-        return subprocess.list2cmdline([value])
-    return shlex.quote(value)
-
-
-def _render_command_stt_template(
-    command_template: str,
-    placeholders: Dict[str, str],
-) -> str:
-    """Replace supported placeholders while preserving ``{{`` / ``}}``.
-
-    Mirrors ``tools.tts_tool._render_command_tts_template``. Placeholders
-    are shell-quote-aware: ``{voice}`` inside single quotes gets
-    single-quote-safe escaping, inside double quotes gets ``$``/`` ` ``/`` " ``
-    escaping, outside quotes gets ``shlex.quote``. Doubled braces ``{{`` and
-    ``}}`` are preserved as literal ``{`` / ``}`` for users who want to
-    embed JSON snippets in their command.
-    """
-    import re
-
-    names = "|".join(re.escape(name) for name in placeholders)
-    pattern = re.compile(
-        rf"(?<!\$)(?:\{{\{{(?P<double>{names})\}}\}}|\{{(?P<single>{names})\}})"
-    )
-    replacements: list[tuple[str, str]] = []
-
-    def replace_match(match: "re.Match[str]") -> str:
-        name = match.group("double") or match.group("single")
-        token = f"__HERMES_STT_PLACEHOLDER_{len(replacements)}__"
-        replacements.append((
-            token,
-            _quote_command_stt_placeholder(
-                placeholders[name],
-                _shell_quote_context_stt(command_template, match.start()),
-            ),
-        ))
-        return token
-
-    rendered = pattern.sub(replace_match, command_template)
-    rendered = rendered.replace("{{", "{").replace("}}", "}")
-    for token, value in replacements:
-        rendered = rendered.replace(token, value)
-    return rendered
-
-
-def _terminate_command_stt_process_tree(proc: subprocess.Popen) -> None:
-    """Best-effort termination of a shell process and all of its children.
-
-    Mirrors ``tools.tts_tool._terminate_command_tts_process_tree``.
-    """
-    if proc.poll() is not None:
-        return
-
-    if os.name == "nt":
-        try:
-            subprocess.run(
-                ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                timeout=5,
-            )
-        except Exception:
-            proc.kill()
-        return
-
-    try:
-        import psutil  # type: ignore
-    except ImportError:
-        # psutil is optional — fall back to single-process terminate/kill
-        proc.terminate()
-        try:
-            proc.wait(timeout=2)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-        return
-
-    try:
-        parent = psutil.Process(proc.pid)
-        for child in parent.children(recursive=True):
-            try:
-                child.terminate()
-            except psutil.NoSuchProcess:
-                pass
-        parent.terminate()
-    except psutil.NoSuchProcess:
-        return
-    except Exception:
-        proc.terminate()
-
-    try:
-        proc.wait(timeout=2)
-        return
-    except subprocess.TimeoutExpired:
-        pass
-
-    try:
-        parent = psutil.Process(proc.pid)
-        for child in parent.children(recursive=True):
-            try:
-                child.kill()
-            except psutil.NoSuchProcess:
-                pass
-        parent.kill()
-    except psutil.NoSuchProcess:
-        return
-    except Exception:
-        proc.kill()
-
-
-def _run_command_stt(command: str, timeout: float) -> subprocess.CompletedProcess:
-    """Run a command-provider shell command with process-tree timeout cleanup.
-
-    Mirrors ``tools.tts_tool._run_command_tts``.
-    """
-    popen_kwargs: Dict[str, Any] = {
-        "shell": True,
-        "stdout": subprocess.PIPE,
-        "stderr": subprocess.PIPE,
-        "text": True,
-    }
-    if os.name == "nt":
-        popen_kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-    else:
-        popen_kwargs["start_new_session"] = True
-
-    proc = subprocess.Popen(command, **popen_kwargs)
-    try:
-        stdout, stderr = proc.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired as exc:
-        _terminate_command_stt_process_tree(proc)
-        try:
-            stdout, stderr = proc.communicate(timeout=1)
-        except Exception:
-            stdout = getattr(exc, "output", None)
-            stderr = getattr(exc, "stderr", None)
-        raise subprocess.TimeoutExpired(
-            command,
-            timeout,
-            output=stdout,
-            stderr=stderr,
-        ) from exc
-
-    if proc.returncode:
-        raise subprocess.CalledProcessError(
-            proc.returncode,
-            command,
-            output=stdout,
-            stderr=stderr,
-        )
-    return subprocess.CompletedProcess(command, proc.returncode, stdout, stderr)
-
-
-def _read_command_stt_output(output_path: Path, stdout: str, fmt: str) -> str:
-    """Return the transcript text from a command-provider invocation.
-
-    Resolution:
-      1. If ``output_path`` exists and is non-empty → read it (raw text).
-      2. Else if ``stdout`` is non-empty → use stdout (lets users write
-         curl-style one-liners that emit transcript to stdout instead of
-         writing a file).
-      3. Else → raise RuntimeError (no usable output produced).
-
-    For JSON format, we still return the raw bytes — extracting a
-    ``text`` field is out of scope; users either configure ``format: txt``
-    or post-process JSON downstream. (Same trade-off as TTS: the runner
-    doesn't try to be clever about output shape.)
-    """
-    if output_path.exists():
-        try:
-            content = output_path.read_text(encoding="utf-8").strip()
-        except UnicodeDecodeError:
-            content = output_path.read_bytes().decode("utf-8", errors="replace").strip()
-        if content:
-            return content
-    if stdout and stdout.strip():
-        return stdout.strip()
-    raise RuntimeError(
-        f"Command STT provider wrote no output file at {output_path} "
-        f"and produced no stdout"
-    )
-
-
-def _transcribe_command_stt(
-    file_path: str,
-    provider_name: str,
-    config: Dict[str, Any],
-    stt_config: Dict[str, Any],
-    model_override: Optional[str] = None,
-) -> Dict[str, Any]:
-    """Transcribe via a user-declared ``stt.providers.<name>: type: command``.
-
-    Placeholder grammar:
-
-    | Placeholder       | Substituted with                                          |
-    |-------------------|-----------------------------------------------------------|
-    | ``{input_path}``  | absolute path to the audio file (original location)       |
-    | ``{output_path}`` | absolute path the provider should write its transcript to |
-    | ``{output_dir}``  | parent dir of ``{output_path}``                           |
-    | ``{format}``      | configured output format (``txt`` / ``json`` / ``srt`` / ``vtt``) |
-    | ``{language}``    | configured language code (default ``en``)                 |
-    | ``{model}``       | configured model id (empty when not set)                  |
-
-    All placeholders are shell-quote-aware (see ``_render_command_stt_template``).
-    Doubled braces ``{{`` and ``}}`` are preserved as literal braces.
-
-    Returns the standard transcribe-response envelope (``success``,
-    ``transcript``, ``provider``, ``error``).
-    """
-    command_template = str(config.get("command") or "").strip()
-    if not command_template:
-        return {
-            "success": False,
-            "transcript": "",
-            "provider": provider_name,
-            "error": f"stt.providers.{provider_name}.command is not configured",
-        }
-
-    audio = Path(file_path).expanduser()
-    if not audio.exists():
-        return {
-            "success": False,
-            "transcript": "",
-            "provider": provider_name,
-            "error": f"Audio file not found: {file_path}",
-        }
-
-    timeout = _get_command_stt_timeout(config)
-    output_format = _get_command_stt_output_format(config)
-    language = (
-        config.get("language")
-        or stt_config.get("language")
-        or DEFAULT_COMMAND_STT_LANGUAGE
-    )
-    model = model_override or config.get("model") or ""
-
-    try:
-        with tempfile.TemporaryDirectory(prefix=f"hermes-cmd-stt-{provider_name}-") as tmpdir:
-            output_path = Path(tmpdir) / f"transcript.{output_format}"
-            placeholders = {
-                "input_path": str(audio.resolve()),
-                "output_path": str(output_path),
-                "output_dir": str(output_path.parent),
-                "format": output_format,
-                "language": str(language),
-                "model": str(model),
-            }
-            command = _render_command_stt_template(command_template, placeholders)
-            logger.info(
-                "Transcribing %s via command STT provider '%s'...",
-                audio.name, provider_name,
-            )
-            try:
-                result = _run_command_stt(command, timeout)
-            except subprocess.TimeoutExpired:
-                return {
-                    "success": False,
-                    "transcript": "",
-                    "provider": provider_name,
-                    "error": (
-                        f"STT command provider '{provider_name}' timed out after "
-                        f"{timeout:g}s"
-                    ),
-                }
-            except subprocess.CalledProcessError as exc:
-                detail_parts = []
-                if exc.stderr:
-                    detail_parts.append(f"stderr: {exc.stderr.strip()}")
-                if exc.stdout:
-                    detail_parts.append(f"stdout: {exc.stdout.strip()}")
-                detail = "; ".join(detail_parts) or "no command output"
-                return {
-                    "success": False,
-                    "transcript": "",
-                    "provider": provider_name,
-                    "error": (
-                        f"STT command provider '{provider_name}' exited with code "
-                        f"{exc.returncode}: {detail}"
-                    ),
-                }
-
-            try:
-                transcript_text = _read_command_stt_output(
-                    output_path, result.stdout or "", output_format,
-                )
-            except RuntimeError as exc:
-                return {
-                    "success": False,
-                    "transcript": "",
-                    "provider": provider_name,
-                    "error": str(exc),
-                }
-
-    except OSError as exc:
-        return {
-            "success": False,
-            "transcript": "",
-            "provider": provider_name,
-            "error": f"STT command provider '{provider_name}' failed: {exc}",
-        }
-
-    logger.info(
-        "Transcribed %s via command STT provider '%s' (%d chars)",
-        audio.name, provider_name, len(transcript_text),
-    )
-    return {
-        "success": True,
-        "transcript": transcript_text,
-        "provider": provider_name,
-    }
-
-
 def _get_provider(stt_config: dict) -> str:
     """Determine which STT provider to use.
 
@@ -792,11 +275,16 @@ def _get_provider(stt_config: dict) -> str:
             return "none"
 
         if provider == "mistral":
-            if _HAS_MISTRAL and get_env_value("MISTRAL_API_KEY"):
-                return "mistral"
+            # `mistralai` PyPI package was quarantined on 2026-05-12 after a
+            # malicious 2.4.6 release. Refuse to use this provider until it's
+            # available again so we surface a clear message instead of an
+            # opaque ImportError mid-call.
             logger.warning(
-                "STT provider 'mistral' configured but mistralai package "
-                "not installed or MISTRAL_API_KEY not set"
+                "STT provider 'mistral' (Voxtral Transcribe) is temporarily "
+                "disabled — `mistralai` PyPI package is quarantined "
+                "(malicious 2.4.6 release on 2026-05-12). Falling back to "
+                "another provider. Set stt.provider in config.yaml to 'local' "
+                "or 'openai' to silence this warning."
             )
             return "none"
 
@@ -810,9 +298,16 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "local_http":
+            # local_http provider uses HTTP to call a local STT service
+            # No local binary or package required — just service availability
+            return "local_http"
+
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > mistral > xai ---
+    # --- Auto-detect (no explicit provider): local > groq > openai > xai ---
+    # mistral is intentionally skipped while `mistralai` is quarantined on
+    # PyPI (malicious 2.4.6 release on 2026-05-12).
 
     if _HAS_FASTER_WHISPER:
         return "local"
@@ -827,12 +322,6 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and _has_openai_audio_backend():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
-    # Only auto-select Mistral if the SDK is already present — don't trigger a
-    # lazy-install during passive auto-detection. Explicit `provider: mistral`
-    # (above) does lazy-install on first transcription call.
-    if _HAS_MISTRAL and get_env_value("MISTRAL_API_KEY"):
-        logger.info("No local STT available, using Mistral Voxtral Transcribe API")
-        return "mistral"
     try:
         from tools.xai_http import resolve_xai_http_credentials
 
@@ -843,155 +332,6 @@ def _get_provider(stt_config: dict) -> str:
         pass
     return "none"
 
-
-# ---------------------------------------------------------------------------
-# Plugin provider dispatch (issue follow-up to #30398 — STT pluggability)
-# ---------------------------------------------------------------------------
-
-
-def _dispatch_to_plugin_provider(
-    file_path: str,
-    provider: str,
-    stt_config: Optional[Dict[str, Any]] = None,
-    *,
-    model: Optional[str] = None,
-    language: Optional[str] = None,
-) -> Optional[Dict[str, Any]]:
-    """Route the call to a plugin-registered transcription provider, or
-    return None.
-
-    Returns the transcribe-response dict on dispatch, or ``None`` to
-    fall through to the legacy "No STT provider available" error path.
-
-    Resolution invariants enforced here:
-
-    1. Built-in provider names short-circuit — never reach the plugin
-       registry. The caller (``transcribe_audio``) handles ``local``,
-       ``groq``, ``openai``, etc. via its existing elif chain; this
-       function defensively rejects those names so a plugin can't be
-       silently dispatched under a built-in name even if it somehow
-       slipped past the registry's built-in shadow guard.
-    2. Same-name command-type provider declared under
-       ``stt.providers.<name>: type: command`` wins over a plugin. The
-       caller short-circuits to the command runner before reaching us,
-       but we re-verify here so a refactor of the caller can't silently
-       break the invariant (matches TTS PR #17843 precedence rule).
-    3. Plugin dispatch fires only when ``provider`` matches a
-       registered :class:`TranscriptionProvider` whose ``name`` equals
-       the configured value. Unknown names with no plugin registered
-       return None (caller surfaces the legacy "No STT provider"
-       message).
-    4. Availability gating: when the matched plugin reports
-       ``is_available() == False`` (missing API key, missing optional
-       SDK, etc.) this returns an error envelope identifying the
-       plugin as unavailable — **not** ``None`` — because the user
-       explicitly opted into this plugin via ``stt.provider`` and the
-       generic fallthrough message would be misleading.
-
-    Provider exceptions are caught and converted into the standard
-    error envelope (matches the legacy built-in error shapes — the
-    gateway/CLI caller already expects ``{success: False, error:
-    "...", transcript: ""}`` on failure).
-    """
-    if not provider:
-        return None
-    key = provider.lower().strip()
-    if key in BUILTIN_STT_PROVIDERS or key == "none":
-        return None
-    # Defense in depth: command-provider check should already have
-    # short-circuited the caller. If a same-name command config exists,
-    # bail so the command path wins.
-    if stt_config is not None and _is_command_stt_provider_config(
-        _get_named_stt_provider_config(stt_config, key)
-    ):
-        return None
-    try:
-        from agent.transcription_registry import get_provider
-        from hermes_cli.plugins import _ensure_plugins_discovered
-
-        _ensure_plugins_discovered()
-        plugin_provider = get_provider(key)
-        if plugin_provider is None:
-            # Long-lived sessions may have discovered plugins before a
-            # bundled backend was patched in or before config changed.
-            # Retry once with a forced refresh before surfacing fall-
-            # through. Mirrors the image_gen / browser dispatcher
-            # recovery pattern.
-            _ensure_plugins_discovered(force=True)
-            plugin_provider = get_provider(key)
-    except Exception as exc:  # noqa: BLE001 — discovery failure is non-fatal
-        logger.debug("STT plugin dispatch skipped (discovery failed): %s", exc)
-        return None
-    if plugin_provider is None:
-        return None
-
-    # Availability gate: when a plugin reports it's not configured
-    # (missing API key, missing optional SDK, etc.) surface a clean
-    # error envelope **instead of** falling through to the generic
-    # "No STT provider" message. The user explicitly set
-    # ``stt.provider: <plugin>`` in config — surfacing the plugin's
-    # own availability failure is more actionable than the generic
-    # auto-detect-failure error, and avoids routing the call into a
-    # plugin that's about to crash messily.
-    #
-    # ``is_available()`` MUST NOT raise per the ABC contract; defend
-    # anyway so a buggy plugin can't break dispatch for everyone.
-    try:
-        available = plugin_provider.is_available()
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "STT plugin provider '%s' is_available() raised: %s — "
-            "treating as unavailable", key, exc, exc_info=True,
-        )
-        available = False
-    if not available:
-        logger.info(
-            "STT plugin provider '%s' reports not available; returning "
-            "unavailability envelope.", key,
-        )
-        return {
-            "success": False,
-            "transcript": "",
-            "error": (
-                f"STT plugin '{key}' is not available — check that its "
-                "required credentials / dependencies are configured."
-            ),
-            "provider": key,
-        }
-
-    logger.info("Transcribing with plugin STT provider '%s'...", key)
-    try:
-        result = plugin_provider.transcribe(
-            file_path,
-            model=model,
-            language=language,
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "STT plugin provider '%s' raised: %s", key, exc, exc_info=True,
-        )
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"STT plugin '{key}' raised: {exc}",
-            "provider": key,
-        }
-
-    # Defensive: plugins should return a dict matching the contract. If
-    # they don't, surface a clear error envelope rather than leaking a
-    # weird object back to the gateway.
-    if not isinstance(result, dict):
-        return {
-            "success": False,
-            "transcript": "",
-            "error": f"STT plugin '{key}' returned a non-dict result",
-            "provider": key,
-        }
-    # Stamp provider if the plugin forgot to.
-    result.setdefault("provider", key)
-    return result
-
-
 # ---------------------------------------------------------------------------
 # Shared validation
 # ---------------------------------------------------------------------------
@@ -1001,8 +341,6 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
     """Validate the audio file.  Returns an error dict or None if OK."""
     audio_path = Path(file_path)
 
-    if os.path.islink(audio_path):
-        return {"success": False, "transcript": "", "error": f"Path is a symbolic link: {file_path}"}
     if not audio_path.exists():
         return {"success": False, "transcript": "", "error": f"Audio file not found: {file_path}"}
     if not audio_path.is_file():
@@ -1370,11 +708,6 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": "MISTRAL_API_KEY not set"}
 
     try:
-        try:
-            from tools.lazy_deps import ensure as _lazy_ensure
-            _lazy_ensure("stt.mistral", prompt=False)
-        except ImportError:
-            pass
         from mistralai.client import Mistral
 
         with Mistral(api_key=api_key) as client:
@@ -1506,6 +839,151 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: local_http (HTTP STT service)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_local_http(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using a local STT service via HTTP API.
+
+    Calls the STT service at ``stt.local_http.service_url`` (default: http://localhost:8001)
+    with a POST /transcribe endpoint. The service runs faster-whisper independently,
+    so Hermes doesn't need to load the model itself.
+
+    Config (config.yaml)::
+
+        stt:
+          provider: local_http
+          local_http:
+            service_url: http://localhost:8001
+            language: zh-CN
+            timeout: 60
+
+    Advantages:
+        - Model stays in memory (no reload per call)
+        - Shared across applications (Hermes + OpenClaw)
+        - Centralized management (model/concurrency/logging)
+        - Upgrade-friendly (just restart the service)
+    """
+    stt_config = _load_stt_config()
+    http_config = stt_config.get("local_http", {})
+
+    service_url = str(
+        http_config.get("service_url")
+        or os.getenv("STT_SERVICE_URL")
+        or "http://localhost:8001"
+    ).strip().rstrip("/")
+
+    language = str(
+        http_config.get("language")
+        or os.getenv("HERMES_LOCAL_STT_LANGUAGE")
+        or DEFAULT_LOCAL_STT_LANGUAGE
+    ).strip()
+
+    timeout = int(
+        http_config.get("timeout")
+        or os.getenv("STT_TIMEOUT")
+        or 60
+    )
+
+    # Use configured model or default to base
+    model = model_name or http_config.get("model") or DEFAULT_LOCAL_MODEL
+
+    try:
+        import requests
+
+        with open(file_path, "rb") as audio_file:
+            response = requests.post(
+                f"{service_url}/transcribe",
+                files={"file": (Path(file_path).name, audio_file)},
+                data={
+                    "language": language,
+                    "model": model,
+                },
+                timeout=timeout,
+            )
+
+        if response.status_code != 200:
+            detail = ""
+            try:
+                err_body = response.json()
+                detail = err_body.get("error", "") or response.text[:300]
+            except Exception:
+                detail = response.text[:300]
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"STT service error (HTTP {response.status_code}): {detail}",
+            }
+
+        result = response.json()
+
+        if not result.get("success", False):
+            error_msg = result.get("error", "Unknown STT service error")
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"STT service failed: {error_msg}",
+            }
+
+        transcript_text = result.get("text", "").strip()
+
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "STT service returned empty transcript",
+            }
+
+        # Extract audio duration if available
+        duration_ms = result.get("duration_ms", 0)
+        duration_s = duration_ms / 1000.0 if duration_ms else 0
+
+        logger.info(
+            "Transcribed %s via local_http STT (lang=%s, %.1fs audio, %d chars)",
+            Path(file_path).name,
+            language,
+            duration_s,
+            len(transcript_text),
+        )
+
+        return {"success": True, "transcript": transcript_text, "provider": "local_http"}
+
+    except ImportError:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": (
+                "The 'requests' library is required for local_http STT. "
+                "Install it with: pip install requests"
+            ),
+        }
+    except requests.exceptions.ConnectionError as e:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": (
+                f"Cannot connect to local_http STT service at {service_url}/transcribe. "
+                f"Is the service running? ({e})"
+            ),
+        }
+    except requests.exceptions.Timeout as e:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": (
+                f"local_http STT service at {service_url}/transcribe timed out "
+                f"after {timeout}s."
+            ),
+        }
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("local_http STT transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"local_http STT transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -1578,47 +1056,10 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or "grok-stt"
         return _transcribe_xai(file_path, model_name)
 
-    # User-declared command-type provider
-    # (``stt.providers.<name>: type: command``). Fires after the built-in
-    # elif chain — built-in names short-circuit upstream so a user's
-    # ``stt.providers.openai.command`` can't override the real OpenAI
-    # handler — and BEFORE the plugin dispatcher, because config is more
-    # local than a plugin install (same precedence rule as TTS PR #17843).
-    command_provider_config = _resolve_command_stt_provider_config(provider, stt_config)
-    if command_provider_config is not None:
-        return _transcribe_command_stt(
-            file_path,
-            provider,
-            command_provider_config,
-            stt_config,
-            model_override=model,
-        )
-
-    # Plugin-registered STT backend (e.g. OpenRouter, SenseAudio,
-    # Gemini-STT). Fires only when ``provider`` is neither a built-in
-    # nor ``"none"`` AND there is no same-name command provider. The
-    # dispatcher enforces built-ins-always-win + command-wins-over-plugin
-    # defensively. Returns None when no plugin is registered for the
-    # configured name, falling through to the legacy "No STT provider"
-    # error message below.
-    #
-    # Plugin-scoped config namespace mirrors the built-in pattern
-    # (``stt.openai.model``, ``stt.mistral.model``): plugins read their
-    # per-provider config under ``stt.<provider>`` and the dispatcher
-    # forwards ``language`` from there. Top-level ``model`` argument
-    # overrides any config-set model.
-    plugin_cfg = stt_config.get(provider, {}) if isinstance(stt_config.get(provider), dict) else {}
-    plugin_language = plugin_cfg.get("language")
-    plugin_model = model or plugin_cfg.get("model")
-    plugin_result = _dispatch_to_plugin_provider(
-        file_path,
-        provider,
-        stt_config,
-        model=plugin_model,
-        language=plugin_language,
-    )
-    if plugin_result is not None:
-        return plugin_result
+    if provider == "local_http":
+        http_cfg = stt_config.get("local_http", {})
+        model_name = model or http_cfg.get("model") or DEFAULT_LOCAL_MODEL
+        return _transcribe_local_http(file_path, model_name)
 
     # No provider available
     return {
@@ -1628,8 +1069,9 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, configure xAI OAuth or set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
-            "or OPENAI_API_KEY for the OpenAI Whisper API."
+            "Voxtral Transcribe, configure xAI OAuth or set XAI_API_KEY for xAI Grok STT, "
+            "or set VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY for the OpenAI Whisper API. "
+            "You can also configure stt.provider: local_http to use a local HTTP STT service."
         ),
     }
 
@@ -1651,12 +1093,7 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
     if managed_gateway is None:
         message = "Neither stt.openai.api_key in config nor VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
         if managed_nous_tools_enabled():
-            message += (
-                ". "
-                + nous_tool_gateway_unavailable_message(
-                    "managed OpenAI audio for transcription",
-                )
-            )
+            message += ", and the managed OpenAI audio gateway is unavailable"
         raise ValueError(message)
 
     return managed_gateway.nous_user_token, urljoin(

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -11,6 +11,7 @@ Provides speech-to-text transcription with six providers:
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
+  - **elevenlabs** — ElevenLabs Scribe API, requires ``ELEVENLABS_API_KEY``.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -38,7 +39,11 @@ from urllib.parse import urljoin
 
 from utils import is_truthy_value
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
-from tools.tool_backend_helpers import managed_nous_tools_enabled, resolve_openai_audio_api_key
+from tools.tool_backend_helpers import (
+    managed_nous_tools_enabled,
+    nous_tool_gateway_unavailable_message,
+    resolve_openai_audio_api_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +89,7 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_ELEVENLABS_STT_MODEL = os.getenv("STT_ELEVENLABS_MODEL", "scribe_v2")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -91,6 +97,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
+ELEVENLABS_STT_BASE_URL = os.getenv("ELEVENLABS_STT_BASE_URL", "https://api.elevenlabs.io/v1")
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
@@ -207,7 +214,11 @@ def _try_lazy_install_stt() -> bool:
     """
     try:
         from tools.lazy_deps import ensure
-        ensure("stt.faster_whisper")
+        # prompt=False: never raise a blocking input() prompt mid-session.
+        # Under the interactive CLI prompt_toolkit owns stdin, so a bare
+        # input() deadlocks the terminal (#40490). The install is already
+        # gated by security.allow_lazy_installs, so reaching here is opt-in.
+        ensure("stt.faster_whisper", prompt=False)
         # Re-check dynamically after install
         import importlib.util as _iu
         if _iu.find_spec("faster_whisper"):
@@ -215,6 +226,519 @@ def _try_lazy_install_stt() -> bool:
     except Exception as exc:
         logger.debug("Lazy install of faster-whisper failed: %s", exc)
     return False
+
+
+# Names of the 6 STT providers with native handlers in this module.
+# Kept in sync with ``agent.transcription_registry._BUILTIN_NAMES`` —
+# a regression test fails if they drift. The plugin hook from
+# issue #30398-style follow-up rejects plugins registering under any
+# of these names; the dispatcher in ``transcribe_audio`` short-circuits
+# them defensively as well.
+BUILTIN_STT_PROVIDERS = frozenset({
+    "local",
+    "local_command",
+    "groq",
+    "openai",
+    "mistral",
+    "xai",
+})
+
+
+# ---------------------------------------------------------------------------
+# Command-provider registry (``stt.providers.<name>: type: command``)
+# ---------------------------------------------------------------------------
+#
+# Mirrors the TTS command-provider registry shipped in PR #17843 — same
+# placeholder grammar, same shell-quote-aware rendering, same process-tree
+# termination on timeout. Lets any whisper CLI / ASR CLI / curl pipeline
+# become an STT backend with zero Python.
+#
+# Resolution order:
+#   1. Built-in (``local``, ``local_command``, ``groq``, ``openai``,
+#      ``mistral``, ``xai``)              → native handler. **Always wins.**
+#   2. ``stt.providers.<name>: type: command``  → command-provider runner.
+#   3. Plugin-registered TranscriptionProvider  → plugin dispatch.
+#   4. No match                                 → "No STT provider available".
+#
+# The single-env-var ``HERMES_LOCAL_STT_COMMAND`` escape hatch is preserved
+# untouched via the built-in ``local_command`` path. Use the command-provider
+# registry when you want MULTIPLE shell-driven STT engines, or you want a
+# named provider you can pick via ``stt.provider`` in config.yaml.
+DEFAULT_COMMAND_STT_TIMEOUT_SECONDS = 300
+DEFAULT_COMMAND_STT_LANGUAGE = "en"
+DEFAULT_COMMAND_STT_OUTPUT_FORMAT = "txt"
+COMMAND_STT_OUTPUT_FORMATS = frozenset({"txt", "json", "srt", "vtt"})
+
+
+def _get_stt_section(stt_config: Dict[str, Any], name: str) -> Dict[str, Any]:
+    """Return an stt sub-section if it's a dict, else an empty dict."""
+    if not isinstance(stt_config, dict):
+        return {}
+    section = stt_config.get(name)
+    return section if isinstance(section, dict) else {}
+
+
+def _get_named_stt_provider_config(
+    stt_config: Dict[str, Any],
+    name: str,
+) -> Dict[str, Any]:
+    """Return the config dict for a user-declared STT command provider.
+
+    Looks up ``stt.providers.<name>`` first (the canonical location), and
+    falls back to ``stt.<name>`` so users who followed the built-in layout
+    still work. Returns an empty dict when the provider is not declared.
+
+    Built-in names are NOT special-cased here — the caller short-circuits
+    them before this is consulted, AND ``_is_command_stt_provider_config``
+    requires an explicit ``command:`` value, so a built-in section like
+    ``stt.openai`` (which has ``model``/``language`` but no ``command``)
+    can't accidentally be treated as a command provider.
+    """
+    providers = _get_stt_section(stt_config, "providers")
+    section = providers.get(name) if isinstance(providers, dict) else None
+    if isinstance(section, dict):
+        return section
+    # Back-compat: allow ``stt.<name>`` for user-declared providers too,
+    # but only when the name is not a built-in (so a user's ``stt.openai``
+    # block still means the OpenAI provider, not a custom command).
+    if name.lower() not in BUILTIN_STT_PROVIDERS:
+        legacy = _get_stt_section(stt_config, name)
+        if legacy:
+            return legacy
+    return {}
+
+
+def _is_command_stt_provider_config(config: Dict[str, Any]) -> bool:
+    """Return True when *config* declares a command-type STT provider."""
+    if not isinstance(config, dict):
+        return False
+    ptype = str(config.get("type") or "").strip().lower()
+    if ptype and ptype != "command":
+        return False
+    command = config.get("command")
+    return isinstance(command, str) and bool(command.strip())
+
+
+def _resolve_command_stt_provider_config(
+    provider: str,
+    stt_config: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Return the provider config if *provider* resolves to a command type.
+
+    Built-in provider names are rejected (they have native handlers).
+    Returns None when the name is a built-in, ``"none"``, unknown, or not
+    a command type.
+    """
+    if not provider:
+        return None
+    key = provider.lower().strip()
+    if key in BUILTIN_STT_PROVIDERS or key == "none":
+        return None
+    config = _get_named_stt_provider_config(stt_config, key)
+    if _is_command_stt_provider_config(config):
+        return config
+    return None
+
+
+def _iter_command_stt_providers(stt_config: Dict[str, Any]):
+    """Yield (name, config) pairs for every declared command-type STT provider."""
+    if not isinstance(stt_config, dict):
+        return
+    providers = _get_stt_section(stt_config, "providers")
+    for name, cfg in (providers or {}).items():
+        if isinstance(name, str) and name.lower() not in BUILTIN_STT_PROVIDERS:
+            if _is_command_stt_provider_config(cfg):
+                yield name, cfg
+
+
+def _has_any_command_stt_provider(stt_config: Optional[Dict[str, Any]] = None) -> bool:
+    """Return True when any command-type STT provider is configured."""
+    if stt_config is None:
+        stt_config = _load_stt_config()
+    for _name, _cfg in _iter_command_stt_providers(stt_config):
+        return True
+    return False
+
+
+def _get_command_stt_timeout(config: Dict[str, Any]) -> float:
+    """Return timeout in seconds, falling back when invalid."""
+    raw = config.get("timeout", config.get("timeout_seconds", DEFAULT_COMMAND_STT_TIMEOUT_SECONDS))
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return float(DEFAULT_COMMAND_STT_TIMEOUT_SECONDS)
+    if value <= 0:
+        return float(DEFAULT_COMMAND_STT_TIMEOUT_SECONDS)
+    return value
+
+
+def _get_command_stt_output_format(config: Dict[str, Any]) -> str:
+    """Return the validated output format (txt/json/srt/vtt)."""
+    raw = (
+        config.get("format")
+        or config.get("output_format")
+        or DEFAULT_COMMAND_STT_OUTPUT_FORMAT
+    )
+    fmt = str(raw).lower().strip().lstrip(".")
+    return fmt if fmt in COMMAND_STT_OUTPUT_FORMATS else DEFAULT_COMMAND_STT_OUTPUT_FORMAT
+
+
+def _shell_quote_context_stt(command_template: str, position: int) -> Optional[str]:
+    """Return the shell quote character active right before *position*.
+
+    Mirrors ``tools.tts_tool._shell_quote_context`` — kept local to avoid
+    cross-module import of a private helper. Returns ``"'"`` / ``'"'`` when
+    inside a quoted region, ``None`` for bare context.
+    """
+    quote: Optional[str] = None
+    escaped = False
+    i = 0
+    while i < position:
+        char = command_template[i]
+        if quote == "'":
+            if char == "'":
+                quote = None
+        elif quote == '"':
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                quote = None
+        elif char == "'":
+            quote = "'"
+        elif char == '"':
+            quote = '"'
+        elif char == "\\":
+            i += 1
+        i += 1
+    return quote
+
+
+def _quote_command_stt_placeholder(value: str, quote_context: Optional[str]) -> str:
+    """Quote a placeholder value for its position in a shell command template.
+
+    Mirrors ``tools.tts_tool._quote_command_tts_placeholder``.
+    """
+    if quote_context == "'":
+        return value.replace("'", r"'\''")
+    if quote_context == '"':
+        return (
+            value
+            .replace("\\", "\\\\")
+            .replace('"', r'\"')
+            .replace("$", r"\$")
+            .replace("`", r"\`")
+        )
+    if os.name == "nt":
+        return subprocess.list2cmdline([value])
+    return shlex.quote(value)
+
+
+def _render_command_stt_template(
+    command_template: str,
+    placeholders: Dict[str, str],
+) -> str:
+    """Replace supported placeholders while preserving ``{{`` / ``}}``.
+
+    Mirrors ``tools.tts_tool._render_command_tts_template``. Placeholders
+    are shell-quote-aware: ``{voice}`` inside single quotes gets
+    single-quote-safe escaping, inside double quotes gets ``$``/`` ` ``/`` " ``
+    escaping, outside quotes gets ``shlex.quote``. Doubled braces ``{{`` and
+    ``}}`` are preserved as literal ``{`` / ``}`` for users who want to
+    embed JSON snippets in their command.
+    """
+    import re
+
+    names = "|".join(re.escape(name) for name in placeholders)
+    pattern = re.compile(
+        rf"(?<!\$)(?:\{{\{{(?P<double>{names})\}}\}}|\{{(?P<single>{names})\}})"
+    )
+    replacements: list[tuple[str, str]] = []
+
+    def replace_match(match: "re.Match[str]") -> str:
+        name = match.group("double") or match.group("single")
+        token = f"__HERMES_STT_PLACEHOLDER_{len(replacements)}__"
+        replacements.append((
+            token,
+            _quote_command_stt_placeholder(
+                placeholders[name],
+                _shell_quote_context_stt(command_template, match.start()),
+            ),
+        ))
+        return token
+
+    rendered = pattern.sub(replace_match, command_template)
+    rendered = rendered.replace("{{", "{").replace("}}", "}")
+    for token, value in replacements:
+        rendered = rendered.replace(token, value)
+    return rendered
+
+
+def _terminate_command_stt_process_tree(proc: subprocess.Popen) -> None:
+    """Best-effort termination of a shell process and all of its children.
+
+    Mirrors ``tools.tts_tool._terminate_command_tts_process_tree``.
+    """
+    if proc.poll() is not None:
+        return
+
+    if os.name == "nt":
+        try:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+            )
+        except Exception:
+            proc.kill()
+        return
+
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        # psutil is optional — fall back to single-process terminate/kill
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        return
+
+    try:
+        parent = psutil.Process(proc.pid)
+        for child in parent.children(recursive=True):
+            try:
+                child.terminate()
+            except psutil.NoSuchProcess:
+                pass
+        parent.terminate()
+    except psutil.NoSuchProcess:
+        return
+    except Exception:
+        proc.terminate()
+
+    try:
+        proc.wait(timeout=2)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+
+    try:
+        parent = psutil.Process(proc.pid)
+        for child in parent.children(recursive=True):
+            try:
+                child.kill()
+            except psutil.NoSuchProcess:
+                pass
+        parent.kill()
+    except psutil.NoSuchProcess:
+        return
+    except Exception:
+        proc.kill()
+
+
+def _run_command_stt(command: str, timeout: float) -> subprocess.CompletedProcess:
+    """Run a command-provider shell command with process-tree timeout cleanup.
+
+    Mirrors ``tools.tts_tool._run_command_tts``.
+    """
+    popen_kwargs: Dict[str, Any] = {
+        "shell": True,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+    }
+    if os.name == "nt":
+        popen_kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    proc = subprocess.Popen(command, **popen_kwargs)
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        _terminate_command_stt_process_tree(proc)
+        try:
+            stdout, stderr = proc.communicate(timeout=1)
+        except Exception:
+            stdout = getattr(exc, "output", None)
+            stderr = getattr(exc, "stderr", None)
+        raise subprocess.TimeoutExpired(
+            command,
+            timeout,
+            output=stdout,
+            stderr=stderr,
+        ) from exc
+
+    if proc.returncode:
+        raise subprocess.CalledProcessError(
+            proc.returncode,
+            command,
+            output=stdout,
+            stderr=stderr,
+        )
+    return subprocess.CompletedProcess(command, proc.returncode, stdout, stderr)
+
+
+def _read_command_stt_output(output_path: Path, stdout: str, fmt: str) -> str:
+    """Return the transcript text from a command-provider invocation.
+
+    Resolution:
+      1. If ``output_path`` exists and is non-empty → read it (raw text).
+      2. Else if ``stdout`` is non-empty → use stdout (lets users write
+         curl-style one-liners that emit transcript to stdout instead of
+         writing a file).
+      3. Else → raise RuntimeError (no usable output produced).
+
+    For JSON format, we still return the raw bytes — extracting a
+    ``text`` field is out of scope; users either configure ``format: txt``
+    or post-process JSON downstream. (Same trade-off as TTS: the runner
+    doesn't try to be clever about output shape.)
+    """
+    if output_path.exists():
+        try:
+            content = output_path.read_text(encoding="utf-8").strip()
+        except UnicodeDecodeError:
+            content = output_path.read_bytes().decode("utf-8", errors="replace").strip()
+        if content:
+            return content
+    if stdout and stdout.strip():
+        return stdout.strip()
+    raise RuntimeError(
+        f"Command STT provider wrote no output file at {output_path} "
+        f"and produced no stdout"
+    )
+
+
+def _transcribe_command_stt(
+    file_path: str,
+    provider_name: str,
+    config: Dict[str, Any],
+    stt_config: Dict[str, Any],
+    model_override: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Transcribe via a user-declared ``stt.providers.<name>: type: command``.
+
+    Placeholder grammar:
+
+    | Placeholder       | Substituted with                                          |
+    |-------------------|-----------------------------------------------------------|
+    | ``{input_path}``  | absolute path to the audio file (original location)       |
+    | ``{output_path}`` | absolute path the provider should write its transcript to |
+    | ``{output_dir}``  | parent dir of ``{output_path}``                           |
+    | ``{format}``      | configured output format (``txt`` / ``json`` / ``srt`` / ``vtt``) |
+    | ``{language}``    | configured language code (default ``en``)                 |
+    | ``{model}``       | configured model id (empty when not set)                  |
+
+    All placeholders are shell-quote-aware (see ``_render_command_stt_template``).
+    Doubled braces ``{{`` and ``}}`` are preserved as literal braces.
+
+    Returns the standard transcribe-response envelope (``success``,
+    ``transcript``, ``provider``, ``error``).
+    """
+    command_template = str(config.get("command") or "").strip()
+    if not command_template:
+        return {
+            "success": False,
+            "transcript": "",
+            "provider": provider_name,
+            "error": f"stt.providers.{provider_name}.command is not configured",
+        }
+
+    audio = Path(file_path).expanduser()
+    if not audio.exists():
+        return {
+            "success": False,
+            "transcript": "",
+            "provider": provider_name,
+            "error": f"Audio file not found: {file_path}",
+        }
+
+    timeout = _get_command_stt_timeout(config)
+    output_format = _get_command_stt_output_format(config)
+    language = (
+        config.get("language")
+        or stt_config.get("language")
+        or DEFAULT_COMMAND_STT_LANGUAGE
+    )
+    model = model_override or config.get("model") or ""
+
+    try:
+        with tempfile.TemporaryDirectory(prefix=f"hermes-cmd-stt-{provider_name}-") as tmpdir:
+            output_path = Path(tmpdir) / f"transcript.{output_format}"
+            placeholders = {
+                "input_path": str(audio.resolve()),
+                "output_path": str(output_path),
+                "output_dir": str(output_path.parent),
+                "format": output_format,
+                "language": str(language),
+                "model": str(model),
+            }
+            command = _render_command_stt_template(command_template, placeholders)
+            logger.info(
+                "Transcribing %s via command STT provider '%s'...",
+                audio.name, provider_name,
+            )
+            try:
+                result = _run_command_stt(command, timeout)
+            except subprocess.TimeoutExpired:
+                return {
+                    "success": False,
+                    "transcript": "",
+                    "provider": provider_name,
+                    "error": (
+                        f"STT command provider '{provider_name}' timed out after "
+                        f"{timeout:g}s"
+                    ),
+                }
+            except subprocess.CalledProcessError as exc:
+                detail_parts = []
+                if exc.stderr:
+                    detail_parts.append(f"stderr: {exc.stderr.strip()}")
+                if exc.stdout:
+                    detail_parts.append(f"stdout: {exc.stdout.strip()}")
+                detail = "; ".join(detail_parts) or "no command output"
+                return {
+                    "success": False,
+                    "transcript": "",
+                    "provider": provider_name,
+                    "error": (
+                        f"STT command provider '{provider_name}' exited with code "
+                        f"{exc.returncode}: {detail}"
+                    ),
+                }
+
+            try:
+                transcript_text = _read_command_stt_output(
+                    output_path, result.stdout or "", output_format,
+                )
+            except RuntimeError as exc:
+                return {
+                    "success": False,
+                    "transcript": "",
+                    "provider": provider_name,
+                    "error": str(exc),
+                }
+
+    except OSError as exc:
+        return {
+            "success": False,
+            "transcript": "",
+            "provider": provider_name,
+            "error": f"STT command provider '{provider_name}' failed: {exc}",
+        }
+
+    logger.info(
+        "Transcribed %s via command STT provider '%s' (%d chars)",
+        audio.name, provider_name, len(transcript_text),
+    )
+    return {
+        "success": True,
+        "transcript": transcript_text,
+        "provider": provider_name,
+    }
 
 
 def _get_provider(stt_config: dict) -> str:
@@ -275,16 +799,11 @@ def _get_provider(stt_config: dict) -> str:
             return "none"
 
         if provider == "mistral":
-            # `mistralai` PyPI package was quarantined on 2026-05-12 after a
-            # malicious 2.4.6 release. Refuse to use this provider until it's
-            # available again so we surface a clear message instead of an
-            # opaque ImportError mid-call.
+            if _HAS_MISTRAL and get_env_value("MISTRAL_API_KEY"):
+                return "mistral"
             logger.warning(
-                "STT provider 'mistral' (Voxtral Transcribe) is temporarily "
-                "disabled — `mistralai` PyPI package is quarantined "
-                "(malicious 2.4.6 release on 2026-05-12). Falling back to "
-                "another provider. Set stt.provider in config.yaml to 'local' "
-                "or 'openai' to silence this warning."
+                "STT provider 'mistral' configured but mistralai package "
+                "not installed or MISTRAL_API_KEY not set"
             )
             return "none"
 
@@ -298,14 +817,22 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "elevenlabs":
+            if get_env_value("ELEVENLABS_API_KEY"):
+                return "elevenlabs"
+            logger.warning(
+                "STT provider 'elevenlabs' configured but ELEVENLABS_API_KEY not set"
+            )
+            return "none"
+
         if provider == "local_http":
-            # local_http provider uses HTTP to call a local STT service
-            # No local binary or package required — just service availability
+            # local_http uses HTTP to call a separately-run STT service.
+            # No local binary or package required — just service availability.
             return "local_http"
 
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > xai ---
+    # --- Auto-detect (no explicit provider): local > groq > openai > xai > elevenlabs -
     # mistral is intentionally skipped while `mistralai` is quarantined on
     # PyPI (malicious 2.4.6 release on 2026-05-12).
 
@@ -322,6 +849,12 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and _has_openai_audio_backend():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
+    # Only auto-select Mistral if the SDK is already present — don't trigger a
+    # lazy-install during passive auto-detection. Explicit `provider: mistral`
+    # (above) does lazy-install on first transcription call.
+    if _HAS_MISTRAL and get_env_value("MISTRAL_API_KEY"):
+        logger.info("No local STT available, using Mistral Voxtral Transcribe API")
+        return "mistral"
     try:
         from tools.xai_http import resolve_xai_http_credentials
 
@@ -330,7 +863,159 @@ def _get_provider(stt_config: dict) -> str:
             return "xai"
     except Exception:
         pass
+    if get_env_value("ELEVENLABS_API_KEY"):
+        logger.info("No local STT available, using ElevenLabs Scribe STT API")
+        return "elevenlabs"
     return "none"
+
+
+# ---------------------------------------------------------------------------
+# Plugin provider dispatch (issue follow-up to #30398 — STT pluggability)
+# ---------------------------------------------------------------------------
+
+
+def _dispatch_to_plugin_provider(
+    file_path: str,
+    provider: str,
+    stt_config: Optional[Dict[str, Any]] = None,
+    *,
+    model: Optional[str] = None,
+    language: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Route the call to a plugin-registered transcription provider, or
+    return None.
+
+    Returns the transcribe-response dict on dispatch, or ``None`` to
+    fall through to the legacy "No STT provider available" error path.
+
+    Resolution invariants enforced here:
+
+    1. Built-in provider names short-circuit — never reach the plugin
+       registry. The caller (``transcribe_audio``) handles ``local``,
+       ``groq``, ``openai``, etc. via its existing elif chain; this
+       function defensively rejects those names so a plugin can't be
+       silently dispatched under a built-in name even if it somehow
+       slipped past the registry's built-in shadow guard.
+    2. Same-name command-type provider declared under
+       ``stt.providers.<name>: type: command`` wins over a plugin. The
+       caller short-circuits to the command runner before reaching us,
+       but we re-verify here so a refactor of the caller can't silently
+       break the invariant (matches TTS PR #17843 precedence rule).
+    3. Plugin dispatch fires only when ``provider`` matches a
+       registered :class:`TranscriptionProvider` whose ``name`` equals
+       the configured value. Unknown names with no plugin registered
+       return None (caller surfaces the legacy "No STT provider"
+       message).
+    4. Availability gating: when the matched plugin reports
+       ``is_available() == False`` (missing API key, missing optional
+       SDK, etc.) this returns an error envelope identifying the
+       plugin as unavailable — **not** ``None`` — because the user
+       explicitly opted into this plugin via ``stt.provider`` and the
+       generic fallthrough message would be misleading.
+
+    Provider exceptions are caught and converted into the standard
+    error envelope (matches the legacy built-in error shapes — the
+    gateway/CLI caller already expects ``{success: False, error:
+    "...", transcript: ""}`` on failure).
+    """
+    if not provider:
+        return None
+    key = provider.lower().strip()
+    if key in BUILTIN_STT_PROVIDERS or key == "none":
+        return None
+    # Defense in depth: command-provider check should already have
+    # short-circuited the caller. If a same-name command config exists,
+    # bail so the command path wins.
+    if stt_config is not None and _is_command_stt_provider_config(
+        _get_named_stt_provider_config(stt_config, key)
+    ):
+        return None
+    try:
+        from agent.transcription_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        plugin_provider = get_provider(key)
+        if plugin_provider is None:
+            # Long-lived sessions may have discovered plugins before a
+            # bundled backend was patched in or before config changed.
+            # Retry once with a forced refresh before surfacing fall-
+            # through. Mirrors the image_gen / browser dispatcher
+            # recovery pattern.
+            _ensure_plugins_discovered(force=True)
+            plugin_provider = get_provider(key)
+    except Exception as exc:  # noqa: BLE001 — discovery failure is non-fatal
+        logger.debug("STT plugin dispatch skipped (discovery failed): %s", exc)
+        return None
+    if plugin_provider is None:
+        return None
+
+    # Availability gate: when a plugin reports it's not configured
+    # (missing API key, missing optional SDK, etc.) surface a clean
+    # error envelope **instead of** falling through to the generic
+    # "No STT provider" message. The user explicitly set
+    # ``stt.provider: <plugin>`` in config — surfacing the plugin's
+    # own availability failure is more actionable than the generic
+    # auto-detect-failure error, and avoids routing the call into a
+    # plugin that's about to crash messily.
+    #
+    # ``is_available()`` MUST NOT raise per the ABC contract; defend
+    # anyway so a buggy plugin can't break dispatch for everyone.
+    try:
+        available = plugin_provider.is_available()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "STT plugin provider '%s' is_available() raised: %s — "
+            "treating as unavailable", key, exc, exc_info=True,
+        )
+        available = False
+    if not available:
+        logger.info(
+            "STT plugin provider '%s' reports not available; returning "
+            "unavailability envelope.", key,
+        )
+        return {
+            "success": False,
+            "transcript": "",
+            "error": (
+                f"STT plugin '{key}' is not available — check that its "
+                "required credentials / dependencies are configured."
+            ),
+            "provider": key,
+        }
+
+    logger.info("Transcribing with plugin STT provider '%s'...", key)
+    try:
+        result = plugin_provider.transcribe(
+            file_path,
+            model=model,
+            language=language,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "STT plugin provider '%s' raised: %s", key, exc, exc_info=True,
+        )
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"STT plugin '{key}' raised: {exc}",
+            "provider": key,
+        }
+
+    # Defensive: plugins should return a dict matching the contract. If
+    # they don't, surface a clear error envelope rather than leaking a
+    # weird object back to the gateway.
+    if not isinstance(result, dict):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"STT plugin '{key}' returned a non-dict result",
+            "provider": key,
+        }
+    # Stamp provider if the plugin forgot to.
+    result.setdefault("provider", key)
+    return result
+
 
 # ---------------------------------------------------------------------------
 # Shared validation
@@ -341,6 +1026,8 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
     """Validate the audio file.  Returns an error dict or None if OK."""
     audio_path = Path(file_path)
 
+    if os.path.islink(audio_path):
+        return {"success": False, "transcript": "", "error": f"Path is a symbolic link: {file_path}"}
     if not audio_path.exists():
         return {"success": False, "transcript": "", "error": f"Audio file not found: {file_path}"}
     if not audio_path.is_file():
@@ -504,8 +1191,11 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
     command = [ffmpeg, "-y", "-i", file_path, converted_path]
 
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True)
+        subprocess.run(command, check=True, capture_output=True, text=True, timeout=300)
         return converted_path, None
+    except subprocess.TimeoutExpired:
+        logger.error("ffmpeg conversion timed out for %s", file_path)
+        return None, "Audio conversion for local STT timed out"
     except subprocess.CalledProcessError as e:
         details = e.stderr.strip() or e.stdout.strip() or str(e)
         logger.error("ffmpeg conversion failed for %s: %s", file_path, details)
@@ -547,9 +1237,9 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
             if use_shell:
-                subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+                subprocess.run(command, shell=True, check=True, capture_output=True, text=True, timeout=300)
             else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True)
+                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, timeout=300)
             
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))
@@ -708,6 +1398,11 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": "MISTRAL_API_KEY not set"}
 
     try:
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            _lazy_ensure("stt.mistral", prompt=False)
+        except ImportError:
+            pass
         from mistralai.client import Mistral
 
         with Mistral(api_key=api_key) as client:
@@ -839,6 +1534,92 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: ElevenLabs (Scribe STT API)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using ElevenLabs Scribe STT API."""
+    api_key = get_env_value("ELEVENLABS_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "ELEVENLABS_API_KEY not set"}
+
+    stt_config = _load_stt_config()
+    elevenlabs_config = stt_config.get("elevenlabs", {})
+    base_url = str(
+        elevenlabs_config.get("base_url")
+        or get_env_value("ELEVENLABS_STT_BASE_URL")
+        or ELEVENLABS_STT_BASE_URL
+    ).strip().rstrip("/")
+    language_code = str(elevenlabs_config.get("language_code") or "").strip()
+    tag_audio_events = is_truthy_value(elevenlabs_config.get("tag_audio_events", False))
+    diarize = is_truthy_value(elevenlabs_config.get("diarize", False))
+
+    try:
+        import requests
+
+        data: Dict[str, str] = {
+            "model_id": model_name,
+            "tag_audio_events": "true" if tag_audio_events else "false",
+            "diarize": "true" if diarize else "false",
+        }
+        if language_code:
+            data["language_code"] = language_code
+
+        with open(file_path, "rb") as audio_file:
+            response = requests.post(
+                f"{base_url}/speech-to-text",
+                headers={"xi-api-key": api_key},
+                files={"file": (Path(file_path).name, audio_file)},
+                data=data,
+                timeout=120,
+            )
+
+        if response.status_code != 200:
+            detail = ""
+            try:
+                err_body = response.json()
+                error_value = err_body.get("detail") or err_body.get("error")
+                if isinstance(error_value, dict):
+                    detail = str(error_value.get("message") or error_value)
+                elif error_value:
+                    detail = str(error_value)
+                else:
+                    detail = response.text[:300]
+            except Exception:
+                detail = response.text[:300]
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"ElevenLabs STT API error (HTTP {response.status_code}): {detail}",
+            }
+
+        result = response.json()
+        transcript_text = _extract_transcript_text(result)
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "ElevenLabs STT returned empty transcript",
+            }
+
+        logger.info(
+            "Transcribed %s via ElevenLabs Scribe (%s, %d chars)",
+            Path(file_path).name,
+            model_name,
+            len(transcript_text),
+        )
+
+        return {"success": True, "transcript": transcript_text, "provider": "elevenlabs"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("ElevenLabs STT transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"ElevenLabs STT transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Provider: local_http (HTTP STT service)
 # ---------------------------------------------------------------------------
 
@@ -846,9 +1627,9 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 def _transcribe_local_http(file_path: str, model_name: str) -> Dict[str, Any]:
     """Transcribe using a local STT service via HTTP API.
 
-    Calls the STT service at ``stt.local_http.service_url`` (default: http://localhost:8001)
-    with a POST /transcribe endpoint. The service runs faster-whisper independently,
-    so Hermes doesn't need to load the model itself.
+    Calls an external STT service over HTTP (default: http://localhost:8001)
+    with a POST /transcribe endpoint. The service runs independently, so
+    Hermes doesn't need to load the model itself.
 
     Config (config.yaml)::
 
@@ -861,8 +1642,8 @@ def _transcribe_local_http(file_path: str, model_name: str) -> Dict[str, Any]:
 
     Advantages:
         - Model stays in memory (no reload per call)
-        - Shared across applications (Hermes + OpenClaw)
-        - Centralized management (model/concurrency/logging)
+        - Shared across processes (Hermes + other tools)
+        - Centralized management (model, concurrency, logging)
         - Upgrade-friendly (just restart the service)
     """
     stt_config = _load_stt_config()
@@ -994,7 +1775,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
 
     Provider priority:
       1. User config (``stt.provider`` in config.yaml)
-      2. Auto-detect: local faster-whisper (free) > Groq (free tier) > OpenAI (paid)
+      2. Auto-detect: local > Groq > OpenAI > Mistral > xAI > ElevenLabs
 
     Args:
         file_path: Absolute path to the audio file to transcribe.
@@ -1056,10 +1837,57 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or "grok-stt"
         return _transcribe_xai(file_path, model_name)
 
+    if provider == "elevenlabs":
+        elevenlabs_cfg = stt_config.get("elevenlabs", {})
+        model_name = model or elevenlabs_cfg.get("model_id", DEFAULT_ELEVENLABS_STT_MODEL)
+        return _transcribe_elevenlabs(file_path, model_name)
+
     if provider == "local_http":
         http_cfg = stt_config.get("local_http", {})
         model_name = model or http_cfg.get("model") or DEFAULT_LOCAL_MODEL
         return _transcribe_local_http(file_path, model_name)
+
+    # User-declared command-type provider
+    # (``stt.providers.<name>: type: command``). Fires after the built-in
+    # elif chain — built-in names short-circuit upstream so a user's
+    # ``stt.providers.openai.command`` can't override the real OpenAI
+    # handler — and BEFORE the plugin dispatcher, because config is more
+    # local than a plugin install (same precedence rule as TTS PR #17843).
+    command_provider_config = _resolve_command_stt_provider_config(provider, stt_config)
+    if command_provider_config is not None:
+        return _transcribe_command_stt(
+            file_path,
+            provider,
+            command_provider_config,
+            stt_config,
+            model_override=model,
+        )
+
+    # Plugin-registered STT backend (e.g. OpenRouter, SenseAudio,
+    # Gemini-STT). Fires only when ``provider`` is neither a built-in
+    # nor ``"none"`` AND there is no same-name command provider. The
+    # dispatcher enforces built-ins-always-win + command-wins-over-plugin
+    # defensively. Returns None when no plugin is registered for the
+    # configured name, falling through to the legacy "No STT provider"
+    # error message below.
+    #
+    # Plugin-scoped config namespace mirrors the built-in pattern
+    # (``stt.openai.model``, ``stt.mistral.model``): plugins read their
+    # per-provider config under ``stt.<provider>`` and the dispatcher
+    # forwards ``language`` from there. Top-level ``model`` argument
+    # overrides any config-set model.
+    plugin_cfg = stt_config.get(provider, {}) if isinstance(stt_config.get(provider), dict) else {}
+    plugin_language = plugin_cfg.get("language")
+    plugin_model = model or plugin_cfg.get("model")
+    plugin_result = _dispatch_to_plugin_provider(
+        file_path,
+        provider,
+        stt_config,
+        model=plugin_model,
+        language=plugin_language,
+    )
+    if plugin_result is not None:
+        return plugin_result
 
     # No provider available
     return {
@@ -1070,7 +1898,8 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
             "Voxtral Transcribe, configure xAI OAuth or set XAI_API_KEY for xAI Grok STT, "
-            "or set VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY for the OpenAI Whisper API. "
+            "set ELEVENLABS_API_KEY for ElevenLabs Scribe, or set VOICE_TOOLS_OPENAI_KEY "
+            "or OPENAI_API_KEY for the OpenAI Whisper API. "
             "You can also configure stt.provider: local_http to use a local HTTP STT service."
         ),
     }
@@ -1093,7 +1922,12 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
     if managed_gateway is None:
         message = "Neither stt.openai.api_key in config nor VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
         if managed_nous_tools_enabled():
-            message += ", and the managed OpenAI audio gateway is unavailable"
+            message += (
+                ". "
+                + nous_tool_gateway_unavailable_message(
+                    "managed OpenAI audio for transcription",
+                )
+            )
         raise ValueError(message)
 
     return managed_gateway.nous_user_token, urljoin(


### PR DESCRIPTION
## What does this PR do?

Adds a new `local_http` STT provider that transcribes audio by calling an external HTTP STT service over `POST /transcribe`.

## Motivation

The existing `local` provider (faster‑whisper) loads the model in‑process, which means:
- Model is reloaded on every call if the process restarts
- Cannot be shared across multiple processes (Hermes + other tools)
- Hard to upgrade independently (model changes require Hermes restart)

The `local_http` provider solves this by connecting to a separately‑run STT service over HTTP. The service can use any STT engine behind the endpoint — faster‑whisper, SenseVoice, WhisperX, etc. — and Hermes treats it as just another provider.

## Advantages over `local` (faster‑whisper)

| | `local` | `local_http` |
|---|---|---|
| Model lifetime | Reloaded per process | Stays in memory |
| Multi‑process sharing | No | Yes (shared endpoint) |
| STT engine | faster‑whisper only | Any HTTP‑compatible engine |
| Upgrade path | Restart Hermes | Restart the STT service only |
| Resource management | Per‑process | Centralized (single service) |

## Config

```yaml
stt:
  provider: local_http
  local_http:
    service_url: http://localhost:8001
    language: zh-CN
    timeout: 60
```

Environment variables supported: `STT_SERVICE_URL`, `HERMES_LOCAL_STT_LANGUAGE`, `STT_TIMEOUT`.

## Changes Made

- `tools/transcription_tools.py` — added `_transcribe_local_http()` function (HTTP POST → service, full error handling for ImportError / ConnectionError / Timeout / PermissionError). Added provider routing in `_get_provider()` (explicit `provider: local_http` config) and `transcribe_audio()` dispatch. Updated the fallback error message to mention `local_http`.

## Related Issue

N/A

## Type of Change

- [x] New feature

## How to Test

1. Start a local STT service at `http://localhost:8001` with a `POST /transcribe` endpoint accepting `multipart/form-data` (fields: `file`, `language`, `model`) and returning `{"success": true, "text": "...", "duration_ms": ...}`.
2. Set `stt.provider: local_http` in config.yaml.
3. Send a voice message through any platform (Telegram, Discord, Feishu, etc.) — the gateway picks up the configured provider automatically.

## Checklist

### Code

- [x] Code follows project style
- [x] No breaking changes to existing providers
- [x] Error handling covers: ImportError, ConnectionError, Timeout, PermissionError, generic Exception
- [x] Config respects the existing `stt.provider` / `stt.<name>` convention

### Documentation & Housekeeping

- [x] No new dependencies (uses `requests` which is already a project dependency)