### PR TITLE
fix(file_tools): normalize shell-escaped spaces in tool paths

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -166,6 +166,21 @@ class TestWriteFileHandler:
         assert "error" in result
         assert "string" in result["error"].lower() or "content" in result["error"].lower()
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_shell_escaped_spaces_are_normalized_before_dispatch(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok"}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool("Obsidian\\ Vault/out.txt", "hello"))
+        assert result["resolved_path"].endswith("Obsidian Vault/out.txt")
+        mock_ops.write_file.assert_called_once()
+        called_path = mock_ops.write_file.call_args.args[0]
+        assert called_path.endswith("Obsidian Vault/out.txt")
+
 
 class TestPatchHandler:
     @patch("tools.file_tools._get_file_ops")
@@ -227,6 +242,25 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         result = json.loads(patch_tool(mode="patch", patch=None))
         assert "error" in result
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_mode_normalizes_shell_escaped_spaces_before_dispatch(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok"}
+        mock_ops.patch_replace.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(
+            mode="replace",
+            path="Obsidian\\ Vault/f.py",
+            old_string="foo",
+            new_string="bar",
+        ))
+        assert result["resolved_path"].endswith("Obsidian Vault/f.py")
+        called_path = mock_ops.patch_replace.call_args.args[0]
+        assert called_path.endswith("Obsidian Vault/f.py")
 
     @patch("tools.file_tools._get_file_ops")
     def test_unknown_mode_errors(self, mock_get):
@@ -472,6 +506,17 @@ class TestWindowsMsysPathResolution:
         resolved = file_tools._resolve_path_for_task("src/app.py", task_id="msys")
         assert str(resolved) == r"C:\Users\Mark\project\src\app.py"
 
+    def test_native_windows_backslash_space_is_not_unescaped(self, monkeypatch):
+        import tools.environments.local as local_mod
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(file_tools.sys, "platform", "win32")
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default": False)
+
+        resolved = file_tools._resolve_path_for_task(r"C:\dir\ file.txt")
+        assert str(resolved) == r"C:\dir\ file.txt"
+
     def test_container_paths_skip_msys_translation(self, monkeypatch):
         """WSL/docker Linux paths must not be rewritten as Windows drives."""
         import tools.environments.local as local_mod
@@ -486,8 +531,8 @@ class TestWindowsMsysPathResolution:
             lambda task_id="default": "/home/don/project",
         )
 
-        resolved = file_tools._resolve_path_for_task("/home/don/.env")
-        assert str(resolved) == "/home/don/.env"
+        resolved = file_tools._resolve_path_for_task("/home/don/My\\ Notes/.env")
+        assert str(resolved) == "/home/don/My Notes/.env"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -275,6 +275,16 @@ class TestWriteFile:
         assert "charlie" in result.content
         _assert_clean(result.content)
 
+    def test_shell_escaped_space_path_writes_to_literal_space_directory(self, ops, tmp_path):
+        target_dir = tmp_path / "Obsidian Vault"
+        escaped_path = str(target_dir / "note.md").replace(" ", "\\ ")
+
+        result = ops.write_file(escaped_path, "vault note\n")
+
+        assert result.error is None
+        assert (target_dir / "note.md").read_text() == "vault note\n"
+        assert not (tmp_path / "Obsidian\\ Vault").exists()
+
 
 # ── patch_replace ────────────────────────────────────────────────────────
 
@@ -299,6 +309,19 @@ class TestPatchReplace:
         result = ops.patch_replace(path, "line2", "REPLACED")
         assert result.error is None
         assert Path(path).read_text() == "line1\nREPLACED\nline3\n"
+
+    def test_shell_escaped_space_path_patches_literal_space_directory(self, ops, tmp_path):
+        target_dir = tmp_path / "Obsidian Vault"
+        target_dir.mkdir()
+        path = target_dir / "note.md"
+        path.write_text("hello\n")
+        escaped_path = str(path).replace(" ", "\\ ")
+
+        result = ops.patch_replace(escaped_path, "hello", "updated")
+
+        assert result.error is None
+        assert path.read_text() == "updated\n"
+        assert not (tmp_path / "Obsidian\\ Vault").exists()
 
 
 # ── search ───────────────────────────────────────────────────────────────
@@ -372,6 +395,19 @@ class TestExpandPath:
 
     def test_relative_unchanged(self, ops):
         assert ops._expand_path("relative/path.txt") == "relative/path.txt"
+
+    def test_shell_escaped_spaces_are_normalized(self, ops):
+        result = ops._expand_path("~/Obsidian\\ Vault/test.txt")
+        expected = f"{Path.home()}/Obsidian Vault/test.txt"
+        assert result == expected
+        _assert_clean(result)
+
+    def test_native_windows_backslash_space_is_not_unescaped(self, monkeypatch, ops):
+        import tools.file_operations as file_operations
+
+        monkeypatch.setattr(file_operations.sys, "platform", "win32")
+        path = r"C:\dir\ file.txt"
+        assert ops._expand_path(path) == path
 
     def test_bare_tilde(self, ops):
         result = ops._expand_path("~")

--- a/tests/tools/test_resolve_path.py
+++ b/tests/tools/test_resolve_path.py
@@ -43,6 +43,14 @@ class TestResolvePath:
         # After expanduser, ~/notes.txt becomes absolute → TERMINAL_CWD ignored
         assert result == Path.home() / "notes.txt"
 
+    def test_shell_escaped_spaces_are_normalized(self, monkeypatch, tmp_path):
+        """macOS shell-style ``\\ `` path input resolves to the literal-space path."""
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        from tools.file_tools import _resolve_path
+
+        result = _resolve_path("Obsidian\\ Vault/notes.txt")
+        assert result == tmp_path / "Obsidian Vault" / "notes.txt"
+
     def test_result_is_resolved(self, monkeypatch, tmp_path):
         """Output path has no '..' components."""
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -27,6 +27,7 @@ Usage:
 
 import os
 import re
+import sys
 import difflib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -72,6 +73,19 @@ def _strip_terminal_fence_leaks(text: str) -> str:
             continue
         cleaned_lines.append(cleaned)
     return "".join(cleaned_lines)
+
+
+def _normalize_posix_shell_path_input(path: str) -> str:
+    """Decode shell-escaped spaces in plain POSIX file-tool path args.
+
+    File tools receive raw strings, not a shell command line. When callers pass
+    macOS-style shell paths such as ``~/My\\ Notes/file.md``, the ``\\ `` should
+    become a literal space in the filesystem path instead of creating a
+    backslash-named directory.
+    """
+    if not path or "\\ " not in path:
+        return path
+    return path.replace("\\ ", " ")
 
 
 def _detect_line_ending(sample: str) -> Optional[str]:
@@ -928,6 +942,13 @@ class ShellFileOperations(FileOperations):
         This must be done BEFORE shell escaping, since ~ doesn't expand
         inside single quotes.
         """
+        # Native Windows paths use backslash as a separator, so ``\\ `` is not
+        # shell escaping there (for example ``C:\\dir\\ file.txt``). Other
+        # backends execute in POSIX environments even when the host is Windows.
+        from tools.environments.local import LocalEnvironment
+
+        if sys.platform != "win32" or not isinstance(self.env, LocalEnvironment):
+            path = _normalize_posix_shell_path_input(path)
         if not path:
             return path
         

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -48,6 +48,12 @@ def _expand_tilde(path: str) -> str:
     return os.path.expanduser(path)
 
 
+def _normalize_posix_path_input(filepath: str) -> str:
+    """Decode shell-escaped spaces in paths with POSIX semantics."""
+    if not filepath or "\\ " not in filepath:
+        return filepath
+    return filepath.replace("\\ ", " ")
+
 # ---------------------------------------------------------------------------
 # Read-size guard: cap the character count returned to the model.
 # We're model-agnostic so we can't count tokens; characters are a safe proxy.
@@ -373,7 +379,7 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     """
     container_paths = _uses_container_paths(task_id)
     if container_paths:
-        expanded = _expand_tilde(filepath)
+        expanded = _expand_tilde(_normalize_posix_path_input(filepath))
         if posixpath.isabs(expanded):
             return _normalize_without_host_deref(expanded)
         resolved = _resolve_base_dir(task_id, container_paths=True) / expanded
@@ -391,6 +397,7 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
         joined = ntpath.join(str(_resolve_base_dir(task_id, container_paths=False)), expanded)
         return Path(ntpath.normpath(joined))
 
+    expanded = _normalize_posix_path_input(expanded)
     p = Path(expanded)
     if p.is_absolute():
         return p.resolve()
@@ -414,7 +421,19 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
     (no ``cd`` run yet) is warned on the very first write.
     """
     try:
-        if Path(_expand_tilde(filepath)).is_absolute():
+        container_paths = _uses_container_paths(task_id)
+        if container_paths:
+            expanded = _expand_tilde(_normalize_posix_path_input(filepath))
+            if posixpath.isabs(expanded):
+                return None
+        elif sys.platform == "win32":
+            import ntpath
+
+            from tools.environments.local import _msys_to_windows_path
+
+            if ntpath.isabs(_expand_tilde(_msys_to_windows_path(filepath))):
+                return None
+        elif Path(_expand_tilde(_normalize_posix_path_input(filepath))).is_absolute():
             return None
         workspace_root = _authoritative_workspace_root(task_id)
         if not workspace_root:


### PR DESCRIPTION
## What does this PR do?

Fixes a file-tools path regression where plain tool arguments containing shell-escaped spaces like `Obsidian\ Vault` were treated as literal backslashes. On current `main`, `write_file` and `patch` could create or target `Obsidian\\ Vault/...` instead of the intended `Obsidian Vault/...` path.

This patch keeps the fix narrowly scoped by normalizing the common `\ ` shell-space escape before file-tool path resolution and shell-layer `~` expansion. That makes `write_file`, `patch_replace`, and the shared `resolved_path` metadata agree on the same literal-space filesystem target.

## Related Issue

Fixes #42556

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Normalize shell-escaped spaces in `tools/file_operations.py` before `ShellFileOperations` expands `~` or shells out to file commands.
- Normalize the same input shape in `tools/file_tools.py` so shared resolution, safety checks, path locking, and `resolved_path` / `files_modified` metadata all use the real literal-space path.
- Add live regression coverage for `write_file`, `patch_replace`, and `_expand_path` with escaped-space paths.
- Add tool-layer regression coverage to verify dispatch and returned `resolved_path` values are normalized before the shell layer runs.

## How to Test

1. Reproduce on pre-fix `main` with a path like `~/Documents/Obsidian\ Vault/test.md` and observe that `write_file` creates `Obsidian\\ Vault` as a literal directory name.
2. Apply this patch and rerun the same `write_file` / `patch` calls.
3. Verify the file lands in `Obsidian Vault/...`, no `Obsidian\\ Vault` sibling directory is created, and `resolved_path` points at the literal-space path.
4. Run:
   `pytest -q tests/tools/test_file_tools_live.py -k 'escaped_space or TestExpandPath' tests/tools/test_resolve_path.py`
5. Run:
   `pytest -q tests/tools/test_file_tools.py -k 'escaped_spaces_are_normalized or normalizes_shell_escaped_spaces_before_dispatch'`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Baseline repro on upstream/main (c3055d61857751ad82a2bf9e4f5de5d26a8f2a16):
- write_file("~/Documents/Obsidian\\ Vault/test.md", ...) created a literal "Obsidian\\ Vault" directory

Post-fix targeted validation:
- pytest -q tests/tools/test_file_tools_live.py -k 'escaped_space or TestExpandPath' tests/tools/test_resolve_path.py
  -> 10 passed, 51 deselected
- pytest -q tests/tools/test_file_tools.py -k 'escaped_spaces_are_normalized or normalizes_shell_escaped_spaces_before_dispatch'
  -> 4 passed, 95 deselected
```
