### PR TITLE
fix(desktop): restore streaming auto-scroll and keep composer visible

### DIFF
--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -489,7 +489,7 @@ describe('assistant-ui streaming renderer', () => {
     expect(viewport.scrollTop).toBe(420)
   })
 
-  it('does not follow streaming content growth even while parked at the bottom', async () => {
+  it('follows streaming content growth while parked at the bottom', async () => {
     const { container } = render(<StreamingHarness />)
 
     const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
@@ -521,9 +521,8 @@ describe('assistant-ui streaming renderer', () => {
       fireEvent.scroll(viewport)
     })
 
-    // Content grows as tokens stream in. Streaming auto-follow is removed, so
-    // the viewport must NOT chase the new bottom — it stays where the user
-    // last left it.
+    // Content grows as tokens stream in. The viewport should follow the new
+    // bottom because the user is parked at the bottom and sticky-bottom is armed.
     scrollHeight = 1_200
 
     await act(async () => {
@@ -533,7 +532,46 @@ describe('assistant-ui streaming renderer', () => {
     })
     await wait(0)
 
-    expect(viewport.scrollTop).toBe(760)
+    expect(viewport.scrollTop).toBe(960)
+  })
+
+  it('does not follow streaming content growth when the user has scrolled up', async () => {
+    const { container } = render(<StreamingHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+    let scrollHeight = 1_000
+
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 200 })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    await wait(80)
+
+    // User scrolls up, disarming sticky-bottom.
+    await act(async () => {
+      viewport.scrollTop = 420
+      fireEvent.scroll(viewport)
+    })
+
+    await act(async () => {
+      fireEvent.wheel(viewport, { deltaY: -120 })
+    })
+
+    // Content grows while streaming, but the user is intentionally reading
+    // earlier messages — the viewport must stay put.
+    scrollHeight = 1_200
+
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.trigger(1_200)
+      }
+    })
+    await wait(0)
+
+    expect(viewport.scrollTop).toBe(420)
   })
 
   it('honors the first upward wheel scroll even when a programmatic bottom-pin scroll event is still pending', async () => {

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -387,15 +387,36 @@ function useThreadScrollAnchor({
     }
   }, [scrollerRef, stickyBottomRef])
 
-  // Intentionally NO streaming auto-follow. Earlier builds ran a
-  // ResizeObserver here that re-pinned the viewport to the bottom on every
-  // content growth while a turn was running, so the chat tracked tokens as
-  // they streamed. That behavior is removed by request: once a turn is in
-  // flight the viewport stays exactly where the user left it. The viewport
-  // is still moved to the bottom ONCE per user submit / new turn / session
-  // change (see the layout effect and the session-change effect below) so a
-  // freshly submitted message lands in view — but it does not chase the
-  // stream afterward.
+  // Streaming auto-follow: while a turn is running and the user is parked at
+  // the bottom, pin the viewport to the bottom as content grows. This is
+  // gated on `isRunning` so the viewport does NOT snap after completion
+  // (e.g., Shiki re-highlight) or during idle layout shifts. The RO watches
+  // the scroll content (not the viewport) so it fires when messages actually
+  // grow, not on every viewport resize. `pinToBottom` bails if already at
+  // bottom, and `scrollToFn` suppresses the virtualizer's measurement-based
+  // adjustments when sticky, so the two systems don't fight.
+  useEffect(() => {
+    if (!enabled || !isRunning) {
+      return undefined
+    }
+
+    const el = scrollerRef.current
+    const content = el?.firstElementChild
+
+    if (!el || !content) {
+      return undefined
+    }
+
+    const ro = new ResizeObserver(() => {
+      if (stickyBottomRef.current) {
+        pinToBottom()
+      }
+    })
+
+    ro.observe(content)
+
+    return () => ro.disconnect()
+  }, [enabled, isRunning, pinToBottom, scrollerRef, stickyBottomRef])
 
   // Jump to bottom on session change OR when an empty thread first gets
   // content. Both share the same intent and the same effect.


### PR DESCRIPTION
fix #42366

Re-introduce a ResizeObserver-gated bottom-pin during active streaming so the chat viewport follows content growth while the user is parked at the bottom. The observer is disconnected when the run completes, so post-run layout shifts (e.g. Shiki re-highlight) do not yank the viewport back down.

## What does this PR do?

Restores streaming auto-scroll in the desktop chat thread.

**Problem:** When the assistant is streaming a response and the user is already at the bottom of the thread, the viewport does not follow the growing content. The user has to manually scroll down to see newly generated tokens. This was reported in #42366.

**Solution:** Add a `ResizeObserver` on the scroll content (not the viewport) inside `VirtualizedThread`. The observer calls `pinToBottom()` only when:
- `stickyBottomRef` is armed (the user is parked at the bottom), and
- `isRunning` is `true` (a turn is actively streaming).

The observer is disconnected as soon as the run completes. This prevents post-run layout shifts—such as Shiki re-highlight or image load—from snapping the viewport back down after the user has already scrolled away.

`pinToBottom` bails if the viewport is already at the bottom, and `scrollToFn` suppresses the virtualizer's measurement-based adjustments while sticky, so the two scrolling systems do not fight each other.

## Related Issue

Fixes #42366

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Updated `apps/desktop/src/components/assistant-ui/streaming.test.tsx`:

- **`follows streaming content growth while parked at the bottom`**  
  Asserts that when `scrollHeight` increases from 1,000 to 1,200 during streaming, the viewport scrolls to the new bottom (`scrollTop === 960`).

- **`does not follow streaming content growth when the user has scrolled up`**  
  Asserts that if the user has intentionally scrolled up (disarming sticky-bottom), a subsequent content growth leaves the viewport at `420`.

## Next Steps

- [ ] QA to verify on long streaming runs (>1,000 tokens) and with mixed media (images, code blocks).
- [ ] Evaluate whether the same pattern is needed for the mobile thread view.
- [ ] Monitor for any `ResizeObserver` performance impact in threads with very large message counts.