### PR TITLE
fix(sessions): fall back to gateway.max_concurrent_sessions when top-level is null

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -529,12 +529,13 @@ session_reset:
   at_hour: 4           # Daily reset hour, 0-23 local time (default: 4 AM)
 
 # Maximum number of simultaneously active chat sessions across CLI, TUI,
-# dashboard chat, and messaging gateway. Set to null, 0, or omit to allow
-# unlimited concurrent sessions. When the limit is reached, new sessions get a
-# clean error while existing active sessions keep their normal behavior. This
-# top-level key takes precedence over gateway.max_concurrent_sessions. The cap
-# is a best-effort single-host/profile runtime guard; Hermes fails open if the
-# local runtime lease registry cannot be read or locked.
+# dashboard chat, and messaging gateway. Set to a positive integer to cap; set
+# to 0 to explicitly disable. When the limit is reached, new sessions get a
+# clean error while existing active sessions keep their normal behavior. When
+# this key is null or omitted it falls back to gateway.max_concurrent_sessions
+# (a non-null value here takes precedence over it). The cap is a best-effort
+# single-host/profile runtime guard; Hermes fails open if the local runtime
+# lease registry cannot be read or locked.
 max_concurrent_sessions: null
 
 # When true, group/channel chats use one session per participant when the platform

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -54,12 +54,22 @@ def coerce_max_concurrent_sessions(value: Any, key: str = "max_concurrent_sessio
 
 
 def resolve_max_concurrent_sessions(config: Any) -> Optional[int]:
-    """Resolve top-level max_concurrent_sessions with gateway.* fallback."""
+    """Resolve top-level max_concurrent_sessions with gateway.* fallback.
+
+    The top-level key takes precedence only when it carries an actual value.
+    A ``None`` top-level value falls back to ``gateway.max_concurrent_sessions``:
+    ``DEFAULT_CONFIG`` injects a top-level ``max_concurrent_sessions: None``, so
+    after the config deep-merge the key is *always present*. Gating the fallback
+    on key presence (``"max_concurrent_sessions" in config``) would therefore
+    make the gateway fallback unreachable and silently ignore an existing
+    ``gateway.max_concurrent_sessions`` cap on the CLI/TUI/dashboard surfaces.
+    """
     raw: Any = None
     key = "max_concurrent_sessions"
     if isinstance(config, dict):
-        if "max_concurrent_sessions" in config:
-            raw = config.get("max_concurrent_sessions")
+        top_level = config.get("max_concurrent_sessions")
+        if top_level is not None:
+            raw = top_level
         else:
             gateway_cfg = config.get("gateway")
             if isinstance(gateway_cfg, dict):

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -27,6 +27,16 @@ def test_resolve_max_concurrent_sessions_values(caplog):
         )
         == 2
     )
+    # A top-level None must fall back to gateway.max_concurrent_sessions.
+    # DEFAULT_CONFIG injects a top-level ``max_concurrent_sessions: None``, so the
+    # deep-merged config always carries the key; the fallback must key off the
+    # value being None, not the key's mere presence.
+    assert (
+        active_sessions.resolve_max_concurrent_sessions(
+            {"max_concurrent_sessions": None, "gateway": {"max_concurrent_sessions": 4}}
+        )
+        == 4
+    )
 
     caplog.set_level(logging.WARNING)
     assert active_sessions.resolve_max_concurrent_sessions({"max_concurrent_sessions": "many"}) is None


### PR DESCRIPTION
## What & why

`max_concurrent_sessions` (added in #42389, `feat(sessions): add optional max session cap`) is documented as a **global** cap across CLI, TUI/dashboard, and the messaging gateway, with the top-level key taking precedence over the older `gateway.max_concurrent_sessions`. But the gateway fallback is currently **unreachable**, so a user who configured only `gateway.max_concurrent_sessions` silently gets *no* cap on the CLI/TUI/dashboard surfaces.

### Root cause

`resolve_max_concurrent_sessions()` gated the fallback on key *presence*:

```python
if "max_concurrent_sessions" in config:
    raw = config.get("max_concurrent_sessions")
else:
    # gateway.max_concurrent_sessions fallback
```

`DEFAULT_CONFIG` now injects a top-level `max_concurrent_sessions: None`, so after `load_config()`'s deep-merge the key is **always present** — the `else` branch never runs. The merged top-level `None` shadows any `gateway.max_concurrent_sessions` value.

Reproduction (before fix):

```python
>>> resolve_max_concurrent_sessions({"max_concurrent_sessions": None,
...                                   "gateway": {"max_concurrent_sessions": 3}})
None      # expected 3
```

Both the CLI resolver (`cli.py` → `try_acquire_active_session`) and the gateway resolver (`gateway/run.py:3399`) call this shared function, so both surfaces are affected.

## Fix

Gate the fallback on the top-level **value being `None`** rather than the key's mere presence:

```python
top_level = config.get("max_concurrent_sessions")
if top_level is not None:
    raw = top_level
else:
    # fall back to gateway.max_concurrent_sessions
```

Semantics after the fix:

| top-level | gateway.* | result |
|-----------|-----------|--------|
| `None` / omitted | `3` | **`3`** (was `None`) |
| `2` | `4` | `2` (explicit precedence) |
| `0` | `4` | `None` (explicit disable still honored) |
| `None` | unset | `None` (unbounded) |

The only behavior change is that a top-level `null` no longer force-overrides a gateway value — which is the intended "unset = no opinion, fall back" semantics and exactly what restores the advertised global cap.

## Changes

- `hermes_cli/active_sessions.py` — the gate change + explanatory docstring.
- `tests/hermes_cli/test_active_sessions.py` — regression test for `(top-level None + gateway set) → gateway value`.
- `cli-config.yaml.example` — correct the comment (null/omit falls back to `gateway.max_concurrent_sessions`).

## How to test

```bash
scripts/run_tests.sh tests/hermes_cli/test_active_sessions.py      # 8 passed
scripts/run_tests.sh tests/gateway/test_max_concurrent_sessions.py # 5 passed (unaffected)
```

## Platforms

Pure config-resolution logic in shared Python; verified via the CI-parity runner. No platform-specific paths touched.