### PR TITLE
fix(desktop): collapse spreadsheet column tabs on paste

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -55,7 +55,7 @@ import {
 import { useComposerScope } from './scope'
 import { ComposerStatusStack } from './status-stack'
 import { CodingStatusRow } from './status-stack/coding-row'
-import { extractClipboardImageBlobs } from './text-utils'
+import { extractClipboardImageBlobs, readPastedText } from './text-utils'
 import { ComposerTriggerPopover } from './trigger-popover'
 import type { ChatBarProps } from './types'
 import { UrlDialog } from './url-dialog'
@@ -347,11 +347,9 @@ export function ChatBar({
       return
     }
 
-    // Trim surrounding whitespace so a copy that dragged along leading/trailing
-    // blank lines (common when selecting from terminals, code blocks, web pages)
-    // doesn't dump multiline padding into the composer. Internal newlines are
-    // preserved — only the edges are cleaned up.
-    const pastedText = sanitizeComposerInput(event.clipboardData.getData('text').trim())
+    // Trim edge whitespace and collapse spreadsheet column tabs (Excel/Sheets)
+    // to spaces; see readPastedText for the rationale.
+    const pastedText = sanitizeComposerInput(readPastedText(event.clipboardData))
 
     if (!pastedText) {
       event.preventDefault()

--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { blobDedupeKey, detectTrigger, extractClipboardImageBlobs } from './text-utils'
+import { blobDedupeKey, detectTrigger, extractClipboardImageBlobs, readPastedText } from './text-utils'
+
+function makeClipboard(data: Record<string, string>): DataTransfer {
+  return {
+    getData: (type: string) => data[type] ?? ''
+  } as unknown as DataTransfer
+}
 
 describe('detectTrigger', () => {
   it('detects a bare slash trigger with an empty query', () => {
@@ -100,6 +106,39 @@ describe('extractClipboardImageBlobs', () => {
     } as unknown as DataTransfer
 
     expect(extractClipboardImageBlobs(clipboard)).toEqual([image])
+  })
+})
+
+describe('readPastedText', () => {
+  it('trims surrounding whitespace but keeps internal newlines', () => {
+    const clipboard = makeClipboard({ text: '\n  first line\nsecond line  \n' })
+
+    expect(readPastedText(clipboard)).toBe('first line\nsecond line')
+  })
+
+  it('collapses column tabs to spaces for a spreadsheet paste', () => {
+    const clipboard = makeClipboard({
+      text: 'FEERUM\t2026-06-05\t17,95 fp5_bear3',
+      'text/html': '<table><tr><td>FEERUM</td><td>2026-06-05</td><td>17,95 fp5_bear3</td></tr></table>'
+    })
+
+    expect(readPastedText(clipboard)).toBe('FEERUM 2026-06-05 17,95 fp5_bear3')
+  })
+
+  it('leaves tab indentation untouched when the paste is not tabular', () => {
+    const code = 'def foo():\n\treturn 1'
+    const clipboard = makeClipboard({ text: code })
+
+    expect(readPastedText(clipboard)).toBe(code)
+  })
+
+  it('keeps tabs when HTML is present but contains no table', () => {
+    const clipboard = makeClipboard({
+      text: 'a\tb',
+      'text/html': '<div>a\tb</div>'
+    })
+
+    expect(readPastedText(clipboard)).toBe('a\tb')
   })
 })
 

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -90,6 +90,32 @@ export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
   return blobs
 }
 
+const TABLE_HTML_RE = /<table[\s>]/i
+
+/**
+ * Plain-text payload for a paste, with surrounding whitespace trimmed.
+ *
+ * Surrounding whitespace is trimmed so a copy that dragged along leading or
+ * trailing blank lines (common when selecting from terminals, code blocks, or
+ * web pages) doesn't dump multiline padding into the composer. Internal
+ * newlines are preserved — only the edges are cleaned up.
+ *
+ * Spreadsheet apps (Excel, Google Sheets, Numbers) put copied cells on the
+ * plain-text clipboard as tab-separated columns and also expose an HTML
+ * `<table>`. Those column tabs render as ragged gaps in the contenteditable
+ * composer, so we collapse them to single spaces — but only when the payload
+ * is genuinely tabular, so tab indentation in pasted code is left untouched.
+ */
+export function readPastedText(clipboard: DataTransfer): string {
+  const text = clipboard.getData('text').trim()
+
+  if (text.includes('\t') && TABLE_HTML_RE.test(clipboard.getData('text/html'))) {
+    return text.replace(/\t/g, ' ')
+  }
+
+  return text
+}
+
 /** Caret-anchored text before the cursor, or null if the selection isn't a collapsed caret inside `editor`. */
 export function textBeforeCaret(editor: HTMLDivElement): string | null {
   const sel = window.getSelection()


### PR DESCRIPTION
## Summary

Pasting several cells from a spreadsheet (Excel / Google Sheets / Numbers) into the Desktop chat composer dumped literal tab characters into the `contentEditable`, which rendered as ragged, uneven column gaps instead of readable text. Closes #42256.

The composer's paste handler took the plain-text clipboard payload verbatim (only `.trim()`-ed it). Spreadsheet apps put cell data on the plain-text clipboard as **tab-separated columns**, so a row like `FEERUM | 2026-06-05 | 17,95` arrived as `FEERUM\t2026-06-05\t17,95`.

## Changes

- **`apps/desktop/src/app/chat/composer/text-utils.ts`** — new pure `readPastedText(clipboard)` helper that trims edge whitespace (preserving internal newlines, as before) and collapses tab columns to single spaces **only when the clipboard also exposes an HTML `<table>`** — the marker spreadsheet apps emit. Gating on the table means tab *indentation* in pasted code is left completely untouched, avoiding a regression for the common "paste code into the agent" workflow.
- **`apps/desktop/src/app/chat/composer/index.tsx`** — route the paste handler through `readPastedText` instead of the inline `.trim()`.
- **`apps/desktop/src/app/chat/composer/text-utils.test.ts`** — unit tests covering the spreadsheet paste, code-with-tabs (untouched), non-table HTML (untouched), and the existing trim behaviour.

## How to test

1. In Excel/Sheets, copy 3 cells in one row, e.g. `FEERUM | 2026-06-05 | 17,95`.
2. Paste into the Desktop composer → text now reads `FEERUM 2026-06-05 17,95` on a single clean line.
3. Copy tab-indented code from an editor and paste → indentation is preserved (no regression).

Unit tests: `npm run test:ui` (from `apps/desktop`), `text-utils.test.ts`.

## Platforms

Logic is platform-independent (clipboard `text` + `text/html`); verified via the new vitest cases. Behaviour matches Excel, Google Sheets, and Numbers, which all expose an HTML `<table>` alongside the tab-separated plain text.
