### PR TITLE
feat(cron): add --delete-after retention for completed jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1036,6 +1036,13 @@ def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Opti
     )
 
 
+def _validate_delete_after(value: Any) -> int:
+    """Return a valid completed-job deletion delay."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError("delete_after must be a non-negative integer")
+    return value
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1054,6 +1061,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    delete_after: Optional[int] = 7,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1098,11 +1106,15 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        delete_after: Days to retain a completed finite job. Zero removes it
+                      immediately. Defaults to seven days for new jobs.
 
     Returns:
         The created job dict
     """
     parsed_schedule = parse_schedule(schedule)
+
+    delete_after = _validate_delete_after(delete_after)
 
     # Normalize repeat: treat 0 or negative values as None (infinite)
     if repeat is not None and repeat <= 0:
@@ -1204,6 +1216,7 @@ def create_job(
             "times": repeat,  # None = forever
             "completed": 0
         },
+        "delete_after": delete_after,
         "enabled": True,
         "state": "scheduled",
         "paused_at": None,
@@ -1282,10 +1295,14 @@ def resolve_job_ref(ref: str) -> Optional[Dict[str, Any]]:
 
 
 def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
-    """List all jobs, optionally including disabled ones."""
+    """List active/completed jobs, optionally including other disabled jobs."""
     jobs = [_normalize_job_record(j) for j in load_jobs()]
     if not include_disabled:
-        jobs = [j for j in jobs if j.get("enabled", True)]
+        jobs = [
+            j
+            for j in jobs
+            if j.get("enabled", True) or j.get("state") == "completed"
+        ]
     return jobs
 
 
@@ -1298,6 +1315,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
     if bad_fields:
         raise ValueError(
             f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}"
+        )
+
+    if "delete_after" in updates:
+        updates["delete_after"] = _validate_delete_after(
+            updates["delete_after"]
         )
 
     with _jobs_lock():
@@ -1471,13 +1493,37 @@ def remove_job(job_id: str) -> bool:
     return False
 
 
+def _mark_job_completed(job: Dict[str, Any], now: datetime) -> bool:
+    """Mark a job completed and return whether to delete it immediately.
+
+    Jobs without ``delete_after`` keep the previous immediate-delete behavior.
+    """
+    job["state"] = "completed"
+    job["enabled"] = False
+    job["next_run_at"] = None
+    job["run_claim"] = None
+    job["fire_claim"] = None
+
+    try:
+        delete_after = _validate_delete_after(job.get("delete_after", 0))
+    except ValueError:
+        return True
+    if delete_after == 0:
+        return True
+
+    if not job.get("delete_at"):
+        job["delete_at"] = (now + timedelta(days=delete_after)).isoformat()
+    return False
+
+
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                  delivery_error: Optional[str] = None):
     """
     Mark a job as having been run.
     
-    Updates last_run_at, last_status, increments completed count,
-    computes next_run_at, and auto-deletes if repeat limit reached.
+    Updates last_run_at and last_status, then schedules the next run or
+    completes the job. Finite one-shots pre-claimed by claim_dispatch() are
+    not incremented again here.
 
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
@@ -1486,8 +1532,9 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         jobs = load_jobs()
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
-                now = _hermes_now().isoformat()
-                job["last_run_at"] = now
+                now = _hermes_now()
+                now_iso = now.isoformat()
+                job["last_run_at"] = now_iso
                 job["last_status"] = "ok" if success else "error"
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
@@ -1522,14 +1569,19 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         repeat["completed"] = completed
 
                     # Check if we've hit the repeat limit
+                    # Pre-claimed finite one-shots were already counted by
+                    # claim_dispatch().
                     if times is not None and times > 0 and completed >= times:
-                        # Remove the job (limit reached)
-                        jobs.pop(i)
+                        # Complete or delete the job (limit reached)
+                        if _mark_job_completed(job, now):
+                            jobs.pop(i)
                         save_jobs(jobs)
                         return
                 
                 # Compute next run
-                job["next_run_at"] = compute_next_run(job["schedule"], now)
+                job["next_run_at"] = compute_next_run(
+                    job["schedule"], now_iso
+                )
 
                 # If no next run, decide whether this is terminal completion
                 # (one-shot) or a transient failure (recurring schedule couldn't
@@ -1537,6 +1589,8 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 # Recurring jobs must NEVER be silently disabled: that turns a
                 # missing runtime dep into "job completed" and the user's
                 # schedule quietly goes off. See issue #16265.
+                # Legacy one-shots without a finite repeat use the same
+                # completion path, applying delete_after when present.
                 if job["next_run_at"] is None:
                     kind = job.get("schedule", {}).get("kind")
                     if kind in {"cron", "interval"}:
@@ -1554,9 +1608,11 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                             job.get("name", job.get("id", "?")),
                             kind,
                         )
-                    else:
+                    elif "delete_after" not in job:
                         job["enabled"] = False
                         job["state"] = "completed"
+                    elif _mark_job_completed(job, now):
+                        jobs.pop(i)
                 elif job.get("state") != "paused":
                     job["state"] = "scheduled"
 
@@ -1577,7 +1633,8 @@ def claim_dispatch(job_id: str) -> bool:
     instead of infinitely (issue #38758).
 
     Returns ``True`` if the caller may proceed to run the job, ``False`` if the
-    dispatch limit is already reached (in which case the stale job is removed).
+    dispatch limit is already reached (in which case the stale job is marked
+    completed or deleted immediately).
 
     Only claims jobs with ``schedule.kind == "once"`` and ``repeat.times > 0``.
     Recurring jobs (they use ``advance_next_run``) and infinite-repeat / no-repeat
@@ -1599,15 +1656,18 @@ def claim_dispatch(job_id: str) -> bool:
             completed = repeat.get("completed", 0)
             if completed >= times:
                 # Already dispatched the max number of times (e.g. a prior
-                # tick claimed then died before mark_job_run could remove it).
-                # Clean up so it stops appearing as due on every tick.
-                jobs.pop(i)
+                # tick claimed then died before mark_job_run could complete it).
+                # Complete it so it stops appearing as due on every tick.
+                delete_job = _mark_job_completed(job, _hermes_now())
+                if delete_job:
+                    jobs.pop(i)
                 save_jobs(jobs)
                 logger.info(
-                    "Job '%s': dispatch limit reached (%d/%d) — removing",
+                    "Job '%s': dispatch limit reached (%d/%d) — %s",
                     job.get("name", job.get("id", "?")),
                     completed,
                     times,
+                    "deleting" if delete_job else "keeping completed",
                 )
                 return False
             # Claim this dispatch before the side effect runs.
@@ -1780,10 +1840,43 @@ def get_due_jobs() -> List[Dict[str, Any]]:
         return _get_due_jobs_locked()
 
 
+def _delete_completed_jobs_after_delete_at(
+    raw_jobs: List[Dict[str, Any]], now: datetime
+) -> List[Dict[str, Any]]:
+    """Delete completed jobs after their delete_at time."""
+    valid_jobs = []
+    needs_delete = False
+    for job in raw_jobs:
+        delete_at_str = job.get("delete_at")
+        if job.get("state") != "completed":
+            valid_jobs.append(job)
+            continue
+        if delete_at_str:
+            try:
+                delete_at = _ensure_aware(
+                    datetime.fromisoformat(delete_at_str)
+                )
+                if delete_at <= now:
+                    logger.info(
+                        "Job '%s' reached delete_at, deleting",
+                        job["id"],
+                    )
+                    needs_delete = True
+                    continue
+            except Exception:
+                pass
+        valid_jobs.append(job)
+
+    if needs_delete:
+        save_jobs(valid_jobs)
+    return valid_jobs
+
+
 def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     """Inner implementation of get_due_jobs(); must be called with _jobs_lock held."""
     now = _hermes_now()
     raw_jobs = load_jobs()
+    raw_jobs = _delete_completed_jobs_after_delete_at(raw_jobs, now)
     needs_save = False
 
     # Repair id-less records BEFORE anything keys off ``job["id"]``. A direct
@@ -2037,7 +2130,8 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                 # claimed via claim_dispatch() but whose tick died before
                 # mark_job_run could remove it will have completed >= times while
                 # still looking due (last_run_at was never written, so the
-                # recovery helper re-armed it). Remove it instead of re-firing.
+                # recovery helper re-armed it). Complete it instead of
+                # re-firing.
                 if kind == "once":
                     repeat = job.get("repeat")
                     if repeat:
@@ -2065,14 +2159,15 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                                 continue
                             logger.info(
                                 "Job '%s': one-shot dispatch limit reached (%d/%d) "
-                                "— removing stale due entry",
+                                "— completing stale due entry",
                                 job.get("name", job.get("id", "?")),
                                 completed,
                                 times,
                             )
                             for rj in raw_jobs:
                                 if rj["id"] == job["id"]:
-                                    raw_jobs.remove(rj)
+                                    if _mark_job_completed(rj, now):
+                                        raw_jobs.remove(rj)
                                     needs_save = True
                                     break
                             continue

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -152,6 +152,7 @@ def cron_list(show_all: bool = False):
         print(f"    Schedule:  {schedule}")
         print(f"    Repeat:    {repeat_str}")
         print(f"    Next run:  {next_run}")
+
         print(f"    Deliver:   {deliver_str}")
         if skills:
             print(f"    Skills:    {', '.join(skills)}")
@@ -282,6 +283,9 @@ def cron_status():
 def _print_active_jobs_summary(jobs) -> None:
     """Print the '<N> active job(s)' + next-run line shared by every status
     path (built-in ticker AND external provider)."""
+    # Default listings include retained completed jobs; status counts only
+    # jobs that can still run.
+    jobs = [job for job in jobs if job.get("enabled", True)]
     if jobs:
         next_runs = [j.get("next_run_at") for j in jobs if j.get("next_run_at")]
         print(f"  {len(jobs)} active job(s)")
@@ -310,6 +314,7 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        delete_after=getattr(args, "delete_after", 7),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -373,6 +378,7 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
+        delete_after=getattr(args, "delete_after", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -40,6 +40,12 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     )
     cron_create.add_argument("--repeat", type=int, help="Optional repeat count")
     cron_create.add_argument(
+        "--delete-after",
+        type=int,
+        default=7,
+        help="Days to keep job after completion.",
+    )
+    cron_create.add_argument(
         "--skill",
         dest="skills",
         action="append",
@@ -81,6 +87,11 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument("--name", help="New job name")
     cron_edit.add_argument("--deliver", help="New delivery target")
     cron_edit.add_argument("--repeat", type=int, help="New repeat count")
+    cron_edit.add_argument(
+        "--delete-after",
+        type=int,
+        help="Days to keep job after completion.",
+    )
     cron_edit.add_argument(
         "--skill",
         dest="skills",

--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -39,3 +39,13 @@ def test_cronjob_schema_required_array_unchanged():
     from tools.cronjob_tools import CRONJOB_SCHEMA
 
     assert CRONJOB_SCHEMA["parameters"]["required"] == ["action"]
+
+
+def test_cronjob_schema_rejects_negative_delete_after():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    delete_after = CRONJOB_SCHEMA["parameters"]["properties"][
+        "delete_after"
+    ]
+    assert delete_after["minimum"] == 0
+    assert delete_after["default"] == 7

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -571,9 +571,59 @@ class TestMarkJobRun:
         assert updated["last_status"] == "ok"
 
     def test_repeat_limit_removes_job(self, tmp_cron_dir):
-        job = create_job(prompt="Once", schedule="30m", repeat=1)
+        job = create_job(
+            prompt="Once", schedule="30m", repeat=1, delete_after=0
+        )
         mark_job_run(job["id"], success=True)
         # Job should be removed after hitting repeat limit
+        assert get_job(job["id"]) is None
+
+    def test_repeat_limit_retains_job_without_double_counting(
+        self, tmp_cron_dir
+    ):
+        job = create_job(
+            prompt="Once", schedule="30m", repeat=1, delete_after=7
+        )
+
+        assert claim_dispatch(job["id"]) is True
+        mark_job_run(job["id"], success=True)
+
+        retained = get_job(job["id"])
+        assert retained["repeat"]["completed"] == 1
+        assert retained["state"] == "completed"
+        assert retained["enabled"] is False
+        assert retained["last_status"] == "ok"
+        assert retained["next_run_at"] is None
+        assert datetime.fromisoformat(retained["delete_at"]) > datetime.now(
+            timezone.utc
+        )
+
+    @pytest.mark.parametrize("value", [-1, -7])
+    def test_delete_after_must_be_non_negative(
+        self, tmp_cron_dir, value
+    ):
+        with pytest.raises(ValueError, match="non-negative"):
+            create_job(prompt="Once", schedule="30m", delete_after=value)
+
+        job = create_job(prompt="Later", schedule="every 1h")
+        with pytest.raises(ValueError, match="non-negative"):
+            update_job(job["id"], {"delete_after": value})
+
+    def test_completed_job_is_deleted_after_delete_at(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        now = datetime(2026, 7, 14, tzinfo=timezone.utc)
+        job = create_job(
+            prompt="Once", schedule="30m", repeat=1, delete_after=2
+        )
+        assert claim_dispatch(job["id"]) is True
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        mark_job_run(job["id"], success=True)
+
+        monkeypatch.setattr(
+            "cron.jobs._hermes_now", lambda: now + timedelta(days=2)
+        )
+        assert get_due_jobs() == []
         assert get_job(job["id"]) is None
 
     def test_repeat_negative_one_is_infinite(self, tmp_cron_dir):
@@ -1820,14 +1870,17 @@ class TestClaimDispatch:
     a tick that dies mid-execution (gateway kill, OOM, hard-timeout) can re-fire
     the job at most ``repeat.times`` times instead of infinitely."""
 
-    def _oneshot(self, times=1, completed=0):
-        return {
+    def _oneshot(self, times=1, completed=0, delete_after=None):
+        job = {
             "id": "os1",
             "name": "one-shot",
             "enabled": True,
             "schedule": {"kind": "once", "run_at": "2026-01-01T00:00:00+00:00"},
             "repeat": {"times": times, "completed": completed},
         }
+        if delete_after is not None:
+            job["delete_after"] = delete_after
+        return job
 
     def test_claim_increments_and_persists(self, tmp_cron_dir):
         save_jobs([self._oneshot(times=1, completed=0)])
@@ -1841,6 +1894,20 @@ class TestClaimDispatch:
         save_jobs([self._oneshot(times=1, completed=1)])
         assert claim_dispatch("os1") is False
         assert load_jobs() == []  # removed, will not re-fire
+
+    def test_already_dispatched_oneshot_is_retained(self, tmp_cron_dir):
+        save_jobs([
+            self._oneshot(times=1, completed=1, delete_after=7)
+        ])
+
+        assert claim_dispatch("os1") is False
+
+        retained = load_jobs()[0]
+        assert retained["repeat"]["completed"] == 1
+        assert retained["state"] == "completed"
+        assert retained["enabled"] is False
+        assert retained["next_run_at"] is None
+        assert retained["delete_at"]
 
     def test_recurring_job_is_not_claimed(self, tmp_cron_dir):
         job = {
@@ -1908,6 +1975,28 @@ class TestClaimDispatch:
         due = get_due_jobs()
         assert due == []
         assert load_jobs() == []  # cleaned up
+
+    def test_get_due_jobs_retains_stale_maxed_oneshot(
+        self, tmp_cron_dir
+    ):
+        past = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat()
+        save_jobs([{
+            "id": "os1",
+            "name": "one-shot",
+            "enabled": True,
+            "schedule": {"kind": "once", "run_at": past},
+            "repeat": {"times": 1, "completed": 1},
+            "delete_after": 7,
+            "next_run_at": None,
+        }])
+
+        assert get_due_jobs() == []
+
+        retained = load_jobs()[0]
+        assert retained["repeat"]["completed"] == 1
+        assert retained["state"] == "completed"
+        assert retained["enabled"] is False
+        assert retained["delete_at"]
 
     def test_bad_schedule_does_not_crash_or_block_sibling_jobs(self, tmp_cron_dir):
         """Regression for a job with non-dict 'schedule' (null / string / etc.

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -5,7 +5,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from cron.jobs import create_job, get_job, list_jobs
+from cron.jobs import (
+    claim_dispatch,
+    create_job,
+    get_job,
+    list_jobs,
+    mark_job_run,
+)
 from hermes_cli import cron as cron_cli
 from hermes_cli.cron import cron_command
 
@@ -133,9 +139,25 @@ class TestCronCommandLifecycle:
         save_jobs(jobs)
 
         cron_command(Namespace(cron_command="list", all=True))
-
         out = capsys.readouterr().out
         assert "Repeat:    ∞" in out
+
+    def test_list_shows_retained_completed_job_by_default(
+        self, tmp_cron_dir, capsys
+    ):
+        job = create_job(
+            prompt="Retained report",
+            schedule="30m",
+            delete_after=7,
+        )
+        assert claim_dispatch(job["id"]) is True
+        mark_job_run(job["id"], success=True)
+
+        cron_command(Namespace(cron_command="list", all=False))
+
+        out = capsys.readouterr().out
+        assert job["id"] in out
+        assert "[completed]" in out
 
     def test_list_does_not_crash_when_deliver_is_null(self, tmp_cron_dir, capsys):
         """A job can be persisted with ``"deliver": null`` (present-but-null).

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -49,6 +49,7 @@ def test_cron_create_options():
     ns = parser.parse_args([
         "cron", "create", "0 9 * * *", "daily task prompt",
         "--name", "daily", "--deliver", "origin", "--repeat", "3",
+        "--delete-after", "4",
         "--skill", "a", "--skill", "b", "--no-agent",
         "--workdir", "/tmp/x",
     ])
@@ -57,6 +58,7 @@ def test_cron_create_options():
     assert ns.name == "daily"
     assert ns.deliver == "origin"
     assert ns.repeat == 3
+    assert ns.delete_after == 4
     assert ns.skills == ["a", "b"]
     assert ns.no_agent is True
     assert ns.workdir == "/tmp/x"

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -264,6 +264,50 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_delete_after_defaults_to_seven_days(self):
+        from cron.jobs import get_job
+
+        created = json.loads(
+            cronjob(
+                action="create", prompt="Check", schedule="every 1h"
+            )
+        )
+
+        assert get_job(created["job_id"])["delete_after"] == 7
+
+    def test_delete_after_survives_unrelated_update(self):
+        from cron.jobs import get_job
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                delete_after=3,
+            )
+        )
+        job_id = created["job_id"]
+
+        updated = json.loads(
+            cronjob(action="update", job_id=job_id, name="Renamed")
+        )
+
+        assert updated["success"] is True
+        assert get_job(job_id)["delete_after"] == 3
+
+    def test_negative_delete_after_is_rejected(self):
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                delete_after=-1,
+            )
+        )
+
+        assert result["success"] is False
+        assert "non-negative" in result["error"]
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -677,6 +677,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    delete_after: Optional[int] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -750,6 +751,9 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                delete_after=(
+                    7 if delete_after is None else delete_after
+                ),
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -947,6 +951,8 @@ def cronjob(
                 repeat_state = dict(job.get("repeat") or {})
                 repeat_state["times"] = normalized_repeat
                 updates["repeat"] = repeat_state
+            if delete_after is not None:
+                updates["delete_after"] = delete_after
             if schedule is not None:
                 parsed_schedule = parse_schedule(schedule)
                 updates["schedule"] = parsed_schedule
@@ -1012,6 +1018,15 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             "repeat": {
                 "type": "integer",
                 "description": "Optional repeat count. Omit for defaults (once for one-shot, forever for recurring)."
+            },
+            "delete_after": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 7,
+                "description": (
+                    "Days to retain a completed finite job. Use 0 to "
+                    "remove it immediately."
+                ),
             },
             "deliver": {
                 "type": "string",
@@ -1140,6 +1155,8 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
+        delete_after=args.get("delete_after"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -51,6 +51,8 @@ Jobs are stored in `~/.hermes/cron/jobs.json` with atomic write semantics (write
     "times": null,
     "completed": 42
   },
+  "delete_after": 7,
+  "delete_at": null,
   "state": "scheduled",
   "enabled": true,
   "next_run_at": "2025-01-16T09:00:00Z",
@@ -69,12 +71,16 @@ Jobs are stored in `~/.hermes/cron/jobs.json` with atomic write semantics (write
 |-------|---------|
 | `scheduled` | Active, will fire at next scheduled time |
 | `paused` | Suspended — won't fire until resumed |
-| `completed` | Repeat count exhausted or one-shot that has fired |
+| `completed` | Repeat exhausted or one-shot fired; retained until `delete_at` |
 | `running` | Currently executing (transient state) |
 
 ### Backward Compatibility
 
 Older jobs may have a single `skill` field instead of the `skills` array. The scheduler normalizes this at load time — single `skill` is promoted to `skills: [skill]`.
+
+Older jobs may also be missing `delete_after`. Exhausted finite jobs without
+the field keep the old immediate-delete behavior, while newly created jobs
+default to seven days.
 
 ## Scheduler Runtime
 
@@ -86,18 +92,19 @@ The scheduler runs on a periodic tick (default: every 60 seconds):
 tick()
   1. Acquire scheduler lock (prevents overlapping ticks)
   2. Load all jobs from jobs.json
-  3. Filter to due jobs (next_run <= now AND state == "scheduled")
-  4. For each due job:
+  3. Delete completed jobs after `delete_at`
+  4. Filter to due jobs (next_run <= now AND state == "scheduled")
+  5. For each due job:
      a. Set state to "running"
      b. Create fresh AIAgent session (no conversation history)
      c. Load attached skills in order (injected as user messages)
      d. Run the job prompt through the agent
      e. Deliver the response to the configured target
      f. Update run_count, compute next_run
-     g. If repeat count exhausted → state = "completed"
+     g. If repeat exhausted → retain until delete_at, or delete immediately
      h. Otherwise → state = "scheduled"
-  5. Write updated jobs back to jobs.json
-  6. Release scheduler lock
+  6. Write updated jobs back to jobs.json
+  7. Release scheduler lock
 ```
 
 ### Gateway Integration

--- a/website/docs/guides/cron-troubleshooting.md
+++ b/website/docs/guides/cron-troubleshooting.md
@@ -32,7 +32,10 @@ A misformatted schedule silently defaults to one-shot or is rejected entirely. T
 | `30m` | 30 minutes from now |
 | `2025-06-01T09:00:00` | June 1, 2025 at 9:00 AM UTC |
 
-If the job fires once and then disappears from the list, it's a one-shot schedule (`30m`, `1d`, or an ISO timestamp) — expected behavior.
+If the job fires once and shows `[completed]`, it's a one-shot schedule (`30m`,
+`1d`, or an ISO timestamp). Completed one-shot jobs remain listed for
+`--delete-after` days (seven by default), then disappear. A job created with
+`--delete-after 0` disappears immediately after running.
 
 ### Check 3: Is the gateway running?
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -551,6 +551,10 @@ NAS-managed provider for scale-to-zero hosted gateways) — configured via the
 the built-in, so cron is never left without a trigger. See the
 [cron internals](../developer-guide/cron-internals.md#gateway-integration) doc.
 
+`create` and `edit` accept `--delete-after <days>` to control how long
+completed finite jobs stay listed before removal. New jobs default to seven
+days; use `--delete-after 0` to delete immediately after completion.
+
 ## `hermes kanban`
 
 ```bash

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -49,6 +49,7 @@ hermes cron create "every 1h" "Use both skills and combine the result" \
   --skill blogwatcher \
   --skill maps \
   --name "Skill combo"
+hermes cron create "30m" "Remind me to check the build" --delete-after 0
 ```
 
 ### Through natural conversation
@@ -559,9 +560,13 @@ every 1d     → Every day
 
 | Schedule type | Default repeat | Behavior |
 |--------------|----------------|----------|
-| One-shot (`30m`, timestamp) | 1 | Runs once |
+| One-shot (`30m`, timestamp) | 1 | Runs once, then becomes `[completed]` |
 | Interval (`every 2h`) | forever | Runs until removed |
 | Cron expression | forever | Runs until removed |
+
+Completed one-shot jobs remain visible for `--delete-after` days, then
+disappear from the list. The default is seven days. Set `--delete-after 0` to
+preserve the old immediate-delete behavior.
 
 You can override it:
 
@@ -571,6 +576,13 @@ cronjob(
     prompt="...",
     schedule="every 2h",
     repeat=5,
+)
+
+cronjob(
+    action="create",
+    prompt="...",
+    schedule="30m",
+    delete_after=0,
 )
 ```
 


### PR DESCRIPTION
## What does this PR do?
- This replaces the previous behavior where one-shot jobs (or recurring jobs hitting their repeat limit) were physically deleted from jobs.json immediately upon completion. They now gracefully transition to a `completed` state and remain visible for a configurable retention window (set to zero for an immediate deletion).
- This refactor also makes the state machine more robust by unifying the completion handling that was previously split between the repeat limit check and the next-run fallback, ensuring all edge cases cleanly reach the same terminal state.

Main pain point: Often times, when a user schedule a run, they later WANT to query the run but the CLI cron list cannot locate it anymore. 

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->
Related to #42371, both touch the mark_job_run() function in cron/jobs.py, but are orthogonal:
- This patch (--delete-after): "What happens to a job after it reaches its repeat limit?"
- #42371: "When does a job count towards its repeat limit?" (only if the delivery succeeds, otherwise don't increment the counter).

Partially related to #29392 but not fixed (the root cause of that issue is to define what it means to "repeat" a one-shot job).

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/`: Added `--delete-after <days>` to `cron create` and `cron edit` (defaults to 7).
- `cron/jobs.py`:
  - Added `delete_expired_jobs()` to the `get_due_jobs()` polling loop to act as a passive garbage collector.
  - Refactored `mark_job_run()` to centralize completion logic into a unified handler. Avoiding split paths between the repeat limit check and the `compute_next_run` fallback ensures all completion edge cases (like tampered one-shot jobs) are caught and handled identically.
  - Completed jobs get a `delete_at` deadline timestamp based on the `delete_after` configured parameter. A value of `0` preserves the legacy immediate-deletion behavior.
- `tools/cronjob_tools.py`: Wired `delete_after` into the model tool.
- `website/docs/`: Updated User Guide, Internals, Troubleshooting, and CLI docs to reflect the new state machine, default parameters, and JSON schema fields.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. prompt the agent or use CLI to create a one-time job
2. check the job before and after it is run/completed:
```
agent@45e9bc1d2553:~$ hermes cron list --all

┌─────────────────────────────────────────────────────────────────────────┐
│                         Scheduled Jobs                                  │
└─────────────────────────────────────────────────────────────────────────┘

  4c08746f0039 [active]
    Name:      吃药提醒
    Schedule:  once in 1m
    Repeat:    0/1
    Next run:  2026-06-09T02:50:45.640971+00:00
    Deliver:   local

agent@45e9bc1d2553:~$ hermes cron list --all

┌─────────────────────────────────────────────────────────────────────────┐
│                         Scheduled Jobs                                  │
└─────────────────────────────────────────────────────────────────────────┘

  4c08746f0039 [completed]
    Name:      吃药提醒
    Schedule:  once in 1m
    Repeat:    1/1
    Next run:  None
    To be deleted at: 2026-06-16T02:51:40.999980+00:00
    Deliver:   local
    Last run:  2026-06-09T02:51:40.999961+00:00  ok

``` 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Docker Debian container.

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

