### PR TITLE
fix(gateway): emit session.info after interrupt to clear Desktop UI running state

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3569,6 +3569,48 @@ def test_interrupt_clears_multiple_own_pending():
             server._answers.pop(key, None)
 
 
+
+def test_interrupt_emits_session_info_with_running_false():
+    """session.interrupt must emit session.info with running=False so the
+    Desktop UI clears the running state immediately, without waiting for
+    the agent thread's finally block."""
+    import types
+
+    from unittest.mock import patch as _patch
+
+    emitted = []
+
+    def fake_emit(event, sid, data):
+        emitted.append((event, sid, data))
+
+    sess = _session()
+    sess["agent"] = types.SimpleNamespace(interrupt=lambda: None)
+    sess["running"] = True  # simulate active agent run
+    server._sessions["sid"] = sess
+
+    try:
+        with _patch.object(server, "_emit", fake_emit):
+            resp = server.handle_request(
+                {"id": "1", "method": "session.interrupt", "params": {"session_id": "sid"}}
+            )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+
+        # session["running"] must be False after interrupt
+        assert sess["running"] is False, "session.running should be False after interrupt"
+
+        # session.info must have been emitted
+        session_info_events = [e for e in emitted if e[0] == "session.info"]
+        assert len(session_info_events) >= 1, (
+            "session.info should be emitted after interrupt; "
+            f"emitted events: {[e[0] for e in emitted]}"
+        )
+        _, sid, info = session_info_events[-1]
+        assert sid == "sid"
+        assert info.get("running") is False, "session.info.running should be False"
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_clear_pending_without_sid_clears_all():
     """_clear_pending(None) is the shutdown path — must still release
     every pending prompt regardless of owning session."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4314,6 +4314,14 @@ def _(rid, params: dict) -> dict:
         resolve_gateway_approval(session["session_key"], "deny", resolve_all=True)
     except Exception:
         pass
+    # Emit session.info with running=False immediately so the Desktop
+    # UI clears the running state without waiting for the agent thread
+    # to finish its cleanup (finally block in _run_prompt_submit's run()).
+    sid = params.get("session_id", "")
+    agent = session.get("agent")
+    with session["history_lock"]:
+        session["running"] = False
+    _emit("session.info", sid, _session_info(agent, session))
     return _ok(rid, {"status": "interrupted"})
 
 


### PR DESCRIPTION
## Problem

When a user clicks the stop button during a streaming response, the Desktop UI does not clear the running state. The stop button remains active, sidebar session dots stay lit, and the session appears to still be working — until the Desktop is reopened and the WebSocket reconnects.

The gateway's `session.interrupt` handler calls `agent.interrupt()` but does not emit `session.info` with `running: false`. The Desktop UI relies on this event to update its running state indicators.

## Root Cause

The `session.interrupt` handler in `tui_gateway/server.py` (line 4299):
1. Calls `session["agent"].interrupt()` to set the interrupt flag
2. Clears pending prompts and resolves approvals
3. Returns `{"status": "interrupted"}`

But it does **not**:
- Set `session["running"] = False`
- Emit `session.info` with the updated state

The agent thread's `finally` block (in `_run_prompt_submit`'s `run()`) eventually sets `session["running"] = False` and emits `session.info`, but this can be delayed or may not reach the Desktop through the existing WebSocket connection.

## Fix

Set `session["running"] = False` and emit `session.info` immediately after calling `agent.interrupt()`, so the Desktop UI updates right away.

**Changes:**
- `tui_gateway/server.py`: Add `session.info` emission in `session.interrupt` handler (+8 lines)
- `tests/test_tui_gateway_server.py`: Add test verifying the behavior (+42 lines)

## Testing

```
pytest tests/test_tui_gateway_server.py -k "interrupt" -xvs
```

All 4 interrupt-related tests pass, including the new `test_interrupt_emits_session_info_with_running_false`.

Fixes #42479
