### PR TITLE
fix: include remove action in memory tool bridge to external providers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1756,12 +1756,14 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 store=agent._memory_store,
             )
             # Bridge: notify external memory provider of built-in memory writes
-            if agent._memory_manager and next_args.get("action") in {"add", "replace"}:
+            if agent._memory_manager and next_args.get("action") in {"add", "replace", "remove"}:
                 try:
+                    # For remove, content is empty — use old_text as the identifier
+                    write_content = next_args.get("content", "") or next_args.get("old_text", "")
                     agent._memory_manager.on_memory_write(
                         next_args.get("action", ""),
                         target,
-                        next_args.get("content", ""),
+                        write_content,
                         metadata=agent._build_memory_write_metadata(
                             task_id=effective_task_id,
                             tool_call_id=tool_call_id,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1021,12 +1021,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     store=agent._memory_store,
                 )
                 # Bridge: notify external memory provider of built-in memory writes
-                if agent._memory_manager and next_args.get("action") in {"add", "replace"}:
+                if agent._memory_manager and next_args.get("action") in {"add", "replace", "remove"}:
                     try:
+                        # For remove, content is empty — use old_text as the identifier
+                        write_content = next_args.get("content", "") or next_args.get("old_text", "")
                         agent._memory_manager.on_memory_write(
                             next_args.get("action", ""),
                             target,
-                            next_args.get("content", ""),
+                            write_content,
                             metadata=agent._build_memory_write_metadata(
                                 task_id=effective_task_id,
                                 tool_call_id=getattr(tool_call, "id", None),


### PR DESCRIPTION
## Summary

The on_memory_write bridge in both invoke_tool (agent_runtime_helpers.py) and tool_executor.py only notified external memory providers for add and replace actions. remove was missing from the action set.

## Changes

Two files, same fix:
- Add remove to the action set
- For remove, use old_text as fallback since content is empty

### Files
- agent/agent_runtime_helpers.py
- agent/tool_executor.py