### PR TITLE
fix(gateway): try launchctl start before detached fallback on exit 5 (#42524)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3102,6 +3102,25 @@ def _launchctl_domain_unsupported(returncode: int) -> bool:
     return returncode in _LAUNCHCTL_DOMAIN_UNSUPPORTED_CODES
 
 
+def _launchd_service_is_loaded() -> bool:
+    """Check whether the gateway launchd service is currently loaded in the domain.
+
+    Returns True when ``launchctl list <label>`` succeeds, meaning the service
+    definition is loaded even if kickstart failed transiently (e.g. exit 5 on
+    macOS 26).  Used to avoid unnecessary fallback to a detached process.
+    """
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", get_launchd_label()],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
 def _gateway_run_command() -> list[str]:
     """Build the `python -m hermes_cli.main [--profile X] gateway run --replace` argv.
 
@@ -3394,6 +3413,19 @@ def launchd_start():
         except subprocess.CalledProcessError as e:
             if not _launchctl_domain_unsupported(e.returncode):
                 raise
+            # Service might be loaded despite kickstart failure — try
+            # launchctl start before falling back to detached (see #42524).
+            if _launchd_service_is_loaded():
+                try:
+                    subprocess.run(
+                        ["launchctl", "start", f"{_launchd_domain()}/{label}"],
+                        check=True,
+                        timeout=30,
+                    )
+                    print("✓ Service started (via launchctl start)")
+                    return
+                except subprocess.CalledProcessError:
+                    pass
             _launchd_fallback_to_detached(f"launchctl exit {e.returncode}")
             return
         print("✓ Service started")
@@ -3423,10 +3455,23 @@ def launchd_start():
                 timeout=30,
             )
         except subprocess.CalledProcessError as e2:
-            # Even a fresh bootstrap can't manage the domain on this host —
-            # degrade to a detached background process (issue #23387).
+            # Even a fresh bootstrap can't manage the domain on this host.
+            # Check whether the service is actually loaded before degrading —
+            # exit 5 can be transient on macOS 26 even when launchd CAN
+            # supervise the service.  If loaded, try `launchctl start`.
             if not _launchctl_domain_unsupported(e2.returncode):
                 raise
+            if _launchd_service_is_loaded():
+                try:
+                    subprocess.run(
+                        ["launchctl", "start", f"{_launchd_domain()}/{label}"],
+                        check=True,
+                        timeout=30,
+                    )
+                    print("✓ Service started (via launchctl start)")
+                    return
+                except subprocess.CalledProcessError:
+                    pass  # start also failed — fall through to detached
             _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
             return
     print("✓ Service started")
@@ -3542,9 +3587,23 @@ def launchd_restart():
     except subprocess.CalledProcessError as e:
         if not _launchd_error_indicates_unloaded(e):
             # Not a "job unloaded" code. If the domain is fundamentally
-            # unmanageable (error 5), degrade to detached; the old process was
-            # already drained/terminated above. Otherwise re-raise.
+            # unmanageable (error 5), check whether the service is actually
+            # loaded first — exit 5 can be a transient kickstart error on
+            # macOS 26 even when launchd CAN supervise the service.  If
+            # loaded, try `launchctl start` (simpler, less error-prone)
+            # before degrading to a detached process.
             if _launchctl_domain_unsupported(e.returncode):
+                if _launchd_service_is_loaded():
+                    try:
+                        subprocess.run(
+                            ["launchctl", "start", target],
+                            check=True,
+                            timeout=30,
+                        )
+                        print("✓ Service restarted (via launchctl start)")
+                        return
+                    except subprocess.CalledProcessError:
+                        pass  # start also failed — fall through to detached
                 _launchd_fallback_to_detached(f"launchctl kickstart exit {e.returncode}")
                 return
             raise

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -731,6 +731,7 @@ class TestLaunchdServiceRecovery:
 
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
         monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_if_needed", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_launchd_service_is_loaded", lambda: False)
 
         def fake_run(cmd, check=False, **kwargs):
             if cmd == ["launchctl", "kickstart", target]:
@@ -790,6 +791,7 @@ class TestLaunchdServiceRecovery:
         monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr(gateway_cli, "_launchd_service_is_loaded", lambda: False)
 
         def fake_run(cmd, check=False, **kwargs):
             if cmd == ["launchctl", "kickstart", "-k", target]:


### PR DESCRIPTION
Fixes #42524. On macOS 26, launchctl kickstart -k returns exit code 5 transiently even when the service IS loaded and launchd CAN supervise it. Previously the code treated exit 5 as 'domain unsupported' and fell back to a detached process. Now it checks if the service is loaded via launchctl list, and if so, tries launchctl start (simpler, less error-prone) before falling back to detached.