### PR TITLE
fix(tools): remove web_search from browser toolset to respect web disable

### DIFF
--- a/tests/hermes_cli/test_tool_token_estimation.py
+++ b/tests/hermes_cli/test_tool_token_estimation.py
@@ -136,8 +136,8 @@ def test_status_fn_returns_formatted_token_count(monkeypatch):
     assert "Est. tool context" in result
 
 
-def test_status_fn_deduplicates_overlapping_tools(monkeypatch):
-    """When toolsets overlap (browser includes web_search), tokens should not double-count."""
+def test_status_fn_no_overlap_after_browser_web_search_removal(monkeypatch):
+    """After removing web_search from browser toolset, web + browser should not double-count."""
     import hermes_cli.tools_config as tc
     from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS
 
@@ -159,7 +159,7 @@ def test_status_fn_deduplicates_overlapping_tools(monkeypatch):
 
     # web alone
     web_only = status_fn({idx_map["web"]})
-    # browser includes web_search, so browser + web should not double-count web_search
+    # browser alone — should NOT include web_search tokens
     browser_only = status_fn({idx_map["browser"]})
     both = status_fn({idx_map["web"], idx_map["browser"]})
 
@@ -179,11 +179,11 @@ def test_status_fn_deduplicates_overlapping_tools(monkeypatch):
     browser_tok = parse_tokens(browser_only)
     both_tok = parse_tokens(both)
 
-    # Both together should be LESS than naive sum (due to web_search dedup)
+    # With no overlap, combined should equal naive sum (or very close due to rounding)
     naive_sum = web_tok + browser_tok
-    assert both_tok < naive_sum, (
-        f"Expected deduplication: web({web_tok}) + browser({browser_tok}) = {naive_sum} "
-        f"but combined = {both_tok}"
+    assert both_tok >= naive_sum * 0.99, (
+        f"Expected no double-counting: web({web_tok}) + browser({browser_tok}) = {naive_sum} "
+        f"but combined = {both_tok} (unexpectedly lower — overlap still exists?)"
     )
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -168,13 +168,13 @@ TOOLSETS = {
     },
     
     "browser": {
-        "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click) with web search for finding URLs",
+        "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click)",
         "tools": [
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp",
-            "browser_dialog", "web_search"
+            "browser_dialog"
         ],
         "includes": []
     },


### PR DESCRIPTION
## What does this PR do?

Removes `web_search` from the `browser` toolset so that disabling the `web` toolset via `hermes tools disable web` properly removes `web_search` from the model-visible tool schema.

## Related Issue

Fixes #42585

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `toolsets.py`: Removed `"web_search"` from the `browser` toolset's tools list and updated the description to no longer mention "with web search for finding URLs"
- `tests/hermes_cli/test_tool_token_estimation.py`: Updated `test_status_fn_deduplicates_overlapping_tools` → `test_status_fn_no_overlap_after_browser_web_search_removal` to reflect that `web` and `browser` no longer share tools

## How to Test

1. Run `hermes tools disable web --platform cli` and verify `web_search` is no longer in the model-visible tool schema
2. Run `hermes tools enable browser --platform cli` and verify browser tools work without `web_search`
3. Run `python3 -m pytest tests/hermes_cli/test_tool_token_estimation.py -v` — all tests pass (tiktoken-dependent tests skip gracefully)
4. Verify `resolve_toolset("browser")` no longer includes `web_search`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `toolsets.py` TOOLSETS["browser"] (tools list overlap with web toolset)
- Blast radius: LOW — only affects toolset resolution for `browser` toolset; no behavioral change for browser automation tools
- Related patterns: Toolset definitions in `toolsets.py`, configurable toolsets in `hermes_cli/tools_config.py`
