### PR TITLE
fix(gateway): use bootout+kickstart to prevent double start (#42446)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3537,7 +3537,30 @@ def launchd_restart():
                     print(
                         f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
                     )
-        subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+        # Use bootout + bootstrap instead of kickstart -k to avoid the race
+        # where kickstart kills the process, launchd sees the exit and restarts
+        # via KeepAlive, while kickstart also starts a new instance — causing
+        # two gateway processes.  bootout unloads the service (preventing
+        # KeepAlive respawn), then bootstrap reloads it fresh.  See #42446.
+        plist_path = get_launchd_plist_path()
+        try:
+            subprocess.run(
+                ["launchctl", "bootout", target],
+                check=True,
+                timeout=30,
+            )
+        except subprocess.CalledProcessError as e:
+            # Job already unloaded (3/113/125) — that's fine for restart.
+            if not _launchd_error_indicates_unloaded(e):
+                raise
+        # Bootstrap the service definition fresh (launchd picks up the plist).
+        subprocess.run(
+            ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+            check=True,
+            timeout=30,
+        )
+        # Kickstart (without -k) to start the service.
+        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:
         if not _launchd_error_indicates_unloaded(e):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -578,7 +578,9 @@ class TestLaunchdServiceRecovery:
 
         assert calls == [
             ("term", 321, False),
-            ["launchctl", "kickstart", "-k", target],
+            ["launchctl", "bootout", target],
+            ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(gateway_cli.get_launchd_plist_path())],
+            ["launchctl", "kickstart", target],
         ]
 
     def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
@@ -792,7 +794,7 @@ class TestLaunchdServiceRecovery:
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
 
         def fake_run(cmd, check=False, **kwargs):
-            if cmd == ["launchctl", "kickstart", "-k", target]:
+            if cmd == ["launchctl", "kickstart", target]:
                 raise gateway_cli.subprocess.CalledProcessError(
                     5, cmd, stderr="Input/output error"
                 )


### PR DESCRIPTION
Fixes #42446. On macOS 26, launchctl kickstart -k races with launchd KeepAlive causing two gateway processes. Fix: use bootout (unloads service, preventing KeepAlive respawn) + bootstrap + kickstart instead of kickstart -k.