### PR TITLE
fix(cli): release the active-session lease on the stdin-unavailable bail

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10533,6 +10533,30 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             ] if item is not None
         ]
 
+    def _abort_if_stdin_unavailable(self) -> bool:
+        """Bail out of the interactive loop when stdin (fd 0) is unusable.
+
+        On some Python installs (e.g. uv-managed cPython on macOS) ``fd 0`` is
+        invalid or can't be registered with the asyncio selector (#6393). When
+        that happens the TUI can't run, so we finalize and return True. This
+        mirrors the normal exit path's teardown — crucially including the
+        active-session lease release, which this early-out previously skipped,
+        leaving the global session slot claimed until interpreter exit.
+        """
+        try:
+            os.fstat(0)
+        except OSError:
+            print(
+                "Error: stdin (fd 0) is not available.\n"
+                "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"
+                "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
+            )
+            _run_cleanup()
+            self._print_exit_summary()
+            self._release_active_session()
+            return True
+        return False
+
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
         if not self._claim_active_session("cli"):
@@ -12815,16 +12839,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Validate stdin before launching prompt_toolkit — on macOS with
         # uv-managed Python, fd 0 can be invalid or unregisterable with the
         # asyncio selector, causing "KeyError: '0 is not registered'" (#6393).
-        try:
-            os.fstat(0)
-        except OSError:
-            print(
-                "Error: stdin (fd 0) is not available.\n"
-                "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"
-                "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
-            )
-            _run_cleanup()
-            self._print_exit_summary()
+        if self._abort_if_stdin_unavailable():
             return
 
         # On macOS with uv-managed Python, kqueue's selector cannot register

--- a/tests/cli/test_cli_stdin_unavailable_bail.py
+++ b/tests/cli/test_cli_stdin_unavailable_bail.py
@@ -1,0 +1,37 @@
+"""The interactive run() stdin-unavailable early-out must release the
+active-session lease, like every other run() exit path.
+
+Regression: the `os.fstat(0)` bail (#6393) ran _run_cleanup() and
+_print_exit_summary() but skipped _release_active_session(), so a claimed
+global session slot lingered until interpreter exit instead of being freed
+when the session ended.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def test_stdin_unavailable_releases_active_session_lease():
+    fake_self = MagicMock()
+    with patch("cli.os.fstat", side_effect=OSError("fd 0 not available")), \
+            patch("cli._run_cleanup") as mock_cleanup:
+        aborted = HermesCLI._abort_if_stdin_unavailable(fake_self)
+
+    assert aborted is True
+    mock_cleanup.assert_called_once()
+    fake_self._print_exit_summary.assert_called_once()
+    # The fix: the lease is released on this early-out, mirroring normal exit.
+    fake_self._release_active_session.assert_called_once()
+
+
+def test_stdin_available_is_a_noop():
+    fake_self = MagicMock()
+    with patch("cli.os.fstat", return_value=object()), \
+            patch("cli._run_cleanup") as mock_cleanup:
+        aborted = HermesCLI._abort_if_stdin_unavailable(fake_self)
+
+    assert aborted is False
+    mock_cleanup.assert_not_called()
+    fake_self._print_exit_summary.assert_not_called()
+    fake_self._release_active_session.assert_not_called()


### PR DESCRIPTION
## What & why

`HermesCLI.run()` claims a global active-session slot (`_claim_active_session("cli")`, the `max_concurrent_sessions` cap) and is expected to release it on exit. It has **three** exit paths that print the exit summary, but only **two** release the lease:

| Exit path | `_run_cleanup()` | `_print_exit_summary()` | `_release_active_session()` |
|-----------|:---:|:---:|:---:|
| normal interactive exit (`cli.py`) | ✓ | ✓ | ✓ |
| single-query `hermes chat -q` (`finally`) | ✓ | ✓ | ✓ |
| **`os.fstat(0)` stdin-unavailable bail (#6393)** | ✓ | ✓ | **✗** |

So when stdin (fd 0) is unusable — the uv-managed-cPython-on-macOS case the bail exists for — the process keeps its active-session slot claimed until interpreter exit instead of freeing it when the session ends. With `max_concurrent_sessions` configured, a failed-to-launch session can hold a slot longer than necessary.

(The `atexit`-registered release does eventually free it at interpreter shutdown, so this isn't a permanent leak — but every other exit path frees the slot immediately, and this one shouldn't be the exception.)

## Fix

Extract the stdin probe into `_abort_if_stdin_unavailable()` so the teardown — including the lease release — lives in **one** place. This both fixes the missing release and removes the duplicated exit sequence that let the paths drift apart in the first place.

```python
if self._abort_if_stdin_unavailable():
    return
```

Behavior is otherwise unchanged: the method runs the exact same `_run_cleanup()` + `_print_exit_summary()` + the (now consistent) lease release, then signals the caller to return.

## How to test

```bash
scripts/run_tests.sh tests/cli/test_cli_stdin_unavailable_bail.py   # 2 passed
```

The new tests drive `_abort_if_stdin_unavailable()` in isolation (mocked `os.fstat`): the unavailable branch finalizes and **releases the lease**; the available branch is a no-op.

## Platforms

Logic change in shared CLI Python; verified via the CI-parity runner on macOS. The stdin-bail path itself is the macOS/uv-cPython case from #6393.