### PR TITLE
feat(desktop): add Graphify local notes lane

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -85,7 +85,7 @@ import {
   sessionPinId
 } from '@/store/session'
 
-import { type AppView, ARTIFACTS_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '../../routes'
+import { type AppView, ARTIFACTS_ROUTE, JARVIS_COCKPIT_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '../../routes'
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
 import type { SidebarNavItem } from '../../types'
 
@@ -114,6 +114,12 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
     label: '',
     icon: props => <Codicon name="symbol-misc" {...props} />,
     route: SKILLS_ROUTE
+  },
+  {
+    id: 'jarvis-cockpit',
+    label: '',
+    icon: props => <Codicon name="dashboard" {...props} />,
+    route: JARVIS_COCKPIT_ROUTE
   },
   { id: 'messaging', label: '', icon: props => <Codicon name="comment" {...props} />, route: MESSAGING_ROUTE },
   { id: 'artifacts', label: '', icon: props => <Codicon name="files" {...props} />, route: ARTIFACTS_ROUTE }
@@ -759,6 +765,7 @@ export function ChatSidebar({
 
                 const active =
                   (item.id === 'skills' && currentView === 'skills') ||
+                  (item.id === 'jarvis-cockpit' && currentView === 'jarvis-cockpit') ||
                   (item.id === 'messaging' && currentView === 'messaging') ||
                   (item.id === 'artifacts' && currentView === 'artifacts')
 

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -110,6 +110,7 @@ const AgentsView = lazy(async () => ({ default: (await import('./agents')).Agent
 const ArtifactsView = lazy(async () => ({ default: (await import('./artifacts')).ArtifactsView }))
 const CommandCenterView = lazy(async () => ({ default: (await import('./command-center')).CommandCenterView }))
 const CronView = lazy(async () => ({ default: (await import('./cron')).CronView }))
+const JarvisCockpitView = lazy(async () => ({ default: (await import('./jarvis-cockpit')).JarvisCockpitView }))
 const MessagingView = lazy(async () => ({ default: (await import('./messaging')).MessagingView }))
 const ProfilesView = lazy(async () => ({ default: (await import('./profiles')).ProfilesView }))
 const SettingsView = lazy(async () => ({ default: (await import('./settings')).SettingsView }))
@@ -929,6 +930,14 @@ export function DesktopController() {
               </Suspense>
             }
             path="artifacts"
+          />
+          <Route
+            element={
+              <Suspense fallback={null}>
+                <JarvisCockpitView />
+              </Suspense>
+            }
+            path="jarvis"
           />
           <Route element={null} path="cron" />
           <Route element={null} path="profiles" />

--- a/apps/desktop/src/app/jarvis-cockpit/index.test.tsx
+++ b/apps/desktop/src/app/jarvis-cockpit/index.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const api = vi.fn()
+const openExternal = vi.fn()
+
+const cockpitResponse = {
+  status: 'ok',
+  updated_at: '2026-06-07T10:00:00+02:00',
+  dispatch_boundary: {
+    dispatch_embedded: false,
+    dispatch_url: 'http://127.0.0.1:3001',
+    rule: 'Dispatch stays in real Dispatch Dashboard'
+  },
+  jarvis_todo: [{ id: 'cockpit-local-report', title: 'Regenerate local Cockpit report', status: 'todo' }],
+  gates: [],
+  status_cards: [],
+  artifacts: [],
+  sources: [],
+  missing: [],
+  safety: {
+    read_only: true,
+    microsoft_writes: false,
+    blikk_writes: false,
+    mail_mutation: false,
+    secrets_read: false,
+    dispatch_embedded: false
+  }
+}
+
+beforeEach(() => {
+  api.mockImplementation(({ method, path }: { method?: string; path: string }) => {
+    if (path === '/api/jarvis/cockpit/local-report' && method === 'POST') {
+      return Promise.resolve({
+        status: 'ok',
+        report_path: '/tmp/jarvis-cockpit-local-report.md',
+        safety: { local_only: true, external_writes: false }
+      })
+    }
+    if (path === '/api/jarvis/cockpit') {
+      return Promise.resolve(cockpitResponse)
+    }
+    return Promise.reject(new Error(`unexpected api call: ${method || 'GET'} ${path}`))
+  })
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { api, openExternal }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('JarvisCockpitView', () => {
+  it('generates a local-only cockpit report via the safe POST endpoint', async () => {
+    const { JarvisCockpitView } = await import('./index')
+
+    render(<JarvisCockpitView />)
+
+    const button = await screen.findByRole('button', { name: /generate local report/i })
+    fireEvent.click(button)
+
+    await waitFor(() =>
+      expect(api).toHaveBeenCalledWith({ path: '/api/jarvis/cockpit/local-report', method: 'POST' })
+    )
+    expect(await screen.findByText(/Local report created/i)).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/jarvis-cockpit/index.test.tsx
+++ b/apps/desktop/src/app/jarvis-cockpit/index.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const api = vi.fn()
 const openExternal = vi.fn()
+const writeText = vi.fn()
 
 const cockpitResponse = {
   status: 'ok',
@@ -13,9 +14,48 @@ const cockpitResponse = {
     rule: 'Dispatch stays in real Dispatch Dashboard'
   },
   jarvis_todo: [{ id: 'cockpit-local-report', title: 'Regenerate local Cockpit report', status: 'todo' }],
-  gates: [],
-  status_cards: [],
+  gates: [
+    {
+      id: 'gate-cockpit-health',
+      title: 'Aktivera Hermes-status v1',
+      status: 'waiting',
+      decision: 'Ska Jarvis bygga enkel trafikljusstatus i Cockpit?',
+      recommendation: 'Kör lokal v1 utan externa writes.',
+      scope: 'Endast lokal Cockpit-UI och read-only kontrakt.',
+      default_action: 'Kör',
+      risk: 'Låg',
+      owner: 'Jarvis',
+      source: 'jarvis-cockpit-session'
+    }
+  ],
+  status_cards: [{ id: 'hermes-jarvis-health', title: 'Hermes / Jarvis hälsa', state: 'attention', summary: 'Lokal trafikljusstatus.' }],
   artifacts: [],
+  graphify: {
+    status: 'ok',
+    state: 'ok',
+    scope: 'Hermes Desktop / Jarvis Cockpit',
+    nodes: 344,
+    edges: 366,
+    communities: 14,
+    token_reduction: '11.3x',
+    updated_at: '2026-06-09T01:03:21+02:00',
+    report_path: '/tmp/graphify-jarvis-cockpit/GRAPH_REPORT.md',
+    html_path: '/tmp/graphify-jarvis-cockpit/graph.html',
+    notes_dir: '/tmp/graphify-jarvis-cockpit/notes',
+    latest_note_path: '/tmp/graphify-jarvis-cockpit/notes/20260609-graphify.md',
+    latest_note_title: 'Affected: healthTone',
+    latest_note_updated_at: '2026-06-09T01:04:21+02:00',
+    safety: {
+      local_only: true,
+      structural_only: true,
+      external_writes: false,
+      semantic_llm: false,
+      hooks: false,
+      mcp: false,
+      watch: false,
+      secrets_found: false
+    }
+  },
   sources: [],
   missing: [],
   safety: {
@@ -25,15 +65,85 @@ const cockpitResponse = {
     mail_mutation: false,
     secrets_read: false,
     dispatch_embedded: false
+  },
+  improvements: {
+    suggestions: [
+      {
+        id: 'cockpit-improvements-history',
+        title: 'Förbättringar med Historik',
+        classification: 'Bygg nu',
+        status: 'active',
+        why: 'Förslag ska kunna köras, parkeras eller avfärdas.',
+        benefit: 'Mindre brus.',
+        risk: 'Låg',
+        next_step: 'Bygg flikar och knappar.'
+      },
+      {
+        id: 'cron-improvement-engine',
+        title: 'Styr om nattligt cronjobb till förbättringsmotor',
+        classification: 'Förbered',
+        status: 'parked',
+        why: 'Cron ska läsa historik.'
+      }
+    ],
+    history: []
   }
 }
 
 beforeEach(() => {
-  api.mockImplementation(({ method, path }: { method?: string; path: string }) => {
+  writeText.mockResolvedValue(undefined)
+  api.mockImplementation(({ body, method, path }: { body?: Record<string, unknown>; method?: string; path: string }) => {
     if (path === '/api/jarvis/cockpit/local-report' && method === 'POST') {
       return Promise.resolve({
         status: 'ok',
         report_path: '/tmp/jarvis-cockpit-local-report.md',
+        safety: { local_only: true, external_writes: false }
+      })
+    }
+    if (path === '/api/jarvis/cockpit/improvements/action' && method === 'POST') {
+      return Promise.resolve({
+        status: 'ok',
+        action: 'park',
+        suggestion_id: 'cockpit-improvements-history',
+        improvements: {
+          suggestions: [
+            {
+              ...cockpitResponse.improvements.suggestions[0],
+              status: 'parked'
+            }
+          ],
+          history: [
+            {
+              id: 'hist-1',
+              suggestion_id: 'cockpit-improvements-history',
+              title: 'Förbättringar med Historik',
+              action: 'park',
+              classification: 'Bygg nu',
+              actor: 'Tobias',
+              at: '2026-06-07T10:01:00+02:00'
+            }
+          ]
+        },
+        safety: { local_only: true, external_writes: false }
+      })
+    }
+    if (path === '/api/jarvis/cockpit/graphify/query' && method === 'POST') {
+      const mode = String(body?.mode || 'query')
+      return Promise.resolve({
+        status: 'ok',
+        mode,
+        output: mode === 'affected' ? 'Affected nodes for healthTone()\n- JarvisCockpitView() [calls]' : '2 nodes found\nJarvisCockpitView -> healthTone',
+        safety: { local_only: true, structural_only: true, external_writes: false, semantic_llm: false, hooks: false, mcp: false, watch: false, query_log: false }
+      })
+    }
+    if (path === '/api/jarvis/cockpit/graphify/note' && method === 'POST') {
+      return Promise.resolve({
+        status: 'ok',
+        action: 'jarvis-cockpit-graphify-note',
+        note_path: '/tmp/jarvis-cockpit-graphify/notes/20260609-graphify.md',
+        note_title: String(body?.title || 'Graphify note'),
+        notes_dir: '/tmp/jarvis-cockpit-graphify/notes',
+        updated_at: '2026-06-09T01:05:21+02:00',
         safety: { local_only: true, external_writes: false }
       })
     }
@@ -45,6 +155,10 @@ beforeEach(() => {
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
     value: { api, openExternal }
+  })
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText }
   })
 })
 
@@ -67,4 +181,111 @@ describe('JarvisCockpitView', () => {
     )
     expect(await screen.findByText(/Local report created/i)).toBeTruthy()
   })
+
+  it('renders Hermes health traffic light and Gates decision cards', async () => {
+    const { JarvisCockpitView } = await import('./index')
+
+    render(<JarvisCockpitView />)
+
+    expect(await screen.findAllByText('Hermes / Jarvis hälsa')).toHaveLength(2)
+    expect(await screen.findByText('Gul')).toBeTruthy()
+    expect(await screen.findByText(/Cockpit fungerar, men något behöver koll eller beslut/i)).toBeTruthy()
+    expect(await screen.findByText('Aktivera Hermes-status v1')).toBeTruthy()
+    expect(await screen.findByText('Ska Jarvis bygga enkel trafikljusstatus i Cockpit?')).toBeTruthy()
+    expect(await screen.findByText('Kör lokal v1 utan externa writes.')).toBeTruthy()
+    expect(await screen.findByText('Endast lokal Cockpit-UI och read-only kontrakt.')).toBeTruthy()
+  })
+
+  it('renders Graphify local project graph lane', async () => {
+    const { JarvisCockpitView } = await import('./index')
+
+    render(<JarvisCockpitView />)
+
+    expect(await screen.findByText('Graphify project graph')).toBeTruthy()
+    expect(await screen.findByText(/344 nodes \/ 366 edges/i)).toBeTruthy()
+    expect(await screen.findByText(/11.3x/i)).toBeTruthy()
+    expect(await screen.findByText(/semantic LLM, hooks, MCP and watch remain gated/i)).toBeTruthy()
+    expect(await screen.findByText('Local notes')).toBeTruthy()
+    expect((await screen.findAllByText('Affected: healthTone')).length).toBeGreaterThanOrEqual(1)
+    expect(await screen.findByRole('button', { name: /Open latest note/i })).toBeTruthy()
+    expect(await screen.findByRole('button', { name: /Open notes folder/i })).toBeTruthy()
+  })
+
+  it('runs Graphify local query helper from the Cockpit lane', async () => {
+    const { JarvisCockpitView } = await import('./index')
+
+    render(<JarvisCockpitView />)
+
+    fireEvent.change(await screen.findByLabelText('Graphify query'), { target: { value: 'JarvisCockpitView' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Query' }))
+
+    await waitFor(() =>
+      expect(api).toHaveBeenCalledWith({
+        path: '/api/jarvis/cockpit/graphify/query',
+        method: 'POST',
+        body: { mode: 'query', question: 'JarvisCockpitView', budget: 1200 }
+      })
+    )
+    expect(await screen.findAllByText(/JarvisCockpitView -> healthTone/i)).toHaveLength(2)
+  })
+
+  it('runs Graphify preset helpers, keeps insight cards, saves notes and copies the result', async () => {
+    const { JarvisCockpitView } = await import('./index')
+
+    render(<JarvisCockpitView />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /What affects Cockpit health\?/i }))
+
+    await waitFor(() =>
+      expect(api).toHaveBeenCalledWith({
+        path: '/api/jarvis/cockpit/graphify/query',
+        method: 'POST',
+        body: { mode: 'affected', node: 'healthTone', depth: 2 }
+      })
+    )
+    expect(await screen.findAllByText(/Affected nodes for healthTone/i)).toHaveLength(2)
+    expect(await screen.findByText(/query log off/i)).toBeTruthy()
+    expect(await screen.findByText('Latest insights')).toBeTruthy()
+    expect((await screen.findAllByText('Affected: healthTone')).length).toBeGreaterThanOrEqual(1)
+
+    fireEvent.click(screen.getByRole('button', { name: /Save as local Cockpit note/i }))
+    await waitFor(() =>
+      expect(api).toHaveBeenCalledWith({
+        path: '/api/jarvis/cockpit/graphify/note',
+        method: 'POST',
+        body: {
+          title: 'Affected: healthTone',
+          mode: 'affected',
+          question: 'healthTone',
+          output: expect.stringContaining('Affected nodes for healthTone')
+        }
+      })
+    )
+    expect(await screen.findByText(/Saved local Graphify note/i)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /Copy result/i }))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Affected nodes for healthTone')))
+    expect(await screen.findByRole('button', { name: /Copied/i })).toBeTruthy()
+  })
+
+  it('renders improvement tabs and records local-only park actions', async () => {
+    const { JarvisCockpitView } = await import('./index')
+
+    render(<JarvisCockpitView />)
+
+    expect(await screen.findByText('Förbättringar med Historik')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Parkera' }))
+
+    await waitFor(() =>
+      expect(api).toHaveBeenCalledWith({
+        path: '/api/jarvis/cockpit/improvements/action',
+        method: 'POST',
+        body: { suggestion_id: 'cockpit-improvements-history', action: 'park', actor: 'Tobias' }
+      })
+    )
+    expect(await screen.findByText(/Lokal förbättringshistorik uppdaterad/i)).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: /Historik \(1\)/i }))
+    expect(await screen.findByText(/Tobias · Bygg nu/i)).toBeTruthy()
+  })
+
 })

--- a/apps/desktop/src/app/jarvis-cockpit/index.tsx
+++ b/apps/desktop/src/app/jarvis-cockpit/index.tsx
@@ -78,6 +78,13 @@ interface JarvisCockpitResponse {
   updated_at?: string
 }
 
+interface JarvisCockpitLocalReportResponse {
+  report_path?: string
+  safety?: Record<string, boolean>
+  status?: string
+  updated_at?: string
+}
+
 const sourceLabels: Record<string, string> = {
   'alfred-dispatch-operator-pack': 'Dispatch operator pointer',
   gates: 'Gates directory',
@@ -138,7 +145,10 @@ const sourceLabel = (source?: CockpitSource | string) => {
 export function JarvisCockpitView() {
   const [data, setData] = useState<JarvisCockpitResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [reportError, setReportError] = useState<string | null>(null)
+  const [reportReceipt, setReportReceipt] = useState<JarvisCockpitLocalReportResponse | null>(null)
   const [refreshing, setRefreshing] = useState(false)
+  const [reporting, setReporting] = useState(false)
 
   const loadCockpit = async () => {
     setRefreshing(true)
@@ -151,6 +161,24 @@ export function JarvisCockpitView() {
       setError(err instanceof Error ? err.message : 'Could not load Jarvis Cockpit')
     } finally {
       setRefreshing(false)
+    }
+  }
+
+  const generateLocalReport = async () => {
+    setReporting(true)
+    setReportError(null)
+    setReportReceipt(null)
+
+    try {
+      const response = await window.hermesDesktop.api<JarvisCockpitLocalReportResponse>({
+        path: '/api/jarvis/cockpit/local-report',
+        method: 'POST'
+      })
+      setReportReceipt(response)
+    } catch (err) {
+      setReportError(err instanceof Error ? err.message : 'Could not generate local Cockpit report')
+    } finally {
+      setReporting(false)
     }
   }
 
@@ -186,6 +214,15 @@ export function JarvisCockpitView() {
             {data?.updated_at && <Pill label={`Updated ${niceDate(data.updated_at)}`} />}
             <button
               className="inline-flex h-8 items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:opacity-60"
+              disabled={reporting || !data}
+              onClick={() => void generateLocalReport()}
+              type="button"
+            >
+              <Codicon className={cn('size-4', reporting && 'animate-pulse')} name="file-media" />
+              {reporting ? 'Generating report' : 'Generate local report'}
+            </button>
+            <button
+              className="inline-flex h-8 items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:opacity-60"
               disabled={refreshing}
               onClick={() => void loadCockpit()}
               type="button"
@@ -199,6 +236,19 @@ export function JarvisCockpitView() {
         {error && (
           <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
             {error}
+          </div>
+        )}
+
+        {reportError && (
+          <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            {reportError}
+          </div>
+        )}
+
+        {reportReceipt && (
+          <div className="mt-4 rounded-xl border border-emerald-500/25 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+            Local report created: <span className="text-emerald-200">{reportReceipt.report_path || 'local Cockpit report'}</span>
+            {reportReceipt.safety?.external_writes === false ? <span className="ml-2 text-emerald-300">External writes: NO</span> : null}
           </div>
         )}
 

--- a/apps/desktop/src/app/jarvis-cockpit/index.tsx
+++ b/apps/desktop/src/app/jarvis-cockpit/index.tsx
@@ -1,0 +1,509 @@
+import type { ReactNode } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+
+import { Codicon } from '@/components/ui/codicon'
+import { cn } from '@/lib/utils'
+
+interface CockpitAction {
+  external_write?: boolean
+  label?: string
+  target?: string
+  type?: string
+}
+
+interface CockpitStatusCard {
+  actions?: CockpitAction[]
+  details?: string[]
+  id?: string
+  kind?: string
+  source?: string
+  state?: string
+  summary?: string
+  title?: string
+  updated_at?: string
+}
+
+interface CockpitTodoItem {
+  area?: string
+  artifact_refs?: string[]
+  id?: string
+  next_step?: string
+  risk?: string
+  source?: string
+  status?: string
+  title?: string
+}
+
+interface CockpitGate {
+  id?: string
+  reason?: string
+  source?: string
+  status?: string
+  title?: string
+  updated_at?: string
+}
+
+interface CockpitArtifact {
+  id?: string
+  kind?: string
+  path?: string
+  safe_to_open_in_cockpit?: boolean
+  summary?: string
+  title?: string
+  updated_at?: string
+}
+
+interface CockpitSource {
+  id?: string
+  path?: string
+  reason?: string
+  state?: string
+  updated_at?: string
+}
+
+interface JarvisCockpitResponse {
+  artifacts?: CockpitArtifact[]
+  dispatch_boundary?: {
+    dispatch_embedded?: boolean
+    dispatch_url?: string
+    rule?: string
+  }
+  gates?: CockpitGate[]
+  jarvis_todo?: CockpitTodoItem[]
+  missing?: CockpitSource[]
+  safety?: Record<string, boolean>
+  sources?: CockpitSource[]
+  status?: string
+  status_cards?: CockpitStatusCard[]
+  updated_at?: string
+}
+
+const sourceLabels: Record<string, string> = {
+  'alfred-dispatch-operator-pack': 'Dispatch operator pointer',
+  gates: 'Gates directory',
+  'hermes-desktop-pinned-session-routing': 'Pinned chat routing',
+  'jarvis-actions': 'Jarvis To Do',
+  'jarvis-system-current-state': 'Jarvis status',
+  'next-recommendation-guard': 'Goals / jobs guard',
+  'personas-dashboards-source-map': 'Profiles / personas map'
+}
+
+const safetyLabels: Record<string, string> = {
+  blikk_writes: 'Blikk writes',
+  dispatch_embedded: 'Dispatch embedded',
+  mail_mutation: 'Mail mutation',
+  microsoft_writes: 'Microsoft writes',
+  read_only: 'Read only',
+  secrets_read: 'Secrets read'
+}
+
+const forbiddenSafetyKeys = new Set(['blikk_writes', 'dispatch_embedded', 'mail_mutation', 'microsoft_writes', 'secrets_read'])
+
+const stateTone = (state?: string) => {
+  if (state === 'ok') {
+    return 'border-emerald-500/25 bg-emerald-500/8 text-emerald-200'
+  }
+
+  if (state === 'attention' || state === 'waiting') {
+    return 'border-amber-500/30 bg-amber-500/10 text-amber-200'
+  }
+
+  if (state === 'missing' || state === 'error') {
+    return 'border-zinc-500/25 bg-zinc-500/10 text-zinc-300'
+  }
+
+  return 'border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) text-(--ui-text-secondary)'
+}
+
+const niceDate = (value?: string) => {
+  if (!value) {
+    return null
+  }
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+const sourceLabel = (source?: CockpitSource | string) => {
+  const id = typeof source === 'string' ? source : source?.id
+
+  return (id && sourceLabels[id]) || id || 'Local source'
+}
+
+export function JarvisCockpitView() {
+  const [data, setData] = useState<JarvisCockpitResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const loadCockpit = async () => {
+    setRefreshing(true)
+    setError(null)
+
+    try {
+      const response = await window.hermesDesktop.api<JarvisCockpitResponse>({ path: '/api/jarvis/cockpit' })
+      setData(response)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load Jarvis Cockpit')
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadCockpit()
+  }, [])
+
+  const sourcesById = useMemo(() => new Map((data?.sources || []).map(source => [source.id, source])), [data?.sources])
+  const dispatchUrl = data?.dispatch_boundary?.dispatch_url
+  const statusCards = data?.status_cards || []
+  const todoItems = data?.jarvis_todo || []
+  const gates = data?.gates || []
+  const artifacts = data?.artifacts || []
+  const sources = data?.sources || []
+  const missing = data?.missing || []
+
+  return (
+    <div className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-(--ui-chat-surface-background) pt-(--titlebar-height) text-foreground">
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 pb-6 pt-4 lg:px-8">
+        <header className="flex flex-col gap-4 border-b border-(--ui-stroke-tertiary) pb-5 md:flex-row md:items-end md:justify-between">
+          <div className="max-w-3xl">
+            <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) px-2.5 py-1 text-[0.72rem] font-medium uppercase tracking-[0.18em] text-(--ui-text-tertiary)">
+              <Codicon className="size-3.5" name="shield" />
+              Read-only local Jarvis docs
+            </div>
+            <h1 className="text-2xl font-semibold tracking-[-0.03em] md:text-3xl">Jarvis Cockpit</h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-(--ui-text-secondary)">
+              Desktop-first operator pane for Jarvis/Hermes system work. Dispatch, Microsoft, Blikk, mail,
+              secrets and NUC/backup controls stay outside this read-only surface.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {data?.updated_at && <Pill label={`Updated ${niceDate(data.updated_at)}`} />}
+            <button
+              className="inline-flex h-8 items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:opacity-60"
+              disabled={refreshing}
+              onClick={() => void loadCockpit()}
+              type="button"
+            >
+              <Codicon className={cn('size-4', refreshing && 'animate-spin')} name="refresh" />
+              {refreshing ? 'Refreshing' : 'Refresh'}
+            </button>
+          </div>
+        </header>
+
+        {error && (
+          <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            {error}
+          </div>
+        )}
+
+        {!data && !error ? <CockpitSkeleton /> : null}
+
+        {data ? (
+          <main className="grid gap-5 pt-5">
+            <section className="grid gap-3 lg:grid-cols-4">
+              <MetricCard label="Status" tone={data.status === 'ok' ? 'ok' : 'muted'} value={data.status || 'unknown'} />
+              <MetricCard detail="local action items" label="Jarvis To Do" value={String(todoItems.length)} />
+              <MetricCard detail="local gates" label="Waiting gates" value={String(gates.filter(gate => gate.status === 'waiting').length)} />
+              <MetricCard detail="reported, not fatal" label="Missing sources" tone={missing.length ? 'attention' : 'ok'} value={String(missing.length)} />
+            </section>
+
+            <section className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(21rem,0.8fr)]">
+              <div className="grid gap-5">
+                <Panel icon="shield" title="Jarvis status / safety">
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {statusCards.map(card => (
+                      <StatusCard card={card} key={card.id || card.title} />
+                    ))}
+                  </div>
+                  <SafetyMatrix safety={data.safety || {}} />
+                </Panel>
+
+                <Panel icon="checklist" title="Jarvis To Do">
+                  {todoItems.length ? (
+                    <div className="grid gap-2">
+                      {todoItems.map(item => (
+                        <TodoRow item={item} key={item.id || item.title} />
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState text="No local Jarvis action items returned by the read-only API." />
+                  )}
+                </Panel>
+
+                <Panel icon="lock" title="Gates">
+                  {gates.length ? (
+                    <div className="grid gap-2">
+                      {gates.map(gate => (
+                        <GateRow gate={gate} key={gate.id || gate.title} />
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState text="No gate files returned. Missing gate directories are shown in source health instead of crashing the pane." />
+                  )}
+                </Panel>
+              </div>
+
+              <aside className="grid content-start gap-5">
+                <Panel icon="link-external" title="Dispatch boundary">
+                  <p className="text-sm leading-6 text-(--ui-text-secondary)">{data.dispatch_boundary?.rule}</p>
+                  <div className="mt-3 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3 text-xs text-(--ui-text-tertiary)">
+                    Dispatch embedded: <strong className="text-foreground">{String(Boolean(data.dispatch_boundary?.dispatch_embedded))}</strong>
+                  </div>
+                  {dispatchUrl && (
+                    <button
+                      className="mt-3 inline-flex h-8 items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground"
+                      onClick={() => void window.hermesDesktop.openExternal(dispatchUrl)}
+                      type="button"
+                    >
+                      <Codicon className="size-4" name="link-external" />
+                      Open Dispatch Dashboard
+                    </button>
+                  )}
+                </Panel>
+
+                <PointerPanel
+                  description="Profiles/personas are surfaced only as source-map pointers, not profile/config mutation controls."
+                  icon="organization"
+                  source={sourcesById.get('personas-dashboards-source-map')}
+                  title="Profiles / personas pointer"
+                />
+
+                <PointerPanel
+                  description="Goals, jobs and pinned-session routing stay pointers into local runbooks. No cron, kanban, profile or gateway controls are rendered here."
+                  icon="target"
+                  source={sourcesById.get('next-recommendation-guard')}
+                  title="Goals / jobs pointer"
+                />
+
+                <PointerPanel
+                  description="Source-map and skill hygiene are represented by allowlisted local docs and their health states."
+                  icon="symbol-misc"
+                  source={sourcesById.get('jarvis-system-current-state')}
+                  title="Source-map / skill hygiene"
+                />
+
+                <Panel icon="file-media" title="Artifacts">
+                  {artifacts.length ? (
+                    <div className="grid gap-2">
+                      {artifacts.map(artifact => (
+                        <ArtifactRow artifact={artifact} key={artifact.id || artifact.path || artifact.title} />
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState text="No safe artifact pointers returned." />
+                  )}
+                </Panel>
+
+                <Panel icon="database" title="Source health">
+                  <div className="grid gap-2">
+                    {sources.map(source => (
+                      <SourceRow key={source.id || source.path} source={source} />
+                    ))}
+                  </div>
+                </Panel>
+              </aside>
+            </section>
+          </main>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function Panel({ children, icon, title }: { children: ReactNode; icon: string; title: string }) {
+  return (
+    <section className="rounded-2xl border border-(--ui-stroke-tertiary) bg-(--ui-surface-elevated-background)/70 p-4 shadow-[0_18px_55px_rgba(0,0,0,0.18)]">
+      <div className="mb-3 flex items-center gap-2">
+        <span className="grid size-7 place-items-center rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) text-(--ui-text-secondary)">
+          <Codicon className="size-4" name={icon} />
+        </span>
+        <h2 className="text-sm font-semibold tracking-[-0.01em]">{title}</h2>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function Pill({ label }: { label: string }) {
+  return (
+    <span className="inline-flex h-8 items-center rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) px-3 text-xs text-(--ui-text-tertiary)">
+      {label}
+    </span>
+  )
+}
+
+function MetricCard({ detail, label, tone = 'muted', value }: { detail?: string; label: string; tone?: 'attention' | 'muted' | 'ok'; value: string }) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border p-4',
+        tone === 'ok'
+          ? 'border-emerald-500/25 bg-emerald-500/8'
+          : tone === 'attention'
+            ? 'border-amber-500/30 bg-amber-500/10'
+            : 'border-(--ui-stroke-tertiary) bg-(--ui-surface-elevated-background)/65'
+      )}
+    >
+      <div className="text-xs uppercase tracking-[0.16em] text-(--ui-text-tertiary)">{label}</div>
+      <div className="mt-2 text-2xl font-semibold tracking-[-0.04em]">{value}</div>
+      {detail && <div className="mt-1 text-xs text-(--ui-text-tertiary)">{detail}</div>}
+    </div>
+  )
+}
+
+function StatusCard({ card }: { card: CockpitStatusCard }) {
+  const openUrlAction = card.actions?.find(action => action.type === 'open-url' && action.target && !action.external_write)
+
+  return (
+    <article className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium">{card.title || card.id}</h3>
+          <p className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">{card.summary}</p>
+        </div>
+        <StateBadge state={card.state} />
+      </div>
+      {card.details?.length ? (
+        <ul className="mt-2 grid gap-1 text-xs text-(--ui-text-tertiary)">
+          {card.details.map(detail => (
+            <li className="flex gap-1.5" key={detail}>
+              <span aria-hidden="true">•</span>
+              <span>{detail}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {openUrlAction?.target && (
+        <button
+          className="mt-3 inline-flex h-7 items-center gap-1.5 rounded-md border border-(--ui-stroke-tertiary) px-2 text-xs text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground"
+          onClick={() => void window.hermesDesktop.openExternal(openUrlAction.target!)}
+          type="button"
+        >
+          <Codicon className="size-3.5" name="link-external" />
+          {openUrlAction.label || 'Open link'}
+        </button>
+      )}
+    </article>
+  )
+}
+
+function SafetyMatrix({ safety }: { safety: Record<string, boolean> }) {
+  return (
+    <div className="mt-4 grid gap-2 rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3 sm:grid-cols-2 lg:grid-cols-3">
+      {Object.entries(safety).map(([key, value]) => {
+        const safe = key === 'read_only' ? value === true : forbiddenSafetyKeys.has(key) ? value === false : !value
+
+        return (
+          <div className="flex items-center justify-between gap-3 text-xs" key={key}>
+            <span className="text-(--ui-text-secondary)">{safetyLabels[key] || key.replaceAll('_', ' ')}</span>
+            <span className={cn('font-medium', safe ? 'text-emerald-300' : 'text-red-300')}>{String(value).toUpperCase()}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function TodoRow({ item }: { item: CockpitTodoItem }) {
+  return (
+    <article className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-medium">{item.title || item.id}</h3>
+          <p className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">{item.next_step || item.source}</p>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <StateBadge state={item.status} />
+          {item.risk && <StateBadge state={item.risk} />}
+        </div>
+      </div>
+      <div className="mt-2 flex flex-wrap gap-2 text-xs text-(--ui-text-tertiary)">
+        {item.area && <span>{item.area}</span>}
+        {item.source && <span>Source: {item.source}</span>}
+      </div>
+    </article>
+  )
+}
+
+function GateRow({ gate }: { gate: CockpitGate }) {
+  return (
+    <article className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-medium">{gate.title || gate.id || 'Gate'}</h3>
+          <p className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">{gate.reason || gate.source || 'Local gate pointer'}</p>
+        </div>
+        <StateBadge state={gate.status} />
+      </div>
+      {gate.updated_at && <div className="mt-2 text-xs text-(--ui-text-tertiary)">Updated {niceDate(gate.updated_at)}</div>}
+    </article>
+  )
+}
+
+function PointerPanel({ description, icon, source, title }: { description: string; icon: string; source?: CockpitSource; title: string }) {
+  return (
+    <Panel icon={icon} title={title}>
+      <p className="text-sm leading-6 text-(--ui-text-secondary)">{description}</p>
+      {source ? <SourceRow source={source} /> : <div className="mt-3"><EmptyState text="Pointer source was not returned." /></div>}
+    </Panel>
+  )
+}
+
+function ArtifactRow({ artifact }: { artifact: CockpitArtifact }) {
+  return (
+    <article className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3 text-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="truncate font-medium">{artifact.title || artifact.id || 'Artifact'}</h3>
+          <p className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">{artifact.summary || artifact.path}</p>
+        </div>
+        <StateBadge state={artifact.safe_to_open_in_cockpit ? 'ok' : 'pointer'} />
+      </div>
+      {artifact.path && <div className="mt-2 truncate font-mono text-[0.7rem] text-(--ui-text-tertiary)">{artifact.path}</div>}
+    </article>
+  )
+}
+
+function SourceRow({ source }: { source: CockpitSource }) {
+  return (
+    <div className="mt-2 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-2.5 text-xs">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium text-(--ui-text-secondary)">{sourceLabel(source)}</span>
+        <StateBadge state={source.state} />
+      </div>
+      {source.path && <div className="mt-1 truncate font-mono text-[0.68rem] text-(--ui-text-tertiary)">{source.path}</div>}
+      {source.reason && <div className="mt-1 text-(--ui-text-tertiary)">{source.reason}</div>}
+    </div>
+  )
+}
+
+function StateBadge({ state }: { state?: string }) {
+  return (
+    <span className={cn('inline-flex h-5 shrink-0 items-center rounded-full border px-2 text-[0.68rem] font-medium', stateTone(state))}>
+      {state || 'unknown'}
+    </span>
+  )
+}
+
+function EmptyState({ text }: { text: string }) {
+  return <div className="rounded-xl border border-dashed border-(--ui-stroke-tertiary) p-4 text-sm text-(--ui-text-tertiary)">{text}</div>
+}
+
+function CockpitSkeleton() {
+  return (
+    <div className="grid gap-5 pt-5">
+      <div className="grid gap-3 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div className="h-28 animate-pulse rounded-2xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background)" key={i} />
+        ))}
+      </div>
+      <div className="h-96 animate-pulse rounded-2xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background)" />
+    </div>
+  )
+}

--- a/apps/desktop/src/app/jarvis-cockpit/index.tsx
+++ b/apps/desktop/src/app/jarvis-cockpit/index.tsx
@@ -35,11 +35,68 @@ interface CockpitTodoItem {
 }
 
 interface CockpitGate {
+  decision?: string
+  default_action?: string
   id?: string
+  owner?: string
+  recommendation?: string
   reason?: string
+  risk?: string
+  scope?: string
   source?: string
   status?: string
   title?: string
+  updated_at?: string
+}
+
+interface CockpitImprovementSuggestion {
+  benefit?: string
+  classification?: 'Bygg nu' | 'Förbered' | 'Utforska' | string
+  created_at?: string
+  gate_required?: boolean
+  id?: string
+  next_step?: string
+  owner?: string
+  risk?: string
+  source?: string
+  status?: string
+  title?: string
+  updated_at?: string
+  why?: string
+}
+
+interface CockpitImprovementHistory {
+  action?: string
+  actor?: string
+  at?: string
+  classification?: string
+  id?: string
+  reason?: string | null
+  status_after?: string
+  suggestion_id?: string
+  title?: string
+}
+
+interface CockpitImprovements {
+  history?: CockpitImprovementHistory[]
+  rules?: {
+    cron_history_rule?: string
+    external_writes_allowed?: boolean
+    labels?: string[]
+    local_only?: boolean
+    tabs?: string[]
+  }
+  suggestions?: CockpitImprovementSuggestion[]
+  updated_at?: string
+  version?: number
+}
+
+interface CockpitImprovementActionResponse {
+  action?: string
+  improvements?: CockpitImprovements
+  safety?: Record<string, boolean>
+  status?: string
+  suggestion_id?: string
   updated_at?: string
 }
 
@@ -69,6 +126,8 @@ interface JarvisCockpitResponse {
     rule?: string
   }
   gates?: CockpitGate[]
+  graphify?: CockpitGraphifyLane
+  improvements?: CockpitImprovements
   jarvis_todo?: CockpitTodoItem[]
   missing?: CockpitSource[]
   safety?: Record<string, boolean>
@@ -85,11 +144,60 @@ interface JarvisCockpitLocalReportResponse {
   updated_at?: string
 }
 
+interface CockpitGraphifyLane {
+  command?: string
+  communities?: number
+  edges?: number
+  graph_path?: string
+  html_path?: string
+  latest_note_path?: string
+  latest_note_title?: string
+  latest_note_updated_at?: string
+  nodes?: number
+  notes_dir?: string
+  report_path?: string
+  safety?: Record<string, boolean>
+  scope?: string
+  state?: string
+  status?: string
+  token_reduction?: string
+  updated_at?: string
+}
+
+interface CockpitGraphifyQueryResponse {
+  graph_path?: string
+  mode?: string
+  output?: string
+  safety?: Record<string, boolean>
+  status?: string
+  stderr?: string
+}
+
+interface CockpitGraphifyNoteResponse {
+  action?: string
+  note_path?: string
+  note_title?: string
+  notes_dir?: string
+  safety?: Record<string, boolean>
+  status?: string
+  updated_at?: string
+}
+
+interface CockpitGraphifyInsight {
+  id: string
+  mode?: string
+  output: string
+  question?: string
+  title: string
+}
+
 const sourceLabels: Record<string, string> = {
   'alfred-dispatch-operator-pack': 'Dispatch operator pointer',
   gates: 'Gates directory',
   'hermes-desktop-pinned-session-routing': 'Pinned chat routing',
   'jarvis-actions': 'Jarvis To Do',
+  'jarvis-cockpit-graphify': 'Graphify project graph',
+  'jarvis-cockpit-improvements': 'Cockpit förbättringar',
   'jarvis-system-current-state': 'Jarvis status',
   'next-recommendation-guard': 'Goals / jobs guard',
   'personas-dashboards-source-map': 'Profiles / personas map'
@@ -105,6 +213,13 @@ const safetyLabels: Record<string, string> = {
 }
 
 const forbiddenSafetyKeys = new Set(['blikk_writes', 'dispatch_embedded', 'mail_mutation', 'microsoft_writes', 'secrets_read'])
+const improvementLabels = ['Bygg nu', 'Förbered', 'Utforska']
+const improvementActionLabels: Record<string, string> = {
+  dismiss: 'Avfärdad',
+  park: 'Parkerad',
+  restore: 'Tillbakalagd',
+  run: 'Körd'
+}
 
 const stateTone = (state?: string) => {
   if (state === 'ok') {
@@ -136,6 +251,21 @@ const niceDate = (value?: string) => {
   return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
 }
 
+const healthTone = (statusCards: CockpitStatusCard[], sources: CockpitSource[], gates: CockpitGate[], safety: Record<string, boolean>) => {
+  const unsafe = Object.entries(safety).some(([key, value]) => key === 'read_only' ? value !== true : forbiddenSafetyKeys.has(key) && value !== false)
+  const errors = statusCards.filter(card => card.state === 'error').length + sources.filter(source => source.state === 'error').length
+  const warnings = statusCards.filter(card => ['attention', 'waiting', 'missing'].includes(card.state || '')).length + sources.filter(source => ['missing', 'waiting'].includes(source.state || '')).length
+  const waitingGates = gates.filter(gate => gate.status === 'waiting').length
+
+  if (unsafe || errors) {
+    return { label: 'Röd', state: 'error', summary: 'Cockpit ser en trasig eller osäker lokal signal.', waitingGates, warnings, errors }
+  }
+  if (warnings || waitingGates) {
+    return { label: 'Gul', state: 'attention', summary: 'Cockpit fungerar, men något behöver koll eller beslut.', waitingGates, warnings, errors }
+  }
+  return { label: 'Grön', state: 'ok', summary: 'Jarvis Cockpit ser frisk ut utifrån lokala, säkra källor.', waitingGates, warnings, errors }
+}
+
 const sourceLabel = (source?: CockpitSource | string) => {
   const id = typeof source === 'string' ? source : source?.id
 
@@ -149,6 +279,10 @@ export function JarvisCockpitView() {
   const [reportReceipt, setReportReceipt] = useState<JarvisCockpitLocalReportResponse | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [reporting, setReporting] = useState(false)
+  const [improvementActionError, setImprovementActionError] = useState<string | null>(null)
+  const [improvementActionReceipt, setImprovementActionReceipt] = useState<string | null>(null)
+  const [improvementActionLoading, setImprovementActionLoading] = useState<string | null>(null)
+  const [improvementTab, setImprovementTab] = useState<'active' | 'history' | 'parked'>('active')
 
   const loadCockpit = async () => {
     setRefreshing(true)
@@ -182,6 +316,29 @@ export function JarvisCockpitView() {
     }
   }
 
+  const applyImprovementAction = async (suggestion: CockpitImprovementSuggestion, action: 'dismiss' | 'park' | 'restore' | 'run') => {
+    if (!suggestion.id) {
+      return
+    }
+    setImprovementActionError(null)
+    setImprovementActionReceipt(null)
+    setImprovementActionLoading(`${suggestion.id}:${action}`)
+
+    try {
+      const response = await window.hermesDesktop.api<CockpitImprovementActionResponse>({
+        path: '/api/jarvis/cockpit/improvements/action',
+        method: 'POST',
+        body: { suggestion_id: suggestion.id, action, actor: 'Tobias' }
+      })
+      setData(previous => (previous ? { ...previous, improvements: response.improvements || previous.improvements } : previous))
+      setImprovementActionReceipt(`${improvementActionLabels[action] || action}: ${suggestion.title || suggestion.id}`)
+    } catch (err) {
+      setImprovementActionError(err instanceof Error ? err.message : 'Could not update improvement suggestion')
+    } finally {
+      setImprovementActionLoading(null)
+    }
+  }
+
   useEffect(() => {
     void loadCockpit()
   }, [])
@@ -192,8 +349,14 @@ export function JarvisCockpitView() {
   const todoItems = data?.jarvis_todo || []
   const gates = data?.gates || []
   const artifacts = data?.artifacts || []
+  const graphify = data?.graphify
   const sources = data?.sources || []
   const missing = data?.missing || []
+  const jarvisHealth = healthTone(statusCards, sources, gates, data?.safety || {})
+  const improvementSuggestions = data?.improvements?.suggestions || []
+  const improvementHistory = data?.improvements?.history || []
+  const activeImprovements = improvementSuggestions.filter(item => (item.status || 'active') === 'active' || item.status === 'running')
+  const parkedImprovements = improvementSuggestions.filter(item => item.status === 'parked')
 
   return (
     <div className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-(--ui-chat-surface-background) pt-(--titlebar-height) text-foreground">
@@ -252,19 +415,36 @@ export function JarvisCockpitView() {
           </div>
         )}
 
+        {improvementActionError && (
+          <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            {improvementActionError}
+          </div>
+        )}
+
+        {improvementActionReceipt && (
+          <div className="mt-4 rounded-xl border border-emerald-500/25 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+            Lokal förbättringshistorik uppdaterad: <span className="text-emerald-200">{improvementActionReceipt}</span>
+          </div>
+        )}
+
         {!data && !error ? <CockpitSkeleton /> : null}
 
         {data ? (
           <main className="grid gap-5 pt-5">
-            <section className="grid gap-3 lg:grid-cols-4">
+            <section className="grid gap-3 lg:grid-cols-5">
               <MetricCard label="Status" tone={data.status === 'ok' ? 'ok' : 'muted'} value={data.status || 'unknown'} />
-              <MetricCard detail="local action items" label="Jarvis To Do" value={String(todoItems.length)} />
-              <MetricCard detail="local gates" label="Waiting gates" value={String(gates.filter(gate => gate.status === 'waiting').length)} />
-              <MetricCard detail="reported, not fatal" label="Missing sources" tone={missing.length ? 'attention' : 'ok'} value={String(missing.length)} />
+              <MetricCard detail="lokala åtgärder" label="Jarvis To Do" value={String(todoItems.length)} />
+              <MetricCard detail="lokala gates" label="Beslut" value={String(gates.filter(gate => gate.status === 'waiting').length)} />
+              <MetricCard detail="aktuella förbättringar" label="Förbättringar" value={String(activeImprovements.length)} />
+              <MetricCard detail="rapporterat, inte fatal" label="Saknade källor" tone={missing.length ? 'attention' : 'ok'} value={String(missing.length)} />
             </section>
 
             <section className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(21rem,0.8fr)]">
               <div className="grid gap-5">
+                <Panel icon="pulse" title="Hermes / Jarvis hälsa">
+                  <JarvisHealthSummary health={jarvisHealth} missing={missing.length} statusCards={statusCards} />
+                </Panel>
+
                 <Panel icon="shield" title="Jarvis status / safety">
                   <div className="grid gap-3 md:grid-cols-2">
                     {statusCards.map(card => (
@@ -286,7 +466,7 @@ export function JarvisCockpitView() {
                   )}
                 </Panel>
 
-                <Panel icon="lock" title="Gates">
+                <Panel icon="lock" title="Gates / Beslut">
                   {gates.length ? (
                     <div className="grid gap-2">
                       {gates.map(gate => (
@@ -294,8 +474,24 @@ export function JarvisCockpitView() {
                       ))}
                     </div>
                   ) : (
-                    <EmptyState text="No gate files returned. Missing gate directories are shown in source health instead of crashing the pane." />
+                    <EmptyState text="Inga lokala gates väntar. Saknade gate-mappar visas under källhälsa utan att stoppa Cockpit." />
                   )}
+                </Panel>
+
+                <Panel icon="graph" title="Graphify project graph">
+                  <GraphifyLane graphify={graphify} />
+                </Panel>
+
+                <Panel icon="sparkle" title="Förbättringar">
+                  <ImprovementBoard
+                    activeItems={activeImprovements}
+                    history={improvementHistory}
+                    loadingKey={improvementActionLoading}
+                    onAction={(suggestion, action) => void applyImprovementAction(suggestion, action)}
+                    parkedItems={parkedImprovements}
+                    selectedTab={improvementTab}
+                    setSelectedTab={setImprovementTab}
+                  />
                 </Panel>
               </div>
 
@@ -407,6 +603,347 @@ function MetricCard({ detail, label, tone = 'muted', value }: { detail?: string;
   )
 }
 
+function JarvisHealthSummary({
+  health,
+  missing,
+  statusCards
+}: {
+  health: ReturnType<typeof healthTone>
+  missing: number
+  statusCards: CockpitStatusCard[]
+}) {
+  return (
+    <div className="grid gap-3 md:grid-cols-[12rem_minmax(0,1fr)]">
+      <div className={cn('rounded-xl border p-4', stateTone(health.state))}>
+        <div className="text-xs uppercase tracking-[0.16em] opacity-80">Trafikljus</div>
+        <div className="mt-2 text-3xl font-semibold tracking-[-0.05em]">{health.label}</div>
+        <div className="mt-1 text-xs opacity-80">{health.summary}</div>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <InfoBlock label="Beslut väntar" value={`${health.waitingGates} lokala gate(s)`} />
+        <InfoBlock label="Källor saknas" value={`${missing} rapporterade, inte fatal`} />
+        <InfoBlock label="Varningar" value={`${health.warnings} gul signal(er)`} />
+        <InfoBlock label="Fel" value={`${health.errors} röd signal(er)`} />
+      </div>
+      {statusCards.length ? (
+        <div className="md:col-span-2 rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3 text-xs text-(--ui-text-secondary)">
+          Hälsan beräknas från lokala statuskort, source health, safety receipt och gates. Ingen Graph, Blikk, mail, secrets, cron- eller gateway-mutation körs här.
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function GraphifyLane({ graphify }: { graphify?: CockpitGraphifyLane }) {
+  const [query, setQuery] = useState('')
+  const [source, setSource] = useState('')
+  const [target, setTarget] = useState('')
+  const [node, setNode] = useState('')
+  const [busyMode, setBusyMode] = useState<string | null>(null)
+  const [queryError, setQueryError] = useState<string | null>(null)
+  const [queryResult, setQueryResult] = useState<CockpitGraphifyQueryResponse | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [insights, setInsights] = useState<CockpitGraphifyInsight[]>([])
+  const [noteError, setNoteError] = useState<string | null>(null)
+  const [noteReceipt, setNoteReceipt] = useState<string | null>(null)
+  const [latestNote, setLatestNote] = useState<{ path?: string; title?: string; updated_at?: string } | null>(null)
+  const [savingNoteId, setSavingNoteId] = useState<string | null>(null)
+
+  useEffect(() => {
+    setLatestNote(graphify?.latest_note_path ? {
+      path: graphify.latest_note_path,
+      title: graphify.latest_note_title || 'Latest Graphify note',
+      updated_at: graphify.latest_note_updated_at
+    } : null)
+  }, [graphify?.latest_note_path, graphify?.latest_note_title, graphify?.latest_note_updated_at])
+
+  if (!graphify || graphify.state === 'missing') {
+    return <EmptyState text="No local Graphify manifest yet. Kör structural-only graph för att fylla projektkartan." />
+  }
+
+  const unsafe = graphify.safety
+    ? graphify.safety.external_writes || graphify.safety.semantic_llm || graphify.safety.hooks || graphify.safety.mcp || graphify.safety.watch || graphify.safety.secrets_found
+    : true
+
+  const insightTitle = (mode: string, body: Record<string, unknown>) => {
+    if (mode === 'affected') {
+      return `Affected: ${String(body.node || body.question || 'node')}`
+    }
+    if (mode === 'path') {
+      return `Path: ${String(body.source || 'source')} → ${String(body.target || 'target')}`
+    }
+    return `Query: ${String(body.question || 'Graphify insight')}`
+  }
+
+  const addInsight = (mode: string, body: Record<string, unknown>, response: CockpitGraphifyQueryResponse) => {
+    if (!response.output) {
+      return
+    }
+    const insight: CockpitGraphifyInsight = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      mode: response.mode || mode,
+      output: response.output,
+      question: String(body.question || body.node || `${body.source || ''} ${body.target || ''}`).trim(),
+      title: insightTitle(response.mode || mode, body)
+    }
+    setInsights(previous => [insight, ...previous].slice(0, 3))
+  }
+
+  const saveInsightNote = async (insight: CockpitGraphifyInsight) => {
+    setSavingNoteId(insight.id)
+    setNoteError(null)
+    setNoteReceipt(null)
+    try {
+      const response = await window.hermesDesktop.api<CockpitGraphifyNoteResponse>({
+        path: '/api/jarvis/cockpit/graphify/note',
+        method: 'POST',
+        body: {
+          title: insight.title,
+          mode: insight.mode,
+          question: insight.question,
+          output: insight.output
+        }
+      })
+      setNoteReceipt(response.note_path || 'local Graphify note')
+      if (response.note_path) {
+        setLatestNote({
+          path: response.note_path,
+          title: response.note_title || insight.title,
+          updated_at: response.updated_at
+        })
+      }
+    } catch (err) {
+      setNoteError(err instanceof Error ? err.message : 'Could not save local Graphify note')
+    } finally {
+      setSavingNoteId(null)
+    }
+  }
+
+  const runHelper = async (mode: 'affected' | 'path' | 'query', overrideBody?: Record<string, unknown>) => {
+    setBusyMode(mode)
+    setQueryError(null)
+    setNoteError(null)
+    setQueryResult(null)
+    setCopied(false)
+    try {
+      const body = overrideBody || (mode === 'query'
+        ? { mode, question: query, budget: 1200 }
+        : mode === 'path'
+          ? { mode, source, target }
+          : { mode, node, depth: 2 })
+      const response = await window.hermesDesktop.api<CockpitGraphifyQueryResponse>({
+        path: '/api/jarvis/cockpit/graphify/query',
+        method: 'POST',
+        body
+      })
+      setQueryResult(response)
+      addInsight(mode, body, response)
+    } catch (err) {
+      setQueryError(err instanceof Error ? err.message : 'Graphify helper failed')
+    } finally {
+      setBusyMode(null)
+    }
+  }
+
+  const runPreset = (preset: { mode: 'affected' | 'path' | 'query'; label: string; node?: string; question?: string; source?: string; target?: string }) => {
+    if (preset.mode === 'query' && preset.question) {
+      setQuery(preset.question)
+      void runHelper('query', { mode: 'query', question: preset.question, budget: 1200 })
+    } else if (preset.mode === 'path' && preset.source && preset.target) {
+      setSource(preset.source)
+      setTarget(preset.target)
+      void runHelper('path', { mode: 'path', source: preset.source, target: preset.target })
+    } else if (preset.mode === 'affected' && preset.node) {
+      setNode(preset.node)
+      void runHelper('affected', { mode: 'affected', node: preset.node, depth: 2 })
+    }
+  }
+
+  const copyResult = async () => {
+    if (!queryResult?.output || !navigator.clipboard?.writeText) {
+      return
+    }
+    await navigator.clipboard.writeText(queryResult.output)
+    setCopied(true)
+  }
+
+  const presets = [
+    { label: 'What affects Cockpit health?', mode: 'affected' as const, node: 'healthTone' },
+    { label: 'API to UI path', mode: 'path' as const, source: 'get_jarvis_cockpit', target: 'JarvisCockpitView' },
+    { label: 'Graphify lane map', mode: 'query' as const, question: 'GraphifyLane JarvisCockpitView' }
+  ]
+
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-2 sm:grid-cols-4">
+        <InfoBlock label="Nodes" value={String(graphify.nodes ?? '—')} />
+        <InfoBlock label="Edges" value={String(graphify.edges ?? '—')} />
+        <InfoBlock label="Communities" value={String(graphify.communities ?? '—')} />
+        <InfoBlock label="Token reduction" value={graphify.token_reduction || '—'} />
+      </div>
+      <div className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3 text-sm leading-6 text-(--ui-text-secondary)">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <span className="font-medium text-foreground">{graphify.nodes ?? 0} nodes / {graphify.edges ?? 0} edges</span>
+            <span className="ml-2 text-(--ui-text-tertiary)">{graphify.scope || 'Local project graph'}</span>
+          </div>
+          <StateBadge state={unsafe ? 'attention' : 'ok'} />
+        </div>
+        <div className="mt-2 text-xs text-(--ui-text-tertiary)">
+          Policy: local structural graph. semantic LLM, hooks, MCP and watch remain gated.
+        </div>
+        {graphify.command && <code className="mt-2 block overflow-hidden text-ellipsis rounded-md bg-black/20 px-2 py-1 text-xs text-(--ui-text-tertiary)">{graphify.command}</code>}
+      </div>
+      <div className="grid gap-3 rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <h3 className="text-sm font-medium">Local graph helpers</h3>
+            <p className="mt-1 text-xs text-(--ui-text-tertiary)">Runs query/path/affected against this approved local graph only. Query log disabled.</p>
+          </div>
+          <StateBadge state={unsafe ? 'attention' : 'ok'} />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {presets.map(preset => (
+            <button
+              className="inline-flex h-8 items-center gap-1.5 rounded-md border border-emerald-500/25 bg-emerald-500/8 px-3 text-xs font-medium text-emerald-100 hover:bg-emerald-500/15 disabled:opacity-60"
+              disabled={unsafe || busyMode !== null}
+              key={preset.label}
+              onClick={() => runPreset(preset)}
+              type="button"
+            >
+              <Codicon className="size-3.5" name={preset.mode === 'path' ? 'type-hierarchy-sub' : preset.mode === 'affected' ? 'target' : 'search'} />
+              {preset.label}
+            </button>
+          ))}
+        </div>
+        <div className="grid gap-2 lg:grid-cols-3">
+          <label className="grid gap-1 text-xs text-(--ui-text-secondary)">
+            Graphify query
+            <input
+              className="h-9 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm text-foreground outline-none focus:border-emerald-500/50"
+              onChange={event => setQuery(event.target.value)}
+              placeholder="JarvisCockpitView"
+              value={query}
+            />
+            <button className="inline-flex h-8 items-center justify-center rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-xs font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) disabled:opacity-60" disabled={unsafe || busyMode !== null || !query.trim()} onClick={() => void runHelper('query')} type="button">
+              {busyMode === 'query' ? 'Querying' : 'Query'}
+            </button>
+          </label>
+          <div className="grid gap-1 text-xs text-(--ui-text-secondary)">
+            Path
+            <input aria-label="Graphify path source" className="h-9 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm text-foreground outline-none focus:border-emerald-500/50" onChange={event => setSource(event.target.value)} placeholder="source node" value={source} />
+            <input aria-label="Graphify path target" className="h-9 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm text-foreground outline-none focus:border-emerald-500/50" onChange={event => setTarget(event.target.value)} placeholder="target node" value={target} />
+            <button className="inline-flex h-8 items-center justify-center rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-xs font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) disabled:opacity-60" disabled={unsafe || busyMode !== null || !source.trim() || !target.trim()} onClick={() => void runHelper('path')} type="button">
+              {busyMode === 'path' ? 'Finding path' : 'Path'}
+            </button>
+          </div>
+          <label className="grid gap-1 text-xs text-(--ui-text-secondary)">
+            Affected node
+            <input
+              className="h-9 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm text-foreground outline-none focus:border-emerald-500/50"
+              onChange={event => setNode(event.target.value)}
+              placeholder="healthTone"
+              value={node}
+            />
+            <button className="inline-flex h-8 items-center justify-center rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-xs font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) disabled:opacity-60" disabled={unsafe || busyMode !== null || !node.trim()} onClick={() => void runHelper('affected')} type="button">
+              {busyMode === 'affected' ? 'Checking' : 'Affected'}
+            </button>
+          </label>
+        </div>
+        {queryError && <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-xs text-red-200">{queryError}</div>}
+        {queryResult?.output && (
+          <div className="grid gap-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="flex flex-wrap gap-1.5">
+                <StateBadge state={queryResult.status || 'ok'} />
+                {queryResult.mode ? <StateBadge state={queryResult.mode} /> : null}
+                {queryResult.safety?.query_log === false ? <StateBadge state="query log off" /> : null}
+              </div>
+              <button className="inline-flex h-7 items-center gap-1.5 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-2 text-xs text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)" onClick={() => void copyResult()} type="button">
+                <Codicon className="size-3.5" name="copy" />
+                {copied ? 'Copied' : 'Copy result'}
+              </button>
+            </div>
+            <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded-lg border border-(--ui-stroke-tertiary) bg-black/25 p-3 text-xs leading-5 text-(--ui-text-secondary)">{queryResult.output}</pre>
+          </div>
+        )}
+        {noteError && <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-xs text-red-200">{noteError}</div>}
+        {noteReceipt && <div className="rounded-lg border border-emerald-500/25 bg-emerald-500/10 p-2 text-xs text-emerald-100">Saved local Graphify note: <span className="text-emerald-200">{noteReceipt}</span></div>}
+        <div className="rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background)/35 p-3">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-[0.16em] text-(--ui-text-tertiary)">Local notes</div>
+              {latestNote?.path ? (
+                <div className="mt-2 grid gap-1">
+                  <div className="text-sm font-medium text-foreground">{latestNote.title || 'Latest Graphify note'}</div>
+                  <div className="text-xs text-(--ui-text-tertiary)">{niceDate(latestNote.updated_at) || 'Saved locally'} · {latestNote.path}</div>
+                </div>
+              ) : (
+                <p className="mt-2 text-xs leading-5 text-(--ui-text-tertiary)">No saved Graphify notes yet. Save an insight to create a local Cockpit note.</p>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {latestNote?.path ? (
+                <button className="inline-flex h-8 items-center gap-1.5 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-xs text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)" onClick={() => void window.hermesDesktop.openExternal(latestNote.path!)} type="button">
+                  <Codicon className="size-3.5" name="note" />
+                  Open latest note
+                </button>
+              ) : null}
+              {graphify.notes_dir ? (
+                <button className="inline-flex h-8 items-center gap-1.5 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-xs text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background)" onClick={() => void window.hermesDesktop.openExternal(graphify.notes_dir!)} type="button">
+                  <Codicon className="size-3.5" name="folder-opened" />
+                  Open notes folder
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+        {insights.length ? (
+          <div className="grid gap-2">
+            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-(--ui-text-tertiary)">Latest insights</div>
+            {insights.map(insight => (
+              <article className="rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background)/45 p-2" key={insight.id}>
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <h4 className="text-xs font-medium text-foreground">{insight.title}</h4>
+                      <StateBadge state={insight.mode || 'query'} />
+                    </div>
+                    <p className="mt-1 line-clamp-2 text-xs leading-5 text-(--ui-text-tertiary)">{insight.output}</p>
+                  </div>
+                  <button
+                    className="inline-flex h-7 items-center gap-1.5 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-2 text-xs text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) disabled:opacity-60"
+                    disabled={savingNoteId !== null}
+                    onClick={() => void saveInsightNote(insight)}
+                    type="button"
+                  >
+                    <Codicon className="size-3.5" name="save" />
+                    {savingNoteId === insight.id ? 'Saving note' : 'Save as local Cockpit note'}
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {graphify.html_path && (
+          <button className="inline-flex h-8 items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground" onClick={() => void window.hermesDesktop.openExternal(graphify.html_path!)} type="button">
+            <Codicon className="size-4" name="graph" />
+            Open graph
+          </button>
+        )}
+        {graphify.report_path && (
+          <button className="inline-flex h-8 items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-3 text-sm font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground" onClick={() => void window.hermesDesktop.openExternal(graphify.report_path!)} type="button">
+            <Codicon className="size-4" name="file-media" />
+            Open report
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function StatusCard({ card }: { card: CockpitStatusCard }) {
   const openUrlAction = card.actions?.find(action => action.type === 'open-url' && action.target && !action.external_write)
 
@@ -484,15 +1021,205 @@ function TodoRow({ item }: { item: CockpitTodoItem }) {
 function GateRow({ gate }: { gate: CockpitGate }) {
   return (
     <article className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3">
-      <div className="flex items-start justify-between gap-2">
-        <div>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
           <h3 className="text-sm font-medium">{gate.title || gate.id || 'Gate'}</h3>
-          <p className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">{gate.reason || gate.source || 'Local gate pointer'}</p>
+          <p className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">{gate.decision || gate.reason || gate.source || 'Lokalt beslut som behöver Tobias ställningstagande.'}</p>
         </div>
-        <StateBadge state={gate.status} />
+        <div className="flex flex-wrap gap-1.5">
+          <StateBadge state={gate.status || 'waiting'} />
+          {gate.risk ? <StateBadge state={gate.risk} /> : null}
+        </div>
       </div>
-      {gate.updated_at && <div className="mt-2 text-xs text-(--ui-text-tertiary)">Updated {niceDate(gate.updated_at)}</div>}
+      <div className="mt-3 grid gap-2 text-xs text-(--ui-text-secondary) md:grid-cols-3">
+        {gate.recommendation && <InfoBlock label="Rekommendation" value={gate.recommendation} />}
+        {gate.scope && <InfoBlock label="Scope" value={gate.scope} />}
+        {gate.default_action && <InfoBlock label="Default" value={gate.default_action} />}
+      </div>
+      <div className="mt-3 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background)/45 p-2 text-xs text-(--ui-text-tertiary)">
+        Gate v1 är ett beslutsunderlag: ett ja betyder bara det scope som står här. Externa writes, secrets, Microsoft/Blikk/mail/NUC/cron kräver fortfarande separat exakt gate.
+      </div>
+      <div className="mt-2 flex flex-wrap gap-2 text-xs text-(--ui-text-tertiary)">
+        {gate.owner && <span>Owner: {gate.owner}</span>}
+        {gate.source && <span>Source: {gate.source}</span>}
+        {gate.updated_at && <span>Updated {niceDate(gate.updated_at)}</span>}
+      </div>
     </article>
+  )
+}
+
+function ImprovementBoard({
+  activeItems,
+  history,
+  loadingKey,
+  onAction,
+  parkedItems,
+  selectedTab,
+  setSelectedTab
+}: {
+  activeItems: CockpitImprovementSuggestion[]
+  history: CockpitImprovementHistory[]
+  loadingKey: string | null
+  onAction: (suggestion: CockpitImprovementSuggestion, action: 'dismiss' | 'park' | 'restore' | 'run') => void
+  parkedItems: CockpitImprovementSuggestion[]
+  selectedTab: 'active' | 'history' | 'parked'
+  setSelectedTab: (tab: 'active' | 'history' | 'parked') => void
+}) {
+  return (
+    <div className="grid gap-3">
+      <div className="flex flex-wrap gap-2">
+        <TabButton active={selectedTab === 'active'} label={`Aktuella (${activeItems.length})`} onClick={() => setSelectedTab('active')} />
+        <TabButton active={selectedTab === 'parked'} label={`Parkerad (${parkedItems.length})`} onClick={() => setSelectedTab('parked')} />
+        <TabButton active={selectedTab === 'history'} label={`Historik (${history.length})`} onClick={() => setSelectedTab('history')} />
+      </div>
+
+      {selectedTab === 'active' ? (
+        <div className="grid gap-4">
+          {improvementLabels.map(label => {
+            const items = activeItems.filter(item => item.classification === label)
+            return (
+              <div className="grid gap-2" key={label}>
+                <h3 className="text-xs font-semibold uppercase tracking-[0.16em] text-(--ui-text-tertiary)">{label}</h3>
+                {items.length ? (
+                  items.map(item => (
+                    <ImprovementCard
+                      item={item}
+                      key={item.id || item.title}
+                      loadingKey={loadingKey}
+                      onAction={onAction}
+                      variant="active"
+                    />
+                  ))
+                ) : (
+                  <EmptyState text={`Inga aktuella förslag under ${label}.`} />
+                )}
+              </div>
+            )
+          })}
+        </div>
+      ) : null}
+
+      {selectedTab === 'parked' ? (
+        parkedItems.length ? (
+          <div className="grid gap-2">
+            {parkedItems.map(item => (
+              <ImprovementCard item={item} key={item.id || item.title} loadingKey={loadingKey} onAction={onAction} variant="parked" />
+            ))}
+          </div>
+        ) : (
+          <EmptyState text="Inga parkerade förslag ännu." />
+        )
+      ) : null}
+
+      {selectedTab === 'history' ? <ImprovementHistoryList history={history} /> : null}
+    </div>
+  )
+}
+
+function TabButton({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      className={cn(
+        'inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium',
+        active
+          ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-100'
+          : 'border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground'
+      )}
+      onClick={onClick}
+      type="button"
+    >
+      {label}
+    </button>
+  )
+}
+
+function ImprovementCard({
+  item,
+  loadingKey,
+  onAction,
+  variant
+}: {
+  item: CockpitImprovementSuggestion
+  loadingKey: string | null
+  onAction: (suggestion: CockpitImprovementSuggestion, action: 'dismiss' | 'park' | 'restore' | 'run') => void
+  variant: 'active' | 'parked'
+}) {
+  const actionBusy = (action: string) => loadingKey === `${item.id}:${action}`
+  const disabled = Boolean(loadingKey)
+
+  return (
+    <article className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-sm font-medium">{item.title || item.id}</h3>
+            <StateBadge state={item.classification} />
+            {item.gate_required ? <StateBadge state="gate" /> : null}
+          </div>
+          <p className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">{item.why}</p>
+        </div>
+        <StateBadge state={item.status || 'active'} />
+      </div>
+      <div className="mt-3 grid gap-2 text-xs text-(--ui-text-secondary) md:grid-cols-3">
+        {item.benefit && <InfoBlock label="Nytta" value={item.benefit} />}
+        {item.risk && <InfoBlock label="Risk" value={item.risk} />}
+        {item.next_step && <InfoBlock label="Nästa steg" value={item.next_step} />}
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <SmallActionButton disabled={disabled} label={actionBusy('run') ? 'Kör…' : 'Kör'} onClick={() => onAction(item, 'run')} />
+        {variant === 'parked' ? (
+          <SmallActionButton disabled={disabled} label={actionBusy('restore') ? 'Tar tillbaka…' : 'Ta tillbaka'} onClick={() => onAction(item, 'restore')} />
+        ) : (
+          <SmallActionButton disabled={disabled} label={actionBusy('park') ? 'Parkerar…' : 'Parkera'} onClick={() => onAction(item, 'park')} />
+        )}
+        <SmallActionButton disabled={disabled} label={actionBusy('dismiss') ? 'Avfärdar…' : 'Avfärda'} onClick={() => onAction(item, 'dismiss')} />
+      </div>
+    </article>
+  )
+}
+
+function InfoBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background)/45 p-2">
+      <div className="text-[0.68rem] uppercase tracking-[0.14em] text-(--ui-text-tertiary)">{label}</div>
+      <div className="mt-1 leading-5">{value}</div>
+    </div>
+  )
+}
+
+function SmallActionButton({ disabled, label, onClick }: { disabled?: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      className="inline-flex h-7 items-center rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-control-background) px-2.5 text-xs font-medium text-(--ui-text-secondary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:cursor-not-allowed disabled:opacity-55"
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+    >
+      {label}
+    </button>
+  )
+}
+
+function ImprovementHistoryList({ history }: { history: CockpitImprovementHistory[] }) {
+  if (!history.length) {
+    return <EmptyState text="Ingen historik ännu. När Tobias kör, parkerar eller avfärdar ett förslag sparas det här så cronjobbet kan undvika dubbletter." />
+  }
+
+  return (
+    <div className="grid gap-2">
+      {history.slice().reverse().slice(0, 20).map(entry => (
+        <article className="rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-control-muted-background) p-3 text-sm" key={entry.id || `${entry.suggestion_id}-${entry.at}`}>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="font-medium">{entry.title || entry.suggestion_id || 'Förslag'}</div>
+            <StateBadge state={improvementActionLabels[entry.action || ''] || entry.action || 'history'} />
+          </div>
+          <div className="mt-1 text-xs leading-5 text-(--ui-text-secondary)">
+            {entry.actor || 'Tobias'} · {entry.classification || 'oklassad'} · {entry.at ? niceDate(entry.at) : 'okänd tid'}
+          </div>
+          {entry.reason ? <div className="mt-1 text-xs text-(--ui-text-tertiary)">Orsak: {entry.reason}</div> : null}
+        </article>
+      ))}
+    </div>
   )
 }
 

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -5,6 +5,7 @@ export const COMMAND_CENTER_ROUTE = '/command-center'
 export const SKILLS_ROUTE = '/skills'
 export const MESSAGING_ROUTE = '/messaging'
 export const ARTIFACTS_ROUTE = '/artifacts'
+export const JARVIS_COCKPIT_ROUTE = '/jarvis'
 export const CRON_ROUTE = '/cron'
 export const PROFILES_ROUTE = '/profiles'
 export const AGENTS_ROUTE = '/agents'
@@ -15,6 +16,7 @@ export type AppView =
   | 'chat'
   | 'command-center'
   | 'cron'
+  | 'jarvis-cockpit'
   | 'messaging'
   | 'profiles'
   | 'settings'
@@ -25,6 +27,7 @@ export type AppRouteId =
   | 'artifacts'
   | 'command-center'
   | 'cron'
+  | 'jarvis-cockpit'
   | 'messaging'
   | 'new'
   | 'profiles'
@@ -44,6 +47,7 @@ export const APP_ROUTES = [
   { id: 'skills', path: SKILLS_ROUTE, view: 'skills' },
   { id: 'messaging', path: MESSAGING_ROUTE, view: 'messaging' },
   { id: 'artifacts', path: ARTIFACTS_ROUTE, view: 'artifacts' },
+  { id: 'jarvis-cockpit', path: JARVIS_COCKPIT_ROUTE, view: 'jarvis-cockpit' },
   { id: 'cron', path: CRON_ROUTE, view: 'cron' },
   { id: 'profiles', path: PROFILES_ROUTE, view: 'profiles' },
   { id: 'agents', path: AGENTS_ROUTE, view: 'agents' }

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -35,6 +35,7 @@ function rawHashLooksLikeSession(): boolean {
   return (
     !hash.startsWith('/settings') &&
     !hash.startsWith('/skills') &&
+    !hash.startsWith('/jarvis') &&
     !hash.startsWith('/messaging') &&
     !hash.startsWith('/artifacts')
   )

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -74,7 +74,14 @@ export type CommandDispatchResponse =
   | SkillCommandDispatchResponse
   | SendCommandDispatchResponse
 
-export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
+export type SidebarNavId =
+  | 'artifacts'
+  | 'command-center'
+  | 'jarvis-cockpit'
+  | 'messaging'
+  | 'new-session'
+  | 'settings'
+  | 'skills'
 
 export interface SidebarNavItem {
   id: SidebarNavId

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1044,6 +1044,7 @@ export const en: Translations = {
     nav: {
       'new-session': 'New session',
       skills: 'Skills & Tools',
+      'jarvis-cockpit': 'Jarvis Cockpit',
       messaging: 'Messaging',
       artifacts: 'Artifacts'
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1231,6 +1231,7 @@ export const zh: Translations = {
     nav: {
       'new-session': '新建会话',
       skills: '技能与工具',
+      'jarvis-cockpit': 'Jarvis 驾驶舱',
       messaging: '消息平台',
       artifacts: '产物'
     },

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3559,6 +3559,73 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+def _persistent_artifact_dir(task_id: str) -> Path:
+    """Persistent directory for kanban completion artifacts for *task_id*."""
+    return kanban_home() / "kanban" / "artifacts" / task_id
+
+
+def _persist_scratch_artifacts(task_id: str, metadata: Optional[dict]) -> Optional[dict]:
+    """Copy artifacts out of ephemeral scratch workspaces before cleanup.
+
+    Workers often pass ``metadata['artifacts']`` via ``kanban_complete`` while
+    the files still live in the task's scratch workspace.  ``complete_task``
+    removes that workspace after completion, so paths in the run row and
+    completed event must be rewritten to durable copies first.
+    """
+    if not isinstance(metadata, dict):
+        return metadata
+    raw = metadata.get("artifacts")
+    if not isinstance(raw, (list, tuple)):
+        return metadata
+
+    artifact_dir: Optional[Path] = None
+    rewritten: list[Any] = []
+    changed = False
+    used_names: set[str] = set()
+
+    for item in raw:
+        if not isinstance(item, str) or not item.strip():
+            rewritten.append(item)
+            continue
+        original = item.strip()
+        src = Path(original).expanduser()
+        try:
+            should_persist = src.is_file() and _is_managed_scratch_path(src)
+        except OSError:
+            should_persist = False
+        if not should_persist:
+            rewritten.append(original)
+            continue
+
+        if artifact_dir is None:
+            artifact_dir = _persistent_artifact_dir(task_id)
+        try:
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            base_name = src.name or "artifact"
+            candidate = artifact_dir / base_name
+            if candidate.name in used_names or (candidate.exists() and candidate.resolve(strict=False) != src.resolve(strict=False)):
+                stem = candidate.stem or "artifact"
+                suffix = candidate.suffix
+                i = 2
+                while True:
+                    candidate = artifact_dir / f"{stem}-{i}{suffix}"
+                    if candidate.name not in used_names and not candidate.exists():
+                        break
+                    i += 1
+            shutil.copy2(src, candidate)
+            used_names.add(candidate.name)
+            rewritten.append(str(candidate))
+            changed = True
+        except OSError:
+            rewritten.append(original)
+
+    if not changed:
+        return metadata
+    updated = dict(metadata)
+    updated["artifacts"] = rewritten
+    return updated
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3660,6 +3727,7 @@ def complete_task(
             )
         if cur.rowcount != 1:
             return False
+        metadata = _persist_scratch_artifacts(task_id, metadata)
         run_id = _end_run(
             conn, task_id,
             outcome="completed", status="done",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -992,14 +992,8 @@ def _jarvis_cockpit_read_gates() -> tuple[list[dict[str, Any]], Dict[str, Any]]:
     return gates, _jarvis_cockpit_source_record("gates", gates_dir, "ok")
 
 
-@app.get("/api/jarvis/cockpit")
-async def get_jarvis_cockpit():
-    """Read-only local Jarvis Cockpit contract for Hermes Desktop.
-
-    This endpoint reads only the narrow Jarvis-Core docs allowlist below. It
-    deliberately does not touch Graph, Blikk, mail, Dispatch databases, auth
-    caches, Keychain, .env, profile config, cron, NUC or backup resources.
-    """
+def _jarvis_cockpit_contract() -> Dict[str, Any]:
+    """Build the read-only local Jarvis Cockpit contract."""
     sources: list[dict[str, Any]] = []
     for source_id, relative_path in _JARVIS_COCKPIT_SAFE_FILES:
         _path, source = _jarvis_cockpit_safe_regular_file(source_id, relative_path)
@@ -1062,6 +1056,110 @@ async def get_jarvis_cockpit():
         "sources": sources,
         "missing": missing_sources,
         "safety": _jarvis_cockpit_safety(),
+    }
+
+
+@app.get("/api/jarvis/cockpit")
+async def get_jarvis_cockpit():
+    """Read-only local Jarvis Cockpit contract for Hermes Desktop.
+
+    This endpoint reads only the narrow Jarvis-Core docs allowlist below. It
+    deliberately does not touch Graph, Blikk, mail, Dispatch databases, auth
+    caches, Keychain, .env, profile config, cron, NUC or backup resources.
+    """
+    return _jarvis_cockpit_contract()
+
+
+def _jarvis_cockpit_report_safety() -> Dict[str, bool]:
+    """Safety receipt for local-only Cockpit report generation."""
+    return {
+        "local_only": True,
+        "read_only_sources": True,
+        "external_writes": False,
+        "microsoft_writes": False,
+        "blikk_writes": False,
+        "mail_mutation": False,
+        "secrets_read": False,
+        "cron_changed": False,
+    }
+
+
+def _jarvis_cockpit_report_dir() -> Path:
+    return _JARVIS_COCKPIT_DOCS_ROOT / "runbooks" / "jarvis-cockpit-reports"
+
+
+def _jarvis_cockpit_write_local_report(contract: Dict[str, Any]) -> Path:
+    """Write a local-only markdown receipt from the read-only Cockpit contract."""
+    report_dir = _jarvis_cockpit_report_dir()
+    if report_dir.exists() and report_dir.is_symlink():
+        raise HTTPException(status_code=400, detail="Jarvis Cockpit report directory is not safe")
+    report_dir.mkdir(parents=True, exist_ok=True)
+    if not report_dir.is_dir() or report_dir.is_symlink():
+        raise HTTPException(status_code=400, detail="Jarvis Cockpit report directory is not safe")
+
+    now = datetime.now(timezone.utc)
+    filename = f"jarvis-cockpit-local-report-{now.strftime('%Y%m%dT%H%M%SZ')}.md"
+    path = report_dir / filename
+    if path.exists() or path.is_symlink():
+        filename = f"jarvis-cockpit-local-report-{now.strftime('%Y%m%dT%H%M%SZ')}-{secrets.token_hex(3)}.md"
+        path = report_dir / filename
+
+    raw_todo_items = contract.get("jarvis_todo")
+    raw_gates = contract.get("gates")
+    raw_missing = contract.get("missing")
+    todo_items: list[dict[str, Any]] = [item for item in raw_todo_items if isinstance(item, dict)] if isinstance(raw_todo_items, list) else []
+    gates: list[dict[str, Any]] = [gate for gate in raw_gates if isinstance(gate, dict)] if isinstance(raw_gates, list) else []
+    missing: list[dict[str, Any]] = [source for source in raw_missing if isinstance(source, dict)] if isinstance(raw_missing, list) else []
+    safety = _jarvis_cockpit_report_safety()
+    todo_lines = [f"- {item.get('id', item.get('title', 'untitled'))}: {item.get('title', item.get('status', ''))}" for item in todo_items[:10]]
+    missing_lines = [f"- {source.get('id', 'unknown')}: {source.get('reason', source.get('state', 'missing'))}" for source in missing[:10]]
+    content = "\n".join([
+        "# Jarvis Cockpit Local Report",
+        "",
+        f"Generated: {now.isoformat()}",
+        "Status: LOCAL ONLY",
+        "",
+        "## Snapshot",
+        "",
+        f"- Cockpit status: {contract.get('status', 'unknown')}",
+        f"- Jarvis To Do items: {len(todo_items)}",
+        f"- Gates returned: {len(gates)}",
+        f"- Missing sources: {len(missing)}",
+        "",
+        "## Jarvis To Do",
+        "",
+        *(todo_lines or ["- No local Jarvis action items returned."]),
+        "",
+        "## Missing sources",
+        "",
+        *(missing_lines or ["- None reported."]),
+        "",
+        "## Safety receipt",
+        "",
+        f"- Local only: {'YES' if safety['local_only'] else 'NO'}",
+        f"- External writes: {'YES' if safety['external_writes'] else 'NO'}",
+        f"- Microsoft writes: {'YES' if safety['microsoft_writes'] else 'NO'}",
+        f"- Blikk writes: {'YES' if safety['blikk_writes'] else 'NO'}",
+        f"- Mail mutation: {'YES' if safety['mail_mutation'] else 'NO'}",
+        f"- Secrets read: {'YES' if safety['secrets_read'] else 'NO'}",
+        f"- Cron changed: {'YES' if safety['cron_changed'] else 'NO'}",
+        "",
+    ])
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+@app.post("/api/jarvis/cockpit/local-report")
+async def post_jarvis_cockpit_local_report():
+    """Generate a local-only markdown receipt from the read-only Cockpit contract."""
+    contract = _jarvis_cockpit_contract()
+    report_path = _jarvis_cockpit_write_local_report(contract)
+    return {
+        "status": "ok",
+        "action": "jarvis-cockpit-local-report",
+        "report_path": str(report_path),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "safety": _jarvis_cockpit_report_safety(),
     }
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -873,6 +873,34 @@ _JARVIS_COCKPIT_SAFE_FILES: tuple[tuple[str, str], ...] = (
 )
 _JARVIS_COCKPIT_TODO_RELATIVE_PATH = Path("runbooks/jarvis-todo/jarvis-actions.json")
 _JARVIS_COCKPIT_GATES_RELATIVE_DIR = Path("runbooks/gates")
+_JARVIS_COCKPIT_IMPROVEMENTS_RELATIVE_PATH = Path("runbooks/jarvis-cockpit-improvements.json")
+_JARVIS_COCKPIT_GRAPHIFY_RELATIVE_PATH = Path("runbooks/jarvis-cockpit-graphify/latest.json")
+_JARVIS_COCKPIT_GRAPHIFY_NOTES_RELATIVE_DIR = Path("runbooks/jarvis-cockpit-graphify/notes")
+_JARVIS_COCKPIT_IMPROVEMENT_ACTIONS = {"run", "park", "dismiss", "restore"}
+
+
+class JarvisCockpitImprovementActionRequest(BaseModel):
+    suggestion_id: str
+    action: str
+    actor: Optional[str] = None
+    reason: Optional[str] = None
+
+
+class JarvisCockpitGraphifyQueryRequest(BaseModel):
+    mode: str
+    question: Optional[str] = None
+    source: Optional[str] = None
+    target: Optional[str] = None
+    node: Optional[str] = None
+    budget: Optional[int] = None
+    depth: Optional[int] = None
+
+
+class JarvisCockpitGraphifyNoteRequest(BaseModel):
+    title: Optional[str] = None
+    mode: Optional[str] = None
+    output: str
+    question: Optional[str] = None
 
 
 def _jarvis_cockpit_safety() -> Dict[str, bool]:
@@ -966,6 +994,502 @@ def _jarvis_cockpit_safe_artifacts(raw_artifacts: Any) -> list[dict[str, Any]]:
     return artifacts
 
 
+
+def _jarvis_cockpit_default_improvements() -> dict[str, Any]:
+    """Default local improvement board seed used when the docs file is absent."""
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "version": 1,
+        "updated_at": now,
+        "rules": {
+            "labels": ["Bygg nu", "Förbered", "Utforska"],
+            "tabs": ["Aktuella", "Parkerad", "Historik"],
+            "cron_history_rule": "Read history before proposing new items; avoid dismissed, parked or completed repeats unless there is a new reason.",
+            "local_only": True,
+            "external_writes_allowed": False,
+        },
+        "suggestions": [
+            {
+                "id": "hermes-status-health",
+                "title": "Hermes-status / Jarvis hälsa",
+                "classification": "Bygg nu",
+                "status": "active",
+                "why": "Cockpit ska visa om Jarvis/Hermes-miljön verkar frisk inifrån Desktop.",
+                "benefit": "Tobias ser snabbt profil, gateway, senaste fel och stale-status utan teknisk letning.",
+                "risk": "Låg — lokal statusvy och inga externa writes.",
+                "next_step": "Visa Hermes/Jarvis-hälsa i Cockpit med tydlig OK/varning/status-copy.",
+                "owner": "Jarvis",
+                "gate_required": False,
+                "created_at": now,
+                "source": "jarvis-cockpit-session-2026-06-07",
+            },
+            {
+                "id": "cockpit-gates-decisions",
+                "title": "Gates / Beslut",
+                "classification": "Bygg nu",
+                "status": "active",
+                "why": "Cockpit ska samla beslut som kräver Tobias godkännande, parkering eller nej.",
+                "benefit": "Minskar lösa beslut i chattar och gör risk/konsekvens synlig.",
+                "risk": "Låg — lokala gate-pointers, inga live-mutationer.",
+                "next_step": "Gör gates-listan mer beslutsorienterad med rekommendation och säkra knappar.",
+                "owner": "Jarvis",
+                "gate_required": False,
+                "created_at": now,
+                "source": "jarvis-cockpit-session-2026-06-07",
+            },
+            {
+                "id": "cockpit-improvements-history",
+                "title": "Förbättringar med Historik",
+                "classification": "Bygg nu",
+                "status": "active",
+                "why": "Förslag ska kunna köras, parkeras eller avfärdas och historiken ska hindra upprepningar.",
+                "benefit": "Cockpit blir en konkret förbättringsmotor istället för ännu en dashboard.",
+                "risk": "Låg — lokal JSON och lokala UI-kvitton.",
+                "next_step": "Bygg Aktuella/Parkerad/Historik med Kör, Parkera och Avfärda.",
+                "owner": "Jarvis",
+                "gate_required": False,
+                "created_at": now,
+                "source": "jarvis-cockpit-session-2026-06-07",
+            },
+            {
+                "id": "cron-improvement-engine",
+                "title": "Styr om nattligt cronjobb till förbättringsmotor",
+                "classification": "Förbered",
+                "status": "active",
+                "why": "Cronjobbet ska föreslå eller förbereda förbättringar, inte skapa nya boards i onödan.",
+                "benefit": "Färre dubbletter och bättre förslag kopplade till Tobias faktiska beslut.",
+                "risk": "Medel — själva cronändringen är automation och ska göras som separat, tydligt scoped steg.",
+                "next_step": "Skriv ny prompt som läser Cockpit-historiken innan nya förslag skapas.",
+                "owner": "Jarvis",
+                "gate_required": True,
+                "created_at": now,
+                "source": "jarvis-cockpit-session-2026-06-07",
+            },
+            {
+                "id": "advanced-health-signals",
+                "title": "Avancerad intern hälsa över tid",
+                "classification": "Utforska",
+                "status": "active",
+                "why": "Det kan bli värdefullt att se tool failures, modell-latens och memory/source-map drift över tid.",
+                "benefit": "Kan ge tidigare varning när Jarvis kvalitet eller drift börjar glida.",
+                "risk": "Oklart värde och kan skapa brus om det byggs för tidigt.",
+                "next_step": "Gör en read-only feasibility/spike senare om grund-Cockpit används.",
+                "owner": "Jarvis",
+                "gate_required": False,
+                "created_at": now,
+                "source": "jarvis-cockpit-session-2026-06-07",
+            },
+        ],
+        "history": [],
+    }
+
+
+def _jarvis_cockpit_improvements_path() -> Path:
+    return _JARVIS_COCKPIT_DOCS_ROOT / _JARVIS_COCKPIT_IMPROVEMENTS_RELATIVE_PATH
+
+
+def _jarvis_cockpit_improvement_source(path: Path, state: str, *, reason: str | None = None) -> Dict[str, Any]:
+    return _jarvis_cockpit_source_record("jarvis-cockpit-improvements", path, state, reason=reason)
+
+
+def _jarvis_cockpit_read_improvements() -> tuple[dict[str, Any], Dict[str, Any]]:
+    path = _jarvis_cockpit_improvements_path()
+    try:
+        stat_result = path.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return _jarvis_cockpit_default_improvements(), _jarvis_cockpit_improvement_source(path, "missing", reason="using_default_seed")
+    except OSError:
+        return _jarvis_cockpit_default_improvements(), _jarvis_cockpit_improvement_source(path, "missing", reason="not_a_safe_regular_file")
+    if stat.S_ISLNK(stat_result.st_mode) or not stat.S_ISREG(stat_result.st_mode):
+        return _jarvis_cockpit_default_improvements(), _jarvis_cockpit_improvement_source(path, "missing", reason="not_a_safe_regular_file")
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return _jarvis_cockpit_default_improvements(), _jarvis_cockpit_improvement_source(path, "error", reason="json_parse_failed")
+    if not isinstance(data, dict):
+        return _jarvis_cockpit_default_improvements(), _jarvis_cockpit_improvement_source(path, "error", reason="json_root_not_object")
+    data.setdefault("version", 1)
+    data.setdefault("rules", _jarvis_cockpit_default_improvements()["rules"])
+    if not isinstance(data.get("suggestions"), list):
+        data["suggestions"] = []
+    if not isinstance(data.get("history"), list):
+        data["history"] = []
+    if not isinstance(data.get("updated_at"), str):
+        data["updated_at"] = datetime.now(timezone.utc).isoformat()
+    return data, _jarvis_cockpit_improvement_source(path, "ok")
+
+
+def _jarvis_cockpit_write_improvements(data: dict[str, Any]) -> Path:
+    path = _jarvis_cockpit_improvements_path()
+    root = _JARVIS_COCKPIT_DOCS_ROOT.resolve()
+    target_parent = path.parent
+    target_parent.mkdir(parents=True, exist_ok=True)
+    if target_parent.is_symlink() or not target_parent.is_dir():
+        raise HTTPException(status_code=400, detail="Jarvis Cockpit improvements directory is not safe")
+    resolved_parent = target_parent.resolve()
+    if root not in (resolved_parent, *resolved_parent.parents):
+        raise HTTPException(status_code=400, detail="Jarvis Cockpit improvements path is outside docs root")
+    if path.exists() and (path.is_symlink() or not path.is_file()):
+        raise HTTPException(status_code=400, detail="Jarvis Cockpit improvements file is not safe")
+    data["updated_at"] = datetime.now(timezone.utc).isoformat()
+    tmp_path = target_parent / f".{path.name}.{secrets.token_hex(6)}.tmp"
+    tmp_path.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
+    return path
+
+
+def _jarvis_cockpit_apply_improvement_action(request: JarvisCockpitImprovementActionRequest) -> dict[str, Any]:
+    action = request.action.strip().lower()
+    if action not in _JARVIS_COCKPIT_IMPROVEMENT_ACTIONS:
+        raise HTTPException(status_code=400, detail="Unsupported improvement action")
+    suggestion_id = request.suggestion_id.strip()
+    if not suggestion_id:
+        raise HTTPException(status_code=400, detail="Missing suggestion_id")
+    data, _source = _jarvis_cockpit_read_improvements()
+    suggestions = [item for item in data.get("suggestions", []) if isinstance(item, dict)]
+    suggestion = next((item for item in suggestions if item.get("id") == suggestion_id), None)
+    if suggestion is None:
+        raise HTTPException(status_code=404, detail="Improvement suggestion not found")
+    next_status = {
+        "run": "running",
+        "park": "parked",
+        "dismiss": "dismissed",
+        "restore": "active",
+    }[action]
+    now = datetime.now(timezone.utc).isoformat()
+    suggestion["status"] = next_status
+    suggestion["updated_at"] = now
+    if action == "run":
+        suggestion["last_run_at"] = now
+    elif action == "park":
+        suggestion["parked_at"] = now
+    elif action == "dismiss":
+        suggestion["dismissed_at"] = now
+    elif action == "restore":
+        suggestion["restored_at"] = now
+    history = [item for item in data.get("history", []) if isinstance(item, dict)]
+    history.append({
+        "id": f"hist-{now.replace(':', '').replace('+', 'Z')}-{secrets.token_hex(3)}",
+        "suggestion_id": suggestion_id,
+        "title": suggestion.get("title"),
+        "action": action,
+        "status_after": next_status,
+        "classification": suggestion.get("classification"),
+        "actor": request.actor or "Tobias",
+        "reason": request.reason,
+        "at": now,
+        "cron_repeat_guard": action in {"park", "dismiss", "run"},
+    })
+    data["suggestions"] = suggestions
+    data["history"] = history
+    written_path = _jarvis_cockpit_write_improvements(data)
+    return {
+        "status": "ok",
+        "action": action,
+        "suggestion_id": suggestion_id,
+        "improvements_path": str(written_path),
+        "updated_at": data["updated_at"],
+        "safety": {
+            "local_only": True,
+            "external_writes": False,
+            "microsoft_writes": False,
+            "blikk_writes": False,
+            "mail_mutation": False,
+            "secrets_read": False,
+            "cron_changed": False,
+        },
+        "improvements": data,
+    }
+
+
+def _jarvis_cockpit_read_graphify_lane() -> tuple[dict[str, Any], Dict[str, Any]]:
+    """Read the local Graphify lane manifest without running Graphify or touching the network."""
+    data, source = _jarvis_cockpit_read_json_source("jarvis-cockpit-graphify", _JARVIS_COCKPIT_GRAPHIFY_RELATIVE_PATH)
+    if data is None:
+        return {"status": "missing", "state": source.get("state", "missing")}, source
+
+    raw_safety = data.get("safety")
+    safety: dict[str, Any] = raw_safety if isinstance(raw_safety, dict) else {}
+    safe = (
+        safety.get("local_only") is True
+        and safety.get("structural_only") is True
+        and safety.get("external_writes") is False
+        and safety.get("semantic_llm") is False
+        and safety.get("hooks") is False
+        and safety.get("mcp") is False
+        and safety.get("watch") is False
+        and safety.get("secrets_found") is False
+    )
+    notes_dir = (_JARVIS_COCKPIT_DOCS_ROOT / _JARVIS_COCKPIT_GRAPHIFY_NOTES_RELATIVE_DIR).resolve()
+    latest_note = _jarvis_cockpit_latest_graphify_note(notes_dir)
+    lane = {
+        "status": data.get("status", "ok" if safe else "attention"),
+        "state": "ok" if safe and source.get("state") == "ok" else "attention",
+        "scope": data.get("scope"),
+        "command": data.get("command"),
+        "nodes": data.get("nodes"),
+        "edges": data.get("edges"),
+        "communities": data.get("communities"),
+        "token_reduction": data.get("token_reduction"),
+        "updated_at": data.get("updated_at"),
+        "report_path": data.get("report_path"),
+        "html_path": data.get("html_path"),
+        "graph_path": data.get("graph_path"),
+        "notes_dir": str(notes_dir),
+        "latest_note_path": latest_note.get("path"),
+        "latest_note_title": latest_note.get("title"),
+        "latest_note_updated_at": latest_note.get("updated_at"),
+        "safety": {
+            "local_only": safety.get("local_only") is True,
+            "structural_only": safety.get("structural_only") is True,
+            "external_writes": safety.get("external_writes") is True,
+            "semantic_llm": safety.get("semantic_llm") is True,
+            "hooks": safety.get("hooks") is True,
+            "mcp": safety.get("mcp") is True,
+            "watch": safety.get("watch") is True,
+            "secrets_found": safety.get("secrets_found") is True,
+        },
+    }
+    return {key: value for key, value in lane.items() if value is not None}, source
+
+
+def _jarvis_cockpit_latest_graphify_note(notes_dir: Path) -> dict[str, str]:
+    """Return latest local Graphify note metadata without creating files or following symlinks."""
+    root = _JARVIS_COCKPIT_DOCS_ROOT.resolve()
+    try:
+        resolved_dir = notes_dir.resolve()
+    except OSError:
+        return {}
+    if root not in (resolved_dir, *resolved_dir.parents):
+        return {}
+    if not notes_dir.exists() or notes_dir.is_symlink() or not notes_dir.is_dir():
+        return {}
+
+    candidates: list[Path] = []
+    for candidate in notes_dir.glob("*.md"):
+        try:
+            if candidate.is_file() and not candidate.is_symlink():
+                candidates.append(candidate)
+        except OSError:
+            continue
+    if not candidates:
+        return {}
+    latest = max(candidates, key=lambda path: path.stat().st_mtime)
+    try:
+        first_line = latest.read_text(encoding="utf-8", errors="replace").splitlines()[0]
+    except (OSError, IndexError):
+        first_line = latest.stem
+    title = first_line.removeprefix("# ").strip() or latest.stem
+    return {
+        "path": str(latest),
+        "title": title[:120],
+        "updated_at": datetime.fromtimestamp(latest.stat().st_mtime, timezone.utc).isoformat(),
+    }
+
+
+def _jarvis_cockpit_graphify_safe_graph_path(graphify: dict[str, Any]) -> Path:
+    raw_safety = graphify.get("safety")
+    safety: dict[str, Any] = raw_safety if isinstance(raw_safety, dict) else {}
+    safe = (
+        graphify.get("state") == "ok"
+        and safety.get("local_only") is True
+        and safety.get("structural_only") is True
+        and safety.get("external_writes") is False
+        and safety.get("semantic_llm") is False
+        and safety.get("hooks") is False
+        and safety.get("mcp") is False
+        and safety.get("watch") is False
+        and safety.get("secrets_found") is False
+    )
+    if not safe:
+        raise HTTPException(status_code=400, detail="Graphify lane is not safe for local query helpers")
+    raw_graph_path = graphify.get("graph_path")
+    if not isinstance(raw_graph_path, str) or not raw_graph_path:
+        raise HTTPException(status_code=400, detail="Graphify graph path is missing")
+    graph_path = Path(raw_graph_path).expanduser().resolve()
+    root = (_JARVIS_COCKPIT_DOCS_ROOT / "runbooks" / "jarvis-cockpit-graphify").resolve()
+    if root not in (graph_path.parent, *graph_path.parents):
+        raise HTTPException(status_code=400, detail="Graphify graph path is outside the approved Cockpit artifact directory")
+    if not graph_path.is_file() or graph_path.is_symlink() or graph_path.suffix != ".json":
+        raise HTTPException(status_code=400, detail="Graphify graph path is not a safe local JSON file")
+    return graph_path
+
+
+def _jarvis_cockpit_graphify_text(value: str | None, *, field: str, max_len: int = 200) -> str:
+    text = (value or "").strip()
+    if not text:
+        raise HTTPException(status_code=400, detail=f"Missing Graphify {field}")
+    if len(text) > max_len:
+        raise HTTPException(status_code=400, detail=f"Graphify {field} is too long")
+    if "\x00" in text or "\n" in text or "\r" in text:
+        raise HTTPException(status_code=400, detail=f"Graphify {field} contains unsupported control characters")
+    return text
+
+
+def _jarvis_cockpit_run_graphify_query(request: JarvisCockpitGraphifyQueryRequest) -> dict[str, Any]:
+    graphify, _source = _jarvis_cockpit_read_graphify_lane()
+    graph_path = _jarvis_cockpit_graphify_safe_graph_path(graphify)
+    mode = request.mode.strip().lower()
+    cmd = ["uvx", "--from", "graphifyy", "graphify"]
+    if mode == "query":
+        question = _jarvis_cockpit_graphify_text(request.question, field="question", max_len=300)
+        budget = max(200, min(int(request.budget or 1200), 3000))
+        cmd += ["query", question, "--budget", str(budget), "--graph", str(graph_path)]
+    elif mode == "path":
+        source = _jarvis_cockpit_graphify_text(request.source, field="source")
+        target = _jarvis_cockpit_graphify_text(request.target, field="target")
+        cmd += ["path", source, target, "--graph", str(graph_path)]
+    elif mode == "affected":
+        node = _jarvis_cockpit_graphify_text(request.node or request.question, field="node")
+        depth = max(1, min(int(request.depth or 2), 4))
+        cmd += ["affected", node, "--depth", str(depth), "--graph", str(graph_path)]
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported Graphify query mode")
+
+    env = os.environ.copy()
+    for key in (
+        "GEMINI_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+        "DEEPSEEK_API_KEY", "KIMI_API_KEY", "MOONSHOT_API_KEY", "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+    ):
+        env.pop(key, None)
+    env["GRAPHIFY_QUERY_LOG_DISABLE"] = "1"
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=str(graph_path.parent),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            shell=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise HTTPException(status_code=504, detail="Graphify query timed out") from exc
+    output = (completed.stdout or "").strip()
+    error_output = (completed.stderr or "").strip()
+    if completed.returncode != 0:
+        raise HTTPException(status_code=400, detail=(error_output or output or "Graphify query failed")[:2000])
+    return {
+        "status": "ok",
+        "mode": mode,
+        "output": output[:8000],
+        "stderr": error_output[:2000],
+        "graph_path": str(graph_path),
+        "safety": {
+            "local_only": True,
+            "structural_only": True,
+            "external_writes": False,
+            "semantic_llm": False,
+            "hooks": False,
+            "mcp": False,
+            "watch": False,
+            "query_log": False,
+        },
+    }
+
+
+def _jarvis_cockpit_graphify_note_slug(value: str | None) -> str:
+    base = (value or "graphify-insight").strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", base).strip("-")
+    return (slug or "graphify-insight")[:64].strip("-") or "graphify-insight"
+
+
+def _jarvis_cockpit_write_graphify_note(request: JarvisCockpitGraphifyNoteRequest) -> dict[str, Any]:
+    output = (request.output or "").strip()
+    if not output:
+        raise HTTPException(status_code=400, detail="Missing Graphify note output")
+    if len(output) > 12000:
+        raise HTTPException(status_code=400, detail="Graphify note output is too long")
+    title = _jarvis_cockpit_graphify_text(request.title or "Graphify insight", field="note title", max_len=120)
+    mode = (request.mode or "query").strip().lower()
+    if mode not in {"query", "path", "affected"}:
+        raise HTTPException(status_code=400, detail="Unsupported Graphify note mode")
+
+    root = _JARVIS_COCKPIT_DOCS_ROOT.resolve()
+    notes_dir = _JARVIS_COCKPIT_DOCS_ROOT / _JARVIS_COCKPIT_GRAPHIFY_NOTES_RELATIVE_DIR
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    if notes_dir.is_symlink() or not notes_dir.is_dir():
+        raise HTTPException(status_code=400, detail="Graphify notes directory is not safe")
+    resolved_dir = notes_dir.resolve()
+    if root not in (resolved_dir, *resolved_dir.parents):
+        raise HTTPException(status_code=400, detail="Graphify notes path is outside docs root")
+
+    now = datetime.now(timezone.utc)
+    slug = _jarvis_cockpit_graphify_note_slug(title)
+    note_path = notes_dir / f"{now.strftime('%Y%m%d-%H%M%S')}-{slug}.md"
+    if note_path.exists() or note_path.is_symlink():
+        raise HTTPException(status_code=400, detail="Graphify note path is not safe")
+    question = (request.question or "").strip()
+    body = [
+        f"# {title}",
+        "",
+        f"- Created: {now.isoformat()}",
+        f"- Mode: {mode}",
+        "- Source: Jarvis Cockpit Graphify local helper",
+        "- Safety: local-only note; no external writes; Graphify query log off",
+    ]
+    if question:
+        body.append(f"- Query: {question[:300]}")
+    body.extend(["", "## Result", "", "```text", output[:12000], "```", ""])
+    tmp_path = notes_dir / f".{note_path.name}.{secrets.token_hex(6)}.tmp"
+    tmp_path.write_text("\n".join(body), encoding="utf-8")
+    tmp_path.replace(note_path)
+    return {
+        "status": "ok",
+        "action": "jarvis-cockpit-graphify-note",
+        "note_path": str(note_path),
+        "note_title": title,
+        "notes_dir": str(notes_dir.resolve()),
+        "updated_at": now.isoformat(),
+        "safety": {
+            "local_only": True,
+            "external_writes": False,
+            "microsoft_writes": False,
+            "blikk_writes": False,
+            "mail_mutation": False,
+            "secrets_read": False,
+            "cron_changed": False,
+        },
+    }
+
+
+def _jarvis_cockpit_graphify_card(graphify: dict[str, Any], updated_at: str) -> dict[str, Any]:
+    state = graphify.get("state", "missing")
+    actions: list[dict[str, Any]] = []
+    html_path = graphify.get("html_path")
+    report_path = graphify.get("report_path")
+    if state == "ok" and isinstance(html_path, str) and html_path:
+        actions.append({"label": "Open Graphify HTML", "type": "open-url", "target": html_path, "external_write": False})
+    if state == "ok" and isinstance(report_path, str) and report_path:
+        actions.append({"label": "Open Graphify report", "type": "open-url", "target": report_path, "external_write": False})
+
+    if state == "ok":
+        summary = f"{graphify.get('nodes', 0)} nodes / {graphify.get('edges', 0)} edges for {graphify.get('scope', 'local project graph')}."
+    elif state == "missing":
+        summary = "No local Graphify manifest yet; run a structural-only graph to populate this lane."
+    else:
+        summary = "Graphify manifest exists but safety receipt needs attention."
+
+    details = [
+        f"Scope: {graphify.get('scope', 'not set')}",
+        f"Token reduction: {graphify.get('token_reduction', 'not measured')}",
+        "Policy: local structural graph only; semantic LLM, hooks, MCP and watch remain gated.",
+    ]
+    return {
+        "id": "graphify-lane",
+        "title": "Graphify project graph",
+        "kind": "system",
+        "state": state,
+        "summary": summary,
+        "details": details,
+        "source": str(_JARVIS_COCKPIT_GRAPHIFY_RELATIVE_PATH),
+        "updated_at": graphify.get("updated_at", updated_at),
+        "actions": actions,
+    }
+
+
 def _jarvis_cockpit_read_gates() -> tuple[list[dict[str, Any]], Dict[str, Any]]:
     gates_dir = _JARVIS_COCKPIT_DOCS_ROOT / _JARVIS_COCKPIT_GATES_RELATIVE_DIR
     try:
@@ -1002,6 +1526,10 @@ def _jarvis_cockpit_contract() -> Dict[str, Any]:
     sources.append(todo_source)
     gates, gates_source = _jarvis_cockpit_read_gates()
     sources.append(gates_source)
+    improvements, improvements_source = _jarvis_cockpit_read_improvements()
+    sources.append(improvements_source)
+    graphify, graphify_source = _jarvis_cockpit_read_graphify_lane()
+    sources.append(graphify_source)
 
     jarvis_todo: list[dict[str, Any]] = []
     artifacts: list[dict[str, Any]] = []
@@ -1016,8 +1544,20 @@ def _jarvis_cockpit_contract() -> Dict[str, Any]:
 
     todo_by_status = _jarvis_cockpit_count_by(jarvis_todo, "status")
     waiting_gates = [gate for gate in gates if gate.get("status") == "waiting"]
+    improvement_suggestions = [item for item in improvements.get("suggestions", []) if isinstance(item, dict)]
+    improvement_history = [item for item in improvements.get("history", []) if isinstance(item, dict)]
+    active_improvements = [item for item in improvement_suggestions if item.get("status", "active") in {"active", "running"}]
+    parked_improvements = [item for item in improvement_suggestions if item.get("status") == "parked"]
     missing_sources = [source for source in sources if source.get("state") == "missing"]
+    error_sources = [source for source in sources if source.get("state") == "error"]
+    health_state = "error" if error_sources else ("attention" if missing_sources or waiting_gates else "ok")
     status_cards = [
+        {
+            "id": "hermes-jarvis-health", "title": "Hermes / Jarvis hälsa", "kind": "system", "state": health_state,
+            "summary": "Lokal trafikljusstatus beräknad från Cockpit-källor, gates och safety receipt.",
+            "details": [f"Missing sources: {len(missing_sources)}", f"Waiting gates: {len(waiting_gates)}", "Desktop-status mäts inte här eftersom Cockpit visas inifrån Desktop."],
+            "source": "api/jarvis/cockpit", "updated_at": updated_at, "actions": [],
+        },
         {
             "id": "safety-boundary", "title": "Safety boundary", "kind": "safety", "state": "ok",
             "summary": "Read-only local Jarvis docs only; no live writes, secrets, Microsoft Graph, Blikk, mail or Dispatch embedding.",
@@ -1039,6 +1579,17 @@ def _jarvis_cockpit_contract() -> Dict[str, Any]:
             "source": str(_JARVIS_COCKPIT_GATES_RELATIVE_DIR), "updated_at": updated_at, "actions": [],
         },
         {
+            "id": "improvements", "title": "Förbättringar", "kind": "system",
+            "state": "ok" if improvements_source.get("state") in {"ok", "missing"} else "attention",
+            "summary": f"{len(active_improvements)} aktuella, {len(parked_improvements)} parkerade, {len(improvement_history)} historikhändelser.",
+            "details": [
+                "Rubriker: Bygg nu, Förbered, Utforska.",
+                "Historik används som spärr mot upprepade cronförslag.",
+            ],
+            "source": str(_JARVIS_COCKPIT_IMPROVEMENTS_RELATIVE_PATH), "updated_at": improvements.get("updated_at", updated_at), "actions": [],
+        },
+        _jarvis_cockpit_graphify_card(graphify, updated_at),
+        {
             "id": "dispatch-link", "title": "Open Dispatch Dashboard", "kind": "dispatch-link", "state": "ok",
             "summary": "Dispatch stays outside Jarvis Cockpit and is available as a link only.",
             "details": [], "source": "dispatch-boundary", "updated_at": updated_at,
@@ -1051,6 +1602,8 @@ def _jarvis_cockpit_contract() -> Dict[str, Any]:
         "dispatch_boundary": {"dispatch_embedded": False, "dispatch_url": _JARVIS_COCKPIT_DISPATCH_URL, "rule": "Dispatch stays in real Dispatch Dashboard"},
         "jarvis_todo": jarvis_todo,
         "gates": gates,
+        "improvements": improvements,
+        "graphify": graphify,
         "status_cards": status_cards,
         "artifacts": artifacts,
         "sources": sources,
@@ -1068,6 +1621,24 @@ async def get_jarvis_cockpit():
     caches, Keychain, .env, profile config, cron, NUC or backup resources.
     """
     return _jarvis_cockpit_contract()
+
+
+@app.post("/api/jarvis/cockpit/improvements/action")
+async def post_jarvis_cockpit_improvement_action(request: JarvisCockpitImprovementActionRequest):
+    """Apply a local-only Cockpit improvement board action and append history."""
+    return _jarvis_cockpit_apply_improvement_action(request)
+
+
+@app.post("/api/jarvis/cockpit/graphify/query")
+async def post_jarvis_cockpit_graphify_query(request: JarvisCockpitGraphifyQueryRequest):
+    """Run local-only Graphify query helpers against the approved Cockpit graph artifact."""
+    return _jarvis_cockpit_run_graphify_query(request)
+
+
+@app.post("/api/jarvis/cockpit/graphify/note")
+async def post_jarvis_cockpit_graphify_note(request: JarvisCockpitGraphifyNoteRequest):
+    """Persist one local-only Graphify insight note under the approved Cockpit notes directory."""
+    return _jarvis_cockpit_write_graphify_note(request)
 
 
 def _jarvis_cockpit_report_safety() -> Dict[str, bool]:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -862,6 +862,207 @@ async def get_media(path: str):
 
     encoded = base64.b64encode(target.read_bytes()).decode("ascii")
     return {"data_url": f"data:{_MEDIA_CONTENT_TYPES[target.suffix.lower()]};base64,{encoded}"}
+_JARVIS_COCKPIT_DOCS_ROOT = Path("/Users/tobias/Company/Jarvis-Core/docs")
+_JARVIS_COCKPIT_DISPATCH_URL = "http://127.0.0.1:3001"
+_JARVIS_COCKPIT_SAFE_FILES: tuple[tuple[str, str], ...] = (
+    ("jarvis-system-current-state", "source-map/jarvis-system-current-state.md"),
+    ("personas-dashboards-source-map", "source-map/personas-dashboards-source-map.md"),
+    ("next-recommendation-guard", "runbooks/next-recommendation-guard.md"),
+    ("hermes-desktop-pinned-session-routing", "runbooks/hermes-desktop-pinned-session-routing.md"),
+    ("alfred-dispatch-operator-pack", "runbooks/alfred-dispatch-operator-pack.md"),
+)
+_JARVIS_COCKPIT_TODO_RELATIVE_PATH = Path("runbooks/jarvis-todo/jarvis-actions.json")
+_JARVIS_COCKPIT_GATES_RELATIVE_DIR = Path("runbooks/gates")
+
+
+def _jarvis_cockpit_safety() -> Dict[str, bool]:
+    """Hard-coded safety contract for the read-only Jarvis Cockpit endpoint."""
+    return {
+        "read_only": True,
+        "microsoft_writes": False,
+        "blikk_writes": False,
+        "mail_mutation": False,
+        "secrets_read": False,
+        "dispatch_embedded": False,
+    }
+
+
+def _jarvis_cockpit_source_record(source_id: str, path: Path, state: str, *, reason: str | None = None) -> Dict[str, Any]:
+    record: Dict[str, Any] = {"id": source_id, "path": str(path), "state": state}
+    if reason:
+        record["reason"] = reason
+    try:
+        stat_result = path.stat(follow_symlinks=False)
+        if state == "ok":
+            record["size_bytes"] = stat_result.st_size
+            record["updated_at"] = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc).isoformat()
+    except OSError:
+        pass
+    return record
+
+
+def _jarvis_cockpit_safe_regular_file(source_id: str, relative_path: Path | str) -> tuple[Path, Dict[str, Any]]:
+    """Return a whitelisted docs path plus source status without following symlinks."""
+    path = _JARVIS_COCKPIT_DOCS_ROOT / relative_path
+    try:
+        stat_result = path.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return path, _jarvis_cockpit_source_record(source_id, path, "missing", reason="missing")
+    except OSError:
+        return path, _jarvis_cockpit_source_record(source_id, path, "missing", reason="not_a_safe_regular_file")
+    if stat.S_ISLNK(stat_result.st_mode) or not stat.S_ISREG(stat_result.st_mode):
+        return path, _jarvis_cockpit_source_record(source_id, path, "missing", reason="not_a_safe_regular_file")
+    return path, _jarvis_cockpit_source_record(source_id, path, "ok")
+
+
+def _jarvis_cockpit_read_json_source(source_id: str, relative_path: Path | str) -> tuple[dict[str, Any] | None, Dict[str, Any]]:
+    path, source = _jarvis_cockpit_safe_regular_file(source_id, relative_path)
+    if source["state"] != "ok":
+        return None, source
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            return data, source
+        source["state"] = "error"
+        source["reason"] = "json_root_not_object"
+        return None, source
+    except (OSError, json.JSONDecodeError):
+        source["state"] = "error"
+        source["reason"] = "json_parse_failed"
+        return None, source
+
+
+def _jarvis_cockpit_count_by(items: list[dict[str, Any]], key: str) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for item in items:
+        value = item.get(key)
+        if isinstance(value, str) and value:
+            counts[value] = counts.get(value, 0) + 1
+    return counts
+
+
+def _jarvis_cockpit_safe_artifacts(raw_artifacts: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_artifacts, list):
+        return []
+    artifacts: list[dict[str, Any]] = []
+    for raw in raw_artifacts:
+        if not isinstance(raw, dict):
+            continue
+        if raw.get("contains_secrets") is True or raw.get("contains_dispatch_operational_data") is True:
+            continue
+        artifact = {
+            "id": raw.get("id"),
+            "title": raw.get("title"),
+            "kind": raw.get("kind"),
+            "path": raw.get("path"),
+            "safe_to_open_in_cockpit": bool(raw.get("safe_to_open_in_cockpit", False)),
+            "summary": raw.get("summary"),
+            "updated_at": raw.get("updated_at"),
+            "contains_dispatch_operational_data": False,
+            "contains_secrets": False,
+        }
+        artifacts.append({key: value for key, value in artifact.items() if value is not None})
+    return artifacts
+
+
+def _jarvis_cockpit_read_gates() -> tuple[list[dict[str, Any]], Dict[str, Any]]:
+    gates_dir = _JARVIS_COCKPIT_DOCS_ROOT / _JARVIS_COCKPIT_GATES_RELATIVE_DIR
+    try:
+        stat_result = gates_dir.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return [], _jarvis_cockpit_source_record("gates", gates_dir, "missing", reason="missing")
+    except OSError:
+        return [], _jarvis_cockpit_source_record("gates", gates_dir, "missing", reason="not_a_safe_directory")
+    if stat.S_ISLNK(stat_result.st_mode) or not stat.S_ISDIR(stat_result.st_mode):
+        return [], _jarvis_cockpit_source_record("gates", gates_dir, "missing", reason="not_a_safe_directory")
+    gates: list[dict[str, Any]] = []
+    for path in sorted(gates_dir.glob("*.json")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict):
+            gates.append(data)
+        elif isinstance(data, list):
+            gates.extend(gate for gate in data if isinstance(gate, dict))
+    return gates, _jarvis_cockpit_source_record("gates", gates_dir, "ok")
+
+
+@app.get("/api/jarvis/cockpit")
+async def get_jarvis_cockpit():
+    """Read-only local Jarvis Cockpit contract for Hermes Desktop.
+
+    This endpoint reads only the narrow Jarvis-Core docs allowlist below. It
+    deliberately does not touch Graph, Blikk, mail, Dispatch databases, auth
+    caches, Keychain, .env, profile config, cron, NUC or backup resources.
+    """
+    sources: list[dict[str, Any]] = []
+    for source_id, relative_path in _JARVIS_COCKPIT_SAFE_FILES:
+        _path, source = _jarvis_cockpit_safe_regular_file(source_id, relative_path)
+        sources.append(source)
+    todo_data, todo_source = _jarvis_cockpit_read_json_source("jarvis-actions", _JARVIS_COCKPIT_TODO_RELATIVE_PATH)
+    sources.append(todo_source)
+    gates, gates_source = _jarvis_cockpit_read_gates()
+    sources.append(gates_source)
+
+    jarvis_todo: list[dict[str, Any]] = []
+    artifacts: list[dict[str, Any]] = []
+    updated_at = datetime.now(timezone.utc).isoformat()
+    if todo_data:
+        raw_items = todo_data.get("items")
+        if isinstance(raw_items, list):
+            jarvis_todo = [item for item in raw_items if isinstance(item, dict)]
+        artifacts = _jarvis_cockpit_safe_artifacts(todo_data.get("artifact_pointers"))
+        if isinstance(todo_data.get("updated_at"), str):
+            updated_at = todo_data["updated_at"]
+
+    todo_by_status = _jarvis_cockpit_count_by(jarvis_todo, "status")
+    waiting_gates = [gate for gate in gates if gate.get("status") == "waiting"]
+    missing_sources = [source for source in sources if source.get("state") == "missing"]
+    status_cards = [
+        {
+            "id": "safety-boundary", "title": "Safety boundary", "kind": "safety", "state": "ok",
+            "summary": "Read-only local Jarvis docs only; no live writes, secrets, Microsoft Graph, Blikk, mail or Dispatch embedding.",
+            "details": ["Dispatch is exposed as a link only.", "Missing allowlisted files are reported, not fatal."],
+            "source": "api/jarvis/cockpit", "updated_at": updated_at, "actions": [],
+        },
+        {
+            "id": "jarvis-todo", "title": "Jarvis To Do", "kind": "system",
+            "state": "ok" if todo_source.get("state") == "ok" else "missing",
+            "summary": f"{len(jarvis_todo)} local Jarvis action item(s).",
+            "details": [f"{status}: {count}" for status, count in sorted(todo_by_status.items())],
+            "source": str(_JARVIS_COCKPIT_TODO_RELATIVE_PATH), "updated_at": updated_at, "actions": [],
+        },
+        {
+            "id": "gates-waiting", "title": "Gates waiting", "kind": "safety",
+            "state": "attention" if waiting_gates else ("missing" if gates_source.get("state") == "missing" else "ok"),
+            "summary": f"{len(waiting_gates)} local gate(s) waiting.",
+            "details": [gate.get("title", gate.get("id", "untitled gate")) for gate in waiting_gates[:3]],
+            "source": str(_JARVIS_COCKPIT_GATES_RELATIVE_DIR), "updated_at": updated_at, "actions": [],
+        },
+        {
+            "id": "dispatch-link", "title": "Open Dispatch Dashboard", "kind": "dispatch-link", "state": "ok",
+            "summary": "Dispatch stays outside Jarvis Cockpit and is available as a link only.",
+            "details": [], "source": "dispatch-boundary", "updated_at": updated_at,
+            "actions": [{"label": "Open Dispatch Dashboard", "type": "open-url", "target": _JARVIS_COCKPIT_DISPATCH_URL, "external_write": False}],
+        },
+    ]
+    return {
+        "status": "ok",
+        "updated_at": updated_at,
+        "dispatch_boundary": {"dispatch_embedded": False, "dispatch_url": _JARVIS_COCKPIT_DISPATCH_URL, "rule": "Dispatch stays in real Dispatch Dashboard"},
+        "jarvis_todo": jarvis_todo,
+        "gates": gates,
+        "status_cards": status_cards,
+        "artifacts": artifacts,
+        "sources": sources,
+        "missing": missing_sources,
+        "safety": _jarvis_cockpit_safety(),
+    }
 
 
 @app.get("/api/status")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1945,6 +1945,41 @@ def test_cleanup_workspace_removes_managed_scratch_dir(kanban_home):
     assert not ws.exists(), "Hermes-managed scratch dir should be cleaned up"
 
 
+def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
+    """Artifacts produced inside ephemeral scratch workspaces remain readable after completion.
+
+    ``kanban_complete(artifacts=[...])`` paths are consumed after the task has
+    completed.  If they still point into the scratch workspace, cleanup deletes
+    the files before notifiers or humans can open them.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="report")
+        task = kb.get_task(conn, t)
+        assert task is not None
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, t, ws)
+        report = ws / "report.md"
+        report.write_text("durable report", encoding="utf-8")
+
+        kb.complete_task(
+            conn,
+            t,
+            summary="report done",
+            metadata={"artifacts": [str(report)]},
+        )
+        run = kb.latest_run(conn, t)
+        assert run is not None
+        completed = [ev for ev in kb.list_events(conn, t) if ev.kind == "completed"][-1]
+
+    assert not ws.exists(), "Hermes-managed scratch dir should still be cleaned up"
+    persisted = Path(run.metadata["artifacts"][0])
+    assert persisted != report
+    assert persisted.exists()
+    assert persisted.read_text(encoding="utf-8") == "durable report"
+    assert completed.payload["artifacts"] == [str(persisted)]
+    assert str(persisted).startswith(str(kanban_home / "kanban" / "artifacts" / t))
+
+
 def test_cleanup_workspace_refuses_path_outside_scratch_root(kanban_home, tmp_path):
     """A scratch task with a user path outside the workspaces root must NOT be deleted (#28818).
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -356,6 +356,172 @@ class TestWebServerEndpoints:
         assert config["dashboard"]["theme"] == "ember"
         assert config["dashboard"]["font"] == "jetbrains-mono"
 
+    def test_get_jarvis_cockpit_reads_only_local_seed_contract(self, tmp_path, monkeypatch):
+        """Jarvis Cockpit exposes a read-only local contract from whitelisted docs."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        todo_dir = docs_root / "runbooks" / "jarvis-todo"
+        todo_dir.mkdir(parents=True)
+        (todo_dir / "jarvis-actions.json").write_text(json.dumps({
+            "version": 1,
+            "updated_at": "2026-06-06T23:36:05+02:00",
+            "scope": "jarvis-system-only",
+            "rules": {
+                "not_microsoft_todo": True,
+                "local_only": True,
+                "external_writes_allowed": False,
+            },
+            "items": [{
+                "id": "cockpit-readonly-api",
+                "title": "Implement narrow read-only Jarvis Cockpit API",
+                "status": "todo",
+                "priority": "P1",
+                "risk": "green-local",
+                "owner": "Hektor",
+                "source": "docs/plans/2026-06-06-hermes-jarvis-cockpit-plan.md",
+                "gate_required": False,
+                "artifact_refs": ["hermes-cockpit-plan"],
+            }],
+            "artifact_pointers": [{
+                "id": "hermes-cockpit-plan",
+                "title": "Hermes Dashboard Jarvis Cockpit Implementation Plan",
+                "kind": "plan",
+                "path": str(docs_root / "plans" / "2026-06-06-hermes-jarvis-cockpit-plan.md"),
+                "safe_to_open_in_cockpit": True,
+                "contains_dispatch_operational_data": False,
+                "contains_secrets": False,
+            }],
+        }))
+        (docs_root / "source-map").mkdir()
+        (docs_root / "source-map" / "personas-dashboards-source-map.md").write_text("# personas\n")
+
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+        resp = self.client.get("/api/jarvis/cockpit")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["jarvis_todo"][0]["id"] == "cockpit-readonly-api"
+        assert data["artifacts"][0]["id"] == "hermes-cockpit-plan"
+        assert data["dispatch_boundary"]["dispatch_embedded"] is False
+        assert data["safety"] == {
+            "read_only": True,
+            "microsoft_writes": False,
+            "blikk_writes": False,
+            "mail_mutation": False,
+            "secrets_read": False,
+            "dispatch_embedded": False,
+        }
+        source_states = {source["id"]: source["state"] for source in data["sources"]}
+        assert source_states["jarvis-actions"] == "ok"
+        assert source_states["personas-dashboards-source-map"] == "ok"
+        assert source_states["jarvis-system-current-state"] == "missing"
+        assert source_states["gates"] == "missing"
+        assert {source["id"] for source in data["missing"]} == {
+            "jarvis-system-current-state",
+            "next-recommendation-guard",
+            "hermes-desktop-pinned-session-routing",
+            "alfred-dispatch-operator-pack",
+            "gates",
+        }
+
+    def test_get_jarvis_cockpit_reports_missing_allowlisted_files_without_crashing(self, tmp_path, monkeypatch):
+        """Missing whitelist entries remain HTTP 200 and are surfaced in sources + missing."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+
+        resp = self.client.get("/api/jarvis/cockpit")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        missing_by_id = {source["id"]: source for source in data["missing"]}
+        expected_missing = {
+            "jarvis-system-current-state",
+            "personas-dashboards-source-map",
+            "next-recommendation-guard",
+            "hermes-desktop-pinned-session-routing",
+            "alfred-dispatch-operator-pack",
+            "jarvis-actions",
+            "gates",
+        }
+        assert set(missing_by_id) == expected_missing
+        assert all(source["state"] == "missing" for source in data["sources"])
+        assert data["jarvis_todo"] == []
+        assert data["artifacts"] == []
+        assert data["gates"] == []
+
+    def test_get_jarvis_cockpit_does_not_touch_forbidden_boundary_helpers(self, tmp_path, monkeypatch):
+        """The endpoint must not use live Graph/Blikk/mail/secrets/config/Dispatch helpers."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        (docs_root / "runbooks" / "jarvis-todo").mkdir(parents=True)
+        (docs_root / "runbooks" / "jarvis-todo" / "jarvis-actions.json").write_text(
+            json.dumps({"items": [], "artifact_pointers": []})
+        )
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError("forbidden boundary helper was called")
+
+        for name in (
+            "load_env",
+            "get_env_path",
+            "get_config_path",
+            "load_config",
+            "save_config",
+            "save_env_value",
+            "remove_env_value",
+            "get_running_pid",
+            "read_runtime_status",
+        ):
+            monkeypatch.setattr(ws, name, forbidden, raising=False)
+        monkeypatch.setattr(ws.urllib.request, "urlopen", forbidden)
+        monkeypatch.setattr(ws.subprocess, "run", forbidden)
+
+        resp = self.client.get("/api/jarvis/cockpit")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dispatch_boundary"] == {
+            "dispatch_embedded": False,
+            "dispatch_url": "http://127.0.0.1:3001",
+            "rule": "Dispatch stays in real Dispatch Dashboard",
+        }
+        assert data["safety"] == {
+            "read_only": True,
+            "microsoft_writes": False,
+            "blikk_writes": False,
+            "mail_mutation": False,
+            "secrets_read": False,
+            "dispatch_embedded": False,
+        }
+
+    def test_get_jarvis_cockpit_does_not_follow_symlinked_forbidden_files(self, tmp_path, monkeypatch):
+        """A whitelisted path that is a symlink to a forbidden file is reported missing."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        todo_dir = docs_root / "runbooks" / "jarvis-todo"
+        todo_dir.mkdir(parents=True)
+        forbidden_env = tmp_path / ".env"
+        forbidden_env.write_text("MICROSOFT_TOKEN=do-not-read\n")
+        (todo_dir / "jarvis-actions.json").symlink_to(forbidden_env)
+
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+        resp = self.client.get("/api/jarvis/cockpit")
+
+        assert resp.status_code == 200
+        body = resp.text
+        data = resp.json()
+        assert "do-not-read" not in body
+        assert data["jarvis_todo"] == []
+        source = next(source for source in data["sources"] if source["id"] == "jarvis-actions")
+        assert source["state"] == "missing"
+        assert source["reason"] == "not_a_safe_regular_file"
 
     def test_get_sessions_uses_only_persisted_cwd(self, monkeypatch):
         """Session rows without persisted cwd must not inherit TERMINAL_CWD.

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -523,6 +523,56 @@ class TestWebServerEndpoints:
         assert source["state"] == "missing"
         assert source["reason"] == "not_a_safe_regular_file"
 
+    def test_post_jarvis_cockpit_report_writes_local_only_markdown_receipt(self, tmp_path, monkeypatch):
+        """Phase 5 report generation writes only a local Cockpit receipt with no external side effects."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        todo_dir = docs_root / "runbooks" / "jarvis-todo"
+        todo_dir.mkdir(parents=True)
+        (todo_dir / "jarvis-actions.json").write_text(json.dumps({
+            "updated_at": "2026-06-07T10:00:00+02:00",
+            "items": [{"id": "cockpit-local-report", "title": "Regenerate local Cockpit report", "status": "todo"}],
+            "artifact_pointers": [],
+        }))
+        (docs_root / "source-map").mkdir()
+        (docs_root / "source-map" / "jarvis-system-current-state.md").write_text("# state\n")
+
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError("external or forbidden helper was called")
+
+        monkeypatch.setattr(ws.urllib.request, "urlopen", forbidden)
+        monkeypatch.setattr(ws.subprocess, "run", forbidden)
+        monkeypatch.setattr(ws, "load_config", forbidden, raising=False)
+
+        resp = self.client.post("/api/jarvis/cockpit/local-report")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["action"] == "jarvis-cockpit-local-report"
+        assert data["safety"] == {
+            "local_only": True,
+            "read_only_sources": True,
+            "external_writes": False,
+            "microsoft_writes": False,
+            "blikk_writes": False,
+            "mail_mutation": False,
+            "secrets_read": False,
+            "cron_changed": False,
+        }
+        report = Path(data["report_path"])
+        assert report.exists()
+        assert report.is_relative_to(docs_root / "runbooks" / "jarvis-cockpit-reports")
+        text = report.read_text(encoding="utf-8")
+        assert "# Jarvis Cockpit Local Report" in text
+        assert "Jarvis To Do items: 1" in text
+        assert "External writes: NO" in text
+        assert "Microsoft writes: NO" in text
+        assert "cockpit-local-report" in text
+
     def test_get_sessions_uses_only_persisted_cwd(self, monkeypatch):
         """Session rows without persisted cwd must not inherit TERMINAL_CWD.
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3,6 +3,7 @@
 import os
 import json
 import shutil
+import subprocess
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -395,6 +396,19 @@ class TestWebServerEndpoints:
         }))
         (docs_root / "source-map").mkdir()
         (docs_root / "source-map" / "personas-dashboards-source-map.md").write_text("# personas\n")
+        gates_dir = docs_root / "runbooks" / "gates"
+        gates_dir.mkdir(parents=True)
+        (gates_dir / "cockpit-health.json").write_text(json.dumps({
+            "id": "gate-cockpit-health",
+            "title": "Aktivera Hermes-status v1",
+            "status": "waiting",
+            "decision": "Ska Jarvis bygga enkel trafikljusstatus i Cockpit?",
+            "recommendation": "Kör lokal v1 utan externa writes.",
+            "scope": "Endast lokal Cockpit-UI och read-only kontrakt.",
+            "default_action": "Kör",
+            "risk": "Låg",
+            "owner": "Jarvis",
+        }))
 
         monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
         resp = self.client.get("/api/jarvis/cockpit")
@@ -417,14 +431,108 @@ class TestWebServerEndpoints:
         assert source_states["jarvis-actions"] == "ok"
         assert source_states["personas-dashboards-source-map"] == "ok"
         assert source_states["jarvis-system-current-state"] == "missing"
-        assert source_states["gates"] == "missing"
+        assert source_states["gates"] == "ok"
+        assert data["gates"][0]["recommendation"] == "Kör lokal v1 utan externa writes."
+        health_card = next(card for card in data["status_cards"] if card["id"] == "hermes-jarvis-health")
+        assert health_card["state"] == "attention"
+        assert "Waiting gates: 1" in health_card["details"]
         assert {source["id"] for source in data["missing"]} == {
             "jarvis-system-current-state",
             "next-recommendation-guard",
             "hermes-desktop-pinned-session-routing",
             "alfred-dispatch-operator-pack",
-            "gates",
+            "jarvis-cockpit-improvements",
+            "jarvis-cockpit-graphify",
         }
+
+    def test_get_jarvis_cockpit_surfaces_local_graphify_lane(self, tmp_path, monkeypatch):
+        """Graphify lane reads only a local manifest and exposes safe graph artifacts."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        graphify_dir = docs_root / "runbooks" / "jarvis-cockpit-graphify"
+        graphify_dir.mkdir(parents=True)
+        notes_dir = graphify_dir / "notes"
+        notes_dir.mkdir()
+        latest_note_path = notes_dir / "20260609-graphify.md"
+        latest_note_path.write_text("# Latest Graphify note\n\nSaved insight.\n", encoding="utf-8")
+        report_path = graphify_dir / "GRAPH_REPORT.md"
+        html_path = graphify_dir / "graph.html"
+        graph_path = graphify_dir / "graph.json"
+        report_path.write_text("# Graph Report\n", encoding="utf-8")
+        html_path.write_text("<html></html>\n", encoding="utf-8")
+        graph_path.write_text("{}\n", encoding="utf-8")
+        (graphify_dir / "latest.json").write_text(json.dumps({
+            "status": "ok",
+            "scope": "Hermes Desktop / Jarvis Cockpit",
+            "command": "graphify update . --no-cluster && graphify cluster-only . --no-label",
+            "nodes": 344,
+            "edges": 366,
+            "communities": 14,
+            "token_reduction": "11.3x",
+            "updated_at": "2026-06-09T01:03:21+02:00",
+            "report_path": str(report_path),
+            "html_path": str(html_path),
+            "graph_path": str(graph_path),
+            "safety": {
+                "local_only": True,
+                "structural_only": True,
+                "external_writes": False,
+                "semantic_llm": False,
+                "hooks": False,
+                "mcp": False,
+                "watch": False,
+                "secrets_found": False,
+            },
+        }), encoding="utf-8")
+
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError("Graphify lane must not run network/subprocess while reading cockpit")
+
+        monkeypatch.setattr(ws.urllib.request, "urlopen", forbidden)
+        monkeypatch.setattr(ws.subprocess, "run", forbidden)
+
+        resp = self.client.get("/api/jarvis/cockpit")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["graphify"] == {
+            "status": "ok",
+            "state": "ok",
+            "scope": "Hermes Desktop / Jarvis Cockpit",
+            "command": "graphify update . --no-cluster && graphify cluster-only . --no-label",
+            "nodes": 344,
+            "edges": 366,
+            "communities": 14,
+            "token_reduction": "11.3x",
+            "updated_at": "2026-06-09T01:03:21+02:00",
+            "report_path": str(report_path),
+            "html_path": str(html_path),
+            "graph_path": str(graph_path),
+            "notes_dir": str(notes_dir.resolve()),
+            "latest_note_path": str(latest_note_path),
+            "latest_note_title": "Latest Graphify note",
+            "latest_note_updated_at": data["graphify"]["latest_note_updated_at"],
+            "safety": {
+                "local_only": True,
+                "structural_only": True,
+                "external_writes": False,
+                "semantic_llm": False,
+                "hooks": False,
+                "mcp": False,
+                "watch": False,
+                "secrets_found": False,
+            },
+        }
+        graphify_card = next(card for card in data["status_cards"] if card["id"] == "graphify-lane")
+        assert graphify_card["state"] == "ok"
+        assert "344 nodes" in graphify_card["summary"]
+        assert graphify_card["actions"] == [
+            {"label": "Open Graphify HTML", "type": "open-url", "target": str(html_path), "external_write": False},
+            {"label": "Open Graphify report", "type": "open-url", "target": str(report_path), "external_write": False},
+        ]
 
     def test_get_jarvis_cockpit_reports_missing_allowlisted_files_without_crashing(self, tmp_path, monkeypatch):
         """Missing whitelist entries remain HTTP 200 and are surfaced in sources + missing."""
@@ -446,6 +554,8 @@ class TestWebServerEndpoints:
             "alfred-dispatch-operator-pack",
             "jarvis-actions",
             "gates",
+            "jarvis-cockpit-improvements",
+            "jarvis-cockpit-graphify",
         }
         assert set(missing_by_id) == expected_missing
         assert all(source["state"] == "missing" for source in data["sources"])
@@ -572,6 +682,190 @@ class TestWebServerEndpoints:
         assert "External writes: NO" in text
         assert "Microsoft writes: NO" in text
         assert "cockpit-local-report" in text
+
+    def test_post_jarvis_cockpit_graphify_query_runs_only_against_safe_local_graph(self, tmp_path, monkeypatch):
+        """Graphify query helpers execute only safe local read-only commands against the approved graph."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        graphify_dir = docs_root / "runbooks" / "jarvis-cockpit-graphify"
+        graphify_dir.mkdir(parents=True)
+        graph_path = graphify_dir / "graph.json"
+        graph_path.write_text("{}\n", encoding="utf-8")
+        (graphify_dir / "latest.json").write_text(json.dumps({
+            "status": "ok",
+            "scope": "Hermes Desktop / Jarvis Cockpit",
+            "graph_path": str(graph_path),
+            "safety": {
+                "local_only": True,
+                "structural_only": True,
+                "external_writes": False,
+                "semantic_llm": False,
+                "hooks": False,
+                "mcp": False,
+                "watch": False,
+                "secrets_found": False,
+            },
+        }), encoding="utf-8")
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            assert cmd == [
+                "uvx", "--from", "graphifyy", "graphify", "query", "JarvisCockpitView",
+                "--budget", "900", "--graph", str(graph_path.resolve())
+            ]
+            assert kwargs["shell"] is False
+            assert kwargs["cwd"] == str(graphify_dir.resolve())
+            assert kwargs["env"]["GRAPHIFY_QUERY_LOG_DISABLE"] == "1"
+            return subprocess.CompletedProcess(cmd, 0, "2 nodes found\nJarvisCockpitView -> healthTone\n", "")
+
+        monkeypatch.setattr(ws.subprocess, "run", fake_run)
+
+        resp = self.client.post("/api/jarvis/cockpit/graphify/query", json={
+            "mode": "query",
+            "question": "JarvisCockpitView",
+            "budget": 900,
+        })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["mode"] == "query"
+        assert data["output"] == "2 nodes found\nJarvisCockpitView -> healthTone"
+        assert data["safety"] == {
+            "local_only": True,
+            "structural_only": True,
+            "external_writes": False,
+            "semantic_llm": False,
+            "hooks": False,
+            "mcp": False,
+            "watch": False,
+            "query_log": False,
+        }
+        assert len(calls) == 1
+
+    def test_post_jarvis_cockpit_graphify_note_writes_local_only_markdown(self, tmp_path, monkeypatch):
+        """Graphify insight cards can persist local notes only inside the approved notes directory."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError("Graphify note save must not use network/subprocess/config helpers")
+
+        monkeypatch.setattr(ws.urllib.request, "urlopen", forbidden)
+        monkeypatch.setattr(ws.subprocess, "run", forbidden)
+        monkeypatch.setattr(ws, "load_config", forbidden, raising=False)
+
+        resp = self.client.post("/api/jarvis/cockpit/graphify/note", json={
+            "title": "What affects Cockpit health?",
+            "mode": "affected",
+            "question": "healthTone",
+            "output": "Affected nodes for healthTone\n- JarvisCockpitView [calls]",
+        })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["action"] == "jarvis-cockpit-graphify-note"
+        assert data["note_title"] == "What affects Cockpit health?"
+        assert data["notes_dir"] == str((docs_root / "runbooks" / "jarvis-cockpit-graphify" / "notes").resolve())
+        assert data["safety"] == {
+            "local_only": True,
+            "external_writes": False,
+            "microsoft_writes": False,
+            "blikk_writes": False,
+            "mail_mutation": False,
+            "secrets_read": False,
+            "cron_changed": False,
+        }
+        note = Path(data["note_path"])
+        assert note.exists()
+        assert note.is_relative_to(docs_root / "runbooks" / "jarvis-cockpit-graphify" / "notes")
+        text = note.read_text(encoding="utf-8")
+        assert "# What affects Cockpit health?" in text
+        assert "- Mode: affected" in text
+        assert "External writes" not in text
+        assert "Affected nodes for healthTone" in text
+
+    def test_post_jarvis_cockpit_graphify_query_rejects_unsafe_manifest(self, tmp_path, monkeypatch):
+        """Graphify query helpers stop if the manifest is not structural/local-only safe."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        graphify_dir = docs_root / "runbooks" / "jarvis-cockpit-graphify"
+        graphify_dir.mkdir(parents=True)
+        graph_path = graphify_dir / "graph.json"
+        graph_path.write_text("{}\n", encoding="utf-8")
+        (graphify_dir / "latest.json").write_text(json.dumps({
+            "graph_path": str(graph_path),
+            "safety": {"local_only": True, "structural_only": True, "semantic_llm": True},
+        }), encoding="utf-8")
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError("unsafe Graphify manifest must not execute subprocess")
+
+        monkeypatch.setattr(ws.subprocess, "run", forbidden)
+        resp = self.client.post("/api/jarvis/cockpit/graphify/query", json={"mode": "affected", "node": "healthTone"})
+
+        assert resp.status_code == 400
+        assert "not safe" in resp.json()["detail"]
+
+    def test_post_jarvis_cockpit_improvement_action_updates_local_history_only(self, tmp_path, monkeypatch):
+        """Improvement actions write only the local Cockpit improvements JSON and append history."""
+        import hermes_cli.web_server as ws
+
+        docs_root = tmp_path / "docs"
+        improvements_path = docs_root / "runbooks" / "jarvis-cockpit-improvements.json"
+        improvements_path.parent.mkdir(parents=True)
+        improvements_path.write_text(json.dumps({
+            "version": 1,
+            "updated_at": "2026-06-07T10:00:00+02:00",
+            "rules": {"local_only": True, "external_writes_allowed": False},
+            "suggestions": [{
+                "id": "cockpit-improvements-history",
+                "title": "Förbättringar med Historik",
+                "classification": "Bygg nu",
+                "status": "active",
+            }],
+            "history": [],
+        }))
+        monkeypatch.setattr(ws, "_JARVIS_COCKPIT_DOCS_ROOT", docs_root)
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError("external or forbidden helper was called")
+
+        monkeypatch.setattr(ws.urllib.request, "urlopen", forbidden)
+        monkeypatch.setattr(ws.subprocess, "run", forbidden)
+        monkeypatch.setattr(ws, "load_config", forbidden, raising=False)
+
+        resp = self.client.post("/api/jarvis/cockpit/improvements/action", json={
+            "suggestion_id": "cockpit-improvements-history",
+            "action": "park",
+            "actor": "Tobias",
+        })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["action"] == "park"
+        assert data["safety"] == {
+            "local_only": True,
+            "external_writes": False,
+            "microsoft_writes": False,
+            "blikk_writes": False,
+            "mail_mutation": False,
+            "secrets_read": False,
+            "cron_changed": False,
+        }
+        saved = json.loads(improvements_path.read_text())
+        assert saved["suggestions"][0]["status"] == "parked"
+        assert saved["history"][0]["action"] == "park"
+        assert saved["history"][0]["cron_repeat_guard"] is True
 
     def test_get_sessions_uses_only_persisted_cwd(self, monkeypatch):
         """Session rows without persisted cwd must not inherit TERMINAL_CWD.


### PR DESCRIPTION
## Summary
- Add a Jarvis Cockpit Graphify lane that reads the local manifest and shows Graphify graph metadata.
- Add local Graphify query presets/custom query controls plus local-only note saving/opening controls in Desktop.
- Add safe backend helpers and tests for local-only Graphify reads, queries, and note metadata.

## Test Plan
- `git diff --check`
- `cd apps/desktop && npm run test:ui -- src/app/jarvis-cockpit/index.test.tsx`
- `cd apps/desktop && npm run type-check`
- `python -m pytest tests/hermes_cli/test_web_server.py -q -o 'addopts='`

## Safety
- Local-only Cockpit/Graphify notes flow; no external writes from the feature itself.
- Backend routes are constrained to the Jarvis-Core docs/runbooks Graphify area.
- Desktop/Electron smoke verified with IPC bridge available.

Actor: jarvis-macmini / default lane
