### PR TITLE
feat(web): make web_extract LLM summarization thresholds configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -996,6 +996,9 @@ DEFAULT_CONFIG = {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "extract_summary_max_chars": 5000,   # Max chars for LLM summarization output
+        "extract_min_length": 5000,          # Min content length to trigger LLM summarization
+        "extract_summary_max_tokens": 20000, # Max tokens for LLM summarization call
     },
 
     "browser": {

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -190,6 +190,9 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("display", "show_reasoning"),
         ("privacy", "redact_pii"),
         ("tts", "provider"),
+        ("web", "extract_summary_max_chars"),
+        ("web", "extract_min_length"),
+        ("web", "extract_summary_max_tokens"),
     ]
 
     for section, key in interesting_paths:

--- a/tests/tools/test_web_extract_config.py
+++ b/tests/tools/test_web_extract_config.py
@@ -1,0 +1,245 @@
+"""Tests for web extract configurable summarization thresholds.
+
+Coverage:
+  _read_web_extract_config() — config reading with fallback to defaults.
+  process_content_with_llm() — uses config values for MAX_OUTPUT_SIZE, min_length, max_tokens.
+  _call_summarizer_llm() — injects character limit into system prompt.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+class TestReadWebExtractConfig:
+    """Test _read_web_extract_config reads config values correctly."""
+
+    def test_defaults_when_no_config(self):
+        """Returns hardcoded defaults when config has no web section."""
+        with patch("hermes_cli.config.load_config", return_value={}):
+            from tools.web_tools import _read_web_extract_config
+            cfg = _read_web_extract_config()
+            assert cfg["max_output_size"] == 5000
+            assert cfg["min_length"] == 5000
+            assert cfg["max_tokens"] == 20000
+
+    def test_defaults_when_config_load_fails(self):
+        """Returns hardcoded defaults when load_config raises."""
+        with patch("hermes_cli.config.load_config", side_effect=Exception("no config")):
+            from tools.web_tools import _read_web_extract_config
+            cfg = _read_web_extract_config()
+            assert cfg["max_output_size"] == 5000
+            assert cfg["min_length"] == 5000
+            assert cfg["max_tokens"] == 20000
+
+    def test_reads_custom_values(self):
+        """Reads custom values from web config section."""
+        config = {
+            "web": {
+                "extract_summary_max_chars": 10000,
+                "extract_min_length": 3000,
+                "extract_summary_max_tokens": 30000,
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            from tools.web_tools import _read_web_extract_config
+            cfg = _read_web_extract_config()
+            assert cfg["max_output_size"] == 10000
+            assert cfg["min_length"] == 3000
+            assert cfg["max_tokens"] == 30000
+
+    def test_ignores_invalid_values(self):
+        """Ignores non-numeric or zero/negative values, uses defaults."""
+        config = {
+            "web": {
+                "extract_summary_max_chars": "not_a_number",
+                "extract_min_length": 0,
+                "extract_summary_max_tokens": -1,
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            from tools.web_tools import _read_web_extract_config
+            cfg = _read_web_extract_config()
+            assert cfg["max_output_size"] == 5000
+            assert cfg["min_length"] == 5000
+            assert cfg["max_tokens"] == 20000
+
+    def test_partial_config_uses_defaults_for_missing(self):
+        """Only overrides values that are present in config."""
+        config = {
+            "web": {
+                "extract_summary_max_chars": 8000,
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            from tools.web_tools import _read_web_extract_config
+            cfg = _read_web_extract_config()
+            assert cfg["max_output_size"] == 8000
+            assert cfg["min_length"] == 5000
+            assert cfg["max_tokens"] == 20000
+
+
+class TestCallSummarizerLlmPromptInjection:
+    """Test that _call_summarizer_llm injects character limit into system prompt."""
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_max_output_size(self):
+        """System prompt should contain the configured max_output_size."""
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content="summary"))]
+
+        with patch(
+            "tools.web_tools._resolve_web_extract_auxiliary",
+            return_value=(MagicMock(base_url="https://api.test.com/v1"), "test-model", {}),
+        ), patch(
+            "tools.web_tools.async_call_llm",
+            new=AsyncMock(return_value=response),
+        ) as mock_call:
+            from tools.web_tools import _call_summarizer_llm
+            await _call_summarizer_llm(
+                "content", "", None, max_output_size=12345,
+            )
+
+        # Check that the system prompt contains the character limit
+        call_args = mock_call.call_args
+        messages = call_args.kwargs["messages"]
+        system_msg = messages[0]["content"]
+        assert "12,345" in system_msg or "12345" in system_msg
+
+    @pytest.mark.asyncio
+    async def test_default_max_output_size_in_prompt(self):
+        """Default 5000 should appear in prompt when no override."""
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content="summary"))]
+
+        with patch(
+            "tools.web_tools._resolve_web_extract_auxiliary",
+            return_value=(MagicMock(base_url="https://api.test.com/v1"), "test-model", {}),
+        ), patch(
+            "tools.web_tools.async_call_llm",
+            new=AsyncMock(return_value=response),
+        ) as mock_call:
+            from tools.web_tools import _call_summarizer_llm
+            await _call_summarizer_llm("content", "", None)
+
+        call_args = mock_call.call_args
+        messages = call_args.kwargs["messages"]
+        system_msg = messages[0]["content"]
+        assert "5,000" in system_msg or "5000" in system_msg
+
+    @pytest.mark.asyncio
+    async def test_chunk_prompt_does_not_include_char_limit(self):
+        """Chunk-specific prompt should NOT include the character limit."""
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content="chunk summary"))]
+
+        with patch(
+            "tools.web_tools._resolve_web_extract_auxiliary",
+            return_value=(MagicMock(base_url="https://api.test.com/v1"), "test-model", {}),
+        ), patch(
+            "tools.web_tools.async_call_llm",
+            new=AsyncMock(return_value=response),
+        ) as mock_call:
+            from tools.web_tools import _call_summarizer_llm
+            await _call_summarizer_llm(
+                "content", "", None, is_chunk=True, chunk_info="[Chunk 1/3]",
+                max_output_size=12345,
+            )
+
+        call_args = mock_call.call_args
+        messages = call_args.kwargs["messages"]
+        system_msg = messages[0]["content"]
+        # Chunk prompt is about extracting from a section, not about output size
+        assert "12,345" not in system_msg
+
+    @pytest.mark.asyncio
+    async def test_max_tokens_passed_to_llm_call(self):
+        """max_tokens parameter should be passed through to async_call_llm."""
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content="summary"))]
+
+        with patch(
+            "tools.web_tools._resolve_web_extract_auxiliary",
+            return_value=(MagicMock(base_url="https://api.test.com/v1"), "test-model", {}),
+        ), patch(
+            "tools.web_tools.async_call_llm",
+            new=AsyncMock(return_value=response),
+        ) as mock_call:
+            from tools.web_tools import _call_summarizer_llm
+            await _call_summarizer_llm("content", "", None, max_tokens=30000)
+
+        call_args = mock_call.call_args
+        assert call_args.kwargs["max_tokens"] == 30000
+
+
+class TestProcessContentWithLlmConfig:
+    """Test that process_content_with_llm reads config values."""
+
+    @pytest.mark.asyncio
+    async def test_uses_config_max_output_size(self):
+        """Output should be capped at config value, not hardcoded 5000."""
+        long_summary = "x" * 8000
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content=long_summary))]
+
+        config = {"web": {"extract_summary_max_chars": 6000}}
+        with patch("hermes_cli.config.load_config", return_value=config), \
+             patch("tools.web_tools._resolve_web_extract_auxiliary",
+                   return_value=(MagicMock(base_url="https://api.test.com/v1"), "test-model", {})), \
+             patch("tools.web_tools.async_call_llm",
+                   new=AsyncMock(return_value=response)):
+            from tools.web_tools import process_content_with_llm
+            result = await process_content_with_llm("a" * 6000, min_length=100)
+
+        truncation_msg = "\n\n[... summary truncated for context management ...]"
+        assert result is not None
+        assert len(result) <= 6000 + len(truncation_msg)
+        assert len(result) > 5000  # Would have been capped at 5000 with old hardcoded value
+
+    @pytest.mark.asyncio
+    async def test_uses_config_min_length(self):
+        """Should skip processing when content < config min_length."""
+        config = {"web": {"extract_min_length": 3000}}
+        with patch("hermes_cli.config.load_config", return_value=config), \
+             patch("tools.web_tools._resolve_web_extract_auxiliary",
+                   return_value=(MagicMock(base_url="https://api.test.com/v1"), "test-model", {})), \
+             patch("tools.web_tools.async_call_llm",
+                   new=AsyncMock(return_value=MagicMock(choices=[MagicMock(message=MagicMock(content="s"))]))):
+            from tools.web_tools import process_content_with_llm
+            # Content is 2000 chars, below config min_length of 3000
+            result = await process_content_with_llm("a" * 2000)
+
+        assert result is None  # Skipped because below min_length
+
+    @pytest.mark.asyncio
+    async def test_explicit_min_length_overrides_config(self):
+        """When caller passes explicit min_length, config is not used."""
+        config = {"web": {"extract_min_length": 10000}}
+        with patch("hermes_cli.config.load_config", return_value=config), \
+             patch("tools.web_tools._resolve_web_extract_auxiliary",
+                   return_value=(MagicMock(base_url="https://api.test.com/v1"), "test-model", {})), \
+             patch("tools.web_tools.async_call_llm",
+                   new=AsyncMock(return_value=MagicMock(choices=[MagicMock(message=MagicMock(content="summary"))]))):
+            from tools.web_tools import process_content_with_llm
+            # Explicit min_length=100 overrides config's 10000
+            result = await process_content_with_llm("a" * 500, min_length=100)
+
+        assert result is not None  # Processed because explicit min_length=100 < 500
+
+
+class TestConfigKeysInDefaultConfig:
+    """Verify the new config keys exist in DEFAULT_CONFIG."""
+
+    def test_extract_summary_max_chars_in_defaults(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert "extract_summary_max_chars" in DEFAULT_CONFIG["web"]
+        assert DEFAULT_CONFIG["web"]["extract_summary_max_chars"] == 5000
+
+    def test_extract_min_length_in_defaults(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert "extract_min_length" in DEFAULT_CONFIG["web"]
+        assert DEFAULT_CONFIG["web"]["extract_min_length"] == 5000
+
+    def test_extract_summary_max_tokens_in_defaults(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert "extract_summary_max_tokens" in DEFAULT_CONFIG["web"]
+        assert DEFAULT_CONFIG["web"]["extract_summary_max_tokens"] == 20000

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -304,6 +304,32 @@ def _web_requires_env() -> list[str]:
 
 DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION = 5000
 
+
+def _read_web_extract_config() -> dict:
+    """Read web extraction config values with fallback to defaults."""
+    cfg = {
+        "max_output_size": 5000,
+        "min_length": DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
+        "max_tokens": 20000,
+    }
+    try:
+        from hermes_cli.config import load_config
+        web_cfg = load_config().get("web", {})
+        if isinstance(web_cfg, dict):
+            val = web_cfg.get("extract_summary_max_chars")
+            if isinstance(val, (int, float)) and val > 0:
+                cfg["max_output_size"] = int(val)
+            val = web_cfg.get("extract_min_length")
+            if isinstance(val, (int, float)) and val > 0:
+                cfg["min_length"] = int(val)
+            val = web_cfg.get("extract_summary_max_tokens")
+            if isinstance(val, (int, float)) and val > 0:
+                cfg["max_tokens"] = int(val)
+    except Exception:
+        pass
+    return cfg
+
+
 def _is_nous_auxiliary_client(client: Any) -> bool:
     """Return True when the resolved auxiliary backend is Nous Portal."""
     from urllib.parse import urlparse
@@ -367,17 +393,24 @@ async def process_content_with_llm(
     MAX_CONTENT_SIZE = 2_000_000  # 2M chars - refuse entirely above this
     CHUNK_THRESHOLD = 500_000     # 500k chars - use chunked processing above this
     CHUNK_SIZE = 100_000          # 100k chars per chunk
-    MAX_OUTPUT_SIZE = 5000        # Hard cap on final output size
-    
+
+    # Read configurable thresholds from web.* config keys
+    _web_cfg = _read_web_extract_config()
+    MAX_OUTPUT_SIZE = _web_cfg["max_output_size"]
+    max_tokens = _web_cfg["max_tokens"]
+    # Use config value when caller passed the module-level default
+    if min_length == DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION:
+        min_length = _web_cfg["min_length"]
+
     try:
         content_len = len(content)
-        
+
         # Refuse if content is absurdly large
         if content_len > MAX_CONTENT_SIZE:
             size_mb = content_len / 1_000_000
             logger.warning("Content too large (%.1fMB > 2MB limit). Refusing to process.", size_mb)
             return f"[Content too large to process: {size_mb:.1f}MB. Try a more focused source URL.]"
-        
+
         # Skip processing if content is too short
         if content_len < min_length:
             logger.debug("Content too short (%d < %d chars), skipping LLM processing", content_len, min_length)
@@ -395,13 +428,17 @@ async def process_content_with_llm(
         if content_len > CHUNK_THRESHOLD:
             logger.info("Content large (%d chars). Using chunked processing...", content_len)
             return await _process_large_content_chunked(
-                content, context_str, model, CHUNK_SIZE, MAX_OUTPUT_SIZE
+                content, context_str, model, CHUNK_SIZE, MAX_OUTPUT_SIZE,
+                max_tokens=max_tokens,
             )
         
         # Standard single-pass processing for normal content
         logger.info("Processing content with LLM (%d characters)", content_len)
         
-        processed_content = await _call_summarizer_llm(content, context_str, model)
+        processed_content = await _call_summarizer_llm(
+            content, context_str, model,
+            max_tokens=max_tokens, max_output_size=MAX_OUTPUT_SIZE,
+        )
         
         if processed_content:
             # Enforce output cap
@@ -437,12 +474,13 @@ async def process_content_with_llm(
 
 
 async def _call_summarizer_llm(
-    content: str, 
-    context_str: str, 
-    model: Optional[str], 
+    content: str,
+    context_str: str,
+    model: Optional[str],
     max_tokens: int = 20000,
     is_chunk: bool = False,
-    chunk_info: str = ""
+    chunk_info: str = "",
+    max_output_size: int = 5000,
 ) -> Optional[str]:
     """
     Make a single LLM call to summarize content.
@@ -482,14 +520,16 @@ Extract all important information from this section in a structured format. Focu
 
     else:
         # Standard full-document prompt
-        system_prompt = """You are an expert content analyst. Your job is to process web content and create a comprehensive yet concise summary that preserves all important information while dramatically reducing bulk.
+        system_prompt = f"""You are an expert content analyst. Your job is to process web content and create a comprehensive yet concise summary that preserves all important information while dramatically reducing bulk.
 
 Create a well-structured markdown summary that includes:
 1. Key excerpts (quotes, code snippets, important facts) in their original format
 2. Comprehensive summary of all other important information
 3. Proper markdown formatting with headers, bullets, and emphasis
 
-Your goal is to preserve ALL important information while reducing length. Never lose key facts, figures, insights, or actionable information. Make it scannable and well-organized."""
+Your goal is to preserve ALL important information while reducing length. Never lose key facts, figures, insights, or actionable information. Make it scannable and well-organized.
+
+Keep the summary concise — ensure the output is no more than {max_output_size:,} characters of well-structured markdown. Do not exceed this limit."""
 
         user_prompt = f"""Please process this web content and create a comprehensive markdown summary:
 
@@ -555,11 +595,12 @@ Create a markdown summary that captures all key information in a well-organized,
 
 
 async def _process_large_content_chunked(
-    content: str, 
-    context_str: str, 
-    model: Optional[str], 
+    content: str,
+    context_str: str,
+    model: Optional[str],
     chunk_size: int,
-    max_output_size: int
+    max_output_size: int,
+    max_tokens: int = 20000,
 ) -> Optional[str]:
     """
     Process large content by chunking, summarizing each chunk in parallel,
@@ -669,7 +710,7 @@ Create a single, unified markdown summary."""
                 {"role": "user", "content": synthesis_prompt},
             ],
             "temperature": 0.1,
-            "max_tokens": 20000,
+            "max_tokens": max_tokens,
         }
         if extra_body:
             call_kwargs["extra_body"] = extra_body


### PR DESCRIPTION
## Problem

`web_extract` LLM summarization in `tools/web_tools.py` has a hardcoded output cap (`MAX_OUTPUT_SIZE=5000` chars) that silently truncates the model's response, discarding most of the generated content.

The model is told to "create a comprehensive yet concise summary" with no character target, so it generates far more than needed. The 5K blind truncation then discards 75%+ of the output — slicing mid-sentence, mid-code-block, or mid-table.

## Changes

Three new config keys under `web.*`:

| Key | Default | Purpose |
|-----|---------|---------|
| `web.extract_summary_max_chars` | 5000 | Max output chars for LLM summarization |
| `web.extract_min_length` | 5000 | Min content length to trigger summarization |
| `web.extract_summary_max_tokens` | 20000 | Max tokens for the LLM call |

### Key behavior change

The system prompt now dynamically includes the configured character limit:

```
Keep the summary concise — ensure the output is no more than {max_output_size:,} characters of well-structured markdown. Do not exceed this limit.
```

This way the model knows the target length and generates accordingly. The hard `MAX_OUTPUT_SIZE` truncation remains as a safety net but rarely triggers once the model respects the prompt.

### Files changed

- `hermes_cli/config.py` — 3 new keys in `DEFAULT_CONFIG["web"]`
- `hermes_cli/dump.py` — 3 new entries in `interesting_paths` for `hermes config display`
- `tools/web_tools.py` — `_read_web_extract_config()` helper, config-driven thresholds in `process_content_with_llm()`, character limit injection in `_call_summarizer_llm()` system prompt, `max_tokens` propagation to chunked processing
- `tests/tools/test_web_extract_config.py` — 15 tests covering config reading, prompt injection, threshold behavior, and default config verification

## Testing

```
15 passed in 0.15s (new tests)
50 passed in 0.60s (existing web_tools_config tests — no regressions)
```

Fixes #42483
