### PR TITLE
fix(cli): /plugins shows installed-but-not-enabled plugins

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7302,24 +7302,66 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._handle_browser_command(cmd_original)
         elif canonical == "plugins":
             try:
-                from hermes_cli.plugins import get_plugin_manager
-                mgr = get_plugin_manager()
-                plugins = mgr.list_plugins()
-                if not plugins:
-                    print("No plugins installed.")
-                    print(f"Drop plugin directories into {display_hermes_home()}/plugins/ to get started.")
+                # Discover from disk (bundled + user), matching `hermes plugins
+                # list` — so installed-but-not-enabled plugins are visible here
+                # too. The plugin manager only knows about *loaded* plugins, so
+                # using it alone made freshly-installed, not-yet-enabled plugins
+                # look like "nothing installed".
+                from hermes_cli.plugins_cmd import (
+                    _discover_all_plugins,
+                    _get_disabled_set,
+                    _get_enabled_set,
+                    _plugin_status,
+                )
+
+                entries = _discover_all_plugins()
+                enabled = _get_enabled_set()
+                disabled = _get_disabled_set()
+
+                # `/plugins` is a quick glance — default to user-installed
+                # plugins (what the user actually added). Bundled provider/
+                # platform plugins are summarized on one line; the full
+                # catalog lives behind `hermes plugins list`.
+                user_entries = [e for e in entries if e[3] != "bundled"]
+                bundled_count = len(entries) - len(user_entries)
+
+                if not user_entries:
+                    print("No user plugins installed.")
+                    print("  Install one: hermes plugins install owner/repo")
+                    print(f"  Or drop a plugin directory into {display_hermes_home()}/plugins/")
+                    if bundled_count:
+                        print(f"  ({bundled_count} bundled plugins available — see: hermes plugins list)")
                 else:
-                    print(f"Plugins ({len(plugins)}):")
-                    for p in plugins:
-                        status = "✓" if p["enabled"] else "✗"
-                        version = f" v{p['version']}" if p["version"] else ""
-                        tools = f"{p['tools']} tools" if p["tools"] else ""
-                        hooks = f"{p['hooks']} hooks" if p["hooks"] else ""
-                        commands = f"{p['commands']} commands" if p.get("commands") else ""
-                        parts = [x for x in [tools, hooks, commands] if x]
-                        detail = f" ({', '.join(parts)})" if parts else ""
-                        error = f" — {p['error']}" if p["error"] else ""
-                        print(f"  {status} {p['name']}{version}{detail}{error}")
+                    # Loaded-plugin details (tools/hooks/commands counts, errors)
+                    # keyed by name, when available.
+                    loaded: dict = {}
+                    try:
+                        from hermes_cli.plugins import get_plugin_manager
+                        for p in get_plugin_manager().list_plugins():
+                            loaded[p["name"]] = p
+                    except Exception:
+                        loaded = {}
+
+                    print(f"User plugins ({len(user_entries)}):")
+                    for name, version, _desc, source, _dir, key in sorted(user_entries):
+                        state = _plugin_status(name, enabled, disabled, key=key)
+                        glyph = {"enabled": "✓", "disabled": "✗"}.get(state, "○")
+                        ver = f" v{version}" if version else ""
+                        info = loaded.get(name) or {}
+                        bits = []
+                        if info.get("tools"):
+                            bits.append(f"{info['tools']} tools")
+                        if info.get("hooks"):
+                            bits.append(f"{info['hooks']} hooks")
+                        if info.get("commands"):
+                            bits.append(f"{info['commands']} commands")
+                        detail = f" ({', '.join(bits)})" if bits else ""
+                        label = "" if state == "enabled" else f" [{state}]"
+                        error = f" — {info['error']}" if info.get("error") else ""
+                        print(f"  {glyph} {name}{ver}{label}{detail}{error}")
+                    if bundled_count:
+                        print(f"  (+{bundled_count} bundled — see: hermes plugins list)")
+                    print("  Enable/disable: hermes plugins enable/disable <name>")
             except Exception as e:
                 print(f"Plugin system error: {e}")
         elif canonical == "rollback":


### PR DESCRIPTION
## What does this PR do?

Fixes the `/plugins` slash command (interactive CLI) reporting **"No plugins installed. Drop plugin directories into ~/.hermes/plugins/ to get started."** even when a plugin *is* installed on disk.

Root cause: the `/plugins` handler in `cli.py` read from the live `PluginManager` (`get_plugin_manager().list_plugins()`), which only knows about **loaded** plugins. Plugins are opt-in, so a freshly-installed-but-not-yet-enabled plugin isn't loaded — and the command rendered the empty-state as if nothing were installed at all. Meanwhile the canonical `hermes plugins list` subcommand discovers from disk and correctly shows such plugins as `not enabled`. This aligns the two surfaces.

## Related Issue

<!-- No tracking issue; surfaced while testing plugin installs. -->
Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py` — `/plugins` slash command handler:
  - Discovers plugins from disk via `_discover_all_plugins()` + `_get_enabled_set()` / `_get_disabled_set()` / `_plugin_status()` (the same source of truth as `hermes plugins list`), instead of only the loaded `PluginManager`.
  - Installed plugins now show their activation state: `✓` enabled, `✗` disabled, `○ [not enabled]`.
  - Defaults the quick view to **user-installed** plugins and summarizes bundled providers/platforms on a single line (`+N bundled — see: hermes plugins list`), so the output isn't drowned by 60+ bundled provider plugins. The full catalog still lives behind `hermes plugins list`.
  - Empty-state and footer now point at the real workflow: `hermes plugins install owner/repo` and `hermes plugins enable/disable <name>`.
  - Loaded-plugin details (tools/hooks/commands counts, load errors) are still merged in by name when the manager has them.

## How to Test

1. `hermes plugins install <owner>/<repo>` and answer **N** to the "Enable now?" prompt (or install via a non-TTY path).
2. Start an interactive session and run `/plugins`.
   - **Before:** "No plugins installed. Drop plugin directories into ~/.hermes/plugins/ to get started."
   - **After:** the plugin is listed as `○ <name> vX.Y.Z [not enabled]`, plus the enable hint.
3. `hermes plugins enable <name>`, restart the session, run `/plugins` → shows `✓ <name>` (enabled).
4. With no user plugins installed → "No user plugins installed." + install hint + a one-line count of available bundled plugins.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single-file change to `cli.py`)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran tests/hermes_cli/test_plugins_cmd.py (65/65) covering the reused discovery helpers + live repro on my install; full suite not run locally — relying on CI -->
- [ ] I've added tests for my changes <!-- the /plugins slash handler is inline in cli.py's process_command and not unit-tested today; the reused discovery helpers (_discover_all_plugins/_plugin_status) are covered by tests/hermes_cli/test_plugins_cmd.py. Happy to add a focused handler test if reviewers want one. -->
- [x] I've tested on my platform: Ubuntu/WSL2 (Python 3.11)

### Documentation & Housekeeping

- [x] N/A — no doc change needed (behavior now matches documented `hermes plugins list`)
- [x] N/A — no new/changed config keys
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact: pure-Python discovery + string formatting; the only glyphs are ✓/✗/○ (already used elsewhere in the CLI).
- [x] N/A — no tool description/schema changes

## Screenshots / Logs

Real output from my install (`evey-goals` installed as a user plugin):

Enabled:
```
User plugins (1):
  ✓ evey-goals v1.0.0
  (+66 bundled — see: hermes plugins list)
  Enable/disable: hermes plugins enable/disable <name>
```

Installed but not enabled (the case that produced the false "No plugins installed"):
```
User plugins (1):
  ○ evey-goals v1.0.0 [not enabled]
  ...
```

Tests: `65 passed` in `tests/hermes_cli/test_plugins_cmd.py`.
