### PR TITLE
fix(photon): migrate user API to Spectrum backend + send-path & status follow-ups

### DIFF
--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -119,14 +119,14 @@ All env vars are documented in `plugin.yaml`. The most important:
 
 ## Attachments & limitations
 
-- **Inbound attachments are downloaded.** The sidecar reads the bytes
-  (`content.read()`) and base64-inlines them on the NDJSON event; the adapter
-  caches them to the shared media cache and populates `media_urls` /
-  `media_types`, so the agent sees the real image/file (vision included) —
-  parity with the BlueBubbles iMessage channel. Attachments larger than
+- **Inbound attachments and voice notes are downloaded.** The sidecar reads
+  the bytes (`content.read()`) and base64-inlines them on the NDJSON event; the
+  adapter caches them to the shared media cache and populates `media_urls` /
+  `media_types`, so the agent sees the real image/file or can transcribe the
+  voice note — parity with the BlueBubbles iMessage channel. Media larger than
   `PHOTON_MAX_INLINE_ATTACHMENT_BYTES` (default 20 MB), or any byte read that
-  fails, fall back to a text marker (`[Photon attachment received: …]`) so the
-  agent still knows something arrived.
+  fails, falls back to a text marker (`[Photon attachment received: …]` or
+  `[Photon voice received: …]`) so the agent still knows something arrived.
 - **Outbound attachments are supported.** Images, voice notes, video, and
   documents are sent via `space.send(attachment(...))` /
   `space.send(voice(...))` through the sidecar's `/send-attachment`

--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -111,6 +111,7 @@ All env vars are documented in `plugin.yaml`. The most important:
 | `PHOTON_SIDECAR_PORT`     | 8789                       | Loopback port for the sidecar        |
 | `PHOTON_SIDECAR_AUTOSTART`| true                       | Spawn the sidecar on connect         |
 | `PHOTON_DASHBOARD_HOST`   | https://app.photon.codes   | Dashboard API host                   |
+| `PHOTON_SPECTRUM_HOST`    | https://spectrum.photon.codes | Spectrum API host                 |
 | `PHOTON_HOME_CHANNEL`     | your number (set by setup) | Default space for cron delivery — a space id, or a bare E.164 number (resolved to a DM) |
 | `PHOTON_ALLOWED_USERS`    | your number (set by setup) | Comma-separated E.164 allowlist      |
 | `PHOTON_REQUIRE_MENTION`  | false                      | Gate group chats on a wake word      |

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -435,13 +435,15 @@ class PhotonAdapter(BasePlatformAdapter):
               "space": {"id": "...", "type": "dm"|"group", "phone": "+E164"},
               "sender": {"id": "+E164"},
               "content": {"type": "text", "text": "..."}
-                       | {"type": "attachment", "id", "name", "mimeType",
-                          "size", "data"?, "encoding"?},
+                       | {"type": "attachment"|"voice", "id", "name",
+                          "mimeType", "size", "duration"?, "data"?,
+                          "encoding"?},
               "timestamp": "2026-05-14T19:06:32.000Z"
 
-        Attachment content carries the bytes inline as base64 ``data`` (with
-        ``encoding == "base64"``) when the sidecar could read them within its
-        size cap; otherwise only metadata is present and we surface a marker.
+        Attachment and voice content carry the bytes inline as base64 ``data``
+        (with ``encoding == "base64"``) when the sidecar could read them
+        within its size cap; otherwise only metadata is present and we surface
+        a marker.
             }
         """
         space = event.get("space") or {}
@@ -476,23 +478,38 @@ class PhotonAdapter(BasePlatformAdapter):
         if ctype == "text":
             text = content.get("text") or ""
             mtype = MessageType.TEXT
-        elif ctype == "attachment":
-            name = content.get("name") or "(unnamed)"
+        elif ctype in {"attachment", "voice"}:
+            is_voice = ctype == "voice"
+            name = content.get("name") or ("voice" if is_voice else "(unnamed)")
             mime = content.get("mimeType") or ""
-            mtype = _attachment_message_type(mime)
-            cached = _cache_inbound_attachment(content, name, mime)
+            mtype = MessageType.VOICE if is_voice else _attachment_message_type(mime)
+            cached = _cache_inbound_attachment(
+                content, name, mime, force_audio=is_voice
+            )
             if cached:
                 media_urls.append(cached)
-                media_types.append(mime or "application/octet-stream")
+                media_types.append(
+                    mime or ("audio/mp4" if is_voice else "application/octet-stream")
+                )
                 # The real bytes are attached, so the agent sees the media
                 # itself — a short marker is enough text, and it keeps group
                 # mention-gating consistent with plain messages.
-                text = "(attachment)"
+                text = "(voice)" if is_voice else "(attachment)"
             else:
                 # No bytes (over the sidecar cap, a failed read, or a caching
                 # failure) — fall back to a metadata marker so the agent still
                 # knows something arrived.
-                text = f"[Photon attachment received: {name} ({mime})]"
+                label = "voice" if is_voice else "attachment"
+                duration = content.get("duration")
+                duration_text = (
+                    f", duration: {duration}s"
+                    if isinstance(duration, (int, float))
+                    else ""
+                )
+                text = (
+                    f"[Photon {label} received: {name} "
+                    f"({mime or 'unknown MIME'}{duration_text})]"
+                )
         else:
             text = f"[Photon content type not handled: {ctype}]"
             mtype = MessageType.TEXT
@@ -950,7 +967,11 @@ _AUDIO_EXT_BY_MIME = {
 
 
 def _cache_inbound_attachment(
-    content: Dict[str, Any], name: str, mime: str
+    content: Dict[str, Any],
+    name: str,
+    mime: str,
+    *,
+    force_audio: bool = False,
 ) -> Optional[str]:
     """Decode a base64-inlined inbound attachment and cache it locally.
 
@@ -988,8 +1009,10 @@ def _cache_inbound_attachment(
                 # Bytes don't look like a supported image (e.g. HEIC magic) —
                 # still deliver them as a document rather than dropping them.
                 return cache_document_from_bytes(raw, name)
-        if mime.startswith("audio/"):
-            ext = suffix or _AUDIO_EXT_BY_MIME.get(mime, ".mp3")
+        if force_audio or mime.startswith("audio/"):
+            ext = suffix or _AUDIO_EXT_BY_MIME.get(
+                mime, ".m4a" if force_audio else ".mp3"
+            )
             return cache_audio_from_bytes(raw, ext)
         # Video, application/*, and everything else → document cache.
         return cache_document_from_bytes(raw, name)

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -60,6 +60,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
 )
+from gateway.platforms.helpers import strip_markdown
 
 from .auth import load_project_credentials
 
@@ -640,7 +641,7 @@ class PhotonAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self._sidecar_send(chat_id, content)
+        return await self._sidecar_send(chat_id, self.format_message(content))
 
     # -- Outbound media (parity with the BlueBubbles iMessage channel) -----
     #
@@ -758,6 +759,74 @@ class PhotonAdapter(BasePlatformAdapter):
         DM/group type, but here we only have the id, so infer conservatively.
         """
         return {"name": chat_id, "type": "dm", "id": chat_id}
+
+    def format_message(self, content: str) -> str:
+        return strip_markdown(content)
+
+    async def _send_with_retry(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Any = None,
+        max_retries: int = 2,
+        base_delay: float = 2.0,
+    ) -> SendResult:
+        """Photon/iMessage is plain text, so never show the generic Markdown banner."""
+        text = self.format_message(content)
+        result = await self.send(
+            chat_id=chat_id,
+            content=text,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        if result.success:
+            return result
+
+        error_str = result.error or ""
+        is_network = result.retryable or self._is_retryable_error(error_str)
+        if not is_network and self._is_timeout_error(error_str):
+            return result
+
+        if is_network:
+            for attempt in range(1, max_retries + 1):
+                delay = base_delay * (2 ** (attempt - 1))
+                logger.warning(
+                    "[photon] Send failed (attempt %d/%d, retrying in %.1fs): %s",
+                    attempt, max_retries, delay, error_str,
+                )
+                await asyncio.sleep(delay)
+                result = await self.send(
+                    chat_id=chat_id,
+                    content=text,
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+                if result.success:
+                    return result
+                error_str = result.error or ""
+                if not (result.retryable or self._is_retryable_error(error_str)):
+                    break
+            else:
+                logger.error(
+                    "[photon] Failed to deliver response after %d retries: %s",
+                    max_retries, error_str,
+                )
+                return result
+
+        logger.warning(
+            "[photon] Send failed: %s - retrying plain-text message",
+            error_str,
+        )
+        fallback_result = await self.send(
+            chat_id=chat_id,
+            content=text[: self.MAX_MESSAGE_LENGTH],
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        if not fallback_result.success:
+            logger.error("[photon] Plain-text retry also failed: %s", fallback_result.error)
+        return fallback_result
 
     async def _sidecar_send(self, space_id: str, text: str) -> SendResult:
         if len(text) > self.MAX_MESSAGE_LENGTH:

--- a/plugins/platforms/photon/auth.py
+++ b/plugins/platforms/photon/auth.py
@@ -27,8 +27,9 @@ Credential storage mirrors every other Hermes channel:
     * runtime SDK creds  -> ``~/.hermes/.env``  (``PHOTON_PROJECT_ID`` =
       spectrumProjectId, ``PHOTON_PROJECT_SECRET``) via ``save_env_value``
     * management metadata -> ``~/.hermes/auth.json`` under
-      ``credential_pool.photon`` (device token) and
-      ``credential_pool.photon_project`` (dashboard id, spectrum id, name)
+      ``credential_pool.photon`` (device token),
+      ``credential_pool.photon_project`` (dashboard id, spectrum id, name), and
+      ``credential_pool.photon_user`` (operator number + assigned text line)
 
 Reference: https://github.com/photon-hq/cli and
 https://photon.codes/docs/api-reference/device-login/request-device-+-user-code
@@ -203,6 +204,30 @@ def store_project_credentials(
     auth.setdefault("credential_pool", {})["photon_project"] = [record]
     _save_auth(auth)
     _persist_runtime_env(spectrum_project_id, project_secret)
+
+
+def store_user_numbers(
+    *,
+    phone_number: Optional[str] = None,
+    assigned_phone_number: Optional[str] = None,
+    user_id: Optional[str] = None,
+    dashboard_project_id: Optional[str] = None,
+) -> None:
+    """Persist non-secret Photon user numbers for offline ``status`` output."""
+    if not phone_number and not assigned_phone_number:
+        return
+    auth = _load_auth()
+    record: Dict[str, Any] = {"issued_at": int(time.time())}
+    if phone_number:
+        record["phone_number"] = phone_number
+    if assigned_phone_number:
+        record["assigned_phone_number"] = assigned_phone_number
+    if user_id:
+        record["user_id"] = user_id
+    if dashboard_project_id:
+        record["dashboard_project_id"] = dashboard_project_id
+    auth.setdefault("credential_pool", {})["photon_user"] = [record]
+    _save_auth(auth)
 
 
 def _persist_runtime_env(spectrum_project_id: str, project_secret: str) -> None:
@@ -766,6 +791,95 @@ def user_assigned_line(user: Optional[Dict[str, Any]]) -> Optional[str]:
     return str(val) if val else None
 
 
+def load_user_numbers() -> Tuple[Optional[str], Optional[str]]:
+    """Return ``(operator_phone_number, assigned_phone_number)`` for status."""
+    auth = _load_auth()
+    user_entries = auth.get("credential_pool", {}).get("photon_user") or []
+    if isinstance(user_entries, list) and user_entries:
+        entry = user_entries[0] or {}
+        if isinstance(entry, dict):
+            phone = entry.get("phone_number") or entry.get("phoneNumber")
+            assigned = (
+                entry.get("assigned_phone_number")
+                or entry.get("assignedPhoneNumber")
+            )
+            if phone or assigned:
+                return (
+                    str(phone) if phone else _configured_operator_phone(),
+                    str(assigned) if assigned else None,
+                )
+    return _configured_operator_phone(), None
+
+
+def refresh_user_numbers(
+    token: str, project_id: str,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Refresh cached user numbers from Photon without provisioning anything."""
+    phone, cached_assigned = load_user_numbers()
+    user: Optional[Dict[str, Any]] = None
+    if phone:
+        user = find_user_by_phone(token, project_id, phone)
+    else:
+        users = list_users(token, project_id)
+        if len(users) == 1:
+            user = users[0]
+
+    user_id = None
+    assigned: Optional[str] = cached_assigned
+    if user:
+        user_id = user.get("id")
+        dashboard_phone = _normalize_phone(str(user.get("phoneNumber") or ""))
+        if E164_RE.match(dashboard_phone):
+            phone = dashboard_phone
+        assigned = user_assigned_line(user)
+
+    if not assigned:
+        try:
+            line = get_imessage_line(token, project_id, create_if_missing=False)
+        except Exception as e:
+            logger.debug("photon: could not refresh iMessage line for status: %s", e)
+        else:
+            if line and line.get("phoneNumber"):
+                assigned = str(line["phoneNumber"])
+
+    store_user_numbers(
+        phone_number=phone,
+        assigned_phone_number=assigned,
+        user_id=str(user_id) if user_id else None,
+        dashboard_project_id=project_id,
+    )
+    return phone, assigned
+
+
+def _configured_operator_phone() -> Optional[str]:
+    """Infer the operator's E.164 number from existing Photon env settings."""
+    home = _get_config_env_value("PHOTON_HOME_CHANNEL")
+    if home:
+        normalized = _normalize_phone(home)
+        if E164_RE.match(normalized):
+            return normalized
+
+    allowed = _get_config_env_value("PHOTON_ALLOWED_USERS")
+    if not allowed:
+        return None
+    candidates = []
+    for part in re.split(r"[,\s]+", allowed):
+        normalized = _normalize_phone(part)
+        if E164_RE.match(normalized):
+            candidates.append(normalized)
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
+def _get_config_env_value(key: str) -> Optional[str]:
+    try:
+        from hermes_cli.config import get_env_value
+    except Exception:
+        return os.getenv(key)
+    return get_env_value(key)
+
+
 # ---------------------------------------------------------------------------
 # Dashboard API: iMessage lines (the assigned number inventory)
 
@@ -836,6 +950,13 @@ def print_credential_summary(emit: Any = print) -> None:
     labels["spectrum_project_id"] = sid if sid else "✗ missing"
     labels["dashboard_project_id"] = load_dashboard_project_id() or "—"
     labels["project_key"] = "✓ stored" if sec else "✗ missing"
+    phone, assigned = load_user_numbers()
+    labels["phone_number"] = (
+        phone if phone else "✗ missing (run `hermes photon setup --phone ...`)"
+    )
+    labels["assigned_phone_number"] = (
+        assigned if assigned else "✗ missing (run `hermes photon setup`)"
+    )
 
     rows = [
         "Photon iMessage status",
@@ -844,6 +965,8 @@ def print_credential_summary(emit: Any = print) -> None:
         "  dashboard project   : " + labels["dashboard_project_id"],
         "  spectrum project id : " + labels["spectrum_project_id"],
         "  project secret      : " + labels["project_key"],
+        "  my number           : " + labels["phone_number"],
+        "  assigned number     : " + labels["assigned_phone_number"],
     ]
     emit("\n".join(rows))
 
@@ -864,9 +987,19 @@ def credential_summary() -> Dict[str, str]:
         _sid, sec = load_project_credentials()
         return "✓ stored" if sec else "✗ missing"
 
+    def _present_phone() -> str:
+        phone, _assigned = load_user_numbers()
+        return phone or "✗ missing (run `hermes photon setup --phone ...`)"
+
+    def _present_assigned_phone() -> str:
+        _phone, assigned = load_user_numbers()
+        return assigned or "✗ missing (run `hermes photon setup`)"
+
     return {
         "device_token": _present_token(),
         "dashboard_project_id": load_dashboard_project_id() or "—",
         "spectrum_project_id": _present_spectrum_id(),
         "project_key": _present_secret(),
+        "phone_number": _present_phone(),
+        "assigned_phone_number": _present_assigned_phone(),
     }

--- a/plugins/platforms/photon/auth.py
+++ b/plugins/platforms/photon/auth.py
@@ -41,6 +41,7 @@ import logging
 import os
 import re
 import time
+from base64 import b64encode
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -68,6 +69,7 @@ DEFAULT_CLIENT_ID = "photon-cli"
 DEFAULT_SCOPE = "openid profile email"
 
 DEFAULT_DASHBOARD_HOST = "https://app.photon.codes"
+DEFAULT_SPECTRUM_HOST = "https://spectrum.photon.codes"
 
 # Default name of the project Hermes provisions for the operator.
 DEFAULT_PROJECT_NAME = "Hermes Agent"
@@ -273,8 +275,41 @@ def _dashboard_host() -> str:
     return (os.getenv("PHOTON_DASHBOARD_HOST") or DEFAULT_DASHBOARD_HOST).rstrip("/")
 
 
+def _spectrum_host() -> str:
+    return (os.getenv("PHOTON_SPECTRUM_HOST") or DEFAULT_SPECTRUM_HOST).rstrip("/")
+
+
 def _bearer(token: str) -> Dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
+
+
+def _basic(project_id: str, project_secret: str) -> Dict[str, str]:
+    token = b64encode(f"{project_id}:{project_secret}".encode("utf-8")).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+def _response_error_detail(resp: Any) -> str:
+    try:
+        data = resp.json()
+    except Exception:
+        data = None
+    if isinstance(data, dict):
+        for key in ("error", "message", "detail"):
+            val = data.get(key)
+            if val:
+                return str(val)
+        return json.dumps(data, sort_keys=True)[:500]
+    text = getattr(resp, "text", "") or ""
+    return text[:500] if text else "no response body"
+
+
+def _raise_for_status(resp: Any, action: str) -> None:
+    status = getattr(resp, "status_code", 200)
+    if status < 400:
+        return
+    raise RuntimeError(
+        f"Photon {action} failed: HTTP {status}: {_response_error_detail(resp)}"
+    )
 
 
 def request_device_code(
@@ -584,6 +619,11 @@ def _unwrap_list(data: Any) -> List[Dict[str, Any]]:
             inner = data.get(key)
             if isinstance(inner, list):
                 return inner
+            if isinstance(inner, dict):
+                for nested_key in ("projects", "users", "lines", "items"):
+                    nested = inner.get(nested_key)
+                    if isinstance(nested, list):
+                        return nested
     return []
 
 
@@ -687,37 +727,37 @@ def regenerate_project_secret(token: str, project_id: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Dashboard API: spectrum users
+# Spectrum API: users
 
 def _normalize_phone(phone: str) -> str:
     """Reduce a phone string to ``+`` and digits for dedup comparison."""
     return re.sub(r"[^\d+]", "", phone or "")
 
 
-def list_users(token: str, project_id: str) -> List[Dict[str, Any]]:
-    """GET ``/api/projects/{id}/spectrum/users`` → ``SpectrumUser[]``."""
+def list_users(project_id: str, project_secret: str) -> List[Dict[str, Any]]:
+    """GET Spectrum Cloud ``/projects/{id}/users/`` → ``SpectrumUser[]``."""
     if httpx is None:
         raise RuntimeError("httpx is required for Photon")
-    url = f"{_dashboard_host()}/api/projects/{project_id}/spectrum/users"
-    resp = httpx.get(url, headers=_bearer(token), timeout=30.0)
-    resp.raise_for_status()
+    url = f"{_spectrum_host()}/projects/{project_id}/users/"
+    resp = httpx.get(url, headers=_basic(project_id, project_secret), timeout=30.0)
+    _raise_for_status(resp, "list-users")
     return _unwrap_list(resp.json())
 
 
 def find_user_by_phone(
-    token: str, project_id: str, phone_number: str,
+    project_id: str, project_secret: str, phone_number: str,
 ) -> Optional[Dict[str, Any]]:
     """Return an existing Spectrum user with the given phone number, or None."""
     target = _normalize_phone(phone_number)
-    for user in list_users(token, project_id):
+    for user in list_users(project_id, project_secret):
         if _normalize_phone(user.get("phoneNumber") or "") == target:
             return user
     return None
 
 
 def create_user(
-    token: str,
     project_id: str,
+    project_secret: str,
     *,
     phone_number: str,
     first_name: Optional[str] = None,
@@ -725,32 +765,42 @@ def create_user(
     email: Optional[str] = None,
     send_invite: bool = False,
 ) -> Dict[str, Any]:
-    """POST ``/api/projects/{id}/spectrum/users`` and return the created user."""
+    """POST Spectrum Cloud ``/projects/{id}/users/`` and return the user."""
     if httpx is None:
         raise RuntimeError("httpx is required for Photon user creation")
     if not E164_RE.match(phone_number):
         raise ValueError(
             f"phone_number must be E.164 (e.g. +15551234567); got {phone_number!r}"
         )
-    url = f"{_dashboard_host()}/api/projects/{project_id}/spectrum/users"
-    body: Dict[str, Any] = {"phoneNumber": phone_number, "sendInvite": send_invite}
+    url = f"{_spectrum_host()}/projects/{project_id}/users/"
+    body: Dict[str, Any] = {"type": "shared", "phoneNumber": phone_number}
+    if send_invite:
+        logger.debug("photon: send_invite is ignored by Spectrum shared-user creation")
     if first_name:
         body["firstName"] = first_name
     if last_name:
         body["lastName"] = last_name
     if email:
         body["email"] = email
-    resp = httpx.post(url, json=body, headers=_bearer(token), timeout=30.0)
-    resp.raise_for_status()
+    resp = httpx.post(
+        url,
+        json=body,
+        headers=_basic(project_id, project_secret),
+        timeout=30.0,
+    )
+    _raise_for_status(resp, "create-user")
     data = resp.json() or {}
     if data.get("error"):
         raise RuntimeError(f"Photon create-user failed: {data['error']}")
-    return data.get("user") or data
+    user = data.get("user") or data.get("data") or data
+    if isinstance(user, dict):
+        return user
+    raise RuntimeError("Photon create-user returned an unexpected response")
 
 
 def register_user_if_absent(
-    token: str,
     project_id: str,
+    project_secret: str,
     *,
     phone_number: str,
     first_name: Optional[str] = None,
@@ -763,11 +813,12 @@ def register_user_if_absent(
     same phone number already exists (the official CLI does no dedup, so we
     add it here to make ``setup`` safely re-runnable).
     """
-    existing = find_user_by_phone(token, project_id, phone_number)
+    existing = find_user_by_phone(project_id, project_secret, phone_number)
     if existing is not None:
         return existing, False
     user = create_user(
-        token, project_id,
+        project_id,
+        project_secret,
         phone_number=phone_number,
         first_name=first_name,
         last_name=last_name,
@@ -812,15 +863,15 @@ def load_user_numbers() -> Tuple[Optional[str], Optional[str]]:
 
 
 def refresh_user_numbers(
-    token: str, project_id: str,
+    project_id: str, project_secret: str,
 ) -> Tuple[Optional[str], Optional[str]]:
     """Refresh cached user numbers from Photon without provisioning anything."""
     phone, cached_assigned = load_user_numbers()
     user: Optional[Dict[str, Any]] = None
     if phone:
-        user = find_user_by_phone(token, project_id, phone)
+        user = find_user_by_phone(project_id, project_secret, phone)
     else:
-        users = list_users(token, project_id)
+        users = list_users(project_id, project_secret)
         if len(users) == 1:
             user = users[0]
 
@@ -833,20 +884,29 @@ def refresh_user_numbers(
             phone = dashboard_phone
         assigned = user_assigned_line(user)
 
+    dashboard_id = load_dashboard_project_id()
     if not assigned:
-        try:
-            line = get_imessage_line(token, project_id, create_if_missing=False)
-        except Exception as e:
-            logger.debug("photon: could not refresh iMessage line for status: %s", e)
-        else:
-            if line and line.get("phoneNumber"):
-                assigned = str(line["phoneNumber"])
+        dashboard_token = load_photon_token()
+        if dashboard_token and dashboard_id:
+            try:
+                line = get_imessage_line(
+                    dashboard_token,
+                    dashboard_id,
+                    create_if_missing=False,
+                )
+            except Exception as e:
+                logger.debug(
+                    "photon: could not refresh iMessage line for status: %s", e
+                )
+            else:
+                if line and line.get("phoneNumber"):
+                    assigned = str(line["phoneNumber"])
 
     store_user_numbers(
         phone_number=phone,
         assigned_phone_number=assigned,
         user_id=str(user_id) if user_id else None,
-        dashboard_project_id=project_id,
+        dashboard_project_id=dashboard_id,
     )
     return phone, assigned
 

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -183,6 +183,8 @@ def _cmd_setup(args: argparse.Namespace) -> int:
         )
     )
     agent_number = None
+    registered_phone = None
+    registered_user_id = None
     if not phone:
         print("      Skipped user registration (no phone given). Re-run with --phone later.")
     else:
@@ -205,6 +207,8 @@ def _cmd_setup(args: argparse.Namespace) -> int:
             print(f"      user registration failed: {e}", file=sys.stderr)
             return 1
         print("  ✓ phone registered" if created else "  ✓ phone already registered")
+        registered_phone = phone
+        registered_user_id = user.get("id")
         # The number to text the agent is the user's assigned iMessage line
         # (the dashboard's "TEXTS ON" column). On shared-number plans there is
         # no dedicated entry in /lines, so this per-user field is the source of
@@ -236,6 +240,16 @@ def _cmd_setup(args: argparse.Namespace) -> int:
         print(color("└──────────────────────────────────────────────────────────────", Colors.GREEN))
     else:
         print("      No iMessage line assigned yet — check the Photon dashboard.")
+    if registered_phone:
+        try:
+            photon_auth.store_user_numbers(
+                phone_number=registered_phone,
+                assigned_phone_number=agent_number,
+                user_id=str(registered_user_id) if registered_user_id else None,
+                dashboard_project_id=dashboard_id,
+            )
+        except Exception as e:
+            print(f"      (could not save Photon status metadata: {e})", file=sys.stderr)
 
     # 6. Sidecar deps (spectrum-ts).
     if args.skip_sidecar_install:
@@ -280,6 +294,7 @@ def _autoconfigure_access(phone: str) -> None:
 
 
 def _cmd_status(_args: argparse.Namespace) -> int:
+    _refresh_status_numbers()
     # Defer the credential rows to auth.print_credential_summary — its emit
     # callback is the only sink that sees credential-derived strings, so
     # cli.py keeps zero taint flow according to CodeQL.
@@ -289,6 +304,20 @@ def _cmd_status(_args: argparse.Namespace) -> int:
     print(f"  node binary         : {node_bin or '✗ missing (install Node 18+)'}")
     print(f"  sidecar deps        : {'✓ installed' if sidecar_installed else '✗ run `hermes photon install-sidecar`'}")
     return 0
+
+
+def _refresh_status_numbers() -> None:
+    phone, assigned = photon_auth.load_user_numbers()
+    if phone and assigned:
+        return
+    token = photon_auth.load_photon_token()
+    dashboard_id = photon_auth.load_dashboard_project_id()
+    if not token or not dashboard_id:
+        return
+    try:
+        photon_auth.refresh_user_numbers(token, dashboard_id)
+    except Exception as e:
+        print(f"      (could not refresh Photon user numbers: {e})", file=sys.stderr)
 
 
 def _cmd_install_sidecar(_args: argparse.Namespace) -> int:

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -194,7 +194,7 @@ def _cmd_setup(args: argparse.Namespace) -> int:
         email = args.email
         try:
             user, created = photon_auth.register_user_if_absent(
-                token, dashboard_id,
+                spectrum_id, secret,
                 phone_number=phone,
                 first_name=first_name,
                 last_name=args.last_name,
@@ -310,12 +310,11 @@ def _refresh_status_numbers() -> None:
     phone, assigned = photon_auth.load_user_numbers()
     if phone and assigned:
         return
-    token = photon_auth.load_photon_token()
-    dashboard_id = photon_auth.load_dashboard_project_id()
-    if not token or not dashboard_id:
+    spectrum_id, project_secret = photon_auth.load_project_credentials()
+    if not spectrum_id or not project_secret:
         return
     try:
-        photon_auth.refresh_user_numbers(token, dashboard_id)
+        photon_auth.refresh_user_numbers(spectrum_id, project_secret)
     except Exception as e:
         print(f"      (could not refresh Photon user numbers: {e})", file=sys.stderr)
 

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -332,9 +332,13 @@ def _install_sidecar() -> int:
             file=sys.stderr,
         )
         return 1
-    print(f"  $ cd {_SIDECAR_DIR} && {npm} install")
+    # Always pull the newest published spectrum-ts so every setup runs against
+    # the latest SDK. `spectrum-ts@latest` bumps package.json + package-lock.json
+    # to the current release before installing — a plain `npm install` would
+    # stay pinned to whatever the committed lockfile already resolved.
+    print(f"  $ cd {_SIDECAR_DIR} && {npm} install spectrum-ts@latest")
     proc = subprocess.run(  # noqa: S603
-        [npm, "install"],
+        [npm, "install", "spectrum-ts@latest"],
         cwd=str(_SIDECAR_DIR),
         check=False,
     )

--- a/plugins/platforms/photon/plugin.yaml
+++ b/plugins/platforms/photon/plugin.yaml
@@ -46,6 +46,10 @@ optional_env:
     description: "Photon Dashboard API host (default https://app.photon.codes)"
     prompt: "Dashboard host"
     password: false
+  - name: PHOTON_SPECTRUM_HOST
+    description: "Photon Spectrum API host (default https://spectrum.photon.codes)"
+    prompt: "Spectrum API host"
+    password: false
   - name: PHOTON_ALLOWED_USERS
     description: "Comma-separated E.164 phone numbers allowed to talk to the bot"
     prompt: "Allowed users (comma-separated)"

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -92,6 +92,7 @@ const app = await Spectrum({
   projectId,
   projectSecret,
   providers: [imessage.config()],
+  options: { flattenGroups: true },
 });
 
 // ---------------------------------------------------------------------------

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -48,11 +48,11 @@ const port = parseInt(process.env.PHOTON_SIDECAR_PORT || "8789", 10);
 const bind = process.env.PHOTON_SIDECAR_BIND || "127.0.0.1";
 const sharedToken = process.env.PHOTON_SIDECAR_TOKEN;
 
-// Inbound attachments are read into memory and base64-inlined on the NDJSON
+// Inbound binary content is read into memory and base64-inlined on the NDJSON
 // event so the Python adapter can cache the real bytes (and the agent can see
-// the image). Cap the size we inline — above it we forward metadata only and
-// the adapter surfaces a text marker, so one large video can't balloon a
-// single NDJSON line. Override via PHOTON_MAX_INLINE_ATTACHMENT_BYTES.
+// images / transcribe voice). Cap the size we inline — above it we forward
+// metadata only and the adapter surfaces a text marker, so one large clip can't
+// balloon a single NDJSON line. Override via PHOTON_MAX_INLINE_ATTACHMENT_BYTES.
 const MAX_INLINE_ATTACHMENT_BYTES =
   Number(process.env.PHOTON_MAX_INLINE_ATTACHMENT_BYTES) || 20 * 1024 * 1024;
 const DM_CHAT_GUID_RE = /^any;-;(\+\d{6,})$/;
@@ -164,6 +164,57 @@ async function deliver(line) {
   }
 }
 
+async function normalizeBinaryContent(content) {
+  const meta = {
+    type: content.type,
+    id: content.id ?? null,
+    name: content.name ?? null,
+    mimeType: content.mimeType ?? null,
+    size: typeof content.size === "number" ? content.size : null,
+  };
+  if (content.type === "voice" && typeof content.duration === "number") {
+    meta.duration = content.duration;
+  }
+
+  // Read the bytes eagerly and base64-inline them as `data` so the Python
+  // adapter can cache the real file (the agent then sees images and can run
+  // STT on voice notes). Spectrum content objects may not outlive this stream
+  // iteration, so a lazy/on-demand fetch isn't safe. Over-cap content (when
+  // size is known up front) is forwarded as metadata only and the adapter falls
+  // back to a text marker. A read failure must never break the inbound loop.
+  const label = `${content.type} ${meta.name ?? meta.id ?? "(unnamed)"}`;
+  if (meta.size !== null && meta.size > MAX_INLINE_ATTACHMENT_BYTES) {
+    console.error(
+      `photon-sidecar: ${label} (${meta.size} bytes) ` +
+        `exceeds inline cap ${MAX_INLINE_ATTACHMENT_BYTES}; forwarding metadata only`
+    );
+    return meta;
+  }
+  if (typeof content.read === "function") {
+    try {
+      const buf = await content.read();
+      // Guard the case where size was unknown but the bytes turn out to be
+      // over the cap.
+      if (buf && buf.length > MAX_INLINE_ATTACHMENT_BYTES) {
+        console.error(
+          `photon-sidecar: ${label} (${buf.length} bytes) ` +
+            `exceeds inline cap after read; forwarding metadata only`
+        );
+        return meta;
+      }
+      meta.data = Buffer.from(buf).toString("base64");
+      meta.encoding = "base64";
+    } catch (e) {
+      console.error(
+        `photon-sidecar: failed to read ${content.type} bytes ` +
+          "(forwarding metadata only): " +
+          (e && e.stack ? e.stack : String(e))
+      );
+    }
+  }
+  return meta;
+}
+
 async function normalizeContent(content) {
   if (!content || typeof content !== "object") {
     return { type: "unknown" };
@@ -171,51 +222,8 @@ async function normalizeContent(content) {
   if (content.type === "text") {
     return { type: "text", text: content.text || "" };
   }
-  if (content.type === "attachment") {
-    const meta = {
-      type: "attachment",
-      id: content.id ?? null,
-      name: content.name ?? null,
-      mimeType: content.mimeType ?? null,
-      size: typeof content.size === "number" ? content.size : null,
-    };
-    // Read the bytes eagerly and base64-inline them as `data` so the Python
-    // adapter can cache the real file (the agent then sees the image itself).
-    // The spectrum-ts attachment object may not outlive this stream
-    // iteration, so a lazy/on-demand fetch isn't safe. Over-cap attachments
-    // (when size is known up front) are forwarded as metadata only and the
-    // adapter falls back to a text marker. A read failure must never break
-    // the inbound loop — we just drop `data` and forward metadata.
-    if (meta.size !== null && meta.size > MAX_INLINE_ATTACHMENT_BYTES) {
-      console.error(
-        `photon-sidecar: attachment ${meta.name ?? meta.id} (${meta.size} bytes) ` +
-          `exceeds inline cap ${MAX_INLINE_ATTACHMENT_BYTES}; forwarding metadata only`
-      );
-      return meta;
-    }
-    if (typeof content.read === "function") {
-      try {
-        const buf = await content.read();
-        // Guard the case where size was unknown but the bytes turn out to be
-        // over the cap.
-        if (buf && buf.length > MAX_INLINE_ATTACHMENT_BYTES) {
-          console.error(
-            `photon-sidecar: attachment ${meta.name ?? meta.id} (${buf.length} bytes) ` +
-              `exceeds inline cap after read; forwarding metadata only`
-          );
-          return meta;
-        }
-        meta.data = Buffer.from(buf).toString("base64");
-        meta.encoding = "base64";
-      } catch (e) {
-        console.error(
-          "photon-sidecar: failed to read attachment bytes " +
-            "(forwarding metadata only): " +
-            (e && e.stack ? e.stack : String(e))
-        );
-      }
-    }
-    return meta;
+  if (content.type === "attachment" || content.type === "voice") {
+    return await normalizeBinaryContent(content);
   }
   return { type: content.type || "unknown" };
 }

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@hermes-agent/photon-sidecar",
       "version": "0.2.0",
       "dependencies": {
-        "spectrum-ts": "^1.17.1"
+        "spectrum-ts": "^1.18.0"
       },
       "engines": {
         "node": ">=18.17"

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -12,6 +12,6 @@
     "node": ">=18.17"
   },
   "dependencies": {
-    "spectrum-ts": "^1.17.1"
+    "spectrum-ts": "^1.18.0"
   }
 }

--- a/tests/plugins/platforms/photon/test_auth.py
+++ b/tests/plugins/platforms/photon/test_auth.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+from base64 import b64encode
 from pathlib import Path
 from typing import Any, Dict
 
@@ -40,6 +41,7 @@ _PHOTON_ENV = (
     "PHOTON_PROJECT_ID",
     "PHOTON_PROJECT_SECRET",
     "PHOTON_DASHBOARD_PROJECT_ID",
+    "PHOTON_SPECTRUM_HOST",
     "PHOTON_ALLOWED_USERS",
     "PHOTON_HOME_CHANNEL",
 )
@@ -140,17 +142,19 @@ def test_refresh_user_numbers_reads_existing_assignment(
     photon_auth.store_user_numbers(phone_number="+15551234567")
 
     def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
-        assert kwargs.get("headers", {}).get("Authorization") == "Bearer tok"
-        assert url.endswith("/projects/dash/spectrum/users")
-        return _FakeResponse(json_body=[{
+        assert kwargs.get("headers", {}).get("Authorization") == (
+            "Basic " + b64encode(b"sp:secret").decode("ascii")
+        )
+        assert url.endswith("/projects/sp/users/")
+        return _FakeResponse(json_body={"succeed": True, "data": {"users": [{
             "id": "user-uuid",
             "phoneNumber": "+1 (555) 123-4567",
             "assignedPhoneNumber": "+16282679185",
-        }])
+        }]}})
 
     monkeypatch.setattr(photon_auth.httpx, "get", fake_get)
 
-    phone, assigned = photon_auth.refresh_user_numbers("tok", "dash")
+    phone, assigned = photon_auth.refresh_user_numbers("sp", "secret")
     assert phone == "+15551234567"
     assert assigned == "+16282679185"
     assert photon_auth.load_user_numbers() == ("+15551234567", "+16282679185")
@@ -361,7 +365,7 @@ def test_regenerate_project_secret(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_create_user_rejects_invalid_phone() -> None:
     with pytest.raises(ValueError, match="E.164"):
-        photon_auth.create_user("tok", "proj", phone_number="not-a-number")
+        photon_auth.create_user("proj", "secret", phone_number="not-a-number")
 
 
 def test_create_user_posts_dashboard_shape(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -371,27 +375,30 @@ def test_create_user_posts_dashboard_shape(monkeypatch: pytest.MonkeyPatch) -> N
         captured["url"] = url
         captured["body"] = kwargs.get("json")
         captured["headers"] = kwargs.get("headers")
-        return _FakeResponse(json_body={"success": True, "user": {
+        return _FakeResponse(json_body={"succeed": True, "data": {
             "id": "user-uuid", "phoneNumber": "+15551234567",
         }})
 
     monkeypatch.setattr(photon_auth.httpx, "post", fake_post)
-    user = photon_auth.create_user("tok", "proj-id", phone_number="+15551234567")
+    user = photon_auth.create_user("proj-id", "secret", phone_number="+15551234567")
     assert user["id"] == "user-uuid"
+    assert captured["body"]["type"] == "shared"
     assert captured["body"]["phoneNumber"] == "+15551234567"
-    assert captured["headers"]["Authorization"] == "Bearer tok"
-    assert "/projects/proj-id/spectrum/users" in captured["url"]
+    assert captured["headers"]["Authorization"] == (
+        "Basic " + b64encode(b"proj-id:secret").decode("ascii")
+    )
+    assert captured["url"].endswith("/projects/proj-id/users/")
 
 
 def test_register_user_if_absent_dedup(monkeypatch: pytest.MonkeyPatch) -> None:
     posted = {"n": 0}
 
     def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
-        return _FakeResponse(json_body=[{
+        return _FakeResponse(json_body={"succeed": True, "data": {"users": [{
             "id": "u1",
             "phoneNumber": "+1 (555) 123-4567",
             "assignedPhoneNumber": "+16282679185",
-        }])
+        }]}})
 
     def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
         posted["n"] += 1
@@ -401,7 +408,7 @@ def test_register_user_if_absent_dedup(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(photon_auth.httpx, "post", fake_post)
     # Same number, different formatting — should match and NOT create.
     user, created = photon_auth.register_user_if_absent(
-        "tok", "proj", phone_number="+15551234567",
+        "proj", "secret", phone_number="+15551234567",
     )
     assert created is False
     assert user["id"] == "u1"
@@ -424,15 +431,15 @@ def test_user_assigned_line() -> None:
 
 def test_register_user_if_absent_creates(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
-        return _FakeResponse(json_body=[])
+        return _FakeResponse(json_body={"succeed": True, "data": {"users": []}})
 
     def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
-        return _FakeResponse(json_body={"success": True, "user": {"id": "u-new"}})
+        return _FakeResponse(json_body={"succeed": True, "data": {"id": "u-new"}})
 
     monkeypatch.setattr(photon_auth.httpx, "get", fake_get)
     monkeypatch.setattr(photon_auth.httpx, "post", fake_post)
     user, created = photon_auth.register_user_if_absent(
-        "tok", "proj", phone_number="+15551234567",
+        "proj", "secret", phone_number="+15551234567",
     )
     assert created is True
     assert user["id"] == "u-new"

--- a/tests/plugins/platforms/photon/test_auth.py
+++ b/tests/plugins/platforms/photon/test_auth.py
@@ -40,6 +40,8 @@ _PHOTON_ENV = (
     "PHOTON_PROJECT_ID",
     "PHOTON_PROJECT_SECRET",
     "PHOTON_DASHBOARD_PROJECT_ID",
+    "PHOTON_ALLOWED_USERS",
+    "PHOTON_HOME_CHANNEL",
 )
 
 
@@ -96,6 +98,62 @@ def test_store_project_credentials_writes_env(tmp_hermes_home: Path) -> None:
     env_text = (tmp_hermes_home / ".env").read_text()
     assert "PHOTON_PROJECT_ID=sp-789" in env_text
     assert "PHOTON_PROJECT_SECRET=sek-ret" in env_text
+
+
+def test_store_user_numbers_round_trip(tmp_hermes_home: Path) -> None:
+    photon_auth.store_user_numbers(
+        phone_number="+15551234567",
+        assigned_phone_number="+16282679185",
+        user_id="user-uuid",
+        dashboard_project_id="dash-uuid",
+    )
+
+    phone, assigned = photon_auth.load_user_numbers()
+    assert phone == "+15551234567"
+    assert assigned == "+16282679185"
+
+    summary = photon_auth.credential_summary()
+    assert summary["phone_number"] == "+15551234567"
+    assert summary["assigned_phone_number"] == "+16282679185"
+
+    rendered: list[str] = []
+    photon_auth.print_credential_summary(rendered.append)
+    assert "  my number           : +15551234567" in rendered[0]
+    assert "  assigned number     : +16282679185" in rendered[0]
+
+
+def test_load_user_numbers_falls_back_to_home_channel(
+    tmp_hermes_home: Path,
+) -> None:
+    from hermes_cli.config import save_env_value
+
+    save_env_value("PHOTON_HOME_CHANNEL", "+15551234567")
+
+    phone, assigned = photon_auth.load_user_numbers()
+    assert phone == "+15551234567"
+    assert assigned is None
+
+
+def test_refresh_user_numbers_reads_existing_assignment(
+    tmp_hermes_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    photon_auth.store_user_numbers(phone_number="+15551234567")
+
+    def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
+        assert kwargs.get("headers", {}).get("Authorization") == "Bearer tok"
+        assert url.endswith("/projects/dash/spectrum/users")
+        return _FakeResponse(json_body=[{
+            "id": "user-uuid",
+            "phoneNumber": "+1 (555) 123-4567",
+            "assignedPhoneNumber": "+16282679185",
+        }])
+
+    monkeypatch.setattr(photon_auth.httpx, "get", fake_get)
+
+    phone, assigned = photon_auth.refresh_user_numbers("tok", "dash")
+    assert phone == "+15551234567"
+    assert assigned == "+16282679185"
+    assert photon_auth.load_user_numbers() == ("+15551234567", "+16282679185")
 
 
 def test_load_project_credentials_env_override(
@@ -435,6 +493,8 @@ def test_credential_summary_no_secret_leak(
     assert summary["project_key"].startswith("✓")
     assert summary["spectrum_project_id"] == "sp-uuid"
     assert summary["dashboard_project_id"] == "dash-uuid"
+    assert summary["phone_number"].startswith("✗ missing")
+    assert summary["assigned_phone_number"].startswith("✗ missing")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -101,6 +101,18 @@ def _attachment_event(
     }
 
 
+def _voice_event(
+    content: Dict[str, Any], msg_id: str = "spc-msg-voice"
+) -> Dict[str, Any]:
+    return {
+        "messageId": msg_id,
+        "space": {"id": "+15551234567", "type": "dm", "phone": "+15551234567"},
+        "sender": {"id": "+15551234567"},
+        "content": {"type": "voice", **content},
+        "timestamp": "2026-05-14T19:06:32.000Z",
+    }
+
+
 @pytest.mark.asyncio
 async def test_dispatch_attachment_without_bytes_surfaces_marker(
     monkeypatch: pytest.MonkeyPatch,
@@ -154,6 +166,64 @@ async def test_dispatch_attachment_downloads_image(
         assert ev.text == "(attachment)"
     finally:
         cached.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_voice_downloads_audio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inbound Spectrum voice content is cached and routed to auto-STT."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    raw = b"OggS" + b"\x00" * 32
+    event = _voice_event(
+        {
+            "name": "note.ogg",
+            "mimeType": "audio/ogg",
+            "duration": 7,
+            "size": len(raw),
+            "data": base64.b64encode(raw).decode("ascii"),
+            "encoding": "base64",
+        }
+    )
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert ev.message_type == MessageType.VOICE
+    assert ev.media_types == ["audio/ogg"]
+    assert len(ev.media_urls) == 1
+    cached = Path(ev.media_urls[0])
+    try:
+        assert cached.is_file()
+        assert cached.read_bytes() == raw
+        assert ev.text == "(voice)"
+    finally:
+        cached.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_voice_without_bytes_surfaces_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Metadata-only voice still tells the agent a voice note arrived."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _voice_event(
+        {"name": "note.m4a", "mimeType": "audio/mp4", "duration": 12, "size": 12345}
+    )
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert "Photon voice received" in ev.text
+    assert "note.m4a" in ev.text
+    assert "duration: 12s" in ev.text
+    assert ev.message_type == MessageType.VOICE
+    assert ev.media_urls == []
+    assert ev.media_types == []
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -222,6 +222,7 @@ Common issues:
 | `PHOTON_REQUIRE_MENTION`  | `false`            | Require a wake word before responding in groups |
 | `PHOTON_MENTION_PATTERNS` | Hermes wake words  | JSON list / comma / newline regex patterns for group mentions |
 | `PHOTON_DASHBOARD_HOST`   | `app.photon.codes` | Override the dashboard / device-login host |
+| `PHOTON_SPECTRUM_HOST`    | `spectrum.photon.codes` | Override the Spectrum API host |
 
 [photon]: https://photon.codes/
 [app]: https://app.photon.codes/

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -162,7 +162,10 @@ Send an iMessage to your assigned number and Hermes will reply.
 hermes photon status
 ```
 
-Prints:
+Prints saved credentials, sidecar health, your registered number, and the
+assigned iMessage line Hermes uses. When a Photon token and dashboard project
+are available, `status` refreshes missing number rows from the dashboard
+without provisioning new lines.
 
 ```
 Photon iMessage status
@@ -171,6 +174,8 @@ Photon iMessage status
   dashboard project   : 3c90c3cc-0d44-4b50-...
   spectrum project id : sp-...
   project secret      : ✓ stored
+  my number           : +15551234567
+  assigned number     : +16282679185
   node binary         : /usr/bin/node
   sidecar deps        : ✓ installed
 ```


### PR DESCRIPTION
## What does this PR do?

Five focused follow-ups on top of the now-merged gRPC-native Photon channel (PR #42444, landed as `4e4d27875…3b983e779`). These harden the user/management plane and the outbound send path that shipped with that rework.

The headline change is moving the **Spectrum user API** off the Dashboard API (Bearer token) and onto the **Spectrum API** (Basic auth with project credentials) — the Dashboard endpoints were the wrong backend for user management and don't return the data the channel needs. The rest are smaller correctness fixes: markdown stripping + send retries, group flattening in the SDK config, persisting/displaying phone numbers in `status`, and bumping the SDK to the latest release.

This branch is rebased on current `main`, so it contains **only** these 5 commits.

## Related Issue

Follow-up to #42444 (merged). No separate tracking issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### Migrate user API calls to the Spectrum backend
- `list_users`, `find_user_by_phone`, `create_user`, `register_user_if_absent`, and `refresh_user_numbers` now hit the **Spectrum API** (`{spectrum_host}/projects/{id}/users/`) with **Basic auth** built from the project credentials, instead of the Dashboard API with a Bearer token. — `auth.py`, `cli.py`
- Added a `_spectrum_host()` resolver, a `_basic(project_id, project_secret)` header helper, and structured error helpers (`_response_error_detail` / `_raise_for_status`); response unwrapping now handles Spectrum's nested `data.users` envelope. `create_user` sends `{"type": "shared", ...}`. — `auth.py`
- New `PHOTON_SPECTRUM_HOST` env var (default `https://spectrum.photon.codes`). — `plugin.yaml`, `README.md`, `website/docs/user-guide/messaging/photon.md`

### Outbound send: strip markdown + retry
- Outbound text is now passed through `format_message()` → `strip_markdown()` so iMessage (plain text) doesn't render raw Markdown. — `adapter.py`
- Added `_send_with_retry()` with exponential backoff for retryable/network errors and a plain-text fallback, so a transient send failure no longer drops the reply. — `adapter.py`

### Group flattening
- Enabled `options: { flattenGroups: true }` in the sidecar's `Spectrum({...})` config so group conversations normalize correctly. — `sidecar/index.mjs`

### Persist & display phone numbers in `status`
- `setup` stores the operator's phone, assigned iMessage line, and user id in `auth.json`; `hermes photon status` surfaces them and auto-refreshes (without provisioning new lines) when they're missing. — `cli.py`, `auth.py`

### Bump SDK
- `spectrum-ts` → `^1.18.0`, and `setup` now runs `npm install spectrum-ts@latest` so every setup picks up the newest published SDK rather than staying pinned to the committed lockfile. — `sidecar/package.json`, `sidecar/package-lock.json`, `cli.py`

## How to Test

```bash
hermes photon setup --phone +15551234567
hermes photon status   # shows operator + assigned iMessage numbers
hermes gateway start --platform photon
```

1. Run `setup` → user is created via the Spectrum API; re-running is idempotent (phone dedup).
2. `hermes photon status` shows the operator phone and assigned iMessage line (auto-refreshes if absent).
3. Have the agent reply with Markdown → it's delivered as clean plain text; a transient send error is retried with backoff.

Automated:

```bash
pytest tests/plugins/platforms/photon/ tests/tools/test_send_message_target_parse.py tests/tools/test_send_message_tool.py -q
# 65 passed, 1 skipped
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (rebased on `main`; 5 commits, no already-merged work)
- [x] I've run the Photon test scope and all tests pass (65 passed, 1 skipped)
- [x] I've added tests for my changes (`tests/plugins/platforms/photon/test_auth.py`)
- [x] I've tested on my platform: macOS (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`) — plugin README + website messaging docs (`PHOTON_SPECTRUM_HOST`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — new env var documented in `plugin.yaml`
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — sidecar runs on Node; iMessage targets macOS
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/plugins/platforms/photon/ tests/tools/test_send_message_target_parse.py tests/tools/test_send_message_tool.py -q
.................................................................         [100%]
65 passed, 1 skipped in 12.33s
```
