### PR TITLE
feat(tui): interactive Plugins Hub overlay for enable/disable

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -175,6 +175,7 @@ _LONG_HANDLERS = frozenset(
     {
         "browser.manage",
         "cli.exec",
+        "plugins.manage",
         "session.branch",
         "session.compress",
         "session.resume",
@@ -9020,7 +9021,83 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5025, str(e))
 
 
-# ── Methods: shell ───────────────────────────────────────────────────
+@method("plugins.manage")
+def _(rid, params: dict) -> dict:
+    """List installed plugins with activation state, or toggle one on/off.
+
+    Backs the TUI Plugins Hub. Uses the same disk-discovery + enable/disable
+    primitives as ``hermes plugins`` / the dashboard, so the three surfaces
+    agree on what's installed and what's enabled.
+
+    Actions:
+      - ``list``   → {"plugins": [{name, version, description, source,
+                       status}], "user_count": N, "bundled_count": M}
+      - ``toggle`` → flip ``name`` based on ``enable`` (bool). Returns the
+                       refreshed row plus {"ok", "unchanged"}.
+    """
+    action = params.get("action", "list")
+    try:
+        from hermes_cli.plugins_cmd import (
+            _discover_all_plugins,
+            _get_disabled_set,
+            _get_enabled_set,
+            _plugin_status,
+        )
+
+        def _rows():
+            enabled = _get_enabled_set()
+            disabled = _get_disabled_set()
+            out = []
+            for name, version, desc, source, _dir, key in sorted(
+                _discover_all_plugins()
+            ):
+                out.append(
+                    {
+                        "name": name,
+                        "version": str(version or ""),
+                        "description": desc or "",
+                        "source": source,
+                        "status": _plugin_status(name, enabled, disabled, key=key),
+                    }
+                )
+            return out
+
+        if action == "list":
+            rows = _rows()
+            user_count = sum(1 for r in rows if r["source"] != "bundled")
+            return _ok(
+                rid,
+                {
+                    "plugins": rows,
+                    "user_count": user_count,
+                    "bundled_count": len(rows) - user_count,
+                },
+            )
+
+        if action == "toggle":
+            from hermes_cli.plugins_cmd import dashboard_set_agent_plugin_enabled
+
+            name = (params.get("name") or "").strip()
+            if not name:
+                return _err(rid, 4019, "plugins.toggle requires a 'name'")
+            enable = bool(params.get("enable"))
+            result = dashboard_set_agent_plugin_enabled(name, enabled=enable)
+            if not result.get("ok"):
+                return _err(rid, 5026, result.get("error") or "toggle failed")
+            row = next((r for r in _rows() if r["name"] == name), None)
+            return _ok(
+                rid,
+                {
+                    "ok": True,
+                    "unchanged": bool(result.get("unchanged")),
+                    "name": name,
+                    "plugin": row,
+                },
+            )
+
+        return _err(rid, 4017, f"unknown plugins action: {action}")
+    except Exception as e:
+        return _err(rid, 5026, str(e))
 
 
 @method("shell.exec")

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -93,6 +93,7 @@ export interface OverlayState {
   confirm: ConfirmReq | null
   modelPicker: boolean
   pager: null | PagerState
+  pluginsHub: boolean
   secret: null | SecretReq
   sessions: boolean
   skillsHub: boolean

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -10,6 +10,7 @@ const buildOverlayState = (): OverlayState => ({
   confirm: null,
   modelPicker: false,
   pager: null,
+  pluginsHub: false,
   secret: null,
   sessions: false,
   skillsHub: false,
@@ -20,8 +21,10 @@ export const $overlayState = atom<OverlayState>(buildOverlayState())
 
 export const $isBlocked = computed(
   $overlayState,
-  ({ agents, approval, clarify, confirm, modelPicker, pager, secret, sessions, skillsHub, sudo }) =>
-    Boolean(agents || approval || clarify || confirm || modelPicker || pager || secret || sessions || skillsHub || sudo)
+  ({ agents, approval, clarify, confirm, modelPicker, pager, pluginsHub, secret, sessions, skillsHub, sudo }) =>
+    Boolean(
+      agents || approval || clarify || confirm || modelPicker || pager || pluginsHub || secret || sessions || skillsHub || sudo
+    )
 )
 
 export const getOverlayState = () => $overlayState.get()
@@ -46,6 +49,7 @@ export const resetFlowOverlays = () =>
     agents: $overlayState.get().agents,
     agentsInitialHistoryIndex: $overlayState.get().agentsInitialHistoryIndex,
     modelPicker: $overlayState.get().modelPicker,
+    pluginsHub: $overlayState.get().pluginsHub,
     sessions: $overlayState.get().sessions,
     skillsHub: $overlayState.get().skillsHub
   })

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -653,6 +653,34 @@ export const opsCommands: SlashCommand[] = [
   },
 
   {
+    help: 'view & toggle plugins (no arg opens the hub; enable/disable <name> for direct toggle)',
+    name: 'plugins',
+    run: (arg, ctx, cmd) => {
+      // No argument → open the interactive Plugins Hub overlay. Any
+      // subcommand (enable/disable/list/install/…) falls through to the
+      // text slash worker so it stays at parity with `hermes plugins`.
+      if (!arg.trim()) {
+        return patchOverlayState({ pluginsHub: true })
+      }
+
+      ctx.gateway.gw
+        .request<SlashExecResponse>('slash.exec', { command: cmd.slice(1), session_id: ctx.sid })
+        .then(r => {
+          if (ctx.stale()) {
+            return
+          }
+
+          const body = r?.output || '/plugins: no output'
+          const text = r?.warning ? `warning: ${r.warning}\n${body}` : body
+          const long = text.length > 180 || text.split('\n').filter(Boolean).length > 2
+
+          long ? ctx.transcript.page(text, 'Plugins') : ctx.transcript.sys(text)
+        })
+        .catch(ctx.guardedErr)
+    }
+  },
+
+  {
     help: 'enable or disable tools (client-side history reset on change)',
     name: 'tools',
     run: (arg, ctx, cmd) => {

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -151,6 +151,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return patchOverlayState({ skillsHub: false })
     }
 
+    if (overlay.pluginsHub) {
+      return patchOverlayState({ pluginsHub: false })
+    }
+
     if (overlay.sessions) {
       return patchOverlayState({ sessions: false })
     }

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -11,6 +11,7 @@ import { FloatBox } from './appChrome.js'
 import { MaskedPrompt } from './maskedPrompt.js'
 import { ModelPicker } from './modelPicker.js'
 import { OverlayHint } from './overlayControls.js'
+import { PluginsHub } from './pluginsHub.js'
 import { ApprovalPrompt, ClarifyPrompt, ConfirmPrompt } from './prompts.js'
 import { SkillsHub } from './skillsHub.js'
 
@@ -125,6 +126,7 @@ export function FloatingOverlays({
     overlay.pager ||
     overlay.sessions ||
     overlay.skillsHub ||
+    overlay.pluginsHub ||
     completions.length
 
   if (!hasAny) {
@@ -171,6 +173,12 @@ export function FloatingOverlays({
       {overlay.skillsHub && (
         <FloatBox color={theme.color.border}>
           <SkillsHub gw={gw} onClose={() => patchOverlayState({ skillsHub: false })} t={theme} />
+        </FloatBox>
+      )}
+
+      {overlay.pluginsHub && (
+        <FloatBox color={theme.color.border}>
+          <PluginsHub gw={gw} onClose={() => patchOverlayState({ pluginsHub: false })} t={theme} />
         </FloatBox>
       )}
 

--- a/ui-tui/src/components/pluginsHub.tsx
+++ b/ui-tui/src/components/pluginsHub.tsx
@@ -1,0 +1,238 @@
+import { Box, Text, useInput, useStdout } from '@hermes/ink'
+import { useEffect, useState } from 'react'
+
+import type { GatewayClient } from '../gatewayClient.js'
+import { rpcErrorMessage } from '../lib/rpc.js'
+import type { Theme } from '../theme.js'
+
+import { OverlayHint, useOverlayKeys, windowItems, windowOffset } from './overlayControls.js'
+
+const VISIBLE = 12
+const MIN_WIDTH = 44
+const MAX_WIDTH = 96
+
+interface PluginRow {
+  description?: string
+  name: string
+  source?: string
+  status?: string
+  version?: string
+}
+
+interface PluginsListResponse {
+  bundled_count?: number
+  plugins?: PluginRow[]
+  user_count?: number
+}
+
+interface PluginsToggleResponse {
+  name?: string
+  ok?: boolean
+  plugin?: PluginRow
+  unchanged?: boolean
+}
+
+type Scope = 'all' | 'user'
+
+const GLYPH: Record<string, string> = {
+  disabled: '✗',
+  enabled: '✓'
+}
+
+export function PluginsHub({ gw, onClose, t }: PluginsHubProps) {
+  const [rows, setRows] = useState<PluginRow[]>([])
+  const [bundledCount, setBundledCount] = useState(0)
+  const [userCount, setUserCount] = useState(0)
+  const [idx, setIdx] = useState(0)
+  const [scope, setScope] = useState<Scope>('user')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  const { stdout } = useStdout()
+  const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
+
+  const load = () => {
+    gw.request<PluginsListResponse>('plugins.manage', { action: 'list' })
+      .then(r => {
+        setRows(r?.plugins ?? [])
+        setUserCount(Number(r?.user_count ?? 0))
+        setBundledCount(Number(r?.bundled_count ?? 0))
+        setErr('')
+        setLoading(false)
+      })
+      .catch((e: unknown) => {
+        setErr(rpcErrorMessage(e))
+        setLoading(false)
+      })
+  }
+
+  useEffect(load, [gw])
+
+  // Default to user plugins; fall back to all when there are none so the
+  // overlay is never empty when bundled plugins exist.
+  const visibleRows = scope === 'user' ? rows.filter(r => r.source !== 'bundled') : rows
+  const effectiveRows = scope === 'user' && !visibleRows.length && rows.length ? rows : visibleRows
+  const effectiveScope: Scope = effectiveRows === visibleRows ? scope : 'all'
+  const clampedIdx = Math.min(idx, Math.max(0, effectiveRows.length - 1))
+
+  useOverlayKeys({ disabled: busy, onClose })
+
+  const toggle = (row: PluginRow) => {
+    if (busy || !row) {
+      return
+    }
+
+    const enable = row.status !== 'enabled'
+    setBusy(true)
+    setErr('')
+
+    gw.request<PluginsToggleResponse>('plugins.manage', { action: 'toggle', enable, name: row.name })
+      .then(r => {
+        if (r?.plugin) {
+          setRows(prev => prev.map(p => (p.name === r.plugin!.name ? r.plugin! : p)))
+        } else {
+          load()
+        }
+      })
+      .catch((e: unknown) => setErr(rpcErrorMessage(e)))
+      .finally(() => setBusy(false))
+  }
+
+  useInput((ch, key) => {
+    if (busy) {
+      return
+    }
+
+    const count = effectiveRows.length
+
+    if (key.upArrow && clampedIdx > 0) {
+      setIdx(clampedIdx - 1)
+
+      return
+    }
+
+    if (key.downArrow && clampedIdx < count - 1) {
+      setIdx(clampedIdx + 1)
+
+      return
+    }
+
+    // Tab toggles user-only vs all (bundled) scope.
+    if (key.tab) {
+      setScope(s => (s === 'user' ? 'all' : 'user'))
+      setIdx(0)
+
+      return
+    }
+
+    if (key.return || ch === ' ') {
+      const row = effectiveRows[clampedIdx]
+
+      if (row) {
+        toggle(row)
+      }
+
+      return
+    }
+
+    const n = ch === '0' ? 10 : parseInt(ch, 10)
+
+    if (!Number.isNaN(n) && n >= 1 && n <= Math.min(10, count)) {
+      const next = windowOffset(count, clampedIdx, VISIBLE) + n - 1
+      const row = effectiveRows[next]
+
+      if (row) {
+        setIdx(next)
+        toggle(row)
+      }
+    }
+  })
+
+  if (loading) {
+    return <Text color={t.color.muted}>loading plugins…</Text>
+  }
+
+  if (err && !rows.length) {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text color={t.color.label}>error: {err}</Text>
+        <OverlayHint t={t}>Esc/q close</OverlayHint>
+      </Box>
+    )
+  }
+
+  if (!rows.length) {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text bold color={t.color.accent}>
+          Plugins Hub
+        </Text>
+        <Text color={t.color.muted}>no plugins installed</Text>
+        <Text color={t.color.muted}>install: hermes plugins install owner/repo</Text>
+        <OverlayHint t={t}>Esc/q close</OverlayHint>
+      </Box>
+    )
+  }
+
+  const labels = effectiveRows.map(r => {
+    const status = r.status ?? 'not enabled'
+    const glyph = GLYPH[status] ?? '○'
+    const ver = r.version ? ` v${r.version}` : ''
+    const src = effectiveScope === 'all' && r.source === 'bundled' ? ' [bundled]' : ''
+    const state = status === 'enabled' ? '' : ` (${status})`
+
+    return `${glyph} ${r.name}${ver}${src}${state}`
+  })
+
+  const { items, offset } = windowItems(labels, clampedIdx, VISIBLE)
+
+  const scopeLabel =
+    effectiveScope === 'user'
+      ? `${userCount} user plugin(s)${bundledCount ? ` · +${bundledCount} bundled (Tab)` : ''}`
+      : `all ${rows.length} plugins`
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Text bold color={t.color.accent}>
+        Plugins Hub
+      </Text>
+
+      <Text color={t.color.muted}>{scopeLabel}</Text>
+      {offset > 0 && <Text color={t.color.muted}> ↑ {offset} more</Text>}
+
+      {items.map((row, i) => {
+        const lineIdx = offset + i
+        const active = clampedIdx === lineIdx
+
+        return (
+          <Text
+            bold={active}
+            color={active ? t.color.accent : t.color.muted}
+            inverse={active}
+            key={effectiveRows[lineIdx]?.name ?? row}
+            wrap="truncate-end"
+          >
+            {active ? '▸ ' : '  '}
+            {i + 1}. {row}
+          </Text>
+        )
+      })}
+
+      {offset + VISIBLE < labels.length && (
+        <Text color={t.color.muted}> ↓ {labels.length - offset - VISIBLE} more</Text>
+      )}
+
+      {err ? <Text color={t.color.label}>error: {err}</Text> : null}
+      {busy ? <Text color={t.color.accent}>updating…</Text> : null}
+
+      <OverlayHint t={t}>↑/↓ select · Enter/Space toggle · Tab user/all · 1-9,0 quick · Esc/q close</OverlayHint>
+    </Box>
+  )
+}
+
+interface PluginsHubProps {
+  gw: GatewayClient
+  onClose: () => void
+  t: Theme
+}


### PR DESCRIPTION
## What does this PR do?

Adds an **interactive Plugins Hub overlay to the TUI** so you can enable/disable plugins without leaving `hermes --tui`.

Before this, the TUI had no plugin toggle at all: `/plugins` only printed a static text list, and the classic `hermes plugins` picker is **curses-based** and cannot run inside the Ink UI (Ink owns the screen). The only way to toggle a plugin while in the TUI was to drop to a separate shell and run `hermes plugins enable/disable <name>`. Skills already have a rich `SkillsHub` overlay; plugins were simply never wired up. This closes that gap using the same overlay pattern.

## Related Issue

<!-- No tracking issue; surfaced from a user asking how to toggle plugins in the TUI. -->
Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Gateway (Python):**
- `tui_gateway/server.py` — new `plugins.manage` RPC with two actions:
  - `list` → `{plugins: [{name, version, description, source, status}], user_count, bundled_count}`
  - `toggle` → flips `name` by `enable` (bool), returns the refreshed row
  - Backed by the existing `_discover_all_plugins` + `_plugin_status` (disk discovery) and `dashboard_set_agent_plugin_enabled` (the dashboard's toggle primitive, which also wires the plugin's toolset into `platform_toolsets`). All three surfaces — CLI, dashboard, TUI — now agree on installed/enabled state.
  - Added to `_LONG_HANDLERS` (does disk + config I/O, runs off the main RPC thread).

**TUI (TypeScript / Ink):**
- `ui-tui/src/components/pluginsHub.tsx` — **new** overlay component (modeled on `skillsHub.tsx`): arrow/number-key select, **Enter/Space toggles live**, **Tab** switches user-only vs all (bundled) scope, shows ✓/✗/○ activation glyphs, defaults to user plugins.
- `ui-tui/src/app/slash/commands/ops.ts` — `/plugins` with no arg opens the hub; any subcommand (`enable`/`disable`/`list`/…) still falls through to the text slash worker for parity with `hermes plugins`.
- `ui-tui/src/app/overlayStore.ts`, `interfaces.ts` — new `pluginsHub` overlay state; included in `$isBlocked` and preserved across turn teardown (`resetFlowOverlays`) like other user-toggled overlays.
- `ui-tui/src/app/useInputHandlers.ts` — Esc closes the hub.
- `ui-tui/src/components/appOverlays.tsx` — renders the `PluginsHub` FloatBox.

## How to Test

1. `hermes --tui`
2. Type `/plugins` (no argument) → the **Plugins Hub overlay** opens.
3. Arrow up/down (or number keys) to select; **Enter/Space** toggles the highlighted plugin — the ✓/✗ glyph and `(disabled)`/`(enabled)` label update live.
4. **Tab** switches between user-only and all-plugins (incl. bundled) views.
5. **Esc/q** closes the overlay.
6. Parity check: `/plugins enable <name>` / `/plugins disable <name>` / `/plugins list` still work as text commands.
7. Verify the toggle actually persisted: in a shell, `hermes plugins list` reflects the new state.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(tui): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (7 source files; no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- backend verified by directly invoking the plugins.manage handler (list + toggle off/on + error paths) against my real install; TUI: tsc typecheck clean, eslint 0 errors, production build OK, createSlashHandler suite 58/58. Full Python suite not run locally — relying on CI. -->
- [ ] I've added tests for my changes <!-- no new unit test yet; the gateway handler reuses primitives already covered by tests/hermes_cli/test_plugins_cmd.py, and the TUI overlay follows the untested-by-convention SkillsHub pattern. Happy to add a plugins.manage handler test and/or a createSlashHandler case for /plugins opening the overlay if reviewers want them. -->
- [x] I've tested on my platform: Ubuntu/WSL2 (Python 3.11, Node via ui-tui)

### Documentation & Housekeeping

- [x] N/A — no doc change needed (mirrors existing SkillsHub behavior)
- [x] N/A — no new/changed config keys
- [x] N/A — no architecture/workflow change (follows the documented TUI overlay + gateway RPC pattern in AGENTS.md)
- [x] I've considered cross-platform impact: the hub is pure Ink/RPC (no curses), so it works wherever the TUI runs — which is precisely why curses `hermes plugins` couldn't.
- [x] N/A — no tool description/schema changes

## Screenshots / Logs

Backend `plugins.manage` verified directly against my install (config restored afterward):

```
LIST user_count=1 bundled_count=66
user plugins: [('evey-goals', 'enabled')]
TOGGLE → ok=True unchanged=False status=disabled   (refreshed row returned)
RESTORE → ok=True unchanged=False status_now=enabled
EMPTY NAME err: {code: 4019, message: "plugins.toggle requires a 'name'"}
UNKNOWN ACTION err: {code: 4017, message: 'unknown plugins action: frobnicate'}
```

TUI build & checks:
```
tsc --noEmit            → clean
eslint (changed files)  → 0 errors
npm run build           → dist/entry.js built; "Plugins Hub" present in bundle
createSlashHandler test → 58 passed
```

Note: 24 pre-existing `textInputWrap`/`cursorDrift`/`virtualHeights` test failures in this checkout are unrelated (verified they fail identically on clean `main` without these changes — a local `wrap-ansi` environment quirk).
