### PR TITLE
fix(desktop): keep new sessions in recency order

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -90,6 +90,7 @@ import { SidebarPanelLabel } from '../../shell/sidebar-label'
 import type { SidebarNavItem } from '../../types'
 
 import { SidebarCronJobsSection } from './cron-jobs-section'
+import { reconcileOrderIds } from './order'
 import { ProfileRail } from './profile-switcher'
 import { SidebarSessionRow } from './session-row'
 import { VirtualSessionList } from './virtual-session-list'
@@ -159,29 +160,6 @@ function orderByIds<T>(items: T[], getId: (item: T) => string, orderIds: string[
   }
 
   return out
-}
-
-function reconcileOrderIds(currentIds: string[], orderIds: string[]): string[] {
-  if (!currentIds.length) {
-    return []
-  }
-
-  if (!orderIds.length) {
-    return currentIds
-  }
-
-  const current = new Set(currentIds)
-  const next = orderIds.filter(id => current.has(id))
-  const known = new Set(next)
-
-  for (const id of currentIds) {
-    if (!known.has(id)) {
-      next.push(id)
-      known.add(id)
-    }
-  }
-
-  return next
 }
 
 function sameIds(left: string[], right: string[]) {

--- a/apps/desktop/src/app/chat/sidebar/order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { reconcileOrderIds } from './order'
+
+describe('reconcileOrderIds', () => {
+  it('does not seed a manual order from the natural session order', () => {
+    expect(reconcileOrderIds(['newest', 'older'], [])).toEqual([])
+  })
+
+  it('clears an old auto-seeded natural order when new sessions arrive', () => {
+    expect(reconcileOrderIds(['newest', 'older', 'oldest'], ['older', 'oldest'])).toEqual([])
+  })
+
+  it('keeps manual order and appends newly loaded ids', () => {
+    expect(reconcileOrderIds(['newest', 'older', 'oldest'], ['oldest', 'older'])).toEqual([
+      'oldest',
+      'older',
+      'newest'
+    ])
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -1,0 +1,30 @@
+export function reconcileOrderIds(currentIds: string[], orderIds: string[]): string[] {
+  if (!currentIds.length || !orderIds.length) {
+    return []
+  }
+
+  const current = new Set(currentIds)
+  const next = orderIds.filter(id => current.has(id))
+
+  if (!next.length) {
+    return []
+  }
+
+  const ordered = new Set(next)
+  const naturalKnownOrder = currentIds.filter(id => ordered.has(id))
+
+  if (naturalKnownOrder.length === next.length && naturalKnownOrder.every((id, index) => id === next[index])) {
+    return []
+  }
+
+  const known = new Set(next)
+
+  for (const id of currentIds) {
+    if (!known.has(id)) {
+      next.push(id)
+      known.add(id)
+    }
+  }
+
+  return next
+}

--- a/apps/desktop/src/lib/storage.test.ts
+++ b/apps/desktop/src/lib/storage.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { persistStringArray, storedStringArray } from './storage'
+
+describe('string array storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('removes the key for an empty array', () => {
+    window.localStorage.setItem('test.order', JSON.stringify(['a']))
+
+    persistStringArray('test.order', [])
+
+    expect(window.localStorage.getItem('test.order')).toBeNull()
+    expect(storedStringArray('test.order')).toEqual([])
+  })
+
+  it('persists non-empty arrays', () => {
+    persistStringArray('test.order', ['a', 'b'])
+
+    expect(window.localStorage.getItem('test.order')).toBe(JSON.stringify(['a', 'b']))
+    expect(storedStringArray('test.order')).toEqual(['a', 'b'])
+  })
+})

--- a/apps/desktop/src/lib/storage.ts
+++ b/apps/desktop/src/lib/storage.ts
@@ -58,7 +58,11 @@ export function storedStringArray(key: string): string[] {
 
 export function persistStringArray(key: string, value: string[]) {
   try {
-    window.localStorage.setItem(key, JSON.stringify(value))
+    if (value.length === 0) {
+      window.localStorage.removeItem(key)
+    } else {
+      window.localStorage.setItem(key, JSON.stringify(value))
+    }
   } catch {
     // Pins are a local preference; restricted storage should not break chat.
   }


### PR DESCRIPTION
## Summary
Fixes #42516.

The desktop sidebar was persisting the initial session order even when the user had not manually reordered sessions. After that saved order existed, newly-created sessions were treated as unknown ids and appended after the saved ids, so they appeared at the bottom instead of following recency order.

This PR:
- keeps missing or empty session order empty instead of initializing it from loaded sessions
- treats saved natural-order subsets as old generated state and clears them
- removes empty string-array localStorage preferences instead of writing []

## Verification
- npx --prefix apps/desktop vitest run src/app/chat/sidebar/order.test.ts src/lib/storage.test.ts --environment jsdom
- npm run --prefix apps/desktop type-check

## Commit Author Check
- Commit: 99e83226aaa0be231bed2a22d1f4014fb9002138
- Author: seyeeL <seyeeliu@gmail.com>
- Committer: seyeeL <seyeeliu@gmail.com>