### PR TITLE
feat(memory): add usememos as a memory provider plugin

### DIFF
--- a/plugins/memory/usememos/README.md
+++ b/plugins/memory/usememos/README.md
@@ -1,0 +1,39 @@
+# Memos Memory Provider
+
+Self-hosted [Memos](https://usememos.com) integration for user-owned memory — lightweight note service, no pip dependencies.
+
+## Requirements
+
+- A running Memos instance (self-hosted or [demo](https://demo.usememos.com))
+- An API access token from Memos → Settings → Access Tokens
+
+## Setup
+
+```bash
+hermes memory setup    # select "usememos"
+```
+
+Or manually:
+```bash
+hermes config set memory.provider usememos
+echo "MEMOS_API_URL=https://memos.example.com" >> ~/.hermes/.env
+echo "MEMOS_ACCESS_TOKEN=your-token" >> ~/.hermes/.env
+```
+
+## Config
+
+Config file: `$HERMES_HOME/usememos.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `api_url` | *(required)* | Memos instance URL |
+| `access_token` | *(required)* | API access token |
+| `default_visibility` | `PRIVATE` | Default visibility for new memos |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `memos_list` | List recent memos from the instance |
+| `memos_search` | Search memos by content keyword |
+| `memos_add` | Store a new memo (Markdown supported) |

--- a/plugins/memory/usememos/__init__.py
+++ b/plugins/memory/usememos/__init__.py
@@ -1,0 +1,337 @@
+"""Memos memory plugin — MemoryProvider interface.
+
+Self-hosted lightweight note service (usememos/memos) for user-owned memory.
+No pip dependencies — uses stdlib urllib for HTTP calls.
+
+Config via environment variables:
+  MEMOS_API_URL    — Memos instance URL (e.g. https://memos.example.com)
+  MEMOS_ACCESS_TOKEN — API access token (required)
+
+Or via $HERMES_HOME/usememos.json.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_config() -> dict:
+    """Load config from env vars, with $HERMES_HOME/usememos.json overrides."""
+    from hermes_constants import get_hermes_home
+
+    config = {
+        "api_url": os.environ.get("MEMOS_API_URL", ""),
+        "access_token": os.environ.get("MEMOS_ACCESS_TOKEN", ""),
+        "default_visibility": "PRIVATE",
+    }
+
+    config_path = get_hermes_home() / "usememos.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            config.update({k: v for k, v in file_cfg.items()
+                           if v is not None and v != ""})
+        except Exception:
+            pass
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _api_request(base_url: str, token: str, method: str, path: str,
+                 body: dict | None = None, params: dict | None = None) -> dict:
+    """Make an authenticated request to the Memos API."""
+    url = f"{base_url.rstrip('/')}/api/v1{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(
+            {k: v for k, v in params.items() if v is not None}
+        )
+
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            raw = resp.read().decode("utf-8")
+            return json.loads(raw) if raw.strip() else {}
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8", errors="replace")[:500]
+        raise RuntimeError(f"HTTP {e.code}: {error_body}") from e
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+LIST_SCHEMA = {
+    "name": "memos_list",
+    "description": (
+        "List recent memos from the Memos instance. "
+        "Returns the most recent notes stored by the user."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "limit": {
+                "type": "integer",
+                "description": "Max memos to return (default: 20, max: 50).",
+            },
+        },
+        "required": [],
+    },
+}
+
+SEARCH_SCHEMA = {
+    "name": "memos_search",
+    "description": (
+        "Search memos by content keyword. Returns matching memos "
+        "from the Memos instance."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Keyword to search for."},
+            "limit": {
+                "type": "integer",
+                "description": "Max results (default: 10, max: 50).",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+ADD_SCHEMA = {
+    "name": "memos_add",
+    "description": (
+        "Store a new memo/note in Memos. Use for durable facts, preferences, "
+        "or observations the user wants to keep."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "The memo content to store (Markdown supported).",
+            },
+            "visibility": {
+                "type": "string",
+                "description": "Memo visibility: PRIVATE (default), PROTECTED, or PUBLIC.",
+                "enum": ["PRIVATE", "PROTECTED", "PUBLIC"],
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# MemoryProvider implementation
+# ---------------------------------------------------------------------------
+
+class MemosMemoryProvider(MemoryProvider):
+    """Memos self-hosted note service memory provider."""
+
+    def __init__(self):
+        self._config = None
+        self._api_url = ""
+        self._access_token = ""
+        self._default_visibility = "PRIVATE"
+        self._prefetch_result = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread = None
+
+    @property
+    def name(self) -> str:
+        return "usememos"
+
+    def is_available(self) -> bool:
+        cfg = _load_config()
+        return bool(cfg.get("api_url") and cfg.get("access_token"))
+
+    def save_config(self, values, hermes_home):
+        """Write config to $HERMES_HOME/usememos.json."""
+        import json
+        from pathlib import Path
+        config_path = Path(hermes_home) / "usememos.json"
+        existing = {}
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text())
+            except Exception:
+                pass
+        existing.update(values)
+        from utils import atomic_json_write
+        atomic_json_write(config_path, existing, mode=0o600)
+
+    def get_config_schema(self):
+        return [
+            {
+                "key": "api_url",
+                "description": "Memos instance URL (e.g. https://memos.example.com)",
+                "required": True,
+                "env_var": "MEMOS_API_URL",
+                "url": "https://usememos.com",
+            },
+            {
+                "key": "access_token",
+                "description": "API access token from Memos settings",
+                "secret": True,
+                "required": True,
+                "env_var": "MEMOS_ACCESS_TOKEN",
+            },
+            {
+                "key": "default_visibility",
+                "description": "Default visibility for new memos",
+                "default": "PRIVATE",
+                "choices": ["PRIVATE", "PROTECTED", "PUBLIC"],
+            },
+        ]
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._config = _load_config()
+        self._api_url = self._config.get("api_url", "")
+        self._access_token = self._config.get("access_token", "")
+        self._default_visibility = self._config.get("default_visibility", "PRIVATE")
+
+    def _list_memos(self, limit: int = 20) -> list:
+        """Fetch recent memos from the Memos API."""
+        result = _api_request(
+            self._api_url, self._access_token, "GET", "/memos",
+            params={"pageSize": str(limit)},
+        )
+        # API returns {"memos": [...]} or {"memos": [...], "nextPageToken": "..."}
+        return result.get("memos", [])
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Memos Memory\n"
+            "Active. Self-hosted Memos instance.\n"
+            "Use memos_list to browse recent notes, memos_search to find specific ones, "
+            "memos_add to store new facts."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"## Memos Memory\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        def _run():
+            try:
+                memos = self._list_memos(limit=5)
+                if memos:
+                    lines = [m.get("content", "") for m in memos if m.get("content")]
+                    with self._prefetch_lock:
+                        self._prefetch_result = "\n".join(f"- {l}" for l in lines)
+            except Exception as e:
+                logger.debug("Memos prefetch failed: %s", e)
+
+        self._prefetch_thread = threading.Thread(
+            target=_run, daemon=True, name="memos-prefetch"
+        )
+        self._prefetch_thread.start()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [LIST_SCHEMA, SEARCH_SCHEMA, ADD_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        if not self._api_url or not self._access_token:
+            return tool_error("Memos not configured. Run: hermes memory setup")
+
+        if tool_name == "memos_list":
+            limit = min(int(args.get("limit", 20)), 50)
+            try:
+                memos = self._list_memos(limit=limit)
+                if not memos:
+                    return json.dumps({"result": "No memos found."})
+                items = [
+                    {
+                        "content": m.get("content", ""),
+                        "created": m.get("createTime", ""),
+                        "visibility": m.get("visibility", ""),
+                    }
+                    for m in memos
+                ]
+                return json.dumps({"results": items, "count": len(items)})
+            except Exception as e:
+                return tool_error(f"Failed to list memos: {e}")
+
+        elif tool_name == "memos_search":
+            query = args.get("query", "")
+            if not query:
+                return tool_error("Missing required parameter: query")
+            limit = min(int(args.get("limit", 10)), 50)
+            try:
+                # Memos v1 API: list with content search via filter
+                # Fallback: list all and filter client-side
+                memos = self._list_memos(limit=50)
+                query_lower = query.lower()
+                matched = [
+                    m for m in memos
+                    if query_lower in m.get("content", "").lower()
+                ][:limit]
+                if not matched:
+                    return json.dumps({"result": "No matching memos found."})
+                items = [
+                    {
+                        "content": m.get("content", ""),
+                        "created": m.get("createTime", ""),
+                    }
+                    for m in matched
+                ]
+                return json.dumps({"results": items, "count": len(items)})
+            except Exception as e:
+                return tool_error(f"Search failed: {e}")
+
+        elif tool_name == "memos_add":
+            content = args.get("content", "")
+            if not content:
+                return tool_error("Missing required parameter: content")
+            visibility = args.get("visibility", self._default_visibility)
+            try:
+                result = _api_request(
+                    self._api_url, self._access_token, "POST", "/memos",
+                    body={"content": content, "visibility": visibility},
+                )
+                memo_name = result.get("name", result.get("uid", ""))
+                return json.dumps({"result": "Memo stored.", "id": memo_name})
+            except Exception as e:
+                return tool_error(f"Failed to store memo: {e}")
+
+        return tool_error(f"Unknown tool: {tool_name}")
+
+    def shutdown(self) -> None:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=5.0)
+
+
+def register(ctx) -> None:
+    """Register Memos as a memory provider plugin."""
+    ctx.register_memory_provider(MemosMemoryProvider())

--- a/plugins/memory/usememos/plugin.yaml
+++ b/plugins/memory/usememos/plugin.yaml
@@ -1,0 +1,3 @@
+name: usememos
+version: 1.0.0
+description: "Memos — self-hosted lightweight note service for user-owned memory. REST API, no pip dependencies."

--- a/tests/plugins/memory/test_usememos_provider.py
+++ b/tests/plugins/memory/test_usememos_provider.py
@@ -1,0 +1,374 @@
+"""Tests for the usememos memory provider plugin."""
+
+import json
+import os
+import stat
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from plugins.memory.usememos import MemosMemoryProvider, _load_config, _api_request
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_MEMOS = [
+    {
+        "name": "memos/1",
+        "uid": "memo-1",
+        "content": "User prefers dark mode",
+        "createTime": "2026-06-09T00:00:00Z",
+        "visibility": "PRIVATE",
+    },
+    {
+        "name": "memos/2",
+        "uid": "memo-2",
+        "content": "Project uses pytest with xdist",
+        "createTime": "2026-06-08T00:00:00Z",
+        "visibility": "PRIVATE",
+    },
+    {
+        "name": "memos/3",
+        "uid": "memo-3",
+        "content": "Meeting notes from standup",
+        "createTime": "2026-06-07T00:00:00Z",
+        "visibility": "PROTECTED",
+    },
+]
+
+
+def _make_provider(monkeypatch, tmp_path, api_url="https://memos.example.com", token="test-token"):
+    """Create an initialized provider with mocked env."""
+    monkeypatch.setenv("MEMOS_API_URL", api_url)
+    monkeypatch.setenv("MEMOS_ACCESS_TOKEN", token)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = MemosMemoryProvider()
+    provider.initialize("test-session")
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+class TestMemosConfig:
+    """Config loading from env vars and JSON file."""
+
+    def test_config_from_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEMOS_API_URL", "https://my-memos.com")
+        monkeypatch.setenv("MEMOS_ACCESS_TOKEN", "tok123")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cfg = _load_config()
+        assert cfg["api_url"] == "https://my-memos.com"
+        assert cfg["access_token"] == "tok123"
+        assert cfg["default_visibility"] == "PRIVATE"
+
+    def test_config_file_overrides_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEMOS_API_URL", "https://env-url.com")
+        monkeypatch.setenv("MEMOS_ACCESS_TOKEN", "env-token")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        config_file = tmp_path / "usememos.json"
+        config_file.write_text(json.dumps({
+            "api_url": "https://file-url.com",
+            "default_visibility": "PUBLIC",
+        }))
+
+        cfg = _load_config()
+        assert cfg["api_url"] == "https://file-url.com"  # file overrides env
+        assert cfg["access_token"] == "env-token"  # env still used for missing keys
+        assert cfg["default_visibility"] == "PUBLIC"
+
+    def test_is_available_with_config(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+        assert provider.is_available() is True
+
+    def test_is_available_without_token(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEMOS_API_URL", "https://memos.example.com")
+        monkeypatch.delenv("MEMOS_ACCESS_TOKEN", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = MemosMemoryProvider()
+        assert provider.is_available() is False
+
+    def test_is_available_without_url(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MEMOS_API_URL", raising=False)
+        monkeypatch.setenv("MEMOS_ACCESS_TOKEN", "tok")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = MemosMemoryProvider()
+        assert provider.is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# Provider basics
+# ---------------------------------------------------------------------------
+
+
+class TestMemosProviderBasics:
+    """Basic provider properties and initialization."""
+
+    def test_name(self):
+        provider = MemosMemoryProvider()
+        assert provider.name == "usememos"
+
+    def test_tool_schemas(self):
+        provider = MemosMemoryProvider()
+        schemas = provider.get_tool_schemas()
+        names = {s["name"] for s in schemas}
+        assert names == {"memos_list", "memos_search", "memos_add"}
+
+    def test_system_prompt_block(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+        block = provider.system_prompt_block()
+        assert "Memos" in block
+        assert "memos_list" in block
+        assert "memos_search" in block
+        assert "memos_add" in block
+
+    def test_initialize_sets_config(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path, api_url="https://test.com", token="abc")
+        assert provider._api_url == "https://test.com"
+        assert provider._access_token == "abc"
+        assert provider._default_visibility == "PRIVATE"
+
+
+# ---------------------------------------------------------------------------
+# Tool calls: memos_list
+# ---------------------------------------------------------------------------
+
+
+class TestMemosList:
+    """memos_list tool call."""
+
+    def test_list_returns_memos(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", return_value={"memos": SAMPLE_MEMOS}):
+            result = json.loads(provider.handle_tool_call("memos_list", {"limit": 20}))
+
+        assert result["count"] == 3
+        assert result["results"][0]["content"] == "User prefers dark mode"
+        assert result["results"][0]["visibility"] == "PRIVATE"
+
+    def test_list_empty(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", return_value={"memos": []}):
+            result = json.loads(provider.handle_tool_call("memos_list", {}))
+
+        assert "No memos" in result["result"]
+
+    def test_list_limit_clamped(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", return_value={"memos": []}) as mock_req:
+            provider.handle_tool_call("memos_list", {"limit": 100})
+
+        # limit should be clamped to 50
+        call_params = mock_req.call_args
+        assert call_params[1]["params"]["pageSize"] == "50"
+
+    def test_list_api_error(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", side_effect=RuntimeError("HTTP 500")):
+            result = json.loads(provider.handle_tool_call("memos_list", {}))
+
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Tool calls: memos_search
+# ---------------------------------------------------------------------------
+
+
+class TestMemosSearch:
+    """memos_search tool call."""
+
+    def test_search_finds_match(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", return_value={"memos": SAMPLE_MEMOS}):
+            result = json.loads(provider.handle_tool_call("memos_search", {"query": "dark mode"}))
+
+        assert result["count"] == 1
+        assert "dark mode" in result["results"][0]["content"]
+
+    def test_search_case_insensitive(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", return_value={"memos": SAMPLE_MEMOS}):
+            result = json.loads(provider.handle_tool_call("memos_search", {"query": "PYTEST"}))
+
+        assert result["count"] == 1
+        assert "pytest" in result["results"][0]["content"].lower()
+
+    def test_search_no_match(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", return_value={"memos": SAMPLE_MEMOS}):
+            result = json.loads(provider.handle_tool_call("memos_search", {"query": "nonexistent"}))
+
+        assert "No matching" in result["result"]
+
+    def test_search_missing_query(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+        result = json.loads(provider.handle_tool_call("memos_search", {}))
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Tool calls: memos_add
+# ---------------------------------------------------------------------------
+
+
+class TestMemosAdd:
+    """memos_add tool call."""
+
+    def test_add_creates_memo(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        mock_response = {"name": "memos/99", "content": "new fact", "visibility": "PRIVATE"}
+        with patch("plugins.memory.usememos._api_request", return_value=mock_response) as mock_req:
+            result = json.loads(provider.handle_tool_call("memos_add", {"content": "new fact"}))
+
+        assert result["result"] == "Memo stored."
+        assert result["id"] == "memos/99"
+
+        # Verify API call
+        call_args = mock_req.call_args
+        assert call_args[0] == ("https://memos.example.com", "test-token", "POST", "/memos")
+        assert call_args[1]["body"]["content"] == "new fact"
+        assert call_args[1]["body"]["visibility"] == "PRIVATE"
+
+    def test_add_custom_visibility(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", return_value={"name": "memos/1"}) as mock_req:
+            provider.handle_tool_call("memos_add", {"content": "public note", "visibility": "PUBLIC"})
+
+        assert mock_req.call_args[1]["body"]["visibility"] == "PUBLIC"
+
+    def test_add_missing_content(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+        result = json.loads(provider.handle_tool_call("memos_add", {}))
+        assert "error" in result
+
+    def test_add_api_error(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", side_effect=RuntimeError("HTTP 401")):
+            result = json.loads(provider.handle_tool_call("memos_add", {"content": "test"}))
+
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Unknown tool
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_tool(monkeypatch, tmp_path):
+    provider = _make_provider(monkeypatch, tmp_path)
+    result = json.loads(provider.handle_tool_call("memos_unknown", {}))
+    assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Prefetch
+# ---------------------------------------------------------------------------
+
+
+class TestMemosPrefetch:
+    """Prefetch behavior."""
+
+    def test_prefetch_returns_recent_memos(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", return_value={"memos": SAMPLE_MEMOS[:2]}):
+            provider.queue_prefetch("test query")
+            provider._prefetch_thread.join(timeout=2)
+
+        result = provider.prefetch("test query")
+        assert "dark mode" in result
+        assert "pytest" in result
+
+    def test_prefetch_empty(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", return_value={"memos": []}):
+            provider.queue_prefetch("test")
+            provider._prefetch_thread.join(timeout=2)
+
+        result = provider.prefetch("test")
+        assert result == ""
+
+    def test_prefetch_failure_graceful(self, monkeypatch, tmp_path):
+        provider = _make_provider(monkeypatch, tmp_path)
+
+        with patch("plugins.memory.usememos._api_request", side_effect=RuntimeError("down")):
+            provider.queue_prefetch("test")
+            provider._prefetch_thread.join(timeout=2)
+
+        result = provider.prefetch("test")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Shutdown
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_joins_thread(monkeypatch, tmp_path):
+    provider = _make_provider(monkeypatch, tmp_path)
+
+    with patch("plugins.memory.usememos._api_request", return_value={"memos": []}):
+        provider.queue_prefetch("test")
+
+    provider.shutdown()  # should not hang or raise
+
+
+# ---------------------------------------------------------------------------
+# Config file permissions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
+def test_save_config_sets_owner_only_permissions(tmp_path):
+    """usememos.json must be written with 0o600 so access token is not world-readable."""
+    provider = MemosMemoryProvider()
+    provider.save_config({"access_token": "secret"}, str(tmp_path))
+    config_file = tmp_path / "usememos.json"
+    assert config_file.exists()
+    mode = stat.S_IMODE(config_file.stat().st_mode)
+    assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+# ---------------------------------------------------------------------------
+# Default visibility
+# ---------------------------------------------------------------------------
+
+
+class TestMemosDefaults:
+    """Default config values."""
+
+    def test_default_visibility_private(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEMOS_API_URL", "https://memos.example.com")
+        monkeypatch.setenv("MEMOS_ACCESS_TOKEN", "tok")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = MemosMemoryProvider()
+        provider.initialize("test")
+        assert provider._default_visibility == "PRIVATE"
+
+    def test_custom_default_visibility(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEMOS_API_URL", "https://memos.example.com")
+        monkeypatch.setenv("MEMOS_ACCESS_TOKEN", "tok")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_file = tmp_path / "usememos.json"
+        config_file.write_text(json.dumps({"default_visibility": "PUBLIC"}))
+        provider = MemosMemoryProvider()
+        provider.initialize("test")
+        assert provider._default_visibility == "PUBLIC"


### PR DESCRIPTION
## Problem

Hermes Agent's memory provider list includes mem0, honcho, supermemory, hindsight, and others — but lacks support for **Memos** (usememos/memos), a popular self-hosted lightweight note service. Users who already use Memos for personal notes cannot integrate it with Hermes's memory system.

## Solution

New memory provider plugin at `plugins/memory/usememos/` following the existing `mem0/` plugin pattern.

**Key design choices:**
- **No pip dependencies** — uses stdlib `urllib.request` for HTTP calls (Memos is self-hosted, no SDK needed)
- **Bearer Token auth** — matches Memos's native API authentication
- **REST API v1** — `GET/POST /api/v1/memos` for list/search/create
- **Client-side search** — lists memos and filters by keyword (Memos API doesn't have full-text search on v1)

**Tools provided:**
| Tool | Description |
|------|-------------|
| `memos_list` | List recent memos |
| `memos_search` | Search memos by content keyword |
| `memos_add` | Store a new memo |

## Config

```bash
# Via env vars
export MEMOS_API_URL=https://memos.example.com
export MEMOS_ACCESS_TOKEN=your-token

# Or via $HERMES_HOME/usememos.json
{"api_url": "https://memos.example.com", "access_token": "...", "default_visibility": "PRIVATE"}
```

## Testing

29 tests covering:
- Config loading (env vars + JSON file override)
- `is_available` checks
- All 3 tool calls (list, search, add) with success/error paths
- Prefetch behavior
- Shutdown cleanup
- Config file permissions (0o600)

```
tests/plugins/memory/test_usememos_provider.py  — 29 passed in 0.15s
```

## Files changed

```
plugins/memory/usememos/__init__.py   — provider implementation (337 lines)
plugins/memory/usememos/plugin.yaml   — plugin metadata
plugins/memory/usememos/README.md     — setup docs
tests/plugins/memory/test_usememos_provider.py — 29 tests (374 lines)
```

Closes #42506
