### PR TITLE
fix(discord): keep live voice transcription bounded

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -317,6 +317,11 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # Named VOICE_TOOLS_OPENAI_KEY to avoid interference with OpenRouter.
 # Get at: https://platform.openai.com/api-keys
 # VOICE_TOOLS_OPENAI_KEY=
+#
+# Discord live voice transcripts are posted to the linked side text channel
+# directly by the gateway by default. Set true only if every transcript snippet
+# should also become an agent turn.
+# HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS=false
 
 # =============================================================================
 # SLACK INTEGRATION

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -699,6 +699,7 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#   voice_transcript_agent_turns: false  # Post live voice transcripts directly; true also invokes agent per snippet
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -922,6 +922,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if plat == Platform.DISCORD and "voice_transcript_agent_turns" in platform_cfg:
+                    bridged["voice_transcript_agent_turns"] = platform_cfg["voice_transcript_agent_turns"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12198,6 +12198,17 @@ class GatewayRunner:
         recent_store[key] = recent[-5:]
         return False
 
+    def _discord_voice_transcript_agent_turns_enabled(self) -> bool:
+        """Whether Discord voice transcript snippets should invoke the agent."""
+        env_value = os.getenv("HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS")
+        if env_value is not None:
+            return is_truthy_value(env_value, default=False)
+
+        config = getattr(self, "config", None)
+        platform_cfg = getattr(config, "platforms", {}).get(Platform.DISCORD) if config else None
+        extra = getattr(platform_cfg, "extra", {}) if platform_cfg else {}
+        return is_truthy_value(extra.get("voice_transcript_agent_turns"), default=False)
+
     async def _handle_voice_channel_input(
         self, guild_id: int, user_id: int, transcript: str
     ):
@@ -12244,6 +12255,10 @@ class GatewayRunner:
             )
             return
 
+        reset_timeout = getattr(adapter, "_reset_voice_timeout", None)
+        if callable(reset_timeout):
+            reset_timeout(guild_id)
+
         # Show transcript in text channel (after auth, with mention sanitization)
         try:
             channel = adapter._client.get_channel(text_ch_id)
@@ -12252,6 +12267,11 @@ class GatewayRunner:
                 await channel.send(f"**[Voice]** <@{user_id}>: {safe_text}")
         except Exception:
             pass
+
+        # LLMs/agents orchestrate reasoning-heavy work; the deterministic
+        # gateway runtime executes repeatable transcript posting by default.
+        if not self._discord_voice_transcript_agent_turns_enabled():
+            return
 
         # Build a synthetic MessageEvent and feed through the normal pipeline
         # Use SimpleNamespace as raw_message so _get_guild_id() can extract

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -181,6 +181,7 @@ class VoiceReceiver:
 
     SILENCE_THRESHOLD = 1.5    # seconds of silence → end of utterance
     MIN_SPEECH_DURATION = 0.5  # minimum seconds to process (skip noise)
+    MAX_UTTERANCE_DURATION = 30.0  # bound hot-path audio buffers during long monologues
     SAMPLE_RATE = 48000        # Discord native rate
     CHANNELS = 2               # Discord sends stereo
 
@@ -478,7 +479,11 @@ class VoiceReceiver:
                 # 48kHz, 16-bit, stereo = 192000 bytes/sec
                 buf_duration = len(buf) / (self.SAMPLE_RATE * self.CHANNELS * 2)
 
-                if silence_duration >= self.SILENCE_THRESHOLD and buf_duration >= self.MIN_SPEECH_DURATION:
+                utterance_complete = (
+                    silence_duration >= self.SILENCE_THRESHOLD
+                    or buf_duration >= self.MAX_UTTERANCE_DURATION
+                )
+                if utterance_complete and buf_duration >= self.MIN_SPEECH_DURATION:
                     user_id = ssrc_user_map.get(ssrc, 0)
                     if not user_id:
                         # SSRC not mapped (SPEAKING event missing after bot rejoin).
@@ -576,6 +581,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
+    VOICE_ACTIVITY_TIMEOUT_REFRESH = 30.0
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
@@ -595,6 +601,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
         self._voice_sources: Dict[int, Dict[str, Any]] = {}  # guild_id -> linked text channel source metadata
         self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
+        self._voice_activity_timeout_resets: Dict[int, float] = {}  # guild_id -> monotonic timestamp
         # Phase 2: voice listening
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
@@ -2154,6 +2161,9 @@ class DiscordAdapter(BasePlatformAdapter):
             task = self._voice_timeout_tasks.pop(guild_id, None)
             if task:
                 task.cancel()
+            resets = getattr(self, "_voice_activity_timeout_resets", None)
+            if resets is not None:
+                resets.pop(guild_id, None)
             self._voice_text_channels.pop(guild_id, None)
             self._voice_sources.pop(guild_id, None)
 
@@ -2252,9 +2262,24 @@ class DiscordAdapter(BasePlatformAdapter):
         task = self._voice_timeout_tasks.pop(guild_id, None)
         if task:
             task.cancel()
+        resets = getattr(self, "_voice_activity_timeout_resets", None)
+        if resets is None:
+            resets = {}
+            self._voice_activity_timeout_resets = resets
+        resets[guild_id] = time.monotonic()
         self._voice_timeout_tasks[guild_id] = asyncio.ensure_future(
             self._voice_timeout_handler(guild_id)
         )
+
+    def _note_voice_activity(self, guild_id: int) -> None:
+        """Refresh the inactivity timer for inbound audio without timer churn."""
+        resets = getattr(self, "_voice_activity_timeout_resets", None)
+        if resets is None:
+            resets = {}
+            self._voice_activity_timeout_resets = resets
+        now = time.monotonic()
+        if now - resets.get(guild_id, 0.0) >= self.VOICE_ACTIVITY_TIMEOUT_REFRESH:
+            self._reset_voice_timeout(guild_id)
 
     async def _voice_timeout_handler(self, guild_id: int) -> None:
         """Auto-disconnect after VOICE_TIMEOUT seconds of inactivity."""
@@ -2382,6 +2407,8 @@ class DiscordAdapter(BasePlatformAdapter):
                         pass
 
                 completed = receiver.check_silence()
+                if receiver._last_packet_time:
+                    self._note_voice_activity(guild_id)
                 # Voice inputs always originate from a specific guild
                 # (guild_id is in scope). Pass it so role checks are
                 # guild-scoped and not cross-guild.
@@ -2393,6 +2420,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         is_dm=False,
                     ):
                         continue
+                    self._note_voice_activity(guild_id)
                     await self._process_voice_input(guild_id, user_id, pcm_data)
         except asyncio.CancelledError:
             pass

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -32,6 +32,22 @@ def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monk
     assert config.stt_enabled is False
 
 
+def test_load_gateway_config_bridges_discord_voice_transcript_agent_turns(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.dump({"discord": {"voice_transcript_agent_turns": True}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.DISCORD].extra["voice_transcript_agent_turns"] is True
+
+
 @pytest.mark.asyncio
 async def test_enrich_message_with_transcription_surfaces_path_when_stt_disabled():
     from gateway.run import GatewayRunner

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -919,18 +919,41 @@ class TestVoiceChannelCommands:
         await runner._handle_voice_channel_input(111, 42, "Hello")
 
     @pytest.mark.asyncio
-    async def test_input_creates_event_and_dispatches(self, runner):
-        """Voice input creates synthetic event and calls handle_message."""
+    async def test_input_posts_transcript_without_agent_by_default(self, runner, monkeypatch):
+        """Voice input posts transcript text without calling the agent by default."""
         from gateway.config import Platform
+        monkeypatch.delenv("HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS", raising=False)
         mock_adapter = AsyncMock()
         mock_adapter._voice_text_channels = {111: 123}
         mock_adapter._voice_sources = {}
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
         await runner._handle_voice_channel_input(111, 42, "Hello from VC")
+        mock_channel.send.assert_called_once()
+        mock_adapter.handle_message.assert_not_called()
+        mock_adapter._reset_voice_timeout.assert_called_once_with(111)
+
+    @pytest.mark.asyncio
+    async def test_input_opt_in_agent_dispatch(self, runner, monkeypatch):
+        """Voice transcript snippets can still dispatch to the agent when opted in."""
+        from gateway.config import Platform
+        monkeypatch.setenv("HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS", "true")
+        mock_adapter = AsyncMock()
+        mock_adapter._voice_text_channels = {111: 123}
+        mock_adapter._voice_sources = {}
+        mock_channel = AsyncMock()
+        mock_adapter._client = MagicMock()
+        mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
+        mock_adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        await runner._handle_voice_channel_input(111, 42, "Hello from VC")
+
         mock_adapter.handle_message.assert_called_once()
         event = mock_adapter.handle_message.call_args[0][0]
         assert event.text == "Hello from VC"
@@ -939,9 +962,37 @@ class TestVoiceChannelCommands:
         assert event.source.chat_type == "channel"
 
     @pytest.mark.asyncio
-    async def test_input_reuses_bound_source_metadata(self, runner):
+    async def test_input_config_opt_in_agent_dispatch(self, runner, monkeypatch):
+        """Config can opt Discord voice transcript snippets into agent turns."""
+        from gateway.config import Platform, PlatformConfig
+        monkeypatch.delenv("HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS", raising=False)
+        runner.config = SimpleNamespace(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    extra={"voice_transcript_agent_turns": True},
+                )
+            }
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter._voice_text_channels = {111: 123}
+        mock_adapter._voice_sources = {}
+        mock_channel = AsyncMock()
+        mock_adapter._client = MagicMock()
+        mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
+        mock_adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        await runner._handle_voice_channel_input(111, 42, "Config opt in")
+
+        mock_adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_input_reuses_bound_source_metadata(self, runner, monkeypatch):
         """Voice input should share the linked text channel session metadata."""
         from gateway.config import Platform
+        monkeypatch.setenv("HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS", "true")
 
         bound_source = SessionSource(
             chat_id="123",
@@ -958,6 +1009,7 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
 
@@ -980,6 +1032,7 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
         await runner._handle_voice_channel_input(111, 42, "Test transcript")
@@ -999,13 +1052,14 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
 
         await runner._handle_voice_channel_input(111, 42, "Hello from VC")
         await runner._handle_voice_channel_input(111, 42, "Hello from VC")
 
-        mock_adapter.handle_message.assert_called_once()
+        mock_adapter.handle_message.assert_not_called()
         mock_channel.send.assert_called_once()
 
     @pytest.mark.asyncio
@@ -1019,13 +1073,14 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
 
         await runner._handle_voice_channel_input(111, 42, "This is a test of the voice system")
         await runner._handle_voice_channel_input(111, 42, "This is a test for the voice system")
 
-        mock_adapter.handle_message.assert_called_once()
+        mock_adapter.handle_message.assert_not_called()
         mock_channel.send.assert_called_once()
 
     # -- _get_guild_id --
@@ -1343,6 +1398,23 @@ class TestVoiceReceiverThreadSafety:
         t1.join()
         t2.join()
         assert len(errors) == 0, f"Race detected: {errors[:3]}"
+
+    def test_completed_utterance_buffer_is_cleared(self):
+        """A completed utterance is returned once and then dropped."""
+        receiver = self._make_receiver()
+        receiver.map_ssrc(100, 42)
+        with receiver._lock:
+            receiver._buffers[100].extend(b"\x00" * 192000)
+            receiver._last_packet_time[100] = time.monotonic() - (
+                receiver.SILENCE_THRESHOLD + 0.1
+            )
+
+        completed = receiver.check_silence()
+
+        assert completed == [(42, b"\x00" * 192000)]
+        assert receiver._buffers[100] == bytearray()
+        assert 100 not in receiver._last_packet_time
+        assert receiver.check_silence() == []
 
 
 # =====================================================================


### PR DESCRIPTION
Brain-Context: none present in Hermes checkout; read AGENTS.md.

## Root cause summary

Discord live voice capture already cleared `VoiceReceiver` buffers after `check_silence()` emitted a completed utterance, so the receiver was not intentionally retranscribing the same in-memory audio forever. The expensive slowdown came from the runtime feeding every completed transcript snippet through `adapter.handle_message()`, which creates a full agent turn by default. Long meetings also had an inactivity timer risk: the Discord voice timeout was reset on join/playback, but not on inbound audio/transcript activity, so an active listening session could still age toward disconnect.

## What changed

- Kept completed transcript side-chat posting in deterministic gateway/runtime code by default.
- Added `HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS` and `discord.voice_transcript_agent_turns` opt-in behavior for deployments that do want every transcript snippet to invoke the agent.
- Refreshed the Discord voice inactivity timer on inbound audio/transcript activity so live sessions stay alive while the voice connection is active.
- Added a max utterance duration in `VoiceReceiver` to bound per-speaker PCM buffers during long monologues.
- Documented the new env/config flag in `.env.example` and `cli-config.yaml.example`.
- Added focused tests for default no-agent transcript posting, opt-in agent dispatch, config bridging, and completed utterance buffer clearing.

## Are we trimming/resetting audio after transcription, or retranscribing everything every time?

We are trimming/resetting. `VoiceReceiver.check_silence()` returns a completed `(user_id, pcm_bytes)` utterance and then clears that SSRC buffer plus its last-packet timestamp. The new regression test asserts the completed utterance is returned once and a second `check_silence()` does not re-emit the same audio. This PR also bounds long utterances so hot-path audio buffers do not grow for an entire meeting.

## Tests run

- `scripts/run_tests.sh tests/gateway/test_voice_command.py tests/gateway/test_stt_config.py tests/gateway/test_discord_voice_mixer.py -- -q`
- `/Users/j/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/run.py gateway/config.py plugins/platforms/discord/adapter.py`
