### PR TITLE
fix(desktop): release profile backends before delete

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4295,20 +4295,31 @@ async function teardownPrimaryBackendAndWait() {
   const dying = hermesProcess && !hermesProcess.killed ? hermesProcess : null
   resetHermesConnection()
 
-  if (!dying) {
+  await waitForBackendExit(dying)
+}
+
+async function waitForBackendExit(child, timeoutMs = 5000) {
+  if (!child) {
+    return
+  }
+  if (child.exitCode !== null || child.signalCode !== null) {
     return
   }
 
   await new Promise(resolve => {
     const timer = setTimeout(() => {
       try {
-        dying.kill('SIGKILL')
+        if (IS_WINDOWS && Number.isInteger(child.pid)) {
+          forceKillProcessTree(child.pid)
+        } else {
+          child.kill('SIGKILL')
+        }
       } catch {
         // Already gone.
       }
       resolve()
-    }, 5000)
-    dying.once('exit', () => {
+    }, timeoutMs)
+    child.once('exit', () => {
       clearTimeout(timer)
       resolve()
     })
@@ -4500,10 +4511,68 @@ function stopPoolBackend(profile) {
   }
 }
 
+async function teardownPoolBackendAndWait(profile) {
+  const entry = backendPool.get(profile)
+  if (!entry) return
+  backendPool.delete(profile)
+
+  if (entry.process && !entry.process.killed) {
+    try {
+      entry.process.kill('SIGTERM')
+    } catch {
+      // Already gone.
+    }
+  }
+
+  await waitForBackendExit(entry.process)
+}
+
 function stopAllPoolBackends() {
   for (const profile of [...backendPool.keys()]) {
     stopPoolBackend(profile)
   }
+}
+
+function profileNameFromDeleteRequest(request) {
+  if (!request || String(request.method || 'GET').toUpperCase() !== 'DELETE') {
+    return null
+  }
+
+  const match = String(request.path || '').match(/^\/api\/profiles\/([^/?#]+)(?:[?#].*)?$/)
+  if (!match) {
+    return null
+  }
+
+  let raw = ''
+  try {
+    raw = decodeURIComponent(match[1])
+  } catch {
+    return null
+  }
+
+  const name = raw.trim()
+  if (!name) {
+    return null
+  }
+  if (name.toLowerCase() === 'default') {
+    return 'default'
+  }
+  return name.toLowerCase()
+}
+
+async function prepareProfileDeleteRequest(request) {
+  const profile = profileNameFromDeleteRequest(request)
+  if (!profile || profile === 'default' || !PROFILE_NAME_RE.test(profile)) {
+    return
+  }
+
+  if (profile === primaryProfileKey()) {
+    writeActiveDesktopProfile('default')
+    await teardownPrimaryBackendAndWait()
+    return
+  }
+
+  await teardownPoolBackendAndWait(profile)
 }
 
 async function startHermes() {
@@ -5123,6 +5192,8 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   if (rerouted !== undefined) {
     return rerouted
   }
+
+  await prepareProfileDeleteRequest(request)
 
   const connection = await ensureBackend(request?.profile)
   const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1010,6 +1010,7 @@ def delete_profile(name: str, yes: bool = False) -> Path:
             print(f"✓ Removed {wrapper_path}")
 
     # 4. Remove profile directory
+    remove_error: Exception | None = None
     try:
         def _make_writable(func, path, exc):
             """onexc/onerror handler: add +w on PermissionError so rmtree can proceed.
@@ -1056,6 +1057,7 @@ def delete_profile(name: str, yes: bool = False) -> Path:
         print(f"✓ Removed {profile_dir}")
     except Exception as e:
         print(f"⚠ Could not remove {profile_dir}: {e}")
+        remove_error = e
 
     # 5. Clear active_profile if it pointed to this profile
     try:
@@ -1065,6 +1067,9 @@ def delete_profile(name: str, yes: bool = False) -> Path:
             print("✓ Active profile reset to default")
     except Exception:
         pass
+
+    if remove_error is not None:
+        raise RuntimeError(f"Could not remove profile directory {profile_dir}: {remove_error}") from remove_error
 
     print(f"\nProfile '{canon}' deleted.")
     return profile_dir

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -442,6 +442,18 @@ class TestDeleteProfile:
         with pytest.raises(FileNotFoundError):
             delete_profile("nonexistent", yes=True)
 
+    def test_rmtree_failure_raises(self, profile_env):
+        profile_dir = create_profile("coder", no_alias=True)
+        set_active_profile("coder")
+
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), \
+             patch("hermes_cli.profiles.shutil.rmtree", side_effect=PermissionError("locked")):
+            with pytest.raises(RuntimeError, match="Could not remove profile directory"):
+                delete_profile("coder", yes=True)
+
+        assert profile_dir.is_dir()
+        assert get_active_profile() == "default"
+
 
 # ===================================================================
 # TestListProfiles


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop profile deletion on Windows when the profile's backend still has files open under the profile home.

The root issue had two parts:

- Desktop could ask the Python dashboard API to delete a profile while the Desktop-owned backend for that same profile was still running.
- `hermes_cli.profiles.delete_profile()` swallowed `shutil.rmtree()` failures, printed a warning, and still returned success, so the Desktop UI could show a successful delete even though the profile directory remained on disk.

This changes Desktop to tear down the relevant local backend before issuing `DELETE /api/profiles/{name}`. For the active primary profile it first switches Desktop's stored active profile to `default` and waits for the primary backend to exit. For non-primary pooled profiles it stops that pooled backend and waits before deleting. The shared wait helper uses the Windows process-tree kill path when a backend does not exit cleanly.

The Python profile delete path now raises if profile directory removal fails, so API callers get a real error instead of a false success.

## Related Issue

Fixes #

Discord support thread: delete profile via desktop app on Windows, where the profile remained until Desktop was restarted and delete was retried.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/main.cjs`
  - Add a shared backend-exit wait helper.
  - Stop/wait the target profile backend before Desktop forwards profile DELETE requests to the dashboard API.
  - Use Windows process-tree kill on forced backend teardown so child processes release profile files.
- `hermes_cli/profiles.py`
  - Raise a `RuntimeError` when profile directory removal fails instead of returning success after a warning.
  - Keep the existing active-profile reset behavior after a failed removal so Hermes does not stay pointed at a profile that was partially deleted.
- `tests/hermes_cli/test_profiles.py`
  - Add regression coverage for a failed `shutil.rmtree()` during profile deletion.

## How to Test

1. On Windows Desktop, create a throwaway profile.
2. Switch to that profile and send a message so Desktop starts the profile backend.
3. Delete that profile from the Desktop profile UI.
4. Confirm the profile disappears without restarting Desktop and the directory under `%LOCALAPPDATA%\hermes\profiles\<profile>` is removed.

Local checks run:

- `node --check apps/desktop/electron/main.cjs`
- `git diff --check HEAD~1..HEAD`
- `/home/gille/.hermes/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_profiles.py::TestDeleteProfile::test_removes_directory tests/hermes_cli/test_profiles.py::TestDeleteProfile::test_rmtree_failure_raises tests/hermes_cli/test_profiles.py::TestEdgeCases::test_delete_clears_active_profile`
- AppData Windows checkout: `node --check apps\desktop\electron\main.cjs`
- AppData Windows checkout: `git diff --check -- apps\desktop\electron\main.cjs hermes_cli\profiles.py tests\hermes_cli\test_profiles.py`
- AppData Windows checkout: `.\venv\Scripts\python.exe -m pytest -o addopts= tests\hermes_cli\test_profiles.py::TestDeleteProfile::test_removes_directory tests\hermes_cli\test_profiles.py::TestDeleteProfile::test_rmtree_failure_raises tests\hermes_cli\test_profiles.py::TestEdgeCases::test_delete_clears_active_profile`
- Manual AppData Windows Desktop repro passed after rebuilding the packaged app.

Not run:

- Full pytest suite; leaving full-suite coverage to CI.
- Desktop Electron test suite in the temporary WSL worktree because that worktree did not have npm dependencies installed; Windows AppData packaged-build validation was run instead.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 AppData Desktop checkout and WSL clean worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Manual Windows AppData Desktop repro passed after rebuilding the packaged app from this branch.

