### PR TITLE
fix(desktop): format artifact epoch seconds

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-time.test.ts
+++ b/apps/desktop/src/app/artifacts/artifact-time.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { artifactTimestampToDate } from './artifact-time'
+
+describe('artifactTimestampToDate', () => {
+  it('treats session timestamps from the backend as epoch seconds', () => {
+    const seconds = 1_765_230_300
+
+    expect(artifactTimestampToDate(seconds).getTime()).toBe(seconds * 1000)
+    expect(artifactTimestampToDate(seconds).getUTCFullYear()).toBeGreaterThan(2024)
+  })
+
+  it('preserves millisecond timestamps from Date.now fallbacks', () => {
+    const millis = 1_765_230_300_000
+
+    expect(artifactTimestampToDate(millis).getTime()).toBe(millis)
+  })
+})

--- a/apps/desktop/src/app/artifacts/artifact-time.ts
+++ b/apps/desktop/src/app/artifacts/artifact-time.ts
@@ -1,0 +1,7 @@
+const EPOCH_SECONDS_CUTOFF = 100_000_000_000
+
+export function artifactTimestampToDate(timestamp: number): Date {
+  const timestampMs = timestamp > 0 && timestamp < EPOCH_SECONDS_CUTOFF ? timestamp * 1000 : timestamp
+
+  return new Date(timestampMs)
+}

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -34,6 +34,8 @@ import { PageSearchShell } from '../page-search-shell'
 import { sessionRoute } from '../routes'
 import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 
+import { artifactTimestampToDate } from './artifact-time'
+
 type ArtifactKind = 'image' | 'file' | 'link'
 type ArtifactFilter = 'all' | ArtifactKind
 const ARTIFACT_FILTERS: readonly ArtifactFilter[] = ['all', 'image', 'file', 'link']
@@ -310,7 +312,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
 }
 
 function formatArtifactTime(timestamp: number): string {
-  return ARTIFACT_TIME_FMT.format(new Date(timestamp))
+  return ARTIFACT_TIME_FMT.format(artifactTimestampToDate(timestamp))
 }
 
 function pageRangeLabel(total: number, page: number, pageSize: number, a: Translations['artifacts']): string {


### PR DESCRIPTION
## Summary
- Fix the Desktop Artifacts timestamp formatter to treat backend session/message timestamps as epoch seconds.
- Preserve millisecond timestamps from `Date.now()` fallbacks so both timestamp sources render correctly.
- Add a focused Vitest regression test for seconds-vs-milliseconds conversion.

## Test Plan
- [x] `npm run test:ui -- src/app/artifacts/artifact-time.test.ts`
- [x] `npx eslint src/app/artifacts/index.tsx src/app/artifacts/artifact-time.ts src/app/artifacts/artifact-time.test.ts`

Fixes #42409
