### PR TITLE
fix(tools): allow Unicode paths in terminal workdir validator

### DIFF
--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -168,3 +168,20 @@ def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project; rm -rf /")
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project$(whoami)")
     assert terminal_tool._validate_workdir("C:\\Users\\Alice\\project\nwhoami")
+
+
+def test_validate_workdir_allows_cjk_unicode_paths():
+    """CJK and other non-ASCII Unicode letters should be accepted as valid paths."""
+    assert terminal_tool._validate_workdir("~/项目") is None
+    assert terminal_tool._validate_workdir("~/文档/报告") is None
+    assert terminal_tool._validate_workdir("~/書類") is None
+    assert terminal_tool._validate_workdir("~/문서") is None
+    assert terminal_tool._validate_workdir("~/développement") is None
+
+
+def test_validate_workdir_still_blocks_shell_metacharacters():
+    """Shell metacharacters must remain blocked even after Unicode support."""
+    assert terminal_tool._validate_workdir("~/项目;rm -rf /") is not None
+    assert terminal_tool._validate_workdir("~/文档`whoami`") is not None
+    assert terminal_tool._validate_workdir("~/研究|cat") is not None
+    assert terminal_tool._validate_workdir("~/data$HOME") is not None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -267,7 +267,7 @@ def _check_all_guards(command: str, env_type: str) -> dict:
 # Covers alphanumeric, path separators, Windows drive/UNC separators, tilde,
 # dot, hyphen, underscore, space, plus, at, equals, and comma.  Everything
 # else is rejected.
-_WORKDIR_SAFE_RE = re.compile(r'^[A-Za-z0-9/\\:_\-.~ +@=,]+$')
+_WORKDIR_SAFE_RE = re.compile(r'^[\w/\\:_\-.~ +@=,]+$')
 
 
 def _validate_workdir(workdir: str) -> str | None:


### PR DESCRIPTION
## What does this PR do?

Allows CJK, Cyrillic, accented Latin, and other non-ASCII Unicode paths in the terminal tool's `workdir` validator. Previously, any path containing characters outside `[A-Za-z0-9]` was rejected with a misleading "shell metacharacter" error.

## Related Issue

Fixes #42619

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py`: Replace ASCII-only `[A-Za-z0-9/\\:_\-.~ +@=,]` regex with Unicode-aware `[\w/\\:_\-.~ +@=,]` in `_WORKDIR_SAFE_RE`. Python's `\w` matches Unicode letters, digits, and underscores by default, enabling paths like `~/项目`, `~/書類`, `~/문서`, `~/développement`.
- `tests/tools/test_terminal_tool.py`: Add `test_validate_workdir_allows_cjk_unicode_paths` (5 CJK/accented path assertions) and `test_validate_workdir_still_blocks_shell_metacharacters` (4 shell metacharacter assertions to verify security is preserved).

## How to Test

1. Run `pytest tests/tools/test_terminal_tool.py -v` — all 16 tests should pass
2. Verify CJK paths work: `terminal(command="pwd", workdir="~/测试")` should succeed
3. Verify shell metacharacters are still blocked: `terminal(command="pwd", workdir="~/test;rm -rf /")` should be rejected

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/terminal_tool.py:_WORKDIR_SAFE_RE` and `_validate_workdir()` (regex pattern used at line 283/286)
- Callers: `terminal_tool.py:2016` (workdir validation in `terminal()` handler)
- Blast radius: LOW — single regex change, only affects workdir path validation
- Related patterns: Windows drive paths (`test_validate_workdir_allows_windows_drive_paths`) and UNC paths (`test_validate_workdir_allows_windows_unc_paths`) already pass with the new regex since `\w` includes ASCII alphanumerics
