### PR TITLE
fix(tui): wire fallback provider chain into desktop GUI / TUI / dashboard chat (salvage #18310)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -58,6 +58,7 @@ AUTHOR_MAP = {
     "thomas.paquette@gmail.com": "RyTsYdUp",
     "techxacm@gmail.com": "ProgramCaiCai",
     "266365592+bmoore210@users.noreply.github.com": "bmoore210",
+    "157839748+psionic73@users.noreply.github.com": "psionic73",
     "manishbyatroy@gmail.com": "manishbyatroy",
     "chilltulpa@gmail.com": "TheGardenGallery",
     "al@randomsnowflake.me": "randomsnowflake",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -902,7 +902,10 @@ def test_startup_runtime_detects_provider_for_model_env(monkeypatch):
     )
 
 
-def test_load_fallback_model_prefers_fallback_providers(monkeypatch):
+def test_load_fallback_model_merges_chain_providers_first(monkeypatch):
+    # Parity with HermesCLI / gateway: fallback_providers stays first and keeps
+    # its order, with any distinct legacy fallback_model entry merged in after
+    # (deduped on provider/model/base_url).
     fallback_chain = [
         {"provider": "openrouter", "model": "openai/gpt-5.5"},
         {"provider": "anthropic", "model": "claude-sonnet-4-6"},
@@ -916,7 +919,11 @@ def test_load_fallback_model_prefers_fallback_providers(monkeypatch):
         },
     )
 
-    assert server._load_fallback_model() == fallback_chain
+    assert server._load_fallback_model() == [
+        {"provider": "openrouter", "model": "openai/gpt-5.5"},
+        {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+        {"provider": "legacy", "model": "legacy-model"},
+    ]
 
 
 def test_make_agent_passes_configured_fallback_chain(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -902,6 +902,108 @@ def test_startup_runtime_detects_provider_for_model_env(monkeypatch):
     )
 
 
+def test_load_fallback_model_prefers_fallback_providers(monkeypatch):
+    fallback_chain = [
+        {"provider": "openrouter", "model": "openai/gpt-5.5"},
+        {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+    ]
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "fallback_model": {"provider": "legacy", "model": "legacy-model"},
+            "fallback_providers": fallback_chain,
+        },
+    )
+
+    assert server._load_fallback_model() == fallback_chain
+
+
+def test_make_agent_passes_configured_fallback_chain(monkeypatch):
+    captured = {}
+    fallback_chain = [
+        {"provider": "openrouter", "model": "openai/gpt-5.5"},
+    ]
+
+    def fake_agent(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(model=kwargs.get("model"))
+
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_TUI_PROVIDER", raising=False)
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "model": {"default": "gpt-5.5", "provider": "openai-codex"},
+            "fallback_providers": fallback_chain,
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, target_model=None: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "token",
+            "api_mode": "codex_responses",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr("run_agent.AIAgent", fake_agent)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    agent = server._make_agent("sid", "session-key")
+
+    assert agent.model == "gpt-5.5"
+    assert captured["fallback_model"] == fallback_chain
+    assert captured["platform"] == "tui"
+
+
+def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
+    chain = [
+        {"provider": "openrouter", "model": "openai/gpt-5.5"},
+        {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+    ]
+    agent = types.SimpleNamespace(
+        model="gpt-5.5",
+        provider="openai-codex",
+        _fallback_chain=chain,
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 25})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    kwargs = server._background_agent_kwargs(agent, "task-id")
+
+    assert kwargs["fallback_model"] == chain
+
+
+def test_background_agent_kwargs_preserves_empty_fallback_chain(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="gpt-5.5",
+        provider="anthropic",
+        _fallback_chain=[],
+    )
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "max_turns": 25,
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "openai/gpt-5.5"},
+            ],
+        },
+    )
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    kwargs = server._background_agent_kwargs(agent, "task-id")
+
+    assert kwargs["fallback_model"] == []
+
+
 def test_startup_runtime_resolves_short_alias_without_network(monkeypatch):
     monkeypatch.setenv("HERMES_MODEL", "sonnet")
     monkeypatch.delenv("HERMES_TUI_PROVIDER", raising=False)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2585,6 +2585,34 @@ def _parse_tui_skills_env() -> list[str]:
     return skills
 
 
+def _load_fallback_model():
+    """Return the configured fallback chain for TUI-created agents.
+
+    Keep this in parity with ``HermesCLI.__init__``: prefer the new
+    ``fallback_providers`` list and accept the legacy single-dict
+    ``fallback_model`` shape.
+    """
+    cfg = _load_cfg()
+    fb = cfg.get("fallback_providers") or cfg.get("fallback_model") or []
+    if isinstance(fb, dict):
+        fb = [fb] if fb.get("provider") and fb.get("model") else []
+    if isinstance(fb, list):
+        return [
+            f for f in fb
+            if isinstance(f, dict) and f.get("provider") and f.get("model")
+        ]
+    return []
+
+
+def _agent_fallback_model(agent):
+    """Return an agent's fallback chain without rehydrating deliberately empty chains."""
+    if hasattr(agent, "_fallback_chain"):
+        return getattr(agent, "_fallback_chain") or []
+    if hasattr(agent, "_fallback_model"):
+        return getattr(agent, "_fallback_model", None)
+    return _load_fallback_model()
+
+
 def _background_agent_kwargs(agent, task_id: str) -> dict:
     cfg = _load_cfg()
 
@@ -2619,7 +2647,7 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "platform": "tui",
         "session_db": _get_db(),
-        "fallback_model": getattr(agent, "_fallback_model", None),
+        "fallback_model": _agent_fallback_model(agent),
     }
 
 
@@ -2878,6 +2906,7 @@ def _make_agent(
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
+        fallback_model=_load_fallback_model(),
         **_agent_cbs(sid),
     )
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2588,20 +2588,15 @@ def _parse_tui_skills_env() -> list[str]:
 def _load_fallback_model():
     """Return the configured fallback chain for TUI-created agents.
 
-    Keep this in parity with ``HermesCLI.__init__``: prefer the new
-    ``fallback_providers`` list and accept the legacy single-dict
-    ``fallback_model`` shape.
+    Delegates to the shared ``get_fallback_chain`` helper so the TUI path
+    stays in parity with ``HermesCLI.__init__`` and ``gateway/run.py``:
+    ``fallback_providers`` is the primary source of truth and keeps its
+    order, with legacy ``fallback_model`` entries merged in afterwards
+    (deduped on provider/model/base_url).
     """
-    cfg = _load_cfg()
-    fb = cfg.get("fallback_providers") or cfg.get("fallback_model") or []
-    if isinstance(fb, dict):
-        fb = [fb] if fb.get("provider") and fb.get("model") else []
-    if isinstance(fb, list):
-        return [
-            f for f in fb
-            if isinstance(f, dict) and f.get("provider") and f.get("model")
-        ]
-    return []
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    return get_fallback_chain(_load_cfg())
 
 
 def _agent_fallback_model(agent):


### PR DESCRIPTION
## Summary
Desktop GUI, `hermes --tui`, and the embedded dashboard chat now respect the configured `fallback_providers` / `fallback_model` chain — previously they silently had an empty fallback chain and a turn would fail on the primary instead of failing over.

Salvages #18310 (@psionic73) onto current `main`, where `_make_agent` has since gained a `model_override` parameter.

## Root cause
`tui_gateway/server.py::_make_agent()` built the chat `AIAgent` without passing `fallback_model=`, so `agent._fallback_chain` ended up `[]` for every TUI-backed session (desktop GUI, Ink TUI, dashboard `/chat`). The CLI (`cli.py`) and the messaging gateway (`gateway/run.py`) both wire this correctly; only the `tui_gateway` path was missed. A second-order bug: `_background_agent_kwargs()` propagated fallback via `getattr(agent, "_fallback_model", None)`, which was always `None` because the foreground agent never had it set.

Fixes #28753.

## Changes
- `tui_gateway/server.py`: pass `fallback_model=_load_fallback_model()` into `_make_agent`; `_load_fallback_model` delegates to the shared `hermes_cli.fallback_config.get_fallback_chain()` (parity with CLI/gateway — `fallback_providers` first + legacy `fallback_model` merged in, deduped). Background/preview agents now forward the full `_fallback_chain` instead of the legacy single entry.
- `tests/test_tui_gateway_server.py`: assert the merged canonical chain semantics.
- `scripts/release.py`: add @psionic73 to `AUTHOR_MAP` (CI gate).

## Validation
| | Before | After |
|---|---|---|
| `_make_agent` agent `_fallback_chain` (config has chain) | `[]` | full chain |
| Background-agent fallback propagation | `None` | full chain |
| `tests/test_tui_gateway_server.py` | — | 243 passed |
| E2E (real `AIAgent` via `_make_agent`, isolated `HERMES_HOME`) | chain empty | chain populated + background propagation verified |

Original PR: #18310 — cherry-picked with @psionic73's authorship preserved.



## Infographic

![Fallback chain wired into Desktop GUI / TUI / Dashboard chat](https://v3b.fal.media/files/b/0a9d9110/iSrDZo5rfN7md1nfcIfVe_og3FyzSE.png)
