### PR TITLE
feat(models): add laguna-m.1 + nemotron-3-ultra to curated OpenRouter list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -73,8 +73,10 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Free tier
     ("openrouter/elephant-alpha",              "free"),
     ("openrouter/owl-alpha",                   "free"),
+    ("poolside/laguna-m.1:free",               "free"),
     ("tencent/hy3-preview:free",               "free"),
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
+    ("nvidia/nemotron-3-ultra-550b-a55b:free", "free"),
     ("inclusionai/ring-2.6-1t:free",           "free"),
 ]
 

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-04T23:57:51Z",
+  "updated_at": "2026-06-09T05:57:24Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -117,11 +117,19 @@
           "description": "free"
         },
         {
+          "id": "poolside/laguna-m.1:free",
+          "description": "free"
+        },
+        {
           "id": "tencent/hy3-preview:free",
           "description": "free"
         },
         {
           "id": "nvidia/nemotron-3-super-120b-a12b:free",
+          "description": "free"
+        },
+        {
+          "id": "nvidia/nemotron-3-ultra-550b-a55b:free",
           "description": "free"
         },
         {


### PR DESCRIPTION
## Summary
Two new free-tier OpenRouter slugs now appear in `/model` and `hermes model` without waiting for the live catalog.

## Changes
- `hermes_cli/models.py` — added `poolside/laguna-m.1:free` and `nvidia/nemotron-3-ultra-550b-a55b:free` to the curated `OPENROUTER_MODELS` fallback. `openrouter/owl-alpha` (the third requested slug) was already present — no-op.

## Validation
| | Before | After |
|---|---|---|
| `poolside/laguna-m.1:free` in curated list | no | yes |
| `nvidia/nemotron-3-ultra-550b-a55b:free` in curated list | no | yes |
| `openrouter/owl-alpha` | already present | present |
| duplicates | — | none (E2E checked via real import) |

## Infographic

![demoscene-cracktro](https://v3b.fal.media/files/b/0a9d90f6/2p489hVMKXkUpMp-OEdrA_vniKxpYW.png)
