### PR TITLE
fix(tools): allow package manager commands with tool-name package arguments

### DIFF
--- a/tests/tools/test_terminal_vite_false_positive.py
+++ b/tests/tools/test_terminal_vite_false_positive.py
@@ -1,0 +1,151 @@
+"""Tests for long-lived foreground process detection in terminal_tool.
+
+Ensures that package manager commands like ``npm update vite`` are not
+incorrectly flagged as long-lived server processes (false positive fix
+for issue #42620).
+"""
+import json
+from unittest.mock import patch, MagicMock
+
+
+def _make_env_config(**overrides):
+    """Return a minimal _get_env_config()-shaped dict with optional overrides."""
+    config = {
+        "env_type": "local",
+        "timeout": 180,
+        "cwd": "/tmp",
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }
+    config.update(overrides)
+    return config
+
+
+def _run_terminal(command: str) -> dict:
+    """Run terminal_tool with mocked env and return the parsed result."""
+    from tools.terminal_tool import terminal_tool
+
+    with patch("tools.terminal_tool._get_env_config", return_value=_make_env_config()), \
+         patch("tools.terminal_tool._start_cleanup_thread"):
+
+        mock_env = MagicMock()
+        mock_env.execute.return_value = {"output": "done", "returncode": 0}
+
+        with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
+             patch("tools.terminal_tool._last_activity", {"default": 0}), \
+             patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+            return json.loads(terminal_tool(command=command))
+
+
+class TestViteFalsePositive:
+    """npm/pnpm/yarn/bun package operations with 'vite' as a package name
+    should NOT be blocked as long-lived processes."""
+
+    def test_npm_update_vite_not_blocked(self):
+        """npm update vite should run in foreground."""
+        result = _run_terminal("npm update vite")
+        assert result.get("error") is None
+
+    def test_npm_install_vite_not_blocked(self):
+        """npm install vite should run in foreground."""
+        result = _run_terminal("npm install vite")
+        assert result.get("error") is None
+
+    def test_npm_install_vite_save_dev_not_blocked(self):
+        """npm install vite --save-dev should run in foreground."""
+        result = _run_terminal("npm install vite --save-dev")
+        assert result.get("error") is None
+
+    def test_npm_remove_vite_not_blocked(self):
+        """npm remove vite should run in foreground."""
+        result = _run_terminal("npm remove vite")
+        assert result.get("error") is None
+
+    def test_pnpm_add_vite_not_blocked(self):
+        """pnpm add vite should run in foreground."""
+        result = _run_terminal("pnpm add vite")
+        assert result.get("error") is None
+
+    def test_yarn_add_vite_not_blocked(self):
+        """yarn add vite should run in foreground."""
+        result = _run_terminal("yarn add vite")
+        assert result.get("error") is None
+
+    def test_bun_add_vite_not_blocked(self):
+        """bun add vite should run in foreground."""
+        result = _run_terminal("bun add vite")
+        assert result.get("error") is None
+
+    def test_npm_uninstall_vite_not_blocked(self):
+        """npm uninstall vite should run in foreground."""
+        result = _run_terminal("npm uninstall vite")
+        assert result.get("error") is None
+
+    def test_npm_update_vite_with_other_packages_not_blocked(self):
+        """npm update vite lodash axios should run in foreground."""
+        result = _run_terminal("npm update vite lodash axios")
+        assert result.get("error") is None
+
+
+class TestViteStillBlocked:
+    """vite as a standalone dev server command should still be blocked."""
+
+    def test_vite_standalone_blocked(self):
+        """vite (standalone) should be blocked."""
+        result = _run_terminal("vite")
+        assert result.get("exit_code") == -1
+        assert "long-lived" in result["error"].lower()
+
+    def test_vite_dev_blocked(self):
+        """vite dev should be blocked."""
+        result = _run_terminal("vite dev")
+        assert result.get("exit_code") == -1
+        assert "long-lived" in result["error"].lower()
+
+    def test_vite_build_blocked(self):
+        """vite build should be blocked."""
+        result = _run_terminal("vite build")
+        assert result.get("exit_code") == -1
+        assert "long-lived" in result["error"].lower()
+
+    def test_vite_preview_blocked(self):
+        """vite preview --port 3000 should be blocked."""
+        result = _run_terminal("vite preview --port 3000")
+        assert result.get("exit_code") == -1
+        assert "long-lived" in result["error"].lower()
+
+
+class TestOtherPmPackageArgsNotBlocked:
+    """Other package manager commands with server-tool package names should
+    also not be falsely blocked."""
+
+    def test_npm_install_nodemon_not_blocked(self):
+        """npm install nodemon should run in foreground (nodemon is a package name)."""
+        result = _run_terminal("npm install nodemon")
+        assert result.get("error") is None
+
+    def test_npm_update_nodemon_not_blocked(self):
+        """npm update nodemon should run in foreground."""
+        result = _run_terminal("npm update nodemon")
+        assert result.get("error") is None
+
+
+class TestNonPmViteCommandsStillBlocked:
+    """Commands that use vite as a server (not package manager arg) should
+    still be blocked."""
+
+    def test_npx_vite_blocked(self):
+        """npx vite should be blocked."""
+        result = _run_terminal("npx vite")
+        assert result.get("exit_code") == -1
+        assert "long-lived" in result["error"].lower()
+
+    def test_npm_run_dev_still_blocked(self):
+        """npm run dev (uses the npm run pattern, not vite pattern) should be blocked."""
+        result = _run_terminal("npm run dev")
+        assert result.get("exit_code") == -1
+        assert "long-lived" in result["error"].lower()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1700,6 +1700,38 @@ def _looks_like_help_or_version_command(command: str) -> bool:
     )
 
 
+
+# Package manager subcommands that take package-name arguments.
+_PM_INSTALL_VERBS = re.compile(
+    r"\b(?:npm|pnpm|yarn|bun)\s+(?:install|add|update|up(?:grade)?|remove|uninstall|rm)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_pm_package_argument(command: str, keyword: str) -> bool:
+    """Return True when *keyword* appears as a package name in a pm install/update command.
+
+    Prevents false-positive long-lived-process detection for commands like
+    ``npm update vite`` or ``pnpm add nodemon`` where the keyword is a
+    *package name argument*, not a standalone server invocation.
+    """
+    if not _PM_INSTALL_VERBS.search(command):
+        return False
+    # Extract tokens after the pm install verb; keyword must be one of them.
+    after_pm = re.split(
+        r"\b(?:npm|pnpm|yarn|bun)\s+(?:install|add|update|up(?:grade)?|remove|uninstall|rm)\b",
+        command,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )
+    if len(after_pm) < 2:
+        return False
+    tokens = after_pm[1].split()
+    # Filter out flags (starting with -)
+    pkg_tokens = [t for t in tokens if not t.startswith("-")]
+    return keyword.lower() in {t.lower() for t in pkg_tokens}
+
+
 def _foreground_background_guidance(command: str) -> str | None:
     """Suggest background mode when a foreground command looks long-lived.
 
@@ -1727,7 +1759,14 @@ def _foreground_background_guidance(command: str) -> str | None:
         )
 
     for pattern in _LONG_LIVED_FOREGROUND_PATTERNS:
-        if pattern.search(unquoted):
+        m = pattern.search(unquoted)
+        if m:
+            # Skip false positives where the matched keyword is a package
+            # name argument to a package-manager install/update command
+            # (e.g. "npm update vite" should not trigger the vite pattern).
+            keyword = m.group().strip().split()[0].lower()
+            if _is_pm_package_argument(unquoted, keyword):
+                continue
             return (
                 "This foreground command appears to start a long-lived server/watch process. "
                 "Run it with background=true, verify readiness (health endpoint/log signal), "


### PR DESCRIPTION
## Problem

The terminal tool's long-lived process detection blocks `npm update vite` (and similar package manager commands) because the regex pattern `\bvite(?:\s|$)` matches `vite` anywhere in the command string, including as a package name argument.

**Affected commands (false positives):**
- `npm update vite` → blocked ❌
- `npm install vite --save-dev` → blocked ❌
- `pnpm add vite` → blocked ❌
- `yarn add vite` → blocked ❌
- `bun add vite` → blocked ❌

**Should still be blocked (true positives):**
- `vite` (standalone dev server) → blocked ✅
- `vite dev` → blocked ✅
- `npx vite` → blocked ✅

## Fix

Add `_is_pm_package_argument()` helper that detects when the matched keyword appears as a package name argument to npm/pnpm/yarn/bun install/add/update/remove/uninstall commands. The pattern-matching loop in `_foreground_background_guidance()` now skips matches that are package-manager arguments.

This approach generalizes to all patterns in `_LONG_LIVED_FOREGROUND_PATTERNS` — e.g. `npm install nodemon` is also correctly allowed through.

## Changes

- `tools/terminal_tool.py`: Add `_PM_INSTALL_VERBS` regex, `_is_pm_package_argument()` helper, and integrate into the pattern-matching loop
- `tests/tools/test_terminal_vite_false_positive.py`: 17 tests covering PM package operations (allowed), standalone vite commands (blocked), and cross-pattern generalization

Fixes #42620
