### PR TITLE
fix(copilot): correct catalog max_prompt_tokens under-report for Claude 1M window

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2618,39 +2618,21 @@ _copilot_context_cache: dict[str, int] = {}
 _copilot_context_cache_time: float = 0.0
 _COPILOT_CONTEXT_CACHE_TTL = 3600  # 1 hour
 
-# ── Copilot catalog under-report correction ─────────────────────────────────
-# GitHub's Copilot /models catalog advertises ``max_prompt_tokens: 200000`` for
-# the Claude family, but the API does NOT enforce that value — it enforces the
-# model's true ~1M input window. Verified empirically (real POSTs to
-# api.githubcopilot.com/chat/completions, the exact endpoint Hermes uses):
-#
-#     claude-opus-4.8   980,024 tok -> 200 OK   |  1,000,048 tok -> 400 ">1000000 maximum"
-#     claude-opus-4.7   980,019 tok -> 200 OK
-#     claude-opus-4.6   825,011 tok -> 200 OK   (catalog said 200k)
-#     claude-sonnet-4.6 825,012 tok -> 200 OK   (catalog said 200k)
-#
-# Trusting the catalog makes Hermes self-impose a ~5x context handicap that the
-# provider never asked for. We correct the known-false value to the real window.
-#
-# TIER SAFETY: the correction is deliberately narrow. It fires ONLY when the
-# catalog reports the EXACT under-reported value we verified wrong (200000) for a
-# matched model. If a Copilot tier ever reports a different number, or GitHub
-# fixes the catalog, this becomes inert and the catalog value passes through
-# untouched — we never inflate a value GitHub might actually be enforcing.
+# GitHub's Copilot /models catalog reports max_prompt_tokens: 200000 for the
+# Claude family, but the API does not enforce it — it serves the model's true
+# ~1M input window (verified Jun 2026 via live chat/completions probes: opus-4.8
+# accepts 980k tokens, rejects at >1,000,000; opus-4.6/4.7 and sonnet-4.6 accept
+# 800k+). Trusting the catalog self-imposes a ~5x context handicap, so we correct
+# the known-false value. Narrow by design: only the exact under-reported value
+# (200000) for a matched model is lifted, so a tier that reports a different
+# number — or a catalog fix — passes through untouched and is never inflated.
 _COPILOT_UNDERREPORTED_PROMPT = 200000
 _COPILOT_TRUE_PROMPT_WINDOW = 1000000
-# Substrings (lowercased) of model ids known to carry the ~1M window on Copilot.
 _COPILOT_1M_MODEL_MARKERS = ("claude-opus-4.6", "claude-opus-4.7", "claude-opus-4.8", "claude-sonnet-4.6")
 
 
 def _correct_copilot_max_prompt(model_id: str, max_prompt: int) -> int:
-    """Correct GitHub's known-false ``max_prompt_tokens`` under-report for Claude.
-
-    Returns the true input window when ``max_prompt`` is the exact verified-wrong
-    catalog value (200000) for a known-1M Claude model; otherwise returns
-    ``max_prompt`` unchanged. See the module-level note for the empirical basis
-    and the tier-safety rationale.
-    """
+    """Lift GitHub's known-false 200000 max_prompt under-report to the real 1M window."""
     if max_prompt != _COPILOT_UNDERREPORTED_PROMPT:
         return max_prompt
     mid = (model_id or "").lower()

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2618,6 +2618,46 @@ _copilot_context_cache: dict[str, int] = {}
 _copilot_context_cache_time: float = 0.0
 _COPILOT_CONTEXT_CACHE_TTL = 3600  # 1 hour
 
+# ── Copilot catalog under-report correction ─────────────────────────────────
+# GitHub's Copilot /models catalog advertises ``max_prompt_tokens: 200000`` for
+# the Claude family, but the API does NOT enforce that value — it enforces the
+# model's true ~1M input window. Verified empirically (real POSTs to
+# api.githubcopilot.com/chat/completions, the exact endpoint Hermes uses):
+#
+#     claude-opus-4.8   980,024 tok -> 200 OK   |  1,000,048 tok -> 400 ">1000000 maximum"
+#     claude-opus-4.7   980,019 tok -> 200 OK
+#     claude-opus-4.6   825,011 tok -> 200 OK   (catalog said 200k)
+#     claude-sonnet-4.6 825,012 tok -> 200 OK   (catalog said 200k)
+#
+# Trusting the catalog makes Hermes self-impose a ~5x context handicap that the
+# provider never asked for. We correct the known-false value to the real window.
+#
+# TIER SAFETY: the correction is deliberately narrow. It fires ONLY when the
+# catalog reports the EXACT under-reported value we verified wrong (200000) for a
+# matched model. If a Copilot tier ever reports a different number, or GitHub
+# fixes the catalog, this becomes inert and the catalog value passes through
+# untouched — we never inflate a value GitHub might actually be enforcing.
+_COPILOT_UNDERREPORTED_PROMPT = 200000
+_COPILOT_TRUE_PROMPT_WINDOW = 1000000
+# Substrings (lowercased) of model ids known to carry the ~1M window on Copilot.
+_COPILOT_1M_MODEL_MARKERS = ("claude-opus-4.6", "claude-opus-4.7", "claude-opus-4.8", "claude-sonnet-4.6")
+
+
+def _correct_copilot_max_prompt(model_id: str, max_prompt: int) -> int:
+    """Correct GitHub's known-false ``max_prompt_tokens`` under-report for Claude.
+
+    Returns the true input window when ``max_prompt`` is the exact verified-wrong
+    catalog value (200000) for a known-1M Claude model; otherwise returns
+    ``max_prompt`` unchanged. See the module-level note for the empirical basis
+    and the tier-safety rationale.
+    """
+    if max_prompt != _COPILOT_UNDERREPORTED_PROMPT:
+        return max_prompt
+    mid = (model_id or "").lower()
+    if any(marker in mid for marker in _COPILOT_1M_MODEL_MARKERS):
+        return _COPILOT_TRUE_PROMPT_WINDOW
+    return max_prompt
+
 
 def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> Optional[int]:
     """Look up max_prompt_tokens for a Copilot model from the live /models API.
@@ -2648,6 +2688,7 @@ def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> O
         limits = caps.get("limits") or {}
         max_prompt = limits.get("max_prompt_tokens")
         if isinstance(max_prompt, int) and max_prompt > 0:
+            max_prompt = _correct_copilot_max_prompt(mid, max_prompt)
             cache[mid] = max_prompt
 
     _copilot_context_cache = cache

--- a/tests/test_copilot_context_correction.py
+++ b/tests/test_copilot_context_correction.py
@@ -1,0 +1,64 @@
+"""Tests for the Copilot catalog max_prompt_tokens under-report correction.
+
+GitHub's Copilot /models catalog advertises ``max_prompt_tokens: 200000`` for
+the Claude family, but the API enforces the true ~1M window. These tests pin the
+correction helper's behaviour and its deliberately narrow, tier-safe scope.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.models import (
+    _correct_copilot_max_prompt,
+    _COPILOT_TRUE_PROMPT_WINDOW,
+    _COPILOT_UNDERREPORTED_PROMPT,
+)
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "claude-opus-4.6",
+        "claude-opus-4.7",
+        "claude-opus-4.8",
+        "claude-sonnet-4.6",
+        "CLAUDE-OPUS-4.8",  # case-insensitive
+    ],
+)
+def test_corrects_known_1m_models_at_underreported_value(model_id: str) -> None:
+    """The exact verified-wrong 200000 is lifted to the true 1M window."""
+    assert (
+        _correct_copilot_max_prompt(model_id, _COPILOT_UNDERREPORTED_PROMPT)
+        == _COPILOT_TRUE_PROMPT_WINDOW
+    )
+
+
+@pytest.mark.parametrize(
+    "model_id, value",
+    [
+        # Non-underreported values pass through untouched, even for known models —
+        # we only correct the EXACT value we proved false.
+        ("claude-opus-4.8", 168000),
+        ("claude-opus-4.8", 1000000),
+        ("claude-opus-4.8", 264000),
+        # Unknown / unmatched models are never inflated, even at 200000.
+        ("gpt-5.5", _COPILOT_UNDERREPORTED_PROMPT),
+        ("gemini-2.5-pro", _COPILOT_UNDERREPORTED_PROMPT),
+        ("claude-haiku-4.5", _COPILOT_UNDERREPORTED_PROMPT),
+        ("claude-sonnet-4.5", _COPILOT_UNDERREPORTED_PROMPT),
+        # Older opus that was never verified at 1M is left alone.
+        ("claude-opus-4.5", _COPILOT_UNDERREPORTED_PROMPT),
+    ],
+)
+def test_leaves_unmatched_or_non_underreported_values_untouched(
+    model_id: str, value: int
+) -> None:
+    """Tier-safety: only the exact (known-model, 200000) pair is corrected."""
+    assert _correct_copilot_max_prompt(model_id, value) == value
+
+
+def test_empty_model_id_is_safe() -> None:
+    assert (
+        _correct_copilot_max_prompt("", _COPILOT_UNDERREPORTED_PROMPT)
+        == _COPILOT_UNDERREPORTED_PROMPT
+    )


### PR DESCRIPTION
## Problem

Hermes reports a **200K** context window for Claude models on the GitHub Copilot provider, when the real enforced window is **~1M**. Every Copilot + Claude user silently runs with a ~5x context handicap (premature compression, `/context` bar capped at 200K).

Root cause: `get_copilot_model_context()` trusts the `max_prompt_tokens` field from GitHub's Copilot `/models` catalog. That field advertises `200000` for the Claude family — but **GitHub does not enforce it**. The API serves the model's true ~1M input window.

## Evidence (empirical, not catalog metadata)

Real `POST`s to `https://api.githubcopilot.com/chat/completions` — the exact endpoint + headers Hermes uses — measuring server-reported `usage.prompt_tokens`:

| model | large prompt | result |
|---|---|---|
| `claude-opus-4.8` | 980,024 tok | ✅ 200 OK |
| `claude-opus-4.8` | 1,000,048 tok | ❌ 400 `prompt is too long: 1000048 tokens > 1000000 maximum` |
| `claude-opus-4.7` | 980,019 tok | ✅ 200 OK |
| `claude-opus-4.6` | 825,011 tok | ✅ 200 OK (catalog said 200k) |
| `claude-sonnet-4.6` | 825,012 tok | ✅ 200 OK (catalog said 200k) |

The catalog's `200000` is contradicted by the API itself. The true ceiling is exactly **1,000,000**.

## Fix

`_correct_copilot_max_prompt()` lifts the known-false catalog value to the real window.

**Tier-safe by design.** The correction fires **only** when the catalog reports the *exact* verified-wrong value (`200000`) for a *matched* known-1M model. Any other reported value — or a future catalog fix — makes it inert and the catalog value passes through untouched. We never inflate a limit GitHub might actually be enforcing on a different subscription tier.

Scope is intentionally a static marker list (`opus-4.6/4.7/4.8`, `sonnet-4.6`) rather than a blind "all Claude = 1M", precisely because I can only personally verify one subscription tier. A more general approach (one-time empirical probe + cache) is noted below as a follow-up.

## Tests

`tests/test_copilot_context_correction.py` — 14 cases: correction fires for the 4 verified models at 200000 (incl. case-insensitive); leaves every other (model, value) pair untouched, including non-200000 values for known models and 200000 for unmatched models (`gpt-5.5`, `haiku-4.5`, `sonnet-4.5`, `opus-4.5`).

```
14 passed in 0.34s
# regression smoke (existing copilot context/model tests):
76 passed, 4 skipped
```

## Follow-up (not in this PR)

For full tier-independence, replace the static marker list with a one-time empirical probe (binary-search the real ceiling with tiny chat calls, cache per `model_id`). That self-maintains across model releases and subscription tiers but costs probe calls + complexity — worth discussing separately.

## Notes
- Output cap (`max_output_tokens`) is genuinely enforced and is **not** touched here; only the input/prompt window is corrected.
- Users can already work around this via `model.context_length: 1000000` in config; this fix makes the correct window the default so users don't have to know the catalog lies.
