### PR TITLE
fix(agent): classify OpenAI regex lookaround schema rejection as recoverable

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -603,6 +603,13 @@ def classify_api_error(
     # recognizable phrases; on match we strip ``pattern``/``format`` from
     # ``self.tools`` in the retry loop and retry once. Cloud providers are
     # unaffected — they accept these keywords and we never hit this branch.
+    #
+    # Some OpenAI-compatible endpoints (e.g. strict GPT tool-schema
+    # validation) also reject ``pattern`` containing regex lookaround
+    # (lookahead / lookbehind) with a different error shape:
+    #   "Invalid JSON schema: regex lookaround is not supported."
+    # Route through the same recovery path — strip ``pattern``/``format``
+    # and retry once.
     if (
         status_code == 400
         and (
@@ -611,6 +618,11 @@ def classify_api_error(
             or (
                 "unable to generate parser" in error_msg
                 and "template" in error_msg
+            )
+            or (
+                "invalid json schema" in error_msg
+                and "regex lookaround" in error_msg
+                and "not supported" in error_msg
             )
         )
     ):

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -743,6 +743,27 @@ class TestClassifyApiError:
         result = classify_api_error(e, provider="openai-compatible")
         assert result.reason != FailoverReason.llama_cpp_grammar_pattern
 
+    def test_openai_regex_lookaround_rejection(self):
+        """OpenAI-compatible endpoints reject regex lookaround in tool schemas."""
+        e = MockAPIError(
+            "Invalid JSON schema: regex lookaround is not supported. "
+            "Found at $...properties.email.pattern.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="custom")
+        assert result.reason == FailoverReason.llama_cpp_grammar_pattern
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_openai_regex_lookaround_requires_all_keywords(self):
+        """Partial match should not trigger — all three keywords needed."""
+        e = MockAPIError(
+            "Invalid JSON schema: regex syntax error in pattern",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="custom")
+        assert result.reason != FailoverReason.llama_cpp_grammar_pattern
+
     # ── Provider-specific: Anthropic long-context tier ──
 
     def test_anthropic_long_context_tier(self):


### PR DESCRIPTION
## What does this PR do?

Classifies HTTP 400 errors from OpenAI-compatible endpoints that reject tool schemas containing regex lookaround patterns as recoverable, routing them through the existing `strip_pattern_and_format()` retry path so the conversation continues instead of failing permanently.

## Related Issue

Fixes #42631

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: Extended the llama.cpp grammar-pattern condition to also match OpenAI-compatible "regex lookaround is not supported" errors, routing them through the same `FailoverReason.llama_cpp_grammar_pattern` recovery path
- `tests/agent/test_error_classifier.py`: Added 2 tests — one verifying the lookaround error is classified as retryable, one verifying partial keyword matches don't trigger false positives

## How to Test

1. Run `pytest tests/agent/test_error_classifier.py -q` — all 157 tests pass (including the 2 new ones)
2. Run `pytest tests/tools/test_schema_sanitizer.py -q` — all 40 schema sanitizer tests pass (verifies the downstream recovery path)
3. The new `test_openai_regex_lookaround_rejection` test verifies the exact error message from the issue is classified as `FailoverReason.llama_cpp_grammar_pattern` with `retryable=True`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/error_classifier.py` (error classification logic), `agent/conversation_loop.py:2304` (recovery path consumer), `tools/schema_sanitizer.py:308` (strip_pattern_and_format)
- Blast radius: LOW — only affects HTTP 400 errors with specific regex lookaround phrasing; all existing llama.cpp grammar tests unchanged
- Related patterns: Existing `llama_cpp_grammar_pattern` recovery path at lines 606-621; this extends the same condition with an additional disjunct
