### PR TITLE
Support Feishu quoted-image edits

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -361,6 +361,13 @@ class FeishuNormalizedMessage:
 
 
 @dataclass(frozen=True)
+class FeishuMessageContext:
+    text: Optional[str] = None
+    media_urls: List[str] = field(default_factory=list)
+    media_types: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
 class FeishuAdapterSettings:
     app_id: str  # Canonical bot/app identifier (credential, not from event payloads)
     app_secret: str
@@ -3129,7 +3136,18 @@ class FeishuAdapter(BasePlatformAdapter):
             or getattr(message, "root_id", None)
             or None
         )
-        reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
+        reply_to_text = None
+        if reply_to_message_id:
+            reply_context = await self._fetch_message_context(reply_to_message_id)
+            reply_to_text = reply_context.text
+            if reply_context.media_urls:
+                media_urls.extend(reply_context.media_urls)
+                media_types.extend(reply_context.media_types)
+                logger.info(
+                    "[Feishu] Attached %d referenced media file(s) from parent message %s",
+                    len(reply_context.media_urls),
+                    reply_to_message_id,
+                )
 
         sender_primary = (
             getattr(sender_id, "open_id", None)
@@ -3534,6 +3552,9 @@ class FeishuAdapter(BasePlatformAdapter):
             return
 
         existing.text = next_text
+        if event.media_urls:
+            existing.media_urls.extend(event.media_urls)
+            existing.media_types.extend(event.media_types)
         existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
         existing.timestamp = event.timestamp
         if event.message_id:
@@ -4055,6 +4076,61 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
             return None
 
+    async def _fetch_message_context(self, message_id: str) -> FeishuMessageContext:
+        if not message_id:
+            return FeishuMessageContext()
+        if not getattr(self, "_client", None):
+            try:
+                return FeishuMessageContext(text=await self._fetch_message_text(message_id))
+            except Exception:
+                return FeishuMessageContext()
+        try:
+            request = self._build_get_message_request(message_id)
+            response = await asyncio.to_thread(self._client.im.v1.message.get, request)
+            if not response or getattr(response, "success", lambda: False)() is False:
+                code = getattr(response, "code", "unknown")
+                msg = getattr(response, "msg", "message lookup failed")
+                logger.warning("[Feishu] Failed to fetch parent message %s: [%s] %s", message_id, code, msg)
+                return FeishuMessageContext()
+
+            items = getattr(getattr(response, "data", None), "items", None) or []
+            parent = items[0] if items else None
+            if parent is None:
+                return FeishuMessageContext()
+
+            body = getattr(parent, "body", None)
+            msg_type = getattr(parent, "msg_type", "") or ""
+            raw_content = getattr(body, "content", "") or ""
+            parent_mentions = getattr(parent, "mentions", None)
+            normalized = normalize_feishu_message(
+                message_type=msg_type,
+                raw_content=raw_content,
+                mentions=parent_mentions,
+                bot=self._bot_identity(),
+            )
+            text = self._text_from_normalized_message(normalized)
+            media_urls, media_types = await self._download_feishu_message_resources(
+                message_id=message_id,
+                normalized=normalized,
+            )
+            if not text and (media_urls or normalized.image_keys or normalized.media_refs):
+                if normalized.image_keys or (media_types and media_types[0].startswith("image/")):
+                    text = "[Image]"
+                else:
+                    text = "[Attachment]"
+
+            if text is not None:
+                self._message_text_cache[message_id] = text
+                while len(self._message_text_cache) > _FEISHU_MESSAGE_TEXT_CACHE_SIZE:
+                    self._message_text_cache.popitem(last=False)
+            return FeishuMessageContext(text=text, media_urls=media_urls, media_types=media_types)
+        except Exception:
+            logger.warning("[Feishu] Failed to fetch parent message context %s", message_id, exc_info=True)
+            try:
+                return FeishuMessageContext(text=await self._fetch_message_text(message_id))
+            except Exception:
+                return FeishuMessageContext()
+
     def _extract_text_from_raw_content(
         self,
         *,
@@ -4068,9 +4144,15 @@ class FeishuAdapter(BasePlatformAdapter):
             mentions=mentions,
             bot=self._bot_identity(),
         )
+        return self._text_from_normalized_message(normalized)
+
+    @staticmethod
+    def _text_from_normalized_message(normalized: FeishuNormalizedMessage) -> Optional[str]:
         if normalized.text_content:
             return normalized.text_content
         placeholder = normalized.metadata.get("placeholder_text") if isinstance(normalized.metadata, dict) else None
+        if placeholder is None:
+            return None
         return str(placeholder).strip() or None
 
     @staticmethod

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,6 +67,15 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
+_IMAGE_EDIT_INTENT_RE = re.compile(
+    r"("
+    r"改一下|修改|改成|改为|换成|变成|修图|p图|P图|重绘|重新画|"
+    r"生成|出图|做成|画成|加上|去掉|替换|换背景|换风格|"
+    r"edit|modify|change|turn\s+.*\s+into|make\s+.*\s+look|generate|redraw"
+    r")",
+    re.IGNORECASE,
+)
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
     r"auxiliary\s+.+\s+failed"
@@ -6171,6 +6180,219 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         await adapter.send(source.chat_id, content, metadata=metadata)
 
+    @staticmethod
+    def _event_image_paths(event: MessageEvent) -> List[str]:
+        paths: List[str] = []
+        media_urls = getattr(event, "media_urls", None) or []
+        media_types = getattr(event, "media_types", None) or []
+        for i, path in enumerate(media_urls):
+            mtype = media_types[i] if i < len(media_types) else ""
+            if mtype.startswith("image/") or getattr(event, "message_type", None) == MessageType.PHOTO:
+                if isinstance(path, str) and path.strip():
+                    paths.append(path.strip())
+        return paths
+
+    @staticmethod
+    def _message_requests_image_edit(text: str) -> bool:
+        if not isinstance(text, str):
+            return False
+        text = text.strip()
+        if not text:
+            return False
+        return bool(_IMAGE_EDIT_INTENT_RE.search(text))
+
+    @staticmethod
+    def _infer_image_generation_aspect(user_text: str, image_path: str) -> str:
+        text = (user_text or "").lower()
+        if any(token in text for token in ("1:1", "方图", "方形", "square")):
+            return "square"
+        if any(token in text for token in ("9:16", "竖图", "竖版", "portrait")):
+            return "portrait"
+        if any(token in text for token in ("16:9", "横图", "横版", "landscape")):
+            return "landscape"
+
+        try:
+            from PIL import Image as _PILImage
+
+            with _PILImage.open(image_path) as img:
+                width, height = img.size
+            if width and height:
+                ratio = width / height
+                if 0.85 <= ratio <= 1.15:
+                    return "square"
+                return "landscape" if ratio > 1 else "portrait"
+        except Exception:
+            pass
+        return "landscape"
+
+    async def _describe_image_for_generation(self, image_path: str, user_text: str) -> str:
+        prompt = (
+            "请用中文详细描述这张参考图，服务于后续文生图/改图提示词。"
+            "重点写主体、人物外貌与姿态、神态、构图、镜头距离、光线、背景、色彩、真实感与原始宽高比例。"
+            "不要编造看不到的内容。用户的修改要求是："
+            f"{user_text}"
+        )
+        try:
+            from tools.vision_tools import vision_analyze_tool
+
+            raw = await vision_analyze_tool(image_path, prompt)
+            payload = json.loads(raw) if isinstance(raw, str) else raw
+            if isinstance(payload, dict) and payload.get("success"):
+                analysis = str(payload.get("analysis") or "").strip()
+                if analysis:
+                    return analysis
+            logger.warning("Image edit shortcut vision description failed: %s", raw[:300] if isinstance(raw, str) else raw)
+        except Exception as exc:
+            logger.warning("Image edit shortcut vision description failed: %s", exc, exc_info=True)
+        return ""
+
+    @staticmethod
+    def _build_image_edit_generation_prompt(
+        *,
+        user_text: str,
+        image_description: str,
+        aspect: str,
+    ) -> str:
+        description = image_description.strip() or "参考图已上传，但自动描述失败；请根据用户要求生成一张合理的新图。"
+        return (
+            "基于一张参考图生成修改后的新图片。\n\n"
+            f"原图描述：{description}\n\n"
+            f"用户修改要求：{user_text.strip() or '按参考图生成一张修改版'}\n\n"
+            "生成要求：参考图会以真实图片输入一并提供；保持参考图的主体身份感、构图关系、镜头距离、光线氛围和整体真实感；"
+            "只执行用户提出的修改，不要额外添加文字、水印、边框或 UI 元素；"
+            f"输出比例按 {aspect} 处理，如果用户要求保持比例，则尽量延续参考图的视觉比例和构图。"
+        )
+
+    async def _maybe_handle_direct_image_edit_request(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+    ) -> Optional[str]:
+        image_paths = self._event_image_paths(event)
+        if not image_paths or not self._message_requests_image_edit(event.text or ""):
+            return None
+
+        adapter = self.adapters.get(source.platform)
+        if adapter is None:
+            return None
+
+        user_text = event.text or ""
+        image_path = image_paths[0]
+        aspect = self._infer_image_generation_aspect(user_text, image_path)
+
+        try:
+            await adapter.send(
+                source.chat_id,
+                "收到，正在按引用图生成修改版。",
+                metadata=None if source.platform == Platform.FEISHU else self._thread_metadata_for_source(source, None),
+            )
+        except Exception:
+            logger.debug("Image edit shortcut progress send failed", exc_info=True)
+
+        description = await self._describe_image_for_generation(image_path, user_text)
+        prompt = self._build_image_edit_generation_prompt(
+            user_text=user_text,
+            image_description=description,
+            aspect=aspect,
+        )
+
+        try:
+            from tools.image_generation_tool import _handle_image_generate
+
+            raw = await asyncio.to_thread(
+                _handle_image_generate,
+                {
+                    "prompt": prompt,
+                    "aspect_ratio": aspect,
+                    "reference_image_paths": image_paths,
+                },
+            )
+            payload = json.loads(raw) if isinstance(raw, str) else raw
+        except Exception as exc:
+            logger.warning("Image edit shortcut generation failed: %s", exc, exc_info=True)
+            await adapter.send(
+                source.chat_id,
+                f"生成失败：{exc}",
+                metadata=None if source.platform == Platform.FEISHU else self._thread_metadata_for_source(source, None),
+            )
+            return ""
+
+        if not isinstance(payload, dict) or not payload.get("success"):
+            error = payload.get("error") if isinstance(payload, dict) else raw
+            await adapter.send(
+                source.chat_id,
+                f"生成失败：{error or 'image_generate 没有返回图片'}",
+                metadata=None if source.platform == Platform.FEISHU else self._thread_metadata_for_source(source, None),
+            )
+            return ""
+
+        image_ref = str(payload.get("image") or "").strip()
+        if not image_ref:
+            await adapter.send(
+                source.chat_id,
+                "生成完成，但没有拿到可发送的图片路径。",
+                metadata=None if source.platform == Platform.FEISHU else self._thread_metadata_for_source(source, None),
+            )
+            return ""
+
+        metadata = None if source.platform == Platform.FEISHU else self._thread_metadata_for_source(source, None)
+        send_result = None
+        try:
+            if image_ref.startswith("file://"):
+                from urllib.parse import unquote as _unquote
+
+                image_ref = _unquote(image_ref[7:])
+            if os.path.isfile(image_ref) and hasattr(adapter, "send_image_file"):
+                send_result = await adapter.send_image_file(
+                    chat_id=source.chat_id,
+                    image_path=image_ref,
+                    metadata=metadata,
+                )
+            elif image_ref.startswith(("http://", "https://")) and hasattr(adapter, "send_image"):
+                send_result = await adapter.send_image(
+                    chat_id=source.chat_id,
+                    image_url=image_ref,
+                    metadata=metadata,
+                )
+            else:
+                from urllib.parse import quote as _quote
+
+                await adapter.send_multiple_images(
+                    chat_id=source.chat_id,
+                    images=[(f"file://{_quote(image_ref)}", "")],
+                    metadata=metadata,
+                )
+        except Exception as exc:
+            logger.warning("Image edit shortcut image delivery failed: %s", exc, exc_info=True)
+            send_result = None
+
+        if send_result is not None and not getattr(send_result, "success", False):
+            logger.warning(
+                "[%s] Image edit shortcut native image send failed: %s",
+                getattr(adapter, "name", source.platform),
+                getattr(send_result, "error", ""),
+            )
+            if os.path.isfile(image_ref) and hasattr(adapter, "send_document"):
+                fallback = await adapter.send_document(
+                    chat_id=source.chat_id,
+                    file_path=image_ref,
+                    metadata=metadata,
+                )
+                if not getattr(fallback, "success", False):
+                    await adapter.send(
+                        source.chat_id,
+                        f"图片已生成，但飞书上传失败：{getattr(send_result, 'error', '') or getattr(fallback, 'error', '')}",
+                        metadata=metadata,
+                    )
+            else:
+                await adapter.send(
+                    source.chat_id,
+                    f"图片已生成，但发送失败：{getattr(send_result, 'error', '')}",
+                    metadata=metadata,
+                )
+
+        return ""
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -7287,6 +7509,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if self._should_send_telegram_lobby_reminder(source):
                 return self._telegram_topic_root_lobby_message()
             return None
+
+        if self._event_image_paths(event) and self._message_requests_image_edit(event.text or ""):
+            self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
+            self._running_agents_ts[_quick_key] = time.time()
+            try:
+                direct_image_edit_response = await self._maybe_handle_direct_image_edit_request(event, source)
+            finally:
+                self._release_running_agent_state(_quick_key)
+            if direct_image_edit_response is not None:
+                return direct_image_edit_response
 
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there
@@ -11347,20 +11579,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     enriched_parts.append(
                         f"[The user sent an image~ Here's what I can see:\n{description}]\n"
                         f"[If you need a closer look, use vision_analyze with "
-                        f"image_url: {path} ~]"
+                        f"image_url: {path} ~]\n"
+                        f"[If the user asks you to edit, redraw, or generate from this image, "
+                        f"call image_generate with reference_image_paths: [\"{path}\"] so the "
+                        f"image backend receives the actual reference image bytes.]"
                     )
                 else:
                     enriched_parts.append(
                         "[The user sent an image but I couldn't quite see it "
                         "this time (>_<) You can try looking at it yourself "
-                        f"with vision_analyze using image_url: {path}]"
+                        f"with vision_analyze using image_url: {path}. If the user asks for "
+                        f"image editing or regeneration, call image_generate with "
+                        f"reference_image_paths: [\"{path}\"] to pass the actual image bytes.]"
                     )
             except Exception as e:
                 logger.error("Vision auto-analysis error: %s", e)
                 enriched_parts.append(
                     f"[The user sent an image but something went wrong when I "
                     f"tried to look at it~ You can try examining it yourself "
-                    f"with vision_analyze using image_url: {path}]"
+                    f"with vision_analyze using image_url: {path}. If the user asks for "
+                    f"image editing or regeneration, call image_generate with "
+                    f"reference_image_paths: [\"{path}\"] to pass the actual image bytes.]"
                 )
 
         # Combine: vision descriptions first, then the user's original text

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -76,6 +76,15 @@ _IMAGE_EDIT_INTENT_RE = re.compile(
     re.IGNORECASE,
 )
 
+_IMAGE_EDIT_INTENT_CLASSIFIER_SYSTEM = (
+    "你是消息网关里的意图分类器。用户消息同时附带或引用了一张真实图片。"
+    "判断用户是否希望基于这张图片生成一张修改版/重做版/新图片。"
+    '只返回 JSON：{"edit": true} 或 {"edit": false}。'
+    "当用户要求修改、重做、再来一版、换风格、调整表情/姿势/背景/主体、添加/删除/替换视觉元素、"
+    "或用参考图生成新图时，edit=true。"
+    "当用户只是问能否看到图片、询问图片内容、请求描述/分析/OCR、讨论图片、或意图不明确时，edit=false。"
+)
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
     r"auxiliary\s+.+\s+failed"
@@ -6202,6 +6211,97 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return bool(_IMAGE_EDIT_INTENT_RE.search(text))
 
     @staticmethod
+    def _parse_image_edit_intent_decision(text: str) -> Optional[bool]:
+        if not isinstance(text, str):
+            return None
+        cleaned = text.strip()
+        if not cleaned:
+            return None
+        if cleaned.startswith("```"):
+            cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.IGNORECASE)
+            cleaned = re.sub(r"\s*```$", "", cleaned).strip()
+
+        candidates = [cleaned]
+        match = re.search(r"\{.*\}", cleaned, flags=re.DOTALL)
+        if match:
+            candidates.insert(0, match.group(0))
+
+        for candidate in candidates:
+            try:
+                payload = json.loads(candidate)
+            except Exception:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            for key in ("edit", "image_edit", "direct_image_edit"):
+                if key not in payload:
+                    continue
+                value = payload.get(key)
+                if isinstance(value, bool):
+                    return value
+                if isinstance(value, str):
+                    normalized = value.strip().lower()
+                    if normalized in {"true", "yes", "1"}:
+                        return True
+                    if normalized in {"false", "no", "0"}:
+                        return False
+
+        normalized = cleaned.strip().lower()
+        if normalized in {"true", "yes", "y", "edit", "image_edit"}:
+            return True
+        if normalized in {"false", "no", "n"}:
+            return False
+        return None
+
+    async def _message_semantically_requests_image_edit(self, text: str) -> bool:
+        user_text = (text or "").strip()
+        if not user_text:
+            return False
+        try:
+            from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
+
+            response = await async_call_llm(
+                task="gateway_intent",
+                messages=[
+                    {"role": "system", "content": _IMAGE_EDIT_INTENT_CLASSIFIER_SYSTEM},
+                    {"role": "user", "content": f"用户消息：{user_text}"},
+                ],
+                temperature=0,
+                max_tokens=64,
+                timeout=15,
+            )
+            content = extract_content_or_reasoning(response)
+        except Exception as exc:
+            logger.info("Image edit semantic intent classifier failed closed: %s", exc)
+            return False
+
+        decision = self._parse_image_edit_intent_decision(content)
+        if decision is None:
+            logger.info(
+                "Image edit semantic intent classifier returned unclear response: %r",
+                (content or "")[:200],
+            )
+            return False
+        return decision
+
+    async def _should_handle_direct_image_edit_request(
+        self,
+        event: MessageEvent,
+        image_paths: Optional[List[str]] = None,
+    ) -> bool:
+        paths = image_paths if image_paths is not None else self._event_image_paths(event)
+        if not paths:
+            return False
+        text = event.text or ""
+        if self._message_requests_image_edit(text):
+            logger.info("Image edit shortcut intent: keyword fast path")
+            return True
+        if await self._message_semantically_requests_image_edit(text):
+            logger.info("Image edit shortcut intent: semantic fallback")
+            return True
+        return False
+
+    @staticmethod
     def _infer_image_generation_aspect(user_text: str, image_path: str) -> str:
         text = (user_text or "").lower()
         if any(token in text for token in ("1:1", "方图", "方形", "square")):
@@ -6267,9 +6367,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self,
         event: MessageEvent,
         source: SessionSource,
+        *,
+        intent_confirmed: bool = False,
+        image_paths: Optional[List[str]] = None,
     ) -> Optional[str]:
-        image_paths = self._event_image_paths(event)
-        if not image_paths or not self._message_requests_image_edit(event.text or ""):
+        image_paths = image_paths if image_paths is not None else self._event_image_paths(event)
+        if not image_paths:
+            return None
+        if not intent_confirmed and not await self._should_handle_direct_image_edit_request(event, image_paths):
             return None
 
         adapter = self.adapters.get(source.platform)
@@ -6392,6 +6497,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         return ""
+
+    async def _handle_direct_image_edit_shortcut(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+        session_key: str,
+        image_paths: List[str],
+        *,
+        interrupt_existing: bool = False,
+    ) -> Optional[str]:
+        if interrupt_existing:
+            await self._interrupt_and_clear_session(
+                session_key,
+                source,
+                interrupt_reason="direct image edit requested",
+                invalidation_reason="direct_image_edit_shortcut",
+            )
+
+        self._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+        self._running_agents_ts[session_key] = time.time()
+        try:
+            return await self._maybe_handle_direct_image_edit_request(
+                event,
+                source,
+                intent_confirmed=True,
+                image_paths=image_paths,
+            )
+        finally:
+            self._release_running_agent_state(session_key)
 
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
@@ -6712,6 +6846,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._release_running_agent_state(_quick_key)
 
         if _quick_key in self._running_agents:
+            _busy_direct_image_paths = self._event_image_paths(event)
+            _busy_text = (event.text or "").lstrip()
+            if (
+                _busy_direct_image_paths
+                and not _busy_text.startswith("/")
+                and await self._should_handle_direct_image_edit_request(event, _busy_direct_image_paths)
+            ):
+                return await self._handle_direct_image_edit_shortcut(
+                    event,
+                    source,
+                    _quick_key,
+                    _busy_direct_image_paths,
+                    interrupt_existing=True,
+                )
+
             if event.get_command() == "status":
                 return await self._handle_status_command(event)
 
@@ -7510,13 +7659,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return self._telegram_topic_root_lobby_message()
             return None
 
-        if self._event_image_paths(event) and self._message_requests_image_edit(event.text or ""):
-            self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
-            self._running_agents_ts[_quick_key] = time.time()
-            try:
-                direct_image_edit_response = await self._maybe_handle_direct_image_edit_request(event, source)
-            finally:
-                self._release_running_agent_state(_quick_key)
+        _direct_image_paths = self._event_image_paths(event)
+        if _direct_image_paths and await self._should_handle_direct_image_edit_request(event, _direct_image_paths):
+            direct_image_edit_response = await self._handle_direct_image_edit_shortcut(
+                event,
+                source,
+                _quick_key,
+                _direct_image_paths,
+            )
             if direct_image_edit_response is not None:
                 return direct_image_edit_response
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -69,7 +69,7 @@ _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-
 
 _IMAGE_EDIT_INTENT_RE = re.compile(
     r"("
-    r"改一下|修改|改成|改为|换成|变成|修图|p图|P图|重绘|重新画|"
+    r"改一下|修改|改成|改为|重改|再改|重新改|改图|修一下|换成|变成|修图|p图|P图|重绘|重新画|"
     r"生成|出图|做成|画成|加上|去掉|替换|换背景|换风格|"
     r"edit|modify|change|turn\s+.*\s+into|make\s+.*\s+look|generate|redraw"
     r")",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1273,6 +1273,14 @@ DEFAULT_CONFIG = {
             "timeout": 30,
             "extra_body": {},
         },
+        "gateway_intent": {
+            "provider": "auto",
+            "model": "",           # short boolean intent classification for messaging gateways
+            "base_url": "",
+            "api_key": "",
+            "timeout": 15,
+            "extra_body": {},
+        },
         "mcp": {
             "provider": "auto",
             "model": "",

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -9,8 +9,8 @@ three virtual model IDs so the ``hermes tools`` model picker and the
     gpt-image-2-medium  ~40s   default — balanced
     gpt-image-2-high    ~2min  slowest, highest fidelity
 
-All three hit the same underlying API model (``gpt-image-2``) with a
-different ``quality`` parameter. Output is base64 JSON → saved under
+All three hit the same underlying API model (``gpt-image-2`` by default)
+with a different ``quality`` parameter. Output is base64 JSON → saved under
 ``$HERMES_HOME/cache/images/``.
 
 Selection precedence (first hit wins):
@@ -19,13 +19,25 @@ Selection precedence (first hit wins):
 2. ``image_gen.openai.model`` in ``config.yaml``
 3. ``image_gen.model`` in ``config.yaml`` (when it's one of our tier IDs)
 4. :data:`DEFAULT_MODEL` — ``gpt-image-2-medium``
+
+The underlying API model and base URL are also configurable:
+
+* ``OPENAI_IMAGE_API_MODEL`` or ``image_gen.openai.api_model``
+* ``OPENAI_IMAGE_BASE_URL`` / ``image_gen.openai.base_url`` /
+  ``OPENAI_BASE_URL``
+* ``OPENAI_IMAGE_API_MODE`` or ``image_gen.openai.api_mode`` (``images`` or
+  ``responses``)
 """
 
 from __future__ import annotations
 
+import base64
 import logging
+import mimetypes
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import unquote
 
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
@@ -49,6 +61,9 @@ logger = logging.getLogger(__name__)
 # ``quality`` is the knob that changes generation time and output fidelity.
 
 API_MODEL = "gpt-image-2"
+API_MODE_IMAGES = "images"
+API_MODE_RESPONSES = "responses"
+RESPONSES_MODEL = "gpt-5.5"
 
 _MODELS: Dict[str, Dict[str, Any]] = {
     "gpt-image-2-low": {
@@ -79,6 +94,20 @@ _SIZES = {
     "portrait": "1024x1536",
 }
 
+_SUPPORTED_REFERENCE_IMAGE_TYPES = {
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+}
+_REFERENCE_IMAGE_EXT_TO_MIME = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+}
+_EDIT_IMAGE_MAX_BYTES = 50 * 1024 * 1024
+_RESPONSES_INPUT_IMAGE_MAX_BYTES = 20 * 1024 * 1024
+
 
 def _load_openai_config() -> Dict[str, Any]:
     """Read ``image_gen`` from config.yaml (returns {} on any failure)."""
@@ -93,6 +122,19 @@ def _load_openai_config() -> Dict[str, Any]:
         return {}
 
 
+def _clean_str(value: Any) -> Optional[str]:
+    """Return a stripped non-empty string, or ``None``."""
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _openai_subconfig(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    openai_cfg = cfg.get("openai") if isinstance(cfg.get("openai"), dict) else {}
+    return openai_cfg if isinstance(openai_cfg, dict) else {}
+
+
 def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     """Decide which tier to use and return ``(model_id, meta)``."""
     env_override = os.environ.get("OPENAI_IMAGE_MODEL")
@@ -100,12 +142,11 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
         return env_override, _MODELS[env_override]
 
     cfg = _load_openai_config()
-    openai_cfg = cfg.get("openai") if isinstance(cfg.get("openai"), dict) else {}
+    openai_cfg = _openai_subconfig(cfg)
     candidate: Optional[str] = None
-    if isinstance(openai_cfg, dict):
-        value = openai_cfg.get("model")
-        if isinstance(value, str) and value in _MODELS:
-            candidate = value
+    value = openai_cfg.get("model")
+    if isinstance(value, str) and value in _MODELS:
+        candidate = value
     if candidate is None:
         top = cfg.get("model")
         if isinstance(top, str) and top in _MODELS:
@@ -115,6 +156,366 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
         return candidate, _MODELS[candidate]
 
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_api_model() -> str:
+    """Resolve the actual model string sent to ``/images/generations``."""
+    env_override = _clean_str(os.environ.get("OPENAI_IMAGE_API_MODEL"))
+    if env_override:
+        return env_override
+
+    cfg = _load_openai_config()
+    openai_cfg = _openai_subconfig(cfg)
+
+    for value in (openai_cfg.get("api_model"), cfg.get("api_model")):
+        cleaned = _clean_str(value)
+        if cleaned:
+            return cleaned
+
+    return API_MODEL
+
+
+def _resolve_base_url() -> Optional[str]:
+    """Resolve an OpenAI-compatible image API base URL, if configured."""
+    env_override = _clean_str(os.environ.get("OPENAI_IMAGE_BASE_URL"))
+    if env_override:
+        return env_override.rstrip("/")
+
+    cfg = _load_openai_config()
+    openai_cfg = _openai_subconfig(cfg)
+
+    for value in (
+        openai_cfg.get("base_url"),
+        cfg.get("base_url"),
+        os.environ.get("OPENAI_BASE_URL"),
+    ):
+        cleaned = _clean_str(value)
+        if cleaned:
+            return cleaned.rstrip("/")
+
+    return None
+
+
+def _resolve_api_mode() -> str:
+    """Resolve whether to use ``/images/generations`` or Responses tools."""
+    env_override = _clean_str(os.environ.get("OPENAI_IMAGE_API_MODE"))
+    if env_override:
+        mode = env_override.lower().replace("-", "_")
+        if mode in {"response", "responses", "codex_responses"}:
+            return API_MODE_RESPONSES
+        return API_MODE_IMAGES
+
+    cfg = _load_openai_config()
+    openai_cfg = _openai_subconfig(cfg)
+
+    for value in (openai_cfg.get("api_mode"), cfg.get("api_mode")):
+        cleaned = _clean_str(value)
+        if cleaned:
+            mode = cleaned.lower().replace("-", "_")
+            if mode in {"response", "responses", "codex_responses"}:
+                return API_MODE_RESPONSES
+            return API_MODE_IMAGES
+
+    return API_MODE_IMAGES
+
+
+def _resolve_responses_model() -> str:
+    """Resolve the chat model that hosts the Responses image_generation tool."""
+    env_override = _clean_str(os.environ.get("OPENAI_IMAGE_RESPONSES_MODEL"))
+    if env_override:
+        return env_override
+
+    cfg = _load_openai_config()
+    openai_cfg = _openai_subconfig(cfg)
+
+    for value in (openai_cfg.get("responses_model"), cfg.get("responses_model")):
+        cleaned = _clean_str(value)
+        if cleaned:
+            return cleaned
+
+    return RESPONSES_MODEL
+
+
+def _normalize_reference_image_paths(value: Any) -> List[Path]:
+    """Validate local reference image paths and return canonical Path objects."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw_items = [value]
+    elif isinstance(value, (list, tuple)):
+        raw_items = list(value)
+    else:
+        return []
+
+    paths: List[Path] = []
+    seen = set()
+    for item in raw_items:
+        if not isinstance(item, str):
+            continue
+        raw = item.strip()
+        if not raw:
+            continue
+        if raw.startswith("file://"):
+            raw = unquote(raw[7:])
+        path = Path(os.path.expanduser(raw))
+        if not path.is_file():
+            raise ValueError(f"Reference image does not exist or is not a file: {raw}")
+        resolved = path.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        size = resolved.stat().st_size
+        if size <= 0:
+            raise ValueError(f"Reference image is empty: {resolved}")
+        if size > _EDIT_IMAGE_MAX_BYTES:
+            raise ValueError(
+                f"Reference image exceeds {_EDIT_IMAGE_MAX_BYTES // (1024 * 1024)}MB: {resolved}"
+            )
+        mime = _guess_reference_image_mime(resolved)
+        if mime not in _SUPPORTED_REFERENCE_IMAGE_TYPES:
+            raise ValueError(
+                f"Unsupported reference image type for {resolved}: {mime}. "
+                "Use PNG, JPEG, or WEBP."
+            )
+        paths.append(resolved)
+    return paths[:16]
+
+
+def _guess_reference_image_mime(path: Path) -> str:
+    """Return an OpenAI-supported image MIME type for a local reference image."""
+    guessed, _ = mimetypes.guess_type(str(path))
+    if guessed in _SUPPORTED_REFERENCE_IMAGE_TYPES:
+        return guessed
+    return _REFERENCE_IMAGE_EXT_TO_MIME.get(path.suffix.lower(), "application/octet-stream")
+
+
+def _reference_image_to_data_url(path: Path) -> str:
+    """Encode a local reference image as a Responses API input_image data URL."""
+    size = path.stat().st_size
+    if size > _RESPONSES_INPUT_IMAGE_MAX_BYTES:
+        raise ValueError(
+            f"Reference image exceeds Responses inline image cap "
+            f"({_RESPONSES_INPUT_IMAGE_MAX_BYTES // (1024 * 1024)}MB): {path}"
+        )
+    mime = _guess_reference_image_mime(path)
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+def _build_responses_payload(
+    *,
+    prompt: str,
+    responses_model: str,
+    api_model: str,
+    size: str,
+    quality: str,
+    reference_image_data_urls: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Build an OpenAI-compatible Responses image_generation request."""
+    content: List[Dict[str, Any]] = [{"type": "input_text", "text": prompt}]
+    for data_url in reference_image_data_urls or []:
+        if isinstance(data_url, str) and data_url.startswith("data:image/"):
+            content.append({"type": "input_image", "image_url": data_url})
+
+    return {
+        "model": responses_model,
+        "store": False,
+        "instructions": (
+            "You are an assistant that must fulfill image generation requests "
+            "by using the image_generation tool when provided."
+        ),
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": content,
+        }],
+        "tools": [{
+            "type": "image_generation",
+            "model": api_model,
+            "size": size,
+            "quality": quality,
+            "output_format": "png",
+            "background": "opaque",
+            "partial_images": 1,
+        }],
+        "tool_choice": {
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "image_generation"}],
+        },
+        "stream": False,
+    }
+
+
+def _extract_image_b64(value: Any) -> Optional[str]:
+    """Return the newest image b64 embedded in a Responses payload."""
+    found: Optional[str] = None
+    if isinstance(value, dict):
+        if value.get("type") == "image_generation_call":
+            result = value.get("result")
+            if isinstance(result, str) and result:
+                found = result
+        partial = value.get("partial_image_b64")
+        if isinstance(partial, str) and partial:
+            found = partial
+        for child in value.values():
+            nested = _extract_image_b64(child)
+            if nested:
+                found = nested
+    elif isinstance(value, list):
+        for child in value:
+            nested = _extract_image_b64(child)
+            if nested:
+                found = nested
+    return found
+
+
+def _collect_responses_image_b64(
+    *,
+    api_key: str,
+    base_url: Optional[str],
+    prompt: str,
+    responses_model: str,
+    api_model: str,
+    size: str,
+    quality: str,
+    reference_image_data_urls: Optional[List[str]] = None,
+) -> Optional[str]:
+    """Call ``/responses`` and return the generated image b64 payload."""
+    import httpx
+
+    root = (base_url or "https://api.openai.com/v1").rstrip("/")
+    payload = _build_responses_payload(
+        prompt=prompt,
+        responses_model=responses_model,
+        api_model=api_model,
+        size=size,
+        quality=quality,
+        reference_image_data_urls=reference_image_data_urls,
+    )
+    timeout = httpx.Timeout(300.0, connect=30.0, read=300.0, write=30.0, pool=30.0)
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    with httpx.Client(timeout=timeout, headers=headers) as http:
+        response = http.post(f"{root}/responses", json=payload)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            body = exc.response.text[:500]
+            raise RuntimeError(
+                f"Responses API returned HTTP {exc.response.status_code}: {body}"
+            ) from exc
+        data = response.json()
+
+    return _extract_image_b64(data)
+
+
+def _save_openai_image_response(
+    response: Any,
+    *,
+    tier_id: str,
+    prompt: str,
+    aspect: str,
+    extra: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Persist an OpenAI images response and return the uniform provider payload."""
+    data = getattr(response, "data", None) or []
+    if not data:
+        return error_response(
+            error="OpenAI returned no image data",
+            error_type="empty_response",
+            provider="openai",
+            model=tier_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+
+    first = data[0]
+    b64 = getattr(first, "b64_json", None)
+    url = getattr(first, "url", None)
+    revised_prompt = getattr(first, "revised_prompt", None)
+
+    if b64:
+        try:
+            saved_path = save_b64_image(b64, prefix=f"openai_{tier_id}")
+        except Exception as exc:
+            return error_response(
+                error=f"Could not save image to cache: {exc}",
+                error_type="io_error",
+                provider="openai",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        image_ref = str(saved_path)
+    elif url:
+        # Defensive — gpt-image-2 returns b64 today, but OpenAI's API has
+        # previously returned URLs. Cache the bytes locally so gateways never
+        # depend on an expiring signed URL.
+        try:
+            saved_path = save_url_image(url, prefix=f"openai_{tier_id}")
+        except Exception as exc:
+            logger.warning(
+                "OpenAI image URL %s could not be cached (%s); falling back to bare URL.",
+                url,
+                exc,
+            )
+            image_ref = url
+        else:
+            image_ref = str(saved_path)
+    else:
+        return error_response(
+            error="OpenAI response contained neither b64_json nor URL",
+            error_type="empty_response",
+            provider="openai",
+            model=tier_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+
+    response_extra = dict(extra)
+    if revised_prompt:
+        response_extra["revised_prompt"] = revised_prompt
+
+    return success_response(
+        image=image_ref,
+        model=tier_id,
+        prompt=prompt,
+        aspect_ratio=aspect,
+        provider="openai",
+        extra=response_extra,
+    )
+
+
+def _call_images_edit(client: Any, payload: Dict[str, Any], image_paths: List[Path]) -> Any:
+    """Call ``images.edit`` with real local image file handles."""
+    handles = [path.open("rb") for path in image_paths]
+    try:
+        edit_payload = dict(payload)
+        edit_payload["image"] = handles if len(handles) != 1 else handles[0]
+        edit_payload["input_fidelity"] = "high"
+        try:
+            return client.images.edit(**edit_payload)
+        except Exception as exc:
+            if "input_fidelity" not in str(exc).lower():
+                raise
+            logger.debug("Retrying OpenAI image edit without input_fidelity", exc_info=True)
+            for handle in handles:
+                try:
+                    handle.seek(0)
+                except Exception:
+                    pass
+            edit_payload.pop("input_fidelity", None)
+            return client.images.edit(**edit_payload)
+    finally:
+        for handle in handles:
+            try:
+                handle.close()
+            except Exception:
+                pass
 
 
 # ---------------------------------------------------------------------------
@@ -211,12 +612,112 @@ class OpenAIImageGenProvider(ImageGenProvider):
             )
 
         tier_id, meta = _resolve_model()
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+        api_mode = _resolve_api_mode()
+        api_model = _resolve_api_model()
+        base_url = _resolve_base_url()
         size = _SIZES.get(aspect, _SIZES["square"])
+        responses_fallback_error: Optional[Exception] = None
+
+        try:
+            reference_image_paths = _normalize_reference_image_paths(
+                kwargs.get("reference_image_paths")
+                or kwargs.get("reference_image_path")
+                or kwargs.get("image_paths")
+            )
+        except ValueError as exc:
+            return error_response(
+                error=str(exc),
+                error_type="invalid_reference_image",
+                provider="openai",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if api_mode == API_MODE_RESPONSES:
+            responses_model = _resolve_responses_model()
+            responses_error: Optional[Exception] = None
+            try:
+                reference_image_data_urls = [
+                    _reference_image_to_data_url(path) for path in reference_image_paths
+                ]
+                b64 = _collect_responses_image_b64(
+                    api_key=api_key,
+                    base_url=base_url,
+                    prompt=prompt,
+                    responses_model=responses_model,
+                    api_model=api_model,
+                    size=size,
+                    quality=meta["quality"],
+                    reference_image_data_urls=reference_image_data_urls,
+                )
+            except Exception as exc:
+                logger.debug("OpenAI Responses image generation failed", exc_info=True)
+                if not reference_image_paths:
+                    return error_response(
+                        error=f"OpenAI Responses image generation failed: {exc}",
+                        error_type="api_error",
+                        provider="openai",
+                        model=tier_id,
+                        prompt=prompt,
+                        aspect_ratio=aspect,
+                    )
+                responses_error = exc
+                b64 = None
+
+            if not b64:
+                if not reference_image_paths:
+                    return error_response(
+                        error="OpenAI Responses returned no image_generation_call result",
+                        error_type="empty_response",
+                        provider="openai",
+                        model=tier_id,
+                        prompt=prompt,
+                        aspect_ratio=aspect,
+                    )
+                if responses_error is None:
+                    responses_error = RuntimeError(
+                        "OpenAI Responses returned no image_generation_call result"
+                    )
+                responses_fallback_error = responses_error
+                logger.info(
+                    "OpenAI Responses reference-image path failed; falling back to images.edit: %s",
+                    responses_error,
+                )
+            else:
+                try:
+                    saved_path = save_b64_image(b64, prefix=f"openai_{tier_id}")
+                except Exception as exc:
+                    return error_response(
+                        error=f"Could not save image to cache: {exc}",
+                        error_type="io_error",
+                        provider="openai",
+                        model=tier_id,
+                        prompt=prompt,
+                        aspect_ratio=aspect,
+                    )
+
+                return success_response(
+                    image=str(saved_path),
+                    model=tier_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                    provider="openai",
+                    extra={
+                        "api_mode": api_mode,
+                        "api_model": api_model,
+                        "responses_model": responses_model,
+                        "size": size,
+                        "quality": meta["quality"],
+                        "reference_image_count": len(reference_image_paths),
+                    },
+                )
 
         # gpt-image-2 returns b64_json unconditionally and REJECTS
         # ``response_format`` as an unknown parameter. Don't send it.
         payload: Dict[str, Any] = {
-            "model": API_MODEL,
+            "model": api_model,
             "prompt": prompt,
             "size": size,
             "n": 1,
@@ -224,12 +725,25 @@ class OpenAIImageGenProvider(ImageGenProvider):
         }
 
         try:
-            client = openai.OpenAI()
-            response = client.images.generate(**payload)
+            client_kwargs: Dict[str, Any] = {}
+            if base_url:
+                client_kwargs["base_url"] = base_url
+            client = openai.OpenAI(**client_kwargs)
+            if reference_image_paths:
+                response = _call_images_edit(client, payload, reference_image_paths)
+            else:
+                response = client.images.generate(**payload)
         except Exception as exc:
-            logger.debug("OpenAI image generation failed", exc_info=True)
+            logger.debug("OpenAI image generation/edit failed", exc_info=True)
+            action = "edit" if reference_image_paths else "generation"
+            error = f"OpenAI image {action} failed: {exc}"
+            if responses_fallback_error is not None:
+                error = (
+                    "OpenAI Responses reference-image path failed "
+                    f"({responses_fallback_error}); images.edit fallback failed: {exc}"
+                )
             return error_response(
-                error=f"OpenAI image generation failed: {exc}",
+                error=error,
                 error_type="api_error",
                 provider="openai",
                 model=tier_id,
@@ -237,71 +751,21 @@ class OpenAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        data = getattr(response, "data", None) or []
-        if not data:
-            return error_response(
-                error="OpenAI returned no image data",
-                error_type="empty_response",
-                provider="openai",
-                model=tier_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
+        extra: Dict[str, Any] = {
+            "api_mode": api_mode,
+            "api_model": api_model,
+            "size": size,
+            "quality": meta["quality"],
+            "reference_image_count": len(reference_image_paths),
+        }
+        if reference_image_paths:
+            extra["api_action"] = "edit"
 
-        first = data[0]
-        b64 = getattr(first, "b64_json", None)
-        url = getattr(first, "url", None)
-        revised_prompt = getattr(first, "revised_prompt", None)
-
-        if b64:
-            try:
-                saved_path = save_b64_image(b64, prefix=f"openai_{tier_id}")
-            except Exception as exc:
-                return error_response(
-                    error=f"Could not save image to cache: {exc}",
-                    error_type="io_error",
-                    provider="openai",
-                    model=tier_id,
-                    prompt=prompt,
-                    aspect_ratio=aspect,
-                )
-            image_ref = str(saved_path)
-        elif url:
-            # Defensive — gpt-image-2 returns b64 today, but OpenAI's API
-            # has previously returned URLs.  Cache the bytes locally so the
-            # gateway never tries to fetch an ephemeral / signed URL after
-            # it expires — same rationale as the xAI provider (#26942).
-            try:
-                saved_path = save_url_image(url, prefix=f"openai_{tier_id}")
-            except Exception as exc:
-                logger.warning(
-                    "OpenAI image URL %s could not be cached (%s); falling back to bare URL.",
-                    url,
-                    exc,
-                )
-                image_ref = url
-            else:
-                image_ref = str(saved_path)
-        else:
-            return error_response(
-                error="OpenAI response contained neither b64_json nor URL",
-                error_type="empty_response",
-                provider="openai",
-                model=tier_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
-
-        extra: Dict[str, Any] = {"size": size, "quality": meta["quality"]}
-        if revised_prompt:
-            extra["revised_prompt"] = revised_prompt
-
-        return success_response(
-            image=image_ref,
-            model=tier_id,
+        return _save_openai_image_response(
+            response,
+            tier_id=tier_id,
             prompt=prompt,
-            aspect_ratio=aspect,
-            provider="openai",
+            aspect=aspect,
             extra=extra,
         )
 

--- a/tests/gateway/test_direct_image_edit_shortcut.py
+++ b/tests/gateway/test_direct_image_edit_shortcut.py
@@ -1,0 +1,153 @@
+import asyncio
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _FakeImageAdapter:
+    name = "Feishu"
+
+    def __init__(self):
+        self.sent_text = []
+        self.sent_images = []
+        self.sent_documents = []
+
+    async def send(self, chat_id, content, **kwargs):
+        self.sent_text.append((chat_id, content, kwargs))
+        return SendResult(success=True)
+
+    async def send_image_file(self, chat_id, image_path, **kwargs):
+        self.sent_images.append((chat_id, image_path, kwargs))
+        return SendResult(success=True)
+
+    async def send_document(self, chat_id, file_path, **kwargs):
+        self.sent_documents.append((chat_id, file_path, kwargs))
+        return SendResult(success=True)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        user_id="ou_user",
+        user_name="张三",
+        chat_type="dm",
+        thread_id="om_parent",
+    )
+
+
+class TestDirectImageEditShortcut(unittest.TestCase):
+    def test_image_edit_intent_requires_generation_or_edit_language(self):
+        self.assertTrue(GatewayRunner._message_requests_image_edit("帮我改一下这张图"))
+        self.assertTrue(GatewayRunner._message_requests_image_edit("make this look cinematic"))
+        self.assertFalse(GatewayRunner._message_requests_image_edit("你能看到这张图吗"))
+        self.assertFalse(GatewayRunner._message_requests_image_edit("这张图里是什么"))
+
+    def test_direct_image_edit_shortcut_generates_and_sends_file(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        adapter = _FakeImageAdapter()
+        runner.adapters = {Platform.FEISHU: adapter}
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            input_image = tmp_path / "input.jpg"
+            input_image.write_bytes(b"\xff\xd8\xff\x00")
+            output_image = tmp_path / "output.png"
+            output_image.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+            vision = AsyncMock(
+                return_value=json.dumps(
+                    {"success": True, "analysis": "地铁车厢内，一位年轻女生低头看手机，竖幅近景。"},
+                    ensure_ascii=False,
+                )
+            )
+            captured = {}
+
+            def fake_image_generate(args, **kwargs):
+                captured.update(args)
+                return json.dumps({"success": True, "image": str(output_image)}, ensure_ascii=False)
+
+            with (
+                patch("tools.vision_tools.vision_analyze_tool", vision),
+                patch("tools.image_generation_tool._handle_image_generate", fake_image_generate),
+            ):
+                source = _source()
+                event = MessageEvent(
+                    source=source,
+                    text="帮我改一下，这张图改成女生温柔地看着镜头",
+                    message_type=MessageType.TEXT,
+                    media_urls=[str(input_image)],
+                    media_types=["image/jpeg"],
+                    raw_message=SimpleNamespace(),
+                )
+
+                result = _run(runner._maybe_handle_direct_image_edit_request(event, source))
+
+        self.assertEqual(result, "")
+        self.assertEqual(adapter.sent_images, [("oc_chat", str(output_image), {"metadata": None})])
+        self.assertIn("女生温柔地看着镜头", captured["prompt"])
+        self.assertIn("地铁车厢内", captured["prompt"])
+        self.assertEqual(captured["aspect_ratio"], "landscape")
+        self.assertEqual(captured["reference_image_paths"], [str(input_image)])
+
+    def test_direct_image_edit_shortcut_uses_document_fallback(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        adapter = _FakeImageAdapter()
+        adapter.send_image_file = AsyncMock(return_value=SendResult(success=False, error="image data error"))
+        runner.adapters = {Platform.FEISHU: adapter}
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            input_image = tmp_path / "input.jpg"
+            input_image.write_bytes(b"\xff\xd8\xff\x00")
+            output_image = tmp_path / "output.png"
+            output_image.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+            with (
+                patch(
+                    "tools.vision_tools.vision_analyze_tool",
+                    AsyncMock(
+                        return_value=json.dumps(
+                            {"success": True, "analysis": "参考图描述"},
+                            ensure_ascii=False,
+                        )
+                    ),
+                ),
+                patch(
+                    "tools.image_generation_tool._handle_image_generate",
+                    lambda args, **kwargs: json.dumps(
+                        {"success": True, "image": str(output_image)},
+                        ensure_ascii=False,
+                    ),
+                ),
+            ):
+                source = _source()
+                event = MessageEvent(
+                    source=source,
+                    text="修改成电影感",
+                    message_type=MessageType.TEXT,
+                    media_urls=[str(input_image)],
+                    media_types=["image/jpeg"],
+                    raw_message=SimpleNamespace(),
+                )
+
+                result = _run(runner._maybe_handle_direct_image_edit_request(event, source))
+
+        self.assertEqual(result, "")
+        self.assertEqual(adapter.sent_documents, [("oc_chat", str(output_image), {"metadata": None})])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_direct_image_edit_shortcut.py
+++ b/tests/gateway/test_direct_image_edit_shortcut.py
@@ -37,6 +37,16 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+def _llm_response(content):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content),
+            )
+        ]
+    )
+
+
 def _source():
     return SessionSource(
         platform=Platform.FEISHU,
@@ -56,6 +66,124 @@ class TestDirectImageEditShortcut(unittest.TestCase):
         self.assertTrue(GatewayRunner._message_requests_image_edit("make this look cinematic"))
         self.assertFalse(GatewayRunner._message_requests_image_edit("你能看到这张图吗"))
         self.assertFalse(GatewayRunner._message_requests_image_edit("这张图里是什么"))
+
+    def test_semantic_image_edit_intent_uses_auxiliary_classifier(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        with patch(
+            "agent.auxiliary_client.async_call_llm",
+            AsyncMock(return_value=_llm_response('{"edit": true}')),
+        ) as classifier:
+            result = _run(runner._message_semantically_requests_image_edit("眼神还是不对，自然一点"))
+
+        self.assertTrue(result)
+        self.assertEqual(classifier.await_args.kwargs["task"], "gateway_intent")
+
+    def test_direct_image_edit_shortcut_semantic_fallback_generates(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        adapter = _FakeImageAdapter()
+        runner.adapters = {Platform.FEISHU: adapter}
+        runner._message_semantically_requests_image_edit = AsyncMock(return_value=True)
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            input_image = tmp_path / "input.jpg"
+            input_image.write_bytes(b"\xff\xd8\xff\x00")
+            output_image = tmp_path / "output.png"
+            output_image.write_bytes(b"\x89PNG\r\n\x1a\n")
+            captured = {}
+
+            def fake_image_generate(args, **kwargs):
+                captured.update(args)
+                return json.dumps({"success": True, "image": str(output_image)}, ensure_ascii=False)
+
+            with (
+                patch(
+                    "tools.vision_tools.vision_analyze_tool",
+                    AsyncMock(
+                        return_value=json.dumps(
+                            {"success": True, "analysis": "参考图是一张人物照片。"},
+                            ensure_ascii=False,
+                        )
+                    ),
+                ),
+                patch("tools.image_generation_tool._handle_image_generate", fake_image_generate),
+            ):
+                source = _source()
+                event = MessageEvent(
+                    source=source,
+                    text="眼神还是不对，自然一点",
+                    message_type=MessageType.TEXT,
+                    media_urls=[str(input_image)],
+                    media_types=["image/jpeg"],
+                    raw_message=SimpleNamespace(),
+                )
+
+                result = _run(runner._maybe_handle_direct_image_edit_request(event, source))
+
+        self.assertEqual(result, "")
+        runner._message_semantically_requests_image_edit.assert_awaited_once_with("眼神还是不对，自然一点")
+        self.assertEqual(adapter.sent_images, [("oc_chat", str(output_image), {"metadata": None})])
+        self.assertEqual(captured["reference_image_paths"], [str(input_image)])
+
+    def test_direct_image_edit_shortcut_semantic_false_falls_through(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.adapters = {Platform.FEISHU: _FakeImageAdapter()}
+        runner._message_semantically_requests_image_edit = AsyncMock(return_value=False)
+
+        with tempfile.TemporaryDirectory() as td:
+            input_image = Path(td) / "input.jpg"
+            input_image.write_bytes(b"\xff\xd8\xff\x00")
+            event = MessageEvent(
+                source=_source(),
+                text="你能看到这张图吗",
+                message_type=MessageType.TEXT,
+                media_urls=[str(input_image)],
+                media_types=["image/jpeg"],
+                raw_message=SimpleNamespace(),
+            )
+
+            result = _run(runner._maybe_handle_direct_image_edit_request(event, _source()))
+
+        self.assertIsNone(result)
+        runner._message_semantically_requests_image_edit.assert_awaited_once_with("你能看到这张图吗")
+
+    def test_direct_image_edit_shortcut_interrupts_existing_run(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._running_agents = {"session-key": object()}
+        runner._running_agents_ts = {"session-key": 123.0}
+        runner._busy_ack_ts = {}
+        runner._pending_messages = {}
+        runner._interrupt_and_clear_session = AsyncMock()
+        runner._maybe_handle_direct_image_edit_request = AsyncMock(return_value="")
+
+        event = MessageEvent(
+            source=_source(),
+            text="眼神还是不对，自然一点",
+            message_type=MessageType.TEXT,
+            media_urls=["/tmp/input.jpg"],
+            media_types=["image/jpeg"],
+            raw_message=SimpleNamespace(),
+        )
+
+        result = _run(
+            runner._handle_direct_image_edit_shortcut(
+                event,
+                _source(),
+                "session-key",
+                ["/tmp/input.jpg"],
+                interrupt_existing=True,
+            )
+        )
+
+        self.assertEqual(result, "")
+        runner._interrupt_and_clear_session.assert_awaited_once()
+        runner._maybe_handle_direct_image_edit_request.assert_awaited_once_with(
+            event,
+            _source(),
+            intent_confirmed=True,
+            image_paths=["/tmp/input.jpg"],
+        )
+        self.assertNotIn("session-key", runner._running_agents)
 
     def test_direct_image_edit_shortcut_generates_and_sends_file(self):
         runner = GatewayRunner.__new__(GatewayRunner)

--- a/tests/gateway/test_direct_image_edit_shortcut.py
+++ b/tests/gateway/test_direct_image_edit_shortcut.py
@@ -51,6 +51,8 @@ def _source():
 class TestDirectImageEditShortcut(unittest.TestCase):
     def test_image_edit_intent_requires_generation_or_edit_language(self):
         self.assertTrue(GatewayRunner._message_requests_image_edit("帮我改一下这张图"))
+        self.assertTrue(GatewayRunner._message_requests_image_edit("没有温柔地看镜头，重改"))
+        self.assertTrue(GatewayRunner._message_requests_image_edit("再改一下，改图"))
         self.assertTrue(GatewayRunner._message_requests_image_edit("make this look cinematic"))
         self.assertFalse(GatewayRunner._message_requests_image_edit("你能看到这张图吗"))
         self.assertFalse(GatewayRunner._message_requests_image_edit("这张图里是什么"))

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1953,6 +1953,55 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.reply_to_text, "父消息内容")
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_message_attaches_referenced_media(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import MessageType
+        from gateway.platforms.feishu import FeishuAdapter, FeishuMessageContext
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu DM", "type": "dm"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_context = AsyncMock(
+            return_value=FeishuMessageContext(
+                text="[Image]",
+                media_urls=["/tmp/quoted-image.jpg"],
+                media_types=["image/jpeg"],
+            )
+        )
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id=None,
+            parent_id="om_parent_image",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"帮我修改这张图"}',
+            message_id="om_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="p2p",
+                message_id="om_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.message_type, MessageType.TEXT)
+        self.assertEqual(event.reply_to_message_id, "om_parent_image")
+        self.assertEqual(event.reply_to_text, "[Image]")
+        self.assertEqual(event.media_urls, ["/tmp/quoted-image.jpg"])
+        self.assertEqual(event.media_types, ["image/jpeg"])
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -4681,6 +4730,28 @@ class TestFeishuFetchMessageText(unittest.TestCase):
         # The rendered text should still have the bot name substituted.
         result = asyncio.run(adapter._fetch_message_text("m_parent"))
         self.assertEqual(result, "@Hermes hi")
+
+    def test_fetch_message_context_downloads_image_media(self):
+        adapter = self._build_adapter()
+        adapter._download_feishu_message_resources = AsyncMock(
+            return_value=(["/tmp/parent-image.jpg"], ["image/jpeg"])
+        )
+        parent = SimpleNamespace(
+            body=SimpleNamespace(content=json.dumps({"image_key": "img_parent"})),
+            msg_type="image",
+            mentions=None,
+        )
+        response = Mock()
+        response.success = Mock(return_value=True)
+        response.data = SimpleNamespace(items=[parent])
+        adapter._client.im.v1.message.get = Mock(return_value=response)
+
+        result = asyncio.run(adapter._fetch_message_context("m_parent_image"))
+
+        self.assertEqual(result.text, "[Image]")
+        self.assertEqual(result.media_urls, ["/tmp/parent-image.jpg"])
+        self.assertEqual(result.media_types, ["image/jpeg"])
+        adapter._download_feishu_message_resources.assert_awaited_once()
 
     def test_build_mentions_map_string_id_shape(self):
         """_build_mentions_map accepts the reply-history shape (id as str +

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -120,6 +120,54 @@ class TestModelResolution:
         assert model_id == "gpt-image-2-high"
         assert meta["quality"] == "high"
 
+    def test_api_model_defaults_to_gpt_image_2(self):
+        assert openai_plugin._resolve_api_model() == "gpt-image-2"
+
+    def test_api_model_env_override(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_IMAGE_API_MODEL", "image-2")
+        assert openai_plugin._resolve_api_model() == "image-2"
+
+    def test_api_model_config_override(self, tmp_path):
+        import yaml
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"api_model": "image-2"}}})
+        )
+        assert openai_plugin._resolve_api_model() == "image-2"
+
+    def test_base_url_config_override(self, tmp_path):
+        import yaml
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump(
+                {"image_gen": {"openai": {"base_url": "http://127.0.0.1:8317/v1/"}}}
+            )
+        )
+        assert openai_plugin._resolve_base_url() == "http://127.0.0.1:8317/v1"
+
+    def test_base_url_openai_env_fallback(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://127.0.0.1:8317/v1/")
+        assert openai_plugin._resolve_base_url() == "http://127.0.0.1:8317/v1"
+
+    def test_api_mode_defaults_to_images(self):
+        assert openai_plugin._resolve_api_mode() == "images"
+
+    def test_api_mode_env_responses(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_IMAGE_API_MODE", "responses")
+        assert openai_plugin._resolve_api_mode() == "responses"
+
+    def test_api_mode_config_responses(self, tmp_path):
+        import yaml
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"api_mode": "responses"}}})
+        )
+        assert openai_plugin._resolve_api_mode() == "responses"
+
+    def test_responses_model_config_override(self, tmp_path):
+        import yaml
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"responses_model": "gpt-5.5"}}})
+        )
+        assert openai_plugin._resolve_responses_model() == "gpt-5.5"
+
 
 # ── Generate ────────────────────────────────────────────────────────────────
 
@@ -162,6 +210,71 @@ class TestGenerate:
         assert call_kwargs["size"] == "1536x1024"
         # gpt-image-2 rejects response_format — we must NOT send it.
         assert "response_format" not in call_kwargs
+        assert result["api_model"] == "gpt-image-2"
+
+    def test_generate_uses_configured_api_model_and_base_url(self, provider, monkeypatch):
+        monkeypatch.setenv("OPENAI_IMAGE_API_MODEL", "image-2")
+        monkeypatch.setenv("OPENAI_IMAGE_BASE_URL", "http://127.0.0.1:8317/v1/")
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client) as patched:
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert result["api_model"] == "image-2"
+        assert fake_client.images.generate.call_args.kwargs["model"] == "image-2"
+        patched["openai"].OpenAI.assert_called_once_with(
+            base_url="http://127.0.0.1:8317/v1"
+        )
+
+    def test_generate_via_responses_saves_b64(self, provider, monkeypatch):
+        monkeypatch.setenv("OPENAI_IMAGE_API_MODE", "responses")
+        monkeypatch.setenv("OPENAI_IMAGE_API_MODEL", "image-2")
+        monkeypatch.setenv("OPENAI_IMAGE_RESPONSES_MODEL", "gpt-5.5")
+        monkeypatch.setenv("OPENAI_IMAGE_BASE_URL", "http://127.0.0.1:8317/v1/")
+        captured = {}
+
+        def _collect(**kwargs):
+            captured.update(kwargs)
+            return _b64_png()
+
+        monkeypatch.setattr(openai_plugin, "_collect_responses_image_b64", _collect)
+
+        result = provider.generate("a cat", aspect_ratio="square")
+
+        assert result["success"] is True
+        assert result["api_mode"] == "responses"
+        assert result["api_model"] == "image-2"
+        assert result["responses_model"] == "gpt-5.5"
+        assert captured["base_url"] == "http://127.0.0.1:8317/v1"
+        assert captured["api_model"] == "image-2"
+        assert captured["responses_model"] == "gpt-5.5"
+        assert captured["size"] == "1024x1024"
+        assert captured["reference_image_data_urls"] == []
+
+    def test_generate_via_responses_passes_reference_image_bytes(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setenv("OPENAI_IMAGE_API_MODE", "responses")
+        captured = {}
+
+        ref = tmp_path / "reference.png"
+        ref.write_bytes(bytes.fromhex(_PNG_HEX))
+
+        def _collect(**kwargs):
+            captured.update(kwargs)
+            return _b64_png()
+
+        monkeypatch.setattr(openai_plugin, "_collect_responses_image_b64", _collect)
+
+        result = provider.generate(
+            "make the reference image cinematic",
+            aspect_ratio="square",
+            reference_image_paths=[str(ref)],
+        )
+
+        assert result["success"] is True
+        assert result["reference_image_count"] == 1
+        assert captured["reference_image_data_urls"][0].startswith("data:image/png;base64,")
 
     @pytest.mark.parametrize("tier,expected_quality", [
         ("gpt-image-2-low", "low"),
@@ -195,6 +308,30 @@ class TestGenerate:
             provider.generate("a cat", aspect_ratio=aspect)
 
         assert fake_client.images.generate.call_args.kwargs["size"] == expected_size
+
+    def test_reference_image_uses_images_edit(self, provider, tmp_path):
+        ref = tmp_path / "reference.png"
+        ref.write_bytes(bytes.fromhex(_PNG_HEX))
+        fake_client = MagicMock()
+        fake_client.images.edit.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate(
+                "edit the reference image",
+                aspect_ratio="portrait",
+                reference_image_paths=[str(ref)],
+            )
+
+        assert result["success"] is True
+        assert result["api_action"] == "edit"
+        assert result["reference_image_count"] == 1
+        fake_client.images.generate.assert_not_called()
+        call_kwargs = fake_client.images.edit.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-image-2"
+        assert call_kwargs["quality"] == "medium"
+        assert call_kwargs["size"] == "1024x1536"
+        assert call_kwargs["input_fidelity"] == "high"
+        assert call_kwargs["image"].name == str(ref.resolve())
 
     def test_revised_prompt_passed_through(self, provider):
         fake_client = MagicMock()
@@ -269,3 +406,44 @@ class TestGenerate:
 
         assert result["success"] is True
         assert result["image"] == "https://example.com/img.png"
+
+    def test_responses_payload_shape(self):
+        payload = openai_plugin._build_responses_payload(
+            prompt="a cat",
+            responses_model="gpt-5.5",
+            api_model="image-2",
+            size="1024x1024",
+            quality="low",
+        )
+        assert payload["model"] == "gpt-5.5"
+        assert payload["stream"] is False
+        tool = payload["tools"][0]
+        assert tool["type"] == "image_generation"
+        assert tool["model"] == "image-2"
+        assert tool["quality"] == "low"
+        assert payload["tool_choice"]["tools"] == [{"type": "image_generation"}]
+
+    def test_responses_payload_includes_reference_images(self):
+        data_url = "data:image/png;base64,QUFB"
+        payload = openai_plugin._build_responses_payload(
+            prompt="edit this",
+            responses_model="gpt-5.5",
+            api_model="image-2",
+            size="1024x1024",
+            quality="low",
+            reference_image_data_urls=[data_url],
+        )
+        content = payload["input"][0]["content"]
+        assert content == [
+            {"type": "input_text", "text": "edit this"},
+            {"type": "input_image", "image_url": data_url},
+        ]
+
+    def test_extract_image_b64_from_responses_payload(self):
+        payload = {
+            "output": [{
+                "type": "image_generation_call",
+                "result": "abc",
+            }]
+        }
+        assert openai_plugin._extract_image_b64(payload) == "abc"

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -26,7 +26,7 @@ import os
 import datetime
 import threading
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 # fal_client is imported lazily — see _load_fal_client(). Pulling it
 # eagerly added ~64 ms to every CLI cold start because
@@ -1024,10 +1024,46 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
             },
+            "reference_image_paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional local image file paths to use as real visual "
+                    "references when editing or regenerating from user-uploaded "
+                    "images. Pass the exact local path(s) shown in the message "
+                    "context, not a textual description. Supported backends "
+                    "will upload the image bytes; unsupported backends may "
+                    "ignore this field."
+                ),
+            },
         },
         "required": ["prompt"],
     },
 }
+
+
+def _normalize_reference_image_paths_arg(value: Any) -> List[str]:
+    """Normalize tool-supplied reference image paths into a small string list."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        candidates = [value]
+    elif isinstance(value, (list, tuple)):
+        candidates = list(value)
+    else:
+        return []
+
+    paths: List[str] = []
+    seen = set()
+    for candidate in candidates:
+        if not isinstance(candidate, str):
+            continue
+        path = candidate.strip()
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        paths.append(path)
+    return paths[:16]
 
 
 def _read_configured_image_model():
@@ -1069,7 +1105,11 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(
+    prompt: str,
+    aspect_ratio: str,
+    reference_image_paths: Optional[List[str]] = None,
+):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -1126,6 +1166,8 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
         if configured_model:
             kwargs["model"] = configured_model
+        if reference_image_paths:
+            kwargs["reference_image_paths"] = reference_image_paths
         result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
@@ -1153,11 +1195,14 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    reference_image_paths = _normalize_reference_image_paths_arg(
+        args.get("reference_image_paths") or args.get("reference_image_path")
+    )
     task_id = kw.get("task_id")
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, reference_image_paths)
     if dispatched is not None:
         return _postprocess_image_generate_result(dispatched, task_id=task_id)
 


### PR DESCRIPTION
## Summary
- add Feishu quoted-image media extraction so replies can carry referenced image files into the gateway event
- pass reference_image_paths through image_generate and OpenAI image generation providers for real image-edit inputs
- add a direct image-edit gateway shortcut with keyword and semantic intent detection, including busy-session interruption for follow-up edits

## Tests
- venv/bin/python -m unittest tests.gateway.test_direct_image_edit_shortcut tests.gateway.test_feishu
- venv/bin/python -m py_compile gateway/run.py gateway/platforms/feishu.py plugins/image_gen/openai/__init__.py tools/image_generation_tool.py hermes_cli/config.py tests/gateway/test_direct_image_edit_shortcut.py tests/gateway/test_feishu.py tests/plugins/image_gen/test_openai_provider.py
- git diff --check upstream/main...HEAD

Note: tests/plugins/image_gen/test_openai_provider.py requires pytest; pytest is not installed in the local venv, so it was syntax-checked but not run here.