### PR TITLE
feat(api_server): add tool_progress_events config to suppress custom SSE events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -766,6 +766,13 @@ class APIServerAdapter(BasePlatformAdapter):
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        # Whether to emit hermes.tool.progress SSE events during streaming.
+        # Set to false via platforms.api_server.tool_progress_events to
+        # suppress custom SSE events for frontends that only handle standard
+        # OpenAI delta chunks.  See #12020.
+        self._tool_progress_events: bool = _coerce_request_bool(
+            extra.get("tool_progress_events", True), default=True,
+        )
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -1156,7 +1163,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_approval_response": True,
-                "tool_progress_events": True,
+                "tool_progress_events": self._tool_progress_events,
                 "approval_events": True,
                 "session_resources": True,
                 "session_chat": True,
@@ -1635,6 +1642,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 _enqueue("assistant.delta", {"message_id": message_id, "delta": delta})
 
         def _tool_progress(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs) -> None:
+            if not self._tool_progress_events:
+                return
             if event_type == "reasoning.available":
                 _enqueue("tool.progress", {"message_id": message_id, "tool_name": tool_name or "_thinking", "delta": preview or ""})
             elif event_type in {"tool.started", "tool.completed", "tool.failed"}:
@@ -1871,7 +1880,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 Skips tools whose names start with ``_`` so internal
                 events (``_thinking``, …) stay off the wire — matching
                 the prior ``_on_tool_progress`` filter exactly.
+
+                Silently suppressed when ``tool_progress_events`` is
+                disabled in the api_server platform config (#12020).
                 """
+                if not self._tool_progress_events:
+                    return
                 if not tool_call_id or function_name.startswith("_"):
                     return
                 _started_tool_call_ids.add(tool_call_id)
@@ -1892,6 +1906,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 id, or never seen) so clients never get an orphaned
                 ``completed`` they can't correlate to a prior ``running``.
                 """
+                if not self._tool_progress_events:
+                    return
                 if not tool_call_id or tool_call_id not in _started_tool_call_ids:
                     return
                 _started_tool_call_ids.discard(tool_call_id)
@@ -3593,6 +3609,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 pass
 
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
+            if not self._tool_progress_events:
+                return
             ts = time.time()
             if event_type == "tool.started":
                 _push({

--- a/tests/gateway/test_api_server_tool_progress_toggle.py
+++ b/tests/gateway/test_api_server_tool_progress_toggle.py
@@ -1,0 +1,155 @@
+"""
+Tests for the api_server tool_progress_events config option (#12020).
+
+When set to false, hermes.tool.progress SSE events should be suppressed
+so frontends that only handle standard OpenAI delta chunks work without
+parse errors.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _make_adapter(**extra_kw) -> APIServerAdapter:
+    """Create an adapter with optional extra config keys."""
+    config = PlatformConfig(enabled=True, extra=extra_kw)
+    return APIServerAdapter(config)
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    from gateway.platforms.api_server import cors_middleware, security_headers_middleware
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    return app
+
+
+class TestToolProgressEventsConfig:
+    """Config parsing for tool_progress_events."""
+
+    def test_default_is_true(self):
+        """By default, tool_progress_events is True (backward compatible)."""
+        adapter = _make_adapter()
+        assert adapter._tool_progress_events is True
+
+    def test_explicit_true(self):
+        adapter = _make_adapter(tool_progress_events=True)
+        assert adapter._tool_progress_events is True
+
+    def test_explicit_false(self):
+        adapter = _make_adapter(tool_progress_events=False)
+        assert adapter._tool_progress_events is False
+
+    def test_string_false(self):
+        adapter = _make_adapter(tool_progress_events="false")
+        assert adapter._tool_progress_events is False
+
+    def test_string_true(self):
+        adapter = _make_adapter(tool_progress_events="true")
+        assert adapter._tool_progress_events is True
+
+    @pytest.mark.asyncio
+    async def test_capabilities_reflects_true(self):
+        """Capabilities endpoint shows tool_progress_events=True by default."""
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            data = await resp.json()
+            assert data["features"]["tool_progress_events"] is True
+
+    @pytest.mark.asyncio
+    async def test_capabilities_reflects_false(self):
+        """Capabilities endpoint shows tool_progress_events=False when disabled."""
+        adapter = _make_adapter(tool_progress_events=False)
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            data = await resp.json()
+            assert data["features"]["tool_progress_events"] is False
+
+
+class TestToolProgressEventsStreaming:
+    """Verify tool progress events are suppressed when disabled."""
+
+    @pytest.mark.asyncio
+    async def test_no_tool_progress_sse_when_disabled(self):
+        """When tool_progress_events=False, no hermes.tool.progress events in SSE."""
+        adapter = _make_adapter(tool_progress_events=False)
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                # Simulate tool_start_callback being called
+                tool_start_cb = kwargs.get("tool_start_callback")
+                tool_complete_cb = kwargs.get("tool_complete_callback")
+                stream_cb = kwargs.get("stream_delta_callback")
+                if tool_start_cb:
+                    tool_start_cb("call_123", "terminal", {"command": "ls"})
+                if stream_cb:
+                    stream_cb("result text")
+                if tool_complete_cb:
+                    tool_complete_cb("call_123", "terminal", {"command": "ls"}, "done")
+                if stream_cb:
+                    stream_cb(None)
+                return (
+                    {"final_response": "result text", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                # Should NOT contain hermes.tool.progress events
+                assert "hermes.tool.progress" not in body
+                # Should still contain normal delta content
+                assert "result text" in body
+
+    @pytest.mark.asyncio
+    async def test_tool_progress_sse_present_when_enabled(self):
+        """When tool_progress_events=True (default), tool progress events are emitted."""
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                tool_start_cb = kwargs.get("tool_start_callback")
+                stream_cb = kwargs.get("stream_delta_callback")
+                if tool_start_cb:
+                    tool_start_cb("call_456", "terminal", {"command": "ls"})
+                if stream_cb:
+                    stream_cb("hello")
+                    stream_cb(None)
+                return (
+                    {"final_response": "hello", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                # Should contain hermes.tool.progress events
+                assert "hermes.tool.progress" in body


### PR DESCRIPTION
## Problem

When using the API server with OpenAI-compatible frontends (Open WebUI, chatbot-ui, etc.), the custom `event: hermes.tool.progress` SSE events cause parse errors on clients that only expect standard `data: {...}` delta chunks. These frontends interpret non-standard SSE event types as malformed responses, breaking the chat display.

Issue #12020 requests a toggle to suppress these events.

## Solution

Add a `tool_progress_events` config option under the `platforms.api_server` section. When set to `false`, all tool progress lifecycle events (`running`, `completed`) and reasoning progress events are suppressed in the SSE stream.

### Config example

```yaml
platforms:
  api_server:
    enabled: true
    tool_progress_events: false
```

### What changes

- **`APIServerAdapter.__init__`** — reads `tool_progress_events` from platform config (default: `True` for backward compatibility)
- **`_handle_capabilities`** — reflects the current setting in `features.tool_progress_events`
- **Chat Completions streaming** — `_on_tool_start` and `_on_tool_complete` skip emitting when disabled
- **Run events SSE** — `_tool_progress` callback returns early when disabled
- **Runs API** — `_make_run_event_callback` inner `_callback` skips when disabled

### What doesn't change

- Normal `delta.content` SSE chunks are always emitted regardless of this setting
- The Responses API path uses `__tool_started__`/`__tool_completed__` (standard format), not `__tool_progress__` — unaffected
- All existing behavior preserved when `tool_progress_events: true` (default)

## Testing

9 new tests covering:
- Default value is `True` (backward compatible)
- Boolean and string config parsing
- Capabilities endpoint reflects the setting
- SSE stream contains no `hermes.tool.progress` events when disabled
- SSE stream contains events when enabled (regression guard)

All 157 existing `test_api_server.py` tests pass with zero regressions.

## Files changed

- `gateway/platforms/api_server.py` — 20 lines added (config read + 4 guard checks + capabilities)
- `tests/gateway/test_api_server_tool_progress_toggle.py` — 155 lines (new test file)

Closes #12020
