### PR TITLE
fix(provider): add DASHSCOPE_BASE_URL env var to alibaba provider

### DIFF
--- a/plugins/model-providers/alibaba/__init__.py
+++ b/plugins/model-providers/alibaba/__init__.py
@@ -6,7 +6,7 @@ from providers.base import ProviderProfile
 alibaba = ProviderProfile(
     name="alibaba",
     aliases=("dashscope", "alibaba-cloud", "qwen-dashscope"),
-    env_vars=("DASHSCOPE_API_KEY",),
+    env_vars=("DASHSCOPE_API_KEY", "DASHSCOPE_BASE_URL"),
     base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
 )
 


### PR DESCRIPTION
## Fixes #42621

### Problem
The Alibaba Cloud DashScope provider (`alibaba` / `dashscope`) defaults to the international endpoint (`dashscope-intl.aliyuncs.com`), which is **not reachable from mainland China**. Chinese users get connection errors with no clear indication of the root cause.

### Fix
Add `DASHSCOPE_BASE_URL` to the alibaba provider plugin's `env_vars` tuple, making it discoverable via `hermes setup` and env var detection.

**Note:** The `auth.py` ProviderConfig already has `base_url_env_var="DASHSCOPE_BASE_URL"` (line 323), but the plugin profile did not list it, so the env var override mechanism was undiscoverable.

### Usage
Mainland China users can now set:
```bash
export DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
```

### Changes
- `plugins/model-providers/alibaba/__init__.py`: Add `"DASHSCOPE_BASE_URL"` to `env_vars` tuple

### Consistency
This matches the pattern used by `alibaba-coding-plan` provider which already includes `ALIBABA_CODING_PLAN_BASE_URL` in its env_vars.
