### PR TITLE
fix(mcp): add timeout to subprocess.run calls in mcp_catalog.py

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -364,7 +364,7 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        proc = subprocess.run(cmd, cwd=str(cwd), shell=True, timeout=120)
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"
@@ -399,6 +399,7 @@ def _do_git_install(entry: CatalogEntry) -> Path:
     if not is_sha_ref:
         proc = subprocess.run(
             [git, "clone", "--depth", "1", "--branch", install.ref, install.url, str(dest)],
+            timeout=120,
         )
         if proc.returncode == 0:
             pass
@@ -410,10 +411,10 @@ def _do_git_install(entry: CatalogEntry) -> Path:
             is_sha_ref = True  # treat the same as a SHA ref from here
 
     if is_sha_ref:
-        proc = subprocess.run([git, "clone", install.url, str(dest)])
+        proc = subprocess.run([git, "clone", install.url, str(dest)], timeout=300)
         if proc.returncode != 0:
             raise CatalogError(f"git clone failed for {install.url}")
-        proc = subprocess.run([git, "-C", str(dest), "checkout", install.ref])
+        proc = subprocess.run([git, "-C", str(dest), "checkout", install.ref], timeout=60)
         if proc.returncode != 0:
             raise CatalogError(f"git checkout {install.ref} failed")
 


### PR DESCRIPTION
## Summary

Four `subprocess.run` calls in `hermes_cli/mcp_catalog.py` lack `timeout` parameters. Without timeout, these operations can hang indefinitely on slow networks, unreachable remotes, or corrupted repos, blocking the entire MCP install process.

### Changes

| Location | Operation | Timeout Added |
|---|---|---|
| `_run_bootstrap_commands` (line 367) | Shell commands with `shell=True` | 120s |
| `_do_git_install` (line 400) | Shallow clone (`--depth 1`) | 120s |
| `_do_git_install` (line 413) | Full clone | 300s |
| `_do_git_install` (line 416) | Git checkout | 60s |

### Timeout Rationale
- **Bootstrap (120s)**: User-facing install commands; long enough for npm/pip install but prevents indefinite hangs
- **Shallow clone (120s)**: Minimal data transfer; 2 minutes is generous for --depth 1
- **Full clone (300s)**: Can be large repos; 5 minutes covers most cases
- **Checkout (60s)**: Local operation; 1 minute is very generous

### Pattern Match
This follows the established pattern throughout the codebase where subprocess calls have explicit timeouts (e.g., `gateway.py` uses `timeout=5-90s` for systemctl calls).
