### PR TITLE
fix(desktop): scope cron jobs sidebar to active profile

### DIFF
--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -34,6 +34,7 @@ import { AlertTriangle, Clock } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { $cronFocusJobId, $cronJobs, setCronFocusJobId, setCronJobs, updateCronJobs } from '@/store/cron'
 import { notify, notifyError } from '@/store/notifications'
+import { $profileScope, ALL_PROFILES } from '@/store/profile'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { OverlayMain, OverlayNewButton, OverlaySidebar, OverlaySplitLayout } from '../overlays/overlay-split-layout'
@@ -251,6 +252,12 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   // sidebar and this overlay never drift — a delete here clears the sidebar row
   // immediately. `loading` only gates the first paint before the atom is filled.
   const jobs = useStore($cronJobs)
+  // Cron jobs are per-profile; follow the same scope as the sidebar. A concrete
+  // profile lists (and creates) just that profile's jobs; ALL_PROFILES shows the
+  // unified view and creates fall back to the backend 'default'.
+  const profileScope = useStore($profileScope)
+  const cronListProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+  const cronCreateProfile = profileScope === ALL_PROFILES ? undefined : profileScope
   const [loading, setLoading] = useState(jobs.length === 0)
   const [query, setQuery] = useState('')
   const [busyJobId, setBusyJobId] = useState<null | string>(null)
@@ -267,13 +274,13 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
 
   const refresh = useCallback(async () => {
     try {
-      setCronJobs(await getCronJobs())
+      setCronJobs(await getCronJobs(cronListProfile))
     } catch (err) {
       notifyError(err, c.failedLoad)
     } finally {
       setLoading(false)
     }
-  }, [c])
+  }, [c, cronListProfile])
 
   useRefreshHotkey(refresh)
 
@@ -377,12 +384,15 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
 
   async function handleEditorSave(values: EditorValues) {
     if (editor.mode === 'create') {
-      const created = await createCronJob({
-        prompt: values.prompt,
-        schedule: values.schedule,
-        name: values.name || undefined,
-        deliver: values.deliver || DEFAULT_DELIVER
-      })
+      const created = await createCronJob(
+        {
+          prompt: values.prompt,
+          schedule: values.schedule,
+          name: values.name || undefined,
+          deliver: values.deliver || DEFAULT_DELIVER
+        },
+        cronCreateProfile
+      )
 
       updateCronJobs(rows => [...rows, created])
       notify({ kind: 'success', title: c.created, message: truncate(jobTitle(created), 60) })

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -286,13 +286,17 @@ export function DesktopController() {
   // next-run/state fresh as the scheduler advances them.
   const refreshCronJobs = useCallback(async () => {
     try {
-      const jobs = await getCronJobs()
+      // Scope to the active profile (cron jobs live per-profile on disk) so the
+      // sidebar shows only this profile's jobs; ALL_PROFILES → 'all' for the
+      // unified browse view. Single-profile users resolve to 'default'.
+      const cronProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+      const jobs = await getCronJobs(cronProfile)
 
       setCronJobs(jobs)
     } catch {
       // Non-fatal: the cron section just keeps its last-known jobs.
     }
-  }, [])
+  }, [profileScope])
 
   const refreshSessions = useCallback(async () => {
     const requestId = refreshSessionsRequestRef.current + 1

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { listAllProfileSessions, listSessions } from './hermes'
+import { createCronJob, getCronJobs, listAllProfileSessions, listSessions } from './hermes'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -45,5 +45,68 @@ describe('Hermes REST session helpers', () => {
         timeoutMs: 60_000
       })
     )
+  })
+})
+
+describe('Hermes REST cron helpers', () => {
+  let api: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    api = vi.fn().mockResolvedValue([])
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { api }
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    Reflect.deleteProperty(window, 'hermesDesktop')
+  })
+
+  it('scopes the cron job listing to a concrete profile', async () => {
+    await getCronJobs('coder')
+
+    expect(api).toHaveBeenCalledWith({ path: '/api/cron/jobs?profile=coder' })
+  })
+
+  it('passes profile=all for the unified cron view', async () => {
+    await getCronJobs('all')
+
+    expect(api).toHaveBeenCalledWith({ path: '/api/cron/jobs?profile=all' })
+  })
+
+  it('omits the profile query when none is given (legacy default)', async () => {
+    await getCronJobs()
+
+    expect(api).toHaveBeenCalledWith({ path: '/api/cron/jobs' })
+  })
+
+  it('encodes profile names with reserved characters', async () => {
+    await getCronJobs('team a/b')
+
+    expect(api).toHaveBeenCalledWith({ path: '/api/cron/jobs?profile=team%20a%2Fb' })
+  })
+
+  it('creates a cron job in the given profile', async () => {
+    const body = { prompt: 'do thing', schedule: '0 9 * * *' }
+    await createCronJob(body, 'coder')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/cron/jobs?profile=coder',
+      method: 'POST',
+      body
+    })
+  })
+
+  it('creates a cron job without a profile (backend defaults to default)', async () => {
+    const body = { prompt: 'do thing', schedule: '0 9 * * *' }
+    await createCronJob(body)
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/cron/jobs',
+      method: 'POST',
+      body
+    })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -498,9 +498,15 @@ export function testMessagingPlatform(platformId: string): Promise<MessagingPlat
   })
 }
 
-export function getCronJobs(): Promise<CronJob[]> {
+// Cron jobs are stored per-profile (<HERMES_HOME>/cron/jobs.json). Pass a
+// concrete profile key to list just that profile's jobs, or 'all' for the
+// unified cross-profile view. Omitting the arg keeps the backend's legacy
+// 'all' default, so non-profile callers are unaffected.
+export function getCronJobs(profile?: string): Promise<CronJob[]> {
+  const suffix = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+
   return window.hermesDesktop.api<CronJob[]>({
-    path: '/api/cron/jobs'
+    path: `/api/cron/jobs${suffix}`
   })
 }
 
@@ -518,9 +524,14 @@ export async function getCronJobRuns(jobId: string, limit = 20): Promise<Session
   return runs ?? []
 }
 
-export function createCronJob(body: CronJobCreatePayload): Promise<CronJob> {
+// Create in a specific profile's store. Omitting `profile` lets the backend
+// default to 'default' (~/.hermes). Callers viewing a concrete profile pass it
+// so the new job lands in — and shows up under — the profile being viewed.
+export function createCronJob(body: CronJobCreatePayload, profile?: string): Promise<CronJob> {
+  const suffix = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+
   return window.hermesDesktop.api<CronJob>({
-    path: '/api/cron/jobs',
+    path: `/api/cron/jobs${suffix}`,
     method: 'POST',
     body
   })


### PR DESCRIPTION
## What does this PR do?

The desktop app's bottom-left "Cron jobs" section showed **every profile's** cron jobs regardless of the active profile. Cron jobs are stored per-profile on disk (`<HERMES_HOME>/cron/jobs.json`) and the REST backend already accepts a `?profile=` query param (`default` / `<name>` / `all`) — the desktop just never sent it, so the endpoint fell back to its `all` default.

This threads the active sidebar scope (`$profileScope`) through the cron fetches so the section only shows the active profile's jobs, while the opt-in "All profiles" view still aggregates everything. No backend change is required — the endpoints were already profile-aware.

## Related Issue

Fixes #42651

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/hermes.ts` — `getCronJobs(profile?)` and `createCronJob(body, profile?)` now append `?profile=<name>` (URL-encoded). Omitting the arg preserves the legacy `all` default.
- `apps/desktop/src/app/desktop-controller.tsx` — `refreshCronJobs` scopes to `$profileScope` (the sidebar driver), mapping `ALL_PROFILES → 'all'`; added `profileScope` to the callback deps so a profile switch re-fetches.
- `apps/desktop/src/app/cron/index.tsx` — the full `/cron` page follows the same scope for both listing and creation (so a job created while viewing a concrete profile lands in — and shows up under — that profile instead of always defaulting to `~/.hermes`).
- `apps/desktop/src/hermes.test.ts` — 6 new tests covering the cron URL construction (concrete profile, `all`, omitted, reserved-char encoding, scoped create, unscoped create).

## How to Test

1. Run Hermes with multiple profiles; add cron jobs in profile X, none in profile Y.
2. Open the desktop app and switch between profiles.
3. The "Cron jobs" section now shows only the active profile's jobs (X's jobs are hidden under Y).
4. Toggle "All profiles" → the unified view still lists every profile's jobs.
5. Creating a job while in a named profile makes it appear under that profile.

Automated: `cd apps/desktop && npm run type-check && npm run test:ui src/hermes.test.ts` (8/8 pass).

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(desktop): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config/doc change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — N/A (pure TS URL construction)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
