### PR TITLE
feat(dashboard): add Android PKCE session handoff

### DIFF
--- a/hermes_cli/dashboard_auth/audit.py
+++ b/hermes_cli/dashboard_auth/audit.py
@@ -54,6 +54,10 @@ class AuditEvent(enum.Enum):
     NATIVE_CODE_ISSUED = "native_code_issued"
     NATIVE_TOKEN_SUCCESS = "native_token_success"
     NATIVE_TOKEN_FAILURE = "native_token_failure"
+    # Browser-session → Android native-app PKCE handoff (/mobile-handoff/start).
+    # Distinct from NATIVE_TOKEN_FAILURE so alerting on code-redemption attacks
+    # at /auth/native/token isn't diluted by routine authenticated throttling.
+    MOBILE_HANDOFF_RATE_LIMITED = "mobile_handoff_rate_limited"
 
 
 def _resolve_log_path() -> Path:

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -593,6 +593,218 @@ def _validate_post_login_target(raw: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Auth-required: browser-session → Android native-app PKCE handoff
+# ---------------------------------------------------------------------------
+
+
+_ANDROID_MOBILE_REDIRECT_URI = (
+    "com.nousresearch.hermes.android://oauth/callback"
+)
+_MOBILE_HANDOFF_STATE_MAX_LENGTH = 512
+_PKCE_UNRESERVED = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789-._~"
+)
+
+# Per-IP throttle on code minting. Unlike the desktop native flow — where an
+# ``_issued`` entry costs a full interactive upstream IDP login and is thus
+# naturally rate-limited — an authenticated browser can mint a code here with a
+# single cheap GET (no IDP round trip). ``native_flow``'s per-IP cap only
+# throttles *pending* entries, and this handler pops its pending immediately
+# (register→complete in one request), so without this budget one authenticated
+# caller could keep the shared, capacity-bounded ``_issued`` store full and 503
+# every other user's native login (desktop and mobile). Mirrors the
+# ``/auth/password-login`` limiter's sliding window.
+_MOBILE_HANDOFF_RATE_MAX = 10
+_MOBILE_HANDOFF_RATE_WINDOW_SEC = 60.0
+_mobile_handoff_attempts: Dict[str, Deque[float]] = defaultdict(deque)
+_mobile_handoff_attempts_lock = threading.Lock()
+
+
+def _mobile_handoff_rate_limited(ip: str) -> bool:
+    """True if ``ip`` has exceeded the mobile-handoff mint budget.
+
+    Sliding window identical to :func:`_password_rate_limited`: prune stale
+    attempts, then check the count. Records the timestamp only when allowed, so
+    a rejected (429) caller does not extend its own lockout. An empty IP shares
+    a single bucket — fail-safe toward throttling unattributable traffic.
+    """
+    now = time.monotonic()
+    cutoff = now - _MOBILE_HANDOFF_RATE_WINDOW_SEC
+    key = ip or "_unknown_"
+    with _mobile_handoff_attempts_lock:
+        bucket = _mobile_handoff_attempts[key]
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if len(bucket) >= _MOBILE_HANDOFF_RATE_MAX:
+            return True
+        bucket.append(now)
+        return False
+
+
+def _reset_mobile_handoff_rate_limit() -> None:
+    """Test-only: clear all mobile-handoff rate-limit buckets."""
+    with _mobile_handoff_attempts_lock:
+        _mobile_handoff_attempts.clear()
+
+
+def _validate_mobile_handoff_challenge(
+    code_challenge: str,
+    code_challenge_method: str,
+) -> str:
+    """Validate an RFC 7636 S256 challenge supplied by the Android app."""
+    if code_challenge_method.upper() != "S256":
+        raise HTTPException(
+            status_code=400,
+            detail="code_challenge_method must be S256",
+        )
+    if not (
+        43 <= len(code_challenge) <= 128
+        and all(ch in _PKCE_UNRESERVED for ch in code_challenge)
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid mobile code challenge",
+        )
+    return code_challenge
+
+
+def _validate_mobile_handoff_state(state: str) -> str:
+    """Require a bounded client state value for response correlation."""
+    if not state or len(state) > _MOBILE_HANDOFF_STATE_MAX_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail="Mobile state is required and must be at most 512 characters",
+        )
+    return state
+
+
+def _mobile_handoff_base_url(request: Request) -> str:
+    """Return the public gateway base URL the Android client should retain."""
+    from hermes_cli.dashboard_auth.prefix import (
+        prefix_from_request,
+        resolve_public_url,
+    )
+
+    public_url = resolve_public_url()
+    if public_url:
+        return public_url
+    return (
+        f"{str(request.base_url).rstrip('/')}"
+        f"{prefix_from_request(request)}"
+    )
+
+
+@router.get("/mobile-handoff/start", name="auth_mobile_handoff_start")
+async def auth_mobile_handoff_start(
+    request: Request,
+    redirect_uri: str,
+    code_challenge: str,
+    code_challenge_method: str = "S256",
+    state: str = "",
+):
+    """Transfer an authenticated browser session to the Android app.
+
+    This route is intentionally absent from the gate's public allowlist. An
+    unauthenticated system-browser navigation therefore enters the normal
+    dashboard login (including one-provider auto-SSO) and returns here through
+    its validated ``next=`` target. Once authenticated, the gateway binds the
+    verified session to the Android app's PKCE challenge and redirects only to
+    the exact registered app scheme. The app redeems the one-time code at the
+    existing ``/auth/native/token`` endpoint and uses bearer auth thereafter;
+    no session token is exposed in the deep link and no mobile cookie is set.
+
+    The minted mobile session is access-token-only: the browser's rotating,
+    reuse-detected refresh token is never shared with the app (see the SECURITY
+    note below). Minting is rate-limited per IP so one authenticated caller
+    cannot exhaust the shared native-flow code store.
+    """
+    if redirect_uri != _ANDROID_MOBILE_REDIRECT_URI:
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported mobile redirect URI",
+        )
+    challenge = _validate_mobile_handoff_challenge(
+        code_challenge,
+        code_challenge_method,
+    )
+    client_state = _validate_mobile_handoff_state(state)
+
+    session = getattr(request.state, "session", None)
+    if session is None:
+        # The gate should have rejected this already. Keep the handler
+        # fail-closed if it is ever mounted without that middleware.
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    if _mobile_handoff_rate_limited(_client_ip(request)):
+        audit_log(
+            AuditEvent.MOBILE_HANDOFF_RATE_LIMITED,
+            provider=session.provider,
+            user_id=session.user_id,
+            ip=_client_ip(request),
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="Too many mobile handoff requests. Try again shortly.",
+        )
+
+    # SECURITY: the mobile session is access-token-only — we deliberately do
+    # NOT hand the browser's refresh token to the app. The dashboard refresh
+    # token is rotating + reuse-detected (see cookies.py): the browser rotates
+    # it transparently on access-token expiry, and the app would rotate the
+    # SAME value via /auth/native/refresh. Two independent clients sharing one
+    # rotating token means whichever refreshes first invalidates the other's
+    # copy, and reuse detection can revoke the whole token family — silently
+    # logging the user out of the browser too. When the app's bearer lapses it
+    # restarts this (cheap) handoff while the browser session is still live,
+    # rather than holding a rotating token it must not share.
+    from dataclasses import replace
+    from hermes_cli.dashboard_auth import native_flow
+
+    native_session = replace(session, refresh_token="")
+
+    try:
+        broker_state = native_flow.register_pending(
+            code_challenge=challenge,
+            redirect_uri=redirect_uri,
+            client_state=client_state,
+            client_ip=_client_ip(request),
+        )
+        code = native_flow.complete_pending(
+            broker_state,
+            session=native_session,
+        )
+    except native_flow.NativeFlowError as exc:
+        _log.warning("mobile auth handoff unavailable: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail="Mobile authorization handoff temporarily unavailable",
+        )
+
+    from urllib.parse import urlencode
+
+    target_params = {
+        "base_url": _mobile_handoff_base_url(request),
+        "code": code,
+        "state": client_state,
+    }
+    target = f"{redirect_uri}?{urlencode(target_params)}"
+    audit_log(
+        AuditEvent.NATIVE_CODE_ISSUED,
+        provider=session.provider,
+        user_id=session.user_id,
+        reason="mobile_handoff",
+        ip=_client_ip(request),
+    )
+    return RedirectResponse(
+        url=target,
+        status_code=302,
+        headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Public: password (non-redirect) login
 # ---------------------------------------------------------------------------
 #

--- a/tests/hermes_cli/test_dashboard_auth_mobile_handoff.py
+++ b/tests/hermes_cli/test_dashboard_auth_mobile_handoff.py
@@ -1,0 +1,285 @@
+"""Browser-session to Android native-app PKCE handoff tests."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth import clear_providers, register_provider
+from hermes_cli.dashboard_auth import native_flow
+from hermes_cli.dashboard_auth.routes import (
+    _MOBILE_HANDOFF_RATE_MAX,
+    _reset_mobile_handoff_rate_limit,
+)
+from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+ANDROID_REDIRECT_URI = "com.nousresearch.hermes.android://oauth/callback"
+ANDROID_VERIFIER = "v" * 43
+ANDROID_STATE = "android-state-7f4b3d"
+
+
+def _code_challenge(verifier: str = ANDROID_VERIFIER) -> str:
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _handoff_start_path(
+    *,
+    redirect_uri: str = ANDROID_REDIRECT_URI,
+    code_challenge: str | None = None,
+    code_challenge_method: str = "S256",
+    state: str = ANDROID_STATE,
+) -> str:
+    return "/mobile-handoff/start?" + urlencode(
+        {
+            "redirect_uri": redirect_uri,
+            "code_challenge": (
+                _code_challenge()
+                if code_challenge is None
+                else code_challenge
+            ),
+            "code_challenge_method": code_challenge_method,
+            "state": state,
+        }
+    )
+
+
+@pytest.fixture
+def gated_app(monkeypatch):
+    clear_providers()
+    register_provider(StubAuthProvider())
+    native_flow._reset_for_tests()
+    _reset_mobile_handoff_rate_limit()
+    monkeypatch.delenv("HERMES_DASHBOARD_PUBLIC_URL", raising=False)
+
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+
+    client = TestClient(
+        web_server.app,
+        base_url="https://fly-app.fly.dev",
+        follow_redirects=False,
+    )
+    yield client
+
+    clear_providers()
+    native_flow._reset_for_tests()
+    _reset_mobile_handoff_rate_limit()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+def _logged_in(client: TestClient) -> None:
+    login = client.get("/auth/login?provider=stub")
+    assert login.status_code == 302
+    callback = client.get(login.headers["location"])
+    assert callback.status_code == 302
+    assert callback.headers["location"] == "/"
+
+
+def _walk_browser_handoff(client: TestClient, *, path: str | None = None) -> dict[str, str]:
+    start_path = path or _handoff_start_path()
+
+    auto_sso = client.get(start_path)
+    assert auto_sso.status_code == 302
+    auto_location = urlparse(auto_sso.headers["location"])
+    assert auto_location.path == "/auth/login"
+    auto_query = parse_qs(auto_location.query)
+    assert auto_query["provider"] == ["stub"]
+    assert auto_query["next"] == [start_path]
+
+    upstream = client.get(auto_sso.headers["location"])
+    assert upstream.status_code == 302
+    callback = client.get(upstream.headers["location"])
+    assert callback.status_code == 302
+    callback_target = urlparse(callback.headers["location"])
+    expected_target = urlparse(start_path)
+    assert callback_target.path == expected_target.path
+    assert parse_qs(callback_target.query) == parse_qs(expected_target.query)
+
+    app_redirect = client.get(callback.headers["location"])
+    assert app_redirect.status_code == 302
+    parsed = urlparse(app_redirect.headers["location"])
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == ANDROID_REDIRECT_URI
+    assert app_redirect.headers["cache-control"] == "no-store, no-cache, must-revalidate"
+
+    values = parse_qs(parsed.query)
+    return {key: item[0] for key, item in values.items()}
+
+
+def test_unauthenticated_start_auto_sso_preserves_handoff_query(gated_app):
+    path = _handoff_start_path()
+
+    response = gated_app.get(path)
+
+    assert response.status_code == 302
+    location = urlparse(response.headers["location"])
+    assert location.path == "/auth/login"
+    query = parse_qs(location.query)
+    assert query["provider"] == ["stub"]
+    assert query["next"] == [path]
+    # Only the challenge crosses the browser. The mobile verifier never does.
+    assert ANDROID_VERIFIER not in response.headers["location"]
+
+
+def test_authenticated_browser_mints_android_code_redeemable_for_bearer(gated_app):
+    values = _walk_browser_handoff(gated_app)
+
+    assert values["state"] == ANDROID_STATE
+    assert values["base_url"] == "https://fly-app.fly.dev"
+    assert len(values["code"]) >= 32
+
+    mobile = TestClient(
+        web_server.app,
+        base_url="https://fly-app.fly.dev",
+        follow_redirects=False,
+    )
+    token = mobile.post(
+        "/auth/native/token",
+        json={"code": values["code"], "code_verifier": ANDROID_VERIFIER},
+    )
+    assert token.status_code == 200
+    body = token.json()
+    assert body["token_type"] == "Bearer"
+    assert body["access_token"]
+    # Access-token-only: the browser's rotating, reuse-detected refresh token
+    # is never shared with the app (a second, independent client rotating the
+    # same token would break both). See test_mobile_handoff_never_shares...
+    assert body["refresh_token"] == ""
+    assert "set-cookie" not in {key.lower() for key in token.headers}
+
+    me = mobile.get(
+        "/api/auth/me",
+        headers={"Authorization": f"Bearer {body['access_token']}"},
+    )
+    assert me.status_code == 200
+    assert me.json()["user_id"] == "stub-user-1"
+
+    replay = mobile.post(
+        "/auth/native/token",
+        json={"code": values["code"], "code_verifier": ANDROID_VERIFIER},
+    )
+    assert replay.status_code == 400
+
+
+def test_logged_in_browser_handoff_skips_upstream_login(gated_app):
+    _logged_in(gated_app)
+
+    response = gated_app.get(_handoff_start_path())
+
+    assert response.status_code == 302
+    parsed = urlparse(response.headers["location"])
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == ANDROID_REDIRECT_URI
+    assert parse_qs(parsed.query)["state"] == [ANDROID_STATE]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "detail"),
+    [
+        ({"redirect_uri": "https://evil.example/callback"}, "redirect URI"),
+        ({"code_challenge": "short"}, "code challenge"),
+        ({"code_challenge_method": "plain"}, "S256"),
+        ({"state": ""}, "state"),
+    ],
+)
+def test_mobile_handoff_rejects_invalid_native_parameters(
+    gated_app,
+    kwargs,
+    detail,
+):
+    _logged_in(gated_app)
+
+    response = gated_app.get(_handoff_start_path(**kwargs))
+
+    assert response.status_code == 400
+    assert detail.lower() in response.json()["detail"].lower()
+
+
+def test_mobile_handoff_base_url_honors_forwarded_prefix(gated_app):
+    _logged_in(gated_app)
+
+    response = gated_app.get(
+        _handoff_start_path(),
+        headers={"X-Forwarded-Prefix": "/hermes"},
+    )
+
+    assert response.status_code == 302
+    values = parse_qs(urlparse(response.headers["location"]).query)
+    assert values["base_url"] == ["https://fly-app.fly.dev/hermes"]
+
+
+def _browser_refresh_cookie(client: TestClient) -> str:
+    """Return the browser session's ``hermes_session_rt`` value (any prefix)."""
+    for cookie in client.cookies.jar:
+        if cookie.name.endswith("hermes_session_rt"):
+            return cookie.value or ""
+    return ""
+
+
+def test_mobile_handoff_never_shares_browser_refresh_token(gated_app):
+    """The app's session is access-token-only.
+
+    The browser holds a rotating, reuse-detected refresh token. Handing that
+    same token to the Android app (a second, independent client) would let
+    either side's rotation invalidate the other and trip Portal's reuse
+    detection — potentially revoking the whole family. The handoff must never
+    expose the browser RT in the deep link or the redeemed token response.
+    """
+    _logged_in(gated_app)
+    browser_rt = _browser_refresh_cookie(gated_app)
+    # Sanity: the browser session really does hold a (rotating) refresh token,
+    # so the "must not leak it" assertions below are meaningful.
+    assert browser_rt
+
+    response = gated_app.get(_handoff_start_path())
+    assert response.status_code == 302
+    deep_link = response.headers["location"]
+    assert browser_rt not in deep_link
+
+    values = parse_qs(urlparse(deep_link).query)
+    mobile = TestClient(
+        web_server.app,
+        base_url="https://fly-app.fly.dev",
+        follow_redirects=False,
+    )
+    token = mobile.post(
+        "/auth/native/token",
+        json={"code": values["code"][0], "code_verifier": ANDROID_VERIFIER},
+    )
+    assert token.status_code == 200
+    body = token.json()
+    # Access-token-only: no refresh token minted for the app, and the browser's
+    # rotating RT never appears anywhere in the native token response.
+    assert body["access_token"]
+    assert body["refresh_token"] == ""
+    assert browser_rt not in token.text
+
+
+def test_mobile_handoff_rate_limited_per_ip(gated_app):
+    """One authenticated caller cannot exhaust the shared native-flow store.
+
+    Each handoff pops its pending entry immediately, so the native-flow per-IP
+    *pending* cap never engages; without the per-IP mint budget a single
+    authenticated browser could keep the shared, capacity-bounded ``_issued``
+    store full and 503 every other user's native login.
+    """
+    _logged_in(gated_app)
+
+    for _ in range(_MOBILE_HANDOFF_RATE_MAX):
+        ok = gated_app.get(_handoff_start_path())
+        assert ok.status_code == 302
+
+    blocked = gated_app.get(_handoff_start_path())
+    assert blocked.status_code == 429
+    assert "too many" in blocked.json()["detail"].lower()


### PR DESCRIPTION
## Summary

This adds a browser-session to Android native-app authentication handoff using the gateway's existing PKCE-native token broker:

- Adds protected `GET /mobile-handoff/start` for the Android system-browser flow.
- Unauthenticated starts enter the normal dashboard login, including the current one-provider auto-SSO path, and return through the validated `next=` target.
- Accepts only the registered Android redirect URI and requires an RFC 7636 S256 challenge plus client state.
- Binds the authenticated browser `Session` to a short-lived, one-time gateway code via `dashboard_auth.native_flow`.
- Redirects only the opaque code, state, and public gateway base URL to the app. No access or refresh token is placed in the deep link.
- The app redeems through the existing public `/auth/native/token` endpoint and uses cookieless bearer auth thereafter.
- Preserves the browser refresh-token cookie in the issued native session so mobile token rotation continues to work.

This replaces the earlier parallel cookie-handoff store with the native broker already present on current `main`, keeping one PKCE/code lifecycle and one bearer-token contract.

## Security properties

- Exact Android custom-scheme allowlist, not an arbitrary redirect.
- S256 PKCE binding and one-time redemption through the existing broker.
- Required bounded client state.
- No tokens in redirect URLs or mobile cookies.
- Capacity/per-IP controls inherited from `native_flow`.
- No-store redirect response.

## Testing

Canonical per-file isolated runner:

```text
9 files, 249 tests passed, 0 failed
```

Covered mobile handoff, native flow, 401/refresh behavior, gate/middleware, password login, prefix handling, and WS authentication/tickets.

Additional checks:

- full Ruff enforcement passed;
- Windows-footgun scan passed across 808 production files;
- `py_compile` and `git diff --check` passed.