### PR TITLE
fix(nemo-relay): preserve downstream errors in adaptive execution

### DIFF
--- a/plugins/observability/nemo_relay/__init__.py
+++ b/plugins/observability/nemo_relay/__init__.py
@@ -293,10 +293,18 @@ class _Runtime:
             return request_body
 
         raw_response: dict[str, Any] = {"set": False, "value": None}
+        # NeMo Relay's native managed execution may wrap callback failures; keep
+        # the real downstream error so Hermes retry classification still sees it.
+        downstream_error: BaseException | None = None
 
         def _impl(next_request: Any) -> Any:
+            nonlocal downstream_error
             next_body = getattr(next_request, "content", next_request)
-            raw = next_call(next_body if isinstance(next_body, dict) else request_body)
+            try:
+                raw = next_call(next_body if isinstance(next_body, dict) else request_body)
+            except Exception as exc:
+                downstream_error = _original_downstream_error(exc)
+                raise
             raw_response["set"] = True
             raw_response["value"] = raw
             return _llm_response_payload(raw)
@@ -322,7 +330,12 @@ class _Runtime:
                 return await result
             return result
 
-        managed_result = _resolve_awaitable(_managed_execute())
+        try:
+            managed_result = _resolve_awaitable(_managed_execute())
+        except Exception as exc:
+            if downstream_error is not None and _is_relay_internal_error(exc):
+                raise downstream_error
+            raise
         return raw_response["value"] if raw_response["set"] else managed_result
 
     def execute_tool(self, kwargs: dict[str, Any]) -> Any:
@@ -334,10 +347,18 @@ class _Runtime:
             return args
 
         raw_response: dict[str, Any] = {"set": False, "value": None}
+        # NeMo Relay's native managed execution may wrap callback failures; keep
+        # the real downstream error so Hermes retry classification still sees it.
+        downstream_error: BaseException | None = None
 
         def _impl(next_args: Any) -> Any:
+            nonlocal downstream_error
             effective_args = next_args if isinstance(next_args, dict) else args
-            raw = next_call(effective_args)
+            try:
+                raw = next_call(effective_args)
+            except Exception as exc:
+                downstream_error = _original_downstream_error(exc)
+                raise
             raw_response["set"] = True
             raw_response["value"] = raw
             return _jsonable(raw)
@@ -362,7 +383,12 @@ class _Runtime:
                 return await result
             return result
 
-        managed_result = _resolve_awaitable(_managed_execute())
+        try:
+            managed_result = _resolve_awaitable(_managed_execute())
+        except Exception as exc:
+            if downstream_error is not None and _is_relay_internal_error(exc):
+                raise downstream_error
+            raise
         return raw_response["value"] if raw_response["set"] else managed_result
 
 
@@ -804,6 +830,17 @@ def _value(obj: Any, key: str, default: Any = None) -> Any:
     if isinstance(obj, dict):
         return obj.get(key, default)
     return getattr(obj, key, default)
+
+
+def _original_downstream_error(exc: Exception) -> BaseException:
+    original = getattr(exc, "original", None)
+    if exc.__class__.__name__ == "_DownstreamExecutionError" and isinstance(original, BaseException):
+        return original
+    return exc
+
+
+def _is_relay_internal_error(exc: Exception) -> bool:
+    return isinstance(exc, RuntimeError) and str(exc).lower().startswith("internal error:")
 
 
 def _llm_response_payload(response: Any) -> Any:

--- a/plugins/observability/nemo_relay/__init__.py
+++ b/plugins/observability/nemo_relay/__init__.py
@@ -295,14 +295,16 @@ class _Runtime:
         raw_response: dict[str, Any] = {"set": False, "value": None}
         # NeMo Relay's native managed execution may wrap callback failures; keep
         # the real downstream error so Hermes retry classification still sees it.
+        callback_error: Exception | None = None
         downstream_error: BaseException | None = None
 
         def _impl(next_request: Any) -> Any:
-            nonlocal downstream_error
+            nonlocal callback_error, downstream_error
             next_body = getattr(next_request, "content", next_request)
             try:
                 raw = next_call(next_body if isinstance(next_body, dict) else request_body)
             except Exception as exc:
+                callback_error = exc
                 downstream_error = _original_downstream_error(exc)
                 raise
             raw_response["set"] = True
@@ -333,7 +335,7 @@ class _Runtime:
         try:
             managed_result = _resolve_awaitable(_managed_execute())
         except Exception as exc:
-            if downstream_error is not None and _is_relay_internal_error(exc):
+            if downstream_error is not None and _is_relay_wrapped_callback_error(exc, callback_error):
                 raise downstream_error
             raise
         return raw_response["value"] if raw_response["set"] else managed_result
@@ -349,14 +351,16 @@ class _Runtime:
         raw_response: dict[str, Any] = {"set": False, "value": None}
         # NeMo Relay's native managed execution may wrap callback failures; keep
         # the real downstream error so Hermes retry classification still sees it.
+        callback_error: Exception | None = None
         downstream_error: BaseException | None = None
 
         def _impl(next_args: Any) -> Any:
-            nonlocal downstream_error
+            nonlocal callback_error, downstream_error
             effective_args = next_args if isinstance(next_args, dict) else args
             try:
                 raw = next_call(effective_args)
             except Exception as exc:
+                callback_error = exc
                 downstream_error = _original_downstream_error(exc)
                 raise
             raw_response["set"] = True
@@ -386,7 +390,7 @@ class _Runtime:
         try:
             managed_result = _resolve_awaitable(_managed_execute())
         except Exception as exc:
-            if downstream_error is not None and _is_relay_internal_error(exc):
+            if downstream_error is not None and _is_relay_wrapped_callback_error(exc, callback_error):
                 raise downstream_error
             raise
         return raw_response["value"] if raw_response["set"] else managed_result
@@ -841,8 +845,11 @@ def _original_downstream_error(exc: Exception) -> BaseException:
     return exc
 
 
-def _is_relay_internal_error(exc: Exception) -> bool:
-    return isinstance(exc, RuntimeError) and str(exc).lower().startswith("internal error:")
+def _is_relay_wrapped_callback_error(exc: Exception, callback_error: Exception | None) -> bool:
+    if callback_error is None or not isinstance(exc, RuntimeError):
+        return False
+    expected = f"internal error: {callback_error.__class__.__name__}: {callback_error}"
+    return str(exc) == expected
 
 
 def _llm_response_payload(response: Any) -> Any:

--- a/plugins/observability/nemo_relay/__init__.py
+++ b/plugins/observability/nemo_relay/__init__.py
@@ -833,6 +833,8 @@ def _value(obj: Any, key: str, default: Any = None) -> Any:
 
 
 def _original_downstream_error(exc: Exception) -> BaseException:
+    # Hermes wraps downstream execution failures in a local/private exception
+    # class, so detect the wrapper by shape instead of importing it here.
     original = getattr(exc, "original", None)
     if exc.__class__.__name__ == "_DownstreamExecutionError" and isinstance(original, BaseException):
         return original

--- a/tests/plugins/test_nemo_relay_plugin.py
+++ b/tests/plugins/test_nemo_relay_plugin.py
@@ -846,6 +846,30 @@ def test_nemo_relay_adaptive_llm_execution_preserves_downstream_error(tmp_path, 
     assert caught.value.status_code == 403
 
 
+def test_nemo_relay_adaptive_llm_execution_keeps_unrelated_internal_error(tmp_path, monkeypatch):
+    fake = _FakeNemoRelay()
+
+    relay_error = RuntimeError("internal error: relay setup failed")
+
+    def internal_error_execute(name, request, func, **kwargs):
+        raise relay_error
+
+    fake.llm.execute = internal_error_execute
+    plugin = _fresh_plugin(monkeypatch, fake)
+    _enable_adaptive_plugin(tmp_path, monkeypatch)
+
+    with pytest.raises(RuntimeError) as caught:
+        plugin.on_llm_execution_middleware(
+            session_id="s1",
+            provider="anthropic",
+            model="demo-model",
+            request={"messages": [{"role": "user", "content": "hi"}]},
+            next_call=lambda request: {"raw": request},
+        )
+
+    assert caught.value is relay_error
+
+
 def test_nemo_relay_adaptive_llm_execution_keeps_relay_translated_error(tmp_path, monkeypatch):
     fake = _FakeNemoRelay()
 
@@ -1050,6 +1074,29 @@ def test_nemo_relay_adaptive_tool_execution_preserves_downstream_error(tmp_path,
 
     assert caught.value is tool_error
     assert caught.value.status_code == 403
+
+
+def test_nemo_relay_adaptive_tool_execution_keeps_unrelated_internal_error(tmp_path, monkeypatch):
+    fake = _FakeNemoRelay()
+
+    relay_error = RuntimeError("internal error: relay setup failed")
+
+    def internal_error_execute(name, args, func, **kwargs):
+        raise relay_error
+
+    fake.tools.execute = internal_error_execute
+    plugin = _fresh_plugin(monkeypatch, fake)
+    _enable_adaptive_plugin(tmp_path, monkeypatch)
+
+    with pytest.raises(RuntimeError) as caught:
+        plugin.on_tool_execution_middleware(
+            session_id="s1",
+            tool_name="terminal",
+            args={"command": "pwd"},
+            next_call=lambda args: {"raw": args},
+        )
+
+    assert caught.value is relay_error
 
 
 def test_nemo_relay_adaptive_tool_execution_keeps_relay_translated_error(tmp_path, monkeypatch):

--- a/tests/plugins/test_nemo_relay_plugin.py
+++ b/tests/plugins/test_nemo_relay_plugin.py
@@ -12,6 +12,7 @@ import warnings
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 import yaml
 
 from hermes_cli.plugins import PluginManager
@@ -151,6 +152,33 @@ def _fresh_plugin(monkeypatch, fake):
     plugin = importlib.import_module("plugins.observability.nemo_relay")
     plugin.reset_for_tests()
     return plugin
+
+
+def _wrapped_downstream_error(original):
+    class _DownstreamExecutionError(Exception):
+        def __init__(self, original):
+            super().__init__(str(original))
+            self.original = original
+
+    return _DownstreamExecutionError(original)
+
+
+def _enable_adaptive_plugin(tmp_path, monkeypatch) -> None:
+    plugins_toml = tmp_path / "plugins.toml"
+    plugins_toml.write_text(
+        """
+version = 1
+
+[[components]]
+kind = "adaptive"
+enabled = true
+
+[components.config.tool_parallelism]
+mode = "observe_only"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_NEMO_RELAY_PLUGINS_TOML", str(plugins_toml))
 
 
 def test_manifest_fields():
@@ -783,6 +811,76 @@ mode = "observe_only"
     }
 
 
+def test_nemo_relay_adaptive_llm_execution_preserves_downstream_error(tmp_path, monkeypatch):
+    fake = _FakeNemoRelay()
+
+    def native_like_execute(name, request, func, **kwargs):
+        fake.events.append(("llm.execute.start", name, request.content, kwargs))
+        try:
+            return func(_FakeLLMRequest(request.headers, {"intercepted": True, **request.content}))
+        except Exception as exc:
+            raise RuntimeError(f"internal error: {type(exc).__name__}: {exc}") from None
+
+    fake.llm.execute = native_like_execute
+    plugin = _fresh_plugin(monkeypatch, fake)
+    _enable_adaptive_plugin(tmp_path, monkeypatch)
+
+    class ProviderAuthError(Exception):
+        status_code = 403
+
+    provider_error = ProviderAuthError("provider auth failed")
+
+    def next_call(request):
+        raise _wrapped_downstream_error(provider_error)
+
+    with pytest.raises(ProviderAuthError) as caught:
+        plugin.on_llm_execution_middleware(
+            session_id="s1",
+            provider="anthropic",
+            model="demo-model",
+            request={"messages": [{"role": "user", "content": "hi"}]},
+            next_call=next_call,
+        )
+
+    assert caught.value is provider_error
+    assert caught.value.status_code == 403
+
+
+def test_nemo_relay_adaptive_llm_execution_keeps_relay_translated_error(tmp_path, monkeypatch):
+    fake = _FakeNemoRelay()
+
+    class RelayPolicyError(Exception):
+        pass
+
+    relay_error = RelayPolicyError("relay policy blocked")
+
+    def translated_execute(name, request, func, **kwargs):
+        try:
+            return func(_FakeLLMRequest(request.headers, {"intercepted": True, **request.content}))
+        except Exception:
+            raise relay_error
+
+    fake.llm.execute = translated_execute
+    plugin = _fresh_plugin(monkeypatch, fake)
+    _enable_adaptive_plugin(tmp_path, monkeypatch)
+
+    provider_error = RuntimeError("provider failed")
+
+    def next_call(request):
+        raise _wrapped_downstream_error(provider_error)
+
+    with pytest.raises(RelayPolicyError) as caught:
+        plugin.on_llm_execution_middleware(
+            session_id="s1",
+            provider="anthropic",
+            model="demo-model",
+            request={"messages": [{"role": "user", "content": "hi"}]},
+            next_call=next_call,
+        )
+
+    assert caught.value is relay_error
+
+
 def _adaptive_llm_execute_mode(tmp_path, monkeypatch, plugins_toml_text: str) -> str:
     fake = _FakeNemoRelay()
     plugin = _fresh_plugin(monkeypatch, fake)
@@ -918,6 +1016,74 @@ mode = "observe_only"
     execute_start = next(event for event in fake.events if event[0] == "tool.execute.start")
     assert execute_start[3]["data"]["mode"] == "observe_only"
     assert execute_start[3]["data"]["tool_call_id"] == "tool-1"
+
+
+def test_nemo_relay_adaptive_tool_execution_preserves_downstream_error(tmp_path, monkeypatch):
+    fake = _FakeNemoRelay()
+
+    def native_like_execute(name, args, func, **kwargs):
+        fake.events.append(("tool.execute.start", name, args, kwargs))
+        try:
+            return func({"intercepted": True, **args})
+        except Exception as exc:
+            raise RuntimeError(f"internal error: {type(exc).__name__}: {exc}") from None
+
+    fake.tools.execute = native_like_execute
+    plugin = _fresh_plugin(monkeypatch, fake)
+    _enable_adaptive_plugin(tmp_path, monkeypatch)
+
+    class ToolAuthError(Exception):
+        status_code = 403
+
+    tool_error = ToolAuthError("tool auth failed")
+
+    def next_call(args):
+        raise _wrapped_downstream_error(tool_error)
+
+    with pytest.raises(ToolAuthError) as caught:
+        plugin.on_tool_execution_middleware(
+            session_id="s1",
+            tool_name="terminal",
+            args={"command": "pwd"},
+            next_call=next_call,
+        )
+
+    assert caught.value is tool_error
+    assert caught.value.status_code == 403
+
+
+def test_nemo_relay_adaptive_tool_execution_keeps_relay_translated_error(tmp_path, monkeypatch):
+    fake = _FakeNemoRelay()
+
+    class RelayPolicyError(Exception):
+        pass
+
+    relay_error = RelayPolicyError("relay policy blocked")
+
+    def translated_execute(name, args, func, **kwargs):
+        try:
+            return func({"intercepted": True, **args})
+        except Exception:
+            raise relay_error
+
+    fake.tools.execute = translated_execute
+    plugin = _fresh_plugin(monkeypatch, fake)
+    _enable_adaptive_plugin(tmp_path, monkeypatch)
+
+    tool_error = RuntimeError("tool failed")
+
+    def next_call(args):
+        raise _wrapped_downstream_error(tool_error)
+
+    with pytest.raises(RelayPolicyError) as caught:
+        plugin.on_tool_execution_middleware(
+            session_id="s1",
+            tool_name="terminal",
+            args={"command": "pwd"},
+            next_call=next_call,
+        )
+
+    assert caught.value is relay_error
 
 
 def test_nemo_relay_tool_execution_middleware_calls_through_without_adaptive(monkeypatch):

--- a/tests/plugins/test_nemo_relay_plugin.py
+++ b/tests/plugins/test_nemo_relay_plugin.py
@@ -870,6 +870,37 @@ def test_nemo_relay_adaptive_llm_execution_keeps_unrelated_internal_error(tmp_pa
     assert caught.value is relay_error
 
 
+def test_nemo_relay_adaptive_llm_execution_keeps_wrapped_relay_error_after_downstream_failure(
+    tmp_path, monkeypatch
+):
+    fake = _FakeNemoRelay()
+    relay_error = RuntimeError("internal error: RuntimeError: relay policy blocked after downstream")
+
+    def translated_execute(name, request, func, **kwargs):
+        try:
+            return func(_FakeLLMRequest(request.headers, {"intercepted": True, **request.content}))
+        except Exception:
+            raise relay_error
+
+    fake.llm.execute = translated_execute
+    plugin = _fresh_plugin(monkeypatch, fake)
+    _enable_adaptive_plugin(tmp_path, monkeypatch)
+
+    def next_call(request):
+        raise _wrapped_downstream_error(RuntimeError("provider failed"))
+
+    with pytest.raises(RuntimeError) as caught:
+        plugin.on_llm_execution_middleware(
+            session_id="s1",
+            provider="anthropic",
+            model="demo-model",
+            request={"messages": [{"role": "user", "content": "hi"}]},
+            next_call=next_call,
+        )
+
+    assert caught.value is relay_error
+
+
 def test_nemo_relay_adaptive_llm_execution_keeps_relay_translated_error(tmp_path, monkeypatch):
     fake = _FakeNemoRelay()
 
@@ -1094,6 +1125,36 @@ def test_nemo_relay_adaptive_tool_execution_keeps_unrelated_internal_error(tmp_p
             tool_name="terminal",
             args={"command": "pwd"},
             next_call=lambda args: {"raw": args},
+        )
+
+    assert caught.value is relay_error
+
+
+def test_nemo_relay_adaptive_tool_execution_keeps_wrapped_relay_error_after_downstream_failure(
+    tmp_path, monkeypatch
+):
+    fake = _FakeNemoRelay()
+    relay_error = RuntimeError("internal error: RuntimeError: relay policy blocked after downstream")
+
+    def translated_execute(name, args, func, **kwargs):
+        try:
+            return func({"intercepted": True, **args})
+        except Exception:
+            raise relay_error
+
+    fake.tools.execute = translated_execute
+    plugin = _fresh_plugin(monkeypatch, fake)
+    _enable_adaptive_plugin(tmp_path, monkeypatch)
+
+    def next_call(args):
+        raise _wrapped_downstream_error(RuntimeError("tool failed"))
+
+    with pytest.raises(RuntimeError) as caught:
+        plugin.on_tool_execution_middleware(
+            session_id="s1",
+            tool_name="terminal",
+            args={"command": "pwd"},
+            next_call=next_call,
         )
 
     assert caught.value is relay_error


### PR DESCRIPTION
## What does this PR do?

This fixes NeMo Relay adaptive execution so downstream provider/tool errors are not hidden when Relay's managed execution boundary reports callback failures as internal runtime errors.

In adaptive mode, Hermes passes real LLM and tool execution through `nemo_relay.llm.execute(...)` and `nemo_relay.tools.execute(...)`. If the downstream callback fails and Relay wraps that callback failure as an internal error, Hermes can lose the original provider/tool exception. That can affect retry classification and user-facing error handling.

This change preserves the original downstream exception only for Relay internal wrapper failures. Relay-translated errors, such as policy or guardrail failures, remain Relay-owned.

## Related Issue

No public issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updated `plugins/observability/nemo_relay/__init__.py` to preserve original downstream LLM/tool exceptions only when NeMo Relay reports the exact callback-wrapper failure shape.
- Kept Relay-translated exceptions intact so Relay policy/guardrail behavior is not overwritten by Hermes.
- Added regression coverage in `tests/plugins/test_nemo_relay_plugin.py` for LLM and tool adaptive execution failure paths, including downstream error preservation, Relay-translated errors, unrelated internal Relay error pass-through, and wrapped Relay/intercept errors after downstream failure.

## How to Test

1. `scripts/run_tests.sh tests/plugins/test_nemo_relay_plugin.py -- -q`
2. `uv run python -m pytest -q tests/plugins/test_nemo_relay_plugin.py`
3. `uv run python -m pytest -q tests/hermes_cli/test_plugins.py tests/plugins/test_nemo_relay_plugin.py`
4. `uv run ruff check plugins/observability/nemo_relay/__init__.py tests/plugins/test_nemo_relay_plugin.py`

I also ran the full `scripts/run_tests.sh`; it failed in unrelated existing/environment-sensitive suites outside this PR's touched surface.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

N/A - regression covered by automated tests.
