### PR TITLE
fix(kanban): inherit board default_workdir when auto-decomposing scratch-workspace tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4490,6 +4490,19 @@ def decompose_triage_task(
         # override with its own 'workspace_kind' / 'workspace_path'.
         root_ws_kind = root_row["workspace_kind"] or "scratch"
         root_ws_path = root_row["workspace_path"]
+        # When the root task was created with the default scratch workspace
+        # (no explicit path), fall back to the board's default_workdir so
+        # children land in the project directory rather than a throwaway
+        # kanban scratch dir. The root itself is also upgraded so its
+        # orchestration run shares the same directory.
+        _board_ws_upgraded = False
+        if root_ws_kind == "scratch" and not root_ws_path:
+            _board_meta = read_board_metadata()
+            _board_default = _board_meta.get("default_workdir")
+            if _board_default:
+                root_ws_kind = "dir"
+                root_ws_path = str(_board_default)
+                _board_ws_upgraded = True
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -4562,11 +4575,18 @@ def decompose_triage_task(
             )
 
         # Flip the root: triage -> todo, set assignee to the orchestrator.
+        # Also persist the resolved board workspace so the orchestration
+        # run lands in the project directory (not a kanban scratch dir).
         sets = ["status = 'todo'"]
         params: list[Any] = []
         if root_assignee is not None:
             sets.append("assignee = ?")
             params.append(root_assignee)
+        if _board_ws_upgraded:
+            sets.append("workspace_kind = ?")
+            sets.append("workspace_path = ?")
+            params.append(root_ws_kind)
+            params.append(root_ws_path)
         params.append(task_id)
         conn.execute(
             f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?",

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -206,6 +206,32 @@ def test_decompose_children_stay_scratch_when_root_scratch(kanban_home):
     assert t.workspace_path is None
 
 
+def test_decompose_children_inherit_board_default_workdir(kanban_home):
+    """Scratch root with board default_workdir → children land in project dir."""
+    proj = "/data/ai-branch"
+    kb.write_board_metadata(board=None, default_workdir=proj)
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="scratch root no path", assignee="worker",
+            workspace_kind="scratch", triage=True,
+        )
+        child_ids = kb.decompose_triage_task(
+            conn, tid, root_assignee="orchestrator",
+            children=[{"title": "c1"}, {"title": "c2"}],
+            author="decomposer",
+        )
+    assert child_ids and len(child_ids) == 2
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        for cid in child_ids:
+            t = kb.get_task(conn, cid)
+            assert t.workspace_kind == "dir", f"child {cid} should be dir, got {t.workspace_kind}"
+            assert t.workspace_path == proj, f"child {cid} workspace_path mismatch"
+    # Root itself is also upgraded so its orchestration run lands in the project dir.
+    assert root.workspace_kind == "dir"
+    assert root.workspace_path == proj
+
+
 def test_decompose_per_child_workspace_override(kanban_home):
     """An explicit per-child workspace beats inheritance."""
     proj = "/home/teknium/myproject"


### PR DESCRIPTION
## Problem

When a triage task is created without an explicit workspace (the default `workspace_kind='scratch'` with no `workspace_path`), the **auto-decompose** fan-out propagates that unset workspace to every child task. When those children are dispatched, `resolve_workspace` creates a fresh throwaway directory under `kanban/workspaces/<task-id>/` — completely disconnected from the user's actual project directory.

The symptom: workers on decomposed child tasks find no project code in their working directory and fall back to `git clone`-ing the repo from scratch, even though the user had a fully-checked-out project at e.g. `/data/ai-branch`.

## Root cause

`decompose_triage_task` in `hermes_cli/kanban_db.py` correctly inherits the root task's workspace for children (the existing code at `child_ws_path = root_ws_path`). But if the root task itself was created with the default `scratch` + no path, there is nothing meaningful to inherit — both root and children end up with `workspace_kind='scratch'` and `workspace_path=None`, triggering a fresh temp dir on dispatch.

The board-level `default_workdir` (already used by `create_task` for `dir`/`worktree` tasks) was not consulted during decomposition for the `scratch` fallback case.

## Fix

In `decompose_triage_task`, after reading the root task's workspace, add a fallback:

```python
if root_ws_kind == "scratch" and not root_ws_path:
    _board_meta = read_board_metadata()
    _board_default = _board_meta.get("default_workdir")
    if _board_default:
        root_ws_kind = "dir"
        root_ws_path = str(_board_default)
        _board_ws_upgraded = True
```

When the root has no explicit workspace **and** the board has a `default_workdir` configured, we upgrade both the root and all children to `workspace_kind='dir'` pointing at the board's project directory. This is done atomically inside the existing `write_txn`, so no partial state is possible.

The root orchestration task (flipped from `triage → todo`) is also updated so its own run — when all children complete and it wakes up — lands in the same project directory.

## Behaviour matrix

| Root workspace | Board `default_workdir` | Children get |
|---|---|---|
| `dir:/data/ai-branch` (explicit) | any | `dir:/data/ai-branch` ✅ (unchanged) |
| `scratch` (no path) | `/data/ai-branch` | `dir:/data/ai-branch` ✅ **(new)** |
| `scratch` (no path) | *(not set)* | `scratch` (tmp dir) — unchanged |
| `worktree` | any | `worktree` (unchanged) |

## How to use

Make sure the board for your project has `default_workdir` set:

```bash
hermes kanban boards edit --default-workdir /data/ai-branch
```

Triage tasks dropped into that board will now fan out into child tasks that run directly inside `/data/ai-branch`, with no git-clone side-effect.

## Tests

Added `test_decompose_children_inherit_board_default_workdir` to `tests/hermes_cli/test_kanban_decompose_db.py`:

- Verifies children get `workspace_kind='dir'` and `workspace_path=<default_workdir>` when the root is scratch + no path and the board has `default_workdir` set.
- Verifies the root task itself is also upgraded.
- Existing `test_decompose_children_stay_scratch_when_root_scratch` still passes (board without `default_workdir` is unaffected).

All 12 tests in `test_kanban_decompose_db.py` pass.