### PR TITLE
fix(gateway): support Discord progress cleanup

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1522,6 +1522,50 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a Discord message by channel/thread ID and message ID.
+
+        The gateway uses this for best-effort cleanup of temporary progress
+        bubbles after the final response is delivered. Discord deletes require
+        the channel (or thread) ID that owns the message, so ``chat_id`` is
+        resolved the same way as ``send()`` resolves its target channel.
+        """
+        if not self._client:
+            return False
+
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                logger.debug("[%s] Discord delete target channel %s not found", self.name, chat_id)
+                return False
+
+            message = await channel.fetch_message(int(message_id))
+            await message.delete()
+            return True
+        except Exception as e:  # pragma: no cover - defensive logging
+            err_text = str(e)
+            if "10008" in err_text or "unknown message" in err_text.lower():
+                # Already gone: treat as successful cleanup so callers don't
+                # keep trying to delete stale progress bubbles.
+                logger.debug(
+                    "[%s] Discord message %s/%s already deleted: %s",
+                    self.name,
+                    chat_id,
+                    message_id,
+                    e,
+                )
+                return True
+            logger.debug(
+                "[%s] Failed to delete Discord message %s/%s: %s",
+                self.name,
+                chat_id,
+                message_id,
+                e,
+            )
+            return False
+
     async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 

--- a/tests/gateway/test_discord_delete_message.py
+++ b/tests/gateway/test_discord_delete_message.py
@@ -1,0 +1,87 @@
+"""Tests for DiscordAdapter.delete_message cleanup support."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import BasePlatformAdapter
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+class _FakeClient:
+    def __init__(self, channel=None, fetched_channel=None):
+        self.channel = channel
+        self.fetched_channel = fetched_channel
+        self.fetch_channel = AsyncMock(return_value=fetched_channel)
+
+    def get_channel(self, channel_id):
+        self.last_get_channel_id = channel_id
+        return self.channel
+
+
+def _adapter(client):
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter._client = client
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_delete_message_overrides_base_adapter():
+    assert DiscordAdapter.delete_message is not BasePlatformAdapter.delete_message
+
+
+@pytest.mark.asyncio
+async def test_delete_message_deletes_message_from_cached_channel():
+    message = SimpleNamespace(delete=AsyncMock())
+    channel = SimpleNamespace(fetch_message=AsyncMock(return_value=message))
+    adapter = _adapter(_FakeClient(channel=channel))
+
+    assert await adapter.delete_message("123", "456") is True
+
+    channel.fetch_message.assert_awaited_once_with(456)
+    message.delete.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_delete_message_fetches_channel_when_not_cached():
+    message = SimpleNamespace(delete=AsyncMock())
+    channel = SimpleNamespace(fetch_message=AsyncMock(return_value=message))
+    client = _FakeClient(channel=None, fetched_channel=channel)
+    adapter = _adapter(client)
+
+    assert await adapter.delete_message("123", "456") is True
+
+    client.fetch_channel.assert_awaited_once_with(123)
+    channel.fetch_message.assert_awaited_once_with(456)
+    message.delete.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_delete_message_returns_false_when_not_connected():
+    adapter = _adapter(None)
+
+    assert await adapter.delete_message("123", "456") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_message_treats_unknown_message_as_cleaned_up():
+    channel = SimpleNamespace(
+        fetch_message=AsyncMock(
+            side_effect=Exception("404 Not Found (error code: 10008): Unknown Message")
+        )
+    )
+    adapter = _adapter(_FakeClient(channel=channel))
+
+    assert await adapter.delete_message("123", "456") is True
+
+
+@pytest.mark.asyncio
+async def test_delete_message_returns_false_on_delete_failure():
+    message = SimpleNamespace(delete=AsyncMock(side_effect=Exception("Missing Permissions")))
+    channel = SimpleNamespace(fetch_message=AsyncMock(return_value=message))
+    adapter = _adapter(_FakeClient(channel=channel))
+
+    assert await adapter.delete_message("123", "456") is False


### PR DESCRIPTION
## Summary
Discord tool-progress bubbles can now be cleaned up after the final response is delivered.

The gateway already has a `cleanup_progress` path that deletes temporary progress messages when an adapter implements `delete_message()`. Telegram and other adapters can participate in that path, but Discord still inherited the base adapter no-op. As a result, setting `display.platforms.discord.cleanup_progress: true` looked valid but the gateway silently disabled cleanup for Discord at runtime, leaving stale tool-progress bubbles in the channel.

## Changes
- `plugins/platforms/discord/adapter.py`: implement `DiscordAdapter.delete_message(chat_id, message_id)` using the Discord channel/thread ID plus message ID.
  - resolves the target via `client.get_channel()` and falls back to `fetch_channel()`
  - fetches the message from that channel/thread and calls `message.delete()`
  - returns `False` when the adapter is not connected or deletion fails
  - treats Discord `10008 Unknown Message` as already cleaned up, so stale queue entries do not keep failing
- `tests/gateway/test_discord_delete_message.py`: add focused coverage for the Discord cleanup contract.

## Why this matters
Without this adapter method, the existing gateway cleanup code detects that Discord is still using `BasePlatformAdapter.delete_message` and disables cleanup even when the config flag is enabled. This PR connects Discord to the already-existing cleanup mechanism instead of changing the gateway flow.

## Validation
| Case | Result |
|---|---|
| Discord adapter overrides base `delete_message()` | covered |
| cached channel delete path | covered |
| `fetch_channel()` fallback path | covered |
| not connected | returns `False` |
| Discord `10008 Unknown Message` | treated as already cleaned |
| delete failure / missing permissions | returns `False` |

Local:
- `python -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_delete_message.py`
- `python -m ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_delete_message.py`
- `python -m pytest tests/gateway/test_discord_delete_message.py tests/gateway/test_run_cleanup_progress.py -q -o 'addopts='` → 11 passed

PR CI is green on the required checks at the time of this update.