### PR TITLE
fix(usage): add fallback field names for cache_read_tokens parsing

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -745,8 +745,16 @@ def normalize_usage(
         # missed when the proxy only surfaces them at the top level.
         # Port of cline/cline#10266.
         cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        if not cache_read_tokens and details:
+            # Some OpenAI-compatible providers (e.g. MiMo/xiaomi) expose
+            # cache hit counts under non-standard field names.
+            cache_read_tokens = _to_int(getattr(details, "cache_hit_tokens", 0))
+        if not cache_read_tokens and details:
+            cache_read_tokens = _to_int(getattr(details, "hit_tokens", 0))
         if not cache_read_tokens:
             cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
+        if not cache_read_tokens:
+            cache_read_tokens = _to_int(getattr(response_usage, "cache_tokens", 0))
         cache_write_tokens = _to_int(
             getattr(details, "cache_write_tokens", 0) if details else 0
         )


### PR DESCRIPTION
## Fixes #42617

### Problem
MiMo (xiaomi) provider returns cache hit data in the API response, but `normalize_usage()` doesn't find it because MiMo uses non-standard field names in `prompt_tokens_details`. This causes:
- `cache_read_tokens = 0` (should be ~2M)
- `input_tokens` inflated by ~3.9x (includes cache hits as miss tokens)

### Root Cause
The OpenAI-compatible branch in `normalize_usage()` only checks:
1. `details.cached_tokens` (standard OpenAI field)
2. `response_usage.cache_read_input_tokens` (Anthropic-style fallback)

MiMo likely uses alternative field names like `cache_hit_tokens` or `hit_tokens` in `prompt_tokens_details`.

### Fix
Added additional fallback checks in the OpenAI-compatible branch:
- `details.cache_hit_tokens` — some Chinese LLM providers use this
- `details.hit_tokens` — another variant
- `response_usage.cache_tokens` — top-level fallback

### Safety
All new checks are guarded by `if not cache_read_tokens` — they only activate when the standard fields return 0. No behavior change for providers that use standard OpenAI field names.

### Testing
- Verify with MiMo API: `state.db` should show `cache_read_tokens > 0` after a multi-turn conversation
- Verify with standard OpenAI provider: no behavior change
