### PR TITLE
fix(desktop): stop archived todo rows from looking live after turn completion

### DIFF
--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -726,6 +726,30 @@ describe('assistant-ui streaming renderer', () => {
     expect(archivedUi.getAllByText('Serve latte').length).toBeGreaterThan(0)
   })
 
+  it('renders archived unfinished todos without a running spinner after turn completion', () => {
+    const todos = [
+      { content: 'Scan large cache and log dirs', id: 'scan-caches', status: 'completed' as const },
+      { content: 'Check trash and downloads leftovers', id: 'scan-trash-downloads', status: 'completed' as const },
+      { content: 'Summarize reclaim candidates safely', id: 'summarize', status: 'completed' as const },
+      { content: 'Inventory deletable downloads archives', id: 'inventory-downloads', status: 'completed' as const },
+      { content: 'Delete archive files and caches', id: 'delete-targets', status: 'completed' as const },
+      { content: 'Verify freed space', id: 'verify-space', status: 'pending' as const },
+      { content: 'Move archives and caches to Trash', id: 'trash-targets', status: 'in_progress' as const }
+    ]
+
+    const { container } = render(<TodoHarness message={assistantTodoMessage(todos, false)} />)
+    const ui = within(container)
+    const panel = container.querySelector('[data-slot="aui_todo-hoisted"]')
+
+    expect(panel).toBeTruthy()
+    expect(ui.getAllByText('Move archives and caches to Trash').length).toBeGreaterThan(0)
+    expect(ui.getAllByText('Verify freed space').length).toBeGreaterThan(0)
+    expect(ui.queryByLabelText('In progress: Move archives and caches to Trash')).toBeNull()
+    expect(ui.getByLabelText('Incomplete: Move archives and caches to Trash')).toBeTruthy()
+    expect(container.querySelectorAll('[data-slot="checkbox"][data-state="checked"]').length).toBe(5)
+    expect(container.querySelectorAll('[data-slot="checkbox"][data-state="unchecked"]').length).toBe(2)
+  })
+
   it('hoists todo outside the thinking disclosure when reasoning is present', () => {
     const { container } = render(
       <TodoHarness

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -237,7 +237,7 @@ const AssistantMessage: FC<{ onBranchInNewChat?: (messageId: string) => void }> 
         className="wrap-anywhere min-w-0 max-w-full overflow-hidden text-pretty text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground"
         data-slot="aui_assistant-message-content"
       >
-        {hoistedTodos.length > 0 && <HoistedTodoPanel todos={hoistedTodos} />}
+        {hoistedTodos.length > 0 && <HoistedTodoPanel active={messageStatus === 'running'} todos={hoistedTodos} />}
         <MessagePrimitive.Parts components={MESSAGE_PARTS_COMPONENTS} />
         {messageStatus === 'running' && <StreamStallIndicator activity={`${content.length}:${messageText.length}`} />}
         {previewTargets.length > 0 && (

--- a/apps/desktop/src/components/assistant-ui/todo-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/todo-tool.tsx
@@ -5,6 +5,14 @@ import { Loader2Icon } from '@/lib/icons'
 import { parseTodos, type TodoItem, type TodoStatus } from '@/lib/todos'
 import { cn } from '@/lib/utils'
 
+type TodoDisplayState = 'cancelled' | 'completed' | 'incomplete' | 'running'
+
+interface TodoPresentation {
+  ariaLabel: string
+  checked: boolean
+  displayState: TodoDisplayState
+}
+
 export function todosFromMessageContent(content: unknown): TodoItem[] {
   if (!Array.isArray(content)) {
     return []
@@ -33,17 +41,100 @@ export function todosFromMessageContent(content: unknown): TodoItem[] {
   return latest ?? []
 }
 
-const headerLabel = (todos: readonly TodoItem[]): string =>
-  todos.find(t => t.status === 'in_progress')?.content ??
-  todos.find(t => t.status === 'pending')?.content ??
-  todos.at(-1)?.content ??
-  'Tasks'
+function displayState(status: TodoStatus, active: boolean): TodoDisplayState {
+  if (status === 'completed') {
+    return 'completed'
+  }
 
-const Checkmark: FC<{ status: TodoStatus; label: string }> = ({ status, label }) => {
-  if (status === 'in_progress') {
+  if (status === 'cancelled') {
+    return 'cancelled'
+  }
+
+  if (status === 'in_progress' && active) {
+    return 'running'
+  }
+
+  return 'incomplete'
+}
+
+function headerPriority(state: TodoDisplayState): number {
+  switch (state) {
+    case 'running':
+      return 0
+    case 'incomplete':
+      return 1
+    case 'completed':
+      return 2
+    case 'cancelled':
+      return 3
+  }
+}
+
+function rowOpacityClass(state: TodoDisplayState): string {
+  switch (state) {
+    case 'running':
+      return 'opacity-100'
+    case 'incomplete':
+      return 'opacity-70'
+    case 'completed':
+    case 'cancelled':
+      return 'opacity-45'
+  }
+}
+
+function presentTodo(status: TodoStatus, label: string, active: boolean): TodoPresentation {
+  const state = displayState(status, active)
+
+  if (state === 'running') {
+    return {
+      ariaLabel: `In progress: ${label}`,
+      checked: false,
+      displayState: state
+    }
+  }
+
+  if (state === 'cancelled') {
+    return {
+      ariaLabel: `Cancelled: ${label}`,
+      checked: false,
+      displayState: state
+    }
+  }
+
+  if (state === 'completed') {
+    return {
+      ariaLabel: label,
+      checked: true,
+      displayState: state
+    }
+  }
+
+  return {
+    ariaLabel: `Incomplete: ${label}`,
+    checked: false,
+    displayState: state
+  }
+}
+
+function headerLabel(todos: readonly TodoItem[], active: boolean): string {
+  const primary = todos.reduce<{ item: TodoItem; priority: number } | null>((best, todo) => {
+    const priority = headerPriority(displayState(todo.status, active))
+
+    if (!best || priority < best.priority) {
+      return { item: todo, priority }
+    }
+
+    return best
+  }, null)
+
+  return primary?.item.content ?? todos.at(-1)?.content ?? 'Tasks'
+}
+
+const Checkmark: FC<{ presentation: TodoPresentation }> = ({ presentation }) => {
+  if (presentation.displayState === 'running') {
     return (
       <span
-        aria-label={`In progress: ${label}`}
+        aria-label={presentation.ariaLabel}
         className="grid size-[1.1rem] shrink-0 place-items-center rounded-full border border-ring/65 bg-[color-mix(in_srgb,var(--dt-ring)_14%,transparent)]"
       >
         <Loader2Icon className="size-3 animate-spin text-ring" />
@@ -51,29 +142,27 @@ const Checkmark: FC<{ status: TodoStatus; label: string }> = ({ status, label })
     )
   }
 
-  const checked = status === 'completed'
-
   return (
     <Checkbox
-      aria-label={label}
-      checked={checked}
+      aria-label={presentation.ariaLabel}
+      checked={presentation.checked}
       className={cn(
         'size-[1.1rem] shrink-0 rounded-full border-border/80 pointer-events-none disabled:cursor-default disabled:opacity-100',
-        checked &&
+        presentation.checked &&
           'data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground [&_[data-slot=checkbox-indicator]_svg]:size-3',
-        status === 'cancelled' && 'border-muted-foreground/40'
+        presentation.displayState === 'cancelled' && 'border-muted-foreground/40'
       )}
       disabled
     />
   )
 }
 
-export const HoistedTodoPanel: FC<{ todos: TodoItem[] }> = ({ todos }) => {
+export const HoistedTodoPanel: FC<{ active?: boolean; todos: TodoItem[] }> = ({ active = false, todos }) => {
   if (!todos.length) {
     return null
   }
 
-  const label = headerLabel(todos)
+  const label = headerLabel(todos, active)
 
   return (
     <section
@@ -89,20 +178,24 @@ export const HoistedTodoPanel: FC<{ todos: TodoItem[] }> = ({ todos }) => {
         </span>
       </header>
       <ul className="grid min-w-0 gap-0.5 px-3 pb-3">
-        {todos.map(todo => (
-          <li
-            // Active row at full presence; everything else fades. Opacity on
-            // the row so the checkbox glyph dims with the text.
-            className={cn(
-              'flex min-w-0 items-center gap-3 py-1.5 transition-opacity',
-              todo.status === 'in_progress' ? 'opacity-100' : 'opacity-45'
-            )}
-            key={todo.id}
-          >
-            <Checkmark label={todo.content} status={todo.status} />
-            <span className="min-w-0 wrap-anywhere text-[0.8rem] leading-[1.2rem] text-foreground">{todo.content}</span>
-          </li>
-        ))}
+        {todos.map(todo => {
+          const presentation = presentTodo(todo.status, todo.content, active)
+
+          return (
+            <li
+              className={cn(
+                'flex min-w-0 items-center gap-3 py-1.5 transition-opacity',
+                rowOpacityClass(presentation.displayState)
+              )}
+              key={todo.id}
+            >
+              <Checkmark presentation={presentation} />
+              <span className="min-w-0 wrap-anywhere text-[0.8rem] leading-[1.2rem] text-foreground">
+                {todo.content}
+              </span>
+            </li>
+          )
+        })}
       </ul>
     </section>
   )


### PR DESCRIPTION
## What does this PR do?

Fixes a Hermes Desktop renderer bug where the hoisted todo card could keep showing an archived `in_progress` row with a live-running affordance after the assistant turn had already completed.

The backend intentionally preserves the final todo snapshot, including unfinished items. The bug was in Desktop's rendering semantics: the UI treated any archived `in_progress` todo row as if it were still live, instead of checking whether the assistant message itself was still running.

This PR separates:
- live assistant execution state
- archived todo status from the final persisted snapshot

and only shows the spinner/running treatment while the assistant message is actually `running`.

## Related Issue

Fixes #42662

Related:
- #42649

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Pass assistant message running state into the hoisted todo panel in `apps/desktop/src/components/assistant-ui/thread.tsx`
- Refactor hoisted todo presentation in `apps/desktop/src/components/assistant-ui/todo-tool.tsx` to derive a small UI presentation model from `TodoStatus + active`
- Only render spinner / live-running affordance for `in_progress` rows while the assistant message is actually running
- Render archived unfinished rows as static incomplete items after turn completion
- Add a regression test for completed turns with archived unfinished todo rows in `apps/desktop/src/components/assistant-ui/streaming.test.tsx`

## How to Test

1. Start Hermes Desktop and send:
   `Make a todo list with two steps, mark the first completed and the second in_progress, then stop.`
2. While the message is still running, verify the `in_progress` todo row uses the live running affordance.
3. After the assistant message completes, verify the same row remains visible but no longer looks live or spinning.

Targeted validation run locally:
- `npm run type-check --workspace apps/desktop`
- `npm run test:ui --workspace apps/desktop -- src/components/assistant-ui/streaming.test.tsx -t "renders live todo rows during a running turn"`
- `npm run test:ui --workspace apps/desktop -- src/components/assistant-ui/streaming.test.tsx -t "renders archived unfinished todos without a running spinner after turn completion"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before:
<img width="689" height="629" alt="image" src="https://github.com/user-attachments/assets/a40aef38-2280-46f0-a2e8-22ed95564b97" />
- completed assistant turns could still show archived `in_progress` todo rows with a live-running spinner

After:
<img width="823" height="660" alt="image" src="https://github.com/user-attachments/assets/ec2670ba-2577-47c9-8722-74f0db6115c7" />
- completed assistant turns still show archived unfinished rows, but they render as static incomplete items instead of live-running rows
