### PR TITLE
fix(desktop): fix artifact timestamps rendering as jan 1970

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -265,6 +265,8 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         return
       }
 
+      const timestamp = message.timestamp || session.last_active || session.started_at || Date.now()
+
       found.set(key, {
         id: key,
         kind: artifactKind(value),
@@ -273,7 +275,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         label: artifactLabel(value),
         sessionId: session.id,
         sessionTitle: title,
-        timestamp: message.timestamp || session.last_active || session.started_at || Date.now()
+        timestamp: timestamp < 1e12 ? timestamp * 1000 : timestamp
       })
     })
   }

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -67,6 +67,21 @@ describe('collectArtifactsForSession', () => {
     })
   })
 
+  it.each([
+    ['epoch seconds', 1_720_000_000, 1_720_000_000_000],
+    ['epoch milliseconds', 1_720_000_000_000, 1_720_000_000_000]
+  ])('normalizes %s at the collection boundary', (_label, timestamp, expected) => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'https://example.com/artifact.pdf',
+        role: 'assistant',
+        timestamp
+      }
+    ])
+
+    expect(artifacts[0]?.timestamp).toBe(expected)
+  })
+
   it('resolves remote image artifact thumbnails through the desktop fs bridge', async () => {
     const api = vi.fn(async ({ path }: { path: string }) => {
       if (path.startsWith('/api/fs/read-data-url?')) {


### PR DESCRIPTION
## What does this PR do?

Artifacts view shows all timestamps as January 1970 because SessionDB stores epoch seconds but the Date constructor expects milliseconds. Normalize artifact timestamps to milliseconds at the collection boundary so sorting and display use consistent units.

## Related Issue

Fixes #42409

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- apps/desktop/src/app/artifacts/artifact-utils.ts: normalize collected timestamps to milliseconds while preserving millisecond inputs
- apps/desktop/src/app/artifacts/index.test.ts: cover epoch-second conversion and epoch-millisecond preservation

## How to Test

1. Open Hermes Desktop with existing session data
2. Navigate to Artifacts view
3. Verify timestamps show actual dates (e.g. Jun 9, 2026) instead of Jan 1970

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform: N/A — trivial normalization, cross-platform safe

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated cli-config.yaml.example — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — N/A
- [x] I've considered cross-platform impact — N/A (pure JS math, no platform assumptions)
- [x] I've updated tool descriptions/schemas — N/A