### PR TITLE
fix(browser): is_camofox_mode respects browser.cdp_url config

### DIFF
--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -61,12 +61,23 @@ def is_camofox_mode() -> bool:
     """True when Camofox backend is configured and no CDP override is active.
 
     When the user has explicitly connected to a live Chromium-family browser via
-    ``/browser connect`` (which sets ``BROWSER_CDP_URL``), the CDP connection
-    takes priority over Camofox so the browser tools operate on the real
-    browser instead of being silently routed to the Camofox backend.
+    ``/browser connect`` (which sets ``BROWSER_CDP_URL``), or has configured a
+    persistent CDP endpoint via ``browser.cdp_url`` in config.yaml, the CDP
+    connection takes priority over Camofox so the browser tools operate on the
+    real browser instead of being silently routed to the Camofox backend.
     """
     if os.getenv("BROWSER_CDP_URL", "").strip():
         return False
+    # If browser.cdp_url is set in config.yaml, CDP takes priority over Camofox.
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        cdp_url = cfg.get("browser", {}).get("cdp_url")
+        if cdp_url and str(cdp_url).strip():
+            return False
+    except Exception:
+        pass  # Can't read config; fall through to env-var check.
     return bool(get_camofox_url())
 
 


### PR DESCRIPTION
When CAMOFOX_URL env var is set but browser.cdp_url is also configured in config.yaml, CDP should take priority. Previously is_camofox_mode() only checked BROWSER_CDP_URL env var, ignoring the persistent config setting. This caused browser tools (navigate/snapshot/click/type/scroll) to silently route to a non-functional Camofox backend even when CDP was correctly configured.

The fix adds a check for browser.cdp_url from config.yaml before returning True from is_camofox_mode(), matching the same priority that _get_cdp_override() already uses.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

