### PR TITLE
fix(agent): forward platform kwarg at compression boundary to context engine

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -564,6 +564,7 @@ def compress_context(
                 agent.session_id or "",
                 boundary_reason="compression",
                 old_session_id=_old_sid,
+                platform=getattr(agent, "platform", None) or "cli",
                 conversation_id=getattr(agent, "_gateway_session_key", None),
             )
     except Exception as _ce_err:

--- a/tests/agent/test_compression_boundary_platform.py
+++ b/tests/agent/test_compression_boundary_platform.py
@@ -1,0 +1,142 @@
+"""Regression: compression boundary must forward platform to context engine.
+
+Issue #27633 -- when Hermes rotates session_id during context compression,
+the on_session_start call at the compression boundary omitted
+platform, causing plugin engines (e.g. hermes-lcm) that track
+per-session source lineage to reset _session_platform to '' to
+'unknown'.  All messages ingested after the compression boundary were
+attributed to source='unknown' instead of the actual platform.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+
+def _make_agent(platform: str = "telegram") -> MagicMock:
+    """Build a mock agent with enough attributes for compress_context."""
+    agent = MagicMock()
+    agent.platform = platform
+    agent.session_id = "old_session_123"
+    agent.model = "test-model"
+    agent.compression_enabled = True
+    agent._compression_feasibility_checked = True
+    agent._cached_system_prompt = "You are Hermes."
+    agent._gateway_session_key = "gw-key-001"
+    agent._session_todos = []
+    agent._session_todos_dirty = False
+    agent._last_compression_lock_error_sid = None
+    agent._last_compression_lock_warning_sid = None
+    agent._last_compression_summary_warning = None
+    agent._last_aux_fallback_warning_key = None
+    agent._compression_lock = None
+    agent._compression_lock_holder = None
+    agent._last_flushed_db_idx = 0
+    agent._memory_manager = None
+    agent._todo_store = MagicMock()
+    agent._todo_store.format_for_injection.return_value = ""
+    agent.log_prefix = ""
+
+    # context_compressor
+    agent.context_compressor.context_length = 128_000
+    agent.context_compressor.has_content_to_compress.return_value = True
+    agent.context_compressor._last_compress_aborted = False
+    agent.context_compressor._last_summary_error = None
+    agent.context_compressor._last_aux_model_failure_model = None
+    agent.context_compressor._last_aux_model_failure_error = None
+    agent.context_compressor.compression_count = 1
+    agent.context_compressor.compress.return_value = (
+        [{"role": "user", "content": "compressed"}],
+        "summary text",
+    )
+
+    # session_db
+    agent._session_db.get_session_title.return_value = "Test Session"
+    agent._session_db.try_acquire_compression_lock.return_value = True
+
+    # system prompt
+    agent._build_system_prompt.return_value = "system: test"
+    agent._invalidate_system_prompt = MagicMock()
+
+    return agent
+
+
+class TestCompressionBoundaryPlatform:
+    """compress_context must pass platform to on_session_start."""
+
+    def test_platform_forwarded_to_on_session_start(self):
+        """The compression boundary on_session_start must include platform."""
+        agent = _make_agent(platform="discord")
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+
+        from agent.conversation_compression import compress_context
+
+        compress_context(agent, messages, "system msg")
+
+        # Find the on_session_start call with boundary_reason="compression"
+        compressor = agent.context_compressor
+        start_calls = [
+            c for c in compressor.on_session_start.call_args_list
+            if "boundary_reason" in c.kwargs
+            and c.kwargs["boundary_reason"] == "compression"
+        ]
+
+        assert len(start_calls) == 1, (
+            f"Expected exactly 1 compression-boundary on_session_start call, "
+            f"got {len(start_calls)}: {compressor.on_session_start.call_args_list}"
+        )
+
+        call_kwargs = start_calls[0].kwargs
+        assert call_kwargs.get("platform") == "discord", (
+            f"platform not forwarded to on_session_start. "
+            f"Got kwargs: {call_kwargs}"
+        )
+
+    def test_platform_defaults_to_cli_when_none(self):
+        """When agent.platform is None/empty, platform should default to 'cli'."""
+        agent = _make_agent(platform="")
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+
+        from agent.conversation_compression import compress_context
+
+        compress_context(agent, messages, "system msg")
+
+        compressor = agent.context_compressor
+        start_calls = [
+            c for c in compressor.on_session_start.call_args_list
+            if "boundary_reason" in c.kwargs
+            and c.kwargs["boundary_reason"] == "compression"
+        ]
+
+        assert len(start_calls) == 1
+        assert start_calls[0].kwargs.get("platform") == "cli"
+
+    def test_platform_telegram_preserved(self):
+        """Verify 'telegram' platform survives compression boundary."""
+        agent = _make_agent(platform="telegram")
+        messages = [
+            {"role": "user", "content": "test"},
+            {"role": "assistant", "content": "reply"},
+        ]
+
+        from agent.conversation_compression import compress_context
+
+        compress_context(agent, messages, "system msg")
+
+        compressor = agent.context_compressor
+        start_calls = [
+            c for c in compressor.on_session_start.call_args_list
+            if "boundary_reason" in c.kwargs
+            and c.kwargs["boundary_reason"] == "compression"
+        ]
+
+        assert len(start_calls) == 1
+        assert start_calls[0].kwargs.get("platform") == "telegram"


### PR DESCRIPTION
## What does this PR do?

Forwards the `platform` kwarg at the compression boundary `on_session_start` call, so plugin context engines (e.g. hermes-lcm) that track per-session source lineage retain the correct platform attribution after context rotation.

## Related Issue

Fixes #27633

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py`: Add `platform=getattr(agent, "platform", None) or "cli"` to the compression boundary `on_session_start` call (line 567), matching the initial session start at `agent_init.py:1599` which already passes platform correctly.
- `tests/agent/test_compression_boundary_platform.py`: 3 regression tests verifying platform is forwarded (discord), defaults to "cli" when empty, and preserves platform name through the compression boundary.

## How to Test

1. Run `pytest tests/agent/test_compression_boundary_platform.py -v` — all 3 tests should pass
2. Run `pytest tests/gateway/test_compress_*.py -v` — existing compression tests should still pass
3. For manual testing: use a plugin context engine (e.g. hermes-lcm), start a Telegram/Discord session, trigger compression via context pressure, then check `lcm_status` — source lineage should show the correct platform (not "unknown") for messages after the compression boundary

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/conversation_compression.py:compress_context` (compression boundary on_session_start call)
- Compared: `agent/agent_init.py:1596` (initial session start — correctly passes platform)
- Blast radius: LOW — single kwarg addition, no control flow change, built-in ContextCompressor ignores kwargs
- Related patterns: The initial `on_session_start` at `agent_init.py:1596` already passes `platform=agent.platform or "cli"`. This fix ensures the compression boundary matches that pattern.
