### PR TITLE
fix(matrix): sanitize markdown library HTML output to prevent injection

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -2798,6 +2798,57 @@ class MatrixAdapter(BasePlatformAdapter):
         parts = mxc_url[6:]  # strip mxc://
         return f"{self._homeserver}/_matrix/client/v1/media/download/{parts}"
 
+    # Tags that the Matrix HTML spec (org.matrix.custom.html) allows.
+    _MATRIX_ALLOWED_TAGS: set[str] = {
+        "font", "del", "h1", "h2", "h3", "h4", "h5", "h6",
+        "blockquote", "p", "a", "ul", "ol", "sup", "sub",
+        "li", "b", "u", "strong", "em", "i", "s", "code",
+        "hr", "br", "div", "table", "thead", "tbody",
+        "tr", "th", "td", "caption", "pre", "span", "img",
+        "details", "summary",
+    }
+
+    # Event-handler attributes that must never appear in outbound HTML.
+    _DANGEROUS_ATTR_RE: "re.Pattern[str]" = re.compile(
+        r"""\s+on\w+\s*=\s*(['"][^'"]*['"]|\S+)""",
+        re.IGNORECASE,
+    )
+
+    @staticmethod
+    def _sanitize_html_output(html: str) -> str:
+        """Sanitize HTML output from the ``markdown`` library.
+
+        The ``markdown`` library preserves raw inline HTML and does not
+        filter dangerous URL schemes.  This method applies three layers
+        of protection:
+
+        1. Strip ``href`` values with ``javascript:``, ``data:``, or
+           ``vbscript:`` schemes (reuses :meth:`_sanitize_link_url`).
+        2. Strip event-handler attributes (``onclick``, ``onerror``, …)
+           from all tags.
+        3. Escape any raw HTML tags that are not in the Matrix-allowed
+           set to prevent content injection via ``<script>`` etc.
+        """
+        # 1. Sanitize dangerous URL schemes in href attributes.
+        html = re.sub(
+            r'href="([^"]*)"',
+            lambda m: f'href="{MatrixAdapter._sanitize_link_url(m.group(1))}"',
+            html,
+        )
+
+        # 2. Strip event-handler attributes (onclick, onerror, onload, …).
+        html = MatrixAdapter._DANGEROUS_ATTR_RE.sub("", html)
+
+        # 3. Escape disallowed HTML tags.
+        def _escape_tag(m: "re.Match[str]") -> str:
+            tag = m.group(1).split()[0].split("/")[0].lower()
+            if tag in MatrixAdapter._MATRIX_ALLOWED_TAGS:
+                return m.group(0)
+            return _html_escape(m.group(0))
+
+        html = re.sub(r"<(/?\w[^>]*)/?>", _escape_tag, html)
+        return html
+
     def _markdown_to_html(self, text: str) -> str:
         """Convert Markdown to Matrix-compatible HTML (org.matrix.custom.html).
 
@@ -2818,6 +2869,8 @@ class MatrixAdapter(BasePlatformAdapter):
 
             html = md.convert(text)
             md.reset()
+
+            html = self._sanitize_html_output(html)
 
             if html.count("<p>") == 1:
                 html = html.replace("<p>", "").replace("</p>", "")

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1854,6 +1854,110 @@ class TestMatrixMarkdownHtmlSecurity:
 
 
 # ---------------------------------------------------------------------------
+# _sanitize_html_output: unit tests
+# ---------------------------------------------------------------------------
+
+class TestMatrixSanitizeHtmlOutput:
+    """Tests for _sanitize_html_output — post-processing on markdown library output."""
+
+    def setup_method(self):
+        from gateway.platforms.matrix import MatrixAdapter
+        self.sanitize = MatrixAdapter._sanitize_html_output
+
+    def test_javascript_href_stripped(self):
+        """javascript: URLs in href attributes must be stripped."""
+        result = self.sanitize('<a href="javascript:alert(1)">click</a>')
+        assert 'href="javascript:' not in result
+
+    def test_data_href_stripped(self):
+        """data: URLs in href attributes must be stripped."""
+        result = self.sanitize('<a href="data:text/html,<script>">click</a>')
+        assert 'href="data:' not in result
+
+    def test_vbscript_href_stripped(self):
+        """vbscript: URLs in href attributes must be stripped."""
+        result = self.sanitize('<a href="vbscript:bad">click</a>')
+        assert 'href="vbscript:' not in result
+
+    def test_safe_href_preserved(self):
+        """Safe https: URLs must be preserved."""
+        result = self.sanitize('<a href="https://example.com">link</a>')
+        assert 'href="https://example.com"' in result
+
+    def test_script_tag_escaped(self):
+        """<script> tags must be escaped (not in allowed set)."""
+        result = self.sanitize('<script>alert(1)</script>')
+        assert '<script>' not in result
+        assert '&lt;script&gt;' in result
+
+    def test_img_onerror_stripped(self):
+        """<img> is allowed but onerror attribute must be stripped."""
+        result = self.sanitize('<img src=x onerror="alert(1)">')
+        assert 'onerror' not in result
+        assert '<img' in result  # tag itself is allowed
+
+    def test_allowed_tags_preserved(self):
+        """Matrix-allowed tags must pass through."""
+        result = self.sanitize('<strong>bold</strong> <em>italic</em> <code>code</code>')
+        assert '<strong>' in result
+        assert '<em>' in result
+        assert '<code>' in result
+
+    def test_allowed_block_tags_preserved(self):
+        """Block-level allowed tags must pass through."""
+        result = self.sanitize('<blockquote>quote</blockquote>')
+        assert '<blockquote>' in result
+
+    def test_self_closing_img_allowed(self):
+        """<img> is in the allowed set but must not carry onerror."""
+        result = self.sanitize('<img src="https://example.com/img.png" />')
+        assert '<img' in result
+
+
+# ---------------------------------------------------------------------------
+# _markdown_to_html: security tests on the primary (markdown library) path
+# ---------------------------------------------------------------------------
+
+class TestMatrixMarkdownToHtmlSecurity:
+    """Tests for HTML injection prevention in the primary _markdown_to_html path."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def test_javascript_link_sanitized(self):
+        """[text](javascript:...) must not survive in formatted_body."""
+        result = self.adapter._markdown_to_html("[click](javascript:alert(1))")
+        assert 'href="javascript:' not in result
+
+    def test_data_link_sanitized(self):
+        """[text](data:...) must not survive in formatted_body."""
+        result = self.adapter._markdown_to_html("[click](data:text/html,<script>)")
+        assert 'href="data:' not in result
+
+    def test_script_tag_escaped(self):
+        """Raw <script> tags must be escaped."""
+        result = self.adapter._markdown_to_html("<script>alert(1)</script>")
+        assert '<script>' not in result
+
+    def test_img_onerror_neutralized(self):
+        """Raw <img onerror=...> must be escaped or stripped."""
+        result = self.adapter._markdown_to_html('<img src=x onerror="alert(1)">')
+        # Either the tag is HTML-escaped (safe) or onerror is stripped (safe)
+        assert '&lt;img' in result or 'onerror' not in result
+
+    def test_safe_markdown_still_works(self):
+        """Normal markdown formatting must not be broken by sanitization."""
+        result = self.adapter._markdown_to_html("**bold** and *italic*")
+        assert '<strong>' in result or '<b>' in result
+        assert '<em>' in result or '<i>' in result
+
+    def test_safe_link_preserved(self):
+        """Normal links must survive sanitization."""
+        result = self.adapter._markdown_to_html("[example](https://example.com)")
+        assert 'href="https://example.com"' in result
+
+
+# ---------------------------------------------------------------------------
 # Markdown to HTML: extended formatting tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

The `markdown` library (used in `_markdown_to_html()` when available) preserves raw inline HTML and does not filter dangerous URL schemes. This means attacker-controlled text passed through the Matrix adapter's rich-text pipeline can inject:

- **Raw HTML**: `<img src=x onerror="alert(1)">` survives into `formatted_body`
- **Dangerous URLs**: `[click](javascript:alert(1))` becomes `<a href="javascript:alert(1)">`

The existing `_markdown_to_html_fallback()` path already sanitizes output via `_sanitize_link_url()` and HTML escaping, but the primary `markdown` library path had no post-processing.

## Fix

Add `_sanitize_html_output()` static method with three layers of protection:

1. **URL scheme sanitization** — reuses `_sanitize_link_url()` to strip `javascript:`, `data:`, `vbscript:` from `href` attributes
2. **Event-handler attribute stripping** — removes `onclick`, `onerror`, `onload`, etc. from all tags
3. **Disallowed tag escaping** — escapes HTML tags not in the Matrix `org.matrix.custom.html` allowed set (`<script>`, `<iframe>`, etc.)

Called in `_markdown_to_html()` immediately after `md.convert(text)` and before the `<p>` unwrapping logic.

## Testing

- 9 new unit tests for `_sanitize_html_output()` (URL sanitization, tag escaping, attribute stripping, allowed-tag preservation)
- 6 new integration tests for the primary `_markdown_to_html()` path with security payloads
- All 23 existing markdown tests continue to pass

Closes #42667
