### PR TITLE
fix: emit Codex gpt-5.5 autoraise notice once

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -68,6 +68,18 @@ def _ra():
     return run_agent
 
 
+_codex_gpt55_notice_emitted = False
+
+
+def _claim_codex_gpt55_autoraise_notice() -> bool:
+    """Return True once per process for the Codex gpt-5.5 autoraise notice."""
+    global _codex_gpt55_notice_emitted
+    if _codex_gpt55_notice_emitted:
+        return False
+    _codex_gpt55_notice_emitted = True
+    return True
+
+
 def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
     """Build the one-time notice shown when Codex gpt-5.5 raises compaction.
 
@@ -1684,7 +1696,7 @@ def init_agent(
         # gateway users get the same text replayed via _compression_warning on
         # turn 1 (set below, after the warning slot is initialized).
         _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled:
+        if _autoraise and compression_enabled and _claim_codex_gpt55_autoraise_notice():
             print(_build_codex_gpt55_autoraise_notice(_autoraise))
 
     # Check immediately so CLI users see the warning at startup.
@@ -1695,7 +1707,7 @@ def init_agent(
     # above only reaches the CLI, so stash the same text here to be replayed
     # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
     _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
+    if _autoraise and compression_enabled and _claim_codex_gpt55_autoraise_notice():
         agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network

--- a/tests/agent/test_codex_gpt55_notice_once.py
+++ b/tests/agent/test_codex_gpt55_notice_once.py
@@ -1,0 +1,100 @@
+"""Tests for the Codex gpt-5.5 auto-compaction notice de-dupe."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+# Stub optional heavy imports so run_agent imports cleanly in isolation.
+_fire = types.ModuleType("fire")
+setattr(_fire, "Fire", lambda *a, **k: None)
+_firecrawl = types.ModuleType("firecrawl")
+setattr(_firecrawl, "Firecrawl", object)
+sys.modules.setdefault("fire", _fire)
+sys.modules.setdefault("firecrawl", _firecrawl)
+sys.modules.setdefault("fal_client", types.ModuleType("fal_client"))
+
+
+def _write_config(home, extra: str = "") -> None:
+    (home / ".env").write_text("", encoding="utf-8")
+    (home / "config.yaml").write_text(extra or "{}\n", encoding="utf-8")
+
+
+def _make_agent(
+    tmp_path,
+    monkeypatch,
+    *,
+    model: str = "gpt-5.5",
+    provider: str = "openai-codex",
+    quiet_mode: bool = True,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from run_agent import AIAgent
+
+    return AIAgent(
+        model=model,
+        provider=provider,
+        api_key="sk-dummy",
+        base_url="https://chatgpt.com/backend-api/codex",
+        quiet_mode=quiet_mode,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="weixin",
+    )
+
+
+def test_codex_gpt55_autoraise_notice_is_emitted_once_per_process(tmp_path, monkeypatch):
+    from agent import agent_init
+
+    _write_config(tmp_path)
+    monkeypatch.setattr(agent_init, "_codex_gpt55_notice_emitted", False)
+
+    first = _make_agent(tmp_path, monkeypatch)
+    second = _make_agent(tmp_path, monkeypatch)
+
+    first_warning = getattr(first, "_compression_warning", None)
+    second_warning = getattr(second, "_compression_warning", None)
+
+    assert first_warning is not None
+    assert "Codex gpt-5.5 caps context" in first_warning
+    assert second_warning is None
+
+
+def test_codex_gpt55_autoraise_notice_prints_once_for_cli(tmp_path, monkeypatch, capsys):
+    from agent import agent_init
+
+    _write_config(tmp_path)
+    monkeypatch.setattr(agent_init, "_codex_gpt55_notice_emitted", False)
+
+    _make_agent(tmp_path, monkeypatch, quiet_mode=False)
+    _make_agent(tmp_path, monkeypatch, quiet_mode=False)
+
+    captured = capsys.readouterr().out
+    assert captured.count("Codex gpt-5.5 caps context") == 1
+
+
+def test_codex_gpt55_autoraise_opt_out_emits_no_notice(tmp_path, monkeypatch):
+    from agent import agent_init
+
+    _write_config(
+        tmp_path,
+        "compression:\n  threshold: 0.5\n  codex_gpt55_autoraise: false\n",
+    )
+    monkeypatch.setattr(agent_init, "_codex_gpt55_notice_emitted", False)
+
+    agent = _make_agent(tmp_path, monkeypatch)
+
+    assert getattr(agent, "_compression_warning", None) is None
+    assert agent_init._codex_gpt55_notice_emitted is False
+
+
+def test_non_codex_gpt55_model_emits_no_notice(tmp_path, monkeypatch):
+    from agent import agent_init
+
+    _write_config(tmp_path)
+    monkeypatch.setattr(agent_init, "_codex_gpt55_notice_emitted", False)
+
+    agent = _make_agent(tmp_path, monkeypatch, model="gpt-5", provider="openai-codex")
+
+    assert getattr(agent, "_compression_warning", None) is None
+    assert agent_init._codex_gpt55_notice_emitted is False


### PR DESCRIPTION
## Summary
- gate the Codex gpt-5.5 auto-compaction notice with a module-level process flag
- ensure CLI startup printing and gateway `_compression_warning` replay share the same once-per-process claim
- add regression coverage for gateway/session re-inits, CLI printing, opt-out, and non-gpt-5.5 models

## Root Cause
The Codex gpt-5.5 autoraise notice was stored on each agent instance, so every new session / agent init (including gateway sessions rebuilt after idle eviction) could replay the same informational message.

## Behavior
This notice is now emitted at most once per process lifetime. A gateway restart can show it once again, but multiple users/sessions in the same process will not each receive it. `compression.codex_gpt55_autoraise: false` still suppresses both the threshold raise and the notice.

## Test Plan
- `uv run --with pytest python -m pytest tests/agent/test_codex_gpt55_notice_once.py tests/agent/test_arcee_trinity_overrides.py -q -o 'addopts='` (44 passed)
