### PR TITLE
fix(desktop): recover session after sleep/wake gateway restart

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -55,16 +55,20 @@ function Harness({
   onReady,
   onSeedState,
   refreshSessions,
-  requestGateway
+  requestGateway,
+  storedSessionId
 }: {
   busyRef?: MutableRefObject<boolean>
   onReady: (handle: HarnessHandle) => void
   onSeedState?: (state: Record<string, unknown>) => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  storedSessionId?: null | string
 }) {
   const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_ID }
-  const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_ID }
+  const selectedStoredSessionIdRef: MutableRefObject<string | null> = {
+    current: storedSessionId === undefined ? RUNTIME_SESSION_ID : storedSessionId
+  }
   const localBusyRef = busyRef ?? { current: false }
 
   const actions = usePromptActions({
@@ -408,3 +412,109 @@ describe('usePromptActions file attachment sync', () => {
     })
   })
 })
+
+describe('usePromptActions sleep/wake session recovery', () => {
+  const STORED_SESSION_ID = 'stored-db-xyz789'
+  const RECOVERED_SESSION_ID = 'rt-recovered-456'
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('resumes the stored session and retries once when prompt.submit reports "session not found"', async () => {
+    // After sleep/wake the gateway's in-memory session table is cleared, so the
+    // first prompt.submit with the stale runtime id fails. The hook resumes the
+    // durable stored id (which survives gateway restarts), gets a fresh live id,
+    // and retries the send transparently.
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let submitAttempts = 0
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+      if (method === 'prompt.submit') {
+        submitAttempts += 1
+        if (submitAttempts === 1) {
+          throw new Error('session not found')
+        }
+        return {} as never
+      }
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID } as never
+      }
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={STORED_SESSION_ID}
+      />
+    )
+
+    const ok = await handle!.submitText('message after wake')
+
+    expect(ok).toBe(true)
+    // First submit (stale id) → session.resume (stored id) → retry submit (fresh id).
+    expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
+    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID })
+    expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
+  })
+
+  it('surfaces the original error (no resume) when the failure is not "session not found"', async () => {
+    const calls: string[] = []
+    const states: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      calls.push(method)
+      if (method === 'prompt.submit') {
+        throw new Error('session busy')
+      }
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={STORED_SESSION_ID}
+      />
+    )
+
+    // submitText swallows the error into an inline bubble and returns false.
+    expect(await handle!.submitText('message')).toBe(false)
+    // No resume attempt for a non-recoverable error.
+    expect(calls).not.toContain('session.resume')
+  })
+
+  it('surfaces "session not found" (no resume) when there is no stored session id', async () => {
+    const calls: string[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      calls.push(method)
+      if (method === 'prompt.submit') {
+        throw new Error('session not found')
+      }
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={null}
+      />
+    )
+
+    // With a null stored ref, the `&& selectedStoredSessionIdRef.current` guard
+    // short-circuits — no resume is attempted and the error surfaces normally.
+    expect(await handle!.submitText('message')).toBe(false)
+    expect(calls).not.toContain('session.resume')
+  })
+})
+

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -486,7 +486,38 @@ export function usePromptActions({
         attachmentRefs = syncedAttachments.map(attachmentDisplayText).filter((r): r is string => Boolean(r))
         rewriteOptimistic(sessionId)
         const text = buildContextText(syncedAttachments)
-        await requestGateway('prompt.submit', { session_id: sessionId, text })
+
+        // On sleep/wake the gateway's in-memory session may have been cleared
+        // while the desktop app still holds the old session ID. Detect this,
+        // resume the stored session to re-register it, and retry once.
+        let submitErr: unknown = null
+
+        try {
+          await requestGateway('prompt.submit', { session_id: sessionId, text })
+        } catch (firstErr) {
+          const firstMsg = firstErr instanceof Error ? firstErr.message : String(firstErr)
+
+          if (/session not found/i.test(firstMsg) && selectedStoredSessionIdRef.current) {
+            // Re-register the session in the gateway and get a fresh live ID.
+            const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+              session_id: selectedStoredSessionIdRef.current
+            })
+            const recoveredId = resumed?.session_id
+
+            if (recoveredId) {
+              activeSessionIdRef.current = recoveredId
+              await requestGateway('prompt.submit', { session_id: recoveredId, text })
+            } else {
+              submitErr = firstErr
+            }
+          } else {
+            submitErr = firstErr
+          }
+        }
+
+        if (submitErr !== null) {
+          throw submitErr
+        }
 
         if (usingComposerAttachments) {
           clearComposerAttachments()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -104,6 +104,7 @@ AUTHOR_MAP = {
     "metalclaudbot@gmail.com": "HashClawAI",
     "tonybear55665566@gmail.com": "TonyPepeBear",
     "kaspersniels@gmail.com": "nielskaspers",
+    "daxxpasquini@gmail.com": "bpasquini",
     "kurobaryo@gmail.com": "kurobaryo",
     "scubamount@users.noreply.github.com": "scubamount",
     "251514042+youngstar-eth@users.noreply.github.com": "youngstar-eth",


### PR DESCRIPTION
## Summary
The desktop app now recovers transparently when a sleep/wake gateway restart clears the in-memory session table — the first message after wake sends instead of failing with "Prompt failed: session not found".

Salvage of #40776 by @bpasquini onto current `main` (the surrounding `prompt.submit` site moved under the remote-media-relay attachment-sync rewrite since the PR was authored).

## Root cause
`requestGateway` retries transport errors (`not connected` / `connection closed`) but never gateway-level `session not found` (error 4001 from `_sess_nowait` in `tui_gateway/server.py`). After sleep/wake the WS reconnects but the gateway's in-memory `_sessions` dict is empty, so the held `activeSessionId` is stale and the first `prompt.submit` always 4001s.

## Changes
- `apps/desktop/.../use-prompt-actions.ts`: on `session not found` + a stored id, call `session.resume` (returns a fresh live `session_id`), update `activeSessionIdRef`, retry `prompt.submit` once. One-shot — any other error re-throws and surfaces normally.
- `apps/desktop/.../use-prompt-actions.test.tsx`: three vitest cases (resume+retry, non-recoverable passthrough, no-stored-id short-circuit).
- `scripts/release.py`: map contributor commit email → `bpasquini`.

## Layering
Complements the already-merged `cadb74ada` ("recover chat after sleep/wake by revalidating a stale remote backend"), which reconnects the *transport*. This fix runs one level up: it re-registers the *session* the reconnect orphaned. Not a replacement — disjoint files, sequential failure points.

## Validation
| | Before | After |
|---|---|---|
| First send after sleep/wake | "session not found" bubble | sends transparently |
| New recovery tests | — | 3/3 pass |
| `tsc -b` | — | clean |

Pre-existing unrelated failure in this file ("clears a leftover interrupted flag") fails on clean `origin/main` too — out of scope here.

## Infographic

![nous-jewelcase](https://v3b.fal.media/files/b/0a9d93cc/_Pd2qGKGhTvC8Y6Odqzqr_DpnjJTP7.png)
