### PR TITLE
fix(gateway): handle PermissionError on stale root-owned lock file

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -467,7 +467,18 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
     if not resolved_lock_path.exists():
         return False
 
-    handle = open(resolved_lock_path, "a+", encoding="utf-8")
+    try:
+        handle = open(resolved_lock_path, "a+", encoding="utf-8")
+    except PermissionError:
+        # Stale root-owned lock file from a previous launchd Background
+        # session that ran as root.  The parent directory owner can unlink
+        # files even when they don't own them, so remove the stale lock
+        # and report inactive — the new process will create a fresh one.
+        try:
+            resolved_lock_path.unlink()
+        except OSError:
+            pass
+        return False
     try:
         if _try_acquire_file_lock(handle):
             _release_file_lock(handle)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1061,3 +1061,55 @@ class TestCorruptStatusFiles:
         p = tmp_path / "gateway.pid"
         p.write_text("4242", encoding="utf-8")
         assert status._read_pid_record(p) == {"pid": 4242}
+
+
+class TestPermissionErrorOnLockFile:
+    """Stale root-owned lock files from launchd Background sessions must not
+    crash the gateway on restart (issue #42685)."""
+
+    def test_permission_error_on_lock_file_returns_false_and_removes(self, tmp_path, monkeypatch):
+        """When the lock file is not writable (root-owned), the function should
+        remove the stale file and report the lock as inactive."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("stale", encoding="utf-8")
+
+        real_open = open
+
+        def deny_write(path, *args, **kwargs):
+            if str(path) == str(lock_path):
+                raise PermissionError(13, "Permission denied", str(path))
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", deny_write)
+
+        result = status.is_gateway_runtime_lock_active(lock_path)
+        assert result is False
+        assert not lock_path.exists(), "stale root-owned lock file should be removed"
+
+    def test_permission_error_unlink_failure_still_returns_false(self, tmp_path, monkeypatch):
+        """Even if unlinking the stale lock file fails (e.g. directory not writable),
+        the function should still return False to allow startup."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("stale", encoding="utf-8")
+
+        real_open = open
+
+        def deny_write(path, *args, **kwargs):
+            if str(path) == str(lock_path):
+                raise PermissionError(13, "Permission denied", str(path))
+            return real_open(path, *args, **kwargs)
+
+        real_unlink = Path.unlink
+
+        def deny_unlink(self, *args, **kwargs):
+            if str(self) == str(lock_path):
+                raise OSError(13, "Permission denied", str(self))
+            return real_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", deny_write)
+        monkeypatch.setattr(Path, "unlink", deny_unlink)
+
+        result = status.is_gateway_runtime_lock_active(lock_path)
+        assert result is False


### PR DESCRIPTION
## Problem

On macOS, when the Hermes gateway launchd service runs in a `Background` session, the process spawns as **root** instead of the logged-in user. The root process creates `gateway.lock` with `root:staff` ownership. On restart as the normal user, `open()` in `is_gateway_runtime_lock_active()` raises `PermissionError`, crashing the gateway immediately and entering a launchd crash loop.

**Traceback:**
```
File ".../gateway/status.py", line 470, in is_gateway_runtime_lock_active
    handle = open(resolved_lock_path, "a+", encoding="utf-8")
PermissionError: [Errno 13] Permission denied: '/Users/<user>/.hermes/gateway.lock'
```

## Fix

Wrap the `open()` call in `is_gateway_runtime_lock_active()` with a `PermissionError` handler. When the lock file is not accessible (stale root-owned file), remove it and return `False` (lock inactive) so the new process can start cleanly.

This is consistent with the existing `PermissionError` handling in `_is_process_alive()` (line 406) in the same file.

**Note:** The issue also proposes removing `Background` from `LimitLoadToSessionType` in the launchd plist (Fix 2). That change is **not included** here because it was intentionally added for macOS 26+ compatibility (#23387) and has a dedicated test (`test_launchd_plist_supports_aqua_and_background_sessions`). Fix 1 alone resolves the crash loop.

Fixes #42685
