### PR TITLE
fix(desktop): sidebar alignment and spacing polish

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -141,7 +141,7 @@ export function SidebarCronJobsSection({
         </button>
       </div>
       {open && (
-        <SidebarGroupContent className="flex max-h-72 shrink-0 flex-col gap-px overflow-y-auto overscroll-contain pb-1.75">
+        <SidebarGroupContent className="flex max-h-72 shrink-0 flex-col gap-px overflow-y-auto overscroll-contain pb-1.75 pt-1">
           {shown.map(job => (
             <CronJobSidebarRow
               expanded={peekJobId === job.id}

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -130,7 +130,9 @@ export function SidebarCronJobsSection({
           onClick={onToggle}
           type="button"
         >
-          <SidebarPanelLabel>{label}</SidebarPanelLabel>
+          {/* pl-3 matches the other left-sidebar section headers so the dither
+              marker aligns with the nav-icon column above. */}
+          <SidebarPanelLabel className="pl-3">{label}</SidebarPanelLabel>
           <span className="text-[0.6875rem] font-medium text-(--ui-text-quaternary)">{countLabel}</span>
           <DisclosureCaret
             className="text-(--ui-text-tertiary) opacity-0 transition group-hover/section-label:opacity-100"

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1033,7 +1033,7 @@ function SidebarPinnedEmptyState() {
   const { t } = useI18n()
 
   return (
-    <div className="flex min-h-7 items-center gap-1.5 rounded-lg pl-2 text-[0.75rem] text-(--ui-text-tertiary)">
+    <div className="flex min-h-7 items-center gap-1.5 rounded-lg pl-2 text-[0.8125rem] text-muted-foreground">
       <span className="grid w-3.5 shrink-0 place-items-center text-(--ui-text-quaternary)">
         <Codicon name="pin" size="0.75rem" />
       </span>

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -982,7 +982,10 @@ function SidebarSectionHeader({ label, open, onToggle, action, meta }: SidebarSe
         onClick={onToggle}
         type="button"
       >
-        <SidebarPanelLabel>{label}</SidebarPanelLabel>
+        {/* pl-3 (vs the component's base pl-2) nudges the dither marker +4px so
+            its center lines up with the nav-icon column above (size-4 icons at
+            px-2 → center 16px from the group edge). */}
+        <SidebarPanelLabel className="pl-3">{label}</SidebarPanelLabel>
         {meta && <SidebarCount>{meta}</SidebarCount>}
         <DisclosureCaret
           className="text-(--ui-text-tertiary) opacity-0 transition group-hover/section-label:opacity-100"

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -819,10 +819,11 @@ export function ChatSidebar({
               aria-label={s.searchAria}
               // Match the nav rows: full width + fixed (no field-sizing growth),
               // px-2 + gap-2 + a size-4 icon so the magnifier and placeholder
-              // line up with the nav icon/label columns.
+              // line up with the nav icon/label columns. text-[0.8125rem] matches
+              // the nav item label size (the shared field defaults to text-sm).
               containerClassName="flex w-full gap-2 px-2"
               iconClassName="size-4"
-              inputClassName="w-full min-w-0 flex-1 [field-sizing:normal]"
+              inputClassName="w-full min-w-0 flex-1 text-[0.8125rem] [field-sizing:normal]"
               inputRef={searchInputRef}
               onChange={setSearchQuery}
               placeholder={s.searchPlaceholder}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1039,7 +1039,7 @@ function SidebarPinnedEmptyState() {
   return (
     <div className="flex min-h-7 items-center gap-2 rounded-lg border-l border-transparent pl-2 text-[0.8125rem] text-muted-foreground">
       <span className="grid size-4 shrink-0 place-items-center text-(--ui-text-quaternary)">
-        <Codicon name="pin" size="0.75rem" />
+        <Codicon name="pin" size="1rem" />
       </span>
       <span>{t.sidebar.shiftClickHint}</span>
     </div>

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -812,9 +812,17 @@ export function ChatSidebar({
         </SidebarGroup>
 
         {contentVisible && showSessionSections && (
-          <div className="shrink-0 px-2 pb-1 pt-1">
+          // No horizontal padding so the field spans the full content-box width
+          // like the nav buttons above (which are w-full inside a p-0 group).
+          <div className="shrink-0 pb-1 pt-1">
             <SearchField
               aria-label={s.searchAria}
+              // Match the nav rows: full width + fixed (no field-sizing growth),
+              // px-2 + gap-2 + a size-4 icon so the magnifier and placeholder
+              // line up with the nav icon/label columns.
+              containerClassName="flex w-full gap-2 px-2"
+              iconClassName="size-4"
+              inputClassName="w-full min-w-0 flex-1 [field-sizing:normal]"
               inputRef={searchInputRef}
               onChange={setSearchQuery}
               placeholder={s.searchPlaceholder}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -750,7 +750,7 @@ export function ChatSidebar({
       )}
       collapsible="none"
     >
-      <SidebarContent className="gap-0 overflow-hidden bg-transparent px-2.5">
+      <SidebarContent className="gap-0 overflow-hidden bg-transparent px-1.5">
         <SidebarGroup className="shrink-0 p-0 pb-2 pt-[calc(var(--titlebar-height)+0.375rem)]">
           <SidebarGroupContent>
             <SidebarMenu className="gap-px">

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1037,8 +1037,8 @@ function SidebarPinnedEmptyState() {
   const { t } = useI18n()
 
   return (
-    <div className="flex min-h-7 items-center gap-1.5 rounded-lg pl-2 text-[0.8125rem] text-muted-foreground">
-      <span className="grid w-3.5 shrink-0 place-items-center text-(--ui-text-quaternary)">
+    <div className="flex min-h-7 items-center gap-2 rounded-lg border-l border-transparent pl-2 text-[0.8125rem] text-muted-foreground">
+      <span className="grid size-4 shrink-0 place-items-center text-(--ui-text-quaternary)">
         <Codicon name="pin" size="0.75rem" />
       </span>
       <span>{t.sidebar.shiftClickHint}</span>

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -814,7 +814,10 @@ export function ChatSidebar({
         {contentVisible && showSessionSections && (
           // No horizontal padding so the field spans the full content-box width
           // like the nav buttons above (which are w-full inside a p-0 group).
-          <div className="shrink-0 pb-1 pt-1">
+          // pl-px compensates for the nav buttons' 1px transparent border (their
+          // content sits at border+px-2 = 9px) so the search icon/text land on
+          // the same column as the nav icon/label.
+          <div className="shrink-0 pb-1 pl-px pt-1">
             <SearchField
               aria-label={s.searchAria}
               // Match the nav rows: full width + fixed (no field-sizing growth),

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1039,7 +1039,7 @@ function SidebarPinnedEmptyState() {
   return (
     <div className="flex min-h-7 items-center gap-2 rounded-lg border-l border-transparent pl-2 text-[0.8125rem] text-muted-foreground">
       <span className="grid size-4 shrink-0 place-items-center text-(--ui-text-quaternary)">
-        <Codicon name="pin" size="1rem" />
+        <Codicon name="pinned" size="1rem" />
       </span>
       <span>{t.sidebar.shiftClickHint}</span>
     </div>

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -818,11 +818,12 @@ export function ChatSidebar({
             <SearchField
               aria-label={s.searchAria}
               // Match the nav rows: full width + fixed (no field-sizing growth),
-              // px-2 + gap-2 + a size-4 icon so the magnifier and placeholder
-              // line up with the nav icon/label columns. text-[0.8125rem] matches
+              // px-2 + gap-2 + a codicon search glyph (size-4) so the icon shares
+              // the same family/size as the nav codicons and the placeholder
+              // lines up with the nav icon/label columns. text-[0.8125rem] matches
               // the nav item label size (the shared field defaults to text-sm).
               containerClassName="flex w-full gap-2 px-2"
-              iconClassName="size-4"
+              icon={<Codicon className="pointer-events-none size-4 shrink-0 text-muted-foreground/70" name="search" />}
               inputClassName="w-full min-w-0 flex-1 text-[0.8125rem] [field-sizing:normal]"
               inputRef={searchInputRef}
               onChange={setSearchQuery}

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -51,7 +51,7 @@ function useSessionActions({ sessionId, title, pinned = false, profile, onPin, o
   const items: ItemSpec[] = [
     {
       disabled: !onPin,
-      icon: 'pin',
+      icon: 'pinned',
       label: pinned ? r.unpin : r.pin,
       onSelect: () => {
         triggerHaptic('selection')

--- a/apps/desktop/src/components/ui/search-field.tsx
+++ b/apps/desktop/src/components/ui/search-field.tsx
@@ -12,6 +12,7 @@ interface SearchFieldProps {
   onChange: (value: string) => void
   containerClassName?: string
   inputClassName?: string
+  iconClassName?: string
   loading?: boolean
   onClear?: () => void
   inputRef?: RefObject<HTMLInputElement | null>
@@ -30,6 +31,7 @@ export function SearchField({
   onChange,
   containerClassName,
   inputClassName,
+  iconClassName,
   loading = false,
   onClear,
   inputRef,
@@ -46,7 +48,7 @@ export function SearchField({
         containerClassName
       )}
     >
-      <Search className="pointer-events-none size-3.5 shrink-0 text-muted-foreground/70" />
+      <Search className={cn('pointer-events-none size-3.5 shrink-0 text-muted-foreground/70', iconClassName)} />
       <input
         aria-label={ariaLabel}
         className={cn(

--- a/apps/desktop/src/components/ui/search-field.tsx
+++ b/apps/desktop/src/components/ui/search-field.tsx
@@ -13,6 +13,7 @@ interface SearchFieldProps {
   containerClassName?: string
   inputClassName?: string
   iconClassName?: string
+  icon?: ReactNode
   loading?: boolean
   onClear?: () => void
   inputRef?: RefObject<HTMLInputElement | null>
@@ -32,6 +33,7 @@ export function SearchField({
   containerClassName,
   inputClassName,
   iconClassName,
+  icon,
   loading = false,
   onClear,
   inputRef,
@@ -48,7 +50,9 @@ export function SearchField({
         containerClassName
       )}
     >
-      <Search className={cn('pointer-events-none size-3.5 shrink-0 text-muted-foreground/70', iconClassName)} />
+      {icon ?? (
+        <Search className={cn('pointer-events-none size-3.5 shrink-0 text-muted-foreground/70', iconClassName)} />
+      )}
       <input
         aria-label={ariaLabel}
         className={cn(


### PR DESCRIPTION
## What does this PR do?

A set of small, focused alignment/spacing refinements to the desktop app's left sidebar so the nav items, search field, section headings, session rows, and the pinned empty-state all share one consistent icon/label column and rhythm.

<img width="4450" height="2256" alt="CleanShot 2026-06-09 at 10 11 33@2x" src="https://github.com/user-attachments/assets/45a0c1e5-619b-4113-af92-829339395ba9" />

Changes with bullets:

1. Search session bar full width, improve typography/make same as pinned empty text
2. Blue heading labels icon alignment
3. Reduce gutter spacing in nav a little bit
4. Align bullets with rest of icons
5. Add a little spacing under 'CRONJOB' header (same as other sections)
6. Swap pin icon by a more vertical one. Cleaner UI. Improve typography of empty text 

No behavior changes — these are purely visual/layout fixes. Each is its own atomic commit.

## Related Issue

None — desktop UI polish.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ♻️ Refactor (no behavior change)

## Changes Made

All under `apps/desktop/src`:

- **`components/ui/search-field.tsx`** — add optional `iconClassName` and `icon` props so a caller can size/replace the leading icon (default lucide `Search` unchanged for all other call sites).
- **`app/chat/sidebar/index.tsx`**
  - Search field: full-width + fixed (no `field-sizing` growth while typing), aligned to the nav column, placeholder sized to match nav labels, and the lucide magnifier swapped for a codicon `search` so it matches the rest of the sidebar icons; +1px nudge to match the nav buttons' transparent-border inset.
  - Outer gutter tightened (`SidebarContent` `px-2.5` → `px-1.5`).
  - Pinned empty-state hint ("Shift-click a chat to pin"): typography, alignment, and icon size matched to the search field; icon switched to the upright `pinned` codicon.
- **`app/chat/sidebar/cron-jobs-section.tsx`** — match the cron section's first-item top spacing to the pinned section; use the `pinned` codicon.
- **`app/chat/sidebar/session-actions-menu.tsx`** — use the upright `pinned` codicon instead of the angled `pin`.

## How to Test

1. Open the desktop app (`cd apps/desktop && npm run dev`).
8. Sidebar nav icons, the search icon/placeholder, section heading markers, and the pinned hint should line up on one column.
9. Type in "Search sessions…" — the field width (and its underline) stays fixed.
10. The pinned hint and the pin action use an upright pin glyph.

Automated: `cd apps/desktop && npm run type-check` and `npm run lint` pass.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(desktop): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Docs — N/A (no user-facing config/behavior change)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (CSS/layout only)
- [x] Tool descriptions/schemas — N/A
