### PR TITLE
fix(gemini): restore Gemma model discovery in model picker

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -29,11 +29,11 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
         normalized_model = normalized_model.split("/", 1)[1]
 
     # ``thinking_config`` is a Gemini-only request parameter. The same
-    # ``gemini`` provider also serves Gemma (and historically PaLM/Bard);
-    # those reject the field with HTTP 400 "Unknown name 'thinking_config':
-    # Cannot find field" — including the polite ``{"includeThoughts": False}``
-    # form. Omit the field entirely on non-Gemini models. (#17426)
-    if not normalized_model.startswith("gemini"):
+    # ``gemini`` provider also serves Gemma (and historically PaLM/Bard).
+    # Gemma <= 3 rejected the field with HTTP 400, but Gemma 4 models
+    # advertise ``thinking: true`` in the API model list and now accept
+    # the parameter. Only emit for Gemini and Gemma 4+ families. (#17426)
+    if not (normalized_model.startswith("gemini") or normalized_model.startswith("gemma-4")):
         return None
 
     if reasoning_config.get("enabled") is False:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -241,6 +241,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3-pro-preview",
         "gemini-3.5-flash",
         "gemini-3.1-flash-lite-preview",
+        "gemma-4-31b-it",
+        "gemma-4-26b-a4b-it",
     ],
     "google-gemini-cli": [
         "gemini-3.1-pro-preview",

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -19,6 +19,67 @@ from providers.base import ProviderProfile
 class GeminiProfile(ProviderProfile):
     """Gemini — translate reasoning_config to thinking_config in extra_body."""
 
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch live model list from Google AI Studio /v1beta/models endpoint.
+
+        Overrides the default Bearer-auth + ``m["id"]`` parser because
+        Google's API requires ``?key=`` query-param auth and returns
+        ``"name": "models/gemma-4-31b-it"`` (not ``"id"``).
+        """
+        import json
+        import logging
+        import os
+        import urllib.request
+
+        logger = logging.getLogger(__name__)
+
+        # Resolve API key: explicit arg > env vars listed in the profile
+        if not api_key:
+            for var in self.env_vars:
+                api_key = os.getenv(var, "").strip()
+                if api_key:
+                    break
+        if not api_key:
+            return None
+
+        url = (self.models_url or "").strip()
+        if not url:
+            if not self.base_url:
+                return None
+            url = f"{self.base_url.rstrip('/')}/models?key={api_key}"
+
+        req = urllib.request.Request(url)
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", "hermes-gemini-fetch-models/1.0")
+
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+        except Exception as exc:
+            logger.debug("fetch_models(gemini): %s", exc)
+            return None
+
+        # Google returns ``{"models": [{"name": "models/gemma-4-31b-it", ...}]}``
+        models = data.get("models", [])
+        if not models:
+            return None
+
+        out: list[str] = []
+        for m in models:
+            name = m.get("name", "")
+            if not isinstance(name, str):
+                continue
+            # Strip the "models/" prefix
+            model_id = name.replace("models/", "", 1) if name.startswith("models/") else name
+            if model_id:
+                out.append(model_id)
+        return out or None
+
     def build_extra_body(
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -10,10 +10,18 @@ carries the thinking_config translation hook so the transport's profile
 path produces the same extra_body shape the legacy flag path did.
 """
 
+import json
+import logging
+import os
+import urllib.request
 from typing import Any
+from urllib.error import URLError
 
 from providers import register_provider
 from providers.base import ProviderProfile
+
+
+_logger = logging.getLogger(__name__)
 
 
 class GeminiProfile(ProviderProfile):
@@ -31,13 +39,6 @@ class GeminiProfile(ProviderProfile):
         Google's API requires ``?key=`` query-param auth and returns
         ``"name": "models/gemma-4-31b-it"`` (not ``"id"``).
         """
-        import json
-        import logging
-        import os
-        import urllib.request
-
-        logger = logging.getLogger(__name__)
-
         # Resolve API key: explicit arg > env vars listed in the profile
         if not api_key:
             for var in self.env_vars:
@@ -47,11 +48,17 @@ class GeminiProfile(ProviderProfile):
         if not api_key:
             return None
 
+        # Build URL — prefer models_url override, fall back to base_url
         url = (self.models_url or "").strip()
         if not url:
             if not self.base_url:
                 return None
-            url = f"{self.base_url.rstrip('/')}/models?key={api_key}"
+            url = self.base_url.rstrip("/")
+
+        # Append models path if not already present, then attach API key
+        if "/models" not in url.rsplit("?", 1)[0]:
+            url = f"{url.rstrip('/')}/models"
+        url = f"{url}?key={api_key}"
 
         req = urllib.request.Request(url)
         req.add_header("Accept", "application/json")
@@ -60,8 +67,12 @@ class GeminiProfile(ProviderProfile):
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
+        except URLError as exc:
+            # Do NOT log the exception string — it includes the URL with API key
+            _logger.debug("fetch_models(gemini): network error (%s)", type(exc).__name__)
+            return None
         except Exception as exc:
-            logger.debug("fetch_models(gemini): %s", exc)
+            _logger.debug("fetch_models(gemini): %s", type(exc).__name__)
             return None
 
         # Google returns ``{"models": [{"name": "models/gemma-4-31b-it", ...}]}``


### PR DESCRIPTION
## Summary

Fixes three independent bugs that conspired to hide Gemma models from the Hermes `/model` picker:

| Bug | Symptom | Root Cause |
|-----|---------|------------|
| Auth | Google API returns 401 | `fetch_models()` sends Bearer token; Google requires `?key=` query param |
| Parsing | Empty model list | `fetch_models()` reads `m["id"]`; Google returns `"name": "models/gemma-4-31b-it"` |
| Fallback | No Gemma shown | `_PROVIDER_MODELS["gemini"]` only had Gemini models |

## Changes

### 1. `plugins/model-providers/gemini/__init__.py` (+61 lines)
Override `fetch_models()` in `GeminiProfile` to:
- Use `?key={api_key}` query-param auth (matching Google API requirements)
- Parse `"name"` field with `models/` prefix stripping
- Return the full live model list including Gemma

### 2. `hermes_cli/models.py` (+2 lines)
Add `gemma-4-31b-it` and `gemma-4-26b-a4b-it` to `_PROVIDER_MODELS["gemini"]` as static fallback when live fetch fails (belt and suspenders).

### 3. `agent/transports/chat_completions.py` (5 lines changed)
Update `_build_gemini_thinking_config()` to accept `gemma-4` models. Google's API now lists both Gemma 4 models with `"thinking": true`, indicating they support `thinking_config`. Limited to `gemma-4` prefix to avoid regressions with older Gemma <=3 models (#17426).

## Verification

Live fetch from Google AI Studio now returns Gemma models:
```
>>> gemma-4-26b-a4b-it  (thinking=true)
>>> gemma-4-31b-it      (thinking=true)
```

Both models appear in `/model` picker with selectable reasoning effort.

## Related

- Closes: #17426 (thinking_config now safe for Gemma 4)
- Delegation and auxiliary model paths were unaffected — they set model name directly
