### PR TITLE
fix(test): track TERMINAL_CONFIG_ENV_MAP after env-sync consolidation

### DIFF
--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -7,9 +7,9 @@ at startup, by THREE separate code paths:
   1. cli.py            -> ``env_mappings`` dict (CLI / TUI startup)
   2. gateway/run.py    -> ``_terminal_env_map`` dict (gateway / messaging
                           platforms)
-  3. hermes_cli/config.py:save_config_value
-                       -> ``_config_to_env_sync`` dict (one-shot when the
-                          user runs ``hermes config set …``)
+  3. hermes_cli/config.py:set_config_value
+                       -> bridges via the canonical ``TERMINAL_CONFIG_ENV_MAP``
+                          (one-shot when the user runs ``hermes config set …``)
 
 If any one of these is missing a key, the corresponding config.yaml setting
 silently does nothing for that entry-point.  This bug already shipped once
@@ -87,14 +87,20 @@ def _gateway_env_map_keys() -> set[str]:
 
 
 def _save_config_env_sync_keys() -> set[str]:
-    """terminal config keys bridged by ``hermes config set foo bar``."""
+    """terminal config keys bridged by ``hermes config set foo bar``.
+
+    ``set_config_value`` no longer carries its own ``_config_to_env_sync``
+    dict — it bridges through the canonical ``TERMINAL_CONFIG_ENV_MAP`` via
+    ``terminal_config_env_var_for_key()`` (config.py), excluding ``cwd``
+    (handled separately).  Read the live map so this test tracks the actual
+    source of truth that the config-set path uses, rather than a string
+    literal that the consolidation removed.
+    """
     from hermes_cli import config as hc_config
-    source = inspect.getsource(hc_config.set_config_value)
-    keys = _extract_dict_keys(source, "_config_to_env_sync")
-    # set_config_value uses fully-qualified ``terminal.foo`` keys; strip the
-    # prefix so we can compare against the other two maps which use bare
-    # leaf keys.
-    return {k.split(".", 1)[1] for k in keys if k.startswith("terminal.")}
+    # set_config_value bridges every TERMINAL_CONFIG_ENV_MAP key except
+    # terminal.cwd (see the ``key != "terminal.cwd"`` guard in
+    # set_config_value); mirror that exclusion here.
+    return {k for k in hc_config.TERMINAL_CONFIG_ENV_MAP if k != "cwd"}
 
 
 # Keys present in cli.py env_mappings but intentionally absent from
@@ -180,8 +186,8 @@ def test_save_config_set_supports_critical_bridged_keys():
     missing = required - save_keys
     assert not missing, (
         f"`hermes config set terminal.X` doesn't sync these load-bearing "
-        f"keys to .env: {sorted(missing)}.  Add them to _config_to_env_sync "
-        f"in hermes_cli/config.py:set_config_value."
+        f"keys to .env: {sorted(missing)}.  Add them to TERMINAL_CONFIG_ENV_MAP "
+        f"in hermes_cli/config.py (set_config_value bridges through it)."
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes `tests/tools/test_terminal_config_env_sync.py`, which is **failing on `main` for every open PR** (8 of 9 tests red).

## Root cause

`_save_config_env_sync_keys()` used `inspect.getsource()` + AST to scan `hermes_cli/config.py:set_config_value` for a `_config_to_env_sync = {...}` dict literal. The terminal-config → env bridging was since consolidated onto the canonical module-level `TERMINAL_CONFIG_ENV_MAP` (now reached via `terminal_config_env_var_for_key()`), so that literal no longer exists. The scanner raised:

```
AssertionError: Could not find `_config_to_env_sync = {...}` literal in source
```

which cascaded into all 5 `*_is_bridged_everywhere` pins plus the `set_config_set` and `env_maps_agree` tests.

This is the *good* kind of consolidation — `set_config_value`, and the env-apply path, now share one source of truth instead of a third hand-maintained dict — but the brittle source-string scanner wasn't updated alongside it.

## Fix

- `_save_config_env_sync_keys()` now reads the live `TERMINAL_CONFIG_ENV_MAP` (the dict `set_config_value` actually bridges through), mirroring its `terminal.cwd` exclusion, instead of AST-scanning for the removed literal.
- Refreshed the stale module docstring (item 3 referenced `save_config_value` / `_config_to_env_sync`) and the now-incorrect assertion hint that pointed contributors at `_config_to_env_sync`.
- `cli.py` (`env_mappings`) and `gateway/run.py` (`_terminal_env_map`) still have their own inline dicts, so scanners 1 and 2 are untouched.

## Verification

```bash
PYTHONPATH=. python -m pytest tests/tools/test_terminal_config_env_sync.py -o 'addopts=' -q
# 9 passed
```

- Reproduced the 8-failure red on clean `origin/main` first.
- **Mutation check:** dropping `docker_volumes` from `TERMINAL_CONFIG_ENV_MAP` still trips `test_docker_volumes_is_bridged_everywhere`, confirming the drift guard retains its teeth (it's not merely papered over).
- ruff clean.

## Type of Change

- [x] ✅ Tests (fixing broken test coverage)

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR contains only changes related to this fix
- [x] Tested on macOS
