### PR TITLE
fix(skills_sync): refresh stale manifest when user copy matches bundled

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -715,6 +715,51 @@ class TestSyncSkills:
         assert manifest["old-skill"] != old_hash
 
 
+
+    def test_stale_manifest_synced_when_user_matches_bundled(self, tmp_path):
+        """When user copy matches current bundled but manifest origin is
+        stale, sync should refresh the manifest — NOT flag as user-modified.
+
+        This covers the curator-archived skill scenario: bundled version
+        updates in the repo, but the manifest still records the old origin
+        hash.  If the user copy happens to match the new bundled version
+        (e.g. from a partial prior sync or manual copy), the skill should
+        be treated as in-sync, not user-modified.
+        """
+        from tools.skills_sync import _dir_hash
+
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        # Step 1: Initial sync — user gets old-skill at version A
+        user_skill = skills_dir / "old-skill"
+        user_skill.mkdir(parents=True)
+        (user_skill / "SKILL.md").write_text("# Old")
+        hash_a = _dir_hash(user_skill)
+        manifest_file.write_text("old-skill:" + hash_a + chr(10))
+
+        # Step 2: Bundled version updates to B (but manifest not synced)
+        (bundled / "old-skill" / "SKILL.md").write_text("# Old v2")
+        hash_b = _dir_hash(bundled / "old-skill")
+
+        # Step 3: User copy also at B (matches new bundled)
+        (user_skill / "SKILL.md").write_text("# Old v2")
+        assert _dir_hash(user_skill) == hash_b
+
+        # Sanity: user_hash != origin_hash (stale manifest)
+        assert hash_b != hash_a
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+            # Should NOT be flagged as user-modified
+            assert "old-skill" not in result["user_modified"]
+            # Manifest should be refreshed to match bundled
+            from tools.skills_sync import _read_manifest
+            manifest = _read_manifest()
+            assert manifest.get("old-skill") == hash_b
+
 class TestGetBundledDir:
     def test_env_var_override(self, tmp_path, monkeypatch):
         """HERMES_BUNDLED_SKILLS env var overrides the default path resolution."""
@@ -758,27 +803,24 @@ class TestResetBundledSkill:
         return stack
 
     def test_reset_clears_stuck_user_modified_flag(self, tmp_path):
-        """The core bug repro: copy-pasted bundled restore doesn't un-stick the flag; reset does."""
+        """Reset works even when sync already fixed the stale manifest."""
         bundled = self._setup_bundled(tmp_path)
         skills_dir = tmp_path / "user_skills"
         manifest_file = skills_dir / ".bundled_manifest"
 
-        # Simulate the stuck state: user edited the skill on an older bundled version,
-        # so manifest has an old origin hash that no longer matches anything on disk.
+        # Simulate: user has the current bundled version, but manifest is stale.
         dest = skills_dir / "productivity" / "google-workspace"
         dest.mkdir(parents=True)
         (dest / "SKILL.md").write_text("---\nname: google-workspace\n---\n# GW v2 (upstream)\n")
-        # Stale origin_hash — from some prior bundled version. User "restored" by pasting
-        # the current bundled contents, so user_hash == current bundled_hash, but manifest
-        # still points at the stale hash → treated as user_modified forever.
         manifest_file.write_text("google-workspace:STALEHASH000000000000000000000000\n")
 
         with self._patches(bundled, skills_dir, manifest_file):
-            # Sanity check: without reset, sync would flag it user_modified
+            # Sync now correctly handles this case — manifest is refreshed,
+            # skill is NOT flagged as user_modified.
             pre = sync_skills(quiet=True)
-            assert "google-workspace" in pre["user_modified"]
+            assert "google-workspace" not in pre["user_modified"]
 
-            # Reset (no --restore) should clear the manifest entry and re-baseline
+            # Reset (no --restore) should still work as a manual override
             result = reset_bundled_skill("google-workspace", restore=False)
 
             assert result["ok"] is True

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -558,6 +558,16 @@ def sync_skills(quiet: bool = False) -> dict:
                 continue
 
             if user_hash != origin_hash:
+                if user_hash == bundled_hash:
+                    # User copy matches current bundled version — the
+                    # manifest origin_hash is stale (e.g. curator archived
+                    # the bundled skill without syncing the manifest).
+                    # Refresh the manifest so the skill is not falsely
+                    # flagged as user-modified on every subsequent sync.
+                    manifest[skill_name] = bundled_hash
+                    if not quiet:
+                        print(f"  ✓ {skill_name} (manifest synced)")
+                    continue
                 # User modified this skill — don't overwrite their changes
                 user_modified.append(skill_name)
                 if not quiet:


### PR DESCRIPTION
## What does this PR do?

Fixes a logic flaw in `sync_skills()` where curator-archived bundled skills were falsely flagged as "user-modified" on every subsequent sync, permanently blocking updates.

## Related Issue

Fixes #42682

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_sync.py`: When `user_hash != origin_hash`, additionally check if `user_hash == bundled_hash`. If the user copy matches the current bundled version, refresh the stale manifest instead of flagging as user-modified. This covers the curator-archived skill scenario where the bundled version was updated but the manifest wasn't synced.
- `tests/tools/test_skills_sync.py`: Added `test_stale_manifest_synced_when_user_matches_bundled` covering the stale-manifest scenario. Updated `test_reset_clears_stuck_user_modified_flag` to reflect that sync now correctly handles this case.

## How to Test

1. Run `pytest tests/tools/test_skills_sync.py -x -q` — all 57 tests pass
2. The new test `test_stale_manifest_synced_when_user_matches_bundled` specifically validates: when user copy matches bundled but manifest origin is stale, sync refreshes the manifest instead of flagging as user-modified
3. The updated `test_reset_clears_stuck_user_modified_flag` confirms reset still works as a manual override even after sync handles the case

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_skills_sync.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `tools/skills_sync.py` `sync_skills()` (line 560), `_dir_hash()`, `_read_manifest()`
- Blast radius: LOW — single branch in existing conditional, no new dependencies
- Related patterns: `test_user_modified_skill_not_overwritten` (existing test validates the unchanged user-modified path still works)
