### PR TITLE
feat(xiaomi-provider): add XIAOMI_BASE_URL env override + fallback_models

### DIFF
--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -3,14 +3,26 @@
 from providers import register_provider
 from providers.base import ProviderProfile
 
+# XIAOMI_BASE_URL is declared alongside XIAOMI_API_KEY in env_vars so the
+# auto-bridge in hermes_cli.auth populates PROVIDER_REGISTRY[*].base_url_env_var
+# and users can repoint the inference endpoint (e.g. to a region-routed
+# token-plan gateway such as https://token-plan-sgp.xiaomimimo.com/v1).
 xiaomi = ProviderProfile(
     name="xiaomi",
     aliases=("mimo", "xiaomi-mimo"),
-    env_vars=("XIAOMI_API_KEY",),
+    env_vars=("XIAOMI_API_KEY", "XIAOMI_BASE_URL"),
     base_url="https://api.xiaomimimo.com/v1",
     supports_health_check=False,  # /v1/models returns 401 even with valid key
-    supports_vision=True,  # mimo-v2-omni is vision-capable
+    supports_vision=True,  # mimo-v2-omni and mimo-v2.5 are vision-capable
     supports_vision_tool_messages=False,  # rejects list-type tool content (400 "text is not set")
+    fallback_models=(
+        # Current token-plan catalog (June 2026). V2-Pro/V2-Omni auto-route
+        # to V2.5; Flash/UltraSpeed require separate tier enrollment.
+        "mimo-v2.5-pro",   # flagship reasoning, 1M ctx, deep thinking
+        "mimo-v2.5",       # omni: text + image + audio + video, 1M ctx
+        "mimo-v2-pro",     # legacy → auto-routes to v2.5 (deprecates 2026-06-30)
+        "mimo-v2-omni",    # legacy → auto-routes to v2.5 (deprecates 2026-06-30)
+    ),
 )
 
 register_provider(xiaomi)


### PR DESCRIPTION
## Summary

The bundled Xiaomi MiMo provider has two gaps that break token-plan subscribers in region-routed gateways:

1. **`base_url` is hardcoded** to `https://api.xiaomimimo.com/v1` (the global marketing endpoint). Token-plan subscribers in SGP and other regions must repoint to their region-routed gateway (e.g. `https://token-plan-sgp.xiaomimimo.com/v1`) or the API returns 401 on every request.

2. **`fallback_models` is empty**. `/v1/models` on the MiMo API returns 401 even with valid keys (per the existing `supports_health_check=False` note), so the `/model` picker has nothing to display for token-plan users.

## Fix

- Add `XIAOMI_BASE_URL` to `env_vars` so the auto-bridge in `hermes_cli.auth` populates `PROVIDER_REGISTRY["xiaomi"].base_url_env_var`. Users can now set `XIAOMI_BASE_URL=https://token-plan-sgp.xiaomimimo.com/v1` (or any other region gateway) and it Just Works — same pattern as `XAI_BASE_URL`, `NVIDIA_BASE_URL`, etc.
- Populate `fallback_models` with the working token-plan catalog (June 2026):
  - `mimo-v2.5-pro` — flagship reasoning, 1M ctx, deep thinking
  - `mimo-v2.5` — omni: text + image + audio + video, 1M ctx
  - `mimo-v2-pro` — legacy → auto-routes to v2.5 (deprecates 2026-06-30)
  - `mimo-v2-omni` — legacy → auto-routes to v2.5 (deprecates 2026-06-30)
- `mimo-v2-flash` and `mimo-v2.5-pro-ultraspeed` intentionally excluded — they require separate tier enrollment and return 400 on the standard token plan.
- Updated `supports_vision` comment to mention `mimo-v2.5` (not just `mimo-v2-omni`).

## Verification

- **52/52** xiaomi tests pass (`tests/hermes_cli/test_xiaomi_provider.py`)
- **163/163** provider tests pass overall (gmi, arcee, tencent_tokenhub, xiaomi)
- **Live chat through `https://token-plan-sgp.xiaomimimo.com/v1`** returns 200 for all four models in `fallback_models`; previously returned 401 with the hardcoded base URL.
- Diff is 1 file, 14 insertions, 2 deletions.

## Notes for Reviewer

- No new dependencies, no schema changes, no tests added (the existing `test_base_url_env_var` test now actually passes against the bridged config).
- Pattern matches the existing `XAI_BASE_URL` / `NVIDIA_BASE_URL` env-var override idiom used by `hermes_cli.auth`'s auto-bridge.
- Backward compatible: the global default `https://api.xiaomimimo.com/v1` is preserved when `XIAOMI_BASE_URL` is unset.