### PR TITLE
fix: hide memory tool from cron agents

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -62,17 +62,19 @@ class CronPromptInjectionBlocked(Exception):
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
-    Three protected toolsets are always disabled in cron context:
+    Four protected toolsets are always disabled in cron context:
       - ``cronjob`` — would let a cron-spawned agent schedule more cron jobs
       - ``messaging`` — interactive, needs a live gateway session
       - ``clarify`` — interactive, blocks waiting for user input
+      - ``memory`` — cron agents are constructed with ``skip_memory=True``, so
+        exposing this tool only gives the model an unbacked tool that fails
 
     User-level ``agent.disabled_toolsets`` from config.yaml is layered on top
     so per-job ``enabled_toolsets`` cannot bypass policy that applies to
     ordinary agent runs (#25752 — LLM-supplied enabled_toolsets was widening
     past config.yaml's denylist).
     """
-    disabled = ["cronjob", "messaging", "clarify"]
+    disabled = ["cronjob", "messaging", "clarify", "memory"]
     agent_cfg = (cfg or {}).get("agent") or {}
     user_disabled = agent_cfg.get("disabled_toolsets") or []
     for name in user_disabled:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1091,8 +1091,35 @@ class TestRunJobSessionPersistence:
 
         kwargs = mock_agent_cls.call_args.kwargs
         assert set(kwargs["disabled_toolsets"]) >= {
-            "cronjob", "messaging", "clarify", "terminal", "file",
+            "cronjob", "messaging", "clarify", "memory", "terminal", "file",
         }
+
+    def test_run_job_disables_memory_even_when_per_job_enables_it(self, tmp_path):
+        """Cron runs pass skip_memory=True, so memory must not be exposed.
+
+        A cron job can request the memory tool through enabled_toolsets, but
+        there is no MemoryStore injected for cron agents. Keep memory in the
+        disabled set so AIAgent filters the unbacked tool out before the model
+        can call it and receive "Memory is not available" failures.
+        """
+        job = {
+            "id": "memory-toolset-job",
+            "name": "test",
+            "prompt": "remember what you learn",
+            "enabled_toolsets": ["memory", "file"],
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["skip_memory"] is True
+        assert kwargs["enabled_toolsets"] == ["memory", "file"]
+        assert "memory" in kwargs["disabled_toolsets"]
 
     def test_run_job_enabled_toolsets_resolves_from_platform_config_when_not_set(self, tmp_path):
         """When a job has no explicit enabled_toolsets, the scheduler now


### PR DESCRIPTION
## Summary
- add `memory` to cron's always-disabled toolsets because cron agents are constructed with `skip_memory=True`
- keep per-job `enabled_toolsets` intact while letting `disabled_toolsets` filter out the unbacked memory tool
- add regression coverage for cron jobs that explicitly request the memory tool

## Tests
- `python -m pytest tests/cron/test_scheduler.py -q -k 'memory or disabled_toolsets or enabled_toolsets' -o 'addopts='`\n- `python -m pytest tests/cron/test_scheduler.py -q -o 'addopts='`