### PR TITLE
fix(approval): flag model config mutations in DANGEROUS_PATTERNS

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -804,6 +804,31 @@ class TestGatewayProtection:
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
 
+    def test_hermes_config_set_model_provider_flagged(self):
+        """hermes config set model.provider should require approval."""
+        cmd = "hermes config set model.provider deepseek"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "connectivity" in desc
+
+    def test_hermes_config_set_model_base_url_flagged(self):
+        """hermes config set model.base_url should require approval."""
+        cmd = "hermes config set model.base_url https://example.com/v1"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_hermes_config_set_model_api_key_flagged(self):
+        """hermes config set model.api_key should require approval."""
+        cmd = "hermes config set model.api_key sk-abc123"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_hermes_config_set_unrelated_not_flagged(self):
+        """hermes config set on non-model keys should not be flagged."""
+        cmd = "hermes config set display.show_cost true"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
 
 class TestNormalizationBypass:
     """Obfuscation techniques must not bypass dangerous command detection."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -419,6 +419,13 @@ DANGEROUS_PATTERNS = [
     # terminates all running agents mid-work.
     (r'\bhermes\s+gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
     (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
+    # Gateway connectivity protection: config mutations that can break the
+    # agent's own ability to reach its model endpoint.  A mismatched
+    # provider + base_url produces 401 loops indistinguishable from an
+    # expired key, but with no recovery path because the agent can't
+    # call home to report the error.
+    (r'\bhermes\s+config\s+set\s+model\.(provider|base_url|api_key)\b',
+     "modify model connectivity config (may break gateway)"),
     # Docker container lifecycle — any user with docker.sock mounted (a common
     # Docker Compose pattern) gives the agent the ability to restart/stop/kill
     # containers without approval.  These are agent-initiated lifecycle operations


### PR DESCRIPTION
## Summary

`hermes config set model.(provider|base_url|api_key)` can silently break gateway connectivity, yet smart approval mode never flags them — `detect_dangerous_command()` returns `False` and `check_all_command_guards()` auto-approves at line 1328-1329 without ever reaching the smart-approval LLM.

## Root cause

The approval system has two layers but a structural gap: `DANGEROUS_PATTERNS` regex matching (Layer 1) catches shell-level destruction (`rm -rf`, `mkfs`) and gateway process death (`hermes gateway stop`, `pkill hermes`), but has no coverage for config mutations that break connectivity without killing the process. The smart-approval LLM (Layer 2) is only invoked for commands already flagged by Layer 1, so it never sees `hermes config set model.provider`.

## Changes

| File | Change |
|------|--------|
| `tools/approval.py` | Add `hermes config set model.(provider|base_url|api_key)` regex to DANGEROUS_PATTERNS alongside existing gateway lifecycle protections |
| `tests/tools/test_approval.py` | Add 4 tests: provider/base_url/api_key flagged, unrelated config not flagged |

## Validation

| | Before | After |
|---|---|---|
| `hermes config set model.provider deepseek` (smart mode) | auto-approved, no prompt | flagged, smart LLM evaluates with context |
| `hermes config set model.base_url https://example.com/v1` | auto-approved | flagged |
| `hermes config set model.api_key sk-abc123` | auto-approved | flagged |
| `hermes config set display.show_cost true` | auto-approved | auto-approved (unchanged) |
| `tests/tools/test_approval.py::TestGatewayProtection` | 10 passed | 14 passed |

```
python -m pytest tests/tools/test_approval.py::TestGatewayProtection -v --tb=short
# 14 passed
```

Closes #42702
