### PR TITLE
fix(gateway): return tuple from transcription placeholder branch for voice-only messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11496,7 +11496,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # when we successfully transcribed the audio — it's redundant.
             _placeholder = "(The user sent a message with no text content)"
             if user_text and user_text.strip() == _placeholder:
-                return prefix
+                return prefix, successful_transcripts
             if user_text:
                 return f"{prefix}\n\n{user_text}", successful_transcripts
             return prefix, successful_transcripts

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -143,3 +143,37 @@ async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
     assert result is not None
     assert "queued voice transcript" in result
     assert "voice message" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_returns_tuple_for_placeholder_text():
+    """Regression: voice-only Discord messages must return tuple, not bare string.
+
+    When user_text equals the Discord adapter's empty-content placeholder and
+    transcription succeeds, the function previously returned ``prefix`` (a str)
+    instead of ``(prefix, successful_transcripts)``.  Callers unpack two values
+    and crash with ``ValueError: too many values to unpack``.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+
+    placeholder = "(The user sent a message with no text content)"
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "hello from voice",
+            "provider": "local_command",
+        },
+    ):
+        result, transcripts = await runner._enrich_message_with_transcription(
+            placeholder,
+            ["/tmp/voice.ogg"],
+        )
+
+    assert "hello from voice" in result
+    assert placeholder not in result
+    assert isinstance(transcripts, list)
+    assert len(transcripts) == 1


### PR DESCRIPTION
## What does this PR do?

Fixes a crash on voice-only Discord messages. `_enrich_message_with_transcription` has one success-path branch that returns a bare string instead of the expected `tuple[str, List[str]]`, causing `ValueError: too many values to unpack` at all four call sites.

## Related Issue

Fixes #42709

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Changed `return prefix` to `return prefix, successful_transcripts` on line 11499 — the placeholder-stripping branch for voice-only messages now returns the expected 2-tuple, matching all sibling returns in the same function.
- `tests/gateway/test_stt_config.py`: Added regression test `test_enrich_message_with_transcription_returns_tuple_for_placeholder_text` that exercises the exact code path (transcription succeeds, user_text equals Discord's empty-content placeholder).

## How to Test

1. Run `pytest tests/gateway/test_stt_config.py -v` — all 7 tests pass including the new regression test.
2. The new test specifically verifies the placeholder branch returns a tuple with the transcript included and the placeholder text stripped.
3. On Discord: send a voice-only message (no text caption) with STT enabled. Before this fix, the handler crashes with `ValueError: too many values to unpack`. After, the voice is transcribed and the agent replies normally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_enrich_message_with_transcription` (callers: 4, all unpack 2 values)
- Blast radius: LOW — single return statement, no control-flow change
- Related patterns: sibling returns at lines 11441, 11444, 11501, 11502 already return tuples correctly
