### PR TITLE
fix(gateway): return a tuple from the voice-only transcription success path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11496,7 +11496,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # when we successfully transcribed the audio — it's redundant.
             _placeholder = "(The user sent a message with no text content)"
             if user_text and user_text.strip() == _placeholder:
-                return prefix
+                return prefix, successful_transcripts
             if user_text:
                 return f"{prefix}\n\n{user_text}", successful_transcripts
             return prefix, successful_transcripts

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -60,6 +60,36 @@ async def test_enrich_message_with_transcription_surfaces_path_when_stt_disabled
 
 
 @pytest.mark.asyncio
+async def test_enrich_voice_only_message_returns_tuple_not_bare_string():
+    """A voice-only message (caption == the Discord empty-content placeholder)
+    whose audio transcribes successfully must return the (enriched_text,
+    successful_transcripts) tuple, not a bare string. Returning a bare string
+    made every caller's ``a, b = await ...`` unpack crash with "too many values
+    to unpack", dropping the whole reply on voice-only Discord messages (#42709).
+    """
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+
+    placeholder = "(The user sent a message with no text content)"
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "hello there"},
+    ):
+        result = await runner._enrich_message_with_transcription(
+            placeholder,
+            ["/tmp/voice.ogg"],
+        )
+
+    # The bug returned a bare ``str`` here; unpacking it would raise.
+    enriched, transcripts = result
+    assert "hello there" in enriched
+    assert placeholder not in enriched  # placeholder dropped once transcribed
+    assert transcripts == ["hello there"]
+
+
+@pytest.mark.asyncio
 async def test_enrich_message_with_transcription_omits_duration_on_probe_failure():
     from gateway.run import GatewayRunner
 


### PR DESCRIPTION
## What & why — closes #42709

Any **voice-only message on Discord** (audio attachment, no text caption) crashed the message handler and the agent never replied:

```
ERROR gateway.platforms.base: [Discord] Error handling message: too many values to unpack (expected 2)
  File "gateway/run.py", line ~7378, in _prepare_inbound_message_text
    message_text, _successful_transcripts = await self._enrich_message_with_transcription(...)
ValueError: too many values to unpack (expected 2)
```

It looks like an STT/provider failure but it's a plain unpacking bug, independent of STT provider/auth/quota.

`_enrich_message_with_transcription` is declared `-> tuple[str, List[str]]` and all four call sites unpack two values. But one **success** branch still returned a bare `prefix` string — a leftover from when the function returned `-> str`:

```python
_placeholder = "(The user sent a message with no text content)"
if user_text and user_text.strip() == _placeholder:
    return prefix                                    # <-- bare str
if user_text:
    return f"{prefix}\n\n{user_text}", successful_transcripts
return prefix, successful_transcripts
```

When a voice-only message arrives (the Discord adapter sets `user_text` to its empty-content placeholder) **and** transcription succeeds, this branch fires and the caller's `a, b = await ...` unpacks the string's characters → crash. The parallel STT-disabled branch right above already returns `return prefix, []` correctly, confirming a missed conversion. A voice note *with* a caption works because it takes the `if user_text:` branch.

## Fix

One line — return the tuple, mirroring the sibling returns:

```diff
-                return prefix
+                return prefix, successful_transcripts
```

## How to test

```bash
scripts/run_tests.sh tests/gateway/test_stt_config.py   # 7 passed
```

Adds `test_enrich_voice_only_message_returns_tuple_not_bare_string`: STT enabled, transcription succeeds, `user_text` == the placeholder; asserts the result unpacks to `(enriched_text, successful_transcripts)` (the bug raised on unpack) with the placeholder dropped and the transcript surfaced. Verified the test fails without the one-line change.

## Platforms

Shared gateway Python; reproduced on Discord per the report but the path is platform-agnostic (any adapter that sets the empty-content placeholder for a transcribable voice-only message). Verified via the CI-parity runner.