### PR TITLE
feat(tui): add display.submit_key config to swap Enter/Cmd+Enter behavior

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1413,6 +1413,10 @@ DEFAULT_CONFIG = {
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.
         "tui_status_indicator": "kaomoji",
+        # TUI composer submit key: "enter" (default) submits on Enter,
+        # newline on Cmd/Ctrl+Enter; "cmd_enter" swaps so Enter inserts
+        # a newline and Cmd/Ctrl+Enter submits.
+        "submit_key": "enter",
         "user_message_preview": {  # CLI: how many submitted user-message lines to echo back in scrollback
             "first_lines": 2,
             "last_lines": 2,

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -48,6 +48,21 @@ describe('applyDisplay', () => {
     expect(s.streaming).toBe(false)
   })
 
+  it('defaults submitKey to enter when config omits submit_key', () => {
+    applyDisplay({ config: { display: {} } }, vi.fn())
+    expect($uiState.get().submitKey).toBe('enter')
+  })
+
+  it('sets submitKey to cmd_enter when config sets submit_key', () => {
+    applyDisplay({ config: { display: { submit_key: 'cmd_enter' } } }, vi.fn())
+    expect($uiState.get().submitKey).toBe('cmd_enter')
+  })
+
+  it('falls back to enter for unknown submit_key values', () => {
+    applyDisplay({ config: { display: { submit_key: 'something_else' } } }, vi.fn())
+    expect($uiState.get().submitKey).toBe('enter')
+  })
+
   it('coerces legacy true + "on" alias to top', () => {
     const setBell = vi.fn()
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -134,6 +134,7 @@ export interface UiState {
   status: string
   statusBar: StatusBarMode
   streaming: boolean
+  submitKey: 'enter' | 'cmd_enter'
   theme: Theme
   usage: Usage
 }

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -28,6 +28,7 @@ const buildUiState = (): UiState => ({
   status: 'summoning hermes…',
   statusBar: 'top',
   streaming: true,
+  submitKey: 'enter',
   theme: DEFAULT_THEME,
   usage: ZERO
 })

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -216,7 +216,8 @@ export const applyDisplay = (
     showCost: !!d.show_cost,
     showReasoning: !!d.show_reasoning,
     statusBar: normalizeStatusBar(d.tui_statusbar),
-    streaming: d.streaming !== false
+    streaming: d.streaming !== false,
+    submitKey: d.submit_key === 'cmd_enter' ? 'cmd_enter' : 'enter'
   })
 }
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -312,6 +312,7 @@ const ComposerPane = memo(function ComposerPane({
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}
                   placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
+                  submitKey={ui.submitKey}
                   value={composer.input}
                   voiceRecordKey={composer.voiceRecordKey}
                 />

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -442,6 +442,7 @@ export function TextInput({
   onSubmit,
   mask,
   mouseApiRef,
+  submitKey = 'enter',
   voiceRecordKey = DEFAULT_VOICE_RECORD_KEY,
   placeholder = '',
   focus = true
@@ -971,10 +972,22 @@ export function TextInput({
         const sequence = (event.keypress as { sequence?: string }).sequence
         const preserveBareLineFeed = shouldPreserveCtrlJNewline() && sequence === '\n'
 
-        if (k.shift || k.ctrl || preserveBareLineFeed || (isMac ? isActionMod(k) : k.meta)) {
-          commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
+        const isModifier = k.shift || k.ctrl || preserveBareLineFeed || (isMac ? isActionMod(k) : k.meta)
+
+        if (submitKey === 'cmd_enter') {
+          // Inverted: modifier+Enter submits, bare Enter inserts newline
+          if (isModifier) {
+            cbSubmit.current?.(vRef.current)
+          } else {
+            commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
+          }
         } else {
-          cbSubmit.current?.(vRef.current)
+          // Default: bare Enter submits, modifier+Enter inserts newline
+          if (isModifier) {
+            commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
+          } else {
+            cbSubmit.current?.(vRef.current)
+          }
         }
 
         return
@@ -1285,6 +1298,8 @@ interface TextInputProps {
   ) => { cursor: number; value: string } | Promise<{ cursor: number; value: string } | null> | null
   onSubmit?: (v: string) => void
   placeholder?: string
+  /** When 'cmd_enter', Enter inserts a newline and Cmd/Ctrl+Enter submits. */
+  submitKey?: 'enter' | 'cmd_enter'
   value: string
   voiceRecordKey?: ParsedVoiceRecordKey
 }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -80,6 +80,8 @@ export interface ConfigDisplayConfig {
   // validation anyway.
   tui_status_indicator?: string
   tui_statusbar?: 'bottom' | 'off' | 'on' | 'top' | boolean
+  /** TUI composer submit key: "enter" (default) or "cmd_enter" (swap). */
+  submit_key?: string
 }
 
 export interface ConfigVoiceConfig {


### PR DESCRIPTION
## Problem

The TUI composer's keybinding is counter-intuitive for users who frequently write multi-line prompts. Currently, Enter submits and Cmd/Ctrl+Enter inserts a newline. Many productivity tools use the opposite convention (Enter for newline, modifier+Enter to submit).

Closes #42648

## Solution

Add a new `display.submit_key` config option:

- `"enter"` (default): Current behavior — Enter submits, Cmd/Ctrl+Enter inserts newline
- `"cmd_enter"`: Swapped — Enter inserts newline, Cmd/Ctrl+Enter submits

**Usage:**
```yaml
display:
  submit_key: cmd_enter
```

## Changes

| File | Change |
|------|--------|
| `hermes_cli/config.py` | Add `display.submit_key` default (`"enter"`) |
| `gatewayTypes.ts` | Add `submit_key` to `ConfigDisplayConfig` |
| `interfaces.ts` | Add `submitKey` to `UiState` |
| `uiStore.ts` | Add `submitKey` default in `buildUiState()` |
| `useConfigSync.ts` | Sync config value to `$uiState` |
| `appLayout.tsx` | Pass `submitKey` prop to `TextInput` |
| `textInput.tsx` | Add `submitKey` prop, swap Enter/modifier logic |
| `useConfigSync.test.ts` | 3 new tests for config sync |

## Testing

- TypeScript type-check: ✅ clean (only pre-existing hermes-ink errors)
- `useConfigSync.test.ts`: ✅ 37/37 passed (34 existing + 3 new)
- Manual: verified `submitKey` defaults to `'enter'`, config sync works

## Scope

- Only affects the TUI composer (`TextInput` in `appLayout.tsx`)
- Other `TextInput` usages (approval prompts, masked prompts, session switcher) retain default behavior
- No new dependencies, no breaking changes
