### PR TITLE
fix(web): add dispatch-time backend availability check for web_search

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -848,6 +848,20 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         )
 
         backend = _get_search_backend()
+        # Validate backend availability at dispatch time (not just at
+        # registration). The registry's check_fn runs once at startup;
+        # backends installed after startup, or whose dependency was
+        # uninstalled between sessions, would otherwise fail silently.
+        if backend and not _is_backend_available(backend):
+            return json.dumps({
+                "success": False,
+                "error": (
+                    f"Web search backend '{backend}' is not available. "
+                    "Install the required package or set a different backend: "
+                    f"hermes config set web.backend <name>"
+                ),
+            })
+
         provider = _wsp_get_provider(backend) if backend else None
         if provider is None or not provider.supports_search():
             # Fall back to availability-walked active provider when the


### PR DESCRIPTION
## What does this PR do?

Add a dispatch-time backend availability check in `web_search_tool` to catch the case where the configured backend's dependency is missing at invocation time. The registry's `check_fn` only runs at startup, so backends whose packages were uninstalled between sessions would otherwise fail silently (echoing the tool call instead of returning an error).

## Related Issue

Fixes #42011

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/web_tools.py`: add `_is_backend_available` check at the top of `web_search_tool` with a descriptive error message

## How to Test

1. Set `web.backend: ddgs` in config, ensure `ddgs` package is not installed
2. Invoke web_search — should return error JSON with clear message instead of silent echo

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains only changes related to this fix
- [ ] I've added tests for my changes
- [ ] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated cli-config.yaml.example — N/A
- [x] I've considered cross-platform impact — N/A