### PR TITLE
fix(delegate): lazy-import STEER_CHANNEL_NOTE to avoid subagent import race

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -36,7 +36,6 @@ from agent.prompt_builder import (
     PLATFORM_HINTS,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
-    STEER_CHANNEL_NOTE,
     TASK_COMPLETION_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
@@ -135,6 +134,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Steering only lands inside tool results, so it's only reachable when the
     # agent has tools. Static text → byte-stable prompt (no cache hit).
     if agent.valid_tool_names:
+        from agent.prompt_builder import STEER_CHANNEL_NOTE
         stable_parts.append(STEER_CHANNEL_NOTE)
 
     # Computer-use (macOS) — goes in as its own block rather than being


### PR DESCRIPTION
## What does this PR do?

Move `STEER_CHANNEL_NOTE` import from module top-level to the only call-site in `build_system_prompt_parts`. This matches the existing pattern used for `COMPUTER_USE_GUIDANCE` and prevents `ImportError` when `delegate_task` subagents are spawned with an incomplete import state.

## Related Issue

Fixes #41986

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `agent/system_prompt.py`: remove `STEER_CHANNEL_NOTE` from top-level import block, add lazy import at the single call-site

## How to Test

1. Call `delegate_task` with any goal
2. Subagent should initialize and execute normally instead of failing with `ImportError: cannot import name 'STEER_CHANNEL_NOTE'`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains only changes related to this fix
- [ ] I've added tests for my changes
- [ ] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated cli-config.yaml.example — N/A
- [x] I've considered cross-platform impact — N/A