### PR TITLE
refactor(yuanbao): consolidate media resolution into dedicated pipeline middlewares

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -157,6 +157,12 @@ _YB_RES_REF_RE = re.compile(
     r"\[(image|voice|video|file(?::[^|\]]*)?)\|ybres:([A-Za-z0-9_\-]+)\]"
 )
 
+# Patched local-media anchors once an inbound resource has been downloaded to the local cache. 
+#   [image: /opt/data/image_cache/img_xxx.bmp]
+#   [file: report.pdf → /opt/data/.../report.pdf]
+#   (and any future kind, e.g. [video: /opt/.../clip.mp4])
+_YB_LOCAL_MEDIA_RE = re.compile(r"\[(\w+):[^\]]*?(/[^\]]+?)\s*\]")
+
 # Media kinds that can be resolved and injected into the model context
 _RESOLVABLE_MEDIA_KINDS = frozenset({"image", "file"})
 
@@ -940,7 +946,11 @@ class InboundContext:
     reply_to_text: Optional[str] = None
     quote_media_refs: list = dc_field(default_factory=list)  # List of (rid, kind, filename)
 
-    # Populated by MediaResolveMiddleware
+    # Populated by MediaResolveMiddleware. Combined list of resolved local
+    # paths from up to three sources (deduped, in this order):
+    #   1) media carried by the current message (always),
+    #   2) media from the quoted message (when reply_to_message_id is set),
+    #   3) recent group-observed media (only when chat_type == "group" and no quote is present).
     media_urls: list = dc_field(default_factory=list)
     media_types: list = dc_field(default_factory=list)
 
@@ -1685,10 +1695,10 @@ class ExtractContentMiddleware(InboundMiddleware):
         """Extract plain text content from MsgBody.
 
         - TIMTextElem      -> text field
-        - TIMImageElem     -> "[image]"
-        - TIMFileElem      -> "[file: {filename}]"
-        - TIMSoundElem     -> "[voice]"
-        - TIMVideoFileElem -> "[video]"
+        - TIMImageElem     -> "[image]" / "[image|ybres:RID]"
+        - TIMFileElem      -> "[file: {filename}]" / "[file:{name}|ybres:RID]"
+        - TIMSoundElem     -> "[voice]" / "[voice|ybres:RID]"
+        - TIMVideoFileElem -> "[video]" / "[video|ybres:RID]"
         - TIMFaceElem      -> "[emoji: {name}]" or "[emoji]"
         - TIMCustomElem    -> try to extract data field, otherwise "[custom message]"
         - Multiple elems joined with spaces
@@ -2187,51 +2197,72 @@ class QuoteContextMiddleware(InboundMiddleware):
 
     name = "quote-context"
 
-    @staticmethod
-    def _extract_quote_context(cloud_custom_data: str) -> Tuple[Optional[str], Optional[str], list]:
-        """Extract quote context, mapping to MessageEvent.reply_to_*.
-
-        Returns:
-          (reply_to_message_id, reply_to_text, quote_media_refs)
-          where quote_media_refs is a list of (rid, kind, filename) tuples
+    def _extract_quote_context(self, cloud_custom_data: str) -> Tuple[Optional[str], Optional[str]]:
+        """Extract quote text context, mapping to MessageEvent.reply_to_*.
         """
         if not cloud_custom_data:
-            return None, None, []
+            return None, None
         try:
             parsed = json.loads(cloud_custom_data)
         except (json.JSONDecodeError, TypeError):
-            return None, None, []
+            return None, None
 
         quote = parsed.get("quote") if isinstance(parsed, dict) else None
         if not isinstance(quote, dict):
-            return None, None, []
-
-        # type=2 corresponds to image reference; desc may be empty, provide a placeholder.
-        quote_type = int(quote.get("type") or 0)
-        desc = str(quote.get("desc") or "").strip()
-        if quote_type == 2 and not desc:
-            desc = "[image]"
-        if not desc:
-            return None, None, []
+            return None, None
 
         quote_id = str(quote.get("id") or "").strip() or None
+        desc = str(quote.get("desc") or "").strip()
         sender = str(quote.get("sender_nickname") or quote.get("sender_id") or "").strip()
-        quote_text = f"{sender}: {desc}" if sender else desc
+        quote_text = (f"{sender}: {desc}" if sender else desc) if desc else None
 
-        # Extract media references from desc using _YB_RES_REF_RE regex
-        media_refs: list = []
-        for m in _YB_RES_REF_RE.finditer(desc):
-            head = m.group(1)  # "image" | "file:<name>" | "voice" | "video"
-            rid = m.group(2)
-            kind, _, filename = head.partition(":")
-            kind = kind.strip()
-            media_refs.append((rid, kind, filename.strip()))
+        return quote_id, quote_text
 
-        return quote_id, quote_text, media_refs
+    async def _extract_media_refs_from_transcript(
+        self, ctx: InboundContext
+    ) -> List[Tuple[str, str, str]]:
+        """Look up the quoted message in the transcript history and return any
+        ``[kind|ybres:RID]`` anchors found in its content as
+        ``(rid, kind, filename)`` tuples.
+
+        Returns ``[]`` when ``ctx.reply_to_message_id`` is unset, when the
+        transcript store / source is unavailable, or when the quoted message
+        carries no resolvable media anchors.
+        """
+        if ctx.reply_to_message_id is None:
+            return []
+        adapter = ctx.adapter
+        media_refs: List[Tuple[str, str, str]] = []
+        try:
+            store = getattr(adapter, "_session_store", None)
+            if not store or ctx.source is None:
+                return []
+            session_entry = store.get_or_create_session(ctx.source)
+            history = store.load_transcript(session_entry.session_id)
+            for msg in reversed(history or []):
+                mid = msg.get("message_id", "")
+                if not mid or mid != ctx.reply_to_message_id:
+                    continue
+                _content = msg.get("content", "")
+                if isinstance(_content, str) and "|ybres:" in _content:
+                    for m in _YB_RES_REF_RE.finditer(_content):
+                        head = m.group(1)
+                        rid = m.group(2)
+                        kind, _, filename = head.partition(":")
+                        kind = kind.strip()
+                        if kind in _RESOLVABLE_MEDIA_KINDS:
+                            media_refs.append((rid, kind, filename.strip()))
+                break
+        except Exception as exc:
+            logger.warning(
+                "[%s] quote transcript lookup failed: %s",
+                getattr(adapter, "name", "yuanbao"), exc,
+            )
+        return media_refs
 
     async def handle(self, ctx: InboundContext, next_fn) -> None:
-        ctx.reply_to_message_id, ctx.reply_to_text, ctx.quote_media_refs = self._extract_quote_context(ctx.cloud_custom_data)
-
+        ctx.reply_to_message_id, ctx.reply_to_text = self._extract_quote_context(ctx.cloud_custom_data)
+        ctx.quote_media_refs = await self._extract_media_refs_from_transcript(ctx)
         await next_fn()
 
 
@@ -2437,11 +2468,6 @@ class MediaResolveMiddleware(InboundMiddleware):
         return local_path, mime
 
     @classmethod
-    async def _resolve_by_resource_id(cls, adapter, resource_id: str) -> str:
-        """Exchange a Yuanbao ``resourceId`` for a short-lived direct download URL. Raises on failure."""
-        return await cls._fetch_resource_url(adapter, resource_id)
-
-    @classmethod
     async def _resolve_media_urls(
         cls, adapter, media_refs: List[Dict[str, str]]
     ) -> Tuple[List[str], List[str]]:
@@ -2456,6 +2482,7 @@ class MediaResolveMiddleware(InboundMiddleware):
         for ref in media_refs:
             kind = str(ref.get("kind") or "").strip().lower()
             url = str(ref.get("url") or "").strip()
+            filename = str(ref.get("name") or "").strip()
             if kind not in _RESOLVABLE_MEDIA_KINDS or not url:
                 continue
 
@@ -2475,7 +2502,7 @@ class MediaResolveMiddleware(InboundMiddleware):
                 adapter,
                 fetch_url=fetch_url,
                 kind=kind,
-                file_name=str(ref.get("name") or "").strip() or None,
+                file_name=filename or None,
                 log_tag=f"placeholder_url={url[:80]}",
                 resource_id=rid,
             )
@@ -2486,6 +2513,44 @@ class MediaResolveMiddleware(InboundMiddleware):
             media_types.append(mime)
 
         return media_urls, media_types
+
+    @classmethod
+    async def _resolve_ybres_refs(
+        cls,
+        adapter,
+        refs: List[Tuple[str, str, str]],
+        *,
+        log_prefix: str,
+    ) -> Tuple[List[str], List[str]]:
+        """Resolve a list of ``(rid, kind, filename)`` ybres tuples to local paths.
+        """
+        media_paths: List[str] = []
+        mimes: List[str] = []
+        for rid, kind, filename in refs:
+            if kind not in _RESOLVABLE_MEDIA_KINDS:
+                continue
+            try:
+                fresh_url = await cls._fetch_resource_url(adapter, rid)
+            except Exception as exc:
+                logger.warning(
+                    "[%s] %s resolve failed: rid=%s kind=%s err=%s",
+                    adapter.name, log_prefix, rid, kind, exc,
+                )
+                continue
+            cached = await cls._download_and_cache(
+                adapter,
+                fetch_url=fresh_url,
+                kind=kind,
+                file_name=filename or None,
+                log_tag=f"{log_prefix} rid={rid}",
+                resource_id=rid,
+            )
+            if cached is None:
+                continue
+            path, mime = cached
+            media_paths.append(path)
+            mimes.append(mime)
+        return media_paths, mimes
 
     @classmethod
     async def _collect_observed_media(
@@ -2533,39 +2598,175 @@ class MediaResolveMiddleware(InboundMiddleware):
         if not order:
             return [], []
 
-        media_paths: List[str] = []
+        return await cls._resolve_ybres_refs(
+            adapter, order, log_prefix="observed-media",
+        )
+
+    @classmethod
+    async def _resolve_quote_media(
+        cls, adapter, quote_media_refs: List[Tuple[str, str, str]],
+    ) -> Tuple[List[str], List[str]]:
+        """Resolve media anchors carried by the quoted message.
+
+        ``quote_media_refs`` is a list of ``(rid, kind, filename)`` tuples
+        produced by :class:`QuoteContextMiddleware` from the transcript.
+        """
+        return await cls._resolve_ybres_refs(
+            adapter, quote_media_refs, log_prefix="quote",
+        )
+
+    @staticmethod
+    def _collect_quote_local_media(ctx: InboundContext) -> Tuple[List[str], List[str]]:
+        """Private-chat fallback for recovering already-local quoted media.
+
+        Only already-local media is handled here: by the time a turn is cached,
+        ``PatchAnchorsMiddleware`` has rewritten resolved ``|ybres:`` anchors to
+        ``[image: /path]`` / ``[file: name → /path]``. Unresolved anchors are an
+        original-turn resolution failure and belong to that turn's handling, not
+        this quote fallback — so no re-download happens here.
+
+        Returns ``(local_paths, mimes)`` for media already downloaded to the
+        local cache on its original turn, ready to inject as-is.
+        """
+        paths: List[str] = []
         mimes: List[str] = []
-        for rid, kind, filename in order:
-            try:
-                fresh_url = await cls._resolve_by_resource_id(adapter, rid)
-            except Exception as exc:
-                logger.warning(
-                    "[%s] observed-media resolve failed: rid=%s kind=%s err=%s",
-                    adapter.name, rid, kind, exc,
-                )
+        rid_key = ctx.reply_to_message_id
+        if not rid_key:
+            return paths, mimes
+        cache = getattr(ctx.adapter, "_msg_content_cache", None)
+        if not cache:
+            return paths, mimes
+        text = cache.get(rid_key)
+        if not isinstance(text, str) or not text:
+            return paths, mimes
+
+        # Already-local media paths written by PatchAnchorsMiddleware. The
+        # generic anchor regex covers every kind _patch emits (image/file today,
+        # video/audio if they later become resolvable) without per-kind upkeep.
+        seen: set = set()
+        for m in _YB_LOCAL_MEDIA_RE.finditer(text):
+            kind = (m.group(1) or "").strip().lower()
+            path = (m.group(2) or "").strip()
+            if not path or path in seen:
                 continue
-            cached = await cls._download_and_cache(
-                adapter,
-                fetch_url=fresh_url,
-                kind=kind,
-                file_name=filename or None,
-                log_tag=f"rid={rid}",
-                resource_id=rid,
+            if not os.path.exists(path):
+                continue
+            seen.add(path)
+            mime = guess_mime_type(os.path.basename(path)) or (
+                "image/jpeg" if kind == "image" else "application/octet-stream"
             )
-            if cached is None:
-                continue
-            path, mime = cached
-            media_paths.append(path)
+            paths.append(path)
             mimes.append(mime)
-        return media_paths, mimes
+
+        return paths, mimes
 
     async def handle(self, ctx: InboundContext, next_fn) -> None:
+        # NOTE: Reaching this middleware in a group chat implies the message has
+        # @-mentioned the bot (or is an owner command). GroupAtGuardMiddleware
+        # short-circuits non-@bot group messages earlier in the pipeline, so we
+        # don't need to re-check @bot status here before downloading media.
         adapter = ctx.adapter
-        ctx.media_urls, ctx.media_types = await self._resolve_media_urls(adapter, ctx.media_refs)
-        # Re-check placeholder after media resolution
-        if PlaceholderFilterMiddleware.is_skippable_placeholder(ctx.raw_text, len(ctx.media_urls)):
+
+        urls: List[str] = []
+        types: List[str] = []
+        seen: set = set()
+
+        def _add_unique_pairs(pair_lists: Tuple[List[str], List[str]]) -> None:
+            u_list, m_list = pair_lists
+            for u, m in zip(u_list, m_list):
+                if not u or u in seen:
+                    continue
+                seen.add(u)
+                urls.append(u)
+                types.append(m)
+
+        # 1) Media carried by the current message itself.
+        own_pairs = await self._resolve_media_urls(adapter, ctx.media_refs)
+        own_count = sum(1 for u in own_pairs[0] if u)
+        _add_unique_pairs(own_pairs)
+
+        # 2) Second source — quoted media takes priority; otherwise fall back
+        #    to observed-media backfill in groups only (DMs already had their
+        #    media resolved on the turn it was sent).
+        if ctx.reply_to_message_id is not None:
+            if ctx.quote_media_refs:
+                _add_unique_pairs(await self._resolve_quote_media(adapter, ctx.quote_media_refs))
+            else:
+                # DM quote fallback: no transcript message_id match (DM user rows
+                # carry no platform message_id), so recover already-local media
+                # from the adapter msg cache. Patched on its original turn — no
+                # re-download needed, inject as-is.
+                _add_unique_pairs(self._collect_quote_local_media(ctx))
+        elif ctx.chat_type == "group":
+            # Group chats: only @-bot turns reach this middleware
+            # (see GroupAtGuardMiddleware note at top of handle()),
+            # so unconditional observed-media hydration is safe here.
+            try:
+                _add_unique_pairs(await self._collect_observed_media(adapter, ctx.source))
+            except Exception as exc:
+                logger.warning(
+                    "[%s] observed-image hydration raised, continuing anyway: %s",
+                    adapter.name, exc,
+                )
+
+        ctx.media_urls = urls
+        ctx.media_types = types
+
+        # Re-check placeholder after media resolution.
+        # Use ``own_count`` (not ``len(urls)``) to preserve the original
+        # semantics: a placeholder text accompanied only by quote/observed
+        # media (i.e. no fresh attachment of its own) is still skippable.
+        if PlaceholderFilterMiddleware.is_skippable_placeholder(ctx.raw_text, own_count):
             logger.debug("[%s] Skip placeholder after media download: %r", adapter.name, ctx.raw_text)
             return  # Stop pipeline
+        await next_fn()
+
+
+class PatchAnchorsMiddleware(InboundMiddleware):
+    """Replace ``[kind|ybres:RID]`` anchors in ``ctx.raw_text`` with local paths.
+
+    Runs after :class:`MediaResolveMiddleware` so that ``ctx.media_urls`` /
+    ``ctx.media_types`` are already populated with downloaded resources
+    (own media + quote media or group-observed media).  The transcript
+    written downstream then records usable local paths for the model
+    instead of opaque ``ybres:`` references.
+
+    Only resolved media (paths starting with ``/``) are substituted; any
+    anchor without a corresponding local resource is left untouched.
+    """
+
+    name = "patch-anchors"
+
+    @staticmethod
+    def _patch(text: str, urls: List[str], types: List[str]) -> str:
+        if not text or not urls:
+            return text
+        patched = text
+        for u, m in zip(urls, types):
+            if not u.startswith("/"):
+                continue
+            anchor_match = _YB_RES_REF_RE.search(patched)
+            if not anchor_match:
+                break
+            head = anchor_match.group(1)
+            kind, _, filename = head.partition(":")
+            kind = kind.strip()
+            if kind == "image" and m.startswith("image/"):
+                replacement = f"[image: {u}]"
+            elif kind == "file":
+                label = filename.strip() or os.path.basename(u)
+                replacement = f"[file: {label} → {u}]"
+            else:
+                continue
+            patched = (
+                patched[: anchor_match.start()]
+                + replacement
+                + patched[anchor_match.end():]
+            )
+        return patched
+
+    async def handle(self, ctx: InboundContext, next_fn) -> None:
+        ctx.raw_text = self._patch(ctx.raw_text, ctx.media_urls, ctx.media_types)
         await next_fn()
 
 
@@ -2584,124 +2785,18 @@ class DispatchMiddleware(InboundMiddleware):
         )
 
         async def _dispatch_inbound_event() -> None:
-            media_urls = list(ctx.media_urls)
-            media_types = list(ctx.media_types)
-
-            # If user quoted a message (reply_to_message_id is set), resolve only
-            # quote_media_refs to avoid injecting unrelated history media.
-            # Otherwise, backfill observed media from recent transcript history.
-            if ctx.reply_to_message_id is not None:
-                # Fallback: if desc didn't contain ybres refs, look up transcript
-                if not ctx.quote_media_refs:
-                    try:
-                        store = getattr(adapter, "_session_store", None)
-                        if store:
-                            session_entry = store.get_or_create_session(ctx.source)
-                            history = store.load_transcript(session_entry.session_id)
-                            for msg in reversed(history or []):
-                                mid = msg.get("message_id", "")
-                                if mid and mid == ctx.reply_to_message_id:
-                                    _content = msg.get("content", "")
-                                    if isinstance(_content, str) and "|ybres:" in _content:
-                                        for m in _YB_RES_REF_RE.finditer(_content):
-                                            head = m.group(1)
-                                            rid = m.group(2)
-                                            kind, _, filename = head.partition(":")
-                                            kind = kind.strip()
-                                            if kind in _RESOLVABLE_MEDIA_KINDS:
-                                                ctx.quote_media_refs.append((rid, kind, filename.strip()))
-                                    break
-                    except Exception as exc:
-                        logger.warning(
-                            "[%s] quote transcript lookup failed: %s",
-                            adapter.name, exc,
-                        )
-                # User quoted a message — resolve only media from the quote
-                for rid, kind, filename in ctx.quote_media_refs:
-                    if kind not in _RESOLVABLE_MEDIA_KINDS:
-                        continue
-                    try:
-                        fresh_url = await MediaResolveMiddleware._resolve_by_resource_id(adapter, rid)
-                    except Exception as exc:
-                        logger.warning(
-                            "[%s] quote media resolve failed: rid=%s kind=%s err=%s",
-                            adapter.name, rid, kind, exc,
-                        )
-                        continue
-                    cached = await MediaResolveMiddleware._download_and_cache(
-                        adapter,
-                        fetch_url=fresh_url,
-                        kind=kind,
-                        file_name=filename or None,
-                        log_tag=f"quote rid={rid}",
-                        resource_id=rid,
-                    )
-                    if cached is None:
-                        continue
-                    path, mime = cached
-                    # Avoid duplicates
-                    if path not in media_urls:
-                        media_urls.append(path)
-                        media_types.append(mime)
-            else:
-                # No quote — backfill observed media from recent transcript history
-                extra_img_urls: List[str] = []
-                extra_img_mimes: List[str] = []
-                try:
-                    extra_img_urls, extra_img_mimes = await MediaResolveMiddleware._collect_observed_media(
-                        adapter, ctx.source,
-                    )
-                except Exception as exc:
-                    logger.warning(
-                        "[%s] observed-image hydration raised, continuing anyway: %s",
-                        adapter.name, exc,
-                    )
-                if extra_img_urls:
-                    current = set(media_urls)
-                    for u, m in zip(extra_img_urls, extra_img_mimes):
-                        if u in current:
-                            continue
-                        media_urls.append(u)
-                        media_types.append(m)
-                        current.add(u)
-
-            # Replace [kind|ybres:xxx] anchors with local cache paths so
-            # the transcript records usable paths for the model.
-            _patched_event_text = ctx.raw_text
-            for u, m in zip(media_urls, media_types):
-                if not u.startswith("/"):
-                    continue
-                anchor_match = _YB_RES_REF_RE.search(_patched_event_text)
-                if not anchor_match:
-                    continue
-                head = anchor_match.group(1)
-                kind, _, filename = head.partition(":")
-                kind = kind.strip()
-                if kind == "image" and m.startswith("image/"):
-                    replacement = f"[image: {u}]"
-                elif kind == "file":
-                    label = filename.strip() or os.path.basename(u)
-                    replacement = f"[file: {label} → {u}]"
-                else:
-                    continue
-                _patched_event_text = (
-                    _patched_event_text[:anchor_match.start()]
-                    + replacement
-                    + _patched_event_text[anchor_match.end():]
-                )
-
             event = MessageEvent(
-                text=_patched_event_text,
+                text=ctx.raw_text,
                 message_type=(
                     MessageType.DOCUMENT
-                    if any(mt.startswith(("application/", "text/")) for mt in media_types)
+                    if any(mt.startswith(("application/", "text/")) for mt in ctx.media_types)
                     else ctx.msg_type
                 ),
                 source=ctx.source,
                 message_id=ctx.msg_id or None,
                 raw_message=ctx.push,
-                media_urls=media_urls,
-                media_types=media_types,
+                media_urls=list(ctx.media_urls),
+                media_types=list(ctx.media_types),
                 reply_to_message_id=ctx.reply_to_message_id,
                 reply_to_text=ctx.reply_to_text,
                 channel_prompt=ctx.channel_prompt,
@@ -2795,6 +2890,7 @@ class InboundPipelineBuilder:
         ClassifyMessageTypeMiddleware,
         QuoteContextMiddleware,
         MediaResolveMiddleware,
+        PatchAnchorsMiddleware,
         DispatchMiddleware,
     ]
 

--- a/tests/test_yuanbao_pipeline.py
+++ b/tests/test_yuanbao_pipeline.py
@@ -20,7 +20,7 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from gateway.platforms.yuanbao import (
     InboundContext,

--- a/tests/test_yuanbao_pipeline.py
+++ b/tests/test_yuanbao_pipeline.py
@@ -38,6 +38,9 @@ from gateway.platforms.yuanbao import (
     OwnerCommandMiddleware,
     BuildSourceMiddleware,
     GroupAtGuardMiddleware,
+    QuoteContextMiddleware,
+    MediaResolveMiddleware,
+    PatchAnchorsMiddleware,
     DispatchMiddleware,
     InboundPipelineBuilder,
     YuanbaoAdapter,
@@ -308,40 +311,7 @@ class TestInboundPipeline:
 
 
 # ============================================================
-# 2. InboundContext Tests
-# ============================================================
-
-class TestInboundContext:
-    def test_default_values(self):
-        """InboundContext has sensible defaults."""
-        adapter = make_adapter()
-        ctx = InboundContext(adapter=adapter)
-        assert ctx.raw_frames == []
-        assert ctx.push is None
-        assert ctx.decoded_via == ""
-        assert ctx.from_account == ""
-        assert ctx.group_code == ""
-        assert ctx.msg_body == []
-        assert ctx.msg_id == ""
-        assert ctx.chat_id == ""
-        assert ctx.chat_type == ""
-        assert ctx.raw_text == ""
-        assert ctx.media_refs == []
-        assert ctx.owner_command is None
-        assert ctx.source is None
-        assert ctx.msg_type is None
-
-    def test_mutable_fields(self):
-        """InboundContext fields are mutable."""
-        ctx = make_ctx()
-        ctx.from_account = "alice"
-        ctx.chat_type = "dm"
-        assert ctx.from_account == "alice"
-        assert ctx.chat_type == "dm"
-
-
-# ============================================================
-# 3. Individual Middleware Tests
+# 2. Individual Middleware Tests
 # ============================================================
 
 class TestDecodeMiddleware:
@@ -720,31 +690,25 @@ class TestCreateInboundPipeline:
         expected = [
             "decode",
             "extract-fields",
+            "recall_guard",
             "dedup",
             "skip-self",
             "chat-routing",
             "access-guard",
+            "auto-sethome",
             "extract-content",
             "placeholder-filter",
             "owner-command",
             "build-source",
             "group-at-guard",
+            "group-attribution",
             "classify-msg-type",
             "quote-context",
             "media-resolve",
+            "patch-anchors",
             "dispatch",
         ]
-        """Pipeline can be customized after creation."""
-        pipeline = InboundPipelineBuilder.build()
-
-        async def custom_mw(ctx, next_fn):
-            await next_fn()
-
-        pipeline.use_before("dispatch", "custom", custom_mw)
-        assert "custom" in pipeline.middleware_names
-        idx_custom = pipeline.middleware_names.index("custom")
-        idx_dispatch = pipeline.middleware_names.index("dispatch")
-        assert idx_custom < idx_dispatch
+        assert pipeline.middleware_names == expected
 
 
 # ============================================================
@@ -861,19 +825,7 @@ if __name__ == "__main__":
 # ============================================================
 
 class TestInboundMiddlewareABC:
-    """Test the InboundMiddleware abstract base class."""
-
-    def test_cannot_instantiate_abc(self):
-        """InboundMiddleware cannot be instantiated directly."""
-        with pytest.raises(TypeError):
-            InboundMiddleware()
-
-    def test_subclass_must_implement_handle(self):
-        """Subclass without handle() raises TypeError."""
-        with pytest.raises(TypeError):
-            class BadMiddleware(InboundMiddleware):
-                name = "bad"
-            BadMiddleware()
+    """Test the InboundMiddleware OOP protocol (callable + named)."""
 
     def test_subclass_with_handle_works(self):
         """Subclass with handle() can be instantiated."""
@@ -900,19 +852,14 @@ class TestInboundMiddlewareABC:
         assert ctx.raw_text == "called"
         next_fn.assert_awaited_once()
 
-    def test_repr(self):
-        """Middleware has a useful repr."""
-        class MyMW(InboundMiddleware):
-            name = "my-mw"
-            async def handle(self, ctx, next_fn):
-                pass
-        mw = MyMW()
-        assert "MyMW" in repr(mw)
-        assert "my-mw" in repr(mw)
-
 
 class TestMiddlewareClasses:
-    """Test that all concrete middleware classes have correct names and are InboundMiddleware subclasses."""
+    """Pin the canonical ``name`` of each concrete middleware class.
+
+    These names are referenced by ``InboundPipelineBuilder.build()`` ordering,
+    by ``use_before`` / ``use_after`` insertion in extensions, and by log
+    messages — so they're a real downstream contract worth pinning.
+    """
 
     MIDDLEWARE_CLASSES = [
         (DecodeMiddleware, "decode"),
@@ -930,21 +877,10 @@ class TestMiddlewareClasses:
     ]
 
     @pytest.mark.parametrize("cls,expected_name", MIDDLEWARE_CLASSES)
-    def test_is_inbound_middleware(self, cls, expected_name):
-        """Each middleware class is a subclass of InboundMiddleware."""
-        assert issubclass(cls, InboundMiddleware)
-
-    @pytest.mark.parametrize("cls,expected_name", MIDDLEWARE_CLASSES)
     def test_has_correct_name(self, cls, expected_name):
         """Each middleware class has the expected name."""
         mw = cls()
         assert mw.name == expected_name
-
-    @pytest.mark.parametrize("cls,expected_name", MIDDLEWARE_CLASSES)
-    def test_is_callable(self, cls, expected_name):
-        """Each middleware instance is callable."""
-        mw = cls()
-        assert callable(mw)
 
 
 class TestPipelineOOPRegistration:
@@ -991,38 +927,457 @@ class TestPipelineOOPRegistration:
         await pipeline.execute(make_ctx())
         assert order == ["oop", "func"]
 
-    def test_use_before_with_middleware_instance(self):
-        """use_before works with OOP middleware instances."""
-        class MwA(InboundMiddleware):
-            name = "a"
-            async def handle(self, ctx, next_fn): await next_fn()
 
-        class MwB(InboundMiddleware):
-            name = "b"
-            async def handle(self, ctx, next_fn): await next_fn()
+# ============================================================
+# QuoteContextMiddleware Tests
+# ============================================================
+#
+# Quote-media resolution used to depend on a process-local
+# msg_id→resids cache populated by ExtractContentMiddleware. After #27866
+# made gateway/run.py write @bot user transcript entries with
+# message_id (symmetric with the observed-group writer at yuanbao.py:2091),
+# QuoteContextMiddleware's transcript-lookup path covers every quote case
+# we used to rely on the cache for, so the cache (and those tests) were
+# removed. ``_extract_quote_context()`` is now a pure (quote_id, quote_text)
+# extractor; quote media references are populated separately by
+# ``_extract_media_refs_from_transcript()`` against the transcript store.
 
-        class MwC(InboundMiddleware):
-            name = "c"
-            async def handle(self, ctx, next_fn): await next_fn()
+class TestQuoteContextMiddleware:
+    """Tests for QuoteContextMiddleware._extract_quote_context."""
 
-        pipeline = InboundPipeline().use(MwA()).use(MwC())
-        pipeline.use_before("c", MwB())
-        assert pipeline.middleware_names == ["a", "b", "c"]
+    def test_extract_quote_context_no_cloud_data(self):
+        """Returns (None, None) when cloud_custom_data is empty."""
+        result = QuoteContextMiddleware()._extract_quote_context("")
+        assert result == (None, None)
 
-    def test_use_after_with_middleware_instance(self):
-        """use_after works with OOP middleware instances."""
-        class MwA(InboundMiddleware):
-            name = "a"
-            async def handle(self, ctx, next_fn): await next_fn()
+    def test_extract_quote_context_no_quote_key(self):
+        """Returns (None, None) when JSON has no 'quote' key."""
+        cloud_data = json.dumps({"foo": "bar"})
+        result = QuoteContextMiddleware()._extract_quote_context(cloud_data)
+        assert result == (None, None)
 
-        class MwB(InboundMiddleware):
-            name = "b"
-            async def handle(self, ctx, next_fn): await next_fn()
+    def test_extract_quote_context_with_desc(self):
+        """Extracts quote_id and quote_text from desc."""
+        cloud_data = json.dumps({
+            "quote": {
+                "id": "quoted-msg-001",
+                "desc": "Hello world",
+                "sender_nickname": "Alice",
+            }
+        })
+        quote_id, quote_text = QuoteContextMiddleware()._extract_quote_context(cloud_data)
+        assert quote_id == "quoted-msg-001"
+        assert quote_text == "Alice: Hello world"
 
-        class MwC(InboundMiddleware):
-            name = "c"
-            async def handle(self, ctx, next_fn): await next_fn()
+    def test_extract_quote_context_empty_desc(self):
+        """When desc is empty, quote_text is None but quote_id is preserved."""
+        cloud_data = json.dumps({
+            "quote": {
+                "id": "quoted-msg-003",
+                "desc": "",
+                "sender_nickname": "Carol",
+            }
+        })
+        quote_id, quote_text = QuoteContextMiddleware()._extract_quote_context(cloud_data)
+        assert quote_id == "quoted-msg-003"
+        assert quote_text is None
 
-        pipeline = InboundPipeline().use(MwA()).use(MwC())
-        pipeline.use_after("a", MwB())
-        assert pipeline.middleware_names == ["a", "b", "c"]
+    def test_extract_quote_context_no_quote_id(self):
+        """When quote.id is empty, quote_id is None."""
+        cloud_data = json.dumps({
+            "quote": {
+                "id": "",
+                "desc": "some text",
+            }
+        })
+        quote_id, _quote_text = QuoteContextMiddleware()._extract_quote_context(cloud_data)
+        assert quote_id is None
+
+    @pytest.mark.asyncio
+    async def test_handle_sets_ctx_fields(self):
+        """QuoteContextMiddleware.handle() sets ctx.reply_to_message_id, reply_to_text, quote_media_refs.
+
+        With no transcript store wired up, quote_media_refs falls back to []
+        — media resolution from transcript is covered by separate tests.
+        """
+        cloud_data = json.dumps({
+            "quote": {
+                "id": "quoted-msg-004",
+                "desc": "Check this image",
+                "sender_nickname": "Dave",
+            }
+        })
+        adapter = make_adapter()
+        adapter._session_store = None  # no transcript lookup path
+        ctx = make_ctx(adapter=adapter, cloud_custom_data=cloud_data)
+        next_fn = AsyncMock()
+
+        await QuoteContextMiddleware()(ctx, next_fn)
+
+        assert ctx.reply_to_message_id == "quoted-msg-004"
+        assert ctx.reply_to_text == "Dave: Check this image"
+        assert ctx.quote_media_refs == []
+        next_fn.assert_awaited_once()
+
+
+# ============================================================
+# MediaResolveMiddleware Tests
+# ============================================================
+#
+# After the dispatch refactor, MediaResolveMiddleware is the single entry
+# point for all inbound media downloads. It merges up to three sources
+# into ``ctx.media_urls`` / ``ctx.media_types`` (deduped, in this order):
+#
+#   1) media carried by the current message itself (always),
+#   2) quote_media_refs (when reply_to_message_id is set),
+#   3) recent group-observed media (only when chat_type == "group" and
+#      no quote is present).
+#
+# Direct messages skip the observed backfill entirely.
+
+class TestResolveYbresRefs:
+    """Direct tests for ``MediaResolveMiddleware._resolve_ybres_refs``.
+
+    This classmethod is the shared engine for both ``_resolve_quote_media``
+    and ``_collect_observed_media``. Patching the two upstream callers from
+    routing tests doesn't exercise its filtering / error-swallowing
+    behavior, so we pin those contracts directly here.
+    """
+
+    @pytest.mark.asyncio
+    async def test_resolves_each_ref_in_order(self):
+        """Successful resolution returns ``(paths, mimes)`` aligned with input order."""
+        adapter = make_adapter()
+        refs = [
+            ("rid-1", "image", "a.jpg"),
+            ("rid-2", "file", "doc.pdf"),
+        ]
+
+        with patch.object(
+            MediaResolveMiddleware, "_fetch_resource_url",
+            new=AsyncMock(side_effect=["https://fresh/1", "https://fresh/2"]),
+        ) as p_fetch, patch.object(
+            MediaResolveMiddleware, "_download_and_cache",
+            new=AsyncMock(side_effect=[
+                ("/cache/a.jpg", "image/jpeg"),
+                ("/cache/doc.pdf", "application/pdf"),
+            ]),
+        ) as p_cache:
+            paths, mimes = await MediaResolveMiddleware._resolve_ybres_refs(
+                adapter, refs, log_prefix="test",
+            )
+
+        assert paths == ["/cache/a.jpg", "/cache/doc.pdf"]
+        assert mimes == ["image/jpeg", "application/pdf"]
+        assert p_fetch.await_count == 2
+        # filename from the ref tuple is forwarded to download_and_cache
+        cache_kwargs = [c.kwargs for c in p_cache.await_args_list]
+        assert cache_kwargs[0]["file_name"] == "a.jpg"
+        assert cache_kwargs[0]["kind"] == "image"
+        assert cache_kwargs[0]["resource_id"] == "rid-1"
+        assert cache_kwargs[1]["file_name"] == "doc.pdf"
+
+    @pytest.mark.asyncio
+    async def test_skips_unresolvable_kinds(self):
+        """Refs whose kind is outside ``_RESOLVABLE_MEDIA_KINDS`` are dropped silently."""
+        adapter = make_adapter()
+        refs = [
+            ("rid-v", "video", ""),       # not resolvable
+            ("rid-i", "image", "ok.jpg"),  # resolvable
+            ("rid-?", "unknown", ""),     # not resolvable
+        ]
+
+        with patch.object(
+            MediaResolveMiddleware, "_fetch_resource_url",
+            new=AsyncMock(return_value="https://fresh/i"),
+        ) as p_fetch, patch.object(
+            MediaResolveMiddleware, "_download_and_cache",
+            new=AsyncMock(return_value=("/cache/ok.jpg", "image/jpeg")),
+        ) as p_cache:
+            paths, mimes = await MediaResolveMiddleware._resolve_ybres_refs(
+                adapter, refs, log_prefix="test",
+            )
+
+        assert paths == ["/cache/ok.jpg"]
+        assert mimes == ["image/jpeg"]
+        # Only the resolvable ref hit the network.
+        p_fetch.assert_awaited_once()
+        p_cache.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_is_swallowed_per_ref(self):
+        """If ``_fetch_resource_url`` raises, that ref is skipped — not the whole batch."""
+        adapter = make_adapter()
+        refs = [
+            ("rid-bad", "image", ""),
+            ("rid-ok", "image", ""),
+        ]
+
+        with patch.object(
+            MediaResolveMiddleware, "_fetch_resource_url",
+            new=AsyncMock(side_effect=[RuntimeError("boom"), "https://fresh/ok"]),
+        ), patch.object(
+            MediaResolveMiddleware, "_download_and_cache",
+            new=AsyncMock(return_value=("/cache/ok.jpg", "image/jpeg")),
+        ) as p_cache:
+            paths, mimes = await MediaResolveMiddleware._resolve_ybres_refs(
+                adapter, refs, log_prefix="test",
+            )
+
+        # bad ref dropped; good ref preserved
+        assert paths == ["/cache/ok.jpg"]
+        assert mimes == ["image/jpeg"]
+        # download_and_cache was only invoked for the surviving ref
+        p_cache.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_drops_ref(self):
+        """If ``_download_and_cache`` returns None, the ref is dropped."""
+        adapter = make_adapter()
+        refs = [("rid-1", "image", "")]
+
+        with patch.object(
+            MediaResolveMiddleware, "_fetch_resource_url",
+            new=AsyncMock(return_value="https://fresh/1"),
+        ), patch.object(
+            MediaResolveMiddleware, "_download_and_cache",
+            new=AsyncMock(return_value=None),
+        ):
+            paths, mimes = await MediaResolveMiddleware._resolve_ybres_refs(
+                adapter, refs, log_prefix="test",
+            )
+
+        assert paths == []
+        assert mimes == []
+
+
+class TestMediaResolveMiddlewareRouting:
+    """Branch-routing tests for MediaResolveMiddleware.handle()."""
+
+    def _make_resolved_ctx(self, *, chat_type: str, reply_to: str = None,
+                            quote_media_refs=None, raw_text: str = "hello"):
+        adapter = make_adapter()
+        ctx = make_ctx(
+            adapter=adapter,
+            chat_type=chat_type,
+            reply_to_message_id=reply_to,
+            quote_media_refs=list(quote_media_refs or []),
+            raw_text=raw_text,
+            media_refs=[],  # no own attachments by default
+        )
+        return adapter, ctx
+
+    @pytest.mark.asyncio
+    async def test_dm_no_quote_skips_observed_backfill(self):
+        """In dm chats, observed-media backfill is never invoked."""
+        _adapter, ctx = self._make_resolved_ctx(chat_type="dm")
+
+        with patch.object(
+            MediaResolveMiddleware, "_resolve_media_urls",
+            new=AsyncMock(return_value=([], [])),
+        ) as p_own, patch.object(
+            MediaResolveMiddleware, "_resolve_quote_media",
+            new=AsyncMock(return_value=([], [])),
+        ) as p_quote, patch.object(
+            MediaResolveMiddleware, "_collect_observed_media",
+            new=AsyncMock(return_value=([], [])),
+        ) as p_observed:
+            next_fn = AsyncMock()
+            await MediaResolveMiddleware()(ctx, next_fn)
+
+        p_own.assert_awaited_once()
+        p_quote.assert_not_awaited()
+        p_observed.assert_not_awaited()
+        next_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dm_with_quote_resolves_quote_media_only(self):
+        """In dm chats with a quote, only quote media (plus own) is resolved."""
+        _adapter, ctx = self._make_resolved_ctx(
+            chat_type="dm",
+            reply_to="quoted-001",
+            quote_media_refs=[("rid-q1", "image", "")],
+        )
+
+        with patch.object(
+            MediaResolveMiddleware, "_resolve_media_urls",
+            new=AsyncMock(return_value=([], [])),
+        ) as p_own, patch.object(
+            MediaResolveMiddleware, "_resolve_quote_media",
+            new=AsyncMock(return_value=(["/cache/q1.jpg"], ["image/jpeg"])),
+        ) as p_quote, patch.object(
+            MediaResolveMiddleware, "_collect_observed_media",
+            new=AsyncMock(return_value=([], [])),
+        ) as p_observed:
+            next_fn = AsyncMock()
+            await MediaResolveMiddleware()(ctx, next_fn)
+
+        p_own.assert_awaited_once()
+        p_quote.assert_awaited_once()
+        p_observed.assert_not_awaited()
+        assert ctx.media_urls == ["/cache/q1.jpg"]
+        assert ctx.media_types == ["image/jpeg"]
+
+    @pytest.mark.asyncio
+    async def test_group_no_quote_runs_observed_backfill(self):
+        """In group chats without quote, observed-media backfill is invoked."""
+        _adapter, ctx = self._make_resolved_ctx(chat_type="group")
+
+        with patch.object(
+            MediaResolveMiddleware, "_resolve_media_urls",
+            new=AsyncMock(return_value=([], [])),
+        ), patch.object(
+            MediaResolveMiddleware, "_resolve_quote_media",
+            new=AsyncMock(return_value=([], [])),
+        ) as p_quote, patch.object(
+            MediaResolveMiddleware, "_collect_observed_media",
+            new=AsyncMock(return_value=(["/cache/o1.jpg"], ["image/jpeg"])),
+        ) as p_observed:
+            next_fn = AsyncMock()
+            await MediaResolveMiddleware()(ctx, next_fn)
+
+        p_quote.assert_not_awaited()
+        p_observed.assert_awaited_once()
+        assert ctx.media_urls == ["/cache/o1.jpg"]
+
+    @pytest.mark.asyncio
+    async def test_group_with_quote_skips_observed_backfill(self):
+        """In group chats with a quote, only quote media is resolved (no backfill)."""
+        _adapter, ctx = self._make_resolved_ctx(
+            chat_type="group",
+            reply_to="quoted-002",
+            quote_media_refs=[("rid-q2", "image", "")],
+        )
+
+        with patch.object(
+            MediaResolveMiddleware, "_resolve_media_urls",
+            new=AsyncMock(return_value=([], [])),
+        ), patch.object(
+            MediaResolveMiddleware, "_resolve_quote_media",
+            new=AsyncMock(return_value=(["/cache/q2.jpg"], ["image/jpeg"])),
+        ) as p_quote, patch.object(
+            MediaResolveMiddleware, "_collect_observed_media",
+            new=AsyncMock(return_value=(["/cache/o2.jpg"], ["image/jpeg"])),
+        ) as p_observed:
+            next_fn = AsyncMock()
+            await MediaResolveMiddleware()(ctx, next_fn)
+
+        p_quote.assert_awaited_once()
+        p_observed.assert_not_awaited()
+        assert ctx.media_urls == ["/cache/q2.jpg"]
+
+    @pytest.mark.asyncio
+    async def test_merges_and_dedupes_three_sources(self):
+        """Own + quote sources are merged with dedup applied."""
+        _adapter, ctx = self._make_resolved_ctx(
+            chat_type="dm",
+            reply_to="quoted-003",
+            quote_media_refs=[("rid", "image", "")],
+        )
+
+        with patch.object(
+            MediaResolveMiddleware, "_resolve_media_urls",
+            new=AsyncMock(return_value=(["/cache/a.jpg"], ["image/jpeg"])),
+        ), patch.object(
+            MediaResolveMiddleware, "_resolve_quote_media",
+            # Same path as own → must be deduped.
+            new=AsyncMock(return_value=(["/cache/a.jpg", "/cache/b.jpg"],
+                                          ["image/jpeg", "image/png"])),
+        ):
+            next_fn = AsyncMock()
+            await MediaResolveMiddleware()(ctx, next_fn)
+
+        assert ctx.media_urls == ["/cache/a.jpg", "/cache/b.jpg"]
+        assert ctx.media_types == ["image/jpeg", "image/png"]
+
+    @pytest.mark.asyncio
+    async def test_placeholder_recheck_uses_own_count_only(self):
+        """Placeholder retry-skip uses ``own_count``, not the merged total.
+
+        A bare placeholder text (e.g. ``[image]``) accompanied only by a
+        quote-resolved image is still skippable — quote media must not
+        flip a placeholder into a non-placeholder.
+        """
+        _adapter, ctx = self._make_resolved_ctx(
+            chat_type="dm",
+            reply_to="quoted-004",
+            quote_media_refs=[("rid", "image", "")],
+            raw_text="[image]",
+        )
+
+        with patch.object(
+            MediaResolveMiddleware, "_resolve_media_urls",
+            new=AsyncMock(return_value=([], [])),  # no own media
+        ), patch.object(
+            MediaResolveMiddleware, "_resolve_quote_media",
+            new=AsyncMock(return_value=(["/cache/q.jpg"], ["image/jpeg"])),
+        ), patch.object(
+            PlaceholderFilterMiddleware, "is_skippable_placeholder",
+            return_value=True,
+        ) as p_check:
+            next_fn = AsyncMock()
+            await MediaResolveMiddleware()(ctx, next_fn)
+
+        # Pipeline short-circuited despite quote media being present.
+        next_fn.assert_not_awaited()
+        # And the second-pass check was called with own_count == 0.
+        p_check.assert_called_once()
+        _text_arg, count_arg = p_check.call_args.args
+        assert count_arg == 0
+
+
+# ============================================================
+# PatchAnchorsMiddleware Tests
+# ============================================================
+
+class TestPatchAnchorsMiddleware:
+    """Tests for PatchAnchorsMiddleware._patch()."""
+
+    def test_no_op_when_text_or_urls_empty(self):
+        assert PatchAnchorsMiddleware._patch("", [], []) == ""
+        assert PatchAnchorsMiddleware._patch("hello", [], []) == "hello"
+
+    def test_replaces_image_anchor_with_local_path(self):
+        text = "look [image|ybres:abc] please"
+        out = PatchAnchorsMiddleware._patch(
+            text, ["/cache/x.jpg"], ["image/jpeg"],
+        )
+        assert out == "look [image: /cache/x.jpg] please"
+
+    def test_replaces_file_anchor_with_filename_label(self):
+        text = "see [file:doc.pdf|ybres:rid-1]"
+        out = PatchAnchorsMiddleware._patch(
+            text, ["/cache/doc.pdf"], ["application/pdf"],
+        )
+        assert "[file: doc.pdf → /cache/doc.pdf]" in out
+
+    def test_skips_non_local_paths(self):
+        """URLs not starting with '/' are left untouched."""
+        text = "[image|ybres:abc]"
+        out = PatchAnchorsMiddleware._patch(
+            text, ["https://example.com/x.jpg"], ["image/jpeg"],
+        )
+        # Anchor preserved verbatim because the resolved url is remote.
+        assert out == text
+
+    def test_anchor_kind_image_requires_image_mime(self):
+        """An [image|...] anchor with a non-image mime is left alone."""
+        text = "[image|ybres:rid]"
+        out = PatchAnchorsMiddleware._patch(
+            text, ["/cache/odd.bin"], ["application/octet-stream"],
+        )
+        assert out == text
+
+    @pytest.mark.asyncio
+    async def test_handle_writes_back_to_ctx(self):
+        adapter = make_adapter()
+        ctx = make_ctx(
+            adapter=adapter,
+            raw_text="hi [image|ybres:rid]",
+            media_urls=["/cache/y.png"],
+            media_types=["image/png"],
+        )
+        next_fn = AsyncMock()
+        await PatchAnchorsMiddleware()(ctx, next_fn)
+        assert ctx.raw_text == "hi [image: /cache/y.png]"
+        next_fn.assert_awaited_once()


### PR DESCRIPTION
## Summary
Yuanbao inbound media resolution moves out of the monolithic `DispatchMiddleware._dispatch_inbound_event()` into composable pipeline middlewares, so each media source (own / quoted / group-observed) is resolved and tested in isolation.

Salvage of #41779 by @loongfay (loongzhao@tencent.com), cherry-picked onto current `main` with authorship preserved, plus a one-line follow-up fixing the missing `patch` import in the new tests.

## Changes
- `gateway/platforms/yuanbao.py`: `QuoteContextMiddleware` now does quote-media transcript lookup directly; `MediaResolveMiddleware.handle()` rewritten to orchestrate the three sources in priority order; new shared `_resolve_ybres_refs()` / `_resolve_quote_media()` / `_collect_quote_local_media()` helpers; new `PatchAnchorsMiddleware` rewrites `[kind|ybres:RID]` anchors to local paths; `DispatchMiddleware` simplified to dispatch only; removed inlined `_resolve_by_resource_id()`.
- `tests/test_yuanbao_pipeline.py`: comprehensive tests for the new helpers + `TestMediaResolveMiddlewareRouting` covering all DM/group ± quote branches.
- Follow-up: add `patch` to the `unittest.mock` import (the PR body claimed this fix but it was missing — 10 new tests were `NameError`-ing).

## Validation
| | Before salvage fix | After |
|---|---|---|
| `tests/test_yuanbao_pipeline.py` | 10 failed, 75 passed | 85 passed |

Plugin-boundary clean: touches only the Yuanbao adapter and its own test.

Closes #41779.


## Infographic

![yuanbao-media-pipeline-refactor](https://v3b.fal.media/files/b/0a9d956a/R6JbkU1b_QBErK9jApfRk_ZVi8t61G.png)
