### PR TITLE
fix(tui): keep background notifications in owning session (#42674)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6736,3 +6736,41 @@ def test_reap_idle_sessions_closes_only_evictable(monkeypatch):
         assert closed == [("stale", "idle_timeout")]
     finally:
         server._sessions.clear()
+
+
+def test_drain_owned_notifications_requeues_foreign_live_session_events(monkeypatch):
+    current = {"session_key": "agent:main:tui:session:current"}
+    other = {"session_key": "agent:main:tui:session:other"}
+    foreign_evt = {
+        "type": "completion",
+        "session_id": "proc_foreign",
+        "session_key": "agent:main:tui:session:other",
+    }
+    owned_evt = {
+        "type": "completion",
+        "session_id": "proc_owned",
+        "session_key": "agent:main:tui:session:current",
+    }
+    global_evt = {"type": "watch_overflow_global", "session_id": "proc_global"}
+    requeued = []
+
+    class _Queue:
+        def put(self, evt):
+            requeued.append(evt)
+
+    class _Registry:
+        completion_queue = _Queue()
+
+        def drain_notifications(self):
+            return [(foreign_evt, "foreign"), (owned_evt, "owned"), (global_evt, "global")]
+
+    monkeypatch.setitem(server._sessions, "current", current)
+    monkeypatch.setitem(server._sessions, "other", other)
+    try:
+        drained = server._drain_owned_notifications(_Registry(), current)
+    finally:
+        server._sessions.pop("current", None)
+        server._sessions.pop("other", None)
+
+    assert drained == [(owned_evt, "owned"), (global_evt, "global")]
+    assert requeued == [foreign_evt]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4698,6 +4698,28 @@ def _notification_event_belongs_elsewhere(session: dict, evt: dict) -> bool:
     )
 
 
+def _drain_owned_notifications(process_registry, session: dict) -> list[tuple[dict, str]]:
+    """Drain pending process notifications owned by this TUI session.
+
+    ``process_registry.drain_notifications()`` drains the global completion
+    queue. In Desktop/TUI, multiple live sessions share that queue, so a
+    post-turn drain in session B must not consume a completion event that was
+    started by session A. Foreign events are put back for their owning poller.
+    """
+    owned: list[tuple[dict, str]] = []
+    deferred: list[dict] = []
+    for evt, text in process_registry.drain_notifications():
+        if _notification_event_belongs_elsewhere(session, evt):
+            deferred.append(evt)
+            continue
+        owned.append((evt, text))
+
+    for evt in deferred:
+        process_registry.completion_queue.put(evt)
+
+    return owned
+
+
 def _notification_event_dedup_key(evt: dict) -> tuple:
     """Return the UI-emission identity for a process notification event.
 
@@ -5254,7 +5276,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         try:
             from tools.process_registry import process_registry
 
-            for _evt, synth in process_registry.drain_notifications():
+            for _evt, synth in _drain_owned_notifications(process_registry, session):
                 with session["history_lock"]:
                     if session.get("running"):
                         process_registry.completion_queue.put(_evt)


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop/TUI cross-session notification path for background process completions.

The poller path already skips events whose `session_key` belongs to another live session, but the post-turn safety drain still called `process_registry.drain_notifications()` directly. That method drains the global process completion queue, so a turn finishing in session B could consume and dispatch a `notify_on_complete` event that was started by session A.

This PR adds a small TUI-owned drain helper that filters drained events with the same ownership check used by the poller, requeues foreign live-session events, and only dispatches notifications owned by the current session (plus global/orphan notifications).

## Related Issue

Fixes #42674

Related to #35652, but this targets the post-turn drain path rather than the between-turn poller path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`
  - Added `_drain_owned_notifications()` to drain only notifications owned by the current TUI session.
  - Requeues foreign live-session events so the owning session's poller can handle them.
  - Uses the helper in the post-turn completion-notification drain.
- `tests/test_tui_gateway_server.py`
  - Added regression coverage for owned, foreign, and global notification events.

## How to Test

1. Open two TUI/Desktop sessions.
2. In session A, start a bounded background process with `notify_on_complete=True`.
3. While it is running, send a normal message in session B.
4. When the process completes, the notification should remain routed to session A instead of being consumed by session B's post-turn drain.

Local verification performed:

```text
python3 -m py_compile /tmp/hermes-fix/tui_gateway/server.py
python3 -m py_compile /tmp/hermes-fix/tests/test_tui_gateway_server.py
```

I could not run the full pytest suite in this PRoot environment because cloning/extracting the full repository repeatedly timed out; the patch was prepared via GitHub Contents API against `main` and syntax-checked locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / PRoot (syntax checks)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Syntax checks:

```text
python3 -m py_compile /tmp/hermes-fix/tui_gateway/server.py
python3 -m py_compile /tmp/hermes-fix/tests/test_tui_gateway_server.py
```
