### PR TITLE
fix(terminal): narrow vite pattern to avoid false positives (#42620)

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1681,7 +1681,12 @@ _LONG_LIVED_FOREGROUND_PATTERNS = (
     re.compile(r"\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:dev|start|serve|watch)\b", re.IGNORECASE),
     re.compile(r"\bdocker\s+compose\s+up\b", re.IGNORECASE),
     re.compile(r"\bnext\s+dev\b", re.IGNORECASE),
-    re.compile(r"\bvite(?:\s|$)", re.IGNORECASE),
+    re.compile(
+        r"(?:^|\s)(?:\./)?vite\b|"
+        r"(?:^|\s)(?:npx|pnpm\s+dlx)(?:\s+\S+)*\s+vite\b|"
+        r"(?:^|\s)(?:npm|pnpm|yarn|bun)\s+run\s+(?:\S+\s+)*vite\b",
+        re.IGNORECASE,
+    ),
     re.compile(r"\bnodemon\b", re.IGNORECASE),
     re.compile(r"\buvicorn\b", re.IGNORECASE),
     re.compile(r"\bgunicorn\b", re.IGNORECASE),


### PR DESCRIPTION
Fixes #42620. The vite long-lived process regex matched vite as an argument to npm install/update, causing false positives. Narrowed the pattern to only match vite when used as a standalone command (e.g. vite, npx vite, npm run vite) and not as a package argument.