### PR TITLE
fix(terminal): ignore malformed docker JSON outside docker backend

### DIFF
--- a/tests/tools/test_parse_env_var.py
+++ b/tests/tools/test_parse_env_var.py
@@ -39,6 +39,40 @@ class TestParseEnvVar:
             config = _tt_mod._get_env_config()
             assert config["docker_forward_env"] == ["GITHUB_TOKEN", "NPM_TOKEN"]
 
+    def test_get_env_config_ignores_invalid_docker_json_for_local_backend(self):
+        with patch.dict("os.environ", {
+            "TERMINAL_ENV": "local",
+            "TERMINAL_DOCKER_VOLUMES": "None",
+            "TERMINAL_DOCKER_ENV": "None",
+            "TERMINAL_DOCKER_EXTRA_ARGS": "None",
+            "TERMINAL_DOCKER_FORWARD_ENV": "None",
+        }, clear=False):
+            config = _tt_mod._get_env_config()
+            assert config["env_type"] == "local"
+            assert config["docker_volumes"] == []
+            assert config["docker_env"] == {}
+            assert config["docker_extra_args"] == []
+            assert config["docker_forward_env"] == []
+
+    def test_get_env_config_still_validates_docker_json_for_docker_backend(self):
+        with patch.dict("os.environ", {
+            "TERMINAL_ENV": "docker",
+            "TERMINAL_DOCKER_VOLUMES": "None",
+        }, clear=False):
+            with pytest.raises(ValueError, match="TERMINAL_DOCKER_VOLUMES"):
+                _tt_mod._get_env_config()
+
+    def test_get_env_config_ignores_invalid_docker_json_for_ssh_backend(self):
+        with patch.dict("os.environ", {
+            "TERMINAL_ENV": "ssh",
+            "TERMINAL_DOCKER_VOLUMES": "None",
+            "TERMINAL_DOCKER_ENV": "None",
+        }, clear=False):
+            config = _tt_mod._get_env_config()
+            assert config["env_type"] == "ssh"
+            assert config["docker_volumes"] == []
+            assert config["docker_env"] == {}
+
     def test_create_environment_passes_docker_forward_env(self):
         fake_env = object()
         with patch.object(_tt_mod, "_DockerEnvironment", return_value=fake_env) as mock_docker:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1046,6 +1046,22 @@ def _parse_env_var(name: str, default: str, converter=int, type_label: str = "in
         )
 
 
+def _parse_env_var_for_backends(
+    name: str,
+    default: str,
+    *,
+    env_type: str,
+    backends: set[str],
+    fallback: Any,
+    converter=int,
+    type_label: str = "integer",
+):
+    """Parse env vars only for the backends that actually consume them."""
+    if env_type not in backends:
+        return fallback
+    return _parse_env_var(name, default, converter, type_label)
+
+
 def _safe_getcwd() -> str:
     """Return the current working directory, tolerating a deleted CWD.
 
@@ -1065,6 +1081,7 @@ def _get_env_config() -> Dict[str, Any]:
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     env_type = os.getenv("TERMINAL_ENV", "local")
+    docker_only_backends = {"docker"}
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
 
@@ -1110,7 +1127,15 @@ def _get_env_config() -> Dict[str, Any]:
         "env_type": env_type,
         "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
         "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
-        "docker_forward_env": _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON"),
+        "docker_forward_env": _parse_env_var_for_backends(
+            "TERMINAL_DOCKER_FORWARD_ENV",
+            "[]",
+            env_type=env_type,
+            backends=docker_only_backends,
+            fallback=[],
+            converter=json.loads,
+            type_label="valid JSON",
+        ),
         "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
         "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
         "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
@@ -1138,10 +1163,34 @@ def _get_env_config() -> Dict[str, Any]:
         "container_memory": _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120"),     # MB (default 5GB)
         "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
-        "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
-        "docker_env": _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON"),
+        "docker_volumes": _parse_env_var_for_backends(
+            "TERMINAL_DOCKER_VOLUMES",
+            "[]",
+            env_type=env_type,
+            backends=docker_only_backends,
+            fallback=[],
+            converter=json.loads,
+            type_label="valid JSON",
+        ),
+        "docker_env": _parse_env_var_for_backends(
+            "TERMINAL_DOCKER_ENV",
+            "{}",
+            env_type=env_type,
+            backends=docker_only_backends,
+            fallback={},
+            converter=json.loads,
+            type_label="valid JSON",
+        ),
         "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_extra_args": _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON"),
+        "docker_extra_args": _parse_env_var_for_backends(
+            "TERMINAL_DOCKER_EXTRA_ARGS",
+            "[]",
+            env_type=env_type,
+            backends=docker_only_backends,
+            fallback=[],
+            converter=json.loads,
+            type_label="valid JSON",
+        ),
         # Cross-process container reuse (issue #20561).  The docs claim
         # "ONE long-lived container shared across sessions" — this toggle
         # makes that real by probing for a labeled container at startup and


### PR DESCRIPTION
## What does this PR do?

Prevents malformed Docker-only terminal JSON config from crashing non-Docker subprocess tools.

On current `main`, `_get_env_config()` eagerly parses `TERMINAL_DOCKER_VOLUMES`, `TERMINAL_DOCKER_ENV`, `TERMINAL_DOCKER_FORWARD_ENV`, and `TERMINAL_DOCKER_EXTRA_ARGS` even when `terminal.backend` is `local` or `ssh`. If one of those bridged values is malformed, `terminal` and `execute_code` both fail before Docker is ever selected.

This change keeps the existing config bridge intact, but scopes Docker JSON parsing to the Docker backend itself. Non-Docker backends now fall back to safe defaults instead of crashing, while Docker still raises the same actionable `ValueError` for bad JSON.

## Related Issue

Fixes #42725

Related: #42733

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Parse Docker-only JSON terminal env vars only when `TERMINAL_ENV=docker`
- Keep safe default values for `local` and `ssh` backends when stale malformed Docker config is present
- Preserve strict Docker validation so actual Docker misconfiguration still surfaces clearly
- Add regression coverage for:
  - local backend ignoring malformed Docker JSON
  - ssh backend ignoring malformed Docker JSON
  - docker backend still rejecting malformed Docker JSON

## How to Test

1. On `main`, run Hermes with `TERMINAL_ENV=local` and `TERMINAL_DOCKER_VOLUMES=None`; observe `_get_env_config()` / `terminal` / `execute_code` fail with `ValueError`.
2. On this branch, repeat the same command; `local` tools should continue working and Docker-only fields should fall back to empty defaults.
3. Set `TERMINAL_ENV=docker` with `TERMINAL_DOCKER_VOLUMES=None`; Docker should still raise the same actionable config error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x local dev checkout

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation run:
- `pytest tests/tools/test_parse_env_var.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_file_tools_container_config.py tests/tools/test_modal_sandbox_fixes.py -q`
- `env TERMINAL_ENV=local TERMINAL_DOCKER_VOLUMES=None TERMINAL_DOCKER_ENV=None TERMINAL_DOCKER_EXTRA_ARGS=None TERMINAL_DOCKER_FORWARD_ENV=None python` smoke
- `env TERMINAL_ENV=ssh TERMINAL_DOCKER_VOLUMES=None TERMINAL_DOCKER_ENV=None python` smoke
