### PR TITLE
fix(gateway): detect macOS launchd for slash restarts

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -44,6 +44,24 @@ from utils import (
 logger = logging.getLogger("gateway.run")
 
 
+def _running_under_service_manager() -> bool:
+    """Return True when the gateway process is supervised by a service manager.
+
+    systemd sets ``INVOCATION_ID``. Native macOS LaunchAgents set
+    ``XPC_SERVICE_NAME`` to the service label (for Hermes: ``ai.hermes.gateway``
+    and profile-suffixed variants). Interactive macOS shells commonly inherit
+    ``XPC_SERVICE_NAME=0`` from launchd; that is not a managed service and must
+    keep using the detached helper path.
+    """
+    if os.environ.get("INVOCATION_ID"):
+        return True
+    if sys.platform == "darwin":
+        xpc_service = (os.environ.get("XPC_SERVICE_NAME") or "").strip()
+        if xpc_service == "ai.hermes.gateway" or xpc_service.startswith("ai.hermes.gateway-"):
+            return True
+    return False
+
+
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
 
@@ -774,9 +792,8 @@ class GatewaySlashCommandsMixin:
         # us.  The detached subprocess approach (setsid + bash) doesn't work
         # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        if _running_under_service_manager() or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -99,10 +99,103 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
-    """Without systemd, /restart uses the detached subprocess approach."""
+async def test_restart_command_uses_service_restart_under_launchd(tmp_path, monkeypatch):
+    """Under macOS launchd (XPC_SERVICE_NAME set), /restart uses via_service=True."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr("gateway.slash_commands.sys.platform", "darwin")
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_service_restart_under_profile_launchd(tmp_path, monkeypatch):
+    """Profile-scoped Hermes launchd labels should also use via_service=True."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr("gateway.slash_commands.sys.platform", "darwin")
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway-coder")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_detached_for_inherited_launchd_zero(tmp_path, monkeypatch):
+    """macOS shells often inherit XPC_SERVICE_NAME=0; that is not a managed service."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr("gateway.slash_commands.sys.platform", "darwin")
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_detached_for_unrelated_launchd_prefix(tmp_path, monkeypatch):
+    """Only Hermes gateway LaunchAgents should be treated as managed services."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr("gateway.slash_commands.sys.platform", "darwin")
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gatewayhelper")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_detached_without_service_manager(tmp_path, monkeypatch):
+    """Without a known service manager, /restart uses the detached subprocess approach."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)


### PR DESCRIPTION
## Summary
- Detect macOS launchd-managed Hermes gateway processes via `XPC_SERVICE_NAME`
- Use service-managed `/restart` for `ai.hermes.gateway` and profile-suffixed labels
- Keep detached restart for interactive macOS shells (`XPC_SERVICE_NAME=0`) and unrelated launchd labels

## Test plan
- `PYTHONPATH=. /Users/nash/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_restart_notification.py -q -o 'addopts='` -> 31 passed
- Static added-line scan: no hardcoded secrets, shell injection, eval/exec, pickle, or SQL string-format patterns
- Independent review: passed, no security concerns or logic errors

## Notes
This keeps the existing systemd/container behavior and only extends the service-manager detection for native macOS LaunchAgents.
