### PR TITLE
fix(kanban): require note in kanban_heartbeat schema to prevent empty heartbeats

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -624,11 +624,14 @@ def test_heartbeat_happy_path(worker_env):
 
 
 def test_heartbeat_without_note(worker_env):
-    """note is optional."""
+    """note is now required — empty/missing note must fail."""
     from tools import kanban_tools as kt
     out = kt._handle_heartbeat({})
     d = json.loads(out)
-    assert d["ok"] is True
+    assert "error" in d
+    out2 = kt._handle_heartbeat({"note": "   "})
+    d2 = json.loads(out2)
+    assert "error" in d2
 
 
 def test_heartbeat_extends_claim_expires(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -652,6 +652,11 @@ def _handle_heartbeat(args: dict, **kw) -> str:
     if ownership_err:
         return ownership_err
     note = args.get("note")
+    if not note or not note.strip():
+        return tool_error(
+            "note is required — describe your current progress "
+            "so humans can track what you're working on"
+        )
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -1117,13 +1122,13 @@ KANBAN_HEARTBEAT_SCHEMA = {
             "note": {
                 "type": "string",
                 "description": (
-                    "Optional short note describing current progress. "
+                    "REQUIRED: short note describing current progress. "
                     "Shown in the event log."
                 ),
             },
             "board": _board_schema_prop(),
         },
-        "required": [],
+        "required": ["note"],
     },
 }
 


### PR DESCRIPTION
## What does this PR do?

Makes `note` a required field in the `kanban_heartbeat` tool schema, preventing workers from sending empty heartbeats that provide zero visibility on progress. Follows the same pattern as PR #41847 (`delegate_task: required: [] → required: ["goal"]`).

## Related Issue

None — the issue was documented internally.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/kanban_tools.py`: Changed `"required": []` to `"required": ["note"]` in `KANBAN_HEARTBEAT_SCHEMA`; updated description to `"REQUIRED: short note"`; added backend validation to reject empty/whitespace notes via `tool_error`.
- `tests/tools/test_kanban_tools.py`: Updated `test_heartbeat_without_note` to assert that missing/empty notes fail with `"error"` instead of succeeding with `"ok"`.

## How to Test

1. Run `pytest tests/tools/test_kanban_tools.py -k "heartbeat" -v` — all 3 heartbeat tests should pass
2. Verify the schema: `python -c "from tools.kanban_tools import KANBAN_HEARTBEAT_SCHEMA; print(KANBAN_HEARTBEAT_SCHEMA['parameters']['required'])"` — should output `['note']`
3. The backend validation also catches empty/whitespace notes:
   ```python
   from tools import kanban_tools as kt
   print(kt._handle_heartbeat({}))        # → error
   print(kt._handle_heartbeat({"note": "   "}))  # → error
   print(kt._handle_heartbeat({"note": "working on X"}))  # → ok
   ```

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/tools/test_kanban_tools.py -k 'heartbeat' -v` — all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: WSL (Ubuntu)
- [x] I've updated tool descriptions/schemas since I changed tool behavior

## Code Intelligence

- Analyzed: `KANBAN_HEARTBEAT_SCHEMA` in `tools/kanban_tools.py`, `_handle_heartbeat` handler, `test_heartbeat_without_note` in test file.
- Blast radius: LOW — schema change only; handler validation added; all capable models already provide `note`.
- Related patterns: PR #41847 (`delegate_task: required: [] → required: ["goal"]`) — same approach, already reviewed by the community.