### PR TITLE
fix(gateway): preserve running state on signal shutdown

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1953,6 +1953,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._exit_code: Optional[int] = None
         self._draining = False
         self._restart_requested = False
+        self._preserve_gateway_running_state_on_stop = False
         self._restart_task_started = False
         self._restart_detached = False
         self._restart_via_service = False
@@ -5952,7 +5953,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._exit_reason = self._exit_reason or "Gateway restart requested"
 
             self._draining = False
-            self._update_runtime_status("stopped", self._exit_reason)
+            final_gateway_state = (
+                "running"
+                if self._preserve_gateway_running_state_on_stop and not self._restart_requested
+                else "stopped"
+            )
+            self._update_runtime_status(final_gateway_state, self._exit_reason)
             logger.info("Gateway stopped (total teardown %.2fs)", _phase_elapsed())
 
         self._stop_task = asyncio.create_task(_stop_impl())
@@ -15711,6 +15717,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             )
         else:
             _signal_initiated_shutdown = True
+            runner._preserve_gateway_running_state_on_stop = True
             logger.info(
                 "Received %s — initiating shutdown",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM/SIGINT",

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -66,6 +66,7 @@ def make_restart_runner(
     runner._background_tasks = set()
     runner._draining = False
     runner._restart_requested = False
+    runner._preserve_gateway_running_state_on_stop = False
     runner._restart_task_started = False
     runner._restart_detached = False
     runner._restart_via_service = False

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -163,6 +163,20 @@ async def test_gateway_stop_launchd_service_restart_keeps_nonzero_exit(tmp_path,
     assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
 
 
+
+@pytest.mark.asyncio
+async def test_unexpected_signal_shutdown_preserves_running_state_for_service_revival():
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._preserve_gateway_running_state_on_stop = True
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    runner._update_runtime_status.assert_called_with("running", None)
+    assert runner._shutdown_event.is_set() is True
+
+
 @pytest.mark.asyncio
 async def test_restart_shutdown_warning_uses_restart_command_reply_anchor_for_active_session():
     runner, adapter = make_restart_runner()


### PR DESCRIPTION
## What does this PR do?

Fixes the Docker/s6 gateway auto-start regression from #42675.

When the gateway receives an unexpected external SIGTERM, `start_gateway()` already exits non-zero so a service manager can revive it. However, the gateway teardown still persisted `gateway_state="stopped"`. In Docker s6 deployments, `container_boot` only auto-starts profile gateway services whose previous state is `running`, so a container restart or image upgrade could leave messaging channels dark even though the gateway had been running before the supervisor stopped it.

This PR preserves `gateway_state="running"` for unexpected signal-initiated shutdowns while keeping intentional stops and planned restarts as `stopped`.

## Related Issue

Fixes #42675

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Track unexpected signal-initiated shutdowns separately from planned stops/restarts.
  - Preserve the persisted runtime gateway state as `running` for those external signal shutdowns so Docker/s6 reconciliation can bring the gateway back up on the next container boot.
  - Keep planned stop/restart behavior unchanged.
- `tests/gateway/test_gateway_shutdown.py`
  - Add regression coverage that signal-preserved shutdowns persist `running`.
- `tests/gateway/restart_test_helpers.py`
  - Initialize the new runner test flag in the object-constructed test helper.

## How to Test

1. Reproduce the bug condition: a running Docker/s6 gateway receives an external SIGTERM during container restart/upgrade; prior behavior writes `gateway_state="stopped"`, so `container_boot` registers the service down on the next boot.
2. Verify the fix: unexpected signal shutdown now sets the preserve flag and final runtime status remains `running`; planned stops/restarts still use the existing paths.
3. Local checks run:
   - `.venv/bin/python -m pytest -o 'addopts=' tests/gateway/test_gateway_shutdown.py -q` → `15 passed in 35.06s`
   - `.venv/bin/python -m compileall -q gateway/run.py tests/gateway/test_gateway_shutdown.py tests/gateway/restart_test_helpers.py`
   - `.venv/bin/python -m ruff check gateway/run.py tests/gateway/test_gateway_shutdown.py tests/gateway/restart_test_helpers.py` → `All checks passed!`
   - `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container/PRoot environment with focused gateway shutdown tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ .venv/bin/python -m pytest -o 'addopts=' tests/gateway/test_gateway_shutdown.py -q
...............                                                          [100%]
15 passed in 35.06s

$ .venv/bin/python -m ruff check gateway/run.py tests/gateway/test_gateway_shutdown.py tests/gateway/restart_test_helpers.py
All checks passed!
```
