### PR TITLE
fix(acp): restore memory tools in ACP transport sessions

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -826,7 +826,7 @@ class HermesACPAgent(acp.Agent):
             from model_tools import get_tool_definitions
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
+                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp", "memory"],
                 mcp_server_names=[server.name for server in mcp_servers],
             )
             state.agent.enabled_toolsets = enabled_toolsets
@@ -1780,7 +1780,7 @@ class HermesACPAgent(acp.Agent):
         try:
             from model_tools import get_tool_definitions
             toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
+                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp", "memory"]
             )
             tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
             if not tools:

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -143,7 +143,7 @@ def _expand_acp_enabled_toolsets(
 ) -> List[str]:
     """Return ACP toolsets plus explicit MCP server toolsets for this session."""
     expanded: List[str] = []
-    for name in list(toolsets or ["hermes-acp"]):
+    for name in list(toolsets or ["hermes-acp", "memory"]):
         if name and name not in expanded:
             expanded.append(name)
 
@@ -591,7 +591,7 @@ class SessionManager:
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                ["hermes-acp", "memory"],
                 mcp_server_names=configured_mcp_servers,
             ),
             "quiet_mode": True,

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -273,7 +273,7 @@ class TestPersistence:
             manager = SessionManager(db=db)
             manager.create_session(cwd="/work")
 
-        assert captured["enabled_toolsets"] == ["hermes-acp", "mcp-olympus", "mcp-exa"]
+        assert captured["enabled_toolsets"] == ["hermes-acp", "memory", "mcp-olympus", "mcp-exa"]
 
     def test_create_session_writes_to_db(self, manager):
         state = manager.create_session(cwd="/project")


### PR DESCRIPTION
## Summary

The ACP adapter hardcoded `enabled_toolsets` as `["hermes-acp"]`, excluding the `"memory"` toolset name. This prevented the 19 mnemosyne tools from loading despite correct configuration.

## Changes

- **`acp_adapter/session.py`**: Added `"memory"` to default `enabled_toolsets` in two locations (~line 146, ~line 594)
- **`acp_adapter/server.py`**: Added `"memory"` to default `enabled_toolsets` in two locations (~line 829, ~line 1783)
- **`tests/acp/test_session.py`**: Updated test expectation at line 276 to include `"memory"` in the assertion

## Root Cause

The `enabled_toolsets` list was used as a gate in `agent_init.py` to decide which tool classes to load. Since `"memory"` was never included, the 19 Mnemosyne memory tools were silently excluded from all ACP transport sessions.

## Testing

All 41 ACP session tests pass with the fix applied.