### PR TITLE
fix(agent): recover from char-based output-cap overflow (#42741)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -968,6 +968,16 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         # OpenRouter/Nous phrasing of the same condition.
         "in the output" in error_lower
         and "maximum context length" in error_lower
+    ) or (
+        # LM Studio / llama.cpp / some OpenAI-compatible servers:
+        #   "This model's maximum context length is 65536 tokens. However, you
+        #    requested 65536 output tokens and your prompt contains 77409
+        #    characters ..."
+        # The "requested N output tokens" phrasing means the OUTPUT cap is the
+        # problem (the input itself fits) — reduce max_tokens, don't compress.
+        "maximum context length" in error_lower
+        and "requested" in error_lower
+        and "output tokens" in error_lower
     )
     if not is_output_cap_error:
         return None
@@ -996,6 +1006,22 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     )
     if _m_ctx and _m_parts:
         _available = int(_m_ctx.group(1)) - int(_m_parts.group(1)) - int(_m_parts.group(2))
+        if _available >= 1:
+            return _available
+
+    # LM Studio / llama.cpp style: context window is reported in tokens but the
+    # prompt size is reported in CHARACTERS, e.g.
+    #   "maximum context length is 65536 tokens ... your prompt contains 77409
+    #    characters ...".
+    # Estimate the input tokens conservatively (~3 chars/token, which
+    # over-reserves the input so the retried output cap stays safely inside the
+    # window) and leave the remainder of the window for output.
+    _m_ctx_tok = re.search(r'maximum context length is (\d+)\s*token', error_lower)
+    _m_chars = re.search(r'prompt contains (\d+)\s*character', error_lower)
+    if _m_ctx_tok and _m_chars:
+        _ctx = int(_m_ctx_tok.group(1))
+        _est_input = (int(_m_chars.group(1)) + 2) // 3
+        _available = _ctx - _est_input
         if _available >= 1:
             return _available
 

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -25,3 +25,40 @@ class TestParseOpenRouterOutputCap:
         msg = ("maximum context length is 1000 tokens "
                "(900 of text input, 200 of tool input, 0 in the output)")
         assert parse_available_output_tokens_from_error(msg) is None
+
+
+class TestParseCharBasedOutputCap:
+    """LM Studio / llama.cpp report context in tokens but prompt in characters.
+
+    These servers send a hard 400 even on a trivial prompt when the default
+    output cap equals the context window (#42741): the request asks for the
+    whole window as output, leaving zero room for input.
+    """
+
+    def test_char_based_output_cap_format(self):
+        msg = ("This model's maximum context length is 65536 tokens. However, "
+               "you requested 65536 output tokens and your prompt contains "
+               "77409 characters (more than 0 characters, which is the upper "
+               "bound for 0 input tokens). Please reduce the length of the "
+               "input prompt or the number of requested output tokens.")
+        # est input = ceil(77409 / 3) = 25803; available = 65536 - 25803 = 39733
+        assert parse_available_output_tokens_from_error(msg) == 39733
+
+    def test_char_based_leaves_room_for_input(self):
+        # The whole point: the retried output cap + the estimated input must
+        # fit inside the reported context window.
+        ctx = 65536
+        chars = 77409
+        available = parse_available_output_tokens_from_error(
+            f"maximum context length is {ctx} tokens. However, you requested "
+            f"{ctx} output tokens and your prompt contains {chars} characters."
+        )
+        assert available is not None
+        assert available + (chars + 2) // 3 <= ctx
+
+    def test_char_based_no_room_returns_none(self):
+        # Prompt larger than the window (in tokens) -> not an output-cap fix;
+        # let the prompt-too-long / compression path handle it.
+        msg = ("maximum context length is 1000 tokens. However, you requested "
+               "1000 output tokens and your prompt contains 9000 characters.")
+        assert parse_available_output_tokens_from_error(msg) is None


### PR DESCRIPTION
## Summary

Fixes #42741. On default config, `hermes chat` → typing `hi` returns a hard `HTTP 400` on the very first turn:

> This model's maximum context length is 65536 tokens. However, you requested 65536 output tokens and your prompt contains 77409 characters (more than 0 characters, which is the upper bound for 0 input tokens).

### Root cause
- Since `09ec26c66` (`fix(ollama): set default_max_tokens for custom/Ollama provider`, #39281), the `custom` provider profile has `default_max_tokens=65536`. For local models whose context window is *also* 65536 (a very common tier), an unset `model.max_tokens` makes Hermes request the **entire window as output**, leaving zero room for input → strict servers (LM Studio / llama.cpp / some OpenAI-compatible backends) reject before generation.
- The agent already has a recovery path for "output cap too large" errors (reduce `max_tokens` and retry, without compressing). But `parse_available_output_tokens_from_error()` only recognised the Anthropic (`available_tokens: N`) and OpenRouter/Nous (`… in the output`) phrasings. This LM Studio/llama.cpp phrasing — context in **tokens**, prompt size in **characters** — was unrecognised, so the overflow was misrouted to the prompt-too-long/compression path, which can't help when the input already fits. The user gets a hard 400 on `hi`.

### Fix
Teach `parse_available_output_tokens_from_error()` to detect the `"requested N output tokens … prompt contains C characters"` form, estimate the input conservatively (~3 chars/token, so the retried cap stays safely inside the window), and return the available output budget. The existing retry logic then shrinks `max_tokens` and the turn succeeds — same mechanism already used for the other provider phrasings (no compression, `context_length` untouched).

This is a self-contained, additive change to the error parser (plus tests). It does not revert the Ollama `default_max_tokens` fix.

## Test plan
- [x] `scripts/run_tests.sh tests/test_output_cap_parsing.py` (7 passed) — new `TestParseCharBasedOutputCap` covers the reported format, the "retried cap + estimated input fits the window" invariant, and the no-room → `None` fallback.
- [x] `scripts/run_tests.sh tests/test_ctx_halving_fix.py` (no regression in the related output-cap/ctx path).