### PR TITLE
fix(config): reject redacted credential placeholders

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5375,6 +5375,112 @@ _COMMENTED_SECTIONS = """
 """
 
 
+_CREDENTIAL_CONFIG_KEYS = {
+    "api_key",
+    "apikey",
+    "api",
+    "token",
+    "access_token",
+    "refresh_token",
+    "oauth_token",
+    "secret",
+    "password",
+}
+
+_REDACTED_CREDENTIAL_PLACEHOLDERS = {
+    "***",
+    "[redacted]",
+    "<redacted>",
+    "redacted",
+    "(redacted)",
+    "[secret]",
+    "<secret>",
+}
+
+
+def _is_env_ref_template(value: str) -> bool:
+    return bool(re.fullmatch(r"\$\{[A-Za-z_][A-Za-z0-9_]*\}", value.strip()))
+
+
+def _looks_like_redacted_credential_placeholder(value: Any) -> bool:
+    """Return True for placeholders produced by redaction, not real secrets.
+
+    Agents only see redacted tool/session output. If they copy those previews
+    back into config, Hermes later treats the preview as the actual credential
+    and model calls fail with auth errors. Keep this intentionally narrow: env
+    refs are allowed, empty values remain the normal opt-out path, and the
+    ellipsis rule is limited to short previews such as ``sk-m...n8ui``.
+    """
+    if not isinstance(value, str):
+        return False
+    candidate = value.strip().strip("\"'")
+    if not candidate or _is_env_ref_template(candidate):
+        return False
+    lowered = candidate.lower()
+    if lowered in _REDACTED_CREDENTIAL_PLACEHOLDERS:
+        return True
+    if "redacted" in lowered and len(candidate) <= 32:
+        return True
+    if "..." in candidate and len(candidate) <= 32:
+        return True
+    return False
+
+
+def _iter_redacted_credential_placeholders(value: Any, path: Tuple[str, ...] = ()):
+    if isinstance(value, dict):
+        for raw_key, child in value.items():
+            key = str(raw_key)
+            child_path = path + (key,)
+            normalized_key = key.lower().replace("-", "_")
+            if normalized_key in _CREDENTIAL_CONFIG_KEYS and _looks_like_redacted_credential_placeholder(child):
+                yield ".".join(child_path)
+            else:
+                yield from _iter_redacted_credential_placeholders(child, child_path)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from _iter_redacted_credential_placeholders(child, path + (str(index),))
+
+
+def _reject_redacted_credential_placeholders(config: Any) -> None:
+    bad_paths = list(_iter_redacted_credential_placeholders(config))
+    if not bad_paths:
+        return
+    joined = ", ".join(bad_paths[:5])
+    if len(bad_paths) > 5:
+        joined += f", ... and {len(bad_paths) - 5} more"
+    raise ValueError(
+        "Refusing to persist redacted credential placeholder(s) at "
+        f"{joined}. Re-enter the real secret or store it via an env reference."
+    )
+
+
+def _reject_redacted_env_secret(key: str, value: Any) -> None:
+    """Reject redacted credential placeholders in env-file writes.
+
+    Credential detection uses two passes:
+    1. A conventional suffix check (_API_KEY, _TOKEN, _SECRET, _PASSWORD)
+       catches most well-known credential naming patterns.
+    2. OPTIONAL_ENV_VARS metadata (``"password": True``) catches
+       non-standard credential names such as FAL_KEY and
+       VOICE_TOOLS_OPENAI_KEY that fall through the suffix net.
+    """
+    if _looks_like_redacted_credential_placeholder(value):
+        key_upper = key.upper()
+        if key_upper.endswith(("_API_KEY", "_TOKEN", "_SECRET", "_PASSWORD")) or key_upper in _EXTRA_ENV_KEYS:
+            raise ValueError(
+                f"Refusing to persist redacted credential placeholder for {key_upper}. "
+                "Re-enter the real secret instead."
+            )
+        # OPTIONAL_ENV_VARS categorisation (password-flagged), e.g. FAL_KEY,
+        # VOICE_TOOLS_OPENAI_KEY — non-standard suffix, still a credential.
+        opt_def = OPTIONAL_ENV_VARS.get(key_upper, {})
+        if isinstance(opt_def, dict) and opt_def.get("password") is True:
+            raise ValueError(
+                f"Refusing to persist redacted credential placeholder for {key_upper}. "
+                "Re-enter the real secret instead."
+            )
+
+
 def save_config(config: Dict[str, Any]):
     """Save configuration to ~/.hermes/config.yaml."""
     with _CONFIG_LOCK:
@@ -5386,14 +5492,18 @@ def save_config(config: Dict[str, Any]):
         ensure_hermes_home()
         config_path = get_config_path()
         current_normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
-        normalized = current_normalized
+        if not isinstance(current_normalized, dict):
+            current_normalized = {}
+        normalized: Dict[str, Any] = current_normalized
         raw_existing = _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config()))
         if raw_existing:
-            normalized = _preserve_env_ref_templates(
+            preserved = _preserve_env_ref_templates(
                 normalized,
                 raw_existing,
                 _LAST_EXPANDED_CONFIG_BY_PATH.get(str(config_path)),
             )
+            normalized = preserved if isinstance(preserved, dict) else {}
+        _reject_redacted_credential_placeholders(normalized)
 
         # Build optional commented-out sections for features that are off by
         # default or only relevant when explicitly configured.
@@ -5651,6 +5761,7 @@ def save_env_value(key: str, value: str):
         raise ValueError(f"Invalid environment variable name: {key!r}")
     _reject_denylisted_env_var(key)
     value = value.replace("\n", "").replace("\r", "")
+    _reject_redacted_env_secret(key, value)
     # API keys / tokens must be ASCII — strip non-ASCII with a warning.
     value = _check_non_ascii_credential(key, value)
     ensure_hermes_home()
@@ -6121,6 +6232,7 @@ def set_config_value(key: str, value: str):
         value = float(value)
 
     _set_nested(user_config, key, value)
+    _reject_redacted_credential_placeholders(user_config)
     
     # Write only user config back (not the full merged defaults)
     ensure_hermes_home()

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -132,3 +132,40 @@ class TestSaveConfigValueAtomic:
 
         assert result is False
         assert config_env.read_text() == original_content
+
+    def test_rejects_redacted_value_on_env_save(self, config_env):
+        """save_env_value must reject redacted placeholders for credential keys."""
+        from hermes_cli.config import save_env_value
+
+        with pytest.raises(ValueError, match="redacted"):
+            save_env_value("OPENAI_API_KEY", "sk-...abc")
+        with pytest.raises(ValueError, match="redacted"):
+            save_env_value("ANTHROPIC_API_KEY", "[redacted]")
+
+    def test_rejects_nonstandard_credential_keys(self, config_env):
+        """FAL_KEY and VOICE_TOOLS_OPENAI_KEY live in OPTIONAL_ENV_VARS
+        with ``"password": True`` but end in ``_KEY``, not ``_API_KEY``.
+        The write-time guard must still reject redacted placeholders."""
+        from hermes_cli.config import save_env_value
+
+        with pytest.raises(ValueError, match="redacted"):
+            save_env_value("FAL_KEY", "***")
+        with pytest.raises(ValueError, match="redacted"):
+            save_env_value("VOICE_TOOLS_OPENAI_KEY", "sk-...xyz")
+
+    def test_allows_real_secret_values(self, config_env):
+        """Real API keys must not be rejected.
+        Boundary: real keys may contain patterns that look like placeholders
+        (e.g. '...') but they should pass through when longer than 32 chars."""
+        from hermes_cli.config import save_env_value
+
+        # Long real key — must succeed.
+        real_key = "sk-proj-" + "a" * 60
+        save_env_value("OPENAI_API_KEY", real_key)
+
+        # Short real value — harmless key, not a placeholder.
+        save_env_value("DINGTALK_CLIENT_ID", "ding123abc")
+
+        # Placeholder mimic — short key with "...", must be rejected.
+        with pytest.raises(ValueError, match="redacted"):
+            save_env_value("ANTHROPIC_API_KEY", "sk-...n8ui")

--- a/tests/hermes_cli/test_config_env_refs.py
+++ b/tests/hermes_cli/test_config_env_refs.py
@@ -1,6 +1,8 @@
 import textwrap
 
-from hermes_cli.config import load_config, save_config
+import pytest
+
+from hermes_cli.config import load_config, save_config, save_env_value, set_config_value
 
 
 def _write_config(tmp_path, body: str):
@@ -136,6 +138,57 @@ def test_save_config_keeps_edited_partial_template_strings_literal(monkeypatch, 
     saved = _read_config(tmp_path)
     assert "Authorization: Token alt-secret" in saved
     assert "Authorization: Bearer ${ALT_SECRET}" not in saved
+
+
+def test_save_config_rejects_redacted_model_api_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        model:
+          provider: custom
+          base_url: https://api.example.test/v1
+          api_key: ${REAL_MODEL_KEY}
+        """,
+    )
+
+    config = load_config()
+    config["model"]["api_key"] = "sk-m...n8ui"
+
+    with pytest.raises(ValueError, match="redacted credential placeholder"):
+        save_config(config)
+
+    assert "api_key: ${REAL_MODEL_KEY}" in _read_config(tmp_path)
+    assert "sk-m...n8ui" not in _read_config(tmp_path)
+
+
+def test_set_config_value_rejects_redacted_auxiliary_api_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        auxiliary:
+          vision:
+            provider: custom
+            api_key: ${AUX_VISION_KEY}
+        """,
+    )
+
+    with pytest.raises(ValueError, match="redacted credential placeholder"):
+        set_config_value("auxiliary.vision.api_key", "[REDACTED]")
+
+    saved = _read_config(tmp_path)
+    assert "api_key: ${AUX_VISION_KEY}" in saved
+    assert "[REDACTED]" not in saved
+
+
+def test_save_env_value_rejects_redacted_api_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with pytest.raises(ValueError, match="redacted credential placeholder"):
+        save_env_value("OPENAI_API_KEY", "sk-...")
+
+    assert not (tmp_path / ".env").exists()
 
 
 def test_save_config_falls_back_to_positional_matching_for_duplicate_names(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -134,7 +134,7 @@ class TestCustomProviderModelSwitch:
         provider_info = {
             "name": "Anthropic Proxy",
             "base_url": "https://proxy.example.com/anthropic",
-            "api_key": "***",
+            "api_key": "sk-test-anthropic-proxy",
             "model": "claude-3",
             "api_mode": "anthropic_messages",
         }
@@ -146,7 +146,7 @@ class TestCustomProviderModelSwitch:
             _model_flow_named_custom({}, provider_info)
 
         mock_fetch.assert_called_once_with(
-            "***",
+            "sk-test-anthropic-proxy",
             "https://proxy.example.com/anthropic",
             timeout=8.0,
             api_mode="anthropic_messages",
@@ -168,7 +168,7 @@ class TestCustomProviderModelSwitch:
         provider_info = {
             "name": "My vLLM",
             "base_url": "https://vllm.example.com/v1",
-            "api_key": "***",
+            "api_key": "sk-test-vllm-key",
             "model": "llama-3",
         }
 


### PR DESCRIPTION
## Summary

- Refuse to persist redacted credential placeholders in `config.yaml` or `.env` credential fields.
- Cover both shared `save_config()` callers and the direct `hermes config set ...` write path.
- Add regression coverage for main model credentials, auxiliary credentials, and `.env` API key writes.

## Root cause

Agents only receive redacted tool/session output for secrets. During troubleshooting, an agent can accidentally copy a redacted preview such as `sk-...` or `[REDACTED]` back into Hermes' own model configuration. Hermes then treats that preview as the real credential on the next model call, causing authentication failures and potentially breaking gateway connectivity.

`hermes config set` also bypassed `save_config()` and wrote `config.yaml` directly, so a guard only in the shared save path would not cover CLI config mutations.

## Changes

| Area | Change |
| --- | --- |
| `hermes_cli/config.py` | Add a narrow redacted-placeholder detector for credential fields. |
| `save_config()` | Reject redacted placeholders before writing `config.yaml`. |
| `save_env_value()` | Reject redacted placeholders before writing `.env` API key/token/secret/password fields. |
| `set_config_value()` | Run the same config guard before its direct `atomic_yaml_write()` path. |
| Tests | Add regressions for `model.api_key`, `auxiliary.*.api_key`, and `.env` writes. |

## Validation

| Command | Result |
| --- | --- |
| `PYTHONPATH=$(pwd) ./venv/bin/python -m pytest tests/hermes_cli/test_config_env_refs.py tests/hermes_cli/test_config.py tests/hermes_cli/test_custom_provider_model_switch.py -q --tb=short -o 'addopts='` | `122 passed` |
| `PYTHONPATH=$(pwd) ./venv/bin/python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q --tb=short -o 'addopts='` | `127 passed` |
| `PYTHONPATH=$(pwd) ./venv/bin/python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_provider_config_validation.py tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_model_validation.py -q --tb=short -o 'addopts='` | `148 passed` |
| `PYTHONPATH=$(pwd) ./venv/bin/python -m py_compile hermes_cli/config.py` | passed |
| Manual CLI check with temporary `HERMES_HOME`: `hermes config set model.api_key 'sk-...'` | exits non-zero, reports guard, does not create `config.yaml` |

A full `tests/hermes_cli` run was attempted in this local environment but timed out after 10 minutes before completing, so the validation above focuses on the changed config/provider paths.

## Out of scope

This does not implement intent-aware approval for agent self-configuration. It only prevents an especially damaging failure mode: persisting redacted credential previews as real credentials.

Closes #42727
