### PR TITLE
fix(config): refuse to persist redacted secret placeholders via config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4601,6 +4601,44 @@ def _default_value_for_key(dotted_key: str):
             return None
         node = node[part]
     return node if not isinstance(node, dict) else None
+_SECRET_KEY_LEAVES = {
+    "api_key", "apikey", "token", "secret", "password", "passwd",
+    "client_secret", "access_token", "auth_token", "refresh_token",
+}
+
+_REDACTED_MASK_RE = re.compile(r"[*•·●×]{3,}")
+
+
+def _is_secret_config_key(key: str) -> bool:
+    """True when ``key`` names a credential/secret field."""
+    leaf = key.rsplit(".", 1)[-1].strip().lower()
+    if leaf in _SECRET_KEY_LEAVES:
+        return True
+    upper = key.upper()
+    return upper.endswith(("_API_KEY", "_TOKEN", "_SECRET", "_PASSWORD"))
+
+
+def _looks_redacted_secret(value: str) -> bool:
+    """Heuristic: does ``value`` look like a masked/redacted display placeholder
+    rather than a real secret? Hermes redacts secrets in tool output and config
+    dumps (e.g. ``sk-...``, ``***``, ``[REDACTED]``); persisting those back as
+    literal credentials silently bricks the provider (issue #42727).
+    """
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    if not stripped:
+        return False
+    low = stripped.lower()
+    if low in {"***", "...", "…", "redacted", "[redacted]", "<redacted>"}:
+        return True
+    if stripped.endswith("...") or "…" in stripped:
+        return True
+    if "[redacted]" in low or "<redacted>" in low:
+        return True
+    if _REDACTED_MASK_RE.search(stripped):
+        return True
+    return False
 
 
 # Known top-level config keys that intentionally accept arbitrary user-supplied
@@ -4810,6 +4848,19 @@ def set_config_value(key: str, value: str, force: bool = False):
             file=sys.stderr,
         )
         sys.exit(1)
+    # Refuse to persist a redacted/masked placeholder into a secret field.
+    # Hermes masks secrets in tool output and config dumps, so an agent (or a
+    # copy-paste) can easily write back the display value (``sk-...``, ``***``,
+    # ``[REDACTED]``); storing that literally breaks the provider with a 401 and
+    # can leave the gateway unable to answer (issue #42727).
+    if _is_secret_config_key(key) and _looks_redacted_secret(value):
+        print(
+            f"✗ Refusing to set {key}: '{value}' looks like a redacted/masked "
+            "placeholder, not a real secret. Hermes redacts secrets in tool output "
+            "and config dumps — copy the real value from your provider (or "
+            f"{get_env_path()}) instead of the masked display value."
+        )
+        return
     # Check if it's an API key (goes to .env)
     if _is_env_config_key(key):
         # Unified lifecycle: also rotates any config.yaml mirror of the old

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -723,3 +723,89 @@ class TestMalformedYAMLConfigPreservation:
         assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Redacted-secret guard (issue #42727): an agent must not be able to brick the
+# provider by persisting a masked display value (sk-... / *** / [REDACTED]).
+# ---------------------------------------------------------------------------
+
+import yaml  # noqa: E402
+
+from hermes_cli.config import (  # noqa: E402
+    _is_secret_config_key,
+    _looks_redacted_secret,
+)
+
+
+class TestRedactedSecretGuard:
+    @pytest.mark.parametrize("key", [
+        "model.api_key",
+        "auxiliary.vision.api_key",
+        "custom_providers.0.api_key",
+        "OPENAI_API_KEY",
+        "honcho.token",
+        "smtp.password",
+        "x.client_secret",
+    ])
+    def test_secret_keys_detected(self, key):
+        assert _is_secret_config_key(key) is True
+
+    @pytest.mark.parametrize("key", [
+        "model.provider",
+        "model.base_url",
+        "model.default",
+        "auxiliary.vision.model",
+        "display.skin",
+    ])
+    def test_non_secret_keys_not_flagged(self, key):
+        assert _is_secret_config_key(key) is False
+
+    @pytest.mark.parametrize("value", [
+        "sk-...",
+        "sk-proj-abc...",
+        "***",
+        "[REDACTED]",
+        "<redacted>",
+        "REDACTED",
+        "sk-****",
+        "••••••",
+        "abc…",
+    ])
+    def test_redacted_values_detected(self, value):
+        assert _looks_redacted_secret(value) is True
+
+    @pytest.mark.parametrize("value", [
+        "sk-proj-9aZ1real-key-material",
+        "hf_abcdef0123456789",
+        "a-real-token-value",
+        "https://example-provider.invalid/v1",
+        "",
+    ])
+    def test_real_values_not_flagged(self, value):
+        assert _looks_redacted_secret(value) is False
+
+    def test_redacted_value_not_persisted_to_config_yaml(self, _isolated_hermes_home):
+        # A real key is already configured.
+        set_config_value("auxiliary.vision.api_key", "real-secret-abc123")
+        assert "real-secret-abc123" in _read_config(_isolated_hermes_home)
+        # The agent tries to write back the masked display value — must be refused.
+        set_config_value("auxiliary.vision.api_key", "sk-...")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["auxiliary"]["vision"]["api_key"] == "real-secret-abc123"
+
+    def test_redacted_value_not_persisted_to_env(self, _isolated_hermes_home):
+        set_config_value("OPENAI_API_KEY", "***")
+        assert "OPENAI_API_KEY=***" not in _read_env(_isolated_hermes_home)
+
+    def test_real_secret_still_persists(self, _isolated_hermes_home):
+        set_config_value("model.api_key", "sk-real-value-not-masked")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["model"]["api_key"] == "sk-real-value-not-masked"
+
+    def test_redacted_value_allowed_for_non_secret_key(self, _isolated_hermes_home):
+        # The guard only applies to secret fields — a non-secret value that
+        # happens to end in "..." is still written.
+        set_config_value("display.welcome", "loading...")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["display"]["welcome"] == "loading..."


### PR DESCRIPTION
## What & why — closes #42727

Hermes masks secrets in tool output and config dumps. So when an agent is troubleshooting a provider error, it only ever *sees* the masked display value:

```yaml
auxiliary:
  vision:
    api_key: sk-...
```

If it then tries to "repair" the config, it writes that mask straight back:

```bash
hermes config set auxiliary.vision.api_key sk-...
```

`set_config_value()` stored the placeholder **verbatim**. The next model/vision call then failed with **HTTP 401**, and when the *main* model credential was the one overwritten, the gateway/session could no longer answer ordinary user messages — a self-inflicted brick that looks like a provider outage even though the real key still works.

## Fix

Reject obviously-masked placeholders for **secret-named keys** before persisting to either `config.yaml` or `.env`:

- **Secret keys**: leaf is `api_key`/`apikey`/`token`/`secret`/`password`/`client_secret`/`access_token`/… , or the env-style `*_API_KEY`/`*_TOKEN`/`*_SECRET`/`*_PASSWORD`.
- **Masked values**: `***`, `...`/`…` (trailing ellipsis, e.g. `sk-...`), `[REDACTED]`/`<redacted>`, or runs of mask glyphs (`****`, `••••`).

On a match, `set_config_value` prints a clear refusal pointing the user at the real value and does **not** write anything.

```
✗ Refusing to set auxiliary.vision.api_key: 'sk-...' looks like a redacted/masked
  placeholder, not a real secret. … copy the real value from your provider (or
  ~/.hermes/.env) instead of the masked display value.
```

Scope notes:
- **Non-secret keys are untouched** — a value that merely ends in `...` (e.g. `display.welcome: "loading..."`) is still written.
- **Real secrets persist normally.**
- This implements the issue's first proposed safeguard (refuse redacted placeholders). The broader options — requiring explicit authorization before an agent mutates its own `model.*`/`auxiliary.*` connectivity — are a larger policy change left for a separate PR.

## How to test

```bash
scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py   # 62 passed
```

Adds `TestRedactedSecretGuard`: secret-key vs non-secret-key detection, redacted vs real value detection, and end-to-end that a masked value is **not** persisted to `config.yaml` or `.env` while a real secret still is.

## Platforms

Pure config-layer Python; verified via the CI-parity runner.