### PR TITLE
fix(security): remove container command guard bypass for defense-in-depth

### DIFF
--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -53,25 +53,29 @@ def _clean_state():
 
 
 # ---------------------------------------------------------------------------
-# Container skip
+# Container environments now go through command guards (defense-in-depth)
 # ---------------------------------------------------------------------------
 
 class TestContainerSkip:
-    def test_docker_skips_both(self):
+    def test_docker_blocks_hardline(self):
         result = check_all_command_guards("rm -rf /", "docker")
-        assert result["approved"] is True
+        assert result["approved"] is False
 
-    def test_singularity_skips_both(self):
+    def test_singularity_blocks_hardline(self):
         result = check_all_command_guards("rm -rf /", "singularity")
-        assert result["approved"] is True
+        assert result["approved"] is False
 
-    def test_modal_skips_both(self):
+    def test_modal_blocks_hardline(self):
         result = check_all_command_guards("rm -rf /", "modal")
-        assert result["approved"] is True
+        assert result["approved"] is False
 
-    def test_daytona_skips_both(self):
+    def test_daytona_blocks_hardline(self):
         result = check_all_command_guards("rm -rf /", "daytona")
-        assert result["approved"] is True
+        assert result["approved"] is False
+
+    def test_vercel_sandbox_blocks_hardline(self):
+        result = check_all_command_guards("rm -rf /", "vercel_sandbox")
+        assert result["approved"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -220,8 +220,8 @@ class TestCronDenyModeAllGuards:
 class TestCronModeInteractions:
     """Cron mode should NOT interfere with other approval bypass mechanisms."""
 
-    def test_container_env_still_auto_approves(self, monkeypatch):
-        """Docker/sandbox environments bypass approvals regardless of cron_mode."""
+    def test_container_env_enforces_hardline(self, monkeypatch):
+        """Container environments now enforce hardline command blocks (defense-in-depth)."""
         monkeypatch.setenv("HERMES_CRON_SESSION", "1")
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
@@ -230,7 +230,7 @@ class TestCronModeInteractions:
         from unittest.mock import patch as mock_patch
         with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
             result = check_dangerous_command("rm -rf /", "docker")
-            assert result["approved"]
+            assert not result["approved"]
 
     def test_yolo_overrides_cron_deny(self, monkeypatch):
         """--yolo still bypasses cron_mode=deny for dangerous (non-hardline) commands."""

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -234,16 +234,16 @@ def test_cron_approve_mode_cannot_bypass_hardline(clean_session, monkeypatch):
     assert result.get("hardline") is True
 
 
-def test_container_backends_still_bypass(clean_session):
-    """Containerized backends remain bypass-approved — they can't touch the host.
+def test_container_backends_now_enforce_guards(clean_session):
+    """Containerized backends now go through command guards (defense-in-depth).
 
-    Hardline only protects environments with real host impact (local, ssh).
+    Hardline and dangerous command detection applies to all environments.
     """
-    for env in ("docker", "singularity", "modal", "daytona"):
+    for env in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
         r1 = check_dangerous_command("rm -rf /", env)
-        assert r1["approved"] is True, f"container {env} should still bypass"
+        assert r1["approved"] is False, f"container {env} should block hardline"
         r2 = check_all_command_guards("rm -rf /", env)
-        assert r2["approved"] is True, f"container {env} should still bypass"
+        assert r2["approved"] is False, f"container {env} should block hardline"
 
 
 def test_hardline_runs_before_dangerous_detection(clean_session):
@@ -368,9 +368,9 @@ def test_sudo_stdin_guard_not_blocked_by_yolo(clean_session, monkeypatch):
         assert result["approved"] is False, f"yolo leaked sudo guard on {cmd!r}"
 
 
-def test_sudo_stdin_guard_container_bypass(clean_session):
-    """Containerized backends still bypass — they can't touch the host."""
-    for env in ("docker", "singularity", "modal", "daytona"):
+def test_sudo_stdin_guard_blocks_in_containers(clean_session):
+    """Containerized backends now enforce the sudo stdin guard (defense-in-depth)."""
+    for env in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
         for cmd in _SUDO_STDIN_BLOCK:
             result = check_all_command_guards(cmd, env)
-            assert result["approved"] is True, f"container {env} should bypass sudo guard on {cmd!r}"
+            assert result["approved"] is False, f"container {env} should block sudo guard on {cmd!r}"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1049,9 +1049,6 @@ def check_dangerous_command(command: str, env_type: str,
     Returns:
         {"approved": True/False, "message": str or None, ...}
     """
-    if env_type in {"docker", "singularity", "modal", "daytona"}:
-        return {"approved": True, "message": None}
-
     # Hardline floor: commands with no recovery path (rm -rf /, mkfs, dd
     # to raw device, shutdown/reboot, fork bomb, kill -1) are blocked
     # unconditionally, BEFORE the yolo bypass.  Opting into yolo is
@@ -1279,10 +1276,6 @@ def check_all_command_guards(command: str, env_type: str,
     a gateway force=True replay from bypassing one check when only the
     other was shown to the user.
     """
-    # Skip containers for both checks
-    if env_type in {"docker", "singularity", "modal", "daytona"}:
-        return {"approved": True, "message": None}
-
     # Hardline floor: unconditional block for catastrophic commands
     # (rm -rf /, mkfs, dd to raw device, shutdown/reboot, fork bomb,
     # kill -1). Applies BEFORE yolo / mode=off / cron approve-mode so


### PR DESCRIPTION
Removes the container environment bypass in `check_dangerous_command()` and `check_all_command_guards()` so hardline and dangerous command detection applies to all environments (docker, singularity, modal, daytona, vercel_sandbox).

**Changes:**
- Removed `if env_type in {docker, singularity, modal, daytona}: return {approved: True}` from both guard functions in `tools/approval.py`
- Updated 3 test files to assert containers now enforce hardline blocks

Part of #24942