### PR TITLE
fix(security): add TELEGRAM_ALLOWED_USERS check to DMs with wildcard support

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5105,6 +5105,18 @@ class TelegramAdapter(BasePlatformAdapter):
         recognised as mentions by :meth:`_message_mentions_bot`.
         """
         if not self._is_group_chat(message):
+            # Apply TELEGRAM_ALLOWED_USERS to DMs (wildcard '*' = allow all)
+            from_user = getattr(message, "from_user", None)
+            if from_user is None:
+                logger.debug("[Telegram] DM with no from_user; rejecting (fail-closed)")
+                return False
+            allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
+            if allowed_csv:
+                allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+                user_id_str = str(getattr(from_user, "id", ""))
+                if "*" not in allowed_ids and user_id_str not in allowed_ids:
+                    logger.debug("[Telegram] DM user %s not in TELEGRAM_ALLOWED_USERS; rejecting", user_id_str)
+                    return False
             return True
 
         thread_id = getattr(message, "message_thread_id", None)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5104,8 +5104,11 @@ class TelegramAdapter(BasePlatformAdapter):
         mentioning the bot (``@botname /command``), both of which are
         recognised as mentions by :meth:`_message_mentions_bot`.
         """
-        if not self._is_group_chat(message):
-            # Apply TELEGRAM_ALLOWED_USERS to DMs (wildcard '*' = allow all)
+        chat = getattr(message, "chat", None)
+        chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower() if chat else ""
+
+        # Apply TELEGRAM_ALLOWED_USERS only to private DMs, not channel posts
+        if chat_type == "private":
             from_user = getattr(message, "from_user", None)
             if from_user is None:
                 logger.debug("[Telegram] DM with no from_user; rejecting (fail-closed)")
@@ -5117,6 +5120,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 if "*" not in allowed_ids and user_id_str not in allowed_ids:
                     logger.debug("[Telegram] DM user %s not in TELEGRAM_ALLOWED_USERS; rejecting", user_id_str)
                     return False
+            return True
+
+        if not self._is_group_chat(message):
             return True
 
         thread_id = getattr(message, "message_thread_id", None)


### PR DESCRIPTION
Adds `TELEGRAM_ALLOWED_USERS` support to DM message handling in the Telegram adapter.

**Changes:**
- DMs now check `TELEGRAM_ALLOWED_USERS` env var (wildcard `*` = allow all users)
- Missing `from_user` with allowlist set = fail-closed (return False)
- Channel messages exempted from `TELEGRAM_ALLOWED_USERS`

Part of #24942