### PR TITLE
fix(tests): remove terminal from SANDBOX_ALLOWED_TOOLS and update tests

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -79,6 +79,38 @@ class TestSandboxRequirements(unittest.TestCase):
         self.assertIn("code", EXECUTE_CODE_SCHEMA["parameters"]["properties"])
         self.assertIn("code", EXECUTE_CODE_SCHEMA["parameters"]["required"])
 
+    def test_terminal_not_in_sandbox_allowed_tools(self):
+        """terminal must be excluded from SANDBOX_ALLOWED_TOOLS.
+
+        execute_code runs arbitrary Python; a terminal() call inside that
+        Python lets the model bypass the dangerous-command approval gate.
+        """
+        from tools.code_execution_tool import SANDBOX_ALLOWED_TOOLS
+        self.assertNotIn("terminal", SANDBOX_ALLOWED_TOOLS)
+
+    def test_schema_omits_terminal_prose_when_excluded(self):
+        """Schema description must not mention terminal() when it is not in
+        the enabled sandbox tools."""
+        from tools.code_execution_tool import build_execute_code_schema
+        schema = build_execute_code_schema(
+            enabled_sandbox_tools={"web_search", "read_file"},
+            mode="project",
+        )
+        desc = schema["description"]
+        self.assertNotIn("terminal() is foreground-only", desc)
+        self.assertNotIn("terminal()", desc)
+
+    def test_schema_includes_terminal_prose_when_enabled(self):
+        """Schema description should include terminal notes when terminal is
+        in the enabled sandbox tools (even though it's excluded by default)."""
+        from tools.code_execution_tool import build_execute_code_schema
+        schema = build_execute_code_schema(
+            enabled_sandbox_tools={"web_search", "terminal"},
+            mode="project",
+        )
+        desc = schema["description"]
+        self.assertIn("terminal() is foreground-only", desc)
+
 
 class TestHermesToolsGeneration(unittest.TestCase):
     def test_generates_all_allowed_tools(self):
@@ -86,11 +118,30 @@ class TestHermesToolsGeneration(unittest.TestCase):
         for tool in SANDBOX_ALLOWED_TOOLS:
             self.assertIn(f"def {tool}(", src)
 
-    def test_generates_subset(self):
-        src = generate_hermes_tools_module(["terminal", "web_search"])
-        self.assertIn("def terminal(", src)
+    def test_terminal_excluded_from_sandbox_stubs(self):
+        """terminal must not generate a stub even when explicitly requested.
+
+        terminal is excluded from SANDBOX_ALLOWED_TOOLS (see #30882, #33057)
+        because execute_code runs arbitrary Python — a terminal() call inside
+        that Python lets the model bypass the dangerous-command approval gate.
+        Regression: generate_hermes_tools_module(['terminal']) used to produce
+        ``def terminal(`` before the allowlist change.
+        """
+        src = generate_hermes_tools_module(["terminal"])
+        self.assertNotIn("def terminal(", src)
+
+    def test_non_terminal_tools_generate_stubs(self):
+        """Non-terminal sandbox tools still generate stubs."""
+        src = generate_hermes_tools_module(["web_search", "read_file"])
         self.assertIn("def web_search(", src)
-        self.assertNotIn("def read_file(", src)
+        self.assertIn("def read_file(", src)
+        self.assertNotIn("def terminal(", src)
+
+    def test_generates_subset(self):
+        src = generate_hermes_tools_module(["web_search", "read_file"])
+        self.assertIn("def web_search(", src)
+        self.assertIn("def read_file(", src)
+        self.assertNotIn("def terminal(", src)
 
     def test_empty_list_generates_nothing(self):
         src = generate_hermes_tools_module([])
@@ -98,12 +149,13 @@ class TestHermesToolsGeneration(unittest.TestCase):
         self.assertIn("def _call(", src)  # infrastructure still present
 
     def test_non_allowed_tools_ignored(self):
-        src = generate_hermes_tools_module(["vision_analyze", "terminal"])
-        self.assertIn("def terminal(", src)
+        src = generate_hermes_tools_module(["vision_analyze", "web_search"])
+        self.assertIn("def web_search(", src)
         self.assertNotIn("def vision_analyze(", src)
+        self.assertNotIn("def terminal(", src)
 
     def test_rpc_infrastructure_present(self):
-        src = generate_hermes_tools_module(["terminal"])
+        src = generate_hermes_tools_module(["web_search"])
         self.assertIn("HERMES_RPC_SOCKET", src)
         self.assertIn("AF_UNIX", src)
         self.assertIn("def _connect(", src)
@@ -111,14 +163,14 @@ class TestHermesToolsGeneration(unittest.TestCase):
 
     def test_convenience_helpers_present(self):
         """Verify json_parse, shell_quote, and retry helpers are generated."""
-        src = generate_hermes_tools_module(["terminal"])
+        src = generate_hermes_tools_module(["web_search"])
         self.assertIn("def json_parse(", src)
         self.assertIn("def shell_quote(", src)
         self.assertIn("def retry(", src)
         self.assertIn("import json, os, socket, shlex, threading, time", src)
 
     def test_file_transport_uses_tempfile_fallback_for_rpc_dir(self):
-        src = generate_hermes_tools_module(["terminal"], transport="file")
+        src = generate_hermes_tools_module(["web_search"], transport="file")
         self.assertIn("import json, os, shlex, tempfile, threading, time", src)
         self.assertIn("os.path.join(tempfile.gettempdir(), \"hermes_rpc\")", src)
         self.assertNotIn('os.environ.get("HERMES_RPC_DIR", "/tmp/hermes_rpc")', src)
@@ -127,7 +179,7 @@ class TestHermesToolsGeneration(unittest.TestCase):
         """Regression: UDS _call() must hold a lock across send+recv so that
         concurrent tool calls from multiple threads don't interleave on the
         shared socket and receive each other's responses."""
-        src = generate_hermes_tools_module(["terminal"], transport="uds")
+        src = generate_hermes_tools_module(["web_search"], transport="uds")
         self.assertIn("_call_lock = threading.Lock()", src)
         self.assertIn("with _call_lock:", src)
 
@@ -135,7 +187,7 @@ class TestHermesToolsGeneration(unittest.TestCase):
         """Regression: file transport _call() must allocate `_seq` under a
         lock, otherwise concurrent threads can pick the same seq and clobber
         each other's request files."""
-        src = generate_hermes_tools_module(["terminal"], transport="file")
+        src = generate_hermes_tools_module(["web_search"], transport="file")
         self.assertIn("_seq_lock = threading.Lock()", src)
         self.assertIn("with _seq_lock:", src)
 

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -311,24 +311,24 @@ class TestExecuteCode(unittest.TestCase):
         self.assertIn("hermes_constants.py", result["output"])
 
     def test_single_tool_call(self):
-        """Script calls terminal and prints the result."""
+        """Script calls web_search and prints the result."""
         code = """
-from hermes_tools import terminal
-result = terminal("echo hello")
-print(result.get("output", ""))
+from hermes_tools import web_search
+result = web_search(query="hello")
+print(result.get("results", [{}])[0].get("title", ""))
 """
         result = self._run(code)
         self.assertEqual(result["status"], "success")
-        self.assertIn("mock output for: echo hello", result["output"])
+        self.assertIn("Example", result["output"])
         self.assertEqual(result["tool_calls_made"], 1)
 
     def test_multi_tool_chain(self):
         """Script calls multiple tools sequentially."""
         code = """
-from hermes_tools import terminal, read_file
-r1 = terminal("ls")
-r2 = read_file("test.py")
-print(f"terminal: {r1['output'][:20]}")
+from hermes_tools import web_search, read_file
+r1 = web_search(query="test")
+r2 = read_file(path="test.py")
+print(f"search: {r1['results'][0]['title']}")
 print(f"file lines: {r2['total_lines']}")
 """
         result = self._run(code)
@@ -363,13 +363,13 @@ print(f"file lines: {r2['total_lines']}")
         code = '''
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from hermes_tools import terminal
+from hermes_tools import web_search
 
 N = 10
 
 def call(i):
-    r = terminal(f"echo TAG-{i}")
-    return i, r.get("output", "")
+    r = web_search(query=f"TAG-{i}")
+    return i, r.get("results", [{}])[0].get("title", "")
 
 with ThreadPoolExecutor(max_workers=N) as ex:
     results = list(ex.map(call, range(N)))
@@ -411,7 +411,7 @@ from hermes_tools import terminal
 result = terminal("echo hi")
 print(result)
 """
-        # Only enable web_search -- terminal should be excluded
+        # Only enable web_search -- terminal is excluded from SANDBOX_ALLOWED_TOOLS
         result = self._run(code, enabled_tools=["web_search"])
         # terminal won't be in hermes_tools.py, so import fails
         self.assertEqual(result["status"], "error")
@@ -899,7 +899,7 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
     def test_none_enabled_tools_uses_all(self):
         """When enabled_tools is None, all sandbox tools should be available."""
         code = (
-            "from hermes_tools import terminal, web_search, read_file\n"
+            "from hermes_tools import web_search, read_file\n"
             "print('all imports ok')\n"
         )
         with patch("model_tools.handle_function_call",
@@ -913,7 +913,7 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
     def test_empty_enabled_tools_uses_all(self):
         """When enabled_tools is [] (empty), all sandbox tools should be available."""
         code = (
-            "from hermes_tools import terminal, web_search\n"
+            "from hermes_tools import web_search, read_file\n"
             "print('imports ok')\n"
         )
         with patch("model_tools.handle_function_call",
@@ -928,7 +928,7 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
         """When enabled_tools has no overlap with SANDBOX_ALLOWED_TOOLS,
         should fall back to all allowed tools."""
         code = (
-            "from hermes_tools import terminal\n"
+            "from hermes_tools import web_search\n"
             "print('fallback ok')\n"
         )
         with patch("model_tools.handle_function_call",

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -338,13 +338,13 @@ class TestExecuteCodeModeIntegration(unittest.TestCase):
         """Regression: hermes_tools still importable from non-tmpdir CWD.
 
         This is the PYTHONPATH fix — without it, switching to session CWD
-        breaks `from hermes_tools import terminal`.
+        breaks `from hermes_tools import web_search`.
         """
         import tempfile
         with tempfile.TemporaryDirectory() as td:
             code = (
-                "from hermes_tools import terminal\n"
-                "r = terminal('echo x')\n"
+                "from hermes_tools import web_search\n"
+                "r = web_search(query='test')\n"
                 "print(r.get('output', 'MISSING'))\n"
             )
             result = self._run(code, mode="project", extra_env={"TERMINAL_CWD": td})
@@ -354,8 +354,8 @@ class TestExecuteCodeModeIntegration(unittest.TestCase):
     def test_strict_mode_can_still_import_hermes_tools(self):
         """Regression: strict mode's tmpdir CWD still works for imports."""
         code = (
-            "from hermes_tools import terminal\n"
-            "r = terminal('echo x')\n"
+            "from hermes_tools import web_search\n"
+            "r = web_search(query='test')\n"
             "print(r.get('output', 'MISSING'))\n"
         )
         result = self._run(code, mode="strict")

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -57,8 +57,11 @@ logger = logging.getLogger(__name__)
 
 SANDBOX_AVAILABLE = True
 
-# The 7 tools allowed inside the sandbox. The intersection of this list
+# The 6 tools allowed inside the sandbox. The intersection of this list
 # and the session's enabled tools determines which stubs are generated.
+# terminal is excluded — execute_code runs arbitrary Python; giving it a
+# terminal() call inside that Python lets the model bypass the dangerous-
+# command approval gate (see #30882, #33057).
 SANDBOX_ALLOWED_TOOLS = frozenset([
     "web_search",
     "web_extract",
@@ -66,7 +69,6 @@ SANDBOX_ALLOWED_TOOLS = frozenset([
     "write_file",
     "search_files",
     "patch",
-    "terminal",
 ])
 
 # Resource limit defaults (overridable via config.yaml → code_execution.*)
@@ -1823,7 +1825,8 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         doc for name, doc in _TOOL_DOC_LINES if name in enabled_sandbox_tools
     )
 
-    # Build example import list from enabled tools
+    # Build example import list from enabled tools (prefer web_search + terminal
+    # when available; fall back to first two alphabetically).
     import_examples = [n for n in ("web_search", "terminal") if n in enabled_sandbox_tools]
     if not import_examples:
         import_examples = sorted(enabled_sandbox_tools)[:2]
@@ -1833,17 +1836,25 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         import_str = "..."
 
     # Mode-specific CWD guidance. Project mode is the default and matches
-    # terminal()'s filesystem/interpreter; strict mode retains the isolated
+    # terminal's filesystem/interpreter; strict mode retains the isolated
     # temp-dir staging and hermes-agent's own python.
     if mode == "strict":
         cwd_note = (
             "Scripts run in their own temp dir, not the session's CWD — use absolute paths "
-            "(os.path.expanduser('~/.hermes/.env')) or terminal()/read_file() for user files."
+            "(os.path.expanduser('~/.hermes/.env')) or read_file() for user files."
         )
     else:
         cwd_note = (
             "Scripts run in the session's working directory with the active venv's python, "
-            "so project deps (pandas, etc.) and relative paths work like in terminal()."
+            "so project deps (pandas, etc.) and relative paths work like in the terminal tool."
+        )
+
+    # Terminal-specific notes — only included when terminal is available in the
+    # sandbox (it is excluded by default; see SANDBOX_ALLOWED_TOOLS comment).
+    terminal_notes = ""
+    if "terminal" in enabled_sandbox_tools:
+        terminal_notes = (
+            "terminal() is foreground-only (no background or pty).\n\n"
         )
 
     description = (
@@ -1857,13 +1868,13 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         "or the task requires interactive user input.\n\n"
         f"Available via `from hermes_tools import ...`:\n\n"
         f"{tool_lines}\n\n"
-        "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "
-        "terminal() is foreground-only (no background or pty).\n\n"
+        f"Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "
+        f"{terminal_notes}"
         f"{cwd_note}\n\n"
         "Print your final result to stdout. Use Python stdlib (json, re, math, csv, "
         "datetime, collections, etc.) for processing between tool calls.\n\n"
         "Also available (no import needed — built into hermes_tools):\n"
-        "  json_parse(text: str) — json.loads with strict=False; use for terminal() output with control chars\n"
+        "  json_parse(text: str) — json.loads with strict=False; use for output with control chars\n"
         "  shell_quote(s: str) — shlex.quote(); use when interpolating dynamic strings into shell commands\n"
         "  retry(fn, max_attempts=3, delay=2) — retry with exponential backoff for transient failures"
     )


### PR DESCRIPTION
Removes `terminal` from `SANDBOX_ALLOWED_TOOLS` (sandbox should use sandbox-native tools, not terminal) and updates 5 tests to use `web_search`/`write_file` instead.

**Changes:**
- Removed `terminal` from `SANDBOX_ALLOWED_TOOLS` in `tools/code_execution_tool.py`
- Updated `test_generates_subset`, `test_non_allowed_tools_ignored`, `test_none_enabled_tools_uses_all`, `test_empty_enabled_tools_uses_all`, `test_nonoverlapping_tools_fallback`

Part of #24942