### PR TITLE
fix(acp): preserve session MCP toolsets across model switches

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1763,6 +1763,8 @@ class HermesACPAgent(acp.Agent):
 
         current_provider = getattr(state.agent, "provider", None) or "openrouter"
         target_provider, new_model = self._resolve_model_selection(args, current_provider)
+        current_enabled_toolsets = list(getattr(state.agent, "enabled_toolsets", None) or [])
+        current_disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
 
         state.model = new_model
         state.agent = self.session_manager._make_agent(
@@ -1770,6 +1772,8 @@ class HermesACPAgent(acp.Agent):
             cwd=state.cwd,
             model=new_model,
             requested_provider=target_provider,
+            enabled_toolsets=current_enabled_toolsets or None,
+            disabled_toolsets=list(current_disabled_toolsets) if current_disabled_toolsets else None,
         )
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
@@ -1980,6 +1984,8 @@ class HermesACPAgent(acp.Agent):
                 model_id,
                 current_provider or "openrouter",
             )
+            current_enabled_toolsets = list(getattr(state.agent, "enabled_toolsets", None) or [])
+            current_disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
             state.model = resolved_model
             provider_changed = bool(current_provider and requested_provider != current_provider)
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
@@ -1991,6 +1997,8 @@ class HermesACPAgent(acp.Agent):
                 requested_provider=requested_provider,
                 base_url=current_base_url,
                 api_mode=current_api_mode,
+                enabled_toolsets=current_enabled_toolsets or None,
+                disabled_toolsets=list(current_disabled_toolsets) if current_disabled_toolsets else None,
             )
             self.session_manager.save_session(session_id)
             logger.info(

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -564,6 +564,8 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        enabled_toolsets: list[str] | None = None,
+        disabled_toolsets: list[str] | None = None,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -590,9 +592,18 @@ class SessionManager:
 
         kwargs = {
             "platform": "acp",
-            "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
-                mcp_server_names=configured_mcp_servers,
+            "enabled_toolsets": (
+                list(enabled_toolsets)
+                if enabled_toolsets is not None
+                else _expand_acp_enabled_toolsets(
+                    ["hermes-acp"],
+                    mcp_server_names=configured_mcp_servers,
+                )
+            ),
+            "disabled_toolsets": (
+                list(disabled_toolsets)
+                if disabled_toolsets is not None
+                else None
             ),
             "quiet_mode": True,
             "session_id": session_id,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -941,6 +941,7 @@ class TestSessionConfiguration:
     @pytest.mark.asyncio
     async def test_set_session_model_accepts_provider_prefixed_choice(self, tmp_path, monkeypatch):
         runtime_calls = []
+        agent_calls = []
 
         def fake_resolve_runtime_provider(requested=None, **kwargs):
             runtime_calls.append(requested)
@@ -955,11 +956,14 @@ class TestSessionConfiguration:
             }
 
         def fake_agent(**kwargs):
+            agent_calls.append(dict(kwargs))
             return SimpleNamespace(
                 model=kwargs.get("model"),
                 provider=kwargs.get("provider"),
                 base_url=kwargs.get("base_url"),
                 api_mode=kwargs.get("api_mode"),
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                disabled_toolsets=kwargs.get("disabled_toolsets"),
             )
 
         monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
@@ -996,6 +1000,20 @@ class TestSessionConfiguration:
         assert state.agent.provider == "anthropic"
         assert state.agent.base_url == "https://anthropic.example/v1"
         assert runtime_calls[-1] == "anthropic"
+
+        # Recreated ACP agents must preserve any session-scoped MCP toolsets
+        # the session already accumulated before the model switch.
+        state.agent.enabled_toolsets = ["hermes-acp", "mcp-demo-search"]
+        state.agent.disabled_toolsets = ["browser"]
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            result = await acp_agent.set_session_model(
+                model_id="anthropic:claude-sonnet-4-6",
+                session_id=state.session_id,
+            )
+
+        assert isinstance(result, SetSessionModelResponse)
+        assert agent_calls[-1]["enabled_toolsets"] == ["hermes-acp", "mcp-demo-search"]
+        assert agent_calls[-1]["disabled_toolsets"] == ["browser"]
 
 
 # ---------------------------------------------------------------------------
@@ -1657,11 +1675,14 @@ class TestSlashCommands:
             }
 
         def fake_agent(**kwargs):
+            runtime_calls.append(kwargs.get("enabled_toolsets"))
             return SimpleNamespace(
                 model=kwargs.get("model"),
                 provider=kwargs.get("provider"),
                 base_url=kwargs.get("base_url"),
                 api_mode=kwargs.get("api_mode"),
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                disabled_toolsets=kwargs.get("disabled_toolsets"),
             )
 
         monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
@@ -1690,11 +1711,15 @@ class TestSlashCommands:
         with patch("run_agent.AIAgent", side_effect=fake_agent):
             acp_agent = HermesACPAgent(session_manager=manager)
             state = manager.create_session(cwd="/tmp")
+            state.agent.enabled_toolsets = ["hermes-acp", "mcp-demo-search"]
+            state.agent.disabled_toolsets = ["browser"]
             result = acp_agent._cmd_model("anthropic:claude-sonnet-4-6", state)
 
         assert "Provider: anthropic" in result
         assert state.agent.provider == "anthropic"
         assert state.agent.base_url == "https://anthropic.example/v1"
+        assert state.agent.enabled_toolsets == ["hermes-acp", "mcp-demo-search"]
+        assert state.agent.disabled_toolsets == ["browser"]
         # ``state.agent.provider == "anthropic"`` plus the base_url check above
         # already prove ``fake_resolve_runtime_provider`` was called with
         # ``requested="anthropic"`` for the model-switch step — the agent's


### PR DESCRIPTION
## What does this PR do?

Preserves ACP session-scoped MCP toolsets when Hermes rebuilds the session agent during model switches.

ACP correctly refreshes `state.agent.enabled_toolsets`, `state.agent.tools`, and `state.agent.valid_tool_names` after session-scoped `mcpServers` registration. The failure happens later: both ACP model-switch paths (`session/set_model` and `/model`) rebuild a fresh `AIAgent`, and that rebuild path was only reloading the default `hermes-acp` toolsets plus config-defined MCP servers. It did not preserve the active ACP session's runtime-added `mcp-*` toolsets.

That meant the rebuilt agent could fall back to the base ACP tool surface, so subsequent requests no longer included MCP tools that had been successfully registered earlier in the same session. In other words, the breakage was in ACP agent reconstruction during model switches, not in `run_conversation()` transiently dropping tools from an otherwise-correct agent instance.

This change keeps the existing session's `enabled_toolsets` / `disabled_toolsets` when rebuilding the ACP agent, so session-provided MCP tools survive model changes.

## Related Issue

Fixes #42719

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Preserve the current ACP session's `enabled_toolsets` and `disabled_toolsets` when `SessionManager._make_agent()` rebuilds an agent for a model switch.
- Apply that preservation to both ACP model-switch entrypoints: protocol `session/set_model` and slash-command `/model`.
- Add regression coverage proving session-scoped MCP toolsets survive both model-switch paths.

## How to Test

1. Start an ACP session with session-provided `mcpServers` and confirm Hermes logs `refreshed tool surface after ACP MCP registration`.
2. Switch models through ACP (`session/set_model` or `/model ...`) in the same session.
3. Verify the session still exposes the same `mcp_*` tools after the switch and that prompts can continue calling them.
4. Run:
   `pytest tests/acp/test_server.py tests/acp/test_session.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable for this ACP/session-state fix.
