### PR TITLE
fix(codex): support native Responses web_search backend

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -235,7 +235,13 @@ def _derive_responses_function_call_id(
 # ---------------------------------------------------------------------------
 
 def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
-    """Convert chat-completions tool schemas to Responses function-tool schemas."""
+    """Convert chat-completions tool schemas to Responses tool schemas.
+
+    Most Hermes tools stay as regular ``{"type":"function", ...}`` entries.
+    A small set of built-in Responses tools are exposed in Hermes as normal
+    function schemas for compatibility with non-Responses transports, then
+    rewritten here into their native Responses form.
+    """
     if not tools:
         return None
 
@@ -244,6 +250,10 @@ def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[L
         fn = item.get("function", {}) if isinstance(item, dict) else {}
         name = fn.get("name")
         if not isinstance(name, str) or not name.strip():
+            continue
+        name = name.strip()
+        if name == "web_search":
+            converted.append({"type": "web_search"})
             continue
         converted.append({
             "type": "function",
@@ -795,8 +805,12 @@ def _preflight_codex_api_kwargs(
         for idx, tool in enumerate(tools):
             if not isinstance(tool, dict):
                 raise ValueError(f"Codex Responses tools[{idx}] must be an object.")
-            if tool.get("type") != "function":
-                raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool.get('type')!r}.")
+            tool_type = tool.get("type")
+            if tool_type == "web_search":
+                normalized_tools.append({"type": "web_search"})
+                continue
+            if tool_type != "function":
+                raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool_type!r}.")
 
             name = tool.get("name")
             parameters = tool.get("parameters")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -36,6 +36,18 @@ class TestCodexTransportBasic:
         assert result[0]["type"] == "function"
         assert result[0]["name"] == "terminal"
 
+    def test_convert_tools_maps_web_search_to_native_responses_tool(self, transport):
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search the web",
+                "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+            }
+        }]
+        result = transport.convert_tools(tools)
+        assert result == [{"type": "web_search"}]
+
 
 class TestCodexBuildKwargs:
 

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -549,9 +549,12 @@ class TestBuildApiKwargsCodex:
         kwargs = agent._build_api_kwargs(messages)
         tools = kwargs.get("tools", [])
         assert len(tools) > 0
+        assert any(t.get("type") == "web_search" for t in tools)
+        function_tools = [t for t in tools if t.get("type") == "function"]
+        assert function_tools
         # Responses format has "name" at top level, not nested under "function"
-        assert "name" in tools[0]
-        assert "function" not in tools[0]
+        assert "name" in function_tools[0]
+        assert "function" not in function_tools[0]
 
 
 # ── Message conversion tests ────────────────────────────────────────────────

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1236,6 +1236,16 @@ def test_preflight_codex_api_kwargs_allows_reasoning_and_temperature(monkeypatch
     assert result["max_output_tokens"] == 4096
 
 
+def test_preflight_codex_api_kwargs_allows_native_web_search_tool(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    kwargs = _codex_request_kwargs()
+    kwargs["tools"] = [{"type": "web_search"}]
+
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+    result = _preflight_codex_api_kwargs(kwargs)
+    assert result["tools"] == [{"type": "web_search"}]
+
+
 def test_preflight_codex_api_kwargs_allows_service_tier(monkeypatch):
     agent = _build_agent(monkeypatch)
     kwargs = _codex_request_kwargs()

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -681,6 +681,18 @@ class TestCheckWebApiKey:
                     assert check_web_api_key() is True
 
 
+class TestCapabilitySpecificWebChecks:
+    def test_search_check_accepts_native_backend(self):
+        with patch("tools.web_tools._load_web_config", return_value={"search_backend": "native"}):
+            from tools.web_tools import check_web_search_api_key
+            assert check_web_search_api_key() is True
+
+    def test_extract_check_rejects_native_backend_without_extract_provider(self):
+        with patch("tools.web_tools._load_web_config", return_value={"extract_backend": "native"}):
+            from tools.web_tools import check_web_extract_api_key
+            assert check_web_extract_api_key() is False
+
+
 def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -149,7 +149,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "native"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -237,6 +237,12 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    if backend == "native":
+        cfg = _load_web_config()
+        return any(
+            str(cfg.get(key) or "").lower().strip() == "native"
+            for key in ("search_backend", "backend")
+        )
     return False
 
 
@@ -1178,16 +1184,46 @@ async def web_extract_tool(
         return tool_error(error_msg)
 
 
-# Convenience function to check Firecrawl credentials
-def check_web_api_key() -> bool:
-    """Check whether the configured web backend is available."""
-    configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
+def check_web_search_api_key() -> bool:
+    """Check whether a search-capable backend is available.
+
+    ``native`` is a special-case for Responses-based models: Hermes exposes
+    ``web_search`` in the normal tool registry, but the Responses transport
+    rewrites it into the provider-native ``{"type":"web_search"}`` tool.
+    We only advertise it when the user explicitly configures
+    ``web.search_backend: native`` or ``web.backend: native``.
+    """
+    cfg = _load_web_config()
+    configured = (
+        str(cfg.get("search_backend") or "").lower().strip()
+        or str(cfg.get("backend") or "").lower().strip()
+    )
+    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai", "native"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
         for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
     )
+
+
+def check_web_extract_api_key() -> bool:
+    """Check whether an extract-capable backend is available."""
+    cfg = _load_web_config()
+    configured = (
+        str(cfg.get("extract_backend") or "").lower().strip()
+        or str(cfg.get("backend") or "").lower().strip()
+    )
+    if configured in {"exa", "parallel", "firecrawl", "tavily"}:
+        return _is_backend_available(configured)
+    return any(
+        _is_backend_available(backend)
+        for backend in ("exa", "parallel", "firecrawl", "tavily")
+    )
+
+
+def check_web_api_key() -> bool:
+    """Backward-compatible union of search/extract availability."""
+    return check_web_search_api_key() or check_web_extract_api_key()
 
 
 def check_auxiliary_model() -> bool:
@@ -1355,7 +1391,7 @@ registry.register(
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
     handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
-    check_fn=check_web_api_key,
+    check_fn=check_web_search_api_key,
     requires_env=_web_requires_env(),
     emoji="🔍",
     max_result_size_chars=100_000,
@@ -1366,7 +1402,7 @@ registry.register(
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
         args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
-    check_fn=check_web_api_key,
+    check_fn=check_web_extract_api_key,
     requires_env=_web_requires_env(),
     is_async=True,
     emoji="📄",

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -26,8 +26,9 @@ Both are configured through a single backend selection. Providers are chosen via
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | 1 000 searches/mo |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | Paid |
 | **xAI (Grok)** | `XAI_API_KEY` or `hermes auth login xai-oauth` | ✔ | — | Paid (SuperGrok or per-token) |
+| **Provider-native Responses search** | — | ✔ | — | Provider/model dependent |
 
-Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
+Brave Search, DDGS, xAI, and provider-native Responses search are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below). Provider-native Responses search is an explicit opt-in for `api_mode: codex_responses`: Hermes exposes `web_search`, then rewrites it to the Responses API `{"type":"web_search"}` tool instead of dispatching through a Hermes search provider.
 
 **Per-capability split:** you can use different providers for search and extract independently — for example SearXNG (free) for search and Firecrawl for extract. See [Per-capability configuration](#per-capability-configuration) below.
 
@@ -330,7 +331,7 @@ Set one provider for all web capabilities:
 ```yaml
 # ~/.hermes/config.yaml
 web:
-  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai
+  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai | native
 ```
 
 ### Per-capability configuration
@@ -363,7 +364,7 @@ If no backend is explicitly configured, Hermes picks the first available one bas
 | `EXA_API_KEY` | exa |
 | `SEARXNG_URL` | searxng |
 
-xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
+xAI Web Search and provider-native Responses search are **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"` or, for Responses-native search on `api_mode: codex_responses`, `web.search_backend: "native"`.
 
 ---
 


### PR DESCRIPTION
## Summary

Enable explicit opt-in to provider-native Responses API web search for `api_mode: codex_responses`.

Root cause: Hermes exposed `web_search` as a normal function tool even on the Responses transport. `_responses_tools()` converted every tool to `{"type":"function", ...}`, and the Codex preflight rejected any non-function Responses tool. That meant users could not use the provider-native Responses `{"type":"web_search"}` tool even when they explicitly wanted it.

This is a clean current-`main` version of the same user-facing fix as #33602, which is currently conflict-marked (`mergeable: CONFLICTING`).

## Changes

- `agent/codex_responses_adapter.py`
  - Rewrite Hermes `web_search` into native Responses `{"type":"web_search"}` for `codex_responses`.
  - Allow native `web_search` through preflight instead of rejecting it as an unsupported tool type.
- `tools/web_tools.py`
  - Add explicit `web.backend: native` / `web.search_backend: native` availability.
  - Split search vs extract availability checks so native search does not also advertise `web_extract`.
- Tests
  - Cover transport conversion to native Responses web search.
  - Cover Codex preflight accepting native web search.
  - Cover native search being accepted while native extract is rejected.
  - Update provider parity expectations for native + function Responses tools coexisting.
- Docs
  - Document provider-native Responses search as a search-only explicit opt-in.

## Validation

| command | result |
|---|---|
| `/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/run_agent/test_provider_parity.py::TestBuildApiKwargsCodex::test_tools_converted_to_responses_format tests/agent/transports/test_codex_transport.py::TestCodexTransportBasic::test_convert_tools_maps_web_search_to_native_responses_tool tests/run_agent/test_run_agent_codex_responses.py::test_preflight_codex_api_kwargs_allows_native_web_search_tool tests/tools/test_web_tools_config.py::TestCapabilitySpecificWebChecks::test_search_check_accepts_native_backend tests/tools/test_web_tools_config.py::TestCapabilitySpecificWebChecks::test_extract_check_rejects_native_backend_without_extract_provider` | 5 passed |
| `/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/run_agent/test_provider_parity.py` | 93 passed |
| `/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py tests/tools/test_web_tools_config.py -k 'not summarizer_re_resolves_backend_after_initial_unavailable_state'` | 175 passed, 1 deselected |
| `git diff --check` | passed |

Note: the one deselected test is an existing async test that requires `pytest-asyncio`; this local venv does not have that plugin installed, so the unfiltered run fails with `async def functions are not natively supported` before exercising this change.

Closes #19320
Supersedes #33602