### PR TITLE
fix(desktop): keep archived cron sessions hidden

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -20,6 +20,8 @@ import {
   $sessions,
   $yoloActive,
   getRememberedWorkspaceCwd,
+  hideArchivedSessionFromSidebar,
+  restoreArchivedSessionToSidebar,
   sessionPinId,
   setActiveSessionId,
   setAwaitingResponse,
@@ -39,7 +41,6 @@ import {
   setSelectedStoredSessionId,
   setSessions,
   setSessionStartedAt,
-  setSessionsTotal,
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
@@ -333,15 +334,18 @@ export function useSessionActions({
         // Route the new chat to the chosen profile's backend (null = primary,
         // so single-profile users are unaffected).
         await ensureGatewayProfile($newChatProfile.get())
+
         const cwd = $currentCwd.get().trim() || getRememberedWorkspaceCwd()
         // Pass the owning profile so a new chat under a non-launch profile (global
         // remote mode) builds its agent + persists against THAT profile's home/db.
         const newChatProfile = $newChatProfile.get()
+
         const created = await requestGateway<SessionCreateResponse>('session.create', {
           cols: 96,
           ...(cwd && { cwd }),
           ...(newChatProfile ? { profile: newChatProfile } : {})
         })
+
         const stored = created.stored_session_id ?? null
 
         if (
@@ -836,7 +840,8 @@ export function useSessionActions({
     async (storedSessionId: string) => {
       clearNotifications()
 
-      const archived = $sessions.get().find(s => s.id === storedSessionId)
+      const archivedSnapshot = hideArchivedSessionFromSidebar(storedSessionId)
+      const archived = archivedSnapshot.session ?? archivedSnapshot.cronSession ?? null
       const wasSelected = selectedStoredSessionId === storedSessionId
       const previousPinned = $pinnedSessionIds.get()
       // Pins are keyed on the durable lineage-root id; the stored id may be the
@@ -844,11 +849,6 @@ export function useSessionActions({
       const archivedPinId = archived ? sessionPinId(archived) : storedSessionId
 
       // Soft-hide: drop from the sidebar immediately, keep the data.
-      setSessions(prev => prev.filter(s => s.id !== storedSessionId))
-      // Archived sessions are hidden by the listSessions(min_messages=1) query
-      // on the next refresh, so they count as "removed" for the load-more
-      // footer math.
-      setSessionsTotal(prev => Math.max(0, prev - 1))
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
 
       if (wasSelected) {
@@ -859,10 +859,7 @@ export function useSessionActions({
         await setSessionArchived(storedSessionId, true, archived?.profile)
         notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
       } catch (err) {
-        if (archived) {
-          setSessions(prev => [archived, ...prev.filter(s => s.id !== storedSessionId)])
-          setSessionsTotal(prev => prev + 1)
-        }
+        restoreArchivedSessionToSidebar(archivedSnapshot, storedSessionId)
 
         $pinnedSessionIds.set(previousPinned)
         notifyError(err, copy.archiveFailed)

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -4,9 +4,14 @@ import type { SessionInfo } from '@/types/hermes'
 
 import {
   $attentionSessionIds,
+  $cronSessions,
+  $sessions,
+  $sessionsTotal,
   $workingSessionIds,
   getRecentlySettledSessionIds,
+  hideArchivedSessionFromSidebar,
   mergeSessionPage,
+  restoreArchivedSessionToSidebar,
   sessionPinId,
   setSessionAttention,
   setSessionWorking
@@ -135,6 +140,50 @@ describe('mergeSessionPage', () => {
     const merged = mergeSessionPage(previous, incoming, ['root'])
 
     expect(merged.map(s => s.id)).toEqual(['tip', 'other'])
+  })
+})
+
+describe('archived sidebar session helpers', () => {
+  afterEach(() => {
+    $sessions.set([])
+    $cronSessions.set([])
+    $sessionsTotal.set(0)
+  })
+
+  it('removes a cron session from the cron sidebar list without touching recents total', () => {
+    $sessions.set([session({ id: 'chat', source: 'tui' })])
+    $cronSessions.set([session({ id: 'cron', source: 'cron' })])
+    $sessionsTotal.set(7)
+
+    const snapshot = hideArchivedSessionFromSidebar('cron')
+
+    expect(snapshot.session).toBeNull()
+    expect(snapshot.cronSession?.id).toBe('cron')
+    expect($sessions.get().map(entry => entry.id)).toEqual(['chat'])
+    expect($cronSessions.get()).toEqual([])
+    expect($sessionsTotal.get()).toBe(7)
+  })
+
+  it('restores a cron session to the cron sidebar list after a failed archive', () => {
+    $cronSessions.set([session({ id: 'cron', source: 'cron' })])
+
+    const snapshot = hideArchivedSessionFromSidebar('cron')
+    restoreArchivedSessionToSidebar(snapshot, 'cron')
+
+    expect($cronSessions.get().map(entry => entry.id)).toEqual(['cron'])
+    expect($sessionsTotal.get()).toBe(0)
+  })
+
+  it('removes a regular session from recents and adjusts the sidebar total', () => {
+    $sessions.set([session({ id: 'chat', source: 'tui' })])
+    $sessionsTotal.set(3)
+
+    const snapshot = hideArchivedSessionFromSidebar('chat')
+
+    expect(snapshot.session?.id).toBe('chat')
+    expect(snapshot.cronSession).toBeNull()
+    expect($sessions.get()).toEqual([])
+    expect($sessionsTotal.get()).toBe(2)
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -164,6 +164,40 @@ export const setIntroSeed = (next: Updater<number>) => updateAtom($introSeed, ne
 export const setContextSuggestions = (next: Updater<ContextSuggestion[]>) => updateAtom($contextSuggestions, next)
 export const setModelPickerOpen = (next: Updater<boolean>) => updateAtom($modelPickerOpen, next)
 
+export interface ArchivedSidebarSessionSnapshot {
+  cronSession: SessionInfo | null
+  session: SessionInfo | null
+}
+
+export function hideArchivedSessionFromSidebar(storedSessionId: string): ArchivedSidebarSessionSnapshot {
+  const session = $sessions.get().find(entry => entry.id === storedSessionId) ?? null
+  const cronSession = $cronSessions.get().find(entry => entry.id === storedSessionId) ?? null
+
+  setSessions(prev => prev.filter(entry => entry.id !== storedSessionId))
+  setCronSessions(prev => prev.filter(entry => entry.id !== storedSessionId))
+
+  if (session) {
+    // Archived sessions are hidden by the listSessions(min_messages=1) query on
+    // the next refresh, so they count as "removed" for the load-more footer.
+    setSessionsTotal(prev => Math.max(0, prev - 1))
+  }
+
+  return { cronSession, session }
+}
+
+export function restoreArchivedSessionToSidebar(snapshot: ArchivedSidebarSessionSnapshot, storedSessionId: string) {
+  if (snapshot.session) {
+    const restoredSession = snapshot.session
+    setSessions(prev => [restoredSession, ...prev.filter(entry => entry.id !== storedSessionId)])
+    setSessionsTotal(prev => prev + 1)
+  }
+
+  if (snapshot.cronSession) {
+    const restoredCronSession = snapshot.cronSession
+    setCronSessions(prev => [restoredCronSession, ...prev.filter(entry => entry.id !== storedSessionId)])
+  }
+}
+
 // Watchdog tracking — when does a "working" session count as stuck?
 // Long-running tool calls (LLM inference, long shell commands, web fetches)
 // can take a few minutes legitimately. We allow 8 minutes of complete


### PR DESCRIPTION
Fixes #42645.

## Summary
- remove archived cron sessions from the dedicated cron sidebar list immediately
- avoid decrementing the regular recents total when the archived row only lived in cron state
- restore the correct list on archive failure and cover the sidebar helpers with tests

## Testing
- npm exec --workspace apps/desktop -- vitest run src/store/session.test.ts --environment jsdom
- npm exec --workspace apps/desktop -- eslint src/store/session.ts src/store/session.test.ts src/app/session/hooks/use-session-actions.ts
- git diff --check