### PR TITLE
feat: auto-compact hint in memory review prompt

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -39,7 +39,13 @@ _MEMORY_REVIEW_PROMPT = (
     "2. Has the user expressed expectations about how you should behave, their work "
     "style, or ways they want you to operate?\n\n"
     "If something stands out, save it using the memory tool. "
-    "If nothing is worth saving, just say 'Nothing to save.' and stop."
+    "If nothing is worth saving, just say 'Nothing to save.' and stop.\n\n"
+    "Additionally, check the current memory usage (shown in the system prompt "
+    "header). If MEMORY.md or USER.md is over approximately 80% full, use "
+    "the memory tool to consolidate: merge overlapping or redundant entries "
+    "into shorter ones using 'replace', and 'remove' entries that are stale, "
+    "duplicated, or no longer relevant. This prevents the memory store from "
+    "hitting its character limit and silently rejecting new entries."
 )
 
 _SKILL_REVIEW_PROMPT = (


### PR DESCRIPTION
 What does this PR do?

    Adds auto-compact instruction to the background memory review prompt. When memory nears the character limit, new entries are silently rejected. This change asks the review agent to proactively check usage and consolidate entries before the limit is hit.

    Related Issue

    Fixes #28424

    Type of Change

    - [x] ✨ New feature (non-breaking change that adds functionality)

    Changes Made

    - Modified agent/background_review.py: added a third instruction to _MEMORY_REVIEW_PROMPT asking the review agent to check memory usage percentage and consolidate/merge entries when over ~80% full

    How to Test

    1. Fill memory to near character limit
    2. Let background review fire (every ~10 turns)
    3. Review agent should proactively compact entries

    Checklist

    Code

    - [x] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits
    - [x] I searched for existing PRs
    - [x] My PR contains only changes related to this fix/feature

    Documentation & Housekeeping

    - [x] N/A
