### PR TITLE
fix(cron): hold _jobs_file_lock in create, update, and remove

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -670,9 +670,10 @@ def create_job(
         "workdir": normalized_workdir,
     }
 
-    jobs = load_jobs()
-    jobs.append(job)
-    save_jobs(jobs)
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        jobs.append(job)
+        save_jobs(jobs)
 
     return job
 
@@ -743,50 +744,51 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}"
         )
 
-    jobs = load_jobs()
-    for i, job in enumerate(jobs):
-        if job["id"] != job_id:
-            continue
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for i, job in enumerate(jobs):
+            if job["id"] != job_id:
+                continue
 
-        # Validate / normalize workdir if present in updates.  Empty string or
-        # None both mean "clear the field" (restore old behaviour).
-        if "workdir" in updates:
-            _wd = updates["workdir"]
-            if _wd in {None, "", False}:
-                updates["workdir"] = None
-            else:
-                updates["workdir"] = _normalize_workdir(_wd)
+            # Validate / normalize workdir if present in updates.  Empty string or
+            # None both mean "clear the field" (restore old behaviour).
+            if "workdir" in updates:
+                _wd = updates["workdir"]
+                if _wd in {None, "", False}:
+                    updates["workdir"] = None
+                else:
+                    updates["workdir"] = _normalize_workdir(_wd)
 
-        updated = _apply_skill_fields({**job, **updates})
-        schedule_changed = "schedule" in updates
+            updated = _apply_skill_fields({**job, **updates})
+            schedule_changed = "schedule" in updates
 
-        if "skills" in updates or "skill" in updates:
-            normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
-            updated["skills"] = normalized_skills
-            updated["skill"] = normalized_skills[0] if normalized_skills else None
+            if "skills" in updates or "skill" in updates:
+                normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
+                updated["skills"] = normalized_skills
+                updated["skill"] = normalized_skills[0] if normalized_skills else None
 
-        if schedule_changed:
-            updated_schedule = updated["schedule"]
-            # The API may pass schedule as a raw string (e.g. "every 10m")
-            # instead of a pre-parsed dict.  Normalize it the same way
-            # create_job() does so downstream code can call .get() safely.
-            if isinstance(updated_schedule, str):
-                updated_schedule = parse_schedule(updated_schedule)
-                updated["schedule"] = updated_schedule
-            updated["schedule_display"] = updates.get(
-                "schedule_display",
-                updated_schedule.get("display", updated.get("schedule_display")),
-            )
-            if updated.get("state") != "paused":
-                updated["next_run_at"] = compute_next_run(updated_schedule)
+            if schedule_changed:
+                updated_schedule = updated["schedule"]
+                # The API may pass schedule as a raw string (e.g. "every 10m")
+                # instead of a pre-parsed dict.  Normalize it the same way
+                # create_job() does so downstream code can call .get() safely.
+                if isinstance(updated_schedule, str):
+                    updated_schedule = parse_schedule(updated_schedule)
+                    updated["schedule"] = updated_schedule
+                updated["schedule_display"] = updates.get(
+                    "schedule_display",
+                    updated_schedule.get("display", updated.get("schedule_display")),
+                )
+                if updated.get("state") != "paused":
+                    updated["next_run_at"] = compute_next_run(updated_schedule)
 
-        if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
-            updated["next_run_at"] = compute_next_run(updated["schedule"])
+            if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
+                updated["next_run_at"] = compute_next_run(updated["schedule"])
 
-        jobs[i] = updated
-        save_jobs(jobs)
-        return _normalize_job_record(jobs[i])
-    return None
+            jobs[i] = updated
+            save_jobs(jobs)
+            return _normalize_job_record(jobs[i])
+        return None
 
 
 def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:
@@ -847,20 +849,21 @@ def remove_job(job_id: str) -> bool:
     if not job:
         return False
     canonical_id = job["id"]
-    jobs = load_jobs()
-    original_len = len(jobs)
-    jobs = [j for j in jobs if j["id"] != canonical_id]
-    if len(jobs) < original_len:
-        # Resolve the output dir BEFORE saving so a legacy unsafe ID (e.g.
-        # left over from before the create-time guard) fails closed without
-        # half-applying the removal.
-        job_output_dir = _job_output_dir(canonical_id)
-        save_jobs(jobs)
-        # Clean up output directory to prevent orphaned dirs accumulating
-        if job_output_dir.exists():
-            shutil.rmtree(job_output_dir)
-        return True
-    return False
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        original_len = len(jobs)
+        jobs = [j for j in jobs if j["id"] != canonical_id]
+        if len(jobs) < original_len:
+            # Resolve the output dir BEFORE saving so a legacy unsafe ID (e.g.
+            # left over from before the create-time guard) fails closed without
+            # half-applying the removal.
+            job_output_dir = _job_output_dir(canonical_id)
+            save_jobs(jobs)
+            # Clean up output directory to prevent orphaned dirs accumulating
+            if job_output_dir.exists():
+                shutil.rmtree(job_output_dir)
+            return True
+        return False
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -859,7 +859,9 @@ def remove_job(job_id: str) -> bool:
             # half-applying the removal.
             job_output_dir = _job_output_dir(canonical_id)
             save_jobs(jobs)
-            # Clean up output directory to prevent orphaned dirs accumulating
+            # Clean up output directory to prevent orphaned dirs accumulating.
+            # rmtree kept inside the lock so a concurrent tick cannot write
+            # new output into this directory between our save and the delete.
             if job_output_dir.exists():
                 shutil.rmtree(job_output_dir)
             return True

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -991,3 +991,68 @@ class TestSaveJobOutput:
         with pytest.raises(ValueError, match="output path"):
             save_job_output(str(tmp_cron_dir / "outside"), "# Results")
         assert not (tmp_cron_dir / "outside").exists()
+
+
+# =========================================================================
+# _jobs_file_lock coverage for CRUD operations
+# =========================================================================
+
+class TestJobsFileLock:
+    """create_job, update_job, and remove_job must hold _jobs_file_lock."""
+
+    def _make_tracking_lock(self, original_lock):
+        counts = {"enter": 0, "exit": 0}
+
+        class TrackingLock:
+            def __enter__(self):
+                counts["enter"] += 1
+                return original_lock.__enter__()
+
+            def __exit__(self, *args):
+                counts["exit"] += 1
+                return original_lock.__exit__(*args)
+
+        return TrackingLock(), counts
+
+    def test_create_job_holds_lock(self, tmp_cron_dir, monkeypatch):
+        """create_job must hold _jobs_file_lock during load→append→save."""
+        import cron.jobs as jobs_mod
+
+        tracking, counts = self._make_tracking_lock(jobs_mod._jobs_file_lock)
+        monkeypatch.setattr(jobs_mod, "_jobs_file_lock", tracking)
+
+        job = create_job(prompt="Lock test", schedule="30m")
+
+        assert job is not None
+        assert counts["enter"] >= 1, f"Lock never acquired (enter={counts['enter']})"
+        assert counts["enter"] == counts["exit"], "Lock acquire/release mismatch"
+
+    def test_update_job_holds_lock(self, tmp_cron_dir, monkeypatch):
+        """update_job must hold _jobs_file_lock during load→modify→save."""
+        import cron.jobs as jobs_mod
+
+        job = create_job(prompt="Update me", schedule="every 1h")
+
+        tracking, counts = self._make_tracking_lock(jobs_mod._jobs_file_lock)
+        monkeypatch.setattr(jobs_mod, "_jobs_file_lock", tracking)
+
+        updated = update_job(job["id"], {"name": "Updated"})
+
+        assert updated is not None
+        assert counts["enter"] >= 1, f"Lock never acquired (enter={counts['enter']})"
+        assert counts["enter"] == counts["exit"], "Lock acquire/release mismatch"
+
+    def test_remove_job_holds_lock(self, tmp_cron_dir, monkeypatch):
+        """remove_job must hold _jobs_file_lock during load→filter→save."""
+        import cron.jobs as jobs_mod
+
+        job = create_job(prompt="To remove", schedule="30m")
+
+        tracking, counts = self._make_tracking_lock(jobs_mod._jobs_file_lock)
+        monkeypatch.setattr(jobs_mod, "_jobs_file_lock", tracking)
+
+        result = remove_job(job["id"])
+
+        assert result is True
+        assert counts["enter"] >= 1, f"Lock never acquired (enter={counts['enter']})"
+        assert counts["enter"] == counts["exit"], "Lock acquire/release mismatch"


### PR DESCRIPTION
## Summary

Extends `_jobs_file_lock` to cover `create_job()`, `update_job()`, and
`remove_job()`. Previously these functions followed a load→modify→save
pattern without holding the lock, leaving them unprotected against
concurrent writes from the scheduler's thread pool.

---

## Root cause

`_jobs_file_lock` was introduced to protect `mark_job_run()` and
`advance_next_run()` from concurrent tick() workers running in a
`ThreadPoolExecutor`. The user-facing CRUD functions (`create_job`,
`update_job`, `remove_job`) were never included in that protection.
Since `save_jobs()` uses `atomic_replace` (temp → fsync → `os.replace`),
file corruption is prevented but lost updates are not. This leaves the
CRUD functions unprotected when a gateway CRUD call on the event loop
thread interleaves with a scheduler worker in the ThreadPoolExecutor
(tick → run_job → mark_job_run).

Practical impact: a job paused during an active tick can end up with
`enabled: false` but a stale `next_run_at` in the past, causing the
scheduler to re-run it on the next tick.

---

## Behavioral change

Before: `create_job()`, `update_job()`, and `remove_job()` ran their
load→modify→save cycle without holding `_jobs_file_lock`, allowing lost
updates when interleaved with scheduler workers.

After: all three functions wrap their critical section in
`with _jobs_file_lock:`. `pause_job()`, `resume_job()`, and
`trigger_job()` delegate to `update_job()` and require no change.

---

## What changed

**`cron/jobs.py`**
- `create_job()`: wrapped `load_jobs() / jobs.append(job) / save_jobs(jobs)` in `with _jobs_file_lock:`
- `update_job()`: wrapped full `load_jobs()` → `save_jobs()` block in `with _jobs_file_lock:`
- `remove_job()`: wrapped `load_jobs()` → `save_jobs()` → `shutil.rmtree()` block in `with _jobs_file_lock:`

**`tests/cron/test_jobs.py`**
- Added `TestJobsFileLock` with 3 tests verifying lock acquisition and
  balanced acquire/release for `create_job`, `update_job`, and `remove_job`

---

## What is NOT changed

- `pause_job()`, `resume_job()`, `trigger_job()` delegate to `update_job()`, no change needed
- `mark_job_run()`, `advance_next_run()`, `get_due_jobs()` already locked, untouched
- `save_jobs()` internals and `atomic_replace` unchanged
- No behavior change when lock contention is absent