### PR TITLE
feat(kanban): auto-scroll worker log to bottom on open and refresh

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3408,6 +3408,14 @@
   function WorkerLogSection(props) {
     const { t } = useI18n();
     const [state, setState] = useState({ loading: false, data: null, err: null });
+    const logRef = useRef(null);
+
+    const scrollToBottom = useCallback(function () {
+      if (logRef.current) {
+        logRef.current.scrollTop = logRef.current.scrollHeight;
+      }
+    }, []);
+
     const load = useCallback(function () {
       setState({ loading: true, data: null, err: null });
       SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/log?tail=100000`, props.boardSlug))
@@ -3418,6 +3426,13 @@
     // Auto-load when the section mounts; the user opened the drawer so the
     // cost is one small HTTP round-trip.
     useEffect(function () { load(); }, [load]);
+
+    // Scroll to bottom whenever log data is freshly loaded (on open and on refresh).
+    useEffect(function () {
+      if (state.data && state.data.exists) {
+        scrollToBottom();
+      }
+    }, [state.data, scrollToBottom]);
 
     const data = state.data;
     let body;
@@ -3431,7 +3446,7 @@
         tx(t, "noWorkerLog",
           "— no worker log yet (task hasn't spawned or log was rotated away) —"));
     } else {
-      body = h("pre", { className: "hermes-kanban-pre hermes-kanban-log" },
+      body = h("pre", { ref: logRef, className: "hermes-kanban-pre hermes-kanban-log" },
         data.content || "(empty)");
     }
 


### PR DESCRIPTION
## Summary

When a task drawer is opened in the Hermes Kanban board, the worker log panel now automatically scrolls to the bottom so the most recent log lines are immediately visible — no manual scrolling needed.

- **On open**: when the task drawer mounts, the log is fetched and the `<pre>` element scrolls to `scrollTop = scrollHeight` as soon as the data lands.
- **On refresh**: clicking the *refresh* button re-fetches the log and again auto-scrolls to the bottom.
- **Manual scroll preserved**: the `<pre>` already has `overflow: auto` (from `.hermes-kanban-log`), so users can freely scroll up to inspect earlier output at any time; the auto-scroll only fires when fresh data is loaded, not on every render.

## Implementation details

All changes are in `plugins/kanban/dashboard/dist/index.js`, inside `WorkerLogSection`:

1. Added a `logRef = useRef(null)` and attached it to the `<pre>` element.
2. Added a `scrollToBottom` helper (`useCallback`) that sets `logRef.current.scrollTop = logRef.current.scrollHeight`.
3. Added a `useEffect` that calls `scrollToBottom()` whenever `state.data` changes to a value where `data.exists` is truthy — this covers both the initial load (triggered on mount) and subsequent refreshes.

No CSS changes were needed; `.hermes-kanban-log` already constrains the element to `max-height: 360px; overflow: auto`.

## Test plan

- [ ] Open a task that has a long worker log — confirm it scrolls to the bottom automatically.
- [ ] Scroll up manually in the log — confirm scrolling works freely.
- [ ] Click the **refresh** button — confirm the log reloads and scrolls to the bottom again.
- [ ] Open a task with no worker log — confirm the "no worker log yet" message appears normally (no scroll side-effects).
- [ ] Open a task with a short log (no overflow) — confirm no visual regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)