### PR TITLE
fix(setup,managed_uv): add timeout to subprocess.run calls

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -117,6 +117,7 @@ def _ensure_uv_path() -> Optional[str]:
             capture_output=True,
             text=True,
             check=False,
+            timeout=10,
         ).stdout.strip()
         print(f"  ✓ Managed uv installed ({version})")
     else:
@@ -172,6 +173,7 @@ def update_managed_uv() -> Optional[str]:
         capture_output=True,
         text=True,
         check=False,
+        timeout=60,
     )
     if result.returncode == 0:
         version = subprocess.run(
@@ -179,6 +181,7 @@ def update_managed_uv() -> Optional[str]:
             capture_output=True,
             text=True,
             check=False,
+            timeout=10,
         ).stdout.strip()
         print(f"  ✓ Managed uv updated ({version})")
     else:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -777,11 +777,11 @@ def _install_neutts_deps() -> bool:
         if prompt_yes_no("Install espeak-ng now?", True):
             try:
                 if sys.platform == "darwin":
-                    subprocess.run(["brew", "install", "espeak-ng"], check=True)
+                    subprocess.run(["brew", "install", "espeak-ng"], check=True, timeout=120)
                 elif sys.platform == "win32":
-                    subprocess.run(["choco", "install", "espeak-ng", "-y"], check=True)
+                    subprocess.run(["choco", "install", "espeak-ng", "-y"], check=True, timeout=120)
                 else:
-                    subprocess.run(["sudo", "apt", "install", "-y", "espeak-ng"], check=True)
+                    subprocess.run(["sudo", "apt", "install", "-y", "espeak-ng"], check=True, timeout=120)
                 print_success("espeak-ng installed")
             except (subprocess.CalledProcessError, FileNotFoundError) as e:
                 print_warning(f"Could not install espeak-ng automatically: {e}")
@@ -1283,12 +1283,14 @@ def setup_terminal_backend(config: dict):
                         ],
                         capture_output=True,
                         text=True,
+                        timeout=120,
                     )
                 else:
                     result = subprocess.run(
                         [sys.executable, "-m", "pip", "install", "modal"],
                         capture_output=True,
                         text=True,
+                        timeout=120,
                     )
                 if result.returncode == 0:
                     print_success("modal SDK installed")
@@ -1336,12 +1338,14 @@ def setup_terminal_backend(config: dict):
                     [uv_bin, "pip", "install", "--python", sys.executable, "daytona"],
                     capture_output=True,
                     text=True,
+                    timeout=120,
                 )
             else:
                 result = subprocess.run(
                     [sys.executable, "-m", "pip", "install", "daytona"],
                     capture_output=True,
                     text=True,
+                    timeout=120,
                 )
             if result.returncode == 0:
                 print_success("daytona SDK installed")
@@ -1985,12 +1989,12 @@ def _setup_matrix():
                 if uv_bin:
                     result = subprocess.run(
                         [uv_bin, "pip", "install", "--python", sys.executable, matrix_pkg],
-                        capture_output=True, text=True,
+                        capture_output=True, text=True, timeout=120,
                     )
                 else:
                     result = subprocess.run(
                         [sys.executable, "-m", "pip", "install", matrix_pkg],
-                        capture_output=True, text=True,
+                        capture_output=True, text=True, timeout=120,
                     )
                 if result.returncode == 0:
                     print_success(f"{matrix_pkg} installed")


### PR DESCRIPTION
## Summary

Add `timeout` parameters to `subprocess.run` calls in `setup.py` and `managed_uv.py` that were missing them. Without timeout, these operations can hang indefinitely on slow networks, broken mirrors, or interactive prompts.

### Changes

**`hermes_cli/setup.py`** (4 locations):
| Operation | Timeout |
|---|---|
| `brew install espeak-ng` | 120s |
| `choco install espeak-ng` | 120s |
| `apt install espeak-ng` | 120s |
| `pip install modal` (uv + fallback) | 120s |
| `pip install daytona` (uv + fallback) | 120s |
| `pip install matrix_pkg` (uv + fallback) | 120s |

**`hermes_cli/managed_uv.py`** (3 locations):
| Operation | Timeout |
|---|---|
| `uv --version` | 10s |
| `uv self update` | 60s |
| `uv --version` (post-update) | 10s |

### Pattern Match
Follows the established pattern throughout the codebase where subprocess calls have explicit timeouts (e.g., `gateway.py` uses `timeout=5-90s` for systemctl calls, `mcp_catalog.py` uses `timeout=60-300s` for git operations).
