### PR TITLE
feat(desktop): add right-click context menu to file tree with copy path options

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/file-tree-context-menu.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/file-tree-context-menu.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from 'react'
+import { ContextMenu as ContextMenuPrimitive } from 'radix-ui'
+
+import { Codicon } from '@/components/ui/codicon'
+import { useI18n } from '@/i18n'
+
+import type { ContextMenuTarget } from './tree'
+
+interface FileTreeContextMenuProps {
+  children: ReactNode
+  cwd: string
+  target: ContextMenuTarget | null
+  onOpenChange: (open: boolean) => void
+}
+
+export function FileTreeContextMenu({ children, cwd, target, onOpenChange }: FileTreeContextMenuProps) {
+  const { t } = useI18n()
+
+  const handleCopyPath = async () => {
+    if (!target) {
+      return
+    }
+
+    await navigator.clipboard.writeText(target.nodeId)
+  }
+
+  const handleCopyRelativePath = async () => {
+    if (!target) {
+      return
+    }
+
+    const relative = cwd && target.nodeId.startsWith(cwd)
+      ? target.nodeId.slice(cwd.length).replace(/^[/\\]+/, '')
+      : target.nodeId
+
+    await navigator.clipboard.writeText(relative)
+  }
+
+  return (
+    <ContextMenuPrimitive.Root onOpenChange={onOpenChange}>
+      <ContextMenuPrimitive.Trigger asChild>
+        {children}
+      </ContextMenuPrimitive.Trigger>
+      <ContextMenuPrimitive.Portal>
+        <ContextMenuPrimitive.Content
+          className="z-50 min-w-36 rounded-lg border border-(--ui-stroke-secondary) bg-[color-mix(in_srgb,var(--ui-bg-elevated)_96%,transparent)] p-1 text-xs text-popover-foreground shadow-md backdrop-blur-md"
+        >
+          <ContextMenuPrimitive.Item
+            className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 outline-hidden select-none focus:bg-(--ui-control-active-background) focus:text-foreground"
+            onSelect={handleCopyPath}
+          >
+            <Codicon name="clippy" size="0.75rem" />
+            {t.rightSidebar.copyPath}
+          </ContextMenuPrimitive.Item>
+          <ContextMenuPrimitive.Item
+            className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 outline-hidden select-none focus:bg-(--ui-control-active-background) focus:text-foreground"
+            onSelect={handleCopyRelativePath}
+          >
+            <Codicon name="file-symlink-file" size="0.75rem" />
+            {t.rightSidebar.copyRelativePath}
+          </ContextMenuPrimitive.Item>
+        </ContextMenuPrimitive.Content>
+      </ContextMenuPrimitive.Portal>
+    </ContextMenuPrimitive.Root>
+  )
+}

--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -7,6 +7,7 @@ import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 
+import { FileTreeContextMenu } from './file-tree-context-menu'
 import type { TreeNode } from './use-project-tree'
 
 const ROW_HEIGHT = 22
@@ -24,6 +25,12 @@ interface ProjectTreeProps {
   openState: Record<string, boolean>
 }
 
+export interface ContextMenuTarget {
+  nodeId: string
+  nodeName: string
+  isDirectory: boolean
+}
+
 export function ProjectTree({
   collapseNonce,
   cwd,
@@ -38,6 +45,7 @@ export function ProjectTree({
   const containerRef = useRef<HTMLDivElement | null>(null)
   const treeRef = useRef<TreeApi<TreeNode> | null>(null)
   const [size, setSize] = useState({ height: 0, width: 0 })
+  const [contextMenuTarget, setContextMenuTarget] = useState<ContextMenuTarget | null>(null)
 
   const syncTreeSize = useCallback(() => {
     const el = containerRef.current
@@ -85,36 +93,52 @@ export function ProjectTree({
     [onPreviewFile]
   )
 
+  const handleContextMenu = useCallback(
+    (nodeId: string, nodeName: string, isDirectory: boolean, event: React.MouseEvent) => {
+      event.preventDefault()
+      event.stopPropagation()
+      setContextMenuTarget({ nodeId, nodeName, isDirectory })
+    },
+    []
+  )
+
   return (
     <div className="min-h-0 flex-1 overflow-hidden" ref={containerRef}>
       {size.height > 0 && size.width > 0 ? (
-        <Tree<TreeNode>
-          childrenAccessor={node => (node?.isDirectory ? (node.children ?? []) : null)}
-          data={data}
-          disableDrag
-          disableDrop
-          disableEdit
-          height={size.height}
-          indent={INDENT}
-          initialOpenState={openState}
-          key={`${cwd}:${collapseNonce}`}
-          onActivate={handleActivate}
-          onToggle={handleToggle}
-          openByDefault={false}
-          padding={0}
-          ref={treeRef}
-          rowHeight={ROW_HEIGHT}
-          width={size.width}
-        >
-          {props => (
-            <ProjectTreeRow
-              {...props}
-              onAttachFile={onActivateFile}
-              onAttachFolder={onActivateFolder}
-              onPreviewFile={onPreviewFile}
-            />
-          )}
-        </Tree>
+        <FileTreeContextMenu cwd={cwd} target={contextMenuTarget} onOpenChange={open => {
+          if (!open) {
+            setContextMenuTarget(null)
+          }
+        }}>
+          <Tree<TreeNode>
+            childrenAccessor={node => (node?.isDirectory ? (node.children ?? []) : null)}
+            data={data}
+            disableDrag
+            disableDrop
+            disableEdit
+            height={size.height}
+            indent={INDENT}
+            initialOpenState={openState}
+            key={`${cwd}:${collapseNonce}`}
+            onActivate={handleActivate}
+            onToggle={handleToggle}
+            openByDefault={false}
+            padding={0}
+            ref={treeRef}
+            rowHeight={ROW_HEIGHT}
+            width={size.width}
+          >
+            {props => (
+              <ProjectTreeRow
+                {...props}
+                onActivateFile={onActivateFile}
+                onActivateFolder={onActivateFolder}
+                onContextMenu={handleContextMenu}
+                onPreviewFile={onPreviewFile}
+              />
+            )}
+          </Tree>
+        </FileTreeContextMenu>
       ) : (
         <TreeSizingState />
       )}
@@ -131,13 +155,15 @@ function TreeSizingState() {
 function ProjectTreeRow({
   dragHandle,
   node,
-  onAttachFile,
-  onAttachFolder,
+  onActivateFile,
+  onActivateFolder,
+  onContextMenu,
   onPreviewFile,
   style
 }: NodeRendererProps<TreeNode> & {
-  onAttachFile: (path: string) => void
-  onAttachFolder: (path: string) => void
+  onActivateFile: (path: string) => void
+  onActivateFolder: (path: string) => void
+  onContextMenu: (nodeId: string, nodeName: string, isDirectory: boolean, event: React.MouseEvent) => void
   onPreviewFile?: (path: string) => void
 }) {
   if (!node.data) {
@@ -165,7 +191,7 @@ function ProjectTreeRow({
         }
 
         if (event.shiftKey) {
-          ;(isFolder ? onAttachFolder : onAttachFile)(node.data.id)
+          ;(isFolder ? onActivateFolder : onActivateFile)(node.data.id)
 
           return
         }
@@ -175,6 +201,13 @@ function ProjectTreeRow({
         } else {
           node.select()
         }
+      }}
+      onContextMenu={event => {
+        if (isPlaceholder || !node.data) {
+          return
+        }
+
+        onContextMenu(node.data.id, node.data.name, node.data.isDirectory, event)
       }}
       onDoubleClick={event => {
         event.stopPropagation()

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1517,7 +1517,9 @@ export const en: Translations = {
     loadingFiles: 'Loading files',
     terminalFocus: 'Focus terminal view',
     terminalSplit: 'Return to split view',
-    addToChat: 'Add to chat'
+    addToChat: 'Add to chat',
+    copyPath: 'Copy path',
+    copyRelativePath: 'Copy relative path'
   },
 
   preview: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1660,7 +1660,9 @@ export const ja = defineLocale({
     loadingFiles: 'ファイルを読み込み中',
     terminalFocus: 'ターミナルビューにフォーカス',
     terminalSplit: '分割ビューに戻る',
-    addToChat: 'チャットに追加'
+    addToChat: 'チャットに追加',
+    copyPath: 'パスをコピー',
+    copyRelativePath: '相対パスをコピー'
   },
 
   preview: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1190,6 +1190,8 @@ export interface Translations {
     terminalFocus: string
     terminalSplit: string
     addToChat: string
+    copyPath: string
+    copyRelativePath: string
   }
 
   preview: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1621,7 +1621,9 @@ export const zhHant = defineLocale({
     loadingFiles: '正在載入檔案',
     terminalFocus: '聚焦終端機檢視',
     terminalSplit: '返回分割檢視',
-    addToChat: '新增至聊天'
+    addToChat: '新增至聊天',
+    copyPath: '複製路徑',
+    copyRelativePath: '複製相對路徑'
   },
 
   preview: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1698,7 +1698,9 @@ export const zh: Translations = {
     loadingFiles: '正在加载文件',
     terminalFocus: '聚焦终端视图',
     terminalSplit: '返回分栏视图',
-    addToChat: '添加到对话'
+    addToChat: '添加到对话',
+    copyPath: '复制路径',
+    copyRelativePath: '复制相对路径'
   },
 
   preview: {


### PR DESCRIPTION
## Problem

The file browser tree in the right sidebar has no context menu. Users who want to reference a specific file path in their conversation must manually navigate to and copy the path — there's no quick way to grab it from the tree view.

The issue requests a right-click option to copy file paths, which is a common pattern in code editors (VS Code, JetBrains, etc.).

## Solution

Add a right-click context menu to the file tree with two options:

- **Copy path** — copies the absolute file path to clipboard
- **Copy relative path** — copies the path relative to the current workspace root

### Implementation

- Uses Radix `ContextMenu` primitive for proper right-click positioning and keyboard accessibility
- New component: `file-tree-context-menu.tsx` — wraps the tree with context menu support
- Modified `tree.tsx` — added `onContextMenu` handler to each tree row
- i18n strings added for all 4 locales (en, zh, zh-hant, ja)

### Files changed

| File | Change |
|------|--------|
| `apps/desktop/src/app/right-sidebar/files/file-tree-context-menu.tsx` | New — context menu component |
| `apps/desktop/src/app/right-sidebar/files/tree.tsx` | Modified — added context menu handler |
| `apps/desktop/src/i18n/types.ts` | Added `copyPath`, `copyRelativePath` types |
| `apps/desktop/src/i18n/en.ts` | English strings |
| `apps/desktop/src/i18n/zh.ts` | Chinese strings |
| `apps/desktop/src/i18n/zh-hant.ts` | Traditional Chinese strings |
| `apps/desktop/src/i18n/ja.ts` | Japanese strings |

Closes #42758
