### PR TITLE
fix: show persisted usage without live agent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7983,7 +7983,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         which would otherwise early-return before any credits showed.
         """
         if not self.agent:
-            if not self._print_nous_credits_block():
+            shown = self._show_persisted_session_usage()
+            credits_shown = self._print_nous_credits_block()
+            if not shown and not credits_shown:
                 print("(._.) No active agent -- send a message first.")
             return
 
@@ -8103,6 +8105,70 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # into stream-retry events, credential rotations, etc.
             # Console quietness is enforced by hermes_logging not
             # installing a console StreamHandler in non-verbose mode.
+
+    def _show_persisted_session_usage(self) -> bool:
+        """Render persisted session usage when /usage runs without a live agent.
+
+        Desktop/TUI slash commands may run in a worker process that resumes the
+        session but does not construct or share the active ``AIAgent``.  The
+        live-agent path above remains authoritative for context-window details;
+        this fallback shows the best persisted DB snapshot instead of the
+        misleading "No active agent" message after a real turn completed.
+        """
+        session_id = getattr(self, "session_id", None)
+        session_db = getattr(self, "_session_db", None)
+        if not session_id or session_db is None:
+            return False
+        try:
+            row = session_db.get_session(session_id)
+        except Exception:
+            logger.debug("Failed to load persisted usage for session %s", session_id, exc_info=True)
+            return False
+        if not row:
+            return False
+
+        input_tokens = int(row.get("input_tokens") or 0)
+        output_tokens = int(row.get("output_tokens") or 0)
+        cache_read_tokens = int(row.get("cache_read_tokens") or 0)
+        cache_write_tokens = int(row.get("cache_write_tokens") or 0)
+        reasoning_tokens = int(row.get("reasoning_tokens") or 0)
+        calls = int(row.get("api_call_count") or 0)
+        total = input_tokens + output_tokens
+        if calls <= 0 and total <= 0:
+            return False
+
+        model = row.get("model") or getattr(self, "model", None) or "unknown"
+        msg_count = int(row.get("message_count") or len(getattr(self, "conversation_history", []) or []))
+        cost_status = row.get("cost_status")
+        cost_source = row.get("cost_source")
+        actual_cost = row.get("actual_cost_usd")
+        estimated_cost = row.get("estimated_cost_usd")
+
+        print("  📊 Persisted Session Token Usage")
+        print(f"  {'─' * 40}")
+        print(f"  Model:                     {model}")
+        print(f"  Input tokens:              {input_tokens:>10,}")
+        print(f"  Cache read tokens:         {cache_read_tokens:>10,}")
+        print(f"  Cache write tokens:        {cache_write_tokens:>10,}")
+        print(f"  Output tokens:             {output_tokens:>10,}")
+        if reasoning_tokens:
+            print(f"  ↳ Reasoning (subset):      {reasoning_tokens:>10,}")
+        print(f"  Total tokens:              {total:>10,}")
+        print(f"  API calls:                 {calls:>10,}")
+        if cost_status:
+            print(f"  Cost status:              {str(cost_status):>10}")
+        if cost_source:
+            print(f"  Cost source:              {str(cost_source):>10}")
+        if actual_cost is not None:
+            print(f"  Total cost:               ${float(actual_cost):>10.4f}")
+        elif estimated_cost is not None:
+            print(f"  Total cost:              ~${float(estimated_cost):>10.4f}")
+        else:
+            print(f"  Total cost:              {'n/a':>10}")
+        print(f"  {'─' * 40}")
+        print(f"  Messages:         {msg_count}")
+        print("  Note:             persisted DB snapshot; live context details unavailable")
+        return True
 
     def _print_nous_credits_block(self) -> bool:
         """Print the Nous credits magnitudes + monthly-grant gauge when a Nous account

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -586,6 +586,59 @@ class TestCLIUsageReport:
         assert "n/a" in output
         assert "Pricing unknown for glm-5" in output
 
+    def test_show_usage_without_live_agent_uses_persisted_session_snapshot(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-usage-fallback"
+        cli_obj._session_db = SimpleNamespace(
+            get_session=lambda session_id: {
+                "id": session_id,
+                "model": "gpt-5.5",
+                "input_tokens": 1234,
+                "output_tokens": 567,
+                "cache_read_tokens": 100,
+                "cache_write_tokens": 25,
+                "reasoning_tokens": 42,
+                "api_call_count": 3,
+                "message_count": 6,
+                "estimated_cost_usd": 0.0123,
+                "actual_cost_usd": None,
+                "cost_status": "estimated",
+                "cost_source": "pricing",
+            }
+        )
+        cli_obj._print_nous_credits_block = lambda: False
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "Persisted Session Token Usage" in output
+        assert "No active agent" not in output
+        assert "gpt-5.5" in output
+        assert "1,234" in output
+        assert "567" in output
+        assert "API calls:" in output
+        assert "3" in output
+        assert "persisted DB snapshot" in output
+
+    def test_show_usage_without_live_agent_keeps_no_agent_message_when_no_snapshot(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "empty-session"
+        cli_obj._session_db = SimpleNamespace(
+            get_session=lambda session_id: {
+                "id": session_id,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "api_call_count": 0,
+            }
+        )
+        cli_obj._print_nous_credits_block = lambda: False
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "No active agent -- send a message first" in output
+        assert "Persisted Session Token Usage" not in output
+
 
 class TestStatusBarWidthSource:
     """Ensure status bar fragments don't overflow the terminal width."""


### PR DESCRIPTION
## Summary
- fixes `/usage` in Desktop/TUI slash-worker contexts where `self.agent` is unavailable
- falls back to the persisted session DB usage snapshot for the current session
- preserves the existing live-agent `/usage` path and the old no-data message

Closes #42764.

## Root Cause
Desktop/TUI slash commands may execute in a worker process that resumes the session ID but does not construct or share the live `AIAgent`. `HermesCLI._show_usage()` only rendered session usage from `self.agent`, so the no-agent worker printed `No active agent -- send a message first` even after the user had already chatted.

## Behavior
When no live agent exists, `/usage` now reads the current session row from `SessionDB` and displays a clearly-labeled persisted usage snapshot including model, input/output/cache/reasoning tokens, API calls, messages, and persisted cost metadata when available. If there is no persisted usage, the old no-agent message remains.

## Test Plan
- `uv run --with pytest python -m pytest tests/cli/test_cli_status_bar.py -q -o 'addopts='` (39 passed)
