### PR TITLE
fix(sms): replace os.environ[] with os.getenv() for Twilio env vars

### DIFF
--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -65,8 +65,13 @@ class SmsAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SMS)
-        self._account_sid: str = os.environ["TWILIO_ACCOUNT_SID"]
-        self._auth_token: str = os.environ["TWILIO_AUTH_TOKEN"]
+        self._account_sid: str = os.getenv("TWILIO_ACCOUNT_SID", "")
+        self._auth_token: str = os.getenv("TWILIO_AUTH_TOKEN", "")
+        if not self._account_sid or not self._auth_token:
+            raise ValueError(
+                "TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN environment variables "
+                "are required for the SMS platform"
+            )
         self._from_number: str = os.getenv("TWILIO_PHONE_NUMBER", "")
         self._webhook_port: int = int(
             os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))


### PR DESCRIPTION
## Summary

Replace `os.environ["TWILIO_ACCOUNT_SID"]` and `os.environ["TWILIO_AUTH_TOKEN"]` with `os.getenv()` + explicit validation in the SMS adapter.

### Problem
`os.environ[key]` raises `KeyError` when the env var is not set. If the SMS platform is configured but the Twilio env vars are missing, the gateway crashes with an unhelpful `KeyError` traceback.

### Fix
Use `os.getenv()` with empty default, then check both values are non-empty and raise a clear `ValueError` explaining what's needed.

### Before
```python
self._account_sid: str = os.environ["TWILIO_ACCOUNT_SID"]  # KeyError if missing
self._auth_token: str = os.environ["TWILIO_AUTH_TOKEN"]     # KeyError if missing
```

### After
```python
self._account_sid: str = os.getenv("TWILIO_ACCOUNT_SID", "")
self._auth_token: str = os.getenv("TWILIO_AUTH_TOKEN", "")
if not self._account_sid or not self._auth_token:
    raise ValueError(
        "TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN environment variables "
        "are required for the SMS platform"
    )
```
