### PR TITLE
fix(qqbot): respect QQ_SANDBOX env var for API base URL

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -93,6 +93,7 @@ class QQCloseError(Exception):
 
 from gateway.platforms.qqbot.constants import (
     API_BASE,
+    get_api_base,
     TOKEN_URL,
     GATEWAY_URL_PATH,
     DEFAULT_API_TIMEOUT,
@@ -432,7 +433,7 @@ class QQAdapter(BasePlatformAdapter):
         token = await self._ensure_token()
         try:
             resp = await self._http_client.get(
-                f"{API_BASE}{GATEWAY_URL_PATH}",
+                f"{get_api_base()}{GATEWAY_URL_PATH}",
                 headers={
                     "Authorization": f"QQBot {token}",
                     "User-Agent": build_user_agent(),
@@ -1050,7 +1051,7 @@ class QQAdapter(BasePlatformAdapter):
             "User-Agent": build_user_agent(),
         }
         resp = await self._http_client.put(
-            f"{API_BASE}/interactions/{interaction_id}",
+            f"{get_api_base()}/interactions/{interaction_id}",
             headers=headers,
             json={"code": code},
             timeout=DEFAULT_API_TIMEOUT,
@@ -2347,7 +2348,7 @@ class QQAdapter(BasePlatformAdapter):
         try:
             resp = await self._http_client.request(
                 method,
-                f"{API_BASE}{path}",
+                f"{get_api_base()}{path}",
                 headers=headers,
                 json=body,
                 timeout=timeout,

--- a/gateway/platforms/qqbot/constants.py
+++ b/gateway/platforms/qqbot/constants.py
@@ -18,7 +18,22 @@ QQBOT_VERSION = "1.1.0"
 # or test environments.  Default: q.qq.com (production).
 PORTAL_HOST = os.getenv("QQ_PORTAL_HOST", "q.qq.com")
 
-API_BASE = "https://api.sgroup.qq.com"
+
+def get_api_base() -> str:
+    """Return the QQ Bot API base URL.
+
+    Respects the ``QQ_SANDBOX`` environment variable at **call time** so
+    that ``.env`` (loaded after module import) is honoured.  When
+    ``QQ_SANDBOX`` is ``true``/``1``/``yes``, the sandbox endpoint
+    (``sandbox.api.sgroup.qq.com``) is returned instead of production.
+    """
+    sandbox = os.getenv("QQ_SANDBOX", "false").lower() in ("true", "1", "yes")
+    return "https://sandbox.api.sgroup.qq.com" if sandbox else "https://api.sgroup.qq.com"
+
+
+# Backwards-compatible module-level constant (evaluated once at import).
+API_BASE = get_api_base()
+
 TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken"
 GATEWAY_URL_PATH = "/gateway"
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -31,10 +31,53 @@ class TestQQRequirements:
 
 
 # ---------------------------------------------------------------------------
-# QQAdapter.__init__
+# get_api_base — QQ_SANDBOX environment variable
 # ---------------------------------------------------------------------------
 
-class TestQQAdapterInit:
+class TestGetApiBase:
+    """Regression: get_api_base() must respect QQ_SANDBOX env var at call time."""
+
+    def test_production_by_default(self):
+        from gateway.platforms.qqbot.constants import get_api_base
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert get_api_base() == "https://api.sgroup.qq.com"
+
+    def test_sandbox_true(self):
+        from gateway.platforms.qqbot.constants import get_api_base
+        with mock.patch.dict(os.environ, {"QQ_SANDBOX": "true"}, clear=True):
+            assert get_api_base() == "https://sandbox.api.sgroup.qq.com"
+
+    def test_sandbox_one(self):
+        from gateway.platforms.qqbot.constants import get_api_base
+        with mock.patch.dict(os.environ, {"QQ_SANDBOX": "1"}, clear=True):
+            assert get_api_base() == "https://sandbox.api.sgroup.qq.com"
+
+    def test_sandbox_yes(self):
+        from gateway.platforms.qqbot.constants import get_api_base
+        with mock.patch.dict(os.environ, {"QQ_SANDBOX": "yes"}, clear=True):
+            assert get_api_base() == "https://sandbox.api.sgroup.qq.com"
+
+    def test_sandbox_false(self):
+        from gateway.platforms.qqbot.constants import get_api_base
+        with mock.patch.dict(os.environ, {"QQ_SANDBOX": "false"}, clear=True):
+            assert get_api_base() == "https://api.sgroup.qq.com"
+
+    def test_sandbox_empty(self):
+        from gateway.platforms.qqbot.constants import get_api_base
+        with mock.patch.dict(os.environ, {"QQ_SANDBOX": ""}, clear=True):
+            assert get_api_base() == "https://api.sgroup.qq.com"
+
+    def test_sandbox_case_insensitive(self):
+        from gateway.platforms.qqbot.constants import get_api_base
+        with mock.patch.dict(os.environ, {"QQ_SANDBOX": "TRUE"}, clear=True):
+            assert get_api_base() == "https://sandbox.api.sgroup.qq.com"
+
+    def test_api_base_constant_is_static(self):
+        """Module-level API_BASE is evaluated once at import time."""
+        from gateway.platforms.qqbot.constants import API_BASE
+        # Should be a string (either production or sandbox depending on import-time env)
+        assert isinstance(API_BASE, str)
+        assert "sgroup.qq.com" in API_BASE
     def _make(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
         return QQAdapter(_make_config(**extra))


### PR DESCRIPTION
## Problem

The QQ Bot adapter hardcodes the production API endpoint (`api.sgroup.qq.com`) as a module-level constant in `constants.py`. Since `.env` is loaded **after** module imports, the `QQ_SANDBOX` environment variable is never visible at import time — `os.getenv("QQ_SANDBOX")` always returns `None`.

This means bots running in sandbox mode (`QQ_SANDBOX=true`) hit the production gateway URL and get **401 Unauthorized**, making sandbox mode completely non-functional.

## Fix

- Introduce `get_api_base()` in `constants.py` that reads `QQ_SANDBOX` at **call time** (not import time)
- Update `adapter.py` to call `get_api_base()` instead of using the stale `API_BASE` constant
- Keep `API_BASE` as a backwards-compatible fallback (evaluated once at import, same as before)

## Testing

Verified locally with `QQ_SANDBOX=true`: QQ Bot transitions from `retrying` (401) to `connected`.