### PR TITLE
fix(windows): resolve compatibility, path resolution, and encoding issues

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -175,10 +175,14 @@ def _path_from_file_uri(uri: str) -> Path | None:
 
     # file:///C:/Users/... or C:\Users\...
     if len(path_text) >= 3 and path_text[0] == "/" and path_text[2] == ":" and path_text[1].isalpha():
+        if os.name == "nt":
+            return Path(path_text[1:])
         drive = path_text[1].lower()
         rest = path_text[3:].lstrip("/\\").replace("\\", "/")
         return Path("/mnt") / drive / rest
     if len(path_text) >= 2 and path_text[1] == ":" and path_text[0].isalpha():
+        if os.name == "nt":
+            return Path(path_text)
         drive = path_text[0].lower()
         rest = path_text[2:].lstrip("/\\").replace("\\", "/")
         return Path("/mnt") / drive / rest
@@ -190,12 +194,16 @@ def _decode_text_bytes(data: bytes, mime_type: str | None) -> str | None:
     """Decode resource bytes if they are probably text; return None for binary."""
     if b"\x00" in data and not _is_text_resource(mime_type):
         return None
+    decoded = None
     for encoding in ("utf-8-sig", "utf-8", "latin-1"):
         try:
-            return data.decode(encoding)
+            decoded = data.decode(encoding)
+            break
         except UnicodeDecodeError:
             continue
-    return data.decode("utf-8", errors="replace")
+    if decoded is None:
+        decoded = data.decode("utf-8", errors="replace")
+    return decoded.replace("\r\n", "\n")
 
 
 def _format_resource_text(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -162,6 +162,13 @@ def _path_from_file_uri(uri: str) -> Path | None:
     if not raw:
         return None
 
+    if len(raw) >= 3 and raw[1] == ":" and raw[0].isalpha() and raw[2] in {"/", "\\"}:
+        if os.name == "nt":
+            return Path(raw)
+        drive = raw[0].lower()
+        rest = raw[2:].lstrip("/\\").replace("\\", "/")
+        return Path("/mnt") / drive / rest
+
     parsed = urlparse(raw)
     if parsed.scheme and parsed.scheme != "file":
         return None

--- a/scripts/check_subprocess_stdin.py
+++ b/scripts/check_subprocess_stdin.py
@@ -134,6 +134,11 @@ def find_subprocess_calls(content: str, filepath: str) -> list[dict]:
 
 
 def main() -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        try:
+            sys.stdout.reconfigure(encoding="utf-8")
+        except Exception:
+            pass
     fix_mode = "--fix" in sys.argv
     repo_root = Path(__file__).resolve().parent.parent
     os.chdir(repo_root)
@@ -146,7 +151,7 @@ def main() -> int:
             continue
 
         for py_file in dirpath.rglob("*.py"):
-            rel = str(py_file.relative_to(repo_root))
+            rel = py_file.relative_to(repo_root).as_posix()
 
             # Skip known-safe files.
             if rel in KNOWN_SAFE:
@@ -157,19 +162,19 @@ def main() -> int:
             if any(skip.rstrip("/") in parts for skip in SKIP_DIRS):
                 continue
 
-            content = py_file.read_text()
+            content = py_file.read_text(encoding="utf-8")
             violations = find_subprocess_calls(content, rel)
             all_violations.extend(violations)
 
     if all_violations:
-        print(f"❌ {len(all_violations)} subprocess calls missing stdin=:")
+        print(f"[FAIL] {len(all_violations)} subprocess calls missing stdin=:")
         for v in all_violations:
             print(f"  {v['file']}:{v['line']}: {v['snippet']}")
         if fix_mode:
             print("\nAdd stdin=subprocess.DEVNULL to each call above.")
         return 1
     else:
-        print("✅ All TUI-context subprocess calls have explicit stdin=")
+        print("[PASS] All TUI-context subprocess calls have explicit stdin=")
         return 0
 
 

--- a/tests/acp_adapter/test_acp_images.py
+++ b/tests/acp_adapter/test_acp_images.py
@@ -1,4 +1,6 @@
 import base64
+import os
+from pathlib import Path
 
 import pytest
 from acp.schema import (
@@ -10,7 +12,12 @@ from acp.schema import (
     TextResourceContents,
 )
 
-from acp_adapter.server import HermesACPAgent, _content_blocks_to_openai_user_content
+from acp_adapter.server import (
+    HermesACPAgent,
+    _content_blocks_to_openai_user_content,
+    _decode_text_bytes,
+    _path_from_file_uri,
+)
 
 
 def test_acp_image_blocks_convert_to_openai_multimodal_content():
@@ -57,6 +64,28 @@ def test_acp_resource_link_file_is_inlined_as_text(tmp_path):
         f"URI: {attached.as_uri()}\n\n"
         "# Notes\n\nAttached file body"
     )
+
+
+def test_path_from_file_uri_accepts_bare_windows_drive_path():
+    path = _path_from_file_uri(r"C:\Users\alice\project\notes.md")
+
+    if os.name == "nt":
+        assert path == Path(r"C:\Users\alice\project\notes.md")
+    else:
+        assert path == Path("/mnt/c/Users/alice/project/notes.md")
+
+
+def test_path_from_file_uri_accepts_windows_drive_file_uri():
+    path = _path_from_file_uri("file:///C:/Users/alice/project/notes.md")
+
+    if os.name == "nt":
+        assert path == Path(r"C:\Users\alice\project\notes.md")
+    else:
+        assert path == Path("/mnt/c/Users/alice/project/notes.md")
+
+
+def test_decode_text_bytes_normalizes_crlf():
+    assert _decode_text_bytes(b"first\r\nsecond\r\n", "text/plain") == "first\nsecond\n"
 
 
 def test_acp_embedded_text_resource_is_inlined_as_text():

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -949,7 +949,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models(
@@ -965,7 +965,7 @@ class TestProbeApiModelsUserAgent:
 
         body = b'{"data":[]}'
         with patch(
-            "hermes_cli.models.urllib.request.urlopen",
+            "hermes_cli.models._urlopen_model_catalog_request",
             return_value=self._make_mock_response(body),
         ) as mock_urlopen:
             probe_api_models("provider-key", "https://api.example.com/v1")


### PR DESCRIPTION
## Summary

This PR addresses multiple Windows-compatibility issues in the test runner, static regression check scripts, and the ACP adapter that currently block developer and CI workflows on Windows hosts.

### Changes Included:

1. **Static Regression Checking (`scripts/check_subprocess_stdin.py` - Unique)**
   - Configured `sys.stdout` to force UTF-8 on launch to prevent `UnicodeEncodeError` when writing outputs on non-UTF-8 Windows consoles.
   - Replaced console-specific emojis (`❌` / `✅`) with standard tags (`[FAIL]` / `[PASS]`) to avoid terminal encoding crashes.
   - Added `encoding="utf-8"` to `Path.read_text()` calls to prevent `UnicodeDecodeError` when scanning files with Unicode comments or docstrings.
   - Normalized scanned paths using `.as_posix()` to resolve backslash separator mismatches (`\\` vs `/`) on Windows, ensuring file exemptions match correctly.

2. **ACP Adapter (`acp_adapter/server.py` - Unique + Alignment)**
   - Normalized carriage returns by converting `\r\n` to `\n` in `_decode_text_bytes()` to prevent line-ending mismatches during local test runs for attached text files.
   - Integrated platform-aware path conversion (`os.name == "nt"`) in `_path_from_file_uri()` so that Windows host editors (e.g. Zed on Windows) do not have their local file URIs rewritten into nonexistent `/mnt/<drive>/...` paths (aligning with changes proposed in #40649).

3. **Test Timeout Configuration (`pyproject.toml` - Alignment)**
   - Removed Unix-only `--timeout-method=signal` from `addopts` (aligns with #39881).
   - Resolves SIGALRM-related suite crashes on Windows hosts by letting `pytest-timeout` default automatically to `thread` on Windows and `signal` on Unix.

## Verification

- Tested locally on Windows.
- Ran static regression checking successfully:
  `python scripts/check_subprocess_stdin.py` yields `[PASS] All TUI-context subprocess calls have explicit stdin=` without crashes.
- Verified ACP image capability tests successfully:
  `pytest tests/acp_adapter/test_acp_images.py` passes cleanly on Windows using the fallback `thread` method automatically.