### PR TITLE
feat(gateway): HERMES_MEDIA_EXTRA_ROOTS to widen /api/media read roots

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -822,6 +822,16 @@ def _media_serve_roots() -> list[Path]:
     """
     home = get_hermes_home()
     roots = [home / "images", home / "screenshots", home / "cache"]
+    # Operators can allow extra read roots (e.g. an agent's project/output dir,
+    # where it writes generated images) via HERMES_MEDIA_EXTRA_ROOTS — an
+    # os.pathsep-separated list of absolute directories. Each is still resolved
+    # symlink-safe below, so this widens the allowlist deliberately without
+    # bypassing the suffix/size guards.
+    extra = os.environ.get("HERMES_MEDIA_EXTRA_ROOTS", "")
+    for raw in extra.split(os.pathsep):
+        raw = raw.strip()
+        if raw:
+            roots.append(Path(raw).expanduser())
     out: list[Path] = []
     for root in roots:
         try:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -266,6 +266,36 @@ class TestWebServerEndpoints:
         resp = self.client.get("/api/media", params={"path": str(outside)})
         assert resp.status_code == 403
 
+    def test_get_media_extra_roots_env_widens_allowlist(self, tmp_path):
+        """HERMES_MEDIA_EXTRA_ROOTS adds extra dirs the gateway may serve from.
+
+        Covers the common multi-host setup where an agent writes generated
+        images into a project/output dir outside ``~/.hermes`` — operators opt
+        that dir in explicitly rather than the endpoint reading anywhere.
+        """
+        extra = tmp_path / "brain" / "output"
+        extra.mkdir(parents=True, exist_ok=True)
+        img = extra / "card.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+
+        # Forbidden by default — the dir is outside the built-in media roots.
+        resp = self.client.get("/api/media", params={"path": str(img)})
+        assert resp.status_code == 403
+
+        # Allowed once the dir is opted in via HERMES_MEDIA_EXTRA_ROOTS.
+        with patch.dict(os.environ, {"HERMES_MEDIA_EXTRA_ROOTS": str(extra)}):
+            resp = self.client.get("/api/media", params={"path": str(img)})
+        assert resp.status_code == 200
+        assert resp.json()["data_url"].startswith("data:image/png;base64,")
+
+        # A sibling dir not listed stays forbidden, so the widening is scoped.
+        sibling = tmp_path / "elsewhere" / "card.png"
+        sibling.parent.mkdir(parents=True, exist_ok=True)
+        sibling.write_bytes(b"\x89PNG\r\n\x1a\n")
+        with patch.dict(os.environ, {"HERMES_MEDIA_EXTRA_ROOTS": str(extra)}):
+            resp = self.client.get("/api/media", params={"path": str(sibling)})
+        assert resp.status_code == 403
+
     def test_get_media_rejects_non_image_extension(self):
         from hermes_constants import get_hermes_home
 


### PR DESCRIPTION
## Summary
`GET /api/media` (remote image display) is confined to `~/.hermes/{images,screenshots,cache}`. That's the right default, but it means a desktop client connected to a **remote** gateway can't display images an agent generated **outside** that tree — e.g. into its project/output directory. Those requests return `403 {"detail":"Path outside media roots"}` and render as dead "Open …png" links instead of inline images.

This adds an opt-in **`HERMES_MEDIA_EXTRA_ROOTS`** env var (an `os.pathsep`-separated list of absolute directories) that operators can set to allow additional read roots.

## Why
Common multi-host setup: gateways on one machine, desktop on another. The agent writes generated images (charts, cards, screenshots) into its working/output dir — outside `~/.hermes` — so they can't be displayed remotely today. There's no way to widen the allowlist without editing source.

## Safety
The widening is deliberate and scoped:
- Each extra root is **resolved symlink-safe** (same `.resolve()` + `root in target.parents` check as the built-in roots).
- The **image-extension allowlist** and **size cap** are unchanged — this only adds directories, it doesn't relax the other guards.
- Default behavior is identical when the env var is unset (single-profile / single-host users are unaffected).

## Changes
- `hermes_cli/web_server.py` — `_media_serve_roots()` appends `HERMES_MEDIA_EXTRA_ROOTS` entries.
- `tests/hermes_cli/test_web_server.py` — new test: a dir is 403 by default, served once opted in via the env var, and a sibling dir not listed stays 403 (scoping).

Verified: `pytest tests/hermes_cli/test_web_server.py -k get_media` → 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)