### PR TITLE
fix(desktop): stabilize chat scroll after send

### DIFF
--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -85,11 +85,11 @@ async function wait(ms: number) {
   })
 }
 
-function userMessage(): ThreadMessage {
+function userMessage(id = 'user-1', text = 'Stream a response'): ThreadMessage {
   return {
-    id: 'user-1',
+    id,
     role: 'user',
-    content: [{ type: 'text', text: 'Stream a response' }],
+    content: [{ type: 'text', text }],
     attachments: [],
     createdAt,
     metadata: { custom: {} }
@@ -274,6 +274,38 @@ function StaticThreadHarness() {
     <AssistantRuntimeProvider runtime={runtime}>
       <Thread />
     </AssistantRuntimeProvider>
+  )
+}
+
+function SubmitJumpHarness() {
+  const [messages, setMessages] = useState<ThreadMessage[]>([
+    userMessage('user-0', 'Earlier prompt'),
+    assistantMessage('Earlier answer', false)
+  ])
+
+  const [isRunning, setIsRunning] = useState(false)
+
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages,
+    isRunning,
+    onNew: async () => {}
+  })
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          setMessages(current => [...current, userMessage('user-2', 'Fresh prompt')])
+          setIsRunning(true)
+        }}
+        type="button"
+      >
+        Send
+      </button>
+      <AssistantRuntimeProvider runtime={runtime}>
+        <Thread loading={isRunning ? 'response' : undefined} />
+      </AssistantRuntimeProvider>
+    </>
   )
 }
 
@@ -534,6 +566,62 @@ describe('assistant-ui streaming renderer', () => {
     await wait(0)
 
     expect(viewport.scrollTop).toBe(760)
+  })
+
+  it('does not jump upward before the submit-time bottom pin completes', async () => {
+    const scrollOffsets: number[] = []
+
+    const scrollToSpy = vi.spyOn(Element.prototype, 'scrollTo').mockImplementation(function scrollTo(
+      xOrOptions: ScrollToOptions | number,
+      y?: number
+    ) {
+      const top =
+        typeof xOrOptions === 'number'
+          ? (y ?? 0)
+          : typeof xOrOptions.top === 'number'
+            ? xOrOptions.top
+            : 0
+
+      scrollOffsets.push(top)
+      ;(this as HTMLElement).scrollTop = top
+    })
+
+    try {
+      const { container } = render(<SubmitJumpHarness />)
+
+      const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+      const viewport = content.parentElement as HTMLDivElement
+      let scrollHeight = 1_000
+
+      Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 200 })
+      Object.defineProperty(viewport, 'scrollHeight', {
+        configurable: true,
+        get: () => scrollHeight
+      })
+
+      await wait(0)
+
+      await act(async () => {
+        viewport.scrollTop = 800
+        fireEvent.scroll(viewport)
+      })
+
+      scrollOffsets.length = 0
+      scrollHeight = 1_240
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+      })
+
+      expect(viewport.scrollTop).toBe(1_240)
+      expect(scrollOffsets.some(offset => offset > 800 && offset < 1_240)).toBe(false)
+
+      await wait(0)
+
+      expect(viewport.scrollTop).toBe(1_240)
+    } finally {
+      scrollToSpy.mockRestore()
+    }
   })
 
   it('honors the first upward wheel scroll even when a programmatic bottom-pin scroll event is still pending', async () => {

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -1,4 +1,4 @@
-import { ThreadPrimitive, useAuiEvent, useAuiState } from '@assistant-ui/react'
+import { ThreadPrimitive, useAuiState } from '@assistant-ui/react'
 import { useVirtualizer, type Virtualizer } from '@tanstack/react-virtual'
 import {
   type ComponentProps,
@@ -77,8 +77,6 @@ const VirtualizedThreadInner: FC<VirtualizedThreadProps> = ({
     s.thread.messages.map((message, index) => `${index}:${message.id}:${message.role}`).join('\n')
   )
 
-  const isRunning = useAuiState(s => s.thread.isRunning)
-
   const groups = useMemo(() => buildGroups(messageSignature), [messageSignature])
   const renderEmpty = groups.length === 0 && Boolean(emptyPlaceholder)
   const scrollerRef = useRef<HTMLDivElement | null>(null)
@@ -125,7 +123,6 @@ const VirtualizedThreadInner: FC<VirtualizedThreadProps> = ({
   useThreadScrollAnchor({
     enabled: !renderEmpty,
     groupCount: groups.length,
-    isRunning,
     scrollerRef,
     sessionKey: sessionKey ?? null,
     stickyBottomRef,
@@ -221,7 +218,6 @@ function scrollElementToBottom(el: HTMLDivElement) {
 interface ScrollAnchorOptions {
   enabled: boolean
   groupCount: number
-  isRunning: boolean
   scrollerRef: React.RefObject<HTMLDivElement | null>
   sessionKey: string | null
   stickyBottomRef: React.MutableRefObject<boolean>
@@ -231,7 +227,6 @@ interface ScrollAnchorOptions {
 function useThreadScrollAnchor({
   enabled,
   groupCount,
-  isRunning,
   scrollerRef,
   sessionKey,
   stickyBottomRef,
@@ -433,12 +428,15 @@ function useThreadScrollAnchor({
     }
 
     if (groupCount > prevGroupCountForLayoutRef.current && stickyBottomRef.current) {
-      // Defer to rAF so that browser scroll/wheel events from the current
-      // frame are processed first.  Without this deferral, a trackpad
-      // scroll-up during streaming can race with this effect: the wheel
-      // event hasn't fired yet so stickyBottomRef is still true, and the
-      // immediate pinToBottom() would snap the viewport back to bottom
-      // against the user's intent.
+      // Pin immediately so a freshly submitted turn lands at its final bottom
+      // position in the same commit. Without this synchronous pin, the
+      // runStart jump can leave the viewport parked at an estimated midpoint
+      // until the next frame, which is visible as a brief upward jump.
+      pinToBottom()
+
+      // Re-pin on the next frame after layout settles. The second pin catches
+      // follow-up measurements from the just-mounted turn without reviving
+      // streaming auto-follow.
       requestAnimationFrame(() => {
         if (stickyBottomRef.current) {
           pinToBottom()
@@ -456,10 +454,4 @@ function useThreadScrollAnchor({
   // though the user is reading earlier content — the opposite of what's
   // wanted. The one-time submit / new-turn jump already covers landing a
   // fresh message in view.
-  const prevIsRunningForLayoutRef = useRef(isRunning)
-  useLayoutEffect(() => {
-    prevIsRunningForLayoutRef.current = isRunning
-  }, [isRunning])
-
-  useAuiEvent('thread.runStart', jumpToBottom)
 }


### PR DESCRIPTION
## Summary
- remove the extra  bottom-jump path from the desktop thread virtualizer
- synchronously pin the viewport when a new turn is appended, then re-pin on the next frame after layout settles
- add a regression test that fails if send-time scroll briefly lands at an intermediate offset

Fixes #42668.

## Testing
- npm --workspace apps/desktop run test:ui -- src/components/assistant-ui/streaming.test.tsx -t "does not (pull the viewport back down|auto-follow idle layout shifts|follow streaming content growth|jump upward before the submit-time bottom pin completes|honors the first upward wheel scroll|snap to the bottom on final code-highlight growth|restart bottom-follow after completion)"
- ../../node_modules/.bin/eslint src/components/assistant-ui/thread-virtualizer.tsx src/components/assistant-ui/streaming.test.tsx
- git diff --check