### PR TITLE
feat: report request context budget

### DIFF
--- a/agent/context_budget.py
+++ b/agent/context_budget.py
@@ -1,0 +1,209 @@
+"""Context budget diagnostics for Hermes model requests.
+
+The estimators here are intentionally rough. They do not try to reproduce a
+provider tokenizer; they split the outgoing request into human-useful buckets so
+operators can see what is filling the window: stable system prompt, recalled
+memory, conversation/tool history, current user text, and tool schemas.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+from agent.model_metadata import estimate_messages_tokens_rough
+
+_MEMORY_BLOCK_RE = re.compile(
+    r"<\s*memory-context\s*>[\s\S]*?</\s*memory-context\s*>",
+    re.IGNORECASE,
+)
+
+
+def _tokens_for_text(value: Any) -> int:
+    if value is None:
+        return 0
+    return (len(str(value)) + 3) // 4
+
+
+def _message_tokens(message: Dict[str, Any]) -> int:
+    return estimate_messages_tokens_rough([message])
+
+
+def _content_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                if isinstance(part.get("text"), str):
+                    parts.append(part["text"])
+                elif isinstance(part.get("content"), str):
+                    parts.append(part["content"])
+                else:
+                    parts.append(str(part))
+            else:
+                parts.append(str(part))
+        return "\n".join(parts)
+    return str(content)
+
+
+def _strip_memory_blocks(text: str) -> tuple[str, int, int]:
+    blocks = _MEMORY_BLOCK_RE.findall(text or "")
+    memory_chars = sum(len(block) for block in blocks)
+    memory_tokens = sum(_tokens_for_text(block) for block in blocks)
+    stripped = _MEMORY_BLOCK_RE.sub("", text or "")
+    return stripped, memory_chars, memory_tokens
+
+
+def build_context_budget_report(
+    *,
+    api_messages: List[Dict[str, Any]],
+    tools: List[Dict[str, Any]] | None,
+    model: str = "",
+    provider: str = "",
+    context_length: int | None = None,
+    session_id: str = "",
+    api_call_count: int = 0,
+) -> Dict[str, Any]:
+    """Return a rough per-bucket token budget for an outgoing request."""
+    api_messages = list(api_messages or [])
+    tools = list(tools or [])
+
+    system_tokens = 0
+    system_chars = 0
+    message_start = 0
+    if api_messages and api_messages[0].get("role") == "system":
+        system_chars = len(_content_text(api_messages[0].get("content")))
+        system_tokens = _message_tokens(api_messages[0])
+        message_start = 1
+
+    current_user_idx = -1
+    for idx in range(len(api_messages) - 1, message_start - 1, -1):
+        if api_messages[idx].get("role") == "user":
+            current_user_idx = idx
+            break
+
+    current_user_tokens = 0
+    memory_context_tokens = 0
+    memory_context_chars = 0
+    prior_messages_tokens = 0
+    role_tokens: dict[str, int] = {}
+    largest_messages: list[dict[str, Any]] = []
+
+    for idx, msg in enumerate(api_messages[message_start:], start=message_start):
+        role = str(msg.get("role") or "unknown")
+        tokens = _message_tokens(msg)
+        role_tokens[role] = role_tokens.get(role, 0) + tokens
+        largest_messages.append({"index": idx, "role": role, "tokens": tokens})
+
+        if idx == current_user_idx:
+            content = _content_text(msg.get("content"))
+            stripped, mem_chars, mem_tokens = _strip_memory_blocks(content)
+            memory_context_chars += mem_chars
+            memory_context_tokens += mem_tokens
+            if mem_tokens:
+                current_user_shadow = dict(msg)
+                current_user_shadow["content"] = stripped
+                current_user_tokens = _message_tokens(current_user_shadow)
+            else:
+                current_user_tokens = tokens
+        else:
+            prior_messages_tokens += tokens
+
+    largest_messages.sort(key=lambda item: int(item.get("tokens") or 0), reverse=True)
+    largest_messages = largest_messages[:5]
+
+    tool_schema_tokens = _tokens_for_text(tools) if tools else 0
+    message_tokens = estimate_messages_tokens_rough(api_messages)
+    total_tokens = message_tokens + tool_schema_tokens
+    pct = None
+    if context_length:
+        try:
+            pct = round((total_tokens / int(context_length)) * 100, 1)
+        except Exception:
+            pct = None
+
+    buckets = {
+        "system_prompt": system_tokens,
+        "memory_context": memory_context_tokens,
+        "current_user": current_user_tokens,
+        "prior_messages": prior_messages_tokens,
+        "tool_schemas": tool_schema_tokens,
+    }
+    # Account for sanitizer/prefill/role wrapper deltas so bucket sum matches the
+    # rough total instead of hiding estimator drift.
+    bucket_sum = sum(buckets.values())
+    if total_tokens > bucket_sum:
+        buckets["other_request_overhead"] = total_tokens - bucket_sum
+
+    return {
+        "model": model,
+        "provider": provider,
+        "session_id": session_id,
+        "api_call": api_call_count,
+        "message_count": len(api_messages),
+        "tool_count": len(tools),
+        "context_length": context_length,
+        "total_tokens": total_tokens,
+        "message_tokens": message_tokens,
+        "percent_of_context": pct,
+        "buckets": buckets,
+        "role_tokens": role_tokens,
+        "largest_messages": largest_messages,
+        "memory_context_chars": memory_context_chars,
+        "system_prompt_chars": system_chars,
+    }
+
+
+def format_context_budget_report(report: Dict[str, Any], *, markdown: bool = False) -> List[str]:
+    """Format a report as compact human-readable lines."""
+    if not report:
+        return []
+    total = int(report.get("total_tokens") or 0)
+    context_length = report.get("context_length") or 0
+    pct = report.get("percent_of_context")
+    pct_part = f" · {pct:.1f}%" if isinstance(pct, (int, float)) else ""
+    if context_length:
+        header = f"Context budget: ~{total:,}/{int(context_length):,} tokens{pct_part}"
+    else:
+        header = f"Context budget: ~{total:,} tokens"
+    lines = [header]
+    buckets = report.get("buckets") or {}
+    if buckets:
+        ordered = sorted(buckets.items(), key=lambda kv: int(kv[1] or 0), reverse=True)
+        lines.append("Buckets: " + ", ".join(f"{name} ~{int(value):,}" for name, value in ordered if value))
+    lines.append(
+        f"Request shape: {int(report.get('message_count') or 0)} messages, "
+        f"{int(report.get('tool_count') or 0)} tools"
+    )
+    largest = report.get("largest_messages") or []
+    if largest:
+        top = ", ".join(
+            f"#{item.get('index')} {item.get('role')} ~{int(item.get('tokens') or 0):,}"
+            for item in largest[:3]
+        )
+        lines.append("Largest messages: " + top)
+    return lines
+
+
+def compact_context_budget_log(report: Dict[str, Any]) -> str:
+    if not report:
+        return "context_budget unavailable"
+    buckets = report.get("buckets") or {}
+    bucket_text = " ".join(
+        f"{name}={int(value or 0)}"
+        for name, value in sorted(buckets.items(), key=lambda kv: int(kv[1] or 0), reverse=True)
+        if value
+    )
+    pct = report.get("percent_of_context")
+    pct_text = f" pct={pct:.1f}" if isinstance(pct, (int, float)) else ""
+    return (
+        f"context_budget session={report.get('session_id') or '-'} "
+        f"call={report.get('api_call') or 0} total={int(report.get('total_tokens') or 0)}"
+        f" context_length={report.get('context_length') or 0}{pct_text} "
+        f"messages={report.get('message_count') or 0} tools={report.get('tool_count') or 0} "
+        f"{bucket_text}"
+    ).strip()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -28,6 +28,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.context_budget import build_context_budget_report, compact_context_budget_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
@@ -750,6 +751,20 @@ def run_conversation(
         approx_request_tokens = estimate_request_tokens_rough(
             api_messages, tools=agent.tools or None
         )
+        try:
+            _context_length = getattr(agent.context_compressor, "context_length", None)
+            agent._last_context_budget = build_context_budget_report(
+                api_messages=api_messages,
+                tools=agent.tools or None,
+                model=getattr(agent, "model", "") or "",
+                provider=getattr(agent, "provider", "") or "",
+                context_length=_context_length,
+                session_id=getattr(agent, "session_id", "") or "",
+                api_call_count=api_call_count,
+            )
+            logger.info(compact_context_budget_log(agent._last_context_budget))
+        except Exception:
+            logger.debug("context budget report failed", exc_info=True)
 
         _runtime_context_error = _ollama_context_limit_error(
             agent, approx_request_tokens

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2809,6 +2809,15 @@ class GatewaySlashCommandsMixin:
             if ctx.last_prompt_tokens:
                 pct = min(100, ctx.last_prompt_tokens / ctx.context_length * 100) if ctx.context_length else 0
                 lines.append(t("gateway.usage.label_context", used=f"{ctx.last_prompt_tokens:,}", total=f"{ctx.context_length:,}", pct=f"{pct:.0f}"))
+            budget = getattr(agent, "_last_context_budget", None)
+            if budget:
+                try:
+                    from agent.context_budget import format_context_budget_report
+                    lines.append("")
+                    lines.append("**Last request context budget**")
+                    lines.extend(format_context_budget_report(budget, markdown=True))
+                except Exception:
+                    pass
             if ctx.compression_count:
                 lines.append(t("gateway.usage.label_compressions", count=ctx.compression_count))
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -202,7 +202,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("help", "Show available commands", "Info"),
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
-    CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
+    CommandDef("usage", "Show token usage, context budget, and rate limits for the current session", "Info"),
     CommandDef("insights", "Show usage insights and analytics", "Info",
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",

--- a/tests/agent/test_context_budget.py
+++ b/tests/agent/test_context_budget.py
@@ -1,0 +1,42 @@
+"""Tests for context budget diagnostics."""
+
+from agent.context_budget import build_context_budget_report, format_context_budget_report
+
+
+def test_context_budget_splits_memory_and_tool_schemas():
+    messages = [
+        {"role": "system", "content": "system rules" * 100},
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer" * 200},
+        {
+            "role": "user",
+            "content": (
+                "current question\n\n"
+                "<memory-context>\nremembered fact " + ("x" * 800) + "\n</memory-context>"
+            ),
+        },
+    ]
+    tools = [{"type": "function", "function": {"name": "big_tool", "description": "d" * 1000}}]
+
+    report = build_context_budget_report(
+        api_messages=messages,
+        tools=tools,
+        model="test-model",
+        provider="test-provider",
+        context_length=100_000,
+        session_id="sess",
+        api_call_count=2,
+    )
+
+    assert report["total_tokens"] > 0
+    assert report["tool_count"] == 1
+    assert report["buckets"]["system_prompt"] > 0
+    assert report["buckets"]["memory_context"] > 0
+    assert report["buckets"]["tool_schemas"] > 0
+    assert report["memory_context_chars"] > 0
+
+    lines = format_context_budget_report(report)
+    rendered = "\n".join(lines)
+    assert "Context budget:" in rendered
+    assert "memory_context" in rendered
+    assert "tool_schemas" in rendered

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -92,6 +92,38 @@ class TestUsageCachedAgent:
         assert "Compressions: 1" in result
 
     @pytest.mark.asyncio
+    async def test_usage_command_includes_last_context_budget(self):
+        agent = _make_mock_agent()
+        agent._last_context_budget = {
+            "total_tokens": 42_000,
+            "context_length": 200_000,
+            "percent_of_context": 21.0,
+            "message_count": 12,
+            "tool_count": 87,
+            "buckets": {
+                "tool_schemas": 20_000,
+                "prior_messages": 15_000,
+                "memory_context": 5_000,
+                "current_user": 2_000,
+            },
+            "largest_messages": [
+                {"index": 4, "role": "tool", "tokens": 9_000},
+            ],
+        }
+        runner = _make_runner(SK, cached_agent=agent)
+        event = MagicMock()
+
+        with patch("agent.rate_limit_tracker.format_rate_limit_compact", return_value="RPM: 50/60"), \
+             patch("agent.usage_pricing.estimate_usage_cost") as mock_cost:
+            mock_cost.return_value = MagicMock(amount_usd=None, status="unknown")
+            result = await runner._handle_usage_command(event)
+
+        assert "Last request context budget" in result
+        assert "42,000/200,000" in result
+        assert "tool_schemas ~20,000" in result
+        assert "memory_context ~5,000" in result
+
+    @pytest.mark.asyncio
     async def test_running_agent_preferred_over_cache(self):
         """When agent is in both dicts, the running one wins."""
         running = _make_mock_agent(session_api_calls=10, session_total_tokens=80_000)


### PR DESCRIPTION
## Summary
- add rough per-request context budget diagnostics split by system prompt, recalled memory, current user, prior messages, and tool schemas
- log compact context_budget lines before model calls
- show the last request context budget in gateway /usage output

## Test Plan
- uv run --with pytest --with pytest-asyncio python -m pytest tests/agent/test_context_budget.py tests/gateway/test_usage_command.py -q -o 'addopts='
- python -m py_compile agent/context_budget.py agent/conversation_loop.py gateway/slash_commands.py hermes_cli/commands.py
- hermes chat -q "Respond with exactly CONTEXT_BUDGET_REBASE_SMOKE_OK and nothing else." --provider openai-codex --model gpt-5.5 --toolsets web