### PR TITLE
fix(gateway/feishu): bridge yaml group_rules/admins/default_group_policy to extra

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1118,6 +1118,19 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(feishu_cfg, dict):
                 if "allow_bots" in feishu_cfg and not os.getenv("FEISHU_ALLOW_BOTS"):
                     os.environ["FEISHU_ALLOW_BOTS"] = str(feishu_cfg["allow_bots"]).lower()
+                # Feishu-specific structured fields → adapter extra.
+                # The shared loop above bridges generic keys like require_mention,
+                # but these structured dicts are feishu-only and must be forwarded
+                # explicitly so FeishuAdapter._load_settings() can read them from
+                # extra (see gateway/platforms/feishu.py L1473-1572).
+                _fs_structured_keys = ("group_rules", "admins", "default_group_policy")
+                if any(k in feishu_cfg for k in _fs_structured_keys):
+                    _, _fs_extra = _ensure_platform_extra_dict(
+                        platforms_data, Platform.FEISHU.value
+                    )
+                    for _k in _fs_structured_keys:
+                        if _k in feishu_cfg:
+                            _fs_extra[_k] = feishu_cfg[_k]
 
     except Exception as e:
         logger.warning(

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -505,6 +505,70 @@ class TestLoadGatewayConfig:
 
         assert os.environ.get("FEISHU_ALLOW_BOTS") == "none"
 
+    def test_bridges_feishu_group_rules_from_config_yaml_to_extra(self, tmp_path, monkeypatch):
+        """yaml feishu.group_rules must reach PlatformConfig.extra so the adapter sees it.
+
+        Regression test: before the bridge was added, FeishuAdapter._load_settings()
+        read group_rules from extra but config.yaml only forwarded allow_bots, so
+        per-group require_mention overrides were silently dropped (see feishu.py
+        L1473-1572 vs config.py L1116-1120).
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "feishu:\n"
+            "  group_rules:\n"
+            "    oc_test_chat_id_001:\n"
+            "      require_mention: false\n"
+            "    oc_test_chat_id_002:\n"
+            "      policy: allowlist\n"
+            "      allowlist: [user_a, user_b]\n"
+            "  admins: [admin_open_id]\n"
+            "  default_group_policy: open\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        # Force-enable feishu so the platform survives into PlatformConfig
+        monkeypatch.setenv("FEISHU_APP_ID", "cli_test_app_id")
+        monkeypatch.setenv("FEISHU_APP_SECRET", "test_secret")
+
+        config = load_gateway_config()
+
+        extra = config.platforms[Platform.FEISHU].extra
+        assert extra["group_rules"] == {
+            "oc_test_chat_id_001": {"require_mention": False},
+            "oc_test_chat_id_002": {"policy": "allowlist", "allowlist": ["user_a", "user_b"]},
+        }
+        assert extra["admins"] == ["admin_open_id"]
+        assert extra["default_group_policy"] == "open"
+
+    def test_feishu_no_structured_fields_leaves_extra_clean(self, tmp_path, monkeypatch):
+        """When feishu yaml has no group_rules/admins/default_group_policy, the
+        bridge must NOT inject empty placeholder keys into extra (the adapter
+        treats presence as meaningful and an empty dict is observably different
+        from 'no key set')."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "feishu:\n  allow_bots: mentions\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("FEISHU_APP_ID", "cli_test_app_id")
+        monkeypatch.setenv("FEISHU_APP_SECRET", "test_secret")
+
+        config = load_gateway_config()
+
+        extra = config.platforms[Platform.FEISHU].extra
+        assert "group_rules" not in extra
+        assert "admins" not in extra
+        assert "default_group_policy" not in extra
+
+
     def test_invalid_quick_commands_in_config_yaml_are_ignored(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
### Problem

`FeishuAdapter._load_settings()` (`gateway/platforms/feishu.py` L1473-1572) reads `group_rules`, `admins`, and `default_group_policy` from `PlatformConfig.extra`, but `gateway/config.py` only forwards `feishu.allow_bots` from `config.yaml` — the structured fields are silently dropped.

### Symptom

Users who configure per-group `require_mention` overrides in `config.yaml` (e.g. "this one group doesn't need @, all other groups still do") find the override completely ignored, even after `hermes gateway restart`.

Repro:

```yaml
# 
feishu:
  group_rules:
    "oc_xxxxxxxxxxxxxxxxxxxxxxxxxxxx":
      require_mention: false
```
With `FEISHU_REQUIRE_MENTION=true` (the default), the per-group override is expected to make that one chat respond without `@bot`. Before this fix the override is dropped during yaml→adapter bridging, so the chat still requires `@bot`. Adapter logic itself (`_require_mention_for`, L4040-4044) is correct — it just never receives the rules.

### Fix
Mirror the existing `allow_bots` bridge: explicitly forward each Feishu-specific structured key when present, so absence stays observably distinct from "empty dict". Other platforms (slack, telegram, whatsapp, signal, dingtalk, matrix) already have analogous structured-key bridges; this brings feishu in line.

```
# gateway/config.py, in the feishu yaml-handling block
_fs_structured_keys = ("group_rules", "admins", "default_group_policy")
if any(k in feishu_cfg for k in _fs_structured_keys):
    _, _fs_extra = _ensure_platform_extra_dict(
        platforms_data, Platform.FEISHU.value
    )

    for _k in _fs_structured_keys:
        if _k in feishu_cfg:
            _fs_extra[_k] = feishu_cfg[_k]
```

### Tests
Two new tests in `tests/gateway/test_config.py`:
- `test_bridges_feishu_group_rules_from_config_yaml_to_extra` — positive case covering all three structured fields (group_rules with nested require_mention + policy/allowlist, admins list, default_group_policy)
- `test_feishu_no_structured_fields_leaves_extra_clean` — negative case ensuring the bridge does NOT inject empty placeholder keys when the yaml has no structured fields (presence is observably meaningful to the adapter)

Both pass; `tests/gateway/test_config.py` is 50/50 green after the change.

### Notes
Full test suite has some pre-existing pollution-sensitive failures unrelated to this PR — they all pass when run in isolation. Verified that running `test_config.py` together with any of the affected files (e.g. `test_telegram_model_picker.py::test_model_selected_edits_message_on_success`) in isolation passes cleanly, so this PR is not the source of the pollution.

### Risk
Low. The bridge only adds three keys to `PlatformConfig.extra` when explicitly present in `config.yaml`. No env-var precedence is changed. Pure additive forwarding — nothing in the existing code path is removed or reordered.