### PR TITLE
fix(skills): re-baseline manifest when user copy matches bundled (#42682)

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -774,9 +774,14 @@ class TestResetBundledSkill:
         manifest_file.write_text("google-workspace:STALEHASH000000000000000000000000\n")
 
         with self._patches(bundled, skills_dir, manifest_file):
-            # Sanity check: without reset, sync would flag it user_modified
+            # With the fix for #42682, sync should re-baseline when user_hash
+            # matches bundled_hash (even with a stale origin_hash in manifest).
             pre = sync_skills(quiet=True)
-            assert "google-workspace" in pre["user_modified"]
+            assert "google-workspace" not in pre["user_modified"]
+            # The manifest should now hold the current bundled hash
+            manifest_after = _read_manifest()
+            expected = _dir_hash(bundled / "productivity" / "google-workspace")
+            assert manifest_after["google-workspace"] == expected
 
             # Reset (no --restore) should clear the manifest entry and re-baseline
             result = reset_bundled_skill("google-workspace", restore=False)

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -558,6 +558,19 @@ def sync_skills(quiet: bool = False) -> dict:
                 continue
 
             if user_hash != origin_hash:
+                # Check if user copy matches the current bundled version
+                # before assuming user modification.  When Curator archives
+                # a skill and later re-adds it (possibly with updates), the
+                # origin_hash in the manifest may be stale.  If the user's
+                # on-disk copy already matches the current bundled version,
+                # the user did NOT modify the skill — just re-baseline the
+                # manifest so future syncs work correctly (issue #42682).
+                if user_hash == bundled_hash:
+                    manifest[skill_name] = bundled_hash
+                    skipped += 1  # user copy == bundled; re-baselined
+                    if not quiet:
+                        print(f"  ~ {skill_name} (re-baselined, user copy matches bundled)")
+                    continue
                 # User modified this skill — don't overwrite their changes
                 user_modified.append(skill_name)
                 if not quiet:


### PR DESCRIPTION
Fixes #42682. When Curator archives a bundled skill and later re-adds it, the origin_hash in the manifest may be stale. If the user's on-disk copy already matches the current bundled version (user_hash == bundled_hash), the code incorrectly flags it as user-modified because it only checked user_hash != origin_hash. The fix adds a check: when user_hash == bundled_hash, re-baseline the manifest instead of flagging as user-modified.