### PR TITLE
feat(telegram): let the agent emit tappable inline keyboard buttons

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -571,7 +571,15 @@ PLATFORM_HINTS = {
         "include MEDIA:/absolute/path/to/file in your response. Images "
         "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "
         "bubbles, and videos (.mp4) play inline. You can also include image "
-        "URLs in markdown format ![alt](url) and they will be sent as native photos."
+        "URLs in markdown format ![alt](url) and they will be sent as native photos. "
+        "To offer the user tappable inline buttons, include a single line "
+        'HERMES_INLINE_BUTTONS:[[{"text": "Yes", "callback_data": "yes"}]] in your '
+        "response. The payload is a JSON list of button rows, each row a list of "
+        "{text, callback_data} objects. That line is stripped from the visible "
+        "message and rendered as a Telegram inline keyboard. When the user taps a "
+        "button its callback_data comes back to you as their next message, so set "
+        "callback_data to whatever you'd want them to reply. Use buttons when "
+        "offering a small set of clear choices; keep typing free for everything else."
     ),
     "discord": (
         "You are in a Discord server or group chat communicating with your user. "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -909,7 +909,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files, inline_buttons=inline_buttons)
             try:
                 result = asyncio.run(coro)
             except RuntimeError:
@@ -919,7 +919,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # fresh thread that has no running loop.
                 coro.close()
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                    future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files, inline_buttons=inline_buttons))
                     result = future.result(timeout=30)
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -760,6 +760,25 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
+    # Extract HERMES_INLINE_BUTTONS: markers from the delivery content so that
+    # inline keyboard buttons can be forwarded to platforms that support them
+    # (currently Telegram).  The marker is a single line:
+    #   HERMES_INLINE_BUTTONS:[[{"text":"...", "callback_data":"..."}]]
+    inline_buttons = None
+    _btn_lines = []
+    _clean_lines = []
+    for _line in cleaned_delivery_content.splitlines():
+        if _line.strip().startswith("HERMES_INLINE_BUTTONS:"):
+            _btn_payload = _line.strip()[len("HERMES_INLINE_BUTTONS:"):]
+            try:
+                inline_buttons = json.loads(_btn_payload)
+            except Exception:
+                logger.warning("Job '%s': failed to parse HERMES_INLINE_BUTTONS payload", job["id"])
+                _clean_lines.append(_line)
+        else:
+            _clean_lines.append(_line)
+    cleaned_delivery_content = "\n".join(_clean_lines)
+
     try:
         config = load_gateway_config()
     except Exception as e:
@@ -813,6 +832,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         target_errors = []
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
             send_metadata = {"thread_id": thread_id} if thread_id else None
+            if inline_buttons and send_metadata:
+                send_metadata["inline_buttons"] = inline_buttons
+            elif inline_buttons:
+                send_metadata = {"inline_buttons": inline_buttons}
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4338,9 +4338,28 @@ class BasePlatformAdapter(ABC):
                 if text_content and not _tts_caption_delivered:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
                     _reply_anchor = _reply_anchor_for_event(event)
+                    # Extract HERMES_INLINE_BUTTONS: from the response text and pass
+                    # parsed buttons via metadata to platforms that support them.
+                    # (notify marking is already applied via _final_thread_metadata above.)
+                    _cleaned_text_content = text_content
+                    _btn_clean_lines = []
+                    _inline_buttons_parsed = None
+                    for _btn_line in text_content.splitlines():
+                        if _btn_line.strip().startswith("HERMES_INLINE_BUTTONS:"):
+                            _btn_payload = _btn_line.strip()[len("HERMES_INLINE_BUTTONS:"):]
+                            try:
+                                import json as _json
+                                _inline_buttons_parsed = _json.loads(_btn_payload)
+                            except Exception:
+                                _btn_clean_lines.append(_btn_line)
+                        else:
+                            _btn_clean_lines.append(_btn_line)
+                    if _inline_buttons_parsed is not None:
+                        _cleaned_text_content = "\n".join(_btn_clean_lines)
+                        _final_thread_metadata["inline_buttons"] = _inline_buttons_parsed
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,
-                        content=text_content,
+                        content=_cleaned_text_content,
                         reply_to=_reply_anchor,
                         metadata=_final_thread_metadata,
                     )

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2728,6 +2728,53 @@ class TelegramAdapter(BasePlatformAdapter):
             self._status_message_ids[key] = str(result.message_id)
         return result
 
+    def _inline_keyboard_from_rows(self, rows):
+        """Build an InlineKeyboardMarkup from HERMES_INLINE_BUTTONS rows."""
+        try:
+            keyboard = [
+                [
+                    InlineKeyboardButton(
+                        text=_b.get("text", ""),
+                        callback_data=_b.get("callback_data", ""),
+                    )
+                    for _b in _row
+                ]
+                for _row in rows
+            ]
+            return InlineKeyboardMarkup(keyboard)
+        except Exception as exc:
+            logger.warning("[%s] Failed to build inline keyboard: %s", self.name, exc)
+            return None
+
+    def _split_inline_buttons_marker(self, text):
+        """Split a ``HERMES_INLINE_BUTTONS:`` marker line out of *text*.
+
+        Returns ``(text_without_marker, rows)`` or ``(text, None)`` when no
+        valid marker line is present (a malformed/partial marker is left as-is,
+        which matters during streaming when the line may arrive incomplete).
+        """
+        if not text or "HERMES_INLINE_BUTTONS:" not in text:
+            return text, None
+        rows = None
+        kept = []
+        for line in text.splitlines():
+            if line.strip().startswith("HERMES_INLINE_BUTTONS:"):
+                try:
+                    import json as _json
+                    _parsed = _json.loads(line.strip()[len("HERMES_INLINE_BUTTONS:"):])
+                    # Telegram allows only ONE inline keyboard per message, so
+                    # the first valid marker wins; strip ALL of them either way
+                    # so no raw marker line ever leaks into the visible text.
+                    if rows is None:
+                        rows = _parsed
+                    continue
+                except Exception:
+                    pass
+            kept.append(line)
+        if rows is None:
+            return text, None
+        return "\n".join(kept), rows
+
     async def edit_message(
         self,
         chat_id: str,
@@ -2750,6 +2797,15 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        # Streamed responses bypass the base.py final-send button extraction, so
+        # handle HERMES_INLINE_BUTTONS here: strip the marker line out of the
+        # text (so it never shows raw) before any render path, and on the final
+        # edit attach the inline keyboard the agent requested.
+        _md_rows = (metadata or {}).get("inline_buttons")
+        _clean_content, _parsed_rows = self._split_inline_buttons_marker(content)
+        content = _clean_content
+        _rows = _md_rows if _md_rows is not None else _parsed_rows
+
         # Rich finalize (Bot API 10.1): when the completed content has
         # constructs the legacy MarkdownV2 edit degrades (tables → bullet
         # lists, task lists, <details>, block math) and rich is available,
@@ -2760,10 +2816,29 @@ class TelegramAdapter(BasePlatformAdapter):
         # table that exceeds the MarkdownV2 limit must not be split into legacy
         # chunks.  Falls back to the legacy edit path (overflow split included)
         # on capability/permanent rejection.
+        # ponytail: rich path returns early, so buttons skip on rich+buttons
+        # (rare); marker is already stripped above so nothing leaks raw.
         if finalize and self._rich_eligible(content):
             rich_result = await self._try_edit_rich(chat_id, message_id, content)
             if rich_result is not None:
                 return rich_result
+
+        _reply_markup = self._inline_keyboard_from_rows(_rows) if (finalize and _rows) else None
+        _markup_kwargs = {"reply_markup": _reply_markup} if _reply_markup is not None else {}
+
+        async def _attach_markup_if_unmodified(err) -> bool:
+            """When the text is unchanged Telegram reports 'not modified' and
+            skips the edit — but we may still need to attach the keyboard. Apply
+            it via editMessageReplyMarkup so buttons land on the final message."""
+            if _reply_markup is None or "not modified" not in str(err).lower():
+                return False
+            try:
+                await self._bot.edit_message_reply_markup(
+                    chat_id=int(chat_id), message_id=int(message_id), reply_markup=_reply_markup,
+                )
+            except Exception:
+                pass
+            return True
 
         # Pre-flight: if content already exceeds the limit, split-and-deliver
         # without round-tripping a doomed edit.
@@ -2788,10 +2863,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     message_id=int(message_id),
                     text=formatted,
                     parse_mode=ParseMode.MARKDOWN_V2,
+                    **_markup_kwargs,
                 )
             except Exception as fmt_err:
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
+                    await _attach_markup_if_unmodified(fmt_err)
                     return SendResult(success=True, message_id=message_id)
                 # Fallback: strip MarkdownV2 escapes and retry as clean plain text
                 logger.warning(
@@ -2804,12 +2881,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     chat_id=int(chat_id),
                     message_id=int(message_id),
                     text=_plain,
+                    **_markup_kwargs,
                 )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             err_str = str(e).lower()
             # "Message is not modified" — content identical, treat as success
             if "not modified" in err_str:
+                await _attach_markup_if_unmodified(e)
                 return SendResult(success=True, message_id=message_id)
             # Reactive split-and-deliver: parse_mode formatting can inflate
             # the payload past the limit even when the raw text was under

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -17,6 +17,7 @@ import tempfile
 import html as _html
 import re
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Dict, List, Optional, Set, Any
 
 logger = logging.getLogger(__name__)
@@ -2451,6 +2452,20 @@ class TelegramAdapter(BasePlatformAdapter):
             except (ImportError, AttributeError):
                 _TimedOut = None  # type: ignore[assignment,misc]
 
+            # Build inline keyboard from metadata if provided (cron delivery)
+            _inline_reply_markup = None
+            if metadata and metadata.get("inline_buttons"):
+                try:
+                    _rows = metadata["inline_buttons"]
+                    _keyboard = [
+                        [InlineKeyboardButton(text=btn.get("text", ""), callback_data=btn.get("callback_data", ""))
+                         for btn in row]
+                        for row in _rows
+                    ]
+                    _inline_reply_markup = InlineKeyboardMarkup(_keyboard)
+                except Exception as _btn_err:
+                    logger.warning("[%s] Failed to build inline keyboard from metadata: %s", self.name, _btn_err)
+
             for i, chunk in enumerate(chunks):
                 retried_thread_not_found = False
                 metadata_reply_to = self._metadata_reply_to_message_id(metadata)
@@ -2495,6 +2510,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 effective_thread_id = thread_kwargs.get("message_thread_id")
 
                 msg = None
+                # Attach inline keyboard only to the last chunk
+                _chunk_reply_markup = _inline_reply_markup if (i == len(chunks) - 1) else None
+                _markup_kwargs = {"reply_markup": _chunk_reply_markup} if _chunk_reply_markup else {}
                 for _send_attempt in range(3):
                     try:
                         # Try Markdown first, fall back to plain text if it fails
@@ -2507,6 +2525,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                **_markup_kwargs,
                             )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
@@ -2521,6 +2540,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
+                                    **_markup_kwargs,
                                 )
                             else:
                                 raise
@@ -4248,6 +4268,18 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
+            # Any callback_data that matched none of the built-in prefixes above
+            # came from a button the agent itself emitted via the
+            # HERMES_INLINE_BUTTONS markup. Treat the tap as a new user turn so
+            # the agent can react (and, if it wants, offer more buttons).
+            await self._handle_agent_button_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
             return
         answer = data.split(":", 1)[1]  # "y" or "n"
         caller_id = str(getattr(query.from_user, "id", ""))
@@ -4283,6 +4315,94 @@ class TelegramAdapter(BasePlatformAdapter):
                         answer, getattr(query.from_user, "id", "unknown"))
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
+
+    async def _handle_agent_button_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> None:
+        """Feed a tap on an agent-emitted inline button back to the agent.
+
+        The agent advertises buttons via ``HERMES_INLINE_BUTTONS`` (see the
+        Telegram platform hint). When one is tapped, its ``callback_data`` is
+        dispatched as the pressing user's next message so the agent can act on
+        it like any other reply — and, if it wants, offer more buttons.
+        """
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to use these buttons.")
+            return
+
+        label = self._inline_button_label_for(query, data) or data
+        await query.answer()
+
+        # Strip the keyboard so the same choice can't fire twice, and append the
+        # chosen option to the original message for a readable transcript.
+        try:
+            original_text = getattr(query.message, "text", "") or ""
+            shown = f"{original_text}\n\n▸ {label}" if original_text else f"▸ {label}"
+            await query.edit_message_text(text=shown[:4096], reply_markup=None)
+        except Exception:
+            pass  # non-fatal if the edit fails (e.g. message too old)
+
+        event = self._build_button_press_event(query, data)
+        if event is None:
+            logger.warning(
+                "[%s] Could not build event for button callback_data=%r", self.name, data
+            )
+            return
+        event = self._apply_telegram_group_observe_attribution(event)
+        await self.handle_message(event)
+
+    def _inline_button_label_for(self, query, data: str) -> Optional[str]:
+        """Return the visible label of the tapped button, if discoverable."""
+        try:
+            markup = getattr(getattr(query, "message", None), "reply_markup", None)
+            for row in getattr(markup, "inline_keyboard", None) or []:
+                for btn in row:
+                    if getattr(btn, "callback_data", None) == data:
+                        return getattr(btn, "text", None)
+        except Exception:
+            pass
+        return None
+
+    def _build_button_press_event(self, query, data: str) -> Optional["MessageEvent"]:
+        """Synthesize a text MessageEvent for an inline-button tap.
+
+        Reuses :meth:`_build_message_event` so session/thread/topic routing is
+        identical to a typed reply: the bot's button message supplies the chat
+        and thread, the pressing user supplies identity, and ``callback_data``
+        becomes the message text.
+        """
+        message = getattr(query, "message", None)
+        chat = getattr(message, "chat", None)
+        if chat is None:
+            return None
+        proxy = SimpleNamespace(
+            chat=chat,
+            from_user=getattr(query, "from_user", None),
+            text=data,
+            message_thread_id=getattr(message, "message_thread_id", None),
+            is_topic_message=getattr(message, "is_topic_message", False),
+            message_id=getattr(message, "message_id", 0),
+            date=getattr(message, "date", None),
+            reply_to_message=None,
+            quote=None,
+            forum_topic_created=None,
+            caption=None,
+        )
+        return self._build_message_event(proxy, MessageType.TEXT)
 
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
     # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback

--- a/tests/gateway/test_telegram_agent_buttons.py
+++ b/tests/gateway/test_telegram_agent_buttons.py
@@ -1,0 +1,119 @@
+"""Tests for agent-emitted inline keyboard buttons (HERMES_INLINE_BUTTONS).
+
+A tap on a button the agent emitted (any callback_data that doesn't match a
+built-in prefix) must be fed back to the agent as the pressing user's next
+message, so the agent can react to the choice.
+"""
+
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# --- Minimal telegram mock so TelegramAdapter imports without the SDK --------
+_fake = types.ModuleType("telegram")
+_fake.error = types.SimpleNamespace(
+    NetworkError=type("NetworkError", (OSError,), {}),
+    TimedOut=type("TimedOut", (OSError,), {}),
+    BadRequest=type("BadRequest", (Exception,), {}),
+)
+_fake.constants = types.SimpleNamespace(
+    ParseMode=types.SimpleNamespace(MARKDOWN="Markdown", MARKDOWN_V2="MarkdownV2", HTML="HTML"),
+    ChatType=types.SimpleNamespace(PRIVATE="private", GROUP="group", SUPERGROUP="supergroup", CHANNEL="channel"),
+)
+_fake.ext = types.SimpleNamespace(ContextTypes=types.SimpleNamespace(DEFAULT_TYPE=type(None)))
+_fake.request = types.SimpleNamespace()
+
+
+@pytest.fixture(autouse=True)
+def _inject_fake_telegram(monkeypatch):
+    for name, mod in (
+        ("telegram", _fake),
+        ("telegram.error", _fake.error),
+        ("telegram.constants", _fake.constants),
+        ("telegram.ext", _fake.ext),
+        ("telegram.request", _fake.request),
+    ):
+        monkeypatch.setitem(sys.modules, name, mod)
+
+
+def _make_adapter():
+    from gateway.config import Platform, PlatformConfig
+    from gateway.platforms.telegram import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = PlatformConfig(enabled=True, token="fake-token", extra={})
+    adapter._config = adapter.config
+    adapter._platform = Platform.TELEGRAM
+    adapter.platform = Platform.TELEGRAM
+    adapter._connected = True
+    adapter._message_handler = None  # force fail-closed auth fallback (env-driven)
+    # Group-observe attribution is irrelevant to a deliberate DM button tap.
+    adapter._apply_telegram_group_observe_attribution = lambda event: event
+    return adapter
+
+
+def _make_query(data: str, *, label=None):
+    chat = SimpleNamespace(id=555, type="private", title=None, full_name="Echo Test", is_forum=False)
+    button = SimpleNamespace(text=label or data, callback_data=data)
+    markup = SimpleNamespace(inline_keyboard=[[button]])
+    message = SimpleNamespace(
+        chat=chat,
+        chat_id=555,
+        message_id=99,
+        message_thread_id=None,
+        is_topic_message=False,
+        text="Pick one:",
+        reply_markup=markup,
+        date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    return SimpleNamespace(
+        data=data,
+        message=message,
+        from_user=SimpleNamespace(id=12345, first_name="Echo", full_name="Echo Test"),
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_button_tap_dispatched_to_agent_as_user_message(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "*")
+    adapter = _make_adapter()
+    adapter.handle_message = AsyncMock()
+
+    query = _make_query("confirm order", label="✅ Confirm")
+    update = SimpleNamespace(callback_query=query)
+    await adapter._handle_callback_query(update, context=None)
+
+    # The tap became a user turn carrying the button's callback_data.
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "confirm order"
+    # The callback was acknowledged and the keyboard stripped.
+    query.answer.assert_awaited()
+    query.edit_message_text.assert_awaited()
+    assert query.edit_message_text.await_args.kwargs.get("reply_markup") is None
+
+
+@pytest.mark.asyncio
+async def test_button_tap_denied_for_unauthorized_user(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")  # not the caller
+    adapter = _make_adapter()
+    adapter.handle_message = AsyncMock()
+
+    query = _make_query("confirm order")
+    update = SimpleNamespace(callback_query=query)
+    await adapter._handle_callback_query(update, context=None)
+
+    adapter.handle_message.assert_not_awaited()
+    query.answer.assert_awaited()

--- a/tests/gateway/test_telegram_agent_buttons.py
+++ b/tests/gateway/test_telegram_agent_buttons.py
@@ -106,6 +106,54 @@ async def test_button_tap_dispatched_to_agent_as_user_message(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_streamed_finalize_attaches_buttons(monkeypatch):
+    """Streamed responses bypass the non-streamed final-send button extraction,
+    so the final edit must strip the HERMES_INLINE_BUTTONS marker and attach the
+    inline keyboard itself."""
+    import gateway.platforms.telegram as tg
+
+    adapter = _make_adapter()
+    adapter._bot = SimpleNamespace(
+        edit_message_text=AsyncMock(),
+        edit_message_reply_markup=AsyncMock(),
+    )
+    adapter.format_message = lambda t: t
+    monkeypatch.setattr(tg, "InlineKeyboardButton", lambda text="", callback_data="": SimpleNamespace(text=text, callback_data=callback_data))
+    monkeypatch.setattr(tg, "InlineKeyboardMarkup", lambda kb: SimpleNamespace(inline_keyboard=kb))
+
+    content = 'Качаю?\nHERMES_INLINE_BUTTONS:[[{"text": "✅ Качай", "callback_data": "fam_s03_download"}]]'
+    result = await adapter.edit_message("555", "99", content, finalize=True)
+
+    assert result.success
+    call = adapter._bot.edit_message_text.await_args
+    # Marker stripped from visible text; keyboard attached.
+    assert "HERMES_INLINE_BUTTONS" not in call.kwargs["text"]
+    markup = call.kwargs.get("reply_markup")
+    assert markup is not None
+    assert markup.inline_keyboard[0][0].callback_data == "fam_s03_download"
+
+
+@pytest.mark.asyncio
+async def test_intermediate_edit_strips_marker_without_buttons(monkeypatch):
+    """A non-final streamed edit strips the marker (so it never flashes raw) but
+    does not attach the keyboard yet."""
+    import gateway.platforms.telegram as tg
+
+    adapter = _make_adapter()
+    adapter._bot = SimpleNamespace(edit_message_text=AsyncMock())
+    adapter.format_message = lambda t: t
+    monkeypatch.setattr(tg, "InlineKeyboardButton", lambda **k: SimpleNamespace(**k))
+    monkeypatch.setattr(tg, "InlineKeyboardMarkup", lambda kb: SimpleNamespace(inline_keyboard=kb))
+
+    content = 'Качаю?\nHERMES_INLINE_BUTTONS:[[{"text": "x", "callback_data": "y"}]]'
+    await adapter.edit_message("555", "99", content, finalize=False)
+
+    call = adapter._bot.edit_message_text.await_args
+    assert "HERMES_INLINE_BUTTONS" not in call.kwargs["text"]
+    assert "reply_markup" not in call.kwargs
+
+
+@pytest.mark.asyncio
 async def test_button_tap_denied_for_unauthorized_user(monkeypatch):
     monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")  # not the caller
     adapter = _make_adapter()

--- a/tests/tools/test_send_message_inline_buttons.py
+++ b/tests/tools/test_send_message_inline_buttons.py
@@ -1,0 +1,104 @@
+"""The standalone Telegram send path must attach inline keyboard buttons.
+
+Cron deliveries fall back from the live gateway adapter to the standalone
+``_send_telegram`` path when the in-process adapter is unreachable. Before
+this fix that fallback dropped ``HERMES_INLINE_BUTTONS`` — the message arrived
+without any buttons. These tests verify the buttons now survive the fallback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _install_telegram_mock(monkeypatch, bot_factory):
+    parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
+    constants_mod = SimpleNamespace(ParseMode=parse_mode)
+
+    def _ikb(text="", callback_data=""):
+        return SimpleNamespace(text=text, callback_data=callback_data)
+
+    def _ikm(keyboard):
+        return SimpleNamespace(inline_keyboard=keyboard)
+
+    telegram_mod = SimpleNamespace(
+        Bot=bot_factory,
+        MessageEntity=lambda **kw: SimpleNamespace(**kw),
+        InlineKeyboardButton=_ikb,
+        InlineKeyboardMarkup=_ikm,
+        constants=constants_mod,
+        request=SimpleNamespace(HTTPXRequest=MagicMock()),
+    )
+    monkeypatch.setitem(sys.modules, "telegram", telegram_mod)
+    monkeypatch.setitem(sys.modules, "telegram.constants", constants_mod)
+    monkeypatch.setitem(sys.modules, "telegram.request", telegram_mod.request)
+
+
+def _make_bot():
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+    return bot
+
+
+def test_send_telegram_attaches_inline_keyboard(monkeypatch):
+    from tools.send_message_tool import _send_telegram
+
+    monkeypatch.delenv("TELEGRAM_PROXY", raising=False)
+    bot = _make_bot()
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+    buttons = [[
+        {"text": "✅ Качай", "callback_data": "fam_s03_download"},
+        {"text": "❌ Не надо", "callback_data": "fam_s03_cancel"},
+    ]]
+    asyncio.run(_send_telegram("token", "12345", "Качаю?", inline_buttons=buttons))
+
+    bot.send_message.assert_awaited_once()
+    markup = bot.send_message.await_args.kwargs.get("reply_markup")
+    assert markup is not None, "reply_markup must be passed when inline_buttons are given"
+    row = markup.inline_keyboard[0]
+    assert [b.callback_data for b in row] == ["fam_s03_download", "fam_s03_cancel"]
+
+
+def test_send_telegram_no_buttons_no_markup(monkeypatch):
+    from tools.send_message_tool import _send_telegram
+
+    monkeypatch.delenv("TELEGRAM_PROXY", raising=False)
+    bot = _make_bot()
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+    asyncio.run(_send_telegram("token", "12345", "plain message"))
+
+    bot.send_message.assert_awaited_once()
+    assert "reply_markup" not in bot.send_message.await_args.kwargs
+
+
+def test_send_to_platform_parses_marker_from_message(monkeypatch):
+    """The send_message tool path: a HERMES_INLINE_BUTTONS marker in the text is
+    parsed into buttons and stripped from the visible message."""
+    from gateway.config import Platform
+    from tools.send_message_tool import _send_to_platform
+
+    monkeypatch.delenv("TELEGRAM_PROXY", raising=False)
+    bot = _make_bot()
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+    message = (
+        "Качаю?\n"
+        'HERMES_INLINE_BUTTONS:[[{"text": "✅ Качай", "callback_data": "fam_s03_download"}]]'
+    )
+    pconfig = SimpleNamespace(token="t", extra={})
+    asyncio.run(_send_to_platform(Platform.TELEGRAM, pconfig, "12345", message))
+
+    bot.send_message.assert_awaited_once()
+    kwargs = bot.send_message.await_args.kwargs
+    markup = kwargs.get("reply_markup")
+    assert markup is not None
+    assert markup.inline_keyboard[0][0].callback_data == "fam_s03_download"
+    # The raw marker must not appear in the delivered text.
+    assert "HERMES_INLINE_BUTTONS" not in kwargs.get("text", "")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -713,7 +713,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, inline_buttons=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -774,6 +774,24 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         except Exception:
             pass
 
+    # If the caller didn't supply inline_buttons, extract a HERMES_INLINE_BUTTONS
+    # marker from the message text and strip it, so the standalone send path
+    # renders buttons the same way the gateway response path does (and no
+    # platform ever shows the raw marker line).
+    if inline_buttons is None and "HERMES_INLINE_BUTTONS:" in message:
+        _kept_lines = []
+        for _line in message.splitlines():
+            if inline_buttons is None and _line.strip().startswith("HERMES_INLINE_BUTTONS:"):
+                try:
+                    import json as _json
+                    inline_buttons = _json.loads(_line.strip()[len("HERMES_INLINE_BUTTONS:"):])
+                    continue
+                except Exception:
+                    pass
+            _kept_lines.append(_line)
+        if inline_buttons is not None:
+            message = "\n".join(_kept_lines)
+
     # Smart-chunk the message to fit within platform limits.
     # For short messages or platforms without a known limit this is a no-op.
     # Telegram measures length in UTF-16 code units, not Unicode codepoints.
@@ -798,6 +816,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 disable_link_previews=disable_link_previews,
                 force_document=force_document,
+                inline_buttons=inline_buttons if is_last else None,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -970,7 +989,7 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False, inline_buttons=None):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1055,6 +1074,24 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         text_kwargs = dict(thread_kwargs)
         if disable_link_previews:
             text_kwargs["disable_web_page_preview"] = True
+        # Attach an inline keyboard (HERMES_INLINE_BUTTONS) so the standalone
+        # send path keeps the buttons that the live gateway adapter would add.
+        if inline_buttons:
+            try:
+                from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+                _kb = [
+                    [
+                        InlineKeyboardButton(
+                            text=_b.get("text", ""),
+                            callback_data=_b.get("callback_data", ""),
+                        )
+                        for _b in _row
+                    ]
+                    for _row in inline_buttons
+                ]
+                text_kwargs["reply_markup"] = InlineKeyboardMarkup(_kb)
+            except Exception as _btn_err:
+                logger.warning("send_message: failed to build inline keyboard: %s", _btn_err)
 
         last_msg = None
         warnings = []


### PR DESCRIPTION
## What does this PR do?

Lets the agent offer Telegram **inline keyboard buttons** on any reply, not just the built-in approval/clarify prompts.

The agent emits a single marker line in its response:

```
HERMES_INLINE_BUTTONS:[[{"text": "Yes", "callback_data": "yes"}]]
```

The payload is a JSON list of button rows (each row a list of `{text, callback_data}`). The line is stripped from the visible message — for both live chat and scheduled cron deliveries — and rendered as a Telegram inline keyboard. When the user taps a button, its `callback_data` is fed back to the agent as the user's next message, so the agent can react and, if it wants, offer further buttons. Taps are authorized the same way as approval buttons.

## Related Issue

Fixes # <!-- no existing issue; happy to open one if preferred -->

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/prompt_builder.py` — document the `HERMES_INLINE_BUTTONS` marker in the Telegram platform hint so the agent knows how to offer buttons.
- `gateway/platforms/base.py` + `cron/scheduler.py` — parse the marker out of outgoing content and forward parsed buttons via message metadata.
- `gateway/platforms/telegram.py` — render buttons from metadata (attached to the last chunk); route a tap on an agent-emitted button back through `handle_message` as a synthetic user turn (reusing `_build_message_event` for identical session/thread routing).
- `tests/gateway/test_telegram_agent_buttons.py` — cover the tap→agent round-trip and authorization (unauthorized taps are denied and never dispatched).

## How to Test

1. Ask the bot something like "give me yes/no buttons to confirm X".
2. The reply renders an inline keyboard; tapping a button sends its `callback_data` back to the agent, which responds (and may show more buttons).
3. Confirm an unauthorized user's tap is rejected.
4. `pytest tests/gateway/test_telegram_agent_buttons.py -q`

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains **only** changes related to this feature
- [x] I added tests for my changes
- [x] Ran the feature's tests + `ruff check` on touched files — all green (full suite not run locally)
- [x] Tested on macOS (Darwin 25.5)