### PR TITLE
fix(cron): decode no-agent script output as UTF-8

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1049,6 +1049,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=script_timeout,
             cwd=str(path.parent),
             env=run_env,

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -172,6 +172,34 @@ class TestRunJobScript:
         parsed = json.loads(output)
         assert parsed["new_prs"][0]["number"] == 42
 
+    def test_script_capture_is_pinned_to_utf8(self, cron_env, monkeypatch):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "utf8.py"
+        script.write_text('print("done")\n')
+
+        seen: dict[str, object] = {}
+
+        class DummyCompletedProcess:
+            returncode = 0
+            stdout = "done\n"
+            stderr = ""
+
+        def fake_run(argv, **kwargs):
+            seen["argv"] = argv
+            seen["kwargs"] = kwargs
+            return DummyCompletedProcess()
+
+        monkeypatch.setattr("cron.scheduler.subprocess.run", fake_run)
+
+        success, output = _run_job_script(str(script))
+
+        assert success is True
+        assert output == "done"
+        assert seen["kwargs"]["text"] is True
+        assert seen["kwargs"]["encoding"] == "utf-8"
+        assert seen["kwargs"]["errors"] == "replace"
+
 
 class TestBuildJobPromptWithScript:
     """Test that script output is injected into the prompt."""


### PR DESCRIPTION
Fixes #42785

## Summary
- pin `_run_job_script()` subprocess capture decoding to `utf-8` with replacement for invalid bytes
- avoid platform-default decoding differences like cp1252 on Windows when cron no-agent scripts print non-ASCII output
- add a regression test that asserts the subprocess text capture parameters

## Local proof
- `python -m pytest -o addopts= tests/cron/test_cron_script.py`\n- `ruff check cron/scheduler.py tests/cron/test_cron_script.py`\n- `git diff --check HEAD^ HEAD`