### PR TITLE
feat(desktop): add sort mode toggle for sidebar sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -53,6 +53,7 @@ import {
   $sidebarPinsOpen,
   $sidebarRecentsOpen,
   $sidebarSessionOrderIds,
+  $sidebarSortMode,
   $sidebarWorkspaceOrderIds,
   pinSession,
   reorderPinnedSession,
@@ -62,6 +63,7 @@ import {
   setSidebarPinsOpen,
   setSidebarRecentsOpen,
   setSidebarSessionOrderIds,
+  setSidebarSortMode,
   setSidebarWorkspaceOrderIds,
   SIDEBAR_SESSIONS_PAGE_SIZE,
   unpinSession
@@ -337,6 +339,7 @@ export function ChatSidebar({
   const contentVisible = sidebarOpen || overlayMounted
   const panesFlipped = useStore($panesFlipped)
   const agentsGrouped = useStore($sidebarAgentsGrouped)
+  const sortMode = useStore($sidebarSortMode)
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const pinsOpen = useStore($sidebarPinsOpen)
   const agentsOpen = useStore($sidebarRecentsOpen)
@@ -524,10 +527,17 @@ export function ChatSidebar({
     }
   }, [agentOrderIds, unpinnedAgentSessions])
 
-  const agentSessions = useMemo(
-    () => orderByIds(unpinnedAgentSessions, s => s.id, agentOrderIds),
-    [unpinnedAgentSessions, agentOrderIds]
-  )
+  const agentSessions = useMemo(() => {
+    if (sortMode === 'recency') {
+      return [...unpinnedAgentSessions].sort((a, b) => sessionTime(b) - sessionTime(a))
+    }
+
+    if (sortMode === 'created') {
+      return [...unpinnedAgentSessions].sort((a, b) => (b.started_at || 0) - (a.started_at || 0))
+    }
+
+    return orderByIds(unpinnedAgentSessions, s => s.id, agentOrderIds)
+  }, [unpinnedAgentSessions, agentOrderIds, sortMode])
 
   const { localSessions: localAgentSessions, sourceGroups } = useMemo(
     () => sourceSessionGroupsFor(agentSessions),
@@ -901,26 +911,47 @@ export function ChatSidebar({
               // Grouping operates on unpinned recents; if everything is pinned
               // the toggle does nothing, and it's irrelevant in the ALL-profiles
               // view (always grouped by profile), so hide the button (not the slot).
-              <div className="grid size-6 shrink-0 place-items-center">
+              <div className="flex shrink-0 items-center gap-0.5">
                 {!showAllProfiles && localAgentSessions.length > 0 ? (
-                  <Tip label={agentsGrouped ? s.groupTitleGrouped : s.groupTitleUngrouped}>
-                    <Button
-                      aria-label={agentsGrouped ? s.groupAriaGrouped : s.groupAriaUngrouped}
-                      className={cn(
-                        'text-(--ui-text-tertiary) opacity-70 hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100',
-                        agentsGrouped && 'bg-(--ui-control-active-background) text-foreground opacity-100'
-                      )}
-                      onClick={event => {
-                        event.stopPropagation()
-                        setSidebarRecentsOpen(true)
-                        setSidebarAgentsGrouped(!agentsGrouped)
-                      }}
-                      size="icon-xs"
-                      variant="ghost"
-                    >
-                      <Codicon name={agentsGrouped ? 'list-unordered' : 'root-folder'} size="0.75rem" />
-                    </Button>
-                  </Tip>
+                  <>
+                    <Tip label={s.sortModeTooltip[sortMode]}>
+                      <Button
+                        aria-label={s.sortModeAria[sortMode]}
+                        className={cn(
+                          'text-(--ui-text-tertiary) opacity-70 hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100',
+                          sortMode !== 'manual' && 'bg-(--ui-control-active-background) text-foreground opacity-100'
+                        )}
+                        onClick={event => {
+                          event.stopPropagation()
+                          const modes: Array<'manual' | 'recency' | 'created'> = ['manual', 'recency', 'created']
+                          const next = modes[(modes.indexOf(sortMode) + 1) % modes.length]
+                          setSidebarSortMode(next)
+                        }}
+                        size="icon-xs"
+                        variant="ghost"
+                      >
+                        <Codicon name={sortMode === 'manual' ? 'list-ordered' : sortMode === 'recency' ? 'history' : 'calendar'} size="0.75rem" />
+                      </Button>
+                    </Tip>
+                    <Tip label={agentsGrouped ? s.groupTitleGrouped : s.groupTitleUngrouped}>
+                      <Button
+                        aria-label={agentsGrouped ? s.groupAriaGrouped : s.groupAriaUngrouped}
+                        className={cn(
+                          'text-(--ui-text-tertiary) opacity-70 hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100',
+                          agentsGrouped && 'bg-(--ui-control-active-background) text-foreground opacity-100'
+                        )}
+                        onClick={event => {
+                          event.stopPropagation()
+                          setSidebarRecentsOpen(true)
+                          setSidebarAgentsGrouped(!agentsGrouped)
+                        }}
+                        size="icon-xs"
+                        variant="ghost"
+                      >
+                        <Codicon name={agentsGrouped ? 'list-unordered' : 'root-folder'} size="0.75rem" />
+                      </Button>
+                    </Tip>
+                  </>
                 ) : null}
               </div>
             }
@@ -937,7 +968,7 @@ export function ChatSidebar({
             pinned={false}
             rootClassName="min-h-0 flex-1 p-0"
             sessions={displayAgentSessions}
-            sortable={!showAllProfiles && agentSessions.length > 1}
+            sortable={sortMode === 'manual' && !showAllProfiles && agentSessions.length > 1}
             workingSessionIdSet={workingSessionIdSet}
           />
         )}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1059,6 +1059,16 @@ export const en: Translations = {
     groupAriaUngrouped: 'Group sessions by workspace',
     groupTitleGrouped: 'Ungroup sessions',
     groupTitleUngrouped: 'Group by workspace',
+    sortModeTooltip: {
+      manual: 'Sort: manual order (click to switch)',
+      recency: 'Sort: recent activity (click to switch)',
+      created: 'Sort: creation time (click to switch)'
+    },
+    sortModeAria: {
+      manual: 'Sort by manual order',
+      recency: 'Sort by recent activity',
+      created: 'Sort by creation time'
+    },
     allPinned: 'Everything here is pinned. Unpin a chat to show it in recents.',
     shiftClickHint: 'Shift-click a chat to pin',
     noWorkspace: 'No workspace',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1202,6 +1202,16 @@ export const ja = defineLocale({
     groupAriaUngrouped: 'ワークスペースごとにセッションをグループ化',
     groupTitleGrouped: 'セッションのグループ化を解除',
     groupTitleUngrouped: 'ワークスペースでグループ化',
+    sortModeTooltip: {
+      manual: '並べ替え：手動順序（クリックで切替）',
+      recency: '並べ替え：最近のアクティビティ（クリックで切替）',
+      created: '並べ替え：作成日時（クリックで切替）'
+    },
+    sortModeAria: {
+      manual: '手動順序で並べ替え',
+      recency: '最近のアクティビティで並べ替え',
+      created: '作成日時で並べ替え'
+    },
     allPinned: 'ここにあるものはすべてピン留めされています。チャットのピン留めを解除すると最近のものに表示されます。',
     shiftClickHint: 'Shift クリックでピン留め · ドラッグで並べ替え',
     noWorkspace: 'ワークスペースなし',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -816,6 +816,8 @@ export interface Translations {
     groupAriaUngrouped: string
     groupTitleGrouped: string
     groupTitleUngrouped: string
+    sortModeTooltip: { manual: string; recency: string; created: string }
+    sortModeAria: { manual: string; recency: string; created: string }
     allPinned: string
     shiftClickHint: string
     noWorkspace: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1168,6 +1168,16 @@ export const zhHant = defineLocale({
     groupAriaUngrouped: '依工作區分組工作階段',
     groupTitleGrouped: '取消分組',
     groupTitleUngrouped: '依工作區分組',
+    sortModeTooltip: {
+      manual: '排序：手動順序（點擊切換）',
+      recency: '排序：最近活動（點擊切換）',
+      created: '排序：建立時間（點擊切換）'
+    },
+    sortModeAria: {
+      manual: '按手動順序排序',
+      recency: '按最近活動排序',
+      created: '按建立時間排序'
+    },
     allPinned: '這裡的全部已釘選。取消釘選某個聊天即可在最近中顯示。',
     shiftClickHint: 'Shift + 點擊聊天以釘選 · 拖曳以重新排序',
     noWorkspace: '無工作區',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1246,6 +1246,16 @@ export const zh: Translations = {
     groupAriaUngrouped: '按工作区分组会话',
     groupTitleGrouped: '取消分组',
     groupTitleUngrouped: '按工作区分组',
+    sortModeTooltip: {
+      manual: '排序：手动顺序（点击切换）',
+      recency: '排序：最近活动（点击切换）',
+      created: '排序：创建时间（点击切换）'
+    },
+    sortModeAria: {
+      manual: '按手动顺序排序',
+      recency: '按最近活动排序',
+      created: '按创建时间排序'
+    },
     allPinned: '这里的全部已置顶。取消置顶某个对话即可在最近中显示。',
     shiftClickHint: 'Shift+ 单击对话以置顶 · 拖动以重新排序',
     noWorkspace: '无工作区',

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -4,8 +4,10 @@ import {
   arraysEqual,
   insertUniqueId,
   persistBoolean,
+  persistString,
   persistStringArray,
   storedBoolean,
+  storedString,
   storedStringArray
 } from '@/lib/storage'
 
@@ -26,6 +28,9 @@ const SIDEBAR_CRON_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarCronOpen'
 const SIDEBAR_SESSION_ORDER_STORAGE_KEY = 'hermes.desktop.sessionOrder'
 const SIDEBAR_WORKSPACE_ORDER_STORAGE_KEY = 'hermes.desktop.workspaceOrder'
 const PANES_FLIPPED_STORAGE_KEY = 'hermes.desktop.panesFlipped'
+const SIDEBAR_SORT_MODE_STORAGE_KEY = 'hermes.desktop.sidebarSortMode'
+
+export type SidebarSortMode = 'manual' | 'recency' | 'created'
 
 export const CHAT_SIDEBAR_PANE_ID = 'chat-sidebar'
 export const FILE_BROWSER_PANE_ID = 'file-browser'
@@ -69,6 +74,9 @@ export const $sidebarRecentsOpen = atom(true)
 // scheduler's `[IMPORTANT: …]` first-message previews don't spam recents.
 export const $sidebarCronOpen = atom(storedBoolean(SIDEBAR_CRON_OPEN_STORAGE_KEY, false))
 export const $sidebarAgentsGrouped = atom(storedBoolean(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, false))
+export const $sidebarSortMode = atom<SidebarSortMode>(
+  (storedString(SIDEBAR_SORT_MODE_STORAGE_KEY) as SidebarSortMode) || 'manual'
+)
 // When true, the sessions sidebar moves to the right and the file browser +
 // preview rail move to the left — a mirror of the default layout.
 export const $panesFlipped = atom(storedBoolean(PANES_FLIPPED_STORAGE_KEY, false))
@@ -80,6 +88,7 @@ $sidebarCronOpen.subscribe(open => persistBoolean(SIDEBAR_CRON_OPEN_STORAGE_KEY,
 $sidebarSessionOrderIds.subscribe(ids => persistStringArray(SIDEBAR_SESSION_ORDER_STORAGE_KEY, [...ids]))
 $sidebarWorkspaceOrderIds.subscribe(ids => persistStringArray(SIDEBAR_WORKSPACE_ORDER_STORAGE_KEY, [...ids]))
 $sidebarAgentsGrouped.subscribe(grouped => persistBoolean(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, grouped))
+$sidebarSortMode.subscribe(mode => persistString(SIDEBAR_SORT_MODE_STORAGE_KEY, mode))
 $panesFlipped.subscribe(flipped => persistBoolean(PANES_FLIPPED_STORAGE_KEY, flipped))
 
 export function setSidebarWidth(width: number) {
@@ -141,6 +150,10 @@ export function setSidebarCronOpen(open: boolean) {
 
 export function setSidebarAgentsGrouped(grouped: boolean) {
   $sidebarAgentsGrouped.set(grouped)
+}
+
+export function setSidebarSortMode(mode: SidebarSortMode) {
+  $sidebarSortMode.set(mode)
 }
 
 export function setSidebarSessionOrderIds(ids: string[]) {


### PR DESCRIPTION
## Summary

Add a sort mode toggle to the Desktop sidebar sessions section, allowing users to cycle through three sorting modes:
- **Manual order**: drag-and-drop reordering (current default behavior)
- **Recent activity**: sessions sorted by `last_active` descending — most recently used sessions appear at the top
- **Creation time**: sessions sorted by `started_at` descending — newest sessions first

## Motivation

When many GUI sessions accumulate, the current sidebar becomes hard to scan. Users often want to return to the thing they just used, but those items may not appear near the top because the sidebar preserves manual ordering. A recency sort option significantly improves usability for heavy desktop GUI users.

## Implementation

### Files changed (7 files, +110/-24):

1. **`apps/desktop/src/store/layout.ts`** — Added `$sidebarSortMode` atom with `storedString`/`persistString` persistence, `SidebarSortMode` type export, and `setSidebarSortMode` function
2. **`apps/desktop/src/app/chat/sidebar/index.tsx`** — Added sort mode toggle button next to the existing grouped toggle, conditionally applies sort logic based on mode, disables drag-and-drop when not in manual mode
3. **`apps/desktop/src/i18n/types.ts`** — Added `sortModeTooltip` and `sortModeAria` type definitions
4. **`apps/desktop/src/i18n/en.ts`** — English strings
5. **`apps/desktop/src/i18n/zh.ts`** — Chinese strings
6. **`apps/desktop/src/i18n/zh-hant.ts`** — Traditional Chinese strings
7. **`apps/desktop/src/i18n/ja.ts`** — Japanese strings

### Key design decisions:
- Sort mode is persisted in localStorage via `storedString`/`persistString` (same pattern as `$sidebarAgentsGrouped`)
- The toggle cycles through manual → recency → created on click
- Drag-and-drop reordering is disabled when not in manual mode (via `sortable` prop)
- The toggle appears next to the existing grouped/ungrouped toggle in the sessions section header
- Active sort mode (non-manual) shows with highlighted styling to indicate non-default state

### Icons used:
- Manual: `list-ordered`
- Recency: `history`
- Created: `calendar`

Closes #42767
