### PR TITLE
fix(desktop): retry startup i18n config load

### DIFF
--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -7,7 +7,7 @@ import { type I18nConfigClient, I18nProvider, useI18n } from './context'
 import type { Locale } from './types'
 
 function LanguageProbe({ target = 'zh' }: { target?: Locale }) {
-  const { isLoadingConfig, isSavingLocale, locale, saveError, setLocale, t } = useI18n()
+  const { configLoadError, isLoadingConfig, isSavingLocale, locale, saveError, setLocale, t } = useI18n()
 
   return (
     <div>
@@ -16,6 +16,7 @@ function LanguageProbe({ target = 'zh' }: { target?: Locale }) {
       <p data-testid="save">{t.common.save}</p>
       <p data-testid="loading">{String(isLoadingConfig)}</p>
       <p data-testid="saving">{String(isSavingLocale)}</p>
+      <p data-testid="config-error">{configLoadError?.message ?? ''}</p>
       <p data-testid="save-error">{saveError?.message ?? ''}</p>
       <button onClick={() => void setLocale(target).catch(() => undefined)} type="button">
         switch
@@ -28,6 +29,7 @@ describe('I18nProvider', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    vi.useRealTimers()
   })
 
   it('defaults to English without a config client', () => {
@@ -76,23 +78,67 @@ describe('I18nProvider', () => {
     expect(configClient.saveConfig).not.toHaveBeenCalled()
   })
 
-  it('keeps English usable when config loading fails', async () => {
-    const configClient: I18nConfigClient = {
-      getConfig: vi.fn().mockRejectedValue(new Error('config unavailable')),
-      saveConfig: vi.fn()
+  it('retries config loading before falling back to English', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const configClient: I18nConfigClient = {
+        getConfig: vi
+          .fn()
+          .mockRejectedValueOnce(new Error('config unavailable'))
+          .mockResolvedValueOnce({ display: { language: 'zh-Hans' } }),
+        saveConfig: vi.fn()
+      }
+
+      render(
+        <I18nProvider configClient={configClient}>
+          <LanguageProbe />
+        </I18nProvider>
+      )
+
+      expect(screen.getByTestId('locale').textContent).toBe('en')
+
+      await vi.advanceTimersByTimeAsync(250)
+      vi.useRealTimers()
+      await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+
+      expect(configClient.getConfig).toHaveBeenCalledTimes(2)
+      expect(screen.getByTestId('locale').textContent).toBe('zh')
+      expect(screen.getByTestId('label').textContent).toBe('语言')
+      expect(screen.getByTestId('config-error').textContent).toBe('')
+      expect(configClient.saveConfig).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
     }
+  })
 
-    render(
-      <I18nProvider configClient={configClient} initialLocale="zh">
-        <LanguageProbe />
-      </I18nProvider>
-    )
+  it('keeps English usable after exhausting config retries', async () => {
+    vi.useFakeTimers()
 
-    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+    try {
+      const configClient: I18nConfigClient = {
+        getConfig: vi.fn().mockRejectedValue(new Error('config unavailable')),
+        saveConfig: vi.fn()
+      }
 
-    expect(screen.getByTestId('locale').textContent).toBe('en')
-    expect(screen.getByTestId('label').textContent).toBe('Language')
-    expect(configClient.saveConfig).not.toHaveBeenCalled()
+      render(
+        <I18nProvider configClient={configClient} initialLocale="zh">
+          <LanguageProbe />
+        </I18nProvider>
+      )
+
+      await vi.runAllTimersAsync()
+      vi.useRealTimers()
+      await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+
+      expect(configClient.getConfig).toHaveBeenCalledTimes(5)
+      expect(screen.getByTestId('locale').textContent).toBe('en')
+      expect(screen.getByTestId('label').textContent).toBe('Language')
+      expect(screen.getByTestId('config-error').textContent).toBe('config unavailable')
+      expect(configClient.saveConfig).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('loads zh-hant from display.language config', async () => {

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -55,6 +55,13 @@ function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error))
 }
 
+const CONFIG_LOAD_MAX_ATTEMPTS = 5
+const CONFIG_LOAD_RETRY_BASE_DELAY_MS = 250
+
+function getConfigLoadRetryDelayMs(attempt: number): number {
+  return CONFIG_LOAD_RETRY_BASE_DELAY_MS * 2 ** attempt
+}
+
 export interface I18nContextValue {
   configLoadError: Error | null
   isLoadingConfig: boolean
@@ -100,31 +107,75 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
     }
 
     let cancelled = false
+    let retryTimer: ReturnType<typeof globalThis.setTimeout> | null = null
+    let resolveRetryWait: (() => void) | null = null
+
+    const finishRetryWait = () => {
+      const resolve = resolveRetryWait
+      resolveRetryWait = null
+      resolve?.()
+    }
+
+    const waitForRetry = (ms: number) =>
+      new Promise<void>(resolve => {
+        resolveRetryWait = resolve
+        retryTimer = globalThis.setTimeout(() => {
+          retryTimer = null
+          finishRetryWait()
+        }, ms)
+      })
 
     setIsLoadingConfig(true)
     setConfigLoadError(null)
 
-    configClient
-      .getConfig()
-      .then(config => {
-        if (!cancelled) {
-          setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
+    void (async () => {
+      let lastError: Error | null = null
+
+      for (let attempt = 0; attempt < CONFIG_LOAD_MAX_ATTEMPTS; attempt += 1) {
+        try {
+          const config = await configClient.getConfig()
+
+          if (!cancelled) {
+            setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
+          }
+
+          return
+        } catch (error) {
+          lastError = toError(error)
+
+          if (cancelled) {
+            return
+          }
+
+          if (attempt < CONFIG_LOAD_MAX_ATTEMPTS - 1) {
+            await waitForRetry(getConfigLoadRetryDelayMs(attempt))
+
+            if (cancelled) {
+              return
+            }
+          }
         }
-      })
-      .catch(error => {
-        if (!cancelled) {
-          setConfigLoadError(toError(error))
-          setLocaleState(DEFAULT_LOCALE)
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoadingConfig(false)
-        }
-      })
+      }
+
+      if (!cancelled && lastError) {
+        setConfigLoadError(lastError)
+        setLocaleState(DEFAULT_LOCALE)
+      }
+    })().finally(() => {
+      if (!cancelled) {
+        setIsLoadingConfig(false)
+      }
+    })
 
     return () => {
       cancelled = true
+
+      if (retryTimer !== null) {
+        globalThis.clearTimeout(retryTimer)
+        retryTimer = null
+      }
+
+      finishRetryWait()
     }
   }, [configClient, initialLocale])
 


### PR DESCRIPTION
## Summary
- retry the desktop i18n config fetch during renderer startup instead of locking into the default locale after the first transient backend miss
- only surface the config-load error after all startup retries are exhausted
- cover both transient recovery and final fallback in the i18n provider tests

Closes #42781

## Verification
- npm run test:ui --workspace apps/desktop -- --run src/i18n/context.test.tsx
- ../../node_modules/.bin/eslint src/i18n/context.tsx src/i18n/context.test.tsx
- git diff --check

Proof: `.paperclip_artifacts/quality-gate/proof-aca450c2043e5cbd5c5e121d447c8f7c9319b94b.json`