### PR TITLE
fix(agent): strip NUL bytes and repair fragmented Unicode escapes in tool-call arguments

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -203,6 +203,23 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
         logger.warning("Sanitized Python-None tool_call arguments for %s", tool_name)
         return "{}"
 
+    # Repair pass -1: strip NUL bytes and normalise fragmented Unicode
+    # escapes.  Some models emit ``\\^@e5`` where ``å`` (\\u00e5) was
+    # intended — the ``\\^@`` decodes to a NUL byte followed by literal
+    # hex text.  Because the result is still valid JSON, the normal
+    # json.loads fast-path accepts it and the corrupted string reaches
+    # the tool silently.  NUL bytes are never legitimate inside tool-call
+    # arguments, so we can safely strip them unconditionally (#42801).
+    if "\x00" in raw_stripped:
+        # First try to repair fragmented escapes: \\^@XX -> \\u00XX
+        repaired_escapes = re.sub(r'\x00([0-9a-fA-F]{2})', r'\\u00\1', raw_stripped)
+        # Then strip any remaining lone NUL bytes
+        raw_stripped = repaired_escapes.replace('\x00', '')
+        logger.warning(
+            "Stripped NUL bytes from tool_call arguments for %s",
+            tool_name,
+        )
+
     # Repair pass 0: llama.cpp backends sometimes emit literal control
     # characters (tabs, newlines) inside JSON string values. json.loads
     # with strict=False accepts these and lets us re-serialise the

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -140,3 +140,52 @@ class TestRepairToolCallArguments:
         parsed = json.loads(result)
         assert "line" in parsed["msg"]
 
+    # -- Stage -1: NUL byte / fragmented Unicode escape repair --
+
+    def test_nul_byte_stripped_from_valid_json(self):
+        """NUL bytes inside valid JSON are stripped transparently."""
+        # "Ume\x00" -> "Ume" (lone NUL at end of string value)
+        raw = '{"query": "Ume\x00"}'
+        result = _repair_tool_call_arguments(raw, "t")
+        parsed = json.loads(result)
+        assert parsed["query"] == "Ume"
+
+    def test_fragmented_nul_hex_repaired_to_unicode(self):
+        """\\x00 + hex digits is repaired to \\u00XX unicode escape."""
+        # Model emits NUL + "e5" where å (\u00e5) was intended
+        raw = '{"query": "Ume\x00e5"}'
+        result = _repair_tool_call_arguments(raw, "t")
+        parsed = json.loads(result)
+        assert parsed["query"] == "Ume\u00e5"  # Umeå
+
+    def test_multiple_nul_bytes_repaired(self):
+        """Multiple NUL bytes in the same string are all handled."""
+        # \x00e5 = å, \x00f6 = ö
+        raw = '{"query": "Ume\x00e5 and \x00f6"}'
+        result = _repair_tool_call_arguments(raw, "t")
+        parsed = json.loads(result)
+        assert parsed["query"] == "Ume\u00e5 and \u00f6"  # Umeå and ö
+        assert "\x00" not in parsed["query"]
+
+    def test_nul_byte_with_non_hex_following_stripped(self):
+        """NUL byte followed by non-hex text is stripped as lone NUL."""
+        raw = '{"query": "test\x00value"}'
+        result = _repair_tool_call_arguments(raw, "t")
+        parsed = json.loads(result)
+        assert parsed["query"] == "testvalue"
+
+    def test_nul_byte_in_already_malformed_json(self):
+        """NUL bytes are stripped even when JSON also has other issues."""
+        # Trailing comma + NUL byte
+        raw = '{"query": "Ume\x00e5",}'
+        result = _repair_tool_call_arguments(raw, "t")
+        parsed = json.loads(result)
+        assert parsed["query"] == "Ume\u00e5"
+
+    def test_no_nul_bytes_unchanged(self):
+        """Strings without NUL bytes pass through normally."""
+        raw = '{"query": "Ume\u00e5"}'
+        result = _repair_tool_call_arguments(raw, "t")
+        parsed = json.loads(result)
+        assert parsed["query"] == "Ume\u00e5"
+


### PR DESCRIPTION
## What does this PR do?

Strips NUL bytes and repairs fragmented Unicode escapes in tool-call arguments before the JSON fast-path, preventing silent corruption of non-ASCII characters (e.g. Swedish å/ä/ö) that breaks downstream FTS, SQL, and semantic searches.

## Related Issue

Fixes #42801

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/message_sanitization.py`: Added "Repair pass -1" before the JSON fast-path that detects NUL bytes (`\x00`), repairs fragmented escapes (`\x00XX` → `\u00XX`), and strips remaining lone NUL bytes.
- `tests/run_agent/test_repair_tool_call_arguments.py`: Added 6 tests covering lone NUL stripping, fragmented escape repair, multiple NUL bytes, non-hex following NUL, NUL with other JSON malformations, and no-NUL passthrough.

## How to Test

1. Run `pytest tests/run_agent/test_repair_tool_call_arguments.py -v` — all 27 tests should pass
2. The fragmented escape test (`test_fragmented_nul_hex_repaired_to_unicode`) verifies that `{"query": "Ume\x00e5"}` is repaired to `{"query": "Umeå"}` instead of the corrupted `{"query": "Ume\x00e5"}` passing through

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure string processing, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/message_sanitization.py::_repair_tool_call_arguments` (callers: 2 — `conversation_loop.py:1107`, `chat_completion_helpers.py:1922`)
- Blast radius: LOW — additive normalization pass before existing fast-path; no control flow changes to existing repairs
- Related patterns: `json.loads(strict=False)` fast-path accepts NUL bytes; the new pass runs before it to normalize
