### PR TITLE
feat(kanban): add event hooks for task state changes

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2266,20 +2266,28 @@ def create_task(
                         "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
                         (pid, task_id),
                     )
+                created_payload = {
+                    "assignee": assignee,
+                    "status": task_status,
+                    "parents": list(parents),
+                    "tenant": tenant,
+                    "branch_name": branch_name,
+                    "skills": list(skills_list) if skills_list else None,
+                    "goal_mode": bool(goal_mode) or None,
+                }
                 _append_event(
                     conn,
                     task_id,
                     "created",
-                    {
-                        "assignee": assignee,
-                        "status": task_status,
-                        "parents": list(parents),
-                        "tenant": tenant,
-                        "branch_name": branch_name,
-                        "skills": list(skills_list) if skills_list else None,
-                        "goal_mode": bool(goal_mode) or None,
-                    },
+                    created_payload,
                 )
+            _emit_kanban_hook_event(
+                conn,
+                "task:created",
+                task_id,
+                new_status=task_status,
+                extra=created_payload,
+            )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -2719,6 +2727,91 @@ def _append_event(
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
     )
+
+
+def _connection_db_path(conn: sqlite3.Connection) -> Optional[Path]:
+    """Return the resolved on-disk path for ``conn``'s main database."""
+    try:
+        rows = conn.execute("PRAGMA database_list").fetchall()
+    except sqlite3.Error:
+        return None
+    for row in rows:
+        name = row[1] if not isinstance(row, sqlite3.Row) else row["name"]
+        if name != "main":
+            continue
+        raw_path = row[2] if not isinstance(row, sqlite3.Row) else row["file"]
+        if not raw_path:
+            return None
+        try:
+            return Path(str(raw_path)).resolve()
+        except OSError:
+            return Path(str(raw_path))
+    return None
+
+
+def _infer_board_for_connection(conn: sqlite3.Connection) -> Optional[str]:
+    """Best-effort board slug for a live connection.
+
+    ``sqlite3.Connection`` does not carry arbitrary metadata, so infer the board
+    by matching the connection's database path against known kanban board paths.
+    Returns ``None`` when the path does not correspond to a named board (e.g. a
+    bespoke test DB opened via explicit ``db_path=...``).
+    """
+    db_path = _connection_db_path(conn)
+    if db_path is None:
+        return None
+
+    candidates: list[str] = []
+    current = get_current_board()
+    if current:
+        candidates.append(current)
+    candidates.append(DEFAULT_BOARD)
+    for meta in list_boards(include_archived=True):
+        slug = str(meta.get("slug") or "").strip()
+        if slug and slug not in candidates:
+            candidates.append(slug)
+
+    seen: set[str] = set()
+    for slug in candidates:
+        if slug in seen:
+            continue
+        seen.add(slug)
+        try:
+            if kanban_db_path(board=slug).resolve() == db_path:
+                return slug
+        except (OSError, ValueError):
+            continue
+    return None
+
+
+def _emit_kanban_hook_event(
+    conn: sqlite3.Connection,
+    event_type: str,
+    task_id: str,
+    *,
+    previous_status: Optional[str] = None,
+    new_status: Optional[str] = None,
+    extra: Optional[dict] = None,
+) -> None:
+    """Fire a best-effort kanban hook event after the DB mutation commits."""
+    context: dict[str, Any] = {"task_id": task_id}
+    board = _infer_board_for_connection(conn)
+    if board is not None:
+        context["board"] = board
+    if previous_status is not None:
+        context["previous_status"] = previous_status
+    if new_status is not None:
+        context["new_status"] = new_status
+    if extra:
+        for key, value in extra.items():
+            if value is not None:
+                context[key] = value
+    try:
+        from kanban_hooks import emit_kanban_event
+
+        emit_kanban_event(event_type, context)
+    except Exception:
+        _log.exception("failed to emit kanban hook %s for task %s", event_type, task_id)
 
 
 def _end_run(
@@ -3626,7 +3719,12 @@ def complete_task(
     else:
         verified_cards = []
 
+    previous_status: Optional[str] = None
+    completed_payload: dict = {}
+    ev_summary = ""
     with write_txn(conn):
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        previous_status = row["status"] if row else None
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -3683,7 +3781,7 @@ def complete_task(
         # full summary stays on the run row.
         ev_summary = (summary if summary is not None else result) or ""
         ev_summary = ev_summary.strip().splitlines()[0][:400] if ev_summary else ""
-        completed_payload: dict = {
+        completed_payload = {
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
         }
@@ -3708,6 +3806,14 @@ def complete_task(
             completed_payload,
             run_id=run_id,
         )
+    _emit_kanban_hook_event(
+        conn,
+        "task:completed",
+        task_id,
+        previous_status=previous_status,
+        new_status="done",
+        extra=completed_payload,
+    )
     # Prose-scan the summary + result for t_<hex> references that do
     # not resolve. Advisory — does not block the completion. Runs in
     # its own txn so the completion itself is already durable by the
@@ -4052,7 +4158,10 @@ def block_task(
     expected_run_id: Optional[int] = None,
 ) -> bool:
     """Transition ``running -> blocked``."""
+    previous_status: Optional[str] = None
     with write_txn(conn):
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        previous_status = row["status"] if row else None
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -4096,7 +4205,15 @@ def block_task(
                 summary=reason,
             )
         _append_event(conn, task_id, "blocked", {"reason": reason}, run_id=run_id)
-        return True
+    _emit_kanban_hook_event(
+        conn,
+        "task:blocked",
+        task_id,
+        previous_status=previous_status,
+        new_status="blocked",
+        extra={"reason": reason},
+    )
+    return True
 
 
 
@@ -4181,11 +4298,15 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     state) holds for the rest of this function's lifetime.
     """
     now = int(time.time())
+    previous_status: Optional[str] = None
+    emitted_status: Optional[str] = None
     with write_txn(conn):
         stale = conn.execute(
             "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (task_id,),
         ).fetchone()
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        previous_status = row["status"] if row else None
         if stale and stale["current_run_id"]:
             conn.execute(
                 """
@@ -4223,7 +4344,15 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             conn, task_id, "unblocked",
             {"status": new_status} if new_status != "ready" else None,
         )
-        return True
+        emitted_status = new_status
+    _emit_kanban_hook_event(
+        conn,
+        "task:unblocked",
+        task_id,
+        previous_status=previous_status,
+        new_status=emitted_status,
+    )
+    return True
 
 
 def specify_triage_task(

--- a/kanban_hooks.py
+++ b/kanban_hooks.py
@@ -1,0 +1,257 @@
+"""Kanban event hook loader and async dispatcher.
+
+Mirrors the gateway hook pattern but is scoped to kanban lifecycle events.
+Kanban DB mutations call ``emit_kanban_event()`` from synchronous code paths,
+so dispatch is offloaded onto a dedicated background event loop thread.
+
+Operational notes:
+- hooks are discovered when the singleton registry is first created; new or
+  changed hooks are picked up on the next Hermes process start, not hot-reloaded
+  into an already-running process.
+- the dispatcher thread is daemonized on purpose; it lives for the lifetime of
+  the current Hermes process and is torn down explicitly only in tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import logging
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import yaml
+
+from hermes_constants import get_hermes_home
+
+
+_log = logging.getLogger(__name__)
+
+KANBAN_HOOKS_DIR = get_hermes_home() / "kanban-hooks"
+SUPPORTED_EVENTS = frozenset(
+    {
+        "task:blocked",
+        "task:unblocked",
+        "task:completed",
+        "task:created",
+    }
+)
+
+
+class HookRegistry:
+    """Singleton kanban hook registry."""
+
+    _instance: "HookRegistry | None" = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._handlers: Dict[str, List[Callable[..., Any]]] = {}
+        self._loaded_hooks: List[dict] = []
+        self.discover_and_load()
+
+    @property
+    def loaded_hooks(self) -> List[dict]:
+        return list(self._loaded_hooks)
+
+    @classmethod
+    def instance(cls) -> "HookRegistry":
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls()
+            return cls._instance
+
+    @classmethod
+    def reset_for_tests(cls) -> None:
+        _shutdown_dispatcher_for_tests()
+        with cls._instance_lock:
+            cls._instance = None
+
+    def discover_and_load(self) -> None:
+        hooks_dir = get_hermes_home() / "kanban-hooks"
+        if not hooks_dir.exists():
+            return
+
+        for hook_dir in sorted(hooks_dir.iterdir()):
+            if not hook_dir.is_dir():
+                continue
+
+            manifest_path = hook_dir / "HOOK.yaml"
+            handler_path = hook_dir / "handler.py"
+            if not manifest_path.exists() or not handler_path.exists():
+                continue
+
+            try:
+                manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+                if not isinstance(manifest, dict):
+                    _log.warning("[kanban-hooks] Skipping %s: invalid HOOK.yaml", hook_dir.name)
+                    continue
+
+                hook_name = str(manifest.get("name") or hook_dir.name)
+                events = manifest.get("events") or []
+                if not isinstance(events, list):
+                    _log.warning("[kanban-hooks] Skipping %s: events must be a list", hook_name)
+                    continue
+                filtered_events = [
+                    str(event).strip() for event in events
+                    if str(event).strip() in SUPPORTED_EVENTS or str(event).strip() == "task:*"
+                ]
+                if not filtered_events:
+                    _log.warning("[kanban-hooks] Skipping %s: no supported events declared", hook_name)
+                    continue
+
+                module_name = f"hermes_kanban_hook_{hook_name.replace('-', '_')}"
+                spec = importlib.util.spec_from_file_location(module_name, handler_path)
+                if spec is None or spec.loader is None:
+                    _log.warning("[kanban-hooks] Skipping %s: could not load handler.py", hook_name)
+                    continue
+
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = module
+                try:
+                    spec.loader.exec_module(module)
+                except Exception:
+                    sys.modules.pop(module_name, None)
+                    raise
+
+                handle_fn = getattr(module, "handle", None)
+                if handle_fn is None:
+                    _log.warning("[kanban-hooks] Skipping %s: no 'handle' function found", hook_name)
+                    continue
+
+                for event in filtered_events:
+                    self._handlers.setdefault(event, []).append(handle_fn)
+
+                self._loaded_hooks.append(
+                    {
+                        "name": hook_name,
+                        "description": str(manifest.get("description") or ""),
+                        "events": filtered_events,
+                        "path": str(hook_dir),
+                    }
+                )
+            except Exception:
+                _log.exception("[kanban-hooks] Error loading hook %s", hook_dir.name)
+
+    def _resolve_handlers(self, event_type: str) -> List[Callable[..., Any]]:
+        handlers = list(self._handlers.get(event_type, []))
+        if ":" in event_type:
+            wildcard_key = f"{event_type.split(':', 1)[0]}:*"
+            handlers.extend(self._handlers.get(wildcard_key, []))
+        return handlers
+
+    async def emit(self, event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
+        if context is None:
+            context = {}
+        for fn in self._resolve_handlers(event_type):
+            try:
+                result = fn(event_type, context)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception:
+                _log.exception("[kanban-hooks] Error in handler for %s", event_type)
+
+
+_dispatcher_lock = threading.Lock()
+_dispatcher_loop: asyncio.AbstractEventLoop | None = None
+_dispatcher_thread: threading.Thread | None = None
+_dispatcher_ready: threading.Event | None = None
+_pending_futures: set[Any] = set()
+
+
+def _dispatcher_main(ready: threading.Event) -> None:
+    global _dispatcher_loop
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    _dispatcher_loop = loop
+    ready.set()
+    try:
+        loop.run_forever()
+    finally:
+        pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.close()
+        _dispatcher_loop = None
+
+
+def _ensure_dispatcher_loop() -> asyncio.AbstractEventLoop:
+    global _dispatcher_thread, _dispatcher_ready
+    with _dispatcher_lock:
+        loop = _dispatcher_loop
+        if loop is not None and loop.is_running():
+            return loop
+        ready = threading.Event()
+        thread = threading.Thread(
+            target=_dispatcher_main,
+            args=(ready,),
+            name="kanban-hooks-dispatcher",
+            daemon=True,
+        )
+        _dispatcher_ready = ready
+        _dispatcher_thread = thread
+        thread.start()
+    ready.wait(timeout=2.0)
+    loop = _dispatcher_loop
+    if loop is None:
+        raise RuntimeError("kanban hook dispatcher failed to start")
+    return loop
+
+
+def _track_future(future: Any) -> None:
+    _pending_futures.add(future)
+
+    def _done(done_future: Any) -> None:
+        _pending_futures.discard(done_future)
+        try:
+            done_future.result()
+        except Exception:
+            _log.exception("[kanban-hooks] Background dispatch failed")
+
+    future.add_done_callback(_done)
+
+
+def emit_kanban_event(event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
+    """Queue a kanban hook event for background delivery.
+
+    Safe to call from synchronous DB mutation paths. Unsupported events are ignored.
+    """
+    if event_type not in SUPPORTED_EVENTS:
+        return
+    registry = HookRegistry.instance()
+    if not registry._resolve_handlers(event_type):
+        return
+    loop = _ensure_dispatcher_loop()
+    future = asyncio.run_coroutine_threadsafe(registry.emit(event_type, dict(context or {})), loop)
+    _track_future(future)
+
+
+def wait_for_pending_events(timeout: float = 2.0) -> None:
+    """Test helper: wait until the current pending hook queue drains."""
+    deadline = time.time() + max(0.0, float(timeout))
+    while True:
+        pending = list(_pending_futures)
+        if not pending:
+            return
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            raise TimeoutError("timed out waiting for kanban hook dispatch")
+        pending[0].result(timeout=remaining)
+
+
+def _shutdown_dispatcher_for_tests() -> None:
+    global _dispatcher_thread, _dispatcher_ready
+    with _dispatcher_lock:
+        loop = _dispatcher_loop
+        thread = _dispatcher_thread
+        _dispatcher_thread = None
+        _dispatcher_ready = None
+    if loop is not None and loop.is_running():
+        loop.call_soon_threadsafe(loop.stop)
+    if thread is not None:
+        thread.join(timeout=2.0)
+    _pending_futures.clear()

--- a/tests/hermes_cli/test_kanban_hooks.py
+++ b/tests/hermes_cli/test_kanban_hooks.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from kanban_hooks import HookRegistry, emit_kanban_event, wait_for_pending_events
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture(autouse=True)
+def reset_hook_registry():
+    HookRegistry.reset_for_tests()
+    yield
+    HookRegistry.reset_for_tests()
+
+
+def _create_hook(home: Path, hook_name: str, events: list[str], sink_path: Path) -> None:
+    hook_dir = home / "kanban-hooks" / hook_name
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text(
+        "name: {name}\n"
+        "description: test hook\n"
+        "events:\n{events_block}".format(
+            name=hook_name,
+            events_block="".join(f"  - {event}\n" for event in events),
+        ),
+        encoding="utf-8",
+    )
+    (hook_dir / "handler.py").write_text(
+        "import json\n"
+        "from pathlib import Path\n\n"
+        f"SINK = Path({str(sink_path)!r})\n\n"
+        "def handle(event_type, context):\n"
+        "    SINK.parent.mkdir(parents=True, exist_ok=True)\n"
+        "    with SINK.open('a', encoding='utf-8') as fh:\n"
+        "        fh.write(json.dumps({'event_type': event_type, 'context': context}, sort_keys=True) + '\\n')\n",
+        encoding="utf-8",
+    )
+
+
+def _read_events(sink_path: Path) -> list[dict]:
+    if not sink_path.exists():
+        return []
+    return [json.loads(line) for line in sink_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_emit_kanban_event_dispatches_only_matching_hooks(kanban_home, tmp_path):
+    sink = tmp_path / "events.jsonl"
+    _create_hook(kanban_home, "blocked-only", ["task:blocked"], sink)
+    _create_hook(kanban_home, "completed-only", ["task:completed"], sink)
+
+    emit_kanban_event("task:blocked", {"task_id": "t_demo", "board": "default"})
+    wait_for_pending_events(timeout=2.0)
+
+    events = _read_events(sink)
+    assert len(events) == 1
+    assert events[0]["event_type"] == "task:blocked"
+    assert events[0]["context"]["task_id"] == "t_demo"
+
+
+@pytest.mark.parametrize(
+    ("event_name", "mutate", "assert_context"),
+    [
+        (
+            "task:created",
+            lambda conn: kb.create_task(conn, title="created", assignee="alice"),
+            lambda event, task_id: (
+                event["context"]["task_id"] == task_id
+                and event["context"]["board"] == "default"
+                and event["context"]["new_status"] == "ready"
+                and event["context"]["assignee"] == "alice"
+            ),
+        ),
+        (
+            "task:blocked",
+            lambda conn: (lambda tid: (kb.block_task(conn, tid, reason="need help"), tid)[1])(
+                kb.create_task(conn, title="blocked")
+            ),
+            lambda event, task_id: (
+                event["context"]["task_id"] == task_id
+                and event["context"]["previous_status"] == "ready"
+                and event["context"]["new_status"] == "blocked"
+                and event["context"]["reason"] == "need help"
+            ),
+        ),
+        (
+            "task:completed",
+            lambda conn: (lambda tid: (kb.complete_task(conn, tid, summary="done summary"), tid)[1])(
+                kb.create_task(conn, title="completed")
+            ),
+            lambda event, task_id: (
+                event["context"]["task_id"] == task_id
+                and event["context"]["previous_status"] == "ready"
+                and event["context"]["new_status"] == "done"
+                and event["context"]["summary"] == "done summary"
+            ),
+        ),
+        (
+            "task:unblocked",
+            lambda conn: (lambda tid: (kb.block_task(conn, tid, reason="wait"), kb.unblock_task(conn, tid), tid)[2])(
+                kb.create_task(conn, title="unblocked")
+            ),
+            lambda event, task_id: (
+                event["context"]["task_id"] == task_id
+                and event["context"]["previous_status"] == "blocked"
+                and event["context"]["new_status"] == "ready"
+            ),
+        ),
+    ],
+)
+def test_kanban_db_transitions_emit_hook_events(
+    kanban_home,
+    tmp_path,
+    event_name,
+    mutate,
+    assert_context,
+):
+    sink = tmp_path / f"{event_name.replace(':', '_')}.jsonl"
+    _create_hook(kanban_home, event_name.replace(":", "-"), [event_name], sink)
+
+    with kb.connect() as conn:
+        task_id = mutate(conn)
+
+    wait_for_pending_events(timeout=2.0)
+    events = _read_events(sink)
+
+    assert len(events) == 1
+    assert events[0]["event_type"] == event_name
+    assert assert_context(events[0], task_id)


### PR DESCRIPTION
## Summary
Adds an event-driven kanban hook system for task lifecycle changes so Hermes can react immediately to board state transitions without relying on polling-style watchers.

This follows the existing Hermes hook pattern (`HOOK.yaml` + `handler.py`) and wires event emission into the real kanban DB mutation layer.

## Problem
Hermes already has cron jobs and webhook subscriptions, but kanban task-state automation still leans on external polling watchers for important follow-up behavior such as blocked-task remediation.

That creates avoidable latency and makes task escalation feel less native than Hermes' existing event-driven systems.

## What this PR adds
- new `kanban_hooks.py` runtime for kanban-scoped hook discovery and dispatch
- support for loading hooks from `~/.hermes/kanban-hooks/<hook-name>/`
- support for `HOOK.yaml` + `handler.py`
- best-effort background dispatch from synchronous kanban DB code paths
- event emission for:
  - `task:created`
  - `task:blocked`
  - `task:unblocked`
  - `task:completed`
- targeted regression tests for hook loading and emitted payloads

## Design notes
- additive only; existing kanban CLI and dashboard behavior do not change
- hook failures are isolated and do not fail the core kanban mutation path
- uses a dedicated background asyncio loop thread so sync DB mutations can emit safely even without an ambient event loop
- hook discovery happens on process start; hot reload is intentionally out of scope for this MVP

## Why this is useful
This adds the missing event boundary for kanban so Hermes can prefer event/state-driven automation first, while still keeping cron for reconciliation, audits, watchdogs, and systems that cannot push events.

## Validation
Ran locally with:

```bash
uv run --python 3.13 --extra dev pytest tests/hermes_cli/test_kanban_hooks.py -q
uv run --python 3.13 --extra dev pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_hooks.py -q
```

Observed results:
- `5 passed` in the targeted hook suite
- `216 passed` in the broader kanban regression suite

## Reviewer focus
Please review:
1. whether `~/.hermes/kanban-hooks/` is the right extension location
2. whether `kanban_db.py` is the right emission boundary
3. whether the background loop design is the right async-safety tradeoff
4. whether the emitted payload should be broadened or narrowed before merge
5. whether Hermes should ship a reference example hook in docs only, or as an optional built-in sample

## Non-goals
This PR does not try to:
- replace cron jobs globally
- turn kanban into a workflow engine
- add retry orchestration, rate limiting, or policy routing to the hook layer
- hot-reload hooks into an already-running Hermes process
