### PR TITLE
fix(usage): report active pool entry usage instead of singleton

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
-from hermes_cli.auth import _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.auth import resolve_codex_runtime_credentials
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 if TYPE_CHECKING:
@@ -350,9 +350,7 @@ def _resolve_codex_usage_url(base_url: str) -> str:
 
 def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
     creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-    token_data = _read_codex_tokens()
-    tokens = token_data.get("tokens") or {}
-    account_id = str(tokens.get("account_id", "") or "").strip() or None
+    account_id = creds.get("account_id")
     headers = {
         "Authorization": f"Bearer {creds['api_key']}",
         "Accept": "application/json",

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -122,6 +122,7 @@ _EXTRA_KEYS = frozenset({
     "token_type", "scope", "client_id", "portal_base_url", "obtained_at",
     "expires_in", "agent_key_id", "agent_key_expires_in", "agent_key_reused",
     "agent_key_obtained_at", "tls", "secret_source", "secret_fingerprint",
+    "account_id",
 })
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3627,7 +3627,8 @@ def resolve_codex_runtime_credentials(
     try:
         data = _read_codex_tokens()
     except AuthError:
-        pool_token = _pool_codex_access_token()
+        pool_result = _pool_codex_access_token()
+        pool_token = pool_result.get("access_token", "")
         if pool_token:
             base_url = (
                 os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
@@ -3640,6 +3641,7 @@ def resolve_codex_runtime_credentials(
                 "source": "credential_pool",
                 "last_refresh": None,
                 "auth_mode": "chatgpt",
+                "account_id": pool_result.get("account_id"),
             }
         raise
 
@@ -3670,6 +3672,8 @@ def resolve_codex_runtime_credentials(
         or DEFAULT_CODEX_BASE_URL
     )
 
+    account_id = str(tokens.get("account_id", "") or "").strip() or None
+
     return {
         "provider": "openai-codex",
         "base_url": base_url,
@@ -3677,28 +3681,32 @@ def resolve_codex_runtime_credentials(
         "source": "hermes-auth-store",
         "last_refresh": data.get("last_refresh"),
         "auth_mode": "chatgpt",
+        "account_id": account_id,
     }
 
 
-def _pool_codex_access_token() -> str:
-    """Return the most-recent usable access_token from the openai-codex pool.
+def _pool_codex_access_token() -> Dict[str, Any]:
+    """Return the most-recent usable entry from the openai-codex pool.
+
+    Returns a dict with ``access_token`` (str) and optionally ``account_id``
+    (str | None) from the first usable pool entry.  Returns
+    ``{"access_token": ""}`` when no usable entry is found (caller handles by
+    raising the original AuthError).
 
     Used as a fallback by ``resolve_codex_runtime_credentials`` when the
     singleton has no creds.  Reads ``credential_pool.openai-codex`` entries
     directly from auth.json and picks the first non-empty access_token,
     preferring entries that are not currently in an exhaustion cooldown.
-    Returns ``""`` when no usable entry is found (caller handles by raising
-    the original AuthError).
     """
     try:
         with _auth_store_lock():
             auth_store = _load_auth_store()
         pool = auth_store.get("credential_pool")
         if not isinstance(pool, dict):
-            return ""
+            return {"access_token": ""}
         entries = pool.get("openai-codex")
         if not isinstance(entries, list):
-            return ""
+            return {"access_token": ""}
 
         def _entry_usable(entry: Dict[str, Any]) -> bool:
             if not isinstance(entry, dict):
@@ -3714,10 +3722,14 @@ def _pool_codex_access_token() -> str:
 
         for entry in entries:
             if _entry_usable(entry):
-                return str(entry.get("access_token", "")).strip()
+                account_id = str(entry.get("account_id", "") or "").strip() or None
+                return {
+                    "access_token": str(entry.get("access_token", "")).strip(),
+                    "account_id": account_id,
+                }
     except Exception:
         logger.debug("Codex pool fallback lookup failed", exc_info=True)
-    return ""
+    return {"access_token": ""}
 
 
 # =============================================================================

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -56,11 +56,8 @@ def test_fetch_account_usage_codex(monkeypatch):
             "provider": "openai-codex",
             "base_url": "https://chatgpt.com/backend-api/codex",
             "api_key": "access-token",
+            "account_id": "acct_123",
         },
-    )
-    monkeypatch.setattr(
-        "agent.account_usage._read_codex_tokens",
-        lambda: {"tokens": {"account_id": "acct_123"}},
     )
     monkeypatch.setattr(
         "agent.account_usage.httpx.Client",


### PR DESCRIPTION
Fixes #42798

When using multiple Codex accounts in the credential pool with
fill_first strategy, /usage always displayed Account 1's usage
even after the pool switched to Account 2. This happened because
_fetch_codex_account_usage() read account_id from the singleton
auth store (providers.openai-codex.tokens) instead of detecting
the active pool entry.

Three changes:

1. credential_pool.py: Added account_id to _EXTRA_KEYS so pool
   entries round-trip the field through JSON.

2. auth.py: _pool_codex_access_token() now returns account_id
   from the first usable pool entry alongside the access_token.
   resolve_codex_runtime_credentials() propagates account_id to
   its callers for both the singleton and pool-fallback paths.

3. account_usage.py: _fetch_codex_account_usage() reads account_id
   from resolve_codex_runtime_credentials() instead of calling
   _read_codex_tokens() separately.