### PR TITLE
fix(delegate): strip skills toolset from leaf subagents

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -145,7 +145,7 @@ class TestChildSystemPrompt(unittest.TestCase):
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):
-        result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution"])
+        result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution", "skills"])
         self.assertEqual(sorted(result), ["file", "terminal"])
 
     def test_preserves_allowed_toolsets(self):

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -46,12 +46,13 @@ class TestToolsetIntersection:
         assert "file" in child
         assert "web" in child
 
-    def test_strip_blocked_removes_delegation(self):
-        """Blocked toolsets (delegation, clarify, etc.) are always removed."""
-        child = _strip_blocked_tools(["terminal", "delegation", "clarify", "memory"])
+    def test_strip_blocked_removes_blocked(self):
+        """Blocked toolsets (delegation, clarify, memory, skills) are always removed."""
+        child = _strip_blocked_tools(["terminal", "delegation", "clarify", "memory", "skills"])
         assert "delegation" not in child
         assert "clarify" not in child
         assert "memory" not in child
+        assert "skills" not in child
         assert "terminal" in child
 
     def test_empty_intersection_yields_empty_toolsets(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -710,6 +710,7 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
         "clarify",
         "memory",
         "code_execution",
+        "skills",
     }
     return [t for t in toolsets if t not in blocked_toolset_names]
 


### PR DESCRIPTION
## Description

Adds `"skills"` to `_strip_blocked_tools()` in `delegate_tool.py` so leaf subagents don't inherit the skills toolset. Without this, the `<available_skills>` block (~2,800 tokens with ~115 skills) is injected into every child agent's system prompt, causing false context-overflow errors on models with tighter real context windows than configured.

The enabled_toolsets control which tools a subagent loads. The "skills" toolset brings skill_view, skill_manage, and skills_list — management tools a focused subagent doesn't need. When these tools aren't in the child's toolset, system_prompt.py:185-201 skips building the <available_skills> index entirely, saving ~2,800 tokens per subagent before its first API call.

## Changes

| File | Change |
|------|--------|
| `tools/delegate_tool.py` | Add `"skills"` to `blocked_toolset_names` in `_strip_blocked_tools()` |
| `tests/tools/test_delegate.py` | Update test input to include `"skills"` |
| `tests/tools/test_delegate_toolset_scope.py` | Add `"skills"` to input and assertion |

## Verification

All 4 logic paths tested against the extracted function:
- Skills removed from mixed toolset
- All blocked toolsets removed
- Empty input returns empty
- Allowed toolsets preserved

Fixes #42809