### PR TITLE
fix(stream): retry empty compatible streams without SSE

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2384,14 +2384,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             "stream" in _err_lower
                             and "not supported" in _err_lower
                         )
-                        if _is_stream_unsupported:
+                        _is_empty_stream_no_finish = (
+                            "provider returned an empty stream with no finish_reason"
+                            in _err_lower
+                        )
+                        if _is_stream_unsupported or _is_empty_stream_no_finish:
                             agent._disable_streaming = True
-                            agent._safe_print(
-                                "\n⚠  Streaming is not supported for this "
-                                "model/provider. Switching to non-streaming.\n"
-                                "   To avoid this delay, set display.streaming: false "
-                                "in config.yaml\n"
-                            )
+                            if _is_stream_unsupported:
+                                agent._safe_print(
+                                    "\n⚠  Streaming is not supported for this "
+                                    "model/provider. Switching to non-streaming.\n"
+                                    "   To avoid this delay, set display.streaming: false "
+                                    "in config.yaml\n"
+                                )
                         logger.info(
                             "Streaming failed before delivery: %s",
                             e,

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -472,8 +472,9 @@ class TestStreamingFallback:
     Previously, streaming errors triggered an inline fallback to
     non-streaming.  Now they propagate so the main retry loop can apply
     richer recovery (credential rotation, provider fallback, backoff).
-    The only special case: 'stream not supported' sets _disable_streaming
-    so the *next* main-loop retry uses non-streaming automatically.
+    The only special cases: 'stream not supported' and zero-chunk
+    empty-stream failures set _disable_streaming so the *next* main-loop
+    retry uses non-streaming automatically.
     """
 
     @patch("run_agent.AIAgent._create_request_openai_client")
@@ -530,6 +531,37 @@ class TestStreamingFallback:
 
         with pytest.raises(Exception, match="Connection reset by peer"):
             agent._interruptible_streaming_api_call({})
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_empty_stream_without_finish_reason_sets_flag_and_raises(
+        self, mock_close, mock_create
+    ):
+        """Zero-chunk stream errors switch the next retry to non-streaming."""
+        from run_agent import AIAgent
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter([])
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.greenpt.ai/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        with pytest.raises(
+            RuntimeError,
+            match="Provider returned an empty stream with no finish_reason",
+        ):
+            agent._interruptible_streaming_api_call({})
+
+        assert agent._disable_streaming is True
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")


### PR DESCRIPTION
## Summary
- switch empty zero-chunk streaming failures onto the existing non-streaming retry path instead of re-failing every streamed retry
- keep the empty-stream guard itself so malformed SSE responses still surface as errors instead of silent empty turns
- add regression coverage for the zero-chunk fallback flag alongside the existing streaming fallback tests

## Testing
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest -o addopts='' -q tests/run_agent/test_streaming.py -k 'TestStreamingFallback or test_text_only_response or test_tool_call_response'`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest -o addopts='' -q tests/run_agent/test_streaming.py -k 'test_empty_stream_without_finish_reason_sets_flag_and_raises'`
- `ruff check agent/chat_completion_helpers.py tests/run_agent/test_streaming.py`
- `git diff --check HEAD^ HEAD`

Closes #42810.
