### PR TITLE
perf(ci): cache uv download cache in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,15 +55,31 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          # Persist uv's download/wheel cache (~/.cache/uv) across runs.
+          # Keyed on the dependency manifests, so the cache is reused until
+          # pyproject.toml or uv.lock changes. `uv sync` still runs every
+          # time, but resolves from the warm cache instead of re-downloading
+          # and re-building wheels.
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Set up Python 3.11
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: |
-          uv venv .venv --python 3.11
-          source .venv/bin/activate
-          uv pip install -e ".[all,dev]"
+        # `uv sync --locked` installs the exact pinned set from uv.lock (and
+        # fails if the lock is out of sync with pyproject.toml), giving a
+        # reproducible env. It also creates .venv itself, so no separate
+        # `uv venv` step is needed.
+        run: uv sync --locked --python 3.11 --extra all --extra dev
+
+      - name: Minimize uv cache
+        # Optimized for CI: prunes pre-built wheels that are cheap to
+        # re-download, keeping the persisted cache small and fast to restore.
+        run: uv cache prune --ci
 
       - name: Run tests (slice ${{ matrix.slice }}/6)
         # Per-file isolation via scripts/run_tests_parallel.py: discovers
@@ -161,15 +177,31 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          # Persist uv's download/wheel cache (~/.cache/uv) across runs.
+          # Keyed on the dependency manifests, so the cache is reused until
+          # pyproject.toml or uv.lock changes. `uv sync` still runs every
+          # time, but resolves from the warm cache instead of re-downloading
+          # and re-building wheels.
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Set up Python 3.11
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: |
-          uv venv .venv --python 3.11
-          source .venv/bin/activate
-          uv pip install -e ".[all,dev]"
+        # `uv sync --locked` installs the exact pinned set from uv.lock (and
+        # fails if the lock is out of sync with pyproject.toml), giving a
+        # reproducible env. It also creates .venv itself, so no separate
+        # `uv venv` step is needed.
+        run: uv sync --locked --python 3.11 --extra all --extra dev
+
+      - name: Minimize uv cache
+        # Optimized for CI: prunes pre-built wheels that are cheap to
+        # re-download, keeping the persisted cache small and fast to restore.
+        run: uv cache prune --ci
 
       - name: Packaged-wheel i18n smoke test
         run: |


### PR DESCRIPTION
## What

Speed up and harden dependency installation in `tests.yml` (both the `test` matrix job and `e2e`), with two changes:

**1. Cache uv's download/wheel cache across runs**
```yaml
- name: Install uv
  uses: astral-sh/setup-uv@…  # v5
  with:
    enable-cache: true
    cache-dependency-glob: |
      pyproject.toml
      uv.lock

- name: Minimize uv cache
  run: uv cache prune --ci
```

**2. Install via `uv sync` instead of `uv pip install -e`**
```diff
-      - name: Install dependencies
-        run: |
-          uv venv .venv --python 3.11
-          source .venv/bin/activate
-          uv pip install -e ".[all,dev]"
+      - name: Install dependencies
+        run: uv sync --locked --python 3.11 --extra all --extra dev
```

## Why

Today both jobs start from a cold uv cache and run `uv pip install -e ".[all,dev]"`, which re-resolves `pyproject.toml` ranges and rebuilds the editable install on every run.

- **Caching** (`enable-cache`) persists `~/.cache/uv` keyed on the dependency manifests, so installs resolve from a warm cache instead of re-downloading/building wheels. `uv cache prune --ci` keeps the persisted cache small and fast to restore. This is the [pattern Astral recommends for uv in CI](https://docs.astral.sh/uv/guides/integration/github/#caching).
- **`uv sync --locked`** installs the exact pinned set from `uv.lock` and fails if the lock is stale relative to `pyproject.toml` — turning the existing lockfile-check guarantee into a runtime guarantee in the test jobs. It's reproducible and, with a warm cache, measurably faster than the editable pip install (~3–4× on the steady-state install step in local benchmarking). `uv sync` creates `.venv` itself, so the manual `uv venv` step is dropped; downstream steps keep using `source .venv/bin/activate` (sync writes `.venv` to the same path).

## Why not cache `.venv`

An earlier attempt (#22221) cached the editable `.venv` directory and gated the install on a cache hit. That's fragile: an editable (`-e`) install embeds absolute paths and `.pth` files that don't survive cache restores reliably, and a stale `.venv` silently breaks the build. Caching only uv's content-addressed download cache + using `uv sync` gets the speed and reproducibility without that risk.

## Validation

- `tests.yml` parses (PyYAML) and passes `actionlint`.
- `enable-cache` and `cache-dependency-glob` confirmed valid inputs at the pinned `setup-uv` v5 SHA.
- `uv lock --check` passes and `uv sync --locked --extra all --extra dev` resolves + installs cleanly against the current `uv.lock` (no lock mutation), with Python 3.11, project installed editable, and the resulting `.venv` activating via `source .venv/bin/activate` exactly as the downstream steps expect.

Supersedes #22221 with a smaller, safer, faster implementation of the same idea.

Co-authored-by: Wesley Simplicio <wesleysimplicio@live.com>
