### PR TITLE
fix(nix): move hermes-agent setup into ExecStartPre

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -4,7 +4,13 @@
 # transitive deps like onnxruntime that lack compatible wheels on
 # aarch64-darwin. The package and devShell still work on macOS.
 { inputs, ... }: {
-  perSystem = { pkgs, lib, self', ... }:
+  perSystem =
+    {
+      pkgs,
+      lib,
+      self',
+      ...
+    }:
     let
       hermes-agent = self'.packages.default;
       hermesVenv = hermes-agent.hermesVenv;
@@ -83,7 +89,8 @@
       # services.hermes-agent. The internal names that the module system adds
       # are not in the list.
       moduleOptionNames =
-        eval: lib.attrNames (lib.filterAttrs (n: _: !lib.hasPrefix "_" n) eval.options.services.hermes-agent);
+        eval:
+        lib.attrNames (lib.filterAttrs (n: _: !lib.hasPrefix "_" n) eval.options.services.hermes-agent);
 
       # These options belong to one module by design. The check does not
       # compare the two lists against each other, because that test only
@@ -104,52 +111,65 @@
       ];
 
       # Auto-generated config key reference — always in sync with Python
-      configKeys = pkgs.runCommand "hermes-config-keys" {} ''
-        set -euo pipefail
-        export HOME=$TMPDIR
-        ${hermesVenv}/bin/python3 -c '
-import json, sys
-from hermes_cli.config import DEFAULT_CONFIG
+      configKeys = pkgs.runCommand "hermes-config-keys" { } ''
+                set -euo pipefail
+                export HOME=$TMPDIR
+                ${hermesVenv}/bin/python3 -c '
+        import json, sys
+        from hermes_cli.config import DEFAULT_CONFIG
 
-def leaf_paths(d, prefix=""):
-    paths = []
-    for k, v in sorted(d.items()):
-        path = f"{prefix}.{k}" if prefix else k
-        if isinstance(v, dict) and v:
-            paths.extend(leaf_paths(v, path))
-        else:
-            paths.append(path)
-    return paths
+        def leaf_paths(d, prefix=""):
+            paths = []
+            for k, v in sorted(d.items()):
+                path = f"{prefix}.{k}" if prefix else k
+                if isinstance(v, dict) and v:
+                    paths.extend(leaf_paths(v, path))
+                else:
+                    paths.append(path)
+            return paths
 
-json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
-' > $out
+        json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
+        ' > $out
       '';
-    in {
+    in
+    {
       packages.configKeys = configKeys;
 
       checks = {
         # Cross-platform evaluation — catches "not supported for interpreter"
         # errors (e.g. sphinx dropping python311) without needing a darwin builder.
         # Evaluation is pure and instant; it doesn't build anything.
-        cross-eval = let
-          targetSystems = builtins.filter
-            (s: inputs.self.packages ? ${s})
-            [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
-          tryEvalPkg = sys:
-            let pkg = inputs.self.packages.${sys}.default;
-            in builtins.tryEval (builtins.seq pkg.drvPath true);
-          results = map (sys: { inherit sys; result = tryEvalPkg sys; }) targetSystems;
-          failures = builtins.filter (r: !r.result.success) results;
-          failMsg = lib.concatMapStringsSep "\n" (r: "  - ${r.sys}") failures;
-        in pkgs.runCommand "hermes-cross-eval" { } (
-          if failures != [] then
-            throw "Package fails to evaluate on:\n${failMsg}"
-          else ''
-            echo "PASS: package evaluates on all ${toString (builtins.length targetSystems)} platforms"
-            mkdir -p $out
-            echo "ok" > $out/result
-          ''
-        );
+        cross-eval =
+          let
+            targetSystems = builtins.filter (s: inputs.self.packages ? ${s}) [
+              "x86_64-linux"
+              "aarch64-linux"
+              "aarch64-darwin"
+              "x86_64-darwin"
+            ];
+            tryEvalPkg =
+              sys:
+              let
+                pkg = inputs.self.packages.${sys}.default;
+              in
+              builtins.tryEval (builtins.seq pkg.drvPath true);
+            results = map (sys: {
+              inherit sys;
+              result = tryEvalPkg sys;
+            }) targetSystems;
+            failures = builtins.filter (r: !r.result.success) results;
+            failMsg = lib.concatMapStringsSep "\n" (r: "  - ${r.sys}") failures;
+          in
+          pkgs.runCommand "hermes-cross-eval" { } (
+            if failures != [ ] then
+              throw "Package fails to evaluate on:\n${failMsg}"
+            else
+              ''
+                echo "PASS: package evaluates on all ${toString (builtins.length targetSystems)} platforms"
+                mkdir -p $out
+                echo "ok" > $out/result
+              ''
+          );
 
         # Verify the default package builds successfully (cross-platform).
         # On Linux the runtime checks below already depend on the package,
@@ -227,10 +247,12 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
             activation = cfg.home.activation.hermesAgentSetup.data;
 
             failures =
-              lib.optional (names != [
-                "hermes-agent"
-                "hermes-backend"
-              ]) "expected hermes-agent + hermes-backend processes, got: ${toString names}"
+              lib.optional (
+                names != [
+                  "hermes-agent"
+                  "hermes-backend"
+                ]
+              ) "expected hermes-agent + hermes-backend processes, got: ${toString names}"
               ++ lib.optional (
                 !lib.hasInfix "bin/hermes gateway" (argvOf "hermes-agent")
               ) "gateway process does not run `hermes gateway`: ${argvOf "hermes-agent"}"
@@ -240,9 +262,9 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
               ++ lib.optional (
                 !lib.hasInfix "--no-open" (argvOf "hermes-backend")
               ) "backend must pass --no-open so a service never opens a browser"
-              ++ lib.optional (
-                lib.any (n: !lib.hasInfix "/home/hermes-check/.hermes" (envOf n)) names
-              ) "gateway and backend must share one HERMES_HOME"
+              ++ lib.optional (lib.any (
+                n: !lib.hasInfix "/home/hermes-check/.hermes" (envOf n)
+              ) names) "gateway and backend must share one HERMES_HOME"
               ++ lib.optional (
                 cfg.home.sessionVariables.HERMES_HOME or null != "/home/hermes-check/.hermes"
               ) "programs.hermes-agent.enable must export HERMES_HOME for interactive shells"
@@ -342,9 +364,7 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
           in
           pkgs.runCommand "hermes-workspace-files-need-a-directory" { } (
             if failed != [ ] then
-              throw "workspace-files rule failed:\n${
-                lib.concatMapStringsSep "\n" (c: "  - ${c.name}") failed
-              }"
+              throw "workspace-files rule failed:\n${lib.concatMapStringsSep "\n" (c: "  - ${c.name}") failed}"
             else
               ''
                 ${lib.concatMapStringsSep "\n" (c: ''echo "PASS: ${c.name}"'') cases}
@@ -427,27 +447,29 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
               builtins.readFile path;
 
             failures =
-              lib.optional (
-                lib.length desktopPackages != 1
-              ) "programs.desktop.enable must install exactly one hermes-desktop package, got ${toString (lib.length desktopPackages)}"
-              ++ lib.optional (
-                setValue "HERMES_HOME" != "/home/hermes-check/.hermes-work"
-              ) "the launcher must carry HERMES_HOME: a GUI launcher reads no shell profile, so home.sessionVariables never reaches it (got: ${toString (setValue "HERMES_HOME")})"
-              ++ lib.optional (
-                setValue "HERMES_MANAGED" != "home-manager"
-              ) "the launcher must report HERMES_MANAGED=home-manager while the services own the configuration (got: ${toString (setValue "HERMES_MANAGED")})"
-              ++ lib.optional (
-                lib.length agentPackages == 1
-                && setValue "HERMES_DESKTOP_HERMES" != "${lib.head agentPackages}/bin/hermes"
-              ) "the launcher must pin the agent package that programs.enable installs, and not a second runtime: ${toString (setValue "HERMES_DESKTOP_HERMES")}"
+              lib.optional (lib.length desktopPackages != 1)
+                "programs.desktop.enable must install exactly one hermes-desktop package, got ${toString (lib.length desktopPackages)}"
+              ++
+                lib.optional (setValue "HERMES_HOME" != "/home/hermes-check/.hermes-work")
+                  "the launcher must carry HERMES_HOME: a GUI launcher reads no shell profile, so home.sessionVariables never reaches it (got: ${toString (setValue "HERMES_HOME")})"
+              ++
+                lib.optional (setValue "HERMES_MANAGED" != "home-manager")
+                  "the launcher must report HERMES_MANAGED=home-manager while the services own the configuration (got: ${toString (setValue "HERMES_MANAGED")})"
+              ++
+                lib.optional
+                  (
+                    lib.length agentPackages == 1
+                    && setValue "HERMES_DESKTOP_HERMES" != "${lib.head agentPackages}/bin/hermes"
+                  )
+                  "the launcher must pin the agent package that programs.enable installs, and not a second runtime: ${toString (setValue "HERMES_DESKTOP_HERMES")}"
 
               # ── The application reaches the backend of the service ──────
-              ++ lib.optional (
-                setValue "HERMES_DESKTOP_REMOTE_URL" != "http://127.0.0.1:9231"
-              ) "the launcher must name the backend of the service, or the application starts a second one (got: ${toString (setValue "HERMES_DESKTOP_REMOTE_URL")})"
-              ++ lib.optional (
-                !lib.hasInfix "HERMES_DESKTOP_REMOTE_TOKEN" wrapper
-              ) "the launcher must give a token with the URL: the desktop resolver throws when the URL is set alone"
+              ++
+                lib.optional (setValue "HERMES_DESKTOP_REMOTE_URL" != "http://127.0.0.1:9231")
+                  "the launcher must name the backend of the service, or the application starts a second one (got: ${toString (setValue "HERMES_DESKTOP_REMOTE_URL")})"
+              ++
+                lib.optional (!lib.hasInfix "HERMES_DESKTOP_REMOTE_TOKEN" wrapper)
+                  "the launcher must give a token with the URL: the desktop resolver throws when the URL is set alone"
               ++ lib.optional (
                 !lib.hasInfix "HERMES_DASHBOARD_SESSION_TOKEN" backendScript
               ) "the backend must read the session token, or it makes a new one that the application cannot know"
@@ -503,19 +525,17 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
               ++ lib.optional (
                 !lib.hasInfix "--set HERMES_HOME" wrapper
               ) "the launcher must carry HERMES_HOME even with no services"
-              ++ lib.optional (
-                lib.hasInfix "HERMES_MANAGED" wrapper
-              ) "the launcher must not claim a managed install when no activation writes one"
-              ++ lib.optional (
-                lib.hasInfix "HERMES_DESKTOP_REMOTE_URL" wrapper
-              ) "the launcher must not name a backend when the services run none"
+              ++ lib.optional (lib.hasInfix "HERMES_MANAGED" wrapper) "the launcher must not claim a managed install when no activation writes one"
+              ++ lib.optional (lib.hasInfix "HERMES_DESKTOP_REMOTE_URL" wrapper) "the launcher must not name a backend when the services run none"
               ++ lib.optional (
                 cfg.systemd.user.services ? hermes-backend || cfg.launchd.agents ? hermes-backend
               ) "programs.enable alone must start no service";
           in
           pkgs.runCommand "hermes-home-manager-desktop-standalone" { } (
             if failures != [ ] then
-              throw "Home Manager standalone desktop check failed:\n${lib.concatMapStringsSep "\n" (f: "  - ${f}") failures}"
+              throw "Home Manager standalone desktop check failed:\n${
+                lib.concatMapStringsSep "\n" (f: "  - ${f}") failures
+              }"
             else
               ''
                 echo "PASS: the application runs with no services, and claims nothing that no activation wrote"
@@ -569,9 +589,7 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
             failures =
               lib.concatMap (
                 case:
-                lib.optional (
-                  !refuses case.value
-                ) "installPackage = ${lib.boolToString case.value} must be refused"
+                lib.optional (!refuses case.value) "installPackage = ${lib.boolToString case.value} must be refused"
                 ++ lib.optional (
                   !lib.hasInfix case.expect (messageFor case.value)
                 ) "the message for installPackage = ${lib.boolToString case.value} must name `${case.expect}`"
@@ -588,7 +606,9 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
           in
           pkgs.runCommand "hermes-home-manager-install-package-removed" { } (
             if failures != [ ] then
-              throw "installPackage removal check failed:\n${lib.concatMapStringsSep "\n" (f: "  - ${f}") failures}"
+              throw "installPackage removal check failed:\n${
+                lib.concatMapStringsSep "\n" (f: "  - ${f}") failures
+              }"
             else
               ''
                 echo "PASS: installPackage is refused with guidance, and its absence evaluates"
@@ -621,18 +641,17 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
             staleHomeOnly = lib.subtractLists homeNames homeOnlyOptions;
 
             failures =
-              lib.optional (
-                missingInHome != [ ]
-              ) "shared options missing from the Home Manager module: ${toString missingInHome} (add to nix/moduleCommon.nix, or list under nixosOnlyOptions if system-scoped)"
-              ++ lib.optional (
-                missingInNixos != [ ]
-              ) "shared options missing from the NixOS module: ${toString missingInNixos} (add to nix/moduleCommon.nix, or list under homeOnlyOptions if user-scoped)"
+              lib.optional (missingInHome != [ ])
+                "shared options missing from the Home Manager module: ${toString missingInHome} (add to nix/moduleCommon.nix, or list under nixosOnlyOptions if system-scoped)"
+              ++
+                lib.optional (missingInNixos != [ ])
+                  "shared options missing from the NixOS module: ${toString missingInNixos} (add to nix/moduleCommon.nix, or list under homeOnlyOptions if user-scoped)"
               ++ lib.optional (
                 staleNixosOnly != [ ]
               ) "nixosOnlyOptions names options the NixOS module no longer defines: ${toString staleNixosOnly}"
-              ++ lib.optional (
-                staleHomeOnly != [ ]
-              ) "homeOnlyOptions names options the Home Manager module no longer defines: ${toString staleHomeOnly}";
+              ++
+                lib.optional (staleHomeOnly != [ ])
+                  "homeOnlyOptions names options the Home Manager module no longer defines: ${toString staleHomeOnly}";
           in
           pkgs.runCommand "hermes-module-option-parity" { } (
             if failures != [ ] then
@@ -644,30 +663,33 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
                 echo "ok" > $out/result
               ''
           );
-      } // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+      }
+      // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
         # ── The NixOS module ─────────────────────────────────────────────
         # This check runs on Linux only. The evaluation of a NixOS module
         # needs a Linux hostPlatform.
         nixos-module =
           let
-            cfg = (evalNixosModule {
-              enable = true;
-              backend.mode = "dashboard";
-              settings.model.default = "test/model";
-              environmentFiles = [ "/run/secrets/hermes-env" ];
-              hermesHomeFiles."SOUL.md" = "test soul";
-            }).config;
+            cfg =
+              (evalNixosModule {
+                enable = true;
+                backend.mode = "dashboard";
+                settings.model.default = "test/model";
+                environmentFiles = [ "/run/secrets/hermes-env" ];
+                hermesHomeFiles."SOUL.md" = "test soul";
+              }).config;
 
             units = lib.filterAttrs (n: _: lib.hasPrefix "hermes" n) cfg.systemd.services;
             names = lib.attrNames units;
             execOf = name: units.${name}.serviceConfig.ExecStart;
-            activation = cfg.system.activationScripts."hermes-agent-setup".text;
 
             failures =
-              lib.optional (names != [
-                "hermes-agent"
-                "hermes-backend"
-              ]) "expected hermes-agent + hermes-backend units, got: ${toString names}"
+              lib.optional (
+                names != [
+                  "hermes-agent"
+                  "hermes-backend"
+                ]
+              ) "expected hermes-agent + hermes-backend units, got: ${toString names}"
               ++ lib.optional (
                 !lib.hasInfix "bin/hermes gateway" (execOf "hermes-agent")
               ) "gateway unit does not run `hermes gateway`: ${execOf "hermes-agent"}"
@@ -676,10 +698,7 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
               ) "backend unit does not run `hermes dashboard`: ${execOf "hermes-backend"}"
               ++ lib.optional (
                 units.hermes-agent.environment.HERMES_HOME != units.hermes-backend.environment.HERMES_HOME
-              ) "gateway and backend must share one HERMES_HOME"
-              ++ lib.optional (
-                !lib.hasInfix "/var/lib/hermes/.hermes/SOUL.md" activation
-              ) "hermesHomeFiles must install into HERMES_HOME";
+              ) "gateway and backend must share one HERMES_HOME";
 
             # You cannot use container mode and the backend together. The
             # module says so with an assertion. Without the assertion it
@@ -719,7 +738,8 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
           let
             execOf =
               settings:
-              (evalNixosModule ({ enable = true; } // settings)).config.systemd.services.hermes-backend.serviceConfig.ExecStart;
+              (evalNixosModule ({ enable = true; } // settings))
+              .config.systemd.services.hermes-backend.serviceConfig.ExecStart;
 
             direct = execOf { backend.mode = "serve"; };
 
@@ -747,57 +767,62 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
             evalFails =
               settings:
               !(builtins.tryEval (
-                lib.deepSeq
-                  (evalNixosModule ({ enable = true; } // settings)).config.system.build.toplevel.drvPath
+                lib.deepSeq (evalNixosModule ({ enable = true; } // settings)).config.system.build.toplevel.drvPath
                   true
               )).success;
 
             failures =
               # The default must not change.
-              lib.optional (!lib.hasInfix "bin/hermes serve --host 127.0.0.1" direct)
-                "without waitFor the backend must exec hermes directly, got: ${direct}"
-              ++ lib.optional (lib.hasInfix "hermes-backend-launch" direct)
-                "without waitFor the backend must not use the launcher"
+              lib.optional (
+                !lib.hasInfix "bin/hermes serve --host 127.0.0.1" direct
+              ) "without waitFor the backend must exec hermes directly, got: ${direct}"
+              ++ lib.optional (lib.hasInfix "hermes-backend-launch" direct) "without waitFor the backend must not use the launcher"
 
               # The hostname mode polls the resolver, then binds the name.
-              ++ lib.optional (!lib.hasInfix "hermes-backend-launch" hostnameWait)
-                "waitFor = hostname must run the launcher, got: ${hostnameWait}"
-              ++ lib.optional (!lib.hasInfix "getent hosts" hostnameScript)
-                "the hostname launcher must poll with getent"
-              ++ lib.optional (!lib.hasInfix "host.example.ts.net" hostnameScript)
-                "the hostname launcher must poll for backend.host"
-              ++ lib.optional (!lib.hasInfix "exec " hostnameScript)
-                "the launcher must exec hermes, so that it keeps the MainPID"
-              ++ lib.optional (!lib.hasInfix ''--host "$_target"'' hostnameScript)
-                "the launcher must bind the address that the poll resolved"
+              ++ lib.optional (
+                !lib.hasInfix "hermes-backend-launch" hostnameWait
+              ) "waitFor = hostname must run the launcher, got: ${hostnameWait}"
+              ++ lib.optional (
+                !lib.hasInfix "getent hosts" hostnameScript
+              ) "the hostname launcher must poll with getent"
+              ++ lib.optional (
+                !lib.hasInfix "host.example.ts.net" hostnameScript
+              ) "the hostname launcher must poll for backend.host"
+              ++ lib.optional (
+                !lib.hasInfix "exec " hostnameScript
+              ) "the launcher must exec hermes, so that it keeps the MainPID"
+              ++ lib.optional (
+                !lib.hasInfix ''--host "$_target"'' hostnameScript
+              ) "the launcher must bind the address that the poll resolved"
 
               # The interface mode reads an address off the interface.
-              ++ lib.optional (!lib.hasInfix "tailscale0" interfaceScript)
-                "the interface launcher must poll backend.interfaceName"
-              ++ lib.optional (!lib.hasInfix "_timeout=30" interfaceScript)
-                "the launcher must use backend.waitTimeout"
-              ++ lib.optional (!lib.hasInfix "bin/hermes dashboard" interfaceScript)
-                "the launcher must keep backend.mode"
+              ++ lib.optional (
+                !lib.hasInfix "tailscale0" interfaceScript
+              ) "the interface launcher must poll backend.interfaceName"
+              ++ lib.optional (
+                !lib.hasInfix "_timeout=30" interfaceScript
+              ) "the launcher must use backend.waitTimeout"
+              ++ lib.optional (
+                !lib.hasInfix "bin/hermes dashboard" interfaceScript
+              ) "the launcher must keep backend.mode"
 
               # The assertions reject what cannot work.
-              ++
-                lib.optional
-                  (!evalFails {
-                    backend = {
-                      mode = "serve";
-                      waitFor = "interface";
-                    };
-                  })
-                  "an assertion must reject waitFor = interface without interfaceName"
-              ++
-                lib.optional
-                  (!evalFails {
-                    backend = {
-                      mode = "serve";
-                      interfaceName = "tailscale0";
-                    };
-                  })
-                  "an assertion must reject interfaceName without waitFor = interface";
+              ++ lib.optional (
+                !evalFails {
+                  backend = {
+                    mode = "serve";
+                    waitFor = "interface";
+                  };
+                }
+              ) "an assertion must reject waitFor = interface without interfaceName"
+              ++ lib.optional (
+                !evalFails {
+                  backend = {
+                    mode = "serve";
+                    interfaceName = "tailscale0";
+                  };
+                }
+              ) "an assertion must reject interfaceName without waitFor = interface";
           in
           pkgs.runCommand "hermes-backend-bind-wait" { } (
             if failures != [ ] then
@@ -937,8 +962,22 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
             }
 
             check "gateway"   ${probe (common.gatewayArgv (cfgFor "none"))}
-            check "serve"     ${probe (common.backendArgv { inherit pkgs; cfg = cfgFor "serve"; })}
-            check "dashboard" ${probe (common.backendArgv { inherit pkgs; cfg = cfgFor "dashboard"; })}
+            check "serve"     ${
+              probe (
+                common.backendArgv {
+                  inherit pkgs;
+                  cfg = cfgFor "serve";
+                }
+              )
+            }
+            check "dashboard" ${
+              probe (
+                common.backendArgv {
+                  inherit pkgs;
+                  cfg = cfgFor "dashboard";
+                }
+              )
+            }
 
             mkdir -p $out
             echo "ok" > $out/result
@@ -1174,54 +1213,58 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
         '';
 
         # Verify extraPythonPackages PYTHONPATH injection
-        extra-python-packages = let
-          testPkg = pkgs.python312Packages.pyfiglet;
-          hermesWithExtra = hermes-agent.override {
-            extraPythonPackages = [ testPkg ];
-          };
-        in pkgs.runCommand "hermes-extra-python-packages" { } ''
-          set -e
-          echo "=== Checking extraPythonPackages PYTHONPATH injection ==="
+        extra-python-packages =
+          let
+            testPkg = pkgs.python312Packages.pyfiglet;
+            hermesWithExtra = hermes-agent.override {
+              extraPythonPackages = [ testPkg ];
+            };
+          in
+          pkgs.runCommand "hermes-extra-python-packages" { } ''
+            set -e
+            echo "=== Checking extraPythonPackages PYTHONPATH injection ==="
 
-          grep -q "PYTHONPATH" ${hermesWithExtra}/bin/hermes || \
-            (echo "FAIL: PYTHONPATH not in wrapper"; exit 1)
-          echo "PASS: PYTHONPATH present in wrapper"
+            grep -q "PYTHONPATH" ${hermesWithExtra}/bin/hermes || \
+              (echo "FAIL: PYTHONPATH not in wrapper"; exit 1)
+            echo "PASS: PYTHONPATH present in wrapper"
 
-          grep -q "${testPkg}" ${hermesWithExtra}/bin/hermes || \
-            (echo "FAIL: test package path not in PYTHONPATH"; exit 1)
-          echo "PASS: test package path found in wrapper"
+            grep -q "${testPkg}" ${hermesWithExtra}/bin/hermes || \
+              (echo "FAIL: test package path not in PYTHONPATH"; exit 1)
+            echo "PASS: test package path found in wrapper"
 
-          echo "=== Checking base package has no PYTHONPATH ==="
-          if grep -q "PYTHONPATH" ${hermes-agent}/bin/hermes; then
-            echo "FAIL: base package should not have PYTHONPATH"; exit 1
-          fi
-          echo "PASS: base package clean"
+            echo "=== Checking base package has no PYTHONPATH ==="
+            if grep -q "PYTHONPATH" ${hermes-agent}/bin/hermes; then
+              echo "FAIL: base package should not have PYTHONPATH"; exit 1
+            fi
+            echo "PASS: base package clean"
 
-          echo "=== All extraPythonPackages checks passed ==="
-          mkdir -p $out
-          echo "ok" > $out/result
-        '';
+            echo "=== All extraPythonPackages checks passed ==="
+            mkdir -p $out
+            echo "ok" > $out/result
+          '';
 
         # Verify extraDependencyGroups passes through to python.nix
-        extra-dependency-groups = let
-          hermesWithGroups = hermes-agent.override {
-            extraDependencyGroups = [ "honcho" ];
-          };
-        in pkgs.runCommand "hermes-extra-dependency-groups" { } ''
-          set -e
-          echo "=== Checking extraDependencyGroups override evaluates ==="
+        extra-dependency-groups =
+          let
+            hermesWithGroups = hermes-agent.override {
+              extraDependencyGroups = [ "honcho" ];
+            };
+          in
+          pkgs.runCommand "hermes-extra-dependency-groups" { } ''
+            set -e
+            echo "=== Checking extraDependencyGroups override evaluates ==="
 
-          # Eval-only: verify the override produces valid derivation paths
-          # without building the full venv (which is expensive and redundant
-          # since the mechanism is just list concatenation into python.nix).
-          echo "derivation: ${hermesWithGroups}"
-          echo "venv: ${hermesWithGroups.hermesVenv}"
-          echo "PASS: extraDependencyGroups override evaluates cleanly"
+            # Eval-only: verify the override produces valid derivation paths
+            # without building the full venv (which is expensive and redundant
+            # since the mechanism is just list concatenation into python.nix).
+            echo "derivation: ${hermesWithGroups}"
+            echo "venv: ${hermesWithGroups.hermesVenv}"
+            echo "PASS: extraDependencyGroups override evaluates cleanly"
 
-          echo "=== All extraDependencyGroups checks passed ==="
-          mkdir -p $out
-          echo "ok" > $out/result
-        '';
+            echo "=== All extraDependencyGroups checks passed ==="
+            mkdir -p $out
+            echo "ok" > $out/result
+          '';
 
         # Regression guard: messaging deps live outside [all], so the
         # #messaging variant must actually ship discord.py — otherwise
@@ -1239,216 +1282,228 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
         # ── Config merge + round-trip test ────────────────────────────────
         # Tests the merge script (Nix activation behavior) across 7
         # scenarios, then verifies Python's load_config() reads correctly.
-        config-roundtrip = let
-          # Nix settings used across scenarios
-          nixSettings = pkgs.writeText "nix-settings.json" (builtins.toJSON {
-            model = "test/nix-model";
-            toolsets = ["nix-toolset"];
-            terminal = { backend = "docker"; timeout = 999; };
-            mcp_servers = {
-              nix-server = { command = "echo"; args = ["nix"]; };
-            };
-          });
+        config-roundtrip =
+          let
+            # Nix settings used across scenarios
+            nixSettings = pkgs.writeText "nix-settings.json" (
+              builtins.toJSON {
+                model = "test/nix-model";
+                toolsets = [ "nix-toolset" ];
+                terminal = {
+                  backend = "docker";
+                  timeout = 999;
+                };
+                mcp_servers = {
+                  nix-server = {
+                    command = "echo";
+                    args = [ "nix" ];
+                  };
+                };
+              }
+            );
 
-          # Pre-built YAML fixtures for each scenario
-          fixtureB = pkgs.writeText "fixture-b.yaml" ''
-            model: "old-model"
-            mcp_servers:
-              old-server:
-                url: "http://old"
-          '';
-          fixtureC = pkgs.writeText "fixture-c.yaml" ''
-            skills:
-              disabled:
-                - skill-a
-                - skill-b
-            session_reset:
-              mode: idle
-              idle_minutes: 30
-            streaming:
-              enabled: true
-            fallback_model:
-              provider: openrouter
-              model: test-fallback
-          '';
-          fixtureD = pkgs.writeText "fixture-d.yaml" ''
-            model: "user-model"
-            skills:
-              disabled:
-                - skill-x
-            streaming:
-              enabled: true
-              transport: edit
-          '';
-          fixtureE = pkgs.writeText "fixture-e.yaml" ''
-            mcp_servers:
-              user-server:
-                url: "http://user-mcp"
-              nix-server:
-                command: "old-cmd"
-                args: ["old"]
-          '';
-          fixtureF = pkgs.writeText "fixture-f.yaml" ''
-            terminal:
-              cwd: "/user/path"
-              custom_key: "preserved"
-              env_passthrough:
-                - USER_VAR
-          '';
+            # Pre-built YAML fixtures for each scenario
+            fixtureB = pkgs.writeText "fixture-b.yaml" ''
+              model: "old-model"
+              mcp_servers:
+                old-server:
+                  url: "http://old"
+            '';
+            fixtureC = pkgs.writeText "fixture-c.yaml" ''
+              skills:
+                disabled:
+                  - skill-a
+                  - skill-b
+              session_reset:
+                mode: idle
+                idle_minutes: 30
+              streaming:
+                enabled: true
+              fallback_model:
+                provider: openrouter
+                model: test-fallback
+            '';
+            fixtureD = pkgs.writeText "fixture-d.yaml" ''
+              model: "user-model"
+              skills:
+                disabled:
+                  - skill-x
+              streaming:
+                enabled: true
+                transport: edit
+            '';
+            fixtureE = pkgs.writeText "fixture-e.yaml" ''
+              mcp_servers:
+                user-server:
+                  url: "http://user-mcp"
+                nix-server:
+                  command: "old-cmd"
+                  args: ["old"]
+            '';
+            fixtureF = pkgs.writeText "fixture-f.yaml" ''
+              terminal:
+                cwd: "/user/path"
+                custom_key: "preserved"
+                env_passthrough:
+                  - USER_VAR
+            '';
 
-        in pkgs.runCommand "hermes-config-roundtrip" {
-          nativeBuildInputs = [ pkgs.jq ];
-        } ''
-          set -e
-          export HOME=$(mktemp -d)
-          ERRORS=""
+          in
+          pkgs.runCommand "hermes-config-roundtrip"
+            {
+              nativeBuildInputs = [ pkgs.jq ];
+            }
+            ''
+                        set -e
+                        export HOME=$(mktemp -d)
+                        ERRORS=""
 
-          fail() { ERRORS="$ERRORS\nFAIL: $1"; }
+                        fail() { ERRORS="$ERRORS\nFAIL: $1"; }
 
-          # Helper: run merge then load with Python, output merged JSON
-          merge_and_load() {
-            local hermes_home="$1"
-            export HERMES_HOME="$hermes_home"
-            ${configMergeScript} ${nixSettings} "$hermes_home/config.yaml"
-            ${hermesVenv}/bin/python3 -c '
-import json, sys
-from hermes_cli.config import load_config
-json.dump(load_config(), sys.stdout, default=str)
-'
-          }
+                        # Helper: run merge then load with Python, output merged JSON
+                        merge_and_load() {
+                          local hermes_home="$1"
+                          export HERMES_HOME="$hermes_home"
+                          ${configMergeScript} ${nixSettings} "$hermes_home/config.yaml"
+                          ${hermesVenv}/bin/python3 -c '
+              import json, sys
+              from hermes_cli.config import load_config
+              json.dump(load_config(), sys.stdout, default=str)
+              '
+                        }
 
-          # ═══════════════════════════════════════════════════════════════
-          # Scenario A: Fresh install — no existing config.yaml
-          # ═══════════════════════════════════════════════════════════════
-          echo "=== Scenario A: Fresh install ==="
-          A_HOME=$(mktemp -d)
-          A_CONFIG=$(merge_and_load "$A_HOME")
+                        # ═══════════════════════════════════════════════════════════════
+                        # Scenario A: Fresh install — no existing config.yaml
+                        # ═══════════════════════════════════════════════════════════════
+                        echo "=== Scenario A: Fresh install ==="
+                        A_HOME=$(mktemp -d)
+                        A_CONFIG=$(merge_and_load "$A_HOME")
 
-          echo "$A_CONFIG" | jq -e '.model == "test/nix-model"' > /dev/null \
-            || fail "A: model not set from Nix"
-          echo "$A_CONFIG" | jq -e '.mcp_servers."nix-server".command == "echo"' > /dev/null \
-            || fail "A: MCP nix-server missing"
-          echo "PASS: Scenario A"
+                        echo "$A_CONFIG" | jq -e '.model == "test/nix-model"' > /dev/null \
+                          || fail "A: model not set from Nix"
+                        echo "$A_CONFIG" | jq -e '.mcp_servers."nix-server".command == "echo"' > /dev/null \
+                          || fail "A: MCP nix-server missing"
+                        echo "PASS: Scenario A"
 
-          # ═══════════════════════════════════════════════════════════════
-          # Scenario B: Nix keys override existing values
-          # ═══════════════════════════════════════════════════════════════
-          echo "=== Scenario B: Nix overrides ==="
-          B_HOME=$(mktemp -d)
-          install -m 0644 ${fixtureB} "$B_HOME/config.yaml"
-          B_CONFIG=$(merge_and_load "$B_HOME")
+                        # ═══════════════════════════════════════════════════════════════
+                        # Scenario B: Nix keys override existing values
+                        # ═══════════════════════════════════════════════════════════════
+                        echo "=== Scenario B: Nix overrides ==="
+                        B_HOME=$(mktemp -d)
+                        install -m 0644 ${fixtureB} "$B_HOME/config.yaml"
+                        B_CONFIG=$(merge_and_load "$B_HOME")
 
-          echo "$B_CONFIG" | jq -e '.model == "test/nix-model"' > /dev/null \
-            || fail "B: Nix model did not override"
-          echo "PASS: Scenario B"
+                        echo "$B_CONFIG" | jq -e '.model == "test/nix-model"' > /dev/null \
+                          || fail "B: Nix model did not override"
+                        echo "PASS: Scenario B"
 
-          # ═══════════════════════════════════════════════════════════════
-          # Scenario C: User-only keys preserved
-          # ═══════════════════════════════════════════════════════════════
-          echo "=== Scenario C: User keys preserved ==="
-          C_HOME=$(mktemp -d)
-          install -m 0644 ${fixtureC} "$C_HOME/config.yaml"
-          C_CONFIG=$(merge_and_load "$C_HOME")
+                        # ═══════════════════════════════════════════════════════════════
+                        # Scenario C: User-only keys preserved
+                        # ═══════════════════════════════════════════════════════════════
+                        echo "=== Scenario C: User keys preserved ==="
+                        C_HOME=$(mktemp -d)
+                        install -m 0644 ${fixtureC} "$C_HOME/config.yaml"
+                        C_CONFIG=$(merge_and_load "$C_HOME")
 
-          echo "$C_CONFIG" | jq -e '.skills.disabled == ["skill-a", "skill-b"]' > /dev/null \
-            || fail "C: skills.disabled not preserved"
-          echo "$C_CONFIG" | jq -e '.session_reset.mode == "idle"' > /dev/null \
-            || fail "C: session_reset.mode not preserved"
-          echo "$C_CONFIG" | jq -e '.session_reset.idle_minutes == 30' > /dev/null \
-            || fail "C: session_reset.idle_minutes not preserved"
-          echo "$C_CONFIG" | jq -e '.streaming.enabled == true' > /dev/null \
-            || fail "C: streaming.enabled not preserved"
-          echo "$C_CONFIG" | jq -e '.fallback_model.provider == "openrouter"' > /dev/null \
-            || fail "C: fallback_model not preserved"
-          echo "PASS: Scenario C"
+                        echo "$C_CONFIG" | jq -e '.skills.disabled == ["skill-a", "skill-b"]' > /dev/null \
+                          || fail "C: skills.disabled not preserved"
+                        echo "$C_CONFIG" | jq -e '.session_reset.mode == "idle"' > /dev/null \
+                          || fail "C: session_reset.mode not preserved"
+                        echo "$C_CONFIG" | jq -e '.session_reset.idle_minutes == 30' > /dev/null \
+                          || fail "C: session_reset.idle_minutes not preserved"
+                        echo "$C_CONFIG" | jq -e '.streaming.enabled == true' > /dev/null \
+                          || fail "C: streaming.enabled not preserved"
+                        echo "$C_CONFIG" | jq -e '.fallback_model.provider == "openrouter"' > /dev/null \
+                          || fail "C: fallback_model not preserved"
+                        echo "PASS: Scenario C"
 
-          # ═══════════════════════════════════════════════════════════════
-          # Scenario D: Mixed — Nix wins for its keys, user keys preserved
-          # ═══════════════════════════════════════════════════════════════
-          echo "=== Scenario D: Mixed merge ==="
-          D_HOME=$(mktemp -d)
-          install -m 0644 ${fixtureD} "$D_HOME/config.yaml"
-          D_CONFIG=$(merge_and_load "$D_HOME")
+                        # ═══════════════════════════════════════════════════════════════
+                        # Scenario D: Mixed — Nix wins for its keys, user keys preserved
+                        # ═══════════════════════════════════════════════════════════════
+                        echo "=== Scenario D: Mixed merge ==="
+                        D_HOME=$(mktemp -d)
+                        install -m 0644 ${fixtureD} "$D_HOME/config.yaml"
+                        D_CONFIG=$(merge_and_load "$D_HOME")
 
-          echo "$D_CONFIG" | jq -e '.model == "test/nix-model"' > /dev/null \
-            || fail "D: Nix model did not override user model"
-          echo "$D_CONFIG" | jq -e '.skills.disabled == ["skill-x"]' > /dev/null \
-            || fail "D: user skills not preserved"
-          echo "$D_CONFIG" | jq -e '.streaming.enabled == true' > /dev/null \
-            || fail "D: user streaming not preserved"
-          echo "PASS: Scenario D"
+                        echo "$D_CONFIG" | jq -e '.model == "test/nix-model"' > /dev/null \
+                          || fail "D: Nix model did not override user model"
+                        echo "$D_CONFIG" | jq -e '.skills.disabled == ["skill-x"]' > /dev/null \
+                          || fail "D: user skills not preserved"
+                        echo "$D_CONFIG" | jq -e '.streaming.enabled == true' > /dev/null \
+                          || fail "D: user streaming not preserved"
+                        echo "PASS: Scenario D"
 
-          # ═══════════════════════════════════════════════════════════════
-          # Scenario E: MCP additive merge
-          # ═══════════════════════════════════════════════════════════════
-          echo "=== Scenario E: MCP additive merge ==="
-          E_HOME=$(mktemp -d)
-          install -m 0644 ${fixtureE} "$E_HOME/config.yaml"
-          E_CONFIG=$(merge_and_load "$E_HOME")
+                        # ═══════════════════════════════════════════════════════════════
+                        # Scenario E: MCP additive merge
+                        # ═══════════════════════════════════════════════════════════════
+                        echo "=== Scenario E: MCP additive merge ==="
+                        E_HOME=$(mktemp -d)
+                        install -m 0644 ${fixtureE} "$E_HOME/config.yaml"
+                        E_CONFIG=$(merge_and_load "$E_HOME")
 
-          echo "$E_CONFIG" | jq -e '.mcp_servers."user-server".url == "http://user-mcp"' > /dev/null \
-            || fail "E: user MCP server not preserved"
-          echo "$E_CONFIG" | jq -e '.mcp_servers."nix-server".command == "echo"' > /dev/null \
-            || fail "E: Nix MCP server did not override same-name user server"
-          echo "$E_CONFIG" | jq -e '.mcp_servers."nix-server".args == ["nix"]' > /dev/null \
-            || fail "E: Nix MCP server args wrong"
-          echo "PASS: Scenario E"
+                        echo "$E_CONFIG" | jq -e '.mcp_servers."user-server".url == "http://user-mcp"' > /dev/null \
+                          || fail "E: user MCP server not preserved"
+                        echo "$E_CONFIG" | jq -e '.mcp_servers."nix-server".command == "echo"' > /dev/null \
+                          || fail "E: Nix MCP server did not override same-name user server"
+                        echo "$E_CONFIG" | jq -e '.mcp_servers."nix-server".args == ["nix"]' > /dev/null \
+                          || fail "E: Nix MCP server args wrong"
+                        echo "PASS: Scenario E"
 
-          # ═══════════════════════════════════════════════════════════════
-          # Scenario F: Nested deep merge
-          # ═══════════════════════════════════════════════════════════════
-          echo "=== Scenario F: Nested deep merge ==="
-          F_HOME=$(mktemp -d)
-          install -m 0644 ${fixtureF} "$F_HOME/config.yaml"
-          F_CONFIG=$(merge_and_load "$F_HOME")
+                        # ═══════════════════════════════════════════════════════════════
+                        # Scenario F: Nested deep merge
+                        # ═══════════════════════════════════════════════════════════════
+                        echo "=== Scenario F: Nested deep merge ==="
+                        F_HOME=$(mktemp -d)
+                        install -m 0644 ${fixtureF} "$F_HOME/config.yaml"
+                        F_CONFIG=$(merge_and_load "$F_HOME")
 
-          echo "$F_CONFIG" | jq -e '.terminal.backend == "docker"' > /dev/null \
-            || fail "F: Nix terminal.backend did not override"
-          echo "$F_CONFIG" | jq -e '.terminal.timeout == 999' > /dev/null \
-            || fail "F: Nix terminal.timeout did not override"
-          echo "$F_CONFIG" | jq -e '.terminal.custom_key == "preserved"' > /dev/null \
-            || fail "F: terminal.custom_key not preserved"
-          echo "$F_CONFIG" | jq -e '.terminal.cwd == "/user/path"' > /dev/null \
-            || fail "F: user terminal.cwd not preserved when Nix does not set it"
-          echo "$F_CONFIG" | jq -e '.terminal.env_passthrough == ["USER_VAR"]' > /dev/null \
-            || fail "F: user terminal.env_passthrough not preserved"
-          echo "PASS: Scenario F"
+                        echo "$F_CONFIG" | jq -e '.terminal.backend == "docker"' > /dev/null \
+                          || fail "F: Nix terminal.backend did not override"
+                        echo "$F_CONFIG" | jq -e '.terminal.timeout == 999' > /dev/null \
+                          || fail "F: Nix terminal.timeout did not override"
+                        echo "$F_CONFIG" | jq -e '.terminal.custom_key == "preserved"' > /dev/null \
+                          || fail "F: terminal.custom_key not preserved"
+                        echo "$F_CONFIG" | jq -e '.terminal.cwd == "/user/path"' > /dev/null \
+                          || fail "F: user terminal.cwd not preserved when Nix does not set it"
+                        echo "$F_CONFIG" | jq -e '.terminal.env_passthrough == ["USER_VAR"]' > /dev/null \
+                          || fail "F: user terminal.env_passthrough not preserved"
+                        echo "PASS: Scenario F"
 
-          # ═══════════════════════════════════════════════════════════════
-          # Scenario G: Idempotency — merging twice yields the same result
-          # ═══════════════════════════════════════════════════════════════
-          echo "=== Scenario G: Idempotency ==="
-          G_HOME=$(mktemp -d)
-          install -m 0644 ${fixtureD} "$G_HOME/config.yaml"
-          ${configMergeScript} ${nixSettings} "$G_HOME/config.yaml"
-          FIRST=$(cat "$G_HOME/config.yaml")
-          ${configMergeScript} ${nixSettings} "$G_HOME/config.yaml"
-          SECOND=$(cat "$G_HOME/config.yaml")
+                        # ═══════════════════════════════════════════════════════════════
+                        # Scenario G: Idempotency — merging twice yields the same result
+                        # ═══════════════════════════════════════════════════════════════
+                        echo "=== Scenario G: Idempotency ==="
+                        G_HOME=$(mktemp -d)
+                        install -m 0644 ${fixtureD} "$G_HOME/config.yaml"
+                        ${configMergeScript} ${nixSettings} "$G_HOME/config.yaml"
+                        FIRST=$(cat "$G_HOME/config.yaml")
+                        ${configMergeScript} ${nixSettings} "$G_HOME/config.yaml"
+                        SECOND=$(cat "$G_HOME/config.yaml")
 
-          if [ "$FIRST" != "$SECOND" ]; then
-            fail "G: second merge produced different output"
-            echo "--- first ---"
-            echo "$FIRST"
-            echo "--- second ---"
-            echo "$SECOND"
-          fi
-          echo "PASS: Scenario G"
+                        if [ "$FIRST" != "$SECOND" ]; then
+                          fail "G: second merge produced different output"
+                          echo "--- first ---"
+                          echo "$FIRST"
+                          echo "--- second ---"
+                          echo "$SECOND"
+                        fi
+                        echo "PASS: Scenario G"
 
-          # ═══════════════════════════════════════════════════════════════
-          # Report
-          # ═══════════════════════════════════════════════════════════════
-          if [ -n "$ERRORS" ]; then
-            echo ""
-            echo "FAILURES:"
-            echo -e "$ERRORS"
-            exit 1
-          fi
+                        # ═══════════════════════════════════════════════════════════════
+                        # Report
+                        # ═══════════════════════════════════════════════════════════════
+                        if [ -n "$ERRORS" ]; then
+                          echo ""
+                          echo "FAILURES:"
+                          echo -e "$ERRORS"
+                          exit 1
+                        fi
 
-          echo ""
-          echo "=== All 7 merge scenarios passed ==="
-          mkdir -p $out
-          echo "ok" > $out/result
-        '';
+                        echo ""
+                        echo "=== All 7 merge scenarios passed ==="
+                        mkdir -p $out
+                        echo "ok" > $out/result
+            '';
       };
     };
 }

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -207,6 +207,163 @@
       then "${containerDataDir}/${lib.removePrefix "${cfg.stateDir}/" cfg.workingDirectory}"
       else cfg.workingDirectory;
 
+    # Setup script — links config + auth + documents and fixes up permissions.
+    # Run as the systemd service's ExecStartPre (with the `+` prefix so it runs
+    # as root). This replaces the former system.activationScripts entry, which
+    # only ordered correctly when sops itself used an activation script; sops
+    # deployments that activate via a systemd unit got no ordering guarantee.
+    setupScript = pkgs.writeShellScript "hermes-agent-setup" ''
+      # Pin a known-good PATH: as an ExecStartPre this script no longer inherits
+      # the NixOS activation PATH, and the unit's own PATH does not include
+      # findutils (Mode A) or anything (Mode B). Without this, every `find`
+      # below would silently fall through its `|| true` — breaking the permission
+      # migration and the stale managed-plugin symlink cleanup.
+      export PATH="${lib.makeBinPath [ pkgs.coreutils pkgs.findutils ]}:$PATH"
+
+      # Ensure directories exist (tmpfiles has already run by ExecStartPre, but
+      # keep these as belt-and-suspenders for first boot / manual restarts)
+      mkdir -p ${cfg.stateDir}/.hermes
+      mkdir -p ${cfg.stateDir}/home
+      mkdir -p ${cfg.workingDirectory}
+      chown ${cfg.user}:${cfg.group} ${cfg.stateDir} ${cfg.stateDir}/.hermes ${cfg.stateDir}/home ${cfg.workingDirectory}
+      chmod 2770 ${cfg.stateDir} ${cfg.stateDir}/.hermes ${cfg.workingDirectory}
+      chmod 0750 ${cfg.stateDir}/home
+
+      # Create subdirs, set setgid + group-writable, migrate existing files.
+      # Nix-managed .env/.managed stay 0640/0644; config.yaml uses
+      # configYamlMode (0660 under addToSystemPackages, else 0640).
+      find ${cfg.stateDir}/.hermes -maxdepth 1 \
+        \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
+        -exec chmod g+rw {} + 2>/dev/null || true
+      for _subdir in cron sessions logs memories plugins; do
+        mkdir -p "${cfg.stateDir}/.hermes/$_subdir"
+        chown ${cfg.user}:${cfg.group} "${cfg.stateDir}/.hermes/$_subdir"
+        chmod 2770 "${cfg.stateDir}/.hermes/$_subdir"
+        find "${cfg.stateDir}/.hermes/$_subdir" -type f \
+          -exec chmod g+rw {} + 2>/dev/null || true
+      done
+
+      # Merge Nix settings into existing config.yaml.
+      # Preserves user-added keys (skills, streaming, etc.); Nix keys win.
+      # If configFile is user-provided (not generated), overwrite instead of merge.
+      # Mode is configYamlMode (0660 under addToSystemPackages so interactive
+      # hermes-group users can save settings via the CLI/TUI, else 0640).
+      ${if cfg.configFile != null then ''
+        install -o ${cfg.user} -g ${cfg.group} -m ${configYamlMode} -D ${configFile} ${cfg.stateDir}/.hermes/config.yaml
+      '' else ''
+        ${configMergeScript} ${generatedConfigFile} ${cfg.stateDir}/.hermes/config.yaml
+        chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/config.yaml
+        chmod ${configYamlMode} ${cfg.stateDir}/.hermes/config.yaml
+      ''}
+
+      # Managed mode marker (so interactive shells also detect NixOS management)
+      touch ${cfg.stateDir}/.hermes/.managed
+      chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/.managed
+      chmod 0644 ${cfg.stateDir}/.hermes/.managed
+
+      # Container mode metadata — tells the host CLI to exec into the
+      # container instead of running locally. Removed when container mode
+      # is disabled so the host CLI falls back to native execution.
+      ${if cfg.container.enable then ''
+        cat > ${cfg.stateDir}/.hermes/.container-mode <<'HERMES_CONTAINER_MODE_EOF'
+    # Written by the NixOS setup script (ExecStartPre). Do not edit manually.
+    backend=${cfg.container.backend}
+    container_name=${containerName}
+    exec_user=${cfg.user}
+    hermes_bin=${containerDataDir}/current-package/bin/hermes
+    HERMES_CONTAINER_MODE_EOF
+        chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/.container-mode
+        chmod 0644 ${cfg.stateDir}/.hermes/.container-mode
+      '' else ''
+        rm -f ${cfg.stateDir}/.hermes/.container-mode
+
+        # Remove symlink bridge for hostUsers
+        ${lib.concatStringsSep "\n" (map (user:
+          let
+            userHome = config.users.users.${user}.home;
+            symlinkPath = "${userHome}/.hermes";
+          in ''
+            if [ -L "${symlinkPath}" ] && [ "$(readlink "${symlinkPath}")" = "${cfg.stateDir}/.hermes" ]; then
+              rm -f "${symlinkPath}"
+              echo "hermes-agent: removed symlink ${symlinkPath}"
+            fi
+          '') cfg.container.hostUsers)}
+      ''}
+
+      # ── Symlink bridge for interactive users ───────────────────────
+      # Create ~/.hermes -> stateDir/.hermes for each hostUser so the
+      # host CLI shares state with the container service.
+      # Only runs when container mode is enabled.
+      ${lib.optionalString cfg.container.enable
+        (lib.concatStringsSep "\n" (map (user:
+          let
+            userHome = config.users.users.${user}.home;
+            symlinkPath = "${userHome}/.hermes";
+            target = "${cfg.stateDir}/.hermes";
+          in ''
+            if [ -d "${symlinkPath}" ] && [ ! -L "${symlinkPath}" ]; then
+              # Real directory — back it up, then create symlink.
+              # (ln -sfn cannot atomically replace a directory.)
+              _backup="${symlinkPath}.bak.$(date +%s)"
+              echo "hermes-agent: backing up existing ${symlinkPath} to $_backup"
+              mv "${symlinkPath}" "$_backup"
+            fi
+            # For everything else (existing symlink, doesn't exist, etc.)
+            # ln -sfn handles it: replaces symlinks, creates new ones.
+            ln -sfn "${target}" "${symlinkPath}"
+            chown -h ${user}:${cfg.group} "${symlinkPath}"
+          '') cfg.container.hostUsers))}
+
+      # Seed auth file if provided
+      ${lib.optionalString (cfg.authFile != null) ''
+        ${if cfg.authFileForceOverwrite then ''
+          install -o ${cfg.user} -g ${cfg.group} -m 0600 ${cfg.authFile} ${cfg.stateDir}/.hermes/auth.json
+        '' else ''
+          if [ ! -f ${cfg.stateDir}/.hermes/auth.json ]; then
+            install -o ${cfg.user} -g ${cfg.group} -m 0600 ${cfg.authFile} ${cfg.stateDir}/.hermes/auth.json
+          fi
+        ''}
+      ''}
+
+      # Seed .env from Nix-declared environment + environmentFiles.
+      # Hermes reads $HERMES_HOME/.env at startup via load_hermes_dotenv(),
+      # so this is the single source of truth for both native and container mode.
+      ${lib.optionalString (cfg.environment != {} || cfg.environmentFiles != []) ''
+        ENV_FILE="${cfg.stateDir}/.hermes/.env"
+        install -o ${cfg.user} -g ${cfg.group} -m 0640 /dev/null "$ENV_FILE"
+        cat > "$ENV_FILE" <<'HERMES_NIX_ENV_EOF'
+    ${envFileContent}
+    HERMES_NIX_ENV_EOF
+        ${lib.concatStringsSep "\n" (map (f: ''
+          if [ -f "${f}" ]; then
+            echo "" >> "$ENV_FILE"
+            cat "${f}" >> "$ENV_FILE"
+          fi
+        '') cfg.environmentFiles)}
+      ''}
+
+      # Link documents into workspace
+      ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: _value: ''
+        install -o ${cfg.user} -g ${cfg.group} -m 0640 ${documentDerivation}/${name} ${cfg.workingDirectory}/${name}
+      '') cfg.documents)}
+
+      # ── Declarative plugins ─────────────────────────────────────────
+      # Remove stale managed symlinks (plugins removed from config)
+      find ${cfg.stateDir}/.hermes/plugins -maxdepth 1 -type l -name 'nix-managed-*' -delete 2>/dev/null || true
+
+      ${lib.concatStringsSep "\n" (map (plugin:
+        let
+          name = lib.getName plugin;
+        in ''
+          if [ ! -f "${plugin}/plugin.yaml" ]; then
+            echo "ERROR: extraPlugins entry '${plugin}' has no plugin.yaml" >&2
+            exit 1
+          fi
+          ln -sfn ${plugin} ${cfg.stateDir}/.hermes/plugins/nix-managed-${name}
+          chown -h ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/plugins/nix-managed-${name}
+        '') cfg.extraPlugins)}
+    '';
+
   in {
     options.services.hermes-agent = with lib; {
       enable = mkEnableOption "Hermes Agent gateway service";
@@ -722,153 +879,6 @@
         ];
       }
 
-      # ── Activation: link config + auth + documents ────────────────────
-      {
-        system.activationScripts."hermes-agent-setup" = lib.stringAfter ([ "users" ] ++ lib.optional (config.system.activationScripts ? setupSecrets) "setupSecrets") ''
-          # Ensure directories exist (activation runs before tmpfiles)
-          mkdir -p ${cfg.stateDir}/.hermes
-          mkdir -p ${cfg.stateDir}/home
-          mkdir -p ${cfg.workingDirectory}
-          chown ${cfg.user}:${cfg.group} ${cfg.stateDir} ${cfg.stateDir}/.hermes ${cfg.stateDir}/home ${cfg.workingDirectory}
-          chmod 2770 ${cfg.stateDir} ${cfg.stateDir}/.hermes ${cfg.workingDirectory}
-          chmod 0750 ${cfg.stateDir}/home
-
-          # Create subdirs, set setgid + group-writable, migrate existing files.
-          # Nix-managed .env/.managed stay 0640/0644; config.yaml uses
-          # configYamlMode (0660 under addToSystemPackages, else 0640).
-          find ${cfg.stateDir}/.hermes -maxdepth 1 \
-            \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
-            -exec chmod g+rw {} + 2>/dev/null || true
-          for _subdir in cron sessions logs memories plugins; do
-            mkdir -p "${cfg.stateDir}/.hermes/$_subdir"
-            chown ${cfg.user}:${cfg.group} "${cfg.stateDir}/.hermes/$_subdir"
-            chmod 2770 "${cfg.stateDir}/.hermes/$_subdir"
-            find "${cfg.stateDir}/.hermes/$_subdir" -type f \
-              -exec chmod g+rw {} + 2>/dev/null || true
-          done
-
-          # Merge Nix settings into existing config.yaml.
-          # Preserves user-added keys (skills, streaming, etc.); Nix keys win.
-          # If configFile is user-provided (not generated), overwrite instead of merge.
-          # Mode is configYamlMode (0660 under addToSystemPackages so interactive
-          # hermes-group users can save settings via the CLI/TUI, else 0640).
-          ${if cfg.configFile != null then ''
-            install -o ${cfg.user} -g ${cfg.group} -m ${configYamlMode} -D ${configFile} ${cfg.stateDir}/.hermes/config.yaml
-          '' else ''
-            ${configMergeScript} ${generatedConfigFile} ${cfg.stateDir}/.hermes/config.yaml
-            chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/config.yaml
-            chmod ${configYamlMode} ${cfg.stateDir}/.hermes/config.yaml
-          ''}
-
-          # Managed mode marker (so interactive shells also detect NixOS management)
-          touch ${cfg.stateDir}/.hermes/.managed
-          chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/.managed
-          chmod 0644 ${cfg.stateDir}/.hermes/.managed
-
-          # Container mode metadata — tells the host CLI to exec into the
-          # container instead of running locally. Removed when container mode
-          # is disabled so the host CLI falls back to native execution.
-          ${if cfg.container.enable then ''
-            cat > ${cfg.stateDir}/.hermes/.container-mode <<'HERMES_CONTAINER_MODE_EOF'
-    # Written by NixOS activation script. Do not edit manually.
-    backend=${cfg.container.backend}
-    container_name=${containerName}
-    exec_user=${cfg.user}
-    hermes_bin=${containerDataDir}/current-package/bin/hermes
-    HERMES_CONTAINER_MODE_EOF
-            chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/.container-mode
-            chmod 0644 ${cfg.stateDir}/.hermes/.container-mode
-          '' else ''
-            rm -f ${cfg.stateDir}/.hermes/.container-mode
-
-            # Remove symlink bridge for hostUsers
-            ${lib.concatStringsSep "\n" (map (user:
-              let
-                userHome = config.users.users.${user}.home;
-                symlinkPath = "${userHome}/.hermes";
-              in ''
-                if [ -L "${symlinkPath}" ] && [ "$(readlink "${symlinkPath}")" = "${cfg.stateDir}/.hermes" ]; then
-                  rm -f "${symlinkPath}"
-                  echo "hermes-agent: removed symlink ${symlinkPath}"
-                fi
-              '') cfg.container.hostUsers)}
-          ''}
-
-          # ── Symlink bridge for interactive users ───────────────────────
-          # Create ~/.hermes -> stateDir/.hermes for each hostUser so the
-          # host CLI shares state with the container service.
-          # Only runs when container mode is enabled.
-          ${lib.optionalString cfg.container.enable
-            (lib.concatStringsSep "\n" (map (user:
-              let
-                userHome = config.users.users.${user}.home;
-                symlinkPath = "${userHome}/.hermes";
-                target = "${cfg.stateDir}/.hermes";
-              in ''
-                if [ -d "${symlinkPath}" ] && [ ! -L "${symlinkPath}" ]; then
-                  # Real directory — back it up, then create symlink.
-                  # (ln -sfn cannot atomically replace a directory.)
-                  _backup="${symlinkPath}.bak.$(date +%s)"
-                  echo "hermes-agent: backing up existing ${symlinkPath} to $_backup"
-                  mv "${symlinkPath}" "$_backup"
-                fi
-                # For everything else (existing symlink, doesn't exist, etc.)
-                # ln -sfn handles it: replaces symlinks, creates new ones.
-                ln -sfn "${target}" "${symlinkPath}"
-                chown -h ${user}:${cfg.group} "${symlinkPath}"
-              '') cfg.container.hostUsers))}
-
-          # Seed auth file if provided
-          ${lib.optionalString (cfg.authFile != null) ''
-            ${if cfg.authFileForceOverwrite then ''
-              install -o ${cfg.user} -g ${cfg.group} -m 0600 ${cfg.authFile} ${cfg.stateDir}/.hermes/auth.json
-            '' else ''
-              if [ ! -f ${cfg.stateDir}/.hermes/auth.json ]; then
-                install -o ${cfg.user} -g ${cfg.group} -m 0600 ${cfg.authFile} ${cfg.stateDir}/.hermes/auth.json
-              fi
-            ''}
-          ''}
-
-          # Seed .env from Nix-declared environment + environmentFiles.
-          # Hermes reads $HERMES_HOME/.env at startup via load_hermes_dotenv(),
-          # so this is the single source of truth for both native and container mode.
-          ${lib.optionalString (cfg.environment != {} || cfg.environmentFiles != []) ''
-            ENV_FILE="${cfg.stateDir}/.hermes/.env"
-            install -o ${cfg.user} -g ${cfg.group} -m 0640 /dev/null "$ENV_FILE"
-            cat > "$ENV_FILE" <<'HERMES_NIX_ENV_EOF'
-    ${envFileContent}
-    HERMES_NIX_ENV_EOF
-            ${lib.concatStringsSep "\n" (map (f: ''
-              if [ -f "${f}" ]; then
-                echo "" >> "$ENV_FILE"
-                cat "${f}" >> "$ENV_FILE"
-              fi
-            '') cfg.environmentFiles)}
-          ''}
-
-          # Link documents into workspace
-          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: _value: ''
-            install -o ${cfg.user} -g ${cfg.group} -m 0640 ${documentDerivation}/${name} ${cfg.workingDirectory}/${name}
-          '') cfg.documents)}
-
-        # ── Declarative plugins ─────────────────────────────────────────
-        # Remove stale managed symlinks (plugins removed from config)
-        find ${cfg.stateDir}/.hermes/plugins -maxdepth 1 -type l -name 'nix-managed-*' -delete 2>/dev/null || true
-
-        ${lib.concatStringsSep "\n" (map (plugin:
-          let
-            name = lib.getName plugin;
-          in ''
-            if [ ! -f "${plugin}/plugin.yaml" ]; then
-              echo "ERROR: extraPlugins entry '${plugin}' has no plugin.yaml" >&2
-              exit 1
-            fi
-            ln -sfn ${plugin} ${cfg.stateDir}/.hermes/plugins/nix-managed-${name}
-            chown -h ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/plugins/nix-managed-${name}
-          '') cfg.extraPlugins)}
-        '';
-      }
-
       # ══════════════════════════════════════════════════════════════════
       # MODE A: Native systemd service (default)
       # ══════════════════════════════════════════════════════════════════
@@ -876,8 +886,10 @@
         systemd.services.hermes-agent = {
           description = "Hermes Agent Gateway";
           wantedBy = [ "multi-user.target" ];
-          after = [ "network-online.target" ];
-          wants = [ "network-online.target" ];
+          after = [ "network-online.target" ]
+            ++ lib.optional (config.systemd.services ? sops-install-secrets) "sops-install-secrets.service";
+          wants = [ "network-online.target" ]
+            ++ lib.optional (config.systemd.services ? sops-install-secrets) "sops-install-secrets.service";
 
           environment = {
             HOME = cfg.stateDir;
@@ -892,8 +904,14 @@
             WorkingDirectory = cfg.workingDirectory;
 
             # cfg.environment and cfg.environmentFiles are written to
-            # $HERMES_HOME/.env by the activation script. load_hermes_dotenv()
+            # $HERMES_HOME/.env by the setup script. load_hermes_dotenv()
             # reads them at Python startup — no systemd EnvironmentFile needed.
+
+            # Setup runs as root (`+` prefix) before the gateway starts — it links
+            # config/auth/documents and fixes permissions. Formerly a
+            # system.activationScripts entry; moved here so it orders correctly
+            # regardless of how sops activates secrets.
+            ExecStartPre = "+${setupScript}";
 
             ExecStart = lib.concatStringsSep " " ([
               "${effectivePackage}/bin/hermes"
@@ -938,11 +956,19 @@
           description = "Hermes Agent Gateway (container)";
           wantedBy = [ "multi-user.target" ];
           after = [ "network-online.target" ]
-            ++ lib.optional (cfg.container.backend == "docker") "docker.service";
-          wants = [ "network-online.target" ];
+            ++ lib.optional (cfg.container.backend == "docker") "docker.service"
+            ++ lib.optional (config.systemd.services ? sops-install-secrets) "sops-install-secrets.service";
+          wants = [ "network-online.target" ]
+            ++ lib.optional (config.systemd.services ? sops-install-secrets) "sops-install-secrets.service";
           requires = lib.optional (cfg.container.backend == "docker") "docker.service";
 
+          # preStart becomes the service's ExecStartPre. The setup script (formerly
+          # a system.activationScripts entry) runs first here so it orders correctly
+          # regardless of how sops activates secrets. preStart already runs as root
+          # (no User= on the container service), so the cross-user chowns succeed.
           preStart = ''
+            ${setupScript}
+
             # Stable symlinks — container references these, not store paths directly
             ln -sfn ${effectivePackage} ${cfg.stateDir}/current-package
             ln -sfn ${containerEntrypoint} ${cfg.stateDir}/current-entrypoint

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -193,7 +193,7 @@
       # The CLI on the host reads this file, in get_container_exec_info. The
       # file tells the CLI to run in the container and not on the host.
       containerModeFile = pkgs.writeText "hermes-container-mode" ''
-        # Written by the NixOS activation script. Do not edit manually.
+        # Written by the NixOS setup script (ExecStartPre). Do not edit manually.
         backend=${cfg.container.backend}
         container_name=${containerName}
         exec_user=${cfg.user}
@@ -239,6 +239,120 @@
       // common.processEnvironment { inherit hermesHome; };
 
       unitPath = common.processPath { inherit pkgs cfg; };
+
+      # ── Setup script ────────────────────────────────────────────────────────
+      # Runs as the systemd service's ExecStartPre (with the `+` prefix so it runs
+      # as root). This replaces the former system.activationScripts entry, which
+      # only ordered correctly when sops itself used an activation script; sops
+      # deployments that activate secrets via a systemd unit got no ordering
+      # guarantee, so the gateway could start before secrets were in place.
+      setupScript = pkgs.writeShellScript "hermes-agent-setup" ''
+        # Pin a known-good PATH: as an ExecStartPre this script no longer inherits
+        # the NixOS activation PATH, and the unit's own PATH does not include
+        # findutils (Mode A) or anything (Mode B). Without this, every `find`
+        # below would silently fall through its `|| true` — breaking the permission
+        # migration and the stale managed-plugin symlink cleanup.
+        export PATH="${lib.makeBinPath [ pkgs.coreutils pkgs.findutils ]}:$PATH"
+
+                  # Ensure directories exist (activation runs before tmpfiles)
+                  mkdir -p ${hermesHome}
+                  mkdir -p ${cfg.stateDir}/home
+                  mkdir -p ${cfg.workingDirectory}
+                  chown ${cfg.user}:${cfg.group} ${cfg.stateDir} ${hermesHome} ${cfg.stateDir}/home ${cfg.workingDirectory}
+                  chmod 2770 ${cfg.stateDir} ${hermesHome} ${cfg.workingDirectory}
+                  chmod 0750 ${cfg.stateDir}/home
+
+                  # Create subdirs, set setgid + group-writable, migrate existing files.
+                  # Nix-managed .env/.managed stay 0640/0644; config.yaml uses
+                  # configYamlMode (0660 under addToSystemPackages, else 0640).
+                  find ${hermesHome} -maxdepth 1 \
+                    \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
+                    -exec chmod g+rw {} + 2>/dev/null || true
+                  for _subdir in ${lib.concatStringsSep " " common.stateSubdirs}; do
+                    mkdir -p "${hermesHome}/$_subdir"
+                    chown ${cfg.user}:${cfg.group} "${hermesHome}/$_subdir"
+                    chmod 2770 "${hermesHome}/$_subdir"
+                    find "${hermesHome}/$_subdir" -type f \
+                      -exec chmod g+rw {} + 2>/dev/null || true
+                  done
+
+                  ${common.mkStateScript {
+                    inherit pkgs cfg hermesHome;
+                    workingDirectory = cfg.workingDirectory;
+                    configWorkingDirectory = effectiveWorkDir;
+                    owner = "${cfg.user}:${cfg.group}";
+                    stateDirs = common.stateSubdirs;
+                    modes = {
+                      config = configYamlMode;
+                      env = "0640";
+                      managed = "0644";
+                      auth = "0600";
+                      document = "0640";
+                    };
+                  }}
+
+                  chown -h ${cfg.user}:${cfg.group} ${hermesHome}/plugins/nix-managed-* 2>/dev/null || true
+
+                  # Container mode metadata — tells the host CLI to exec into the
+                  # container instead of running locally. Removed when container mode
+                  # is disabled so the host CLI falls back to native execution.
+                  ${
+                    if cfg.container.enable then
+                      ''
+                        install -o ${cfg.user} -g ${cfg.group} -m 0644 ${containerModeFile} ${hermesHome}/.container-mode
+                      ''
+                    else
+                      ''
+                        rm -f ${hermesHome}/.container-mode
+
+                        # Remove symlink bridge for hostUsers
+                        ${lib.concatStringsSep "\n" (
+                          map (
+                            user:
+                            let
+                              userHome = config.users.users.${user}.home;
+                              symlinkPath = "${userHome}/.hermes";
+                            in
+                            ''
+                              if [ -L "${symlinkPath}" ] && [ "$(readlink "${symlinkPath}")" = "${hermesHome}" ]; then
+                                rm -f "${symlinkPath}"
+                                echo "hermes-agent: removed symlink ${symlinkPath}"
+                              fi
+                            ''
+                          ) cfg.container.hostUsers
+                        )}
+                      ''
+                  }
+
+                  # ── Symlink bridge for interactive users ───────────────────────
+                  # Create ~/.hermes -> stateDir/.hermes for each hostUser so the
+                  # host CLI shares state with the container service.
+                  # Only runs when container mode is enabled.
+                  ${lib.optionalString cfg.container.enable (
+                    lib.concatStringsSep "\n" (
+                      map (
+                        user:
+                        let
+                          userHome = config.users.users.${user}.home;
+                          symlinkPath = "${userHome}/.hermes";
+                        in
+                        ''
+                          if [ -d "${symlinkPath}" ] && [ ! -L "${symlinkPath}" ]; then
+                            # Real directory — back it up, then create symlink.
+                            # (ln -sfn cannot atomically replace a directory.)
+                            _backup="${symlinkPath}.bak.$(date +%s)"
+                            echo "hermes-agent: backing up existing ${symlinkPath} to $_backup"
+                            mv "${symlinkPath}" "$_backup"
+                          fi
+                          # For everything else (existing symlink, doesn't exist, etc.)
+                          # ln -sfn handles it: replaces symlinks, creates new ones.
+                          ln -sfn "${hermesHome}" "${symlinkPath}"
+                          chown -h ${user}:${cfg.group} "${symlinkPath}"
+                        ''
+                      ) cfg.container.hostUsers
+                    )
+                  )}
+      '';
 
     in
     {
@@ -433,114 +547,6 @@
             ++ map (d: "d ${hermesHome}/${d} 2770 ${cfg.user} ${cfg.group} - -") common.stateSubdirs;
           }
 
-          # ── Activation: link config + auth + documents ────────────────────
-          {
-            system.activationScripts."hermes-agent-setup" =
-              lib.stringAfter
-                (
-                  [ "users" ] ++ lib.optional (config.system.activationScripts ? setupSecrets) "setupSecrets"
-                )
-                ''
-                  # Ensure directories exist (activation runs before tmpfiles)
-                  mkdir -p ${hermesHome}
-                  mkdir -p ${cfg.stateDir}/home
-                  mkdir -p ${cfg.workingDirectory}
-                  chown ${cfg.user}:${cfg.group} ${cfg.stateDir} ${hermesHome} ${cfg.stateDir}/home ${cfg.workingDirectory}
-                  chmod 2770 ${cfg.stateDir} ${hermesHome} ${cfg.workingDirectory}
-                  chmod 0750 ${cfg.stateDir}/home
-
-                  # Create subdirs, set setgid + group-writable, migrate existing files.
-                  # Nix-managed .env/.managed stay 0640/0644; config.yaml uses
-                  # configYamlMode (0660 under addToSystemPackages, else 0640).
-                  find ${hermesHome} -maxdepth 1 \
-                    \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
-                    -exec chmod g+rw {} + 2>/dev/null || true
-                  for _subdir in ${lib.concatStringsSep " " common.stateSubdirs}; do
-                    mkdir -p "${hermesHome}/$_subdir"
-                    chown ${cfg.user}:${cfg.group} "${hermesHome}/$_subdir"
-                    chmod 2770 "${hermesHome}/$_subdir"
-                    find "${hermesHome}/$_subdir" -type f \
-                      -exec chmod g+rw {} + 2>/dev/null || true
-                  done
-
-                  ${common.mkStateScript {
-                    inherit pkgs cfg hermesHome;
-                    workingDirectory = cfg.workingDirectory;
-                    configWorkingDirectory = effectiveWorkDir;
-                    owner = "${cfg.user}:${cfg.group}";
-                    stateDirs = common.stateSubdirs;
-                    modes = {
-                      config = configYamlMode;
-                      env = "0640";
-                      managed = "0644";
-                      auth = "0600";
-                      document = "0640";
-                    };
-                  }}
-
-                  chown -h ${cfg.user}:${cfg.group} ${hermesHome}/plugins/nix-managed-* 2>/dev/null || true
-
-                  # Container mode metadata — tells the host CLI to exec into the
-                  # container instead of running locally. Removed when container mode
-                  # is disabled so the host CLI falls back to native execution.
-                  ${
-                    if cfg.container.enable then
-                      ''
-                        install -o ${cfg.user} -g ${cfg.group} -m 0644 ${containerModeFile} ${hermesHome}/.container-mode
-                      ''
-                    else
-                      ''
-                        rm -f ${hermesHome}/.container-mode
-
-                        # Remove symlink bridge for hostUsers
-                        ${lib.concatStringsSep "\n" (
-                          map (
-                            user:
-                            let
-                              userHome = config.users.users.${user}.home;
-                              symlinkPath = "${userHome}/.hermes";
-                            in
-                            ''
-                              if [ -L "${symlinkPath}" ] && [ "$(readlink "${symlinkPath}")" = "${hermesHome}" ]; then
-                                rm -f "${symlinkPath}"
-                                echo "hermes-agent: removed symlink ${symlinkPath}"
-                              fi
-                            ''
-                          ) cfg.container.hostUsers
-                        )}
-                      ''
-                  }
-
-                  # ── Symlink bridge for interactive users ───────────────────────
-                  # Create ~/.hermes -> stateDir/.hermes for each hostUser so the
-                  # host CLI shares state with the container service.
-                  # Only runs when container mode is enabled.
-                  ${lib.optionalString cfg.container.enable (
-                    lib.concatStringsSep "\n" (
-                      map (
-                        user:
-                        let
-                          userHome = config.users.users.${user}.home;
-                          symlinkPath = "${userHome}/.hermes";
-                        in
-                        ''
-                          if [ -d "${symlinkPath}" ] && [ ! -L "${symlinkPath}" ]; then
-                            # Real directory — back it up, then create symlink.
-                            # (ln -sfn cannot atomically replace a directory.)
-                            _backup="${symlinkPath}.bak.$(date +%s)"
-                            echo "hermes-agent: backing up existing ${symlinkPath} to $_backup"
-                            mv "${symlinkPath}" "$_backup"
-                          fi
-                          # For everything else (existing symlink, doesn't exist, etc.)
-                          # ln -sfn handles it: replaces symlinks, creates new ones.
-                          ln -sfn "${hermesHome}" "${symlinkPath}"
-                          chown -h ${user}:${cfg.group} "${symlinkPath}"
-                        ''
-                      ) cfg.container.hostUsers
-                    )
-                  )}
-                '';
-          }
 
           # ══════════════════════════════════════════════════════════════════
           # MODE A: Native systemd service (default)
@@ -549,15 +555,22 @@
             systemd.services.hermes-agent = {
               description = "Hermes Agent Gateway";
               wantedBy = [ "multi-user.target" ];
-              after = [ "network-online.target" ];
-              wants = [ "network-online.target" ];
+              after = [ "network-online.target" ]
+                ++ lib.optional (config.systemd.services ? sops-install-secrets) "sops-install-secrets.service";
+              wants = [ "network-online.target" ]
+                ++ lib.optional (config.systemd.services ? sops-install-secrets) "sops-install-secrets.service";
 
               # cfg.environment and cfg.environmentFiles are written to
-              # $HERMES_HOME/.env by the activation script. load_hermes_dotenv()
+              # $HERMES_HOME/.env by the setup script. load_hermes_dotenv()
               # reads them at Python startup — no systemd EnvironmentFile needed.
               environment = commonUnitEnvironment;
 
               serviceConfig = commonServiceConfig // {
+                # Setup runs as root (`+` prefix) before the gateway starts — it
+                # links config/auth/documents and fixes permissions. Formerly a
+                # system.activationScripts entry; moved here so it orders correctly
+                # regardless of how sops activates secrets.
+                ExecStartPre = "+${setupScript}";
                 ExecStart = lib.escapeShellArgs (common.gatewayArgv cfg);
               };
 
@@ -572,12 +585,17 @@
             systemd.services.hermes-backend = {
               description = common.backendDescription cfg;
               wantedBy = [ "multi-user.target" ];
-              after = [ "network-online.target" ];
-              wants = [ "network-online.target" ];
+              after = [ "network-online.target" ]
+                ++ lib.optional (config.systemd.services ? sops-install-secrets) "sops-install-secrets.service";
+              wants = [ "network-online.target" ]
+                ++ lib.optional (config.systemd.services ? sops-install-secrets) "sops-install-secrets.service";
 
               environment = commonUnitEnvironment;
 
               serviceConfig = commonServiceConfig // {
+                # Same setup as the gateway: this service reads the same
+                # HERMES_HOME, so it must also run after the setup finished.
+                ExecStartPre = "+${setupScript}";
                 ExecStart = lib.escapeShellArgs (common.backendArgv { inherit pkgs cfg; });
               };
 
@@ -598,11 +616,19 @@
               after = [
                 "network-online.target"
               ]
-              ++ lib.optional (cfg.container.backend == "docker") "docker.service";
-              wants = [ "network-online.target" ];
+              ++ lib.optional (cfg.container.backend == "docker") "docker.service"
+              ++ lib.optional (config.systemd.services ? sops-install-secrets) "sops-install-secrets.service";
+              wants = [ "network-online.target" ]
+                ++ lib.optional (config.systemd.services ? sops-install-secrets) "sops-install-secrets.service";
               requires = lib.optional (cfg.container.backend == "docker") "docker.service";
 
+              # preStart becomes the service's ExecStartPre. The setup script (formerly
+              # a system.activationScripts entry) runs first here so it orders correctly
+              # regardless of how sops activates secrets. preStart already runs as root
+              # (no User= on the container service), so the cross-user chowns succeed.
               preStart = ''
+                ${setupScript}
+
                 # Stable symlinks — container references these, not store paths directly
                 ln -sfn ${effectivePackage} ${cfg.stateDir}/current-package
                 ln -sfn ${containerEntrypoint} ${cfg.stateDir}/current-entrypoint


### PR DESCRIPTION
The setup logic ran as a system.activationScripts entry, which only ordered after sops when sops itself used an activation script. sops deployments that activate secrets via a systemd unit got no ordering guarantee, so the gateway could start before secrets were in place.

Move the script into the service's ExecStartPre (with the `+` prefix so it still runs as root for the cross-user chowns) and order both the native and container services after sops-install-secrets.service when that unit exists.



## What does this PR do?

It moves the entirety of the system.activationScripts  into ExecStartPre of the systemd unit. Avoiding sops related race conditions.

## Related Issue

Fixes #39883

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

-  Move ActivationScript (mostly) verbatim to ExecStartPre

## How to Test
On a system with sops `useSystemdActivation=true` and using sops secrets, do a reboot and check if the `HERMES_HOME/.hermes/.env` file is empty.
## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

### AI Disclaimer
This code was written by Claude Opus 4.8 under strict guardrails