### PR TITLE
refactor(agent): remove dead _budget_grace_call / _budget_exhausted_injected flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,11 +144,10 @@ class AIAgent:
 ### Agent Loop
 
 The core loop is inside `run_conversation()` — entirely synchronous, with
-interrupt checks, budget tracking, and a one-turn grace call:
+interrupt checks and budget tracking:
 
 ```python
-while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) \
-        or self._budget_grace_call:
+while api_call_count < self.max_iterations and self.iteration_budget.remaining > 0:
     if self._interrupt_requested: break
     response = client.chat.completions.create(model=model, messages=messages, tools=tool_schemas)
     if response.tool_calls:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -509,15 +509,6 @@ def init_agent(
     except Exception:
         pass
 
-    # Iteration budget: the LLM is only notified when it actually exhausts
-    # the iteration budget (api_call_count >= max_iterations).  At that
-    # point we inject ONE message, allow one final API call, and if the
-    # model doesn't produce a text response, force a user-message asking
-    # it to summarise.  No intermediate pressure warnings — they caused
-    # models to "give up" prematurely on complex tasks (#7915).
-    agent._budget_exhausted_injected = False
-    agent._budget_grace_call = False
-
     # Activity tracking — updated on each API call, tool execution, and
     # stream chunk.  Used by the gateway timeout handler to report what the
     # agent was doing when it was killed, and by the "still working"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -458,7 +458,7 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
-    while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+    while api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
 
@@ -474,12 +474,7 @@ def run_conversation(
         agent._api_call_count = api_call_count
         agent._touch_activity(f"starting API call #{api_call_count}")
 
-        # Grace call: the budget is exhausted but we gave the model one
-        # more chance.  Consume the grace flag so the loop exits after
-        # this iteration regardless of outcome.
-        if agent._budget_grace_call:
-            agent._budget_grace_call = False
-        elif not agent.iteration_budget.consume():
+        if not agent.iteration_budget.consume():
             _turn_exit_reason = "budget_exhausted"
             if not agent.quiet_mode:
                 agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5231,15 +5231,6 @@ class TestSystemPromptStability:
         # Empty string is falsy, so should fall through to fresh build
         assert "Hermes Agent" in agent._cached_system_prompt
 
-class TestBudgetPressure:
-    """Budget exhaustion grace call system."""
-
-    def test_grace_call_flags_initialized(self, agent):
-        """Agent should have budget grace call flags."""
-        assert agent._budget_exhausted_injected is False
-        assert agent._budget_grace_call is False
-
-
 class TestSafeWriter:
     """Verify _SafeWriter guards stdout against OSError (broken pipes)."""
 


### PR DESCRIPTION
## Summary

Removes two unreachable flags — `_budget_grace_call` and `_budget_exhausted_injected` — along with their leftover consumer logic. Both are dead code: nothing in the tree ever sets either to `True`, so the branches that read them are unreachable and behaviorally equivalent to being deleted.

## Why these are dead

The flags backed the one-turn **budget grace** mechanism introduced in #7983.

#8935 found that mechanism was broken: the flag was set *after* the `while` loop had already exited (so the loop could never re-enter to use the "grace" call), and worse, it blocked the `_handle_max_iterations` fallback from running — leaving `final_response = None` and surfacing **empty responses** on budget exhaustion. #8935 fixed this by calling `_handle_max_iterations` directly from the post-loop tail (now `agent/turn_finalizer.finalize_turn`), which already injects a summary request and makes one extra tool-less API call.

However, #8935 only removed the **producer** side (the setter + grace-message injection). The **consumer** side survived and was later carried into its current location by the god-file extraction refactors (`extract run_conversation` → `agent/conversation_loop.py`, `extract __init__` → `agent/agent_init.py`):

- `agent/conversation_loop.py` — the `or agent._budget_grace_call` disjunct in the `while` condition, and the `if agent._budget_grace_call: ... = False` branch
- `agent/agent_init.py` — the `_budget_grace_call` and `_budget_exhausted_injected` initializers (the latter's setter was also removed in #8935)

Since neither flag is ever set `True`, `... or agent._budget_grace_call` reduces to `... or False` and `if agent._budget_grace_call:` is never taken — the loop always falls through to the normal `iteration_budget.consume()` path.

## Changes

- `agent/conversation_loop.py`: drop the dead disjunct from the loop condition; collapse the `if/elif` so budget consumption is the single check.
- `agent/agent_init.py`: remove both flag initializers and their (now-stale) comment block.
- `tests/run_agent/test_run_agent.py`: remove the obsolete `TestBudgetPressure::test_grace_call_flags_initialized` (asserted the removed flags init to `False`).
- `AGENTS.md`: drop the stale `or self._budget_grace_call` line and "one-turn grace call" wording from the loop pseudocode.

Net: **4 insertions, 28 deletions**. No behavior change.

## Verification

- `python -m py_compile` on all touched modules — clean.
- `grep -rn "_budget_grace_call\|_budget_exhausted_injected"` across the tree — zero remaining references.
- `pytest tests/run_agent/test_run_agent.py -k "budget or iteration or grace or max_iter or loop"` — 13 passed; full file collects cleanly (371 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
