### PR TITLE
fix(honcho): include observer_id and observed_id in conclusion payload for v3 API compatibility

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1177,16 +1177,24 @@ class HonchoSessionManager:
             if target_peer_id == session.assistant_peer_id:
                 assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
                 conclusions_scope = assistant_peer.conclusions_of(session.assistant_peer_id)
+                observer_id = session.assistant_peer_id
+                observed_id = session.assistant_peer_id
             elif self._ai_observe_others:
                 assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
                 conclusions_scope = assistant_peer.conclusions_of(target_peer_id)
+                observer_id = session.assistant_peer_id
+                observed_id = target_peer_id
             else:
                 target_peer = self._get_or_create_peer(target_peer_id)
                 conclusions_scope = target_peer.conclusions_of(target_peer_id)
+                observer_id = target_peer_id
+                observed_id = target_peer_id
 
             conclusions_scope.create([{
                 "content": content.strip(),
                 "session_id": session.honcho_session_id,
+                "observer_id": observer_id,
+                "observed_id": observed_id,
             }])
             logger.info("Created conclusion about %s for %s: %s", target_peer_id, session_key, content[:80])
             return True

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -365,6 +365,8 @@ class TestPeerLookupHelpers:
         scope.create.assert_called_once_with([{
             "content": "User prefers dark mode",
             "session_id": session.honcho_session_id,
+            "observer_id": session.assistant_peer_id,
+            "observed_id": session.user_peer_id,
         }])
 
     def test_create_conclusion_can_target_ai_peer(self):
@@ -381,6 +383,8 @@ class TestPeerLookupHelpers:
         scope.create.assert_called_once_with([{
             "content": "Assistant prefers terse summaries",
             "session_id": session.honcho_session_id,
+            "observer_id": session.assistant_peer_id,
+            "observed_id": session.assistant_peer_id,
         }])
 
     def test_create_conclusion_accepts_explicit_user_peer_id(self):
@@ -397,6 +401,28 @@ class TestPeerLookupHelpers:
         scope.create.assert_called_once_with([{
             "content": "Robert prefers vinyl",
             "session_id": session.honcho_session_id,
+            "observer_id": session.assistant_peer_id,
+            "observed_id": session.user_peer_id,
+        }])
+
+
+    def test_create_conclusion_user_observe_self_when_ai_observe_others_disabled(self):
+        mgr, session = self._make_cached_manager()
+        mgr._ai_observe_others = False
+        target_peer = MagicMock()
+        scope = MagicMock()
+        target_peer.conclusions_of.return_value = scope
+        mgr._get_or_create_peer = MagicMock(return_value=target_peer)
+
+        ok = mgr.create_conclusion(session.key, "User prefers dark mode")
+
+        assert ok is True
+        target_peer.conclusions_of.assert_called_once_with(session.user_peer_id)
+        scope.create.assert_called_once_with([{
+            "content": "User prefers dark mode",
+            "session_id": session.honcho_session_id,
+            "observer_id": session.user_peer_id,
+            "observed_id": session.user_peer_id,
         }])
 
 


### PR DESCRIPTION
## What does this PR do?

Adds explicit `observer_id` and `observed_id` fields to the Honcho conclusion payload so that Honcho v3.0.9+ servers accept the request. Previously, the Honcho Python SDK v2.0.1 sent only `peer_id` (v2 format), which v3 servers reject with "Field required" errors.

## Related Issue

Fixes #42815

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/honcho/session.py`: Add `observer_id` and `observed_id` to the conclusion payload in `create_conclusion()`. The observer/observed relationship follows the existing scope logic: self-observation (assistant→assistant), AI observes others (assistant→target), or user self-observation (target→target).
- `tests/honcho_plugin/test_session.py`: Updated 3 existing conclusion tests to verify the new fields, added 1 new test for the `_ai_observe_others=False` path.

## How to Test

1. Configure Hermes with `memory.provider=honcho` pointing to a Honcho v3.0.9+ server
2. Create a workspace + peer, then call `honcho_conclude` with a fact about the user
3. Verify the conclusion is saved without "Field required" errors
4. Run `pytest tests/honcho_plugin/test_session.py -v` — all 119 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/honcho_plugin/test_session.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/memory/honcho/session.py::create_conclusion` (callers: 1 via tool dispatch)
- Blast radius: LOW — conclusion creation only, no other code paths affected
- Related patterns: Honcho v2→v3 API field migration; `observer_id`/`observed_id` replace `peer_id` in v3 ConclusionCreate schema
