### PR TITLE
feat(tools): add ektro_mv_create — one sentence → a music video

### DIFF
--- a/optional-skills/creative/ektro-mv/SKILL.md
+++ b/optional-skills/creative/ektro-mv/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: ektro-mv
+description: Turn one sentence into a finished music video with EKTRO-MV — it writes the song (lyrics + vocals), generates the video, optionally captions it, and renders a delivery-compliant MP4. Use when the user asks to "make an MV / music video / 神曲 / 一句话出片" from a short description.
+version: 1.0.0
+author: Hermes Agent (Nous Research)
+license: MIT
+metadata:
+  hermes:
+    tags: [Creative, Music-Video, Text-to-Video, Generative, Remotion]
+    related_skills: [songwriting-and-ai-music]
+    requires_toolsets: [ektro_mv]
+---
+
+# EKTRO-MV — one sentence → a music video
+
+[EKTRO-MV](https://github.com/HorizonNowhere/EKTRO-MV) is an open-source TypeScript engine
+that turns one sentence into a finished music video: an LLM writes the song and shotlist,
+ACE-Step sings it, Seedance generates the visuals, Whisper aligns captions, and Remotion
+renders the final MP4 (H.264 / yuv420p / AAC).
+
+## Preferred: the `ektro_mv_create` tool
+
+When the `ektro_mv` toolset is enabled (the `ektro-mv` CLI is resolvable), call the
+**`ektro_mv_create`** tool:
+
+- `prompt` (string): one sentence, e.g. `做一首赛博朋克 AI 觉醒神曲`.
+- `brief` (optional): path to a CreativeBrief JSON — skips the LLM brain (no ANTHROPIC_API_KEY needed).
+- `out` (optional): where to move the finished `.mp4`.
+- `skip_subtitles` (optional, default true): the Whisper stage is opt-in.
+- `timeout` (optional): seconds (default 900; raise for longer songs).
+
+It returns JSON with `output_mp4` (path to the rendered video).
+
+## Prerequisites (tell the user if missing)
+
+- **Node.js 20+** and the EKTRO-MV CLI resolvable, via one of:
+  - `npm install -g ektro-mv`, **or**
+  - `EKTRO_MV_DIR=/path/to/EKTRO-MV` (a cloned + built repo), **or**
+  - `EKTRO_MV_BIN=/path/to/EKTRO-MV/packages/cli/dist/bin.js`
+- **`ARK_API_KEY`** — Volcengine Ark key for Seedance video.
+- **`ANTHROPIC_API_KEY`** — only for `prompt` mode (the creative brain); not needed with `brief`.
+- **ComfyUI running with ACE-Step** (local, GPU) for the vocal song.
+- `ffmpeg` / `ffprobe` on PATH.
+- Generation takes several minutes; the music stage needs a GPU.
+
+## CLI fallback (via the terminal toolset)
+
+If the tool isn't wired, drive the CLI directly:
+
+```bash
+ektro-mv "做一首赛博朋克 AI 觉醒神曲" --out mv.mp4 --skip-subtitles
+# or from a cloned repo:
+node /path/to/EKTRO-MV/packages/cli/dist/bin.js "make a cyberpunk anthem" --out mv.mp4 --skip-subtitles
+```
+
+## MCP alternative
+
+EKTRO-MV also ships an MCP server exposing `ektro_mv_create`. Register it once:
+
+```bash
+hermes mcp add ektro-mv --command "node /path/to/EKTRO-MV/mcp/ektro-mv-mcp/dist/bin.js"
+```
+
+## Notes
+
+- Output targets H.264 / yuv420p / AAC for broad platform compatibility.
+- For a keyless, deterministic run, hand-write or generate a CreativeBrief JSON and pass `brief`.
+- This skill drives the open-source EKTRO-MV engine; it creates no proprietary content itself.

--- a/tools/ektro_mv.py
+++ b/tools/ektro_mv.py
@@ -1,0 +1,208 @@
+"""
+ektro_mv — generate a complete music video from one sentence via the
+open-source EKTRO-MV CLI (a separate TypeScript engine).
+
+Pipeline: a creative brief (LLM or a provided JSON) -> ACE-Step vocal song ->
+Seedance video -> optional Whisper subtitles -> Remotion compositing -> a
+delivery-compliant MP4. This tool shells out to the `ektro-mv` CLI and returns
+the path to the rendered MP4.
+
+Mirrors the external-CLI subprocess pattern of tools/claude_max.py.
+
+EKTRO-MV: https://github.com/HorizonNowhere/EKTRO-MV
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from typing import Any, Dict, List, Optional
+
+
+_DEFAULT_TIMEOUT_SEC = 900  # 15 min — song + video generation + render is slow
+
+
+def _resolve_cmd() -> Optional[List[str]]:
+    """Return the base command to invoke the EKTRO-MV CLI, or None if unresolvable.
+
+    Resolution order:
+      1. ``ektro-mv`` on PATH (global npm install).
+      2. ``EKTRO_MV_BIN`` env — absolute path to the CLI entry (a ``.js`` file is
+         run with node; anything else is executed directly).
+      3. ``EKTRO_MV_DIR`` env — path to a cloned EKTRO-MV repo; runs
+         ``node <dir>/packages/cli/dist/bin.js``.
+    """
+    on_path = shutil.which("ektro-mv")
+    if on_path:
+        return [on_path]
+
+    bin_env = os.environ.get("EKTRO_MV_BIN")
+    if bin_env and os.path.isfile(bin_env):
+        if bin_env.endswith(".js"):
+            node = shutil.which("node")
+            if node:
+                return [node, bin_env]
+        else:
+            return [bin_env]
+
+    dir_env = os.environ.get("EKTRO_MV_DIR")
+    if dir_env:
+        entry = os.path.join(dir_env, "packages", "cli", "dist", "bin.js")
+        node = shutil.which("node")
+        if node and os.path.isfile(entry):
+            return [node, entry]
+
+    return None
+
+
+def check_requirements() -> bool:
+    """True iff the EKTRO-MV CLI is resolvable (PATH, EKTRO_MV_BIN, or EKTRO_MV_DIR)."""
+    return _resolve_cmd() is not None
+
+
+def _extract_output_path(stdout: str) -> str:
+    """Pull the final MP4 path from CLI stdout (printed as a ``✅ <path>`` line)."""
+    path = ""
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if line.startswith("✅"):  # ✅
+            path = line.lstrip("✅").strip()
+    return path
+
+
+def ektro_mv_create(
+    prompt: str = "",
+    *,
+    brief: Optional[str] = None,
+    out: Optional[str] = None,
+    workdir: Optional[str] = None,
+    skip_subtitles: bool = True,
+    timeout: int = _DEFAULT_TIMEOUT_SEC,
+    task_id: Optional[str] = None,
+) -> str:
+    """Render a music video from one sentence (or a brief JSON). Returns a JSON string.
+
+    Either ``prompt`` (one sentence; the engine writes the song + shotlist, needs
+    ANTHROPIC_API_KEY) or ``brief`` (path to a CreativeBrief JSON; no LLM needed) must
+    be given. The engine also needs ARK_API_KEY (Seedance) and a running ComfyUI with
+    ACE-Step for the vocal song — these come from the environment, not this tool.
+    """
+    base = _resolve_cmd()
+    if base is None:
+        return json.dumps({
+            "ok": False, "error": "ektro_mv_not_found",
+            "text": "EKTRO-MV CLI not found. Install it (npm i -g ektro-mv) or set "
+                    "EKTRO_MV_BIN / EKTRO_MV_DIR.",
+        })
+    if not (prompt and prompt.strip()) and not brief:
+        return json.dumps({
+            "ok": False, "error": "empty_input",
+            "text": "Provide either 'prompt' (one sentence) or 'brief' (path to a brief JSON).",
+        })
+
+    cmd = list(base)
+    if brief:
+        cmd += ["--brief", brief]
+    elif prompt.strip():
+        cmd.append(prompt.strip())
+    if skip_subtitles:
+        cmd.append("--skip-subtitles")
+    if workdir:
+        cmd += ["--workdir", workdir]
+    if out:
+        cmd += ["--out", out]
+
+    try:
+        proc = subprocess.run(
+            cmd, text=True, capture_output=True, timeout=timeout, env=os.environ.copy(),
+        )
+    except subprocess.TimeoutExpired:
+        return json.dumps({"ok": False, "error": "timeout",
+                           "text": f"EKTRO-MV exceeded {timeout}s"})
+    except FileNotFoundError:
+        return json.dumps({"ok": False, "error": "exec_failed",
+                           "text": f"could not execute: {cmd[0]}"})
+
+    output_mp4 = _extract_output_path(proc.stdout) if proc.returncode == 0 else ""
+    tail = (proc.stdout or proc.stderr or "")[-1500:]
+    return json.dumps({
+        "ok": proc.returncode == 0 and bool(output_mp4),
+        "output_mp4": output_mp4,
+        "exit_code": proc.returncode,
+        "log_tail": tail,
+        "error": None if proc.returncode == 0 else "cli_error",
+    })
+
+
+# ---------------------------------------------------------------------------
+# Tool schema + registry wiring
+# ---------------------------------------------------------------------------
+
+EKTRO_MV_CREATE_SCHEMA: Dict[str, Any] = {
+    "name": "ektro_mv_create",
+    "description": (
+        "Create a complete music video from one sentence using the open-source "
+        "EKTRO-MV engine (https://github.com/HorizonNowhere/EKTRO-MV). It writes a "
+        "song (lyrics + vocals via ACE-Step), generates video (Seedance), optionally "
+        "captions it (Whisper), and renders a delivery-compliant MP4 (Remotion). "
+        "Returns JSON with 'ok', 'output_mp4' (path to the finished MP4), 'exit_code', "
+        "and 'log_tail'. Provide 'prompt' (one sentence — needs ANTHROPIC_API_KEY for "
+        "the creative brain) OR 'brief' (path to a CreativeBrief JSON — no LLM needed). "
+        "Requires ARK_API_KEY (Seedance) and a running ComfyUI with ACE-Step in the env. "
+        "Generation takes minutes; raise 'timeout' for longer songs."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "One sentence describing the music video to make.",
+            },
+            "brief": {
+                "type": "string",
+                "description": "Optional path to a CreativeBrief JSON (skips the LLM brain; no ANTHROPIC_API_KEY needed).",
+            },
+            "out": {
+                "type": "string",
+                "description": "Optional output .mp4 path to move the finished video to.",
+            },
+            "workdir": {
+                "type": "string",
+                "description": "Optional working directory for intermediate + output files.",
+            },
+            "skip_subtitles": {
+                "type": "boolean",
+                "description": "Skip the Whisper subtitle stage (default true; subtitles need an optional dependency).",
+            },
+            "timeout": {
+                "type": "integer",
+                "description": "Seconds before killing the run (default 900).",
+                "minimum": 60,
+                "maximum": 3600,
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="ektro_mv_create",
+    toolset="ektro_mv",
+    schema=EKTRO_MV_CREATE_SCHEMA,
+    handler=lambda args, **kw: ektro_mv_create(
+        prompt=args.get("prompt", ""),
+        brief=args.get("brief"),
+        out=args.get("out"),
+        workdir=args.get("workdir"),
+        skip_subtitles=bool(args.get("skip_subtitles", True)),
+        timeout=int(args.get("timeout") or _DEFAULT_TIMEOUT_SEC),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_requirements,
+    requires_env=["ARK_API_KEY"],
+    emoji="\U0001f3ac",  # 🎬
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -90,7 +90,13 @@ TOOLSETS = {
         "tools": ["image_generate"],
         "includes": []
     },
-    
+
+    "ektro_mv": {
+        "description": "EKTRO-MV: turn one sentence into a finished music video (song + video + render) via the open-source ektro-mv CLI",
+        "tools": ["ektro_mv_create"],
+        "includes": []
+    },
+
     "terminal": {
         "description": "Terminal/command execution and process management tools",
         "tools": ["terminal", "process"],


### PR DESCRIPTION
## Summary

Adds an integration for **[EKTRO-MV](https://github.com/HorizonNowhere/EKTRO-MV)**, an
open-source TypeScript engine that turns one sentence into a finished music video
(LLM writes the song + shotlist → ACE-Step sings it → Seedance generates video →
Whisper captions → Remotion renders a delivery-compliant MP4).

So Hermes can do: *"make a cyberpunk AI-awakening anthem"* → an MP4.

## What this adds

- **`tools/ektro_mv.py`** — an `ektro_mv_create` tool that shells out to the `ektro-mv`
  CLI via `subprocess`, mirroring the external-CLI pattern already used by
  `tools/claude_max.py` (`shutil.which` check_fn + JSON-string return). The CLI is
  resolved via PATH, `EKTRO_MV_BIN`, or `EKTRO_MV_DIR`; `check_fn` gates the tool so it
  only appears when the CLI is actually installed.
- **`toolsets.py`** — registers the `ektro_mv` toolset.
- **`optional-skills/creative/ektro-mv/SKILL.md`** — usage skill (tool + CLI + MCP paths).

## On "skill vs tool"

Per CONTRIBUTING, tools are rarely needed and skills are preferred. EKTRO-MV also ships
an MCP server, so this integration works **skill-only + MCP** with no Python at all. I've
included the thin `ektro_mv_create` tool for convenience (it follows the `claude_max`
precedent and degrades cleanly when the CLI is absent), but I'm happy to **drop the tool
and ship only the skill** if maintainers prefer — just say the word.

## Testing

- Auto-discovery picks up `tools.ektro_mv`; `toolsets.py` parses with the new toolset.
- `check_requirements()` correctly resolves the CLI via `EKTRO_MV_DIR` and returns False
  when unresolvable; empty input returns a clear error without spawning a subprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)