### PR TITLE
fix(auth): keep OpenRouter pool when base URL stays canonical

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1310,14 +1310,23 @@ def resolve_runtime_provider(
         cfg_base_url = str(model_cfg.get("base_url") or "").strip()
         env_openai_base_url = os.getenv("OPENAI_BASE_URL", "").strip()
         env_openrouter_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip()
+        explicit_openrouter_host = bool(
+            explicit_base_url and base_url_host_matches(explicit_base_url, "openrouter.ai")
+        )
         has_custom_endpoint = bool(
-            explicit_base_url
+            (explicit_base_url and not explicit_openrouter_host)
             or env_openai_base_url
             or env_openrouter_base_url
         )
         if cfg_base_url and cfg_provider in {"auto", "custom"}:
             has_custom_endpoint = True
-        has_runtime_override = bool(explicit_api_key or explicit_base_url)
+        # A caller may pass the canonical OpenRouter URL explicitly (for
+        # example, persisted CLI model-switch state). Treat that as the same
+        # OpenRouter route, not as a custom-endpoint override that disables the
+        # auth pool.
+        has_runtime_override = bool(
+            explicit_api_key or (explicit_base_url and not explicit_openrouter_host)
+        )
         should_use_pool = (
             requested_provider in {"openrouter", "auto"}
             and not has_custom_endpoint

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -421,6 +421,39 @@ def test_resolve_runtime_provider_openrouter_explicit_api_key_skips_pool(monkeyp
     assert resolved.get("credential_pool") is None
 
 
+def test_resolve_runtime_provider_openrouter_explicit_default_base_url_keeps_pool(monkeypatch):
+    class _Entry:
+        access_token = "pool-key"
+        source = "manual"
+        base_url = "https://openrouter.ai/api/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="openrouter",
+        explicit_base_url=rp.OPENROUTER_BASE_URL,
+    )
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "pool-key"
+    assert resolved["base_url"] == "https://openrouter.ai/api/v1"
+    assert resolved["source"] == "manual"
+    assert resolved.get("credential_pool") is not None
+
+
 def test_resolve_runtime_provider_openrouter_ignores_codex_config_base_url(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
     monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

Keeps OpenRouter auth-pool credentials active when the runtime resolver is called with the canonical OpenRouter base URL explicitly.

Today that explicit `https://openrouter.ai/api/v1` value is treated like a custom-endpoint override, which bypasses `load_pool("openrouter")` and collapses to an empty API key unless `OPENROUTER_API_KEY` is also present in the environment. This change preserves pool resolution for canonical OpenRouter hosts while still bypassing the pool for real mirror/custom hosts.

Fixes #42835.

## Changes made

- Treat explicit base URLs on the canonical `openrouter.ai` host as the normal OpenRouter route instead of a custom-endpoint override.
- Keep the existing pool-bypass behavior for mirror/custom hosts and for explicit API key overrides.
- Add a regression test covering the auth-pool-only + explicit canonical base-url case.

## How to test

- `uv run --frozen python -m pytest -q tests/hermes_cli/test_runtime_provider_resolution.py -k 'openrouter'`
- `uv run --frozen ruff check hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py`
- `git diff --check`
