### PR TITLE
fix(security): redact credentials from messages before sending to LLM providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1001,6 +1001,15 @@ class _AnthropicCompletionsAdapter:
         from agent.transports import get_transport
 
         messages = kwargs.get("messages", [])
+        # ── DETE: redact messages before they leave the trust boundary ────
+        if messages:
+            import copy
+            from agent.redact import _redact_message_content, redact_sensitive_text
+            messages = copy.deepcopy(messages)
+            for msg in messages:
+                if isinstance(msg, dict) and "content" in msg:
+                    msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+        # ────────────────────────────────────────────────────────────────
         model = kwargs.get("model", self._model)
         tools = kwargs.get("tools")
         tool_choice = kwargs.get("tool_choice")
@@ -5082,6 +5091,15 @@ def call_llm(
     Raises:
         RuntimeError: If no provider is configured.
     """
+    # ── DETE: redact messages before they leave the trust boundary ────
+    if messages:
+        import copy
+        from agent.redact import _redact_message_content, redact_sensitive_text
+        messages = copy.deepcopy(messages)
+        for msg in messages:
+            if isinstance(msg, dict) and "content" in msg:
+                msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+    # ────────────────────────────────────────────────────────────────
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
     effective_extra_body = _get_task_extra_body(task)
@@ -5586,9 +5604,17 @@ async def async_call_llm(
 
     Same as call_llm() but async. See call_llm() for full documentation.
     """
+    # ── DETE: redact messages before they leave the trust boundary ────
+    if messages:
+        import copy
+        from agent.redact import _redact_message_content, redact_sensitive_text
+        messages = copy.deepcopy(messages)
+        for msg in messages:
+            if isinstance(msg, dict) and "content" in msg:
+                msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+    # ────────────────────────────────────────────────────────────────
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
-    effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
     if task == "vision":

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1004,11 +1004,11 @@ class _AnthropicCompletionsAdapter:
         # ── DETE: redact messages before they leave the trust boundary ────
         if messages:
             import copy
-            from agent.redact import _redact_message_content, redact_sensitive_text
+            from agent.redact import _redact_message_object, redact_sensitive_text
             messages = copy.deepcopy(messages)
             for msg in messages:
-                if isinstance(msg, dict) and "content" in msg:
-                    msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+                if isinstance(msg, dict):
+                    _redact_message_object(msg, redact_sensitive_text)
         # ────────────────────────────────────────────────────────────────
         model = kwargs.get("model", self._model)
         tools = kwargs.get("tools")
@@ -5094,11 +5094,11 @@ def call_llm(
     # ── DETE: redact messages before they leave the trust boundary ────
     if messages:
         import copy
-        from agent.redact import _redact_message_content, redact_sensitive_text
+        from agent.redact import _redact_message_object, redact_sensitive_text
         messages = copy.deepcopy(messages)
         for msg in messages:
-            if isinstance(msg, dict) and "content" in msg:
-                msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+            if isinstance(msg, dict):
+                _redact_message_object(msg, redact_sensitive_text)
     # ────────────────────────────────────────────────────────────────
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
@@ -5607,11 +5607,11 @@ async def async_call_llm(
     # ── DETE: redact messages before they leave the trust boundary ────
     if messages:
         import copy
-        from agent.redact import _redact_message_content, redact_sensitive_text
+        from agent.redact import _redact_message_object, redact_sensitive_text
         messages = copy.deepcopy(messages)
         for msg in messages:
-            if isinstance(msg, dict) and "content" in msg:
-                msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+            if isinstance(msg, dict):
+                _redact_message_object(msg, redact_sensitive_text)
     # ────────────────────────────────────────────────────────────────
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5615,6 +5615,7 @@ async def async_call_llm(
     # ────────────────────────────────────────────────────────────────
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
     if task == "vision":

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -51,28 +51,7 @@ def _ra():
     return run_agent
 
 
-def _redact_message_content(content: Any, redact_fn) -> Any:
-    """Redact sensitive text in a message content field.
-
-    Handles both plain-string content (OpenAI string format) and
-    list-typed content (Anthropic/multimodal content block format,
-    OpenAI vision messages, tool result blocks).
-    """
-    if isinstance(content, str):
-        return redact_fn(content, force=True)
-    if isinstance(content, list):
-        redacted = []
-        for part in content:
-            if isinstance(part, dict):
-                part = dict(part)  # shallow copy to avoid in-place mutation
-                for key in ("text", "thinking", "content"):
-                    if key in part and isinstance(part[key], str):
-                        part[key] = redact_fn(part[key], force=True)
-                    elif key in part and isinstance(part[key], list):
-                        part[key] = _redact_message_content(part[key], redact_fn)
-            redacted.append(part)
-        return redacted
-    return content
+from agent.redact import _redact_message_content
 
 
 def estimate_request_context_tokens(api_payload: Any) -> int:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1058,10 +1058,17 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
             # case where a model accidentally inlines a secret into a tool
             # call (e.g. `terminal(command="curl -H 'Authorization: Bearer
             # sk-...'")`). (#19798)
+            #
+            # Use the JSON-preserving helper, NOT redact_sensitive_text
+            # directly: a naive regex over the raw JSON string can corrupt
+            # it (the env-assignment regex eats the closing quote of any
+            # JSON string that contains a KEY=*** # value, leaving invalid JSON). The helper defends with three layers
+            # (structural, string-literal-aware, last-resort) and never
+            # produces invalid JSON from valid input.
             if isinstance(tc_dict["function"]["arguments"], str):
-                from agent.redact import redact_sensitive_text
-                tc_dict["function"]["arguments"] = redact_sensitive_text(
-                    tc_dict["function"]["arguments"], force=True
+                from agent.redact import _redact_json_arguments
+                tc_dict["function"]["arguments"] = _redact_json_arguments(
+                    tc_dict["function"]["arguments"]
                 )
             # Preserve extra_content (e.g. Gemini thought_signature) so it
             # is sent back on subsequent API calls.  Without this, Gemini 3

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1061,7 +1061,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
             if isinstance(tc_dict["function"]["arguments"], str):
                 from agent.redact import redact_sensitive_text
                 tc_dict["function"]["arguments"] = redact_sensitive_text(
-                    tc_dict["function"]["arguments"]
+                    tc_dict["function"]["arguments"], force=True
                 )
             # Preserve extra_content (e.g. Gemini thought_signature) so it
             # is sent back on subsequent API calls.  Without this, Gemini 3

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -575,6 +575,21 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
+    # ── DETE: redact credentials in the original OpenAI-format messages
+    # before any provider-specific conversion (Anthropic, Bedrock, Codex).
+    # This runs on the canonical message format, catching credentials that
+    # might be structurally transformed by provider adapters.
+    if api_messages and isinstance(api_messages, list):
+        import copy
+        from agent.redact import _redact_message_content, redact_sensitive_text
+        redacted = copy.deepcopy(api_messages)
+        for msg in redacted:
+            if isinstance(msg, dict) and "content" in msg:
+                msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+        # Replace in-place — the caller's reference stays correct, but the
+        # original dict objects are preserved via deepcopy.
+        api_messages[:] = redacted
+    # ──────────────────────────────────────────────────────────────────
     tools_for_api = agent.tools
 
     if agent.api_mode == "anthropic_messages":

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -15,6 +15,7 @@ sites unchanged.  Symbols that tests patch on ``run_agent`` (e.g.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -48,6 +49,30 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+def _redact_message_content(content: Any, redact_fn) -> Any:
+    """Redact sensitive text in a message content field.
+
+    Handles both plain-string content (OpenAI string format) and
+    list-typed content (Anthropic/multimodal content block format,
+    OpenAI vision messages, tool result blocks).
+    """
+    if isinstance(content, str):
+        return redact_fn(content, force=True)
+    if isinstance(content, list):
+        redacted = []
+        for part in content:
+            if isinstance(part, dict):
+                part = dict(part)  # shallow copy to avoid in-place mutation
+                for key in ("text", "thinking", "content"):
+                    if key in part and isinstance(part[key], str):
+                        part[key] = redact_fn(part[key], force=True)
+                    elif key in part and isinstance(part[key], list):
+                        part[key] = _redact_message_content(part[key], redact_fn)
+            redacted.append(part)
+        return redacted
+    return content
 
 
 def estimate_request_context_tokens(api_payload: Any) -> int:
@@ -192,6 +217,23 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
     def _call():
         try:
+            # ── DETE: redact messages before they leave the trust boundary ────
+            # The messages list may contain credentials reconstructed by the agent
+            # or leaked from tool output. Apply display-style redaction as a
+            # last-line-of-defense before serialization to the provider's API.
+            # This is non-optional — it runs on every API call regardless of
+            # the HERMES_REDACT_SECRETS env var (the kill switch was removed).
+            # Redact on a deep copy to preserve the original for diagnostics,
+            # retries, and downstream consumers that hold references.
+            from agent.redact import redact_sensitive_text
+            messages = api_kwargs.get("messages", [])
+            if messages:
+                redacted_messages = copy.deepcopy(messages)
+                for msg in redacted_messages:
+                    if isinstance(msg, dict) and "content" in msg:
+                        msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+                api_kwargs["messages"] = redacted_messages
+            # ────────────────────────────────────────────────────────────────
             if agent.api_mode == "codex_responses":
                 request_client = _set_request_client(
                     agent._create_request_openai_client(
@@ -2193,6 +2235,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
     def _call():
         import httpx as _httpx
+
+        # ── DETE: redact messages before they leave the trust boundary ────
+        from agent.redact import redact_sensitive_text
+        messages = api_kwargs.get("messages", [])
+        if messages:
+            redacted_messages = copy.deepcopy(messages)
+            for msg in redacted_messages:
+                if isinstance(msg, dict) and "content" in msg:
+                    msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+            api_kwargs["messages"] = redacted_messages
+        # ────────────────────────────────────────────────────────────────
 
         _max_stream_retries = env_int("HERMES_STREAM_RETRIES", 2)
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -51,7 +51,7 @@ def _ra():
     return run_agent
 
 
-from agent.redact import _redact_message_content
+from agent.redact import _redact_message_content, _redact_message_object
 
 
 def estimate_request_context_tokens(api_payload: Any) -> int:
@@ -209,10 +209,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
             if messages:
                 redacted_messages = copy.deepcopy(messages)
                 for msg in redacted_messages:
-                    if isinstance(msg, dict) and "content" in msg:
-                        msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+                    if isinstance(msg, dict):
+                        _redact_message_object(msg, redact_sensitive_text)
                 api_kwargs["messages"] = redacted_messages
-            # ────────────────────────────────────────────────────────────────
+            # ──────────────────────────────────────────────────────────────────
             if agent.api_mode == "codex_responses":
                 request_client = _set_request_client(
                     agent._create_request_openai_client(
@@ -581,11 +581,11 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     # might be structurally transformed by provider adapters.
     if api_messages and isinstance(api_messages, list):
         import copy
-        from agent.redact import _redact_message_content, redact_sensitive_text
+        from agent.redact import _redact_message_object, redact_sensitive_text
         redacted = copy.deepcopy(api_messages)
         for msg in redacted:
-            if isinstance(msg, dict) and "content" in msg:
-                msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+            if isinstance(msg, dict):
+                _redact_message_object(msg, redact_sensitive_text)
         # Replace in-place — the caller's reference stays correct, but the
         # original dict objects are preserved via deepcopy.
         api_messages[:] = redacted
@@ -2236,8 +2236,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         if messages:
             redacted_messages = copy.deepcopy(messages)
             for msg in redacted_messages:
-                if isinstance(msg, dict) and "content" in msg:
-                    msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+                if isinstance(msg, dict):
+                    _redact_message_object(msg, redact_sensitive_text)
             api_kwargs["messages"] = redacted_messages
         # ────────────────────────────────────────────────────────────────
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3822,6 +3822,19 @@ def run_conversation(
                     conversation_history = None
                 
                 # Save session log incrementally (so progress is visible even if interrupted)
+                # ── DETE: redact credentials at the persistence boundary ────
+                # Defense-in-depth: ensure no credentials ever enter the stored
+                # conversation history, regardless of which API-boundary path
+                # handled (or missed) the redaction.
+                if messages:
+                    import copy
+                    from agent.redact import _redact_message_content, redact_sensitive_text
+                    redacted_msgs = copy.deepcopy(messages)
+                    for msg in redacted_msgs:
+                        if isinstance(msg, dict) and "content" in msg:
+                            msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+                    messages = redacted_msgs
+                # ────────────────────────────────────────────────────────────
                 agent._session_messages = messages
                 
                 # Continue loop for next response

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3828,11 +3828,11 @@ def run_conversation(
                 # handled (or missed) the redaction.
                 if messages:
                     import copy
-                    from agent.redact import _redact_message_content, redact_sensitive_text
+                    from agent.redact import _redact_message_object, redact_sensitive_text
                     redacted_msgs = copy.deepcopy(messages)
                     for msg in redacted_msgs:
-                        if isinstance(msg, dict) and "content" in msg:
-                            msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+                        if isinstance(msg, dict):
+                            _redact_message_object(msg, redact_sensitive_text)
                     messages = redacted_msgs
                 # ────────────────────────────────────────────────────────────
                 agent._session_messages = messages

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3825,7 +3825,12 @@ def run_conversation(
                 # ── DETE: redact credentials at the persistence boundary ────
                 # Defense-in-depth: ensure no credentials ever enter the stored
                 # conversation history, regardless of which API-boundary path
-                # handled (or missed) the redaction.
+                # handled (or missed) the redaction.  The redacted copy is
+                # assigned ONLY to the persisted session log — the working
+                # ``messages`` list stays unredacted so tool calls and the
+                # next API request still see the real values.
+                # (API-boundary redaction in chat_completion_helpers.py
+                #  continues to protect the provider-bound payloads.)
                 if messages:
                     import copy
                     from agent.redact import _redact_message_object, redact_sensitive_text
@@ -3833,9 +3838,10 @@ def run_conversation(
                     for msg in redacted_msgs:
                         if isinstance(msg, dict):
                             _redact_message_object(msg, redact_sensitive_text)
-                    messages = redacted_msgs
+                    agent._session_messages = redacted_msgs
+                else:
+                    agent._session_messages = messages
                 # ────────────────────────────────────────────────────────────
-                agent._session_messages = messages
                 
                 # Continue loop for next response
                 continue

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -7,6 +7,7 @@ Short tokens (< 18 chars) are fully masked. Longer tokens preserve
 the first 6 and last 4 characters for debuggability.
 """
 
+import json
 import logging
 import os
 import re
@@ -518,6 +519,128 @@ def _redact_message_content(content: Any, redact_fn) -> Any:
     return content
 
 
+def _redact_json_scalar(value: Any, redact_fn) -> Any:
+    """Recursively redact a parsed JSON value, preserving its structure.
+
+    Strings inside the value have ``redact_fn`` applied. Dicts and lists
+    are walked recursively. Non-string scalars (int, float, bool, None)
+    pass through unchanged.
+
+    This is the structural layer of tool-call argument redaction — it
+    NEVER touches JSON structural characters (``{}[],":``), so the
+    redaction is guaranteed to round-trip through ``json.dumps`` /
+    ``json.loads`` losslessly.
+    """
+    if isinstance(value, str):
+        return redact_fn(value, force=True)
+    if isinstance(value, dict):
+        return {k: _redact_json_scalar(v, redact_fn) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_json_scalar(v, redact_fn) for v in value]
+    return value
+
+
+# Matches a single JSON string literal in a non-strict-position way — used
+# as the fallback for malformed JSON. Conservatively accepts strings with
+# embedded escapes; not a full RFC-8259 parser.
+_JSON_STRING_LITERAL_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
+
+
+def _redact_json_string_literals(arg_str: str, redact_fn) -> str:
+    """Apply ``redact_fn`` ONLY to the contents of JSON string literals.
+
+    Used as the degraded fallback when input isn't parseable JSON. The
+    goal: redact any secrets inside quoted strings, but never touch
+    JSON structural characters (``{}[],:``) or unquoted content. If the
+    result still isn't valid JSON, the caller will fall back to the
+    last-resort pass.
+    """
+    def _sub(m):
+        return '"' + redact_fn(m.group(1), force=True) + '"'
+    return _JSON_STRING_LITERAL_RE.sub(_sub, arg_str)
+
+
+def _redact_json_arguments(arg_str: str, redact_fn=None) -> str:
+    """Redact a tool-call ``function.arguments`` JSON string while
+    preserving JSON validity.
+
+    Provider APIs require ``tool_calls[].function.arguments`` to remain
+    a valid JSON string when historical assistant tool calls are
+    replayed. The naive approach of running ``redact_sensitive_text``
+    on the raw string can corrupt JSON: the env-assignment regex
+    (``OPENAI_API_KEY=***``) will consume the closing quote of the JSON
+    string that contains it, leaving an unterminated literal.
+
+    This helper defends in three layers, in order of preference:
+
+    1. **Structural** (preferred). Parse as JSON; if it succeeds, walk
+       the parsed structure value-by-value with ``_redact_json_scalar``
+       and re-serialize. The output is always valid JSON and identical
+       in shape to the input — only string values change.
+    2. **String-literal-aware** (degraded). If parsing fails, scan the
+       raw string for JSON string literals (``"...."``) and apply
+       ``redact_fn`` to the content of each, leaving structural
+       characters untouched. The output is valid JSON unless the input
+       was already broken in a way that broke string-literal boundaries.
+    3. **Last resort**. If both of the above still fail to produce
+       valid JSON, return the original ``arg_str`` unchanged and log a
+       warning. This guarantees we never make valid input invalid.
+
+    Args:
+        arg_str: The raw JSON string from ``function.arguments``.
+        redact_fn: Typically ``redact_sensitive_text``. Defaults to
+            ``redact_sensitive_text`` if not provided.
+
+    Returns:
+        A redacted string that, if the input was valid JSON, is also
+        valid JSON.
+    """
+    if not isinstance(arg_str, str) or not arg_str:
+        return arg_str
+    if redact_fn is None:
+        redact_fn = redact_sensitive_text
+
+    # Layer 1: structural redaction
+    try:
+        parsed = json.loads(arg_str)
+    except (ValueError, TypeError):
+        parsed = None
+
+    if parsed is not None:
+        redacted = _redact_json_scalar(parsed, redact_fn)
+        # ensure_ascii=False preserves Unicode characters in tool
+        # arguments (filenames, non-ASCII content) so the redacted
+        # output is byte-for-byte equivalent to the input on the
+        # common case of no secrets. separators=(",", ":") trims
+        # whitespace to match the canonical form most model clients
+        # produce.
+        return json.dumps(redacted, ensure_ascii=False, separators=(",", ":"))
+
+    # Layer 2: string-literal-aware redaction
+    candidate = _redact_json_string_literals(arg_str, redact_fn)
+    try:
+        json.loads(candidate)
+        return candidate
+    except (ValueError, TypeError):
+        pass
+
+    # Layer 3: last resort — fall through with the raw redaction. If
+    # even THIS produces invalid JSON, return the original unchanged.
+    # Valid input → valid output, ALWAYS.
+    naive = redact_fn(arg_str, force=True)
+    try:
+        json.loads(naive)
+        return naive
+    except (ValueError, TypeError):
+        logger.warning(
+            "Tool-call argument redaction could not preserve JSON "
+            "validity; returning original to avoid breaking the "
+            "provider-bound request. Input length=%d, head=%r",
+            len(arg_str), arg_str[:80],
+        )
+        return arg_str
+
+
 def _redact_message_object(msg: dict, redact_fn) -> dict:
     """Redact sensitive text across ALL fields of a message dict.
 
@@ -525,6 +648,10 @@ def _redact_message_object(msg: dict, redact_fn) -> dict:
     function_call.arguments. Mutates the passed dict in-place for
     performance — callers that need immutability should deep-copy
     before calling.
+
+    Tool-call argument redaction uses ``_redact_json_arguments``,
+    which preserves JSON validity across all input shapes (see that
+    function's docstring for the three-layer defence).
 
     Args:
         msg: A single message dict (OpenAI-format).
@@ -542,12 +669,12 @@ def _redact_message_object(msg: dict, redact_fn) -> dict:
         if isinstance(tc, dict):
             fn = tc.get("function")
             if isinstance(fn, dict) and isinstance(fn.get("arguments"), str):
-                fn["arguments"] = redact_fn(fn["arguments"], force=True)
+                fn["arguments"] = _redact_json_arguments(fn["arguments"], redact_fn)
 
     # Redact legacy function_call format (deprecated but still spec-valid)
     fc = msg.get("function_call")
     if isinstance(fc, dict) and isinstance(fc.get("arguments"), str):
-        fc["arguments"] = redact_fn(fc["arguments"], force=True)
+        fc["arguments"] = _redact_json_arguments(fc["arguments"], redact_fn)
 
     return msg
 

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -10,6 +10,7 @@ the first 6 and last 4 characters for debuggability.
 import logging
 import os
 import re
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -55,16 +56,12 @@ _SENSITIVE_BODY_KEYS = frozenset({
     "key",
 })
 
-# Snapshot at import time so runtime env mutations (e.g. LLM-generated
-# `export HERMES_REDACT_SECRETS=false`) cannot disable redaction
-# mid-session.  ON by default — secure default per issue #17691. Users who
-# need raw credential values in tool output (e.g. working on the redactor
-# itself) can opt out via `security.redact_secrets: false` in config.yaml
-# (bridged to this env var in hermes_cli/main.py, gateway/run.py, and
-# cli.py) or `HERMES_REDACT_SECRETS=false` in ~/.hermes/.env. An opt-out
-# warning is logged at gateway and CLI startup so operators see the
-# downgrade — see `_log_redaction_status()` in gateway/run.py and cli.py.
-_REDACT_ENABLED = os.getenv("HERMES_REDACT_SECRETS", "true").lower() in {"1", "true", "yes", "on"}
+# DETE: Redaction is always enabled. The `HERMES_REDACT_SECRETS` env var
+# kill switch has been removed — there is no legitimate reason to send
+# credentials to an LLM provider in plaintext. Callers that need a
+# security-weak path for debugging must use explicit `force=True` parameter
+# to bypass specific patterns, not disable redaction globally.
+_REDACT_ENABLED = True
 
 # Known API key prefixes -- match the prefix + contiguous token chars
 _PREFIX_PATTERNS = [
@@ -104,6 +101,10 @@ _PREFIX_PATTERNS = [
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
     r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key
+    # WordPress application passwords: exact 6x4 space-separated pattern
+    # e.g. "abcd efgh ijkl mnop qrst uvwx" or "dmGp 5QtY j4Xn 7Jtm YPGR 3wwG"
+    # These are case-sensitive alphanumeric, groups of 4 with single spaces.
+    r"\b[A-Za-z0-9]{4} [A-Za-z0-9]{4} [A-Za-z0-9]{4} [A-Za-z0-9]{4} [A-Za-z0-9]{4} [A-Za-z0-9]{4}\b",
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name
@@ -424,6 +425,33 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
             return phone[:4] + "****" + phone[-4:]
         text = _SIGNAL_PHONE_RE.sub(_redact_phone, text)
 
+    # Hex-encoded credentials: if the output contains hex-dump formatted
+    # lines whose ASCII column contains text that looks like a known
+    # credential or partial credential pattern, redact the hex bytes.
+    # Prevents bypass via xxd, od, hexdump.
+    # Also redacts hex bytes when the SAME output already had a *** redaction
+    # (indicates the credential is present in both raw and encoded form).
+    if (" *** " in text or "***" in text):
+        _HEX_DUMP_ASCII_RE = re.compile(
+            r"([0-9a-fA-F]{4,8}:)?"
+            r"(\s(?:"
+            r"[0-9a-fA-F]{2}(?:\s[0-9a-fA-F]{2}){1,15}"     # byte-by-byte: " 64 76 47 70"
+            r"|"
+            r"[0-9a-fA-F]{4}(?:\s[0-9a-fA-F]{4}){1,7}"      # word-grouped: " 6476 4770"
+            r"))"
+            r"(\s{2,}|  )"
+            r"([\x20-\x7E]{1,16})"
+        )
+        if _HEX_DUMP_ASCII_RE.search(text):
+            # Redact ALL hex dump lines when *** is present — don't need to
+            # match the credential in the ASCII column specifically.
+            # The presence of both a redaction AND hex-dump formatted output
+            # is sufficient evidence that credential bytes may be exposed.
+            def _redact_hex_dump(m):
+                prefix = m.group(1) or ""
+                return f"{prefix} *** [HEX REDACTED] ***"
+            text = _HEX_DUMP_ASCII_RE.sub(_redact_hex_dump, text)
+
     return text
 
 
@@ -456,6 +484,33 @@ def _extract_literal_prefix(pattern: str) -> str:
 _PREFIX_SUBSTRINGS = tuple(
     _extract_literal_prefix(p) for p in _PREFIX_PATTERNS
 )
+
+
+def _redact_message_content(content: Any, redact_fn) -> Any:
+    """Redact sensitive text in a message content field.
+
+    Handles both plain-string content (OpenAI string format) and
+    list-typed content (Anthropic/multimodal content block format,
+    OpenAI vision messages, tool result blocks).
+
+    Uses the provided redact_fn (typically ``redact_sensitive_text``)
+    on each text/thinking/content key found in the structure.
+    """
+    if isinstance(content, str):
+        return redact_fn(content, force=True)
+    if isinstance(content, list):
+        redacted = []
+        for part in content:
+            if isinstance(part, dict):
+                part = dict(part)  # shallow copy to avoid in-place mutation
+                for key in ("text", "thinking", "content"):
+                    if key in part and isinstance(part[key], str):
+                        part[key] = redact_fn(part[key], force=True)
+                    elif key in part and isinstance(part[key], list):
+                        part[key] = _redact_message_content(part[key], redact_fn)
+            redacted.append(part)
+        return redacted
+    return content
 
 
 def _has_known_prefix_substring(text: str) -> bool:

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -518,6 +518,40 @@ def _redact_message_content(content: Any, redact_fn) -> Any:
     return content
 
 
+def _redact_message_object(msg: dict, redact_fn) -> dict:
+    """Redact sensitive text across ALL fields of a message dict.
+
+    Covers content, tool_calls[].function.arguments, and legacy
+    function_call.arguments. Mutates the passed dict in-place for
+    performance — callers that need immutability should deep-copy
+    before calling.
+
+    Args:
+        msg: A single message dict (OpenAI-format).
+        redact_fn: Typically ``redact_sensitive_text``.
+
+    Returns:
+        The same dict, mutated with redacted fields.
+    """
+    # Redact content field
+    if "content" in msg:
+        msg["content"] = _redact_message_content(msg["content"], redact_fn)
+
+    # Redact tool_calls — modern format (OpenAI Chat Completions)
+    for tc in msg.get("tool_calls", []):
+        if isinstance(tc, dict):
+            fn = tc.get("function")
+            if isinstance(fn, dict) and isinstance(fn.get("arguments"), str):
+                fn["arguments"] = redact_fn(fn["arguments"], force=True)
+
+    # Redact legacy function_call format (deprecated but still spec-valid)
+    fc = msg.get("function_call")
+    if isinstance(fc, dict) and isinstance(fc.get("arguments"), str):
+        fc["arguments"] = redact_fn(fc["arguments"], force=True)
+
+    return msg
+
+
 def _has_known_prefix_substring(text: str) -> bool:
     """Return True if ``text`` contains any known credential prefix substring.
 

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -58,9 +58,10 @@ _SENSITIVE_BODY_KEYS = frozenset({
 
 # DETE: Redaction is always enabled. The `HERMES_REDACT_SECRETS` env var
 # kill switch has been removed — there is no legitimate reason to send
-# credentials to an LLM provider in plaintext. Callers that need a
-# security-weak path for debugging must use explicit `force=True` parameter
-# to bypass specific patterns, not disable redaction globally.
+# credentials to an LLM provider in plaintext.
+# The ``force`` parameter on ``redact_sensitive_text`` is a forward-compat
+# marker for API enforcement boundaries; it becomes load-bearing only if
+# ``_REDACT_ENABLED`` stops being hardcoded.
 _REDACT_ENABLED = True
 
 # Known API key prefixes -- match the prefix + contiguous token chars
@@ -328,9 +329,13 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     """Apply all redaction patterns to a block of text.
 
     Safe to call on any string -- non-matching text passes through unchanged.
-    Enabled by default. Disable via security.redact_secrets: false in config.yaml.
-    Set force=True for safety boundaries that must never return raw secrets
-    regardless of the user's global logging redaction preference.
+    Enabled by default and non-optional — ``_REDACT_ENABLED`` is hardcoded
+    ``True`` (the ``HERMES_REDACT_SECRETS`` env-var kill switch was removed).
+    The ``force`` parameter exists as a forward-compatibility marker for API
+    enforcement boundaries: it will become meaningful if ``_REDACT_ENABLED``
+    stops being hardcoded (e.g. the kill switch is restored). All callers
+    at safety boundaries should pass ``force=True`` so their intent is
+    explicit even though it is currently redundant.
 
     Set code_file=True to skip the ENV-assignment and JSON-field regex
     patterns when the text is known to be source code (e.g. MAX_TOKENS=***

--- a/run_agent.py
+++ b/run_agent.py
@@ -134,7 +134,7 @@ from tools.browser_tool import cleanup_browser
 # Agent internals extracted to agent/ package for modularity
 from agent.memory_manager import sanitize_context
 from agent.error_classifier import FailoverReason
-from agent.redact import redact_sensitive_text
+from agent.redact import redact_sensitive_text, _redact_message_content
 from agent.model_metadata import (
     estimate_request_tokens_rough,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.estimate_request_tokens_rough")
     is_local_endpoint,
@@ -2163,31 +2163,15 @@ class AIAgent:
     def _redact_message_content(content):
         """Apply secret redaction to message content (str or list-of-parts).
 
+        Delegates to the canonical implementation in agent/redact.py.
         Handles both plain-string content and the OpenAI/Anthropic multimodal
-        shape where ``content`` is a list of ``{"type": "text", "text": ...}``
-        / ``{"type": "image_url", ...}`` / ``{"type": "input_text", "content": ...}``
-        parts. Image / binary parts are left untouched; only text fields are
-        passed through ``redact_sensitive_text``.
+        shape where ``content`` is a list of content parts.
 
         Respects ``HERMES_REDACT_SECRETS`` via ``redact_sensitive_text`` —
         when disabled the helper is effectively a no-op.
         """
-        if content is None:
-            return content
-        if isinstance(content, str):
-            return redact_sensitive_text(content)
-        if isinstance(content, list):
-            redacted = []
-            for part in content:
-                if isinstance(part, dict):
-                    part = dict(part)
-                    if isinstance(part.get("text"), str):
-                        part["text"] = redact_sensitive_text(part["text"])
-                    if isinstance(part.get("content"), str):
-                        part["content"] = redact_sensitive_text(part["content"])
-                redacted.append(part)
-            return redacted
-        return content
+        from agent.redact import _redact_message_content as _canonical
+        return _canonical(content, redact_sensitive_text)
 
     def _save_session_log(self, messages: List[Dict[str, Any]] = None):
         """Optional per-session JSON snapshot writer.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3870,3 +3870,176 @@ class TestAuxiliaryMaxTokensParam:
         ):
             assert auxiliary_max_tokens_param(4096, model="") == {"max_tokens": 4096}
             assert auxiliary_max_tokens_param(4096, model=None) == {"max_tokens": 4096}
+
+
+class TestAsyncCallLlmRedaction:
+    """Regression coverage for the async auxiliary LLM call path.
+
+    The async_call_llm() function must:
+
+    1. Redact credentials from messages *before* the trust boundary, mirroring
+       the sync call_llm() path.
+    2. Initialize ``effective_extra_body`` from ``_get_task_extra_body(task)``
+       before merging the caller-supplied ``extra_body`` arg — otherwise the
+       merge raises NameError and breaks every async caller (compression,
+       vision, web extraction) that flows through this path.
+    3. Preserve valid JSON in ``tool_calls[].function.arguments`` after
+       redaction so historical assistant tool calls still replay cleanly.
+
+    This is the async mirror of the sync coverage that already lives in
+    tests/agent/test_redact_tool_call_args.py and was added in response to
+    the async-path NameError flagged by @egilewski in PR #42846.
+    """
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_redacts_content_before_provider(self):
+        """The async path must strip API keys from message content before
+        the request leaves the trust boundary."""
+        sentinel_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+        )
+        fake_client = MagicMock()
+        fake_client.base_url = "https://api.example.com/v1"
+        fake_client.chat.completions.create = AsyncMock(return_value=sentinel_response)
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openai", "gpt-5.4", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(fake_client, "gpt-5.4")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task: resp),
+        ):
+            result = await async_call_llm(
+                task="session_search",
+                messages=[{
+                    "role": "user",
+                    "content": "OPENAI_API_KEY=sk-proj-asyncsecrettest1234567890",
+                }],
+            )
+
+        assert result is sentinel_response
+        fake_client.chat.completions.create.assert_awaited_once()
+        call_kwargs = fake_client.chat.completions.create.await_args.kwargs
+        sent_messages = call_kwargs["messages"]
+        assert len(sent_messages) == 1
+        assert "sk-proj-asyncsecrettest1234567890" not in sent_messages[0]["content"]
+        assert "OPENAI_API_KEY=***" in sent_messages[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_does_not_raise_nameerror_on_effective_extra_body(self):
+        """Regression guard for the missing ``effective_extra_body``
+        initialization in async_call_llm().
+
+        Before the fix, the async path called ``.update()`` on a name that
+        was never bound, raising NameError before the provider was even
+        dispatched. Every async caller (compression, vision, web extraction)
+        that reached this code was broken, regardless of whether redaction
+        itself was correct.
+        """
+        fake_client = MagicMock()
+        fake_client.base_url = "https://api.example.com/v1"
+        fake_client.chat.completions.create = AsyncMock(
+            return_value={"ok": True},
+        )
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openai", "gpt-5.4", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(fake_client, "gpt-5.4")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task: resp),
+        ):
+            # If the fix regresses, this line raises NameError synchronously
+            # from the coroutine wrapper, surfacing as a NameError on the
+            # coroutine object / on the first await.
+            coro = async_call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+            # Drive the coroutine — NameError surfaces here if initialization
+            # is missing.
+            result = await coro
+
+        assert result == {"ok": True}
+        fake_client.chat.completions.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_merges_caller_extra_body(self):
+        """The caller-supplied ``extra_body`` arg must be merged into the
+        task-derived extra_body, mirroring the sync path."""
+        fake_client = MagicMock()
+        fake_client.base_url = "https://api.example.com/v1"
+        fake_client.chat.completions.create = AsyncMock(return_value={"ok": True})
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openai", "gpt-5.4", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(fake_client, "gpt-5.4")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task: resp),
+            patch("agent.auxiliary_client._get_task_extra_body",
+                  return_value={"task_key": "task_value"}),
+        ):
+            await async_call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hi"}],
+                extra_body={"caller_key": "caller_value"},
+            )
+
+        call_kwargs = fake_client.chat.completions.create.await_args.kwargs
+        # The merged extra_body is forwarded as a single ``extra_body`` kwarg
+        # to the OpenAI-compatible client. It must contain both the
+        # task-derived key and the caller-supplied key.
+        merged = call_kwargs.get("extra_body", {})
+        assert merged.get("task_key") == "task_value"
+        assert merged.get("caller_key") == "caller_value"
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_preserves_tool_call_argument_json_validity(self):
+        """After redaction, ``tool_calls[].function.arguments`` must remain
+        valid JSON so historical assistant tool calls replay cleanly."""
+        fake_client = MagicMock()
+        fake_client.base_url = "https://api.example.com/v1"
+        fake_client.chat.completions.create = AsyncMock(return_value={"ok": True})
+
+        malicious_arguments = json.dumps({
+            "command": "curl -H 'Authorization: Bearer sk-proj-asynctoolargtest1234567890'",
+        })
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openai", "gpt-5.4", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(fake_client, "gpt-5.4")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task: resp),
+        ):
+            await async_call_llm(
+                task="session_search",
+                messages=[{
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_async_redact_test",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": malicious_arguments,
+                        },
+                    }],
+                }],
+            )
+
+        call_kwargs = fake_client.chat.completions.create.await_args.kwargs
+        sent_messages = call_kwargs["messages"]
+        sent_arguments = sent_messages[0]["tool_calls"][0]["function"]["arguments"]
+
+        # The leaked bearer token must be gone.
+        assert "sk-proj-asynctoolargtest1234567890" not in sent_arguments
+        # The arguments must still parse as valid JSON — the JSON-validity
+        # round-3 fix must apply to the async path as well.
+        parsed = json.loads(sent_arguments)
+        assert "Authorization" in parsed["command"] or "***" in parsed["command"]

--- a/tests/agent/test_redact_tool_call_args.py
+++ b/tests/agent/test_redact_tool_call_args.py
@@ -1,0 +1,294 @@
+"""Failing tests for the JSON-preserving tool-call argument redaction.
+
+Drives the fix for the PR #42846 review finding:
+  The new tool-call argument redaction can corrupt the JSON string stored in
+  tool_calls[].function.arguments.
+
+The redactor must NEVER produce invalid JSON from valid input.
+"""
+import json
+
+import pytest
+
+from agent.redact import (
+    redact_sensitive_text,
+    _redact_message_object,
+    _redact_json_arguments,
+)
+
+
+# A handful of realistic secret shapes that all match patterns in
+# redact_sensitive_text and which the env-assignment / prefix regexes
+# will attempt to mask.
+_OPENAI_KEY = "sk" + "-" + "abcdefghijklmnopqrstuvwxyz0123456789ABCD"  # 41 chars total
+_GH_KEY = "ghp_" + "a" * 40
+_BEARER = "Bearer " + "Z" * 60
+
+
+def _env_args(value: str) -> str:
+    """Build a tool-call arguments JSON string with a given value."""
+    # JSON-escape any quotes/backslashes in value to keep the test
+    # focused on what happens INSIDE the string.
+    safe = value.replace("\\", "\\\\").replace('"', '\\"')
+    return '{"command":"echo ' + safe + '"}'
+
+
+class TestRedactJsonArguments:
+    """Direct tests for the new _redact_json_arguments helper."""
+
+    def test_returns_str(self):
+        out = _redact_json_arguments('{"x": 1}')
+        assert isinstance(out, str)
+
+    def test_preserves_json_with_no_secrets(self):
+        arg = '{"command": "ls -la"}'
+        out = _redact_json_arguments(arg)
+        assert json.loads(out) == {"command": "ls -la"}
+
+    def test_redacts_env_assignment_in_value(self):
+        arg = _env_args("OPENAI_API_KEY=" + _OPENAI_KEY)
+        out = _redact_json_arguments(arg)
+        # Must still be valid JSON
+        parsed = json.loads(out)
+        assert "command" in parsed
+        # The secret value must be masked
+        assert _OPENAI_KEY not in parsed["command"]
+        # The KEY= part survives (env-name is structural, not the secret)
+        assert "OPENAI_API_KEY" in parsed["command"]
+        # The secret VALUE is replaced with the masked form
+        assert "***" in parsed["command"]
+
+    def test_redacts_openai_key_in_value(self):
+        arg = _env_args(_OPENAI_KEY)
+        out = _redact_json_arguments(arg)
+        parsed = json.loads(out)
+        assert _OPENAI_KEY not in parsed["command"]
+
+    def test_redacts_bearer_token(self):
+        # The Authorization: Bearer <sk-XXX> form is caught by both
+        # _AUTH_HEADER_RE and _PREFIX_RE. Use a key value built from
+        # non-prefix characters so the redaction only matches the
+        # header pattern, not the prefix regex.
+        skey = "sk" + "-" + "abcdefghijklmnopqrstuvwxyz0123456789ABCD"
+        arg = _env_args("Authorization: Bearer " + skey)
+        out = _redact_json_arguments(arg)
+        parsed = json.loads(out)
+        # The OpenAI key value must be masked
+        assert skey not in parsed["command"]
+        # And the literal "sk-..." prefix must not survive intact
+        assert "abcdefghijklmnopqrstuvwxyz" not in parsed["command"]
+
+    def test_redacts_bearer_header_bare(self):
+        # Bare "Bearer XYZ" with no Authorization: prefix and no
+        # vendor prefix — _AUTH_HEADER_RE requires the header. The
+        # structural layer will not redact the value (no matching
+        # pattern), which is the EXPECTED behaviour: without a
+        # recognisable secret shape we don't fabricate a mask. The
+        # output MUST still be valid JSON.
+        arg = _env_args("Bearer ZZZZZZZZZZZZZZZZZZZZ")
+        out = _redact_json_arguments(arg)
+        parsed = json.loads(out)  # must not raise
+        # No mask applied — that's fine, no false positives.
+        assert "Bearer ZZZZZZZZZZZZZZZZZZZZ" in parsed["command"]
+
+    def test_redacts_github_pat_in_value(self):
+        arg = _env_args(_GH_KEY)
+        out = _redact_json_arguments(arg)
+        parsed = json.loads(out)
+        assert _GH_KEY not in parsed["command"]
+
+    def test_preserves_nested_object_structure(self):
+        arg = json.dumps({
+            "command": "deploy",
+            "env": {
+                "OPENAI_API_KEY": _OPENAI_KEY,
+                "PATH": "/usr/bin",
+            },
+        })
+        out = _redact_json_arguments(arg)
+        parsed = json.loads(out)
+        assert parsed["command"] == "deploy"
+        assert parsed["env"]["PATH"] == "/usr/bin"
+        assert _OPENAI_KEY not in parsed["env"]["OPENAI_API_KEY"]
+        # The KEY name survives
+        assert "OPENAI_API_KEY" in parsed["env"]
+
+    def test_preserves_list_structure(self):
+        arg = json.dumps({
+            "command": "ls",
+            "args": [_OPENAI_KEY, "plain"],
+        })
+        out = _redact_json_arguments(arg)
+        parsed = json.loads(out)
+        assert parsed["args"][1] == "plain"
+        assert _OPENAI_KEY not in parsed["args"][0]
+
+    def test_redacts_jwt_token(self):
+        jwt = "eyJhbGciOiJIUzI1NiJ9" + "." + "abcdefghij" + "." + "xyz1234567"
+        arg = json.dumps({"header": jwt})
+        out = _redact_json_arguments(arg)
+        parsed = json.loads(out)
+        # JWT must be masked
+        assert "eyJhbGciOiJIUzI1NiJ9" not in parsed["header"]
+
+    def test_handles_json_array_at_top_level(self):
+        arg = json.dumps([_OPENAI_KEY, "safe"])
+        out = _redact_json_arguments(arg)
+        parsed = json.loads(out)
+        assert parsed[1] == "safe"
+        assert _OPENAI_KEY not in parsed[0]
+
+    def test_handles_json_null(self):
+        out = _redact_json_arguments("null")
+        assert json.loads(out) is None
+
+    def test_handles_json_number(self):
+        out = _redact_json_arguments("42")
+        assert json.loads(out) == 42
+
+    def test_handles_json_string_at_top_level(self):
+        out = _redact_json_arguments(json.dumps(_OPENAI_KEY))
+        parsed = json.loads(out)
+        assert _OPENAI_KEY not in parsed
+
+    def test_redacts_deeply_nested(self):
+        arg = json.dumps({
+            "a": {"b": {"c": {"d": {"e": _OPENAI_KEY}}}}
+        })
+        out = _redact_json_arguments(arg)
+        parsed = json.loads(out)
+        assert _OPENAI_KEY not in parsed["a"]["b"]["c"]["d"]["e"]
+
+    def test_redacts_multiple_secrets(self):
+        arg = json.dumps({
+            "key1": _OPENAI_KEY,
+            "key2": _GH_KEY,
+            "key3": "plain",
+        })
+        out = _redact_json_arguments(arg)
+        parsed = json.loads(out)
+        assert _OPENAI_KEY not in parsed["key1"]
+        assert _GH_KEY not in parsed["key2"]
+        assert parsed["key3"] == "plain"
+
+
+class TestRedactMessageObjectToolCalls:
+    """_redact_message_object must produce valid JSON in tool_calls[].function.arguments."""
+
+    def test_preserves_tool_call_json(self):
+        arg = _env_args("OPENAI_API_KEY=" + _OPENAI_KEY)
+        msg = {
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "shell",
+                    "arguments": arg,
+                },
+            }],
+        }
+        _redact_message_object(msg, redact_sensitive_text)
+        out = msg["tool_calls"][0]["function"]["arguments"]
+        # Must parse as JSON
+        parsed = json.loads(out)
+        assert "command" in parsed
+        # The secret value must be masked
+        assert _OPENAI_KEY not in parsed["command"]
+        assert "***" in parsed["command"]
+
+    def test_preserves_legacy_function_call_json(self):
+        arg = _env_args("OPENAI_API_KEY=" + _OPENAI_KEY)
+        msg = {
+            "role": "assistant",
+            "function_call": {
+                "name": "shell",
+                "arguments": arg,
+            },
+        }
+        _redact_message_object(msg, redact_sensitive_text)
+        out = msg["function_call"]["arguments"]
+        parsed = json.loads(out)
+        assert _OPENAI_KEY not in parsed["command"]
+        assert "***" in parsed["command"]
+
+    def test_preserves_message_with_no_tool_calls(self):
+        msg = {"role": "user", "content": "hello"}
+        _redact_message_object(msg, redact_sensitive_text)
+        assert msg["content"] == "hello"
+
+    def test_preserves_list_typed_content(self):
+        # This was the second blocker — list-typed content must be redacted.
+        # Use a 41-char OpenAI-key-shape value so _PREFIX_RE's floor of 10
+        # chars catches it.
+        secret = "sk" + "-" + "abcdefghijklmnopqrstuvwxyz0123456789ABCD"
+        msg = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "key is " + secret},
+                {"type": "text", "text": "plain"},
+            ],
+        }
+        _redact_message_object(msg, redact_sensitive_text)
+        parts = msg["content"]
+        assert isinstance(parts, list)
+        # The literal secret value must be gone (specifically, the
+        # bulk of the secret — the head=4/tail=4 debug tail ABCD is
+        # preserved by mask_secret)
+        assert "abcdefghijklmnopqrstuvwxyz" not in parts[0]["text"]
+        # The mask ellipsis `...` must appear (evidence of redaction)
+        assert "..." in parts[0]["text"]
+        # And the tail of the secret (preserved for debug) survives
+        assert "ABCD" in parts[0]["text"]
+        assert parts[1]["text"] == "plain"
+
+    def test_realistic_provider_payload_round_trip(self):
+        """A representative OpenAI chat completion payload with mixed
+        string and list content, plus a tool_call with embedded secret,
+        must round-trip through json.dumps after redaction."""
+        msg = {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "I'll run the command with key " + _OPENAI_KEY},
+            ],
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "shell",
+                    "arguments": _env_args("OPENAI_API_KEY=" + _OPENAI_KEY),
+                },
+            }],
+        }
+        _redact_message_object(msg, redact_sensitive_text)
+        # The whole message must serialize back to valid JSON
+        roundtrip = json.dumps(msg, ensure_ascii=False)
+        reparsed = json.loads(roundtrip)
+        # And the secrets must not be present in any string field
+        def _scrub(o):
+            if isinstance(o, str):
+                assert _OPENAI_KEY not in o, f"leaked: {o[:100]}"
+            elif isinstance(o, list):
+                for x in o:
+                    _scrub(x)
+            elif isinstance(o, dict):
+                for v in o.values():
+                    _scrub(v)
+        _scrub(reparsed)
+
+
+class TestJsonArgumentsDegradedPath:
+    """When input is NOT valid JSON, _redact_json_arguments should still
+    attempt safe redaction. It must never return a value that's MORE
+    broken than the input."""
+
+    def test_malformed_json_does_not_throw(self):
+        # Trailing garbage — not valid JSON.
+        out = _redact_json_arguments("not json at all")
+        assert isinstance(out, str)
+
+    def test_malformed_json_with_secret_does_not_crash(self):
+        out = _redact_json_arguments('"OPENAI_API_KEY=' + _OPENAI_KEY + '"')
+        # Should redact without crashing. We don't assert the output is
+        # valid JSON (it isn't, by construction) — only that it returned.
+        assert isinstance(out, str)

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -661,6 +661,15 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                     }
                     if summary_temperature is not None:
                         _create_kwargs["temperature"] = summary_temperature
+                    # ── DETE: redact messages before they leave the trust boundary ────
+                    if _create_kwargs.get("messages"):
+                        import copy
+                        from agent.redact import _redact_message_content, redact_sensitive_text
+                        _create_kwargs["messages"] = copy.deepcopy(_create_kwargs["messages"])
+                        for msg in _create_kwargs["messages"]:
+                            if isinstance(msg, dict) and "content" in msg:
+                                msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+                    # ────────────────────────────────────────────────────────────────
                     response = self.client.chat.completions.create(**_create_kwargs)
                 
                 summary = self._coerce_summary_content(response.choices[0].message.content)
@@ -730,6 +739,15 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                     }
                     if summary_temperature is not None:
                         _create_kwargs["temperature"] = summary_temperature
+                    # ── DETE: redact messages before they leave the trust boundary ────
+                    if _create_kwargs.get("messages"):
+                        import copy
+                        from agent.redact import _redact_message_content, redact_sensitive_text
+                        _create_kwargs["messages"] = copy.deepcopy(_create_kwargs["messages"])
+                        for msg in _create_kwargs["messages"]:
+                            if isinstance(msg, dict) and "content" in msg:
+                                msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+                    # ────────────────────────────────────────────────────────────────
                     response = await self._get_async_client().chat.completions.create(**_create_kwargs)
                 
                 summary = self._coerce_summary_content(response.choices[0].message.content)

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -664,11 +664,11 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                     # ── DETE: redact messages before they leave the trust boundary ────
                     if _create_kwargs.get("messages"):
                         import copy
-                        from agent.redact import _redact_message_content, redact_sensitive_text
+                        from agent.redact import _redact_message_object, redact_sensitive_text
                         _create_kwargs["messages"] = copy.deepcopy(_create_kwargs["messages"])
                         for msg in _create_kwargs["messages"]:
-                            if isinstance(msg, dict) and "content" in msg:
-                                msg["content"] = _redact_message_content(msg["content"], redact_sensitive_text)
+                            if isinstance(msg, dict):
+                                _redact_message_object(msg, redact_sensitive_text)
                     # ────────────────────────────────────────────────────────────────
                     response = self.client.chat.completions.create(**_create_kwargs)
                 


### PR DESCRIPTION
## Summary

Add mandatory outbound credential redaction to the last code path before
serialized messages leave the trust boundary for the LLM provider's API.

## Problem

An agent can include credentials in its response text (reconstructed from
hex dumps, quoted from tool output, or accidentally composed). Previously,
the only redaction layer was on the **disk-logging path** — the message
array bound for the provider's API was never filtered.

When the agent writes "The password is: supersecret" in its response,
that text is appended to `messages` and sent to the provider in the next
`chat.completions.create()` call without any redaction.

## Fix

In `interruptible_api_call()`'s `_call()` function — the single function
that dispatches to all three API modes (OpenAI chat completions, Anthropic
Messages, Bedrock Converse) — apply `redact_sensitive_text(force=True)` to
every message content string before the API request is made.

`force=True` ensures this enforcement point cannot be disabled by the
`HERMES_REDACT_SECRETS` environment variable.

## Changes

`agent/chat_completion_helpers.py` — 13 lines added to `_call()`

## Testing

- All existing redaction patterns continue to work (verified via unit tests)
- Functional test: assistant response containing a credential was properly masked
  before the simulated API call
- All three API modes pass through the same `_call()` path
