### PR TITLE
Add YouTube Chapters skill with transcript provider MVP

### DIFF
--- a/optional-skills/youtube-chapters/README.md
+++ b/optional-skills/youtube-chapters/README.md
@@ -54,11 +54,27 @@ From the skill directory:
 python scripts/fetch_transcript.py "https://www.youtube.com/watch?v=VIDEO_ID"
 ```
 
-Specify preferred languages by repeating `--language`:
+Specify preferred languages in descending preference order. The default is `tr,en`:
 
 ```text
-python scripts/fetch_transcript.py "VIDEO_ID" --language tr --language en
+python scripts/fetch_transcript.py "VIDEO_ID" --languages tr,en
 ```
+
+Inspect the available transcript tracks:
+
+```text
+python scripts/fetch_transcript.py "VIDEO_ID" --list-transcripts
+```
+
+The CLI accepts a cookie-file option for forward compatibility:
+
+```text
+python scripts/fetch_transcript.py "VIDEO_ID" --cookies path/to/cookies.txt
+```
+
+The currently supported `youtube-transcript-api` provider does not support cookie-based
+retrieval and returns `CookiesUnsupported`. Cookies are private credentials. Never commit,
+share, or include cookie files in a pull request.
 
 Successful output is normalized JSON containing `start`, `end`, and cleaned `text`.
 Missing or disabled captions produce a structured JSON error and a non-zero exit code:
@@ -69,6 +85,9 @@ Missing or disabled captions produce a structured JSON error and a non-zero exit
   "message": "No captions or transcript could be retrieved for this video."
 }
 ```
+
+Provider failures include a short `detail` containing only the provider exception class name.
+No traceback or private request data is returned.
 
 Invalid YouTube URLs or video IDs are rejected before transcript retrieval:
 
@@ -87,6 +106,27 @@ Invalid YouTube URLs or video IDs are rejected before transcript retrieval:
 4. Validate the chapters and return paste-ready markers.
 5. If the script returns an error, explain that captions are unavailable and ASR fallback is
    not implemented yet.
+
+`fetch_transcript.py` only fetches and normalizes transcript data. It does not call an LLM.
+Hermes uses the timestamped transcript with its configured LLM to generate chapter markers.
+
+## YouTube shows a transcript, but the CLI returns TranscriptUnavailable
+
+The YouTube UI and an unauthenticated transcript provider do not always have the same access.
+The transcript may not exist in the requested language, may require browser/session context,
+or may be blocked for automated requests from the current IP or environment. Region, age, and
+account restrictions can also prevent access. In some cases, the provider cannot access the
+same transcript track displayed by the YouTube UI.
+
+Recommended troubleshooting:
+
+1. Try `--list-transcripts`.
+2. Try `--languages tr,en`.
+3. Try another captioned public video.
+4. If a future provider version supports cookies, try `--cookies path/to/cookies.txt`. Treat
+   cookies as private credentials and never commit them.
+5. If captions still cannot be retrieved, a future ASR fallback using Whisper and `yt-dlp`
+   may be needed.
 
 ## Validation
 

--- a/optional-skills/youtube-chapters/README.md
+++ b/optional-skills/youtube-chapters/README.md
@@ -1,0 +1,110 @@
+# YouTube Chapters Skill
+
+Generates paste-ready YouTube chapter markers from a YouTube video URL, video ID, or
+timestamped transcript.
+
+## Expected Input
+
+Typical prompts:
+
+```text
+Generate chapters for this YouTube video: <url>
+Create YouTube timestamps from this video: <url>
+Make a paste-ready chapter list for: <url>
+```
+
+The current MVP retrieves public captions through the optional `youtube-transcript-api`
+dependency. It does not require YouTube Data API credentials.
+
+## Expected Output
+
+```text
+00:00 Introduction
+01:42 Project setup
+04:18 Hermes Agent architecture
+08:35 Transcript processing
+12:10 Final result
+```
+
+## Transcript Strategy
+
+1. Try public YouTube captions/transcripts through `youtube-transcript-api`.
+2. For a user-owned video, optionally use the official YouTube Captions API when OAuth,
+   caption permission, and acceptable quota are available.
+3. If captions are unavailable, return a structured error instead of inventing
+   timestamps.
+
+The official YouTube Data API is not the sole MVP transcript method because downloading
+captions for arbitrary public videos is permission/OAuth dependent and may incur quota cost.
+Audio download and Whisper/ASR fallback are planned future work and are not included.
+
+## Install the Optional Live Provider
+
+From the skill directory:
+
+```text
+python -m pip install -r requirements.txt
+```
+
+## Fetch a Transcript Manually
+
+From the skill directory:
+
+```text
+python scripts/fetch_transcript.py "https://www.youtube.com/watch?v=VIDEO_ID"
+```
+
+Specify preferred languages by repeating `--language`:
+
+```text
+python scripts/fetch_transcript.py "VIDEO_ID" --language tr --language en
+```
+
+Successful output is normalized JSON containing `start`, `end`, and cleaned `text`.
+Missing or disabled captions produce a structured JSON error and a non-zero exit code:
+
+```json
+{
+  "error": "TranscriptUnavailable",
+  "message": "No captions or transcript could be retrieved for this video."
+}
+```
+
+Invalid YouTube URLs or video IDs are rejected before transcript retrieval:
+
+```json
+{
+  "error": "InvalidYouTubeURL",
+  "message": "The provided input is not a valid YouTube URL or video ID."
+}
+```
+
+## Hermes Workflow
+
+1. Parse the YouTube URL or video ID.
+2. Run `scripts/fetch_transcript.py` and read its JSON output.
+3. Group the returned timestamped segments and generate transcript-supported chapters.
+4. Validate the chapters and return paste-ready markers.
+5. If the script returns an error, explain that captions are unavailable and ASR fallback is
+   not implemented yet.
+
+## Validation
+
+The deterministic utilities verify timestamp syntax, a `00:00` first chapter, strictly
+increasing timestamps, non-empty titles, duplicate rejection, minimum chapter count when
+appropriate, and known-duration bounds.
+
+Run focused offline tests from the repository root:
+
+```text
+python -m unittest discover -s optional-skills/youtube-chapters/tests -v
+```
+
+## Limitations
+
+- Does not guarantee transcripts for every YouTube video.
+- Does not bypass YouTube restrictions or download private videos.
+- Does not include Whisper, `yt-dlp`, ffmpeg, audio download, or ASR fallback.
+- Does not invent precise timestamps without a timestamp source.
+- Live retrieval depends on YouTube availability and the optional `youtube-transcript-api`
+  dependency.

--- a/optional-skills/youtube-chapters/SKILL.md
+++ b/optional-skills/youtube-chapters/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: youtube-chapters
+description: Generate paste-ready, validated YouTube chapter markers from a YouTube URL, video ID, or timestamped transcript. Use when asked to create YouTube chapters, timestamps, description markers, or a chapter-based summary of a YouTube video.
+---
+
+# YouTube Chapters
+
+Generate YouTube-compatible chapters from transcript-supported topic transitions. Prefer
+deterministic helpers in `utils/` for parsing, normalization, chunking, formatting, and
+validation.
+
+## Workflow
+
+1. Extract and normalize a YouTube video ID from the user message with
+   `utils.youtube.extract_video_id`.
+2. Run `python scripts/fetch_transcript.py "<youtube-url-or-video-id>"` from this skill
+   directory when the live transcript dependency is available.
+3. Read the normalized timestamped transcript from the script's JSON output.
+4. If the script returns a structured error, explain that captions could not be retrieved,
+   audio transcription fallback is not implemented yet, and the user may provide a
+   timestamped transcript or enable captions.
+5. Normalize segments with `utils.transcript.normalize_segments` into:
+
+   ```json
+   [{"start": 0.0, "end": 4.2, "text": "..."}]
+   ```
+
+6. Group segments chronologically with `utils.transcript.group_segments`. Preserve the
+   earliest source timestamp for each chunk.
+7. Generate candidate chapters using the prompt in `references/prompts.md`.
+8. Parse and validate candidates with `utils.validation.parse_chapter_lines` and
+   `utils.validation.validate_chapters`.
+9. If validation fails, apply the repair prompt once, then validate again.
+10. Return only the paste-ready chapter list unless the user asks for explanation.
+
+## Chapter Rules
+
+- Start with `00:00`.
+- Use at least 3 chapters when transcript length and content support them.
+- Keep timestamps strictly increasing and within the known duration.
+- Use `MM:SS`, or `HH:MM:SS` when needed for long videos.
+- Use concise, meaningful, transcript-supported titles.
+- Avoid generic titles such as `Part 1`, `Section 2`, or `Topic`.
+- Prefer major topic transitions over sentence-level changes.
+- Prefer roughly 5-12 chapters for a normal 10-30 minute video.
+- Do not invent content or precise timestamps.
+- Say reliable chapter generation is not possible when the transcript is too short,
+  incomplete, untimestamped, or unusable.
+
+## Provider Decisions
+
+- Use the isolated `youtube-transcript-api` provider for public YouTube captions. It requires
+  neither a browser nor YouTube API key.
+- Do not use the official YouTube Data API as the sole arbitrary-public-video transcript
+  provider; caption download generally requires OAuth permission and quota.
+- Treat official caption download as optional for videos the user owns.
+- Do not attempt audio download or ASR fallback in this MVP.
+- Do not bypass access restrictions or download private videos.
+
+Read `references/provider-architecture.md` before implementing or selecting a provider.
+
+## Output
+
+Return plain text without bullets or fences:
+
+```text
+00:00 Introduction
+01:42 Project setup
+04:18 Hermes Agent architecture
+08:35 Transcript processing
+12:10 Final result
+```
+
+For examples and failure behavior, read the relevant file in `examples/`.

--- a/optional-skills/youtube-chapters/agents/openai.yaml
+++ b/optional-skills/youtube-chapters/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "YouTube Chapters"
+  short_description: "Generate validated YouTube chapter markers"
+  default_prompt: "Generate paste-ready YouTube chapters for this video."

--- a/optional-skills/youtube-chapters/examples/basic.md
+++ b/optional-skills/youtube-chapters/examples/basic.md
@@ -1,0 +1,17 @@
+# Basic Video
+
+Input:
+
+```text
+Generate YouTube chapters for https://youtube.com/watch?v=example1234
+```
+
+Expected output:
+
+```text
+00:00 Introduction
+01:20 Project overview
+03:45 Installation
+06:10 Configuration
+09:30 Final test
+```

--- a/optional-skills/youtube-chapters/examples/long-video.md
+++ b/optional-skills/youtube-chapters/examples/long-video.md
@@ -1,0 +1,15 @@
+# Long Video
+
+For a long video, group related details into broad sections. Do not create a chapter for each
+speaker turn or sentence.
+
+Expected output:
+
+```text
+00:00 Opening and agenda
+08:15 System architecture
+24:40 Data ingestion pipeline
+43:05 Reliability and monitoring
+01:02:30 Deployment walkthrough
+01:18:10 Questions and wrap-up
+```

--- a/optional-skills/youtube-chapters/examples/missing-transcript.md
+++ b/optional-skills/youtube-chapters/examples/missing-transcript.md
@@ -1,0 +1,7 @@
+# Missing Transcript
+
+When captions and timestamp-preserving fallback transcription are unavailable, return:
+
+```text
+I could not retrieve captions or a timestamped transcript for this video. Audio transcription fallback is not implemented yet; provide a timestamped transcript or enable captions.
+```

--- a/optional-skills/youtube-chapters/examples/poor-transcript.md
+++ b/optional-skills/youtube-chapters/examples/poor-transcript.md
@@ -1,0 +1,7 @@
+# Poor Transcript Quality
+
+When source quality is too low to support reliable topics, return:
+
+```text
+The transcript appears incomplete or low quality, so reliable chapter generation is not possible.
+```

--- a/optional-skills/youtube-chapters/references/prompts.md
+++ b/optional-skills/youtube-chapters/references/prompts.md
@@ -1,0 +1,39 @@
+# Chapter Generation Prompts
+
+## Generation
+
+```text
+You are generating YouTube chapter markers from a timestamped transcript.
+
+Rules:
+- Return only chapter lines.
+- First timestamp must be 00:00.
+- Use concise titles.
+- Use meaningful topic transitions.
+- Do not create chapters for every sentence.
+- Do not invent topics.
+- Prefer 5-12 chapters for a normal 10-30 minute video.
+- Use more chapters only for long videos with clear sections.
+- If transcript quality is poor, say so clearly instead of inventing chapters.
+
+Input transcript chunks:
+{chunks}
+
+Return:
+00:00 ...
+```
+
+## Repair
+
+```text
+The chapter list below failed validation.
+
+Validation errors:
+{errors}
+
+Chapter list:
+{chapters}
+
+Fix the chapter list while preserving only transcript-supported topics.
+Return only valid chapter lines.
+```

--- a/optional-skills/youtube-chapters/references/provider-architecture.md
+++ b/optional-skills/youtube-chapters/references/provider-architecture.md
@@ -1,0 +1,41 @@
+# Transcript Provider Architecture
+
+Providers must return chronological segments containing `start`, `end`, and `text`.
+Normalize provider output before chapter generation.
+
+## Priority 1: Public Captions
+
+Use the isolated `utils.provider` adapter backed by `youtube-transcript-api` when dependencies
+and network access are allowed. Invoke it through `scripts/fetch_transcript.py`. The MVP does
+not require a browser or YouTube API key.
+
+Handle unavailable, disabled, malformed, or rate-limited captions as provider failures.
+Do not silently convert untimestamped text into precise segments.
+
+## Priority 2: Official YouTube Captions API
+
+Keep this optional. Use only when the user owns the video, OAuth is configured, caption
+download permission exists, and quota cost is acceptable. It is not a general solution for
+arbitrary public video transcripts.
+
+## Future: Audio Transcription
+
+Audio transcription is not implemented in this MVP. A future integration may use
+timestamp-preserving ASR after caption retrieval fails.
+
+Requirements:
+
+- Preserve segment-level timestamps.
+- Do not generate precise chapters when the ASR result has no timestamps.
+
+## Adapter Contract
+
+The live provider adapter exposes behavior equivalent to:
+
+```python
+def get_transcript(video_id: str) -> list[dict]:
+    """Return timestamped segments or raise a provider-specific retrieval error."""
+```
+
+Provider-specific failures are converted into stable structured errors. No fallback provider is
+configured in this MVP.

--- a/optional-skills/youtube-chapters/requirements.txt
+++ b/optional-skills/youtube-chapters/requirements.txt
@@ -1,0 +1,1 @@
+youtube-transcript-api>=1.0,<2.0

--- a/optional-skills/youtube-chapters/scripts/__init__.py
+++ b/optional-skills/youtube-chapters/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Executable helpers for the YouTube chapters skill."""

--- a/optional-skills/youtube-chapters/scripts/fetch_transcript.py
+++ b/optional-skills/youtube-chapters/scripts/fetch_transcript.py
@@ -1,0 +1,62 @@
+"""Fetch a normalized timestamped transcript for a YouTube URL or video ID."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+if str(SKILL_ROOT) not in sys.path:
+    sys.path.insert(0, str(SKILL_ROOT))
+
+from utils.provider import TranscriptProviderError, fetch_transcript
+from utils.youtube import extract_video_id
+
+
+def run(
+    user_input: str,
+    *,
+    languages: Sequence[str] | None = None,
+    provider: Callable[..., list[dict[str, float | str]]] = fetch_transcript,
+) -> list[dict[str, float | str]] | dict[str, str]:
+    """Return normalized segments or a structured error without raising."""
+    try:
+        video_id = extract_video_id(user_input)
+        return provider(video_id, languages=languages)
+    except ValueError:
+        return {
+            "error": "InvalidYouTubeURL",
+            "message": "The provided input is not a valid YouTube URL or video ID.",
+        }
+    except TranscriptProviderError as exc:
+        return exc.as_dict()
+    except Exception:
+        return {
+            "error": "TranscriptFetchFailed",
+            "message": "Transcript retrieval failed. Try again later or provide a timestamped transcript.",
+        }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("video", help="YouTube URL or 11-character video ID")
+    parser.add_argument(
+        "--language",
+        action="append",
+        dest="languages",
+        help="Preferred transcript language code; may be repeated",
+    )
+    args = parser.parse_args(argv)
+
+    result = run(args.video, languages=args.languages)
+    json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 1 if isinstance(result, dict) and "error" in result else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/optional-skills/youtube-chapters/scripts/fetch_transcript.py
+++ b/optional-skills/youtube-chapters/scripts/fetch_transcript.py
@@ -13,20 +13,41 @@ SKILL_ROOT = Path(__file__).resolve().parents[1]
 if str(SKILL_ROOT) not in sys.path:
     sys.path.insert(0, str(SKILL_ROOT))
 
-from utils.provider import TranscriptProviderError, fetch_transcript
+from utils.provider import DEFAULT_LANGUAGES, TranscriptProviderError, fetch_transcript, list_transcripts
 from utils.youtube import extract_video_id
+
+
+def parse_languages(value: str | None) -> list[str]:
+    """Parse comma-separated language codes in preference order."""
+    languages = [language.strip() for language in (value or "").split(",") if language.strip()]
+    return languages or list(DEFAULT_LANGUAGES)
 
 
 def run(
     user_input: str,
     *,
     languages: Sequence[str] | None = None,
-    provider: Callable[..., list[dict[str, float | str]]] = fetch_transcript,
-) -> list[dict[str, float | str]] | dict[str, str]:
+    list_only: bool = False,
+    cookies: str | None = None,
+    cookies_from_browser: str | None = None,
+    provider: Callable[..., Any] = fetch_transcript,
+    list_provider: Callable[..., dict[str, Any]] = list_transcripts,
+) -> list[dict[str, float | str]] | dict[str, Any]:
     """Return normalized segments or a structured error without raising."""
     try:
         video_id = extract_video_id(user_input)
-        return provider(video_id, languages=languages)
+        if list_only:
+            return list_provider(
+                video_id,
+                cookies=cookies,
+                cookies_from_browser=cookies_from_browser,
+            )
+        return provider(
+            video_id,
+            languages=languages,
+            cookies=cookies,
+            cookies_from_browser=cookies_from_browser,
+        )
     except ValueError:
         return {
             "error": "InvalidYouTubeURL",
@@ -34,10 +55,11 @@ def run(
         }
     except TranscriptProviderError as exc:
         return exc.as_dict()
-    except Exception:
+    except Exception as exc:
         return {
             "error": "TranscriptFetchFailed",
             "message": "Transcript retrieval failed. Try again later or provide a timestamped transcript.",
+            "detail": type(exc).__name__,
         }
 
 
@@ -45,14 +67,26 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("video", help="YouTube URL or 11-character video ID")
     parser.add_argument(
-        "--language",
-        action="append",
-        dest="languages",
-        help="Preferred transcript language code; may be repeated",
+        "--languages",
+        default=",".join(DEFAULT_LANGUAGES),
+        help="Comma-separated transcript language codes in preference order (default: tr,en)",
     )
+    parser.add_argument(
+        "--list-transcripts",
+        action="store_true",
+        help="List available transcript tracks instead of fetching transcript text",
+    )
+    parser.add_argument("--cookies", help="Path to a private Netscape-format cookies file")
+    parser.add_argument("--cookies-from-browser", help="Browser name to load private cookies from")
     args = parser.parse_args(argv)
 
-    result = run(args.video, languages=args.languages)
+    result = run(
+        args.video,
+        languages=parse_languages(args.languages),
+        list_only=args.list_transcripts,
+        cookies=args.cookies,
+        cookies_from_browser=args.cookies_from_browser,
+    )
     json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
     sys.stdout.write("\n")
     return 1 if isinstance(result, dict) and "error" in result else 0

--- a/optional-skills/youtube-chapters/tests/fixtures/transcript_basic.json
+++ b/optional-skills/youtube-chapters/tests/fixtures/transcript_basic.json
@@ -1,0 +1,7 @@
+[
+  {"start": 0.0, "duration": 20.0, "text": "Welcome and introduction to the project."},
+  {"start": 20.0, "duration": 45.0, "text": "We explain the goals and expected result."},
+  {"start": 65.0, "duration": 55.0, "text": "Install the dependencies and prepare the workspace."},
+  {"start": 120.0, "duration": 70.0, "text": "Configure the application and environment."},
+  {"start": 190.0, "duration": 40.0, "text": "Run the final test and review the result."}
+]

--- a/optional-skills/youtube-chapters/tests/fixtures/transcript_long.json
+++ b/optional-skills/youtube-chapters/tests/fixtures/transcript_long.json
@@ -1,0 +1,8 @@
+[
+  {"start": 0.0, "end": 240.0, "text": "Opening, goals, and agenda."},
+  {"start": 240.0, "end": 720.0, "text": "System architecture and component responsibilities."},
+  {"start": 720.0, "end": 1500.0, "text": "Data ingestion, transformation, and storage pipeline."},
+  {"start": 1500.0, "end": 2700.0, "text": "Reliability, observability, and incident response."},
+  {"start": 2700.0, "end": 3900.0, "text": "Deployment walkthrough and production checks."},
+  {"start": 3900.0, "end": 4800.0, "text": "Questions, conclusions, and wrap-up."}
+]

--- a/optional-skills/youtube-chapters/tests/test_provider.py
+++ b/optional-skills/youtube-chapters/tests/test_provider.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_ROOT))
+
+from scripts.fetch_transcript import run
+from utils.provider import TranscriptProviderError, fetch_transcript
+
+
+class FakeFetchedTranscript:
+    def to_raw_data(self) -> list[dict[str, float | str]]:
+        return [
+            {"start": 0.0, "duration": 1.5, "text": "  Hello   world  "},
+            {"start": 1.5, "duration": 2.0, "text": "Next topic"},
+        ]
+
+
+class FakeApi:
+    def fetch(self, video_id: str, languages: list[str]) -> FakeFetchedTranscript:
+        return FakeFetchedTranscript()
+
+
+class TranscriptsDisabled(Exception):
+    pass
+
+
+class DisabledApi:
+    def fetch(self, video_id: str, languages: list[str]) -> None:
+        raise TranscriptsDisabled()
+
+
+class ProviderTests(unittest.TestCase):
+    def test_fetches_and_normalizes_mocked_provider_output(self) -> None:
+        transcript = fetch_transcript("abcdefghijk", api_factory=FakeApi)
+        self.assertEqual(
+            transcript,
+            [
+                {"start": 0.0, "end": 1.5, "text": "Hello world"},
+                {"start": 1.5, "end": 3.5, "text": "Next topic"},
+            ],
+        )
+
+    def test_disabled_transcript_returns_stable_provider_error(self) -> None:
+        with self.assertRaises(TranscriptProviderError) as context:
+            fetch_transcript("abcdefghijk", api_factory=DisabledApi)
+        self.assertEqual(
+            context.exception.as_dict(),
+            {
+                "error": "TranscriptUnavailable",
+                "message": "No captions or transcript could be retrieved for this video.",
+            },
+        )
+
+    def test_invalid_video_id_is_rejected_before_provider_construction(self) -> None:
+        provider_constructed = False
+
+        def api_factory() -> FakeApi:
+            nonlocal provider_constructed
+            provider_constructed = True
+            return FakeApi()
+
+        with self.assertRaises(TranscriptProviderError) as context:
+            fetch_transcript("too-short", api_factory=api_factory)
+
+        self.assertFalse(provider_constructed)
+        self.assertEqual(
+            context.exception.as_dict(),
+            {
+                "error": "InvalidYouTubeURL",
+                "message": "The provided input is not a valid YouTube URL or video ID.",
+            },
+        )
+
+    def test_runner_rejects_invalid_youtube_url_without_calling_provider(self) -> None:
+        def unexpected_provider(video_id: str, **kwargs: object) -> list[dict[str, float | str]]:
+            self.fail("provider must not be called for invalid input")
+
+        self.assertEqual(
+            run("https://example.com/video", provider=unexpected_provider),
+            {
+                "error": "InvalidYouTubeURL",
+                "message": "The provided input is not a valid YouTube URL or video ID.",
+            },
+        )
+
+    def test_runner_rejects_invalid_video_id_without_calling_provider(self) -> None:
+        def unexpected_provider(video_id: str, **kwargs: object) -> list[dict[str, float | str]]:
+            self.fail("provider must not be called for invalid input")
+
+        self.assertEqual(
+            run("invalid-url", provider=unexpected_provider),
+            {
+                "error": "InvalidYouTubeURL",
+                "message": "The provided input is not a valid YouTube URL or video ID.",
+            },
+        )
+
+    def test_valid_youtube_url_reaches_provider_failure_path(self) -> None:
+        def unavailable_provider(video_id: str, **kwargs: object) -> list[dict[str, float | str]]:
+            self.assertEqual(video_id, "dQw4w9WgXcQ")
+            raise TranscriptProviderError("TranscriptUnavailable", "Unavailable")
+
+        self.assertEqual(
+            run("https://www.youtube.com/watch?v=dQw4w9WgXcQ", provider=unavailable_provider),
+            {"error": "TranscriptUnavailable", "message": "Unavailable"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/optional-skills/youtube-chapters/tests/test_provider.py
+++ b/optional-skills/youtube-chapters/tests/test_provider.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import sys
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 SKILL_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SKILL_ROOT))
 
-from scripts.fetch_transcript import run
-from utils.provider import TranscriptProviderError, fetch_transcript
+from scripts.fetch_transcript import main, parse_languages, run
+from utils.provider import TranscriptProviderError, fetch_transcript, list_transcripts
 
 
 class FakeFetchedTranscript:
@@ -19,9 +22,49 @@ class FakeFetchedTranscript:
         ]
 
 
-class FakeApi:
-    def fetch(self, video_id: str, languages: list[str]) -> FakeFetchedTranscript:
+class NoTranscriptFound(Exception):
+    pass
+
+
+class FakeTrack:
+    def __init__(
+        self,
+        language: str = "Turkish",
+        language_code: str = "tr",
+        *,
+        is_generated: bool = True,
+        is_translatable: bool = True,
+    ) -> None:
+        self.language = language
+        self.language_code = language_code
+        self.is_generated = is_generated
+        self.is_translatable = is_translatable
+
+    def fetch(self) -> FakeFetchedTranscript:
         return FakeFetchedTranscript()
+
+    def translate(self, language_code: str) -> FakeTrack:
+        return FakeTrack(language_code, language_code, is_generated=self.is_generated)
+
+
+class FakeTranscriptList:
+    def __init__(self, tracks: list[FakeTrack] | None = None) -> None:
+        self.tracks = tracks or [FakeTrack()]
+
+    def __iter__(self):
+        return iter(self.tracks)
+
+    def find_transcript(self, languages: list[str] | tuple[str, ...]) -> FakeTrack:
+        for language in languages:
+            for track in self.tracks:
+                if track.language_code == language:
+                    return track
+        raise NoTranscriptFound()
+
+
+class FakeApi:
+    def list(self, video_id: str) -> FakeTranscriptList:
+        return FakeTranscriptList()
 
 
 class TranscriptsDisabled(Exception):
@@ -29,7 +72,7 @@ class TranscriptsDisabled(Exception):
 
 
 class DisabledApi:
-    def fetch(self, video_id: str, languages: list[str]) -> None:
+    def list(self, video_id: str) -> None:
         raise TranscriptsDisabled()
 
 
@@ -52,8 +95,58 @@ class ProviderTests(unittest.TestCase):
             {
                 "error": "TranscriptUnavailable",
                 "message": "No captions or transcript could be retrieved for this video.",
+                "detail": "TranscriptsDisabled",
             },
         )
+
+    def test_translates_available_track_to_first_requested_language(self) -> None:
+        class EnglishApi:
+            def list(self, video_id: str) -> FakeTranscriptList:
+                return FakeTranscriptList([FakeTrack("English", "en")])
+
+        transcript = fetch_transcript("abcdefghijk", languages=["tr"], api_factory=EnglishApi)
+        self.assertEqual(transcript[0]["text"], "Hello world")
+
+    def test_lists_mocked_transcript_tracks(self) -> None:
+        self.assertEqual(
+            list_transcripts("abcdefghijk", api_factory=FakeApi),
+            {
+                "video_id": "abcdefghijk",
+                "transcripts": [
+                    {
+                        "language": "Turkish",
+                        "language_code": "tr",
+                        "is_generated": True,
+                        "is_translatable": True,
+                    }
+                ],
+            },
+        )
+
+    def test_list_failure_returns_stable_provider_error_with_detail(self) -> None:
+        with self.assertRaises(TranscriptProviderError) as context:
+            list_transcripts("abcdefghijk", api_factory=DisabledApi)
+        self.assertEqual(
+            context.exception.as_dict(),
+            {
+                "error": "TranscriptListUnavailable",
+                "message": "Could not list available transcripts for this video.",
+                "detail": "TranscriptsDisabled",
+            },
+        )
+
+    def test_cookie_option_is_rejected_before_provider_construction(self) -> None:
+        provider_constructed = False
+
+        def api_factory() -> FakeApi:
+            nonlocal provider_constructed
+            provider_constructed = True
+            return FakeApi()
+
+        with self.assertRaises(TranscriptProviderError) as context:
+            fetch_transcript("abcdefghijk", cookies="private-cookies.txt", api_factory=api_factory)
+        self.assertFalse(provider_constructed)
+        self.assertEqual(context.exception.error, "CookiesUnsupported")
 
     def test_invalid_video_id_is_rejected_before_provider_construction(self) -> None:
         provider_constructed = False
@@ -107,6 +200,30 @@ class ProviderTests(unittest.TestCase):
         self.assertEqual(
             run("https://www.youtube.com/watch?v=dQw4w9WgXcQ", provider=unavailable_provider),
             {"error": "TranscriptUnavailable", "message": "Unavailable"},
+        )
+
+    def test_runner_lists_transcripts_with_mocked_provider(self) -> None:
+        def listing_provider(video_id: str, **kwargs: object) -> dict[str, object]:
+            return {"video_id": video_id, "transcripts": []}
+
+        self.assertEqual(
+            run("abcdefghijk", list_only=True, list_provider=listing_provider),
+            {"video_id": "abcdefghijk", "transcripts": []},
+        )
+
+    def test_languages_cli_argument_parsing(self) -> None:
+        self.assertEqual(parse_languages("tr,en"), ["tr", "en"])
+        self.assertEqual(parse_languages(" de, en ,"), ["de", "en"])
+        self.assertEqual(parse_languages(None), ["tr", "en"])
+
+        with patch("scripts.fetch_transcript.run", return_value=[]) as mocked_run, redirect_stdout(StringIO()):
+            self.assertEqual(main(["abcdefghijk", "--languages", "tr,en"]), 0)
+        mocked_run.assert_called_once_with(
+            "abcdefghijk",
+            languages=["tr", "en"],
+            list_only=False,
+            cookies=None,
+            cookies_from_browser=None,
         )
 
 

--- a/optional-skills/youtube-chapters/tests/test_transcript.py
+++ b/optional-skills/youtube-chapters/tests/test_transcript.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_ROOT))
+
+from utils.transcript import group_segments, normalize_segments
+
+
+class TranscriptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        fixture = Path(__file__).parent / "fixtures" / "transcript_basic.json"
+        self.segments = json.loads(fixture.read_text(encoding="utf-8"))
+
+    def test_normalizes_duration_and_text(self) -> None:
+        normalized = normalize_segments(self.segments)
+        self.assertEqual(normalized[0]["start"], 0.0)
+        self.assertEqual(normalized[0]["end"], 20.0)
+        self.assertEqual(normalized[0]["text"], "Welcome and introduction to the project.")
+        self.assertEqual(normalized[-1]["end"], 230.0)
+
+    def test_groups_chronologically(self) -> None:
+        chunks = group_segments(self.segments, target_seconds=100)
+        self.assertGreaterEqual(len(chunks), 2)
+        self.assertEqual(chunks[0]["start"], 0.0)
+        self.assertEqual(chunks[-1]["end"], 230.0)
+        self.assertTrue(all(chunks[index]["start"] < chunks[index + 1]["start"] for index in range(len(chunks) - 1)))
+
+    def test_rejects_untimestamped_segment(self) -> None:
+        with self.assertRaises(ValueError):
+            normalize_segments([{"start": 0, "text": "No duration"}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/optional-skills/youtube-chapters/tests/test_validation.py
+++ b/optional-skills/youtube-chapters/tests/test_validation.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_ROOT))
+
+from utils.validation import (
+    Chapter,
+    format_chapters,
+    format_timestamp,
+    parse_chapter_lines,
+    parse_timestamp,
+    validate_chapters,
+)
+
+
+class TimestampTests(unittest.TestCase):
+    def test_parses_and_formats_timestamp_forms(self) -> None:
+        self.assertEqual(parse_timestamp("01:42"), 102)
+        self.assertEqual(parse_timestamp("75:00"), 4500)
+        self.assertEqual(parse_timestamp("01:15:00"), 4500)
+        self.assertEqual(format_timestamp(102), "01:42")
+        self.assertEqual(format_timestamp(4500), "01:15:00")
+
+    def test_rejects_invalid_timestamp(self) -> None:
+        for value in ["1", "01:60", "01:75:00", "-01:00"]:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                parse_timestamp(value)
+
+
+class ChapterValidationTests(unittest.TestCase):
+    def test_valid_chapters_are_paste_ready(self) -> None:
+        raw = "00:00 Introduction\n01:42 Setup\n04:18 Architecture"
+        chapters = parse_chapter_lines(raw)
+        self.assertEqual(validate_chapters(chapters, duration_seconds=300), [])
+        self.assertEqual(format_chapters(chapters), raw)
+
+    def test_invalid_output_produces_repair_errors(self) -> None:
+        chapters = [
+            Chapter(5, "Introduction"),
+            Chapter(5, "Part 1"),
+            Chapter(400, "Conclusion"),
+        ]
+        errors = validate_chapters(chapters, duration_seconds=300)
+        self.assertIn("First chapter must start at 00:00", errors)
+        self.assertIn("Chapter 2 has a generic title", errors)
+        self.assertIn("Chapter 2 timestamp must be strictly increasing", errors)
+        self.assertIn("Chapter 3 exceeds the known video duration", errors)
+
+    def test_minimum_can_be_disabled_for_short_transcript(self) -> None:
+        chapters = [Chapter(0, "Only supported topic")]
+        self.assertEqual(validate_chapters(chapters, require_minimum=False), [])
+
+    def test_empty_output_is_invalid(self) -> None:
+        self.assertEqual(validate_chapters([]), ["Chapter list is empty"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/optional-skills/youtube-chapters/tests/test_youtube.py
+++ b/optional-skills/youtube-chapters/tests/test_youtube.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_ROOT))
+
+from utils.youtube import extract_video_id, normalize_video_id
+
+
+class YouTubeIdTests(unittest.TestCase):
+    def test_extracts_supported_url_forms(self) -> None:
+        expected = "dQw4w9WgXcQ"
+        inputs = [
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "https://youtu.be/dQw4w9WgXcQ?t=42",
+            "https://youtube.com/shorts/dQw4w9WgXcQ",
+            "https://youtube.com/embed/dQw4w9WgXcQ",
+            "https://youtube.com/live/dQw4w9WgXcQ",
+            "Create chapters for https://youtube.com/watch?v=dQw4w9WgXcQ please",
+        ]
+        for value in inputs:
+            with self.subTest(value=value):
+                self.assertEqual(extract_video_id(value), expected)
+
+    def test_accepts_raw_video_id(self) -> None:
+        self.assertEqual(normalize_video_id("dQw4w9WgXcQ"), "dQw4w9WgXcQ")
+
+    def test_rejects_invalid_input(self) -> None:
+        invalid_inputs = [
+            "https://example.com/video",
+            "too-short",
+            "invalid-url",
+        ]
+        for value in invalid_inputs:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                extract_video_id(value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/optional-skills/youtube-chapters/utils/__init__.py
+++ b/optional-skills/youtube-chapters/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic helpers for the YouTube chapters skill."""

--- a/optional-skills/youtube-chapters/utils/provider.py
+++ b/optional-skills/youtube-chapters/utils/provider.py
@@ -1,0 +1,93 @@
+"""Optional live transcript provider backed by youtube-transcript-api."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import Any
+
+from .transcript import normalize_segments
+from .youtube import normalize_video_id
+
+UNAVAILABLE_EXCEPTIONS = {
+    "NoTranscriptFound",
+    "TranscriptsDisabled",
+    "VideoUnavailable",
+}
+
+
+class TranscriptProviderError(Exception):
+    """A stable provider failure suitable for structured CLI output."""
+
+    def __init__(self, error: str, message: str) -> None:
+        super().__init__(message)
+        self.error = error
+        self.message = message
+
+    def as_dict(self) -> dict[str, str]:
+        return {"error": self.error, "message": self.message}
+
+
+def fetch_transcript(
+    video_id: str,
+    *,
+    languages: Sequence[str] | None = None,
+    api_factory: Callable[[], Any] | None = None,
+) -> list[dict[str, float | str]]:
+    """Fetch and normalize captions for a YouTube video ID."""
+    try:
+        video_id = normalize_video_id(video_id)
+    except ValueError as exc:
+        raise TranscriptProviderError(
+            "InvalidYouTubeURL",
+            "The provided input is not a valid YouTube URL or video ID.",
+        ) from exc
+
+    if api_factory is None:
+        try:
+            from youtube_transcript_api import YouTubeTranscriptApi
+        except ImportError as exc:
+            raise TranscriptProviderError(
+                "DependencyUnavailable",
+                "youtube-transcript-api is not installed. Install the skill requirements first.",
+            ) from exc
+        api_factory = YouTubeTranscriptApi
+
+    try:
+        fetched = api_factory().fetch(video_id, languages=list(languages or ("en",)))
+        raw_segments = _to_raw_segments(fetched)
+        normalized = normalize_segments(raw_segments)
+    except TranscriptProviderError:
+        raise
+    except Exception as exc:
+        if type(exc).__name__ in UNAVAILABLE_EXCEPTIONS:
+            raise TranscriptProviderError(
+                "TranscriptUnavailable",
+                "No captions or transcript could be retrieved for this video.",
+            ) from exc
+        raise TranscriptProviderError(
+            "TranscriptFetchFailed",
+            "Transcript retrieval failed. Try again later or provide a timestamped transcript.",
+        ) from exc
+
+    if not normalized:
+        raise TranscriptProviderError(
+            "TranscriptUnavailable",
+            "No captions or transcript could be retrieved for this video.",
+        )
+    return normalized
+
+
+def _to_raw_segments(fetched: Any) -> Iterable[Mapping[str, Any]]:
+    """Convert current provider objects or raw mappings into normalization input."""
+    if hasattr(fetched, "to_raw_data"):
+        return fetched.to_raw_data()
+    return [
+        segment
+        if isinstance(segment, Mapping)
+        else {
+            "start": segment.start,
+            "duration": segment.duration,
+            "text": segment.text,
+        }
+        for segment in fetched
+    ]

--- a/optional-skills/youtube-chapters/utils/provider.py
+++ b/optional-skills/youtube-chapters/utils/provider.py
@@ -8,6 +8,7 @@ from typing import Any
 from .transcript import normalize_segments
 from .youtube import normalize_video_id
 
+DEFAULT_LANGUAGES = ("tr", "en")
 UNAVAILABLE_EXCEPTIONS = {
     "NoTranscriptFound",
     "TranscriptsDisabled",
@@ -18,42 +19,36 @@ UNAVAILABLE_EXCEPTIONS = {
 class TranscriptProviderError(Exception):
     """A stable provider failure suitable for structured CLI output."""
 
-    def __init__(self, error: str, message: str) -> None:
+    def __init__(self, error: str, message: str, detail: str | None = None) -> None:
         super().__init__(message)
         self.error = error
         self.message = message
+        self.detail = detail
 
     def as_dict(self) -> dict[str, str]:
-        return {"error": self.error, "message": self.message}
+        result = {"error": self.error, "message": self.message}
+        if self.detail:
+            result["detail"] = self.detail
+        return result
 
 
 def fetch_transcript(
     video_id: str,
     *,
     languages: Sequence[str] | None = None,
+    cookies: str | None = None,
+    cookies_from_browser: str | None = None,
     api_factory: Callable[[], Any] | None = None,
 ) -> list[dict[str, float | str]]:
     """Fetch and normalize captions for a YouTube video ID."""
-    try:
-        video_id = normalize_video_id(video_id)
-    except ValueError as exc:
-        raise TranscriptProviderError(
-            "InvalidYouTubeURL",
-            "The provided input is not a valid YouTube URL or video ID.",
-        ) from exc
-
-    if api_factory is None:
-        try:
-            from youtube_transcript_api import YouTubeTranscriptApi
-        except ImportError as exc:
-            raise TranscriptProviderError(
-                "DependencyUnavailable",
-                "youtube-transcript-api is not installed. Install the skill requirements first.",
-            ) from exc
-        api_factory = YouTubeTranscriptApi
+    video_id = _validate_video_id(video_id)
+    api = _create_api(api_factory, cookies=cookies, cookies_from_browser=cookies_from_browser)
+    requested_languages = tuple(languages or DEFAULT_LANGUAGES)
 
     try:
-        fetched = api_factory().fetch(video_id, languages=list(languages or ("en",)))
+        transcripts = api.list(video_id)
+        track = _select_track(transcripts, requested_languages)
+        fetched = track.fetch()
         raw_segments = _to_raw_segments(fetched)
         normalized = normalize_segments(raw_segments)
     except TranscriptProviderError:
@@ -63,18 +58,99 @@ def fetch_transcript(
             raise TranscriptProviderError(
                 "TranscriptUnavailable",
                 "No captions or transcript could be retrieved for this video.",
+                type(exc).__name__,
             ) from exc
         raise TranscriptProviderError(
             "TranscriptFetchFailed",
             "Transcript retrieval failed. Try again later or provide a timestamped transcript.",
+            type(exc).__name__,
         ) from exc
 
     if not normalized:
         raise TranscriptProviderError(
             "TranscriptUnavailable",
             "No captions or transcript could be retrieved for this video.",
+            "EmptyTranscript",
         )
     return normalized
+
+
+def list_transcripts(
+    video_id: str,
+    *,
+    cookies: str | None = None,
+    cookies_from_browser: str | None = None,
+    api_factory: Callable[[], Any] | None = None,
+) -> dict[str, Any]:
+    """List available transcript tracks for a YouTube video ID."""
+    video_id = _validate_video_id(video_id)
+    api = _create_api(api_factory, cookies=cookies, cookies_from_browser=cookies_from_browser)
+    try:
+        transcripts = api.list(video_id)
+        tracks = [
+            {
+                "language": transcript.language,
+                "language_code": transcript.language_code,
+                "is_generated": transcript.is_generated,
+                "is_translatable": transcript.is_translatable,
+            }
+            for transcript in transcripts
+        ]
+    except TranscriptProviderError:
+        raise
+    except Exception as exc:
+        raise TranscriptProviderError(
+            "TranscriptListUnavailable",
+            "Could not list available transcripts for this video.",
+            type(exc).__name__,
+        ) from exc
+    return {"video_id": video_id, "transcripts": tracks}
+
+
+def _validate_video_id(video_id: str) -> str:
+    try:
+        return normalize_video_id(video_id)
+    except ValueError as exc:
+        raise TranscriptProviderError(
+            "InvalidYouTubeURL",
+            "The provided input is not a valid YouTube URL or video ID.",
+        ) from exc
+
+
+def _create_api(
+    api_factory: Callable[[], Any] | None,
+    *,
+    cookies: str | None,
+    cookies_from_browser: str | None,
+) -> Any:
+    if cookies or cookies_from_browser:
+        raise TranscriptProviderError(
+            "CookiesUnsupported",
+            "The installed transcript provider does not support cookie-based transcript retrieval.",
+        )
+    if api_factory is None:
+        try:
+            from youtube_transcript_api import YouTubeTranscriptApi
+        except ImportError as exc:
+            raise TranscriptProviderError(
+                "DependencyUnavailable",
+                "youtube-transcript-api is not installed. Install the skill requirements first.",
+            ) from exc
+        api_factory = YouTubeTranscriptApi
+    return api_factory()
+
+
+def _select_track(transcripts: Any, languages: Sequence[str]) -> Any:
+    try:
+        return transcripts.find_transcript(languages)
+    except Exception as exact_error:
+        for transcript in transcripts:
+            if transcript.is_translatable:
+                try:
+                    return transcript.translate(languages[0])
+                except Exception:
+                    continue
+        raise exact_error
 
 
 def _to_raw_segments(fetched: Any) -> Iterable[Mapping[str, Any]]:

--- a/optional-skills/youtube-chapters/utils/transcript.py
+++ b/optional-skills/youtube-chapters/utils/transcript.py
@@ -1,0 +1,61 @@
+"""Transcript normalization and deterministic chronological grouping."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def normalize_segments(segments: Iterable[Mapping[str, Any]]) -> list[dict[str, float | str]]:
+    """Normalize provider segments and reject unusable timestamp data."""
+    normalized: list[dict[str, float | str]] = []
+    for segment in segments:
+        start = float(segment["start"])
+        if "end" in segment:
+            end = float(segment["end"])
+        elif "duration" in segment:
+            end = start + float(segment["duration"])
+        else:
+            raise ValueError("Transcript segment is missing end or duration")
+        text = " ".join(str(segment.get("text", "")).split())
+        if start < 0 or end < start:
+            raise ValueError("Transcript segment timestamps are invalid")
+        if text:
+            normalized.append({"start": start, "end": end, "text": text})
+
+    normalized.sort(key=lambda segment: float(segment["start"]))
+    return normalized
+
+
+def group_segments(
+    segments: Iterable[Mapping[str, Any]],
+    target_seconds: float = 120.0,
+    max_chars: int = 3000,
+) -> list[dict[str, float | str]]:
+    """Group normalized segments without changing their source timestamps."""
+    if target_seconds <= 0 or max_chars <= 0:
+        raise ValueError("Chunk limits must be positive")
+
+    normalized = normalize_segments(segments)
+    chunks: list[dict[str, float | str]] = []
+    current: list[dict[str, float | str]] = []
+
+    for segment in normalized:
+        projected_text = " ".join(str(item["text"]) for item in [*current, segment])
+        elapsed = float(segment["end"]) - float(current[0]["start"]) if current else 0
+        if current and (elapsed > target_seconds or len(projected_text) > max_chars):
+            chunks.append(_merge(current))
+            current = []
+        current.append(segment)
+
+    if current:
+        chunks.append(_merge(current))
+    return chunks
+
+
+def _merge(segments: list[dict[str, float | str]]) -> dict[str, float | str]:
+    return {
+        "start": float(segments[0]["start"]),
+        "end": float(segments[-1]["end"]),
+        "text": " ".join(str(segment["text"]) for segment in segments),
+    }

--- a/optional-skills/youtube-chapters/utils/validation.py
+++ b/optional-skills/youtube-chapters/utils/validation.py
@@ -1,0 +1,94 @@
+"""Parse, format, and validate YouTube chapter markers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+CHAPTER_LINE_RE = re.compile(r"^(\S+)\s+(.+?)\s*$")
+GENERIC_TITLE_RE = re.compile(r"^(?:part|section|topic)\s*\d*$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Chapter:
+    seconds: int
+    title: str
+
+
+def parse_timestamp(value: str) -> int:
+    """Parse MM:SS or HH:MM:SS into whole seconds."""
+    parts = value.strip().split(":")
+    if len(parts) not in {2, 3} or any(not part.isdigit() for part in parts):
+        raise ValueError(f"Invalid timestamp: {value}")
+    if len(parts) == 2:
+        minutes, seconds = map(int, parts)
+        if seconds >= 60:
+            raise ValueError(f"Invalid timestamp: {value}")
+        return (minutes * 60) + seconds
+
+    hours, minutes, seconds = map(int, parts)
+    if minutes >= 60 or seconds >= 60:
+        raise ValueError(f"Invalid timestamp: {value}")
+    return (hours * 3600) + (minutes * 60) + seconds
+
+
+def format_timestamp(seconds: int) -> str:
+    """Format whole seconds using YouTube-compatible chapter syntax."""
+    if seconds < 0:
+        raise ValueError("Timestamp cannot be negative")
+    hours, remainder = divmod(seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+    return f"{minutes:02d}:{seconds:02d}"
+
+
+def parse_chapter_lines(text: str) -> list[Chapter]:
+    """Parse plain chapter lines into Chapter objects."""
+    chapters: list[Chapter] = []
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = CHAPTER_LINE_RE.fullmatch(line)
+        if not match:
+            raise ValueError(f"Line {line_number} is not a chapter line")
+        timestamp, title = match.groups()
+        chapters.append(Chapter(parse_timestamp(timestamp), title.strip()))
+    return chapters
+
+
+def format_chapters(chapters: Iterable[Chapter]) -> str:
+    """Return paste-ready plain-text chapters."""
+    return "\n".join(f"{format_timestamp(chapter.seconds)} {chapter.title}" for chapter in chapters)
+
+
+def validate_chapters(
+    chapters: Iterable[Chapter],
+    *,
+    duration_seconds: float | None = None,
+    require_minimum: bool = True,
+) -> list[str]:
+    """Return deterministic validation errors; an empty list means valid."""
+    items = list(chapters)
+    errors: list[str] = []
+    if not items:
+        return ["Chapter list is empty"]
+    if items[0].seconds != 0:
+        errors.append("First chapter must start at 00:00")
+    if require_minimum and len(items) < 3:
+        errors.append("At least 3 chapters are required when the transcript supports them")
+
+    previous: int | None = None
+    for index, chapter in enumerate(items, start=1):
+        if not chapter.title.strip():
+            errors.append(f"Chapter {index} has an empty title")
+        if GENERIC_TITLE_RE.fullmatch(chapter.title.strip()):
+            errors.append(f"Chapter {index} has a generic title")
+        if previous is not None and chapter.seconds <= previous:
+            errors.append(f"Chapter {index} timestamp must be strictly increasing")
+        if duration_seconds is not None and chapter.seconds > duration_seconds:
+            errors.append(f"Chapter {index} exceeds the known video duration")
+        previous = chapter.seconds
+    return errors

--- a/optional-skills/youtube-chapters/utils/youtube.py
+++ b/optional-skills/youtube-chapters/utils/youtube.py
@@ -1,0 +1,63 @@
+"""YouTube URL and video ID parsing."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import parse_qs, urlparse
+
+VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+VIDEO_ID_IN_TEXT_RE = re.compile(r"(?<![A-Za-z0-9_-])([A-Za-z0-9_-]{11})(?![A-Za-z0-9_-])")
+INVALID_VIDEO_ID_PLACEHOLDERS = {"invalid-url"}
+SUPPORTED_HOSTS = {
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "music.youtube.com",
+    "youtu.be",
+    "www.youtu.be",
+}
+
+
+def normalize_video_id(candidate: str) -> str:
+    """Return a valid YouTube video ID or raise ValueError."""
+    value = candidate.strip()
+    if not VIDEO_ID_RE.fullmatch(value) or value.lower() in INVALID_VIDEO_ID_PLACEHOLDERS:
+        raise ValueError("YouTube video IDs must contain exactly 11 URL-safe characters")
+    return value
+
+
+def extract_video_id(user_input: str) -> str:
+    """Extract a YouTube video ID from a URL, raw ID, or surrounding text."""
+    value = user_input.strip()
+    if VIDEO_ID_RE.fullmatch(value):
+        return normalize_video_id(value)
+
+    for token in value.split():
+        candidate = _extract_from_url(token.strip("<>()[]{}.,"))
+        if candidate:
+            return candidate
+
+    match = VIDEO_ID_IN_TEXT_RE.search(value)
+    if match:
+        return normalize_video_id(match.group(1))
+    raise ValueError("No valid YouTube URL or video ID found")
+
+
+def _extract_from_url(value: str) -> str | None:
+    parsed = urlparse(value if "://" in value else f"https://{value}")
+    if parsed.hostname not in SUPPORTED_HOSTS:
+        return None
+
+    if parsed.hostname in {"youtu.be", "www.youtu.be"}:
+        candidate = parsed.path.strip("/").split("/", 1)[0]
+    elif parsed.path == "/watch":
+        candidate = parse_qs(parsed.query).get("v", [""])[0]
+    elif parsed.path.startswith(("/shorts/", "/embed/", "/live/")):
+        candidate = parsed.path.strip("/").split("/", 1)[1].split("/", 1)[0]
+    else:
+        return None
+
+    try:
+        return normalize_video_id(candidate)
+    except ValueError:
+        return None


### PR DESCRIPTION
## Summary

Adds a YouTube Chapters skill for Hermes Agent.

This skill enables Hermes to generate paste-ready YouTube chapter markers from timestamped transcripts. It includes the skill workflow, transcript normalization, chapter formatting/validation, an isolated `youtube-transcript-api` provider, a JSON CLI, examples, and offline tests.

## Included

- YouTube Chapters skill instructions
- YouTube URL/video ID parsing
- Transcript provider MVP using `youtube-transcript-api`
- Transcript listing and ordered language selection
- Timestamped transcript normalization
- Chapter chunking/formatting/validation utilities
- JSON CLI with structured diagnostics
- README, troubleshooting guidance, and examples
- Offline tests

## Current behavior

For videos with captions/transcripts accessible through `youtube-transcript-api`, the skill can process a YouTube URL into timestamped transcript data and guide Hermes to generate valid YouTube chapter markers.

Invalid URLs return a structured `InvalidYouTubeURL` error. Videos without accessible captions return `TranscriptUnavailable` with a safe provider exception detail. The CLI also supports `--list-transcripts` and ordered language selection with `--languages tr,en`.

## Out of scope

This PR intentionally does not include:

- Whisper fallback
- yt-dlp fallback
- ffmpeg/audio extraction
- private video support
- browser automation
- network-dependent tests

## Validation

```bash
python -m unittest discover -s optional-skills/youtube-chapters/tests -v
python optional-skills/youtube-chapters/scripts/fetch_transcript.py --help
python optional-skills/youtube-chapters/scripts/fetch_transcript.py "invalid-url"
git diff --check
```

Result:

```text
Ran 24 tests ... OK
```