### PR TITLE
fix(model_metadata): guard against list-typed pricing values in _extract_pricing (#32618)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -603,7 +603,7 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         pricing: Dict[str, Any] = {}
         for target, aliases in alias_map.items():
             for alias in aliases:
-                if alias in normalized and normalized[alias] not in {None, ""}:
+                if alias in normalized and isinstance(normalized[alias], (int, float, str)) and normalized[alias] not in {None, ""}:
                     pricing[target] = normalized[alias]
                     break
         if pricing:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -757,7 +757,7 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         pricing: Dict[str, Any] = {}
         for target, aliases in alias_map.items():
             for alias in aliases:
-                if alias in normalized and normalized[alias] not in {None, ""}:
+                if alias in normalized and isinstance(normalized[alias], (int, float, str)) and normalized[alias] not in {None, ""}:
                     pricing[target] = normalized[alias]
                     break
         if pricing:

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1172,6 +1172,31 @@ class TestNovitaProvider:
         assert float(result["prompt"]) == 2690 / 10_000 / 1_000_000
         assert float(result["completion"]) == 4000 / 10_000 / 1_000_000
 
+    def test_extract_pricing_skips_list_typed_values(self):
+        """_extract_pricing must not crash when pricing values are lists.
+
+        Some providers (e.g. zenmux.ai) return pricing as a list of objects
+        instead of a scalar number.  The ``not in {None, ""}`` membership
+        check raises ``TypeError: unhashable type: 'list'`` on list values.
+        """
+        from agent.model_metadata import _extract_pricing
+
+        payload = {
+            "id": "some/model",
+            "pricing": {
+                "prompt": [{"value": 2, "unit": "perMTokens"}],
+                "completion": [{"value": 4, "unit": "perMTokens"}],
+                "request": 0.001,
+            },
+        }
+        # Must not raise TypeError; list values are skipped, scalar is kept.
+        result = _extract_pricing(payload)
+        assert "request" in result
+        assert result["request"] == 0.001
+        # List-typed fields are silently ignored.
+        assert "prompt" not in result
+        assert "completion" not in result
+
     def test_novita_pricing_cache(self, monkeypatch):
         """_fetch_novita_pricing should cache results in _pricing_cache."""
         from hermes_cli import models as models_mod

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -924,6 +924,37 @@ class TestNovitaProvider:
         assert "prompt" not in result
         assert "completion" not in result
 
+    def test_extract_pricing_skips_dict_typed_values(self):
+        """_extract_pricing must not crash when alias keys hold nested dicts.
+
+        Self-hosted OpenAI-compatible gateways may emit per-model
+        ``capabilities`` objects (nested dicts such as ``modalities.input``).
+        ``_iter_nested_dicts`` walks into them, keys like ``input``/``output``
+        alias-match the pricing map, and the ``not in {None, ""}`` membership
+        check raises ``TypeError: unhashable type: 'dict'`` on dict values —
+        wiping out metadata for every model on the endpoint.
+        """
+        from agent.model_metadata import _extract_pricing
+
+        payload = {
+            "id": "some/model",
+            "capabilities": {
+                "vision": True,
+                "modalities": {
+                    "input": {"text": True},
+                    "output": {"text": True},
+                },
+            },
+            "pricing": {"request": 0.001},
+        }
+        # Must not raise TypeError; dict values are skipped, scalar is kept.
+        result = _extract_pricing(payload)
+        assert "request" in result
+        assert result["request"] == 0.001
+        # Dict-typed modalities fields are silently ignored.
+        assert "prompt" not in result
+        assert "completion" not in result
+
     def test_novita_pricing_cache(self, monkeypatch):
         """_fetch_novita_pricing should cache results in _pricing_cache."""
         from hermes_cli import models as models_mod

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -899,6 +899,31 @@ class TestNovitaProvider:
 
 
 
+    def test_extract_pricing_skips_list_typed_values(self):
+        """_extract_pricing must not crash when pricing values are lists.
+
+        Some providers (e.g. zenmux.ai) return pricing as a list of objects
+        instead of a scalar number.  The ``not in {None, ""}`` membership
+        check raises ``TypeError: unhashable type: 'list'`` on list values.
+        """
+        from agent.model_metadata import _extract_pricing
+
+        payload = {
+            "id": "some/model",
+            "pricing": {
+                "prompt": [{"value": 2, "unit": "perMTokens"}],
+                "completion": [{"value": 4, "unit": "perMTokens"}],
+                "request": 0.001,
+            },
+        }
+        # Must not raise TypeError; list values are skipped, scalar is kept.
+        result = _extract_pricing(payload)
+        assert "request" in result
+        assert result["request"] == 0.001
+        # List-typed fields are silently ignored.
+        assert "prompt" not in result
+        assert "completion" not in result
+
     def test_novita_pricing_cache(self, monkeypatch):
         """_fetch_novita_pricing should cache results in _pricing_cache."""
         from hermes_cli import models as models_mod


### PR DESCRIPTION
## What does this PR do?

Fixes `_extract_pricing()` crashing with `TypeError: unhashable type: 'list'` when a provider's `/v1/models` endpoint returns pricing values as lists of objects instead of scalar numbers.

Fixes #32618

## Root Cause

Line 606 in `agent/model_metadata.py`:

```python
if alias in normalized and normalized[alias] not in {None, ""}:
```

When `normalized[alias]` is a `list` (e.g. zenmux.ai returns `"completion": [{"value": 2, "unit": "perMTokens"}]`), the `not in {None, ""}` membership check raises `TypeError` because lists are unhashable. The outer `except Exception` silently swallows this, causing `fetch_endpoint_model_metadata()` to return `{}` and fall through to `DEFAULT_FALLBACK_CONTEXT` (256K).

## Fix

One-line `isinstance()` guard to skip non-scalar pricing values:

```python
if alias in normalized and isinstance(normalized[alias], (int, float, str)) and normalized[alias] not in {None, ""}:
```

List-typed values are silently skipped; scalar values (the common case) continue to work normally.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS
