### PR TITLE
[kanban] archive_task: kill the worker process instead of leaving it orphaned

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4606,6 +4606,18 @@ def decompose_triage_task(
 
 
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    # Snapshot pid+claim before the DB update clears them, so we can
+    # terminate the worker process even after those columns are NULLed.
+    row = conn.execute(
+        "SELECT worker_pid, claim_lock FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    prev_pid = row["worker_pid"] if row else None
+    prev_lock = row["claim_lock"] if row else None
+    # Terminate the worker process first (same order as reclaim_task).
+    # If the task wasn't running on this host, this is a safe no-op.
+    termination = _terminate_reclaimed_worker(prev_pid, prev_lock)
+
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -4623,7 +4635,9 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        payload = {}
+        payload.update(termination)
+        _append_event(conn, task_id, "archived", payload, run_id=run_id)
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.


### PR DESCRIPTION
## Problem

`archive_task()` is a pure-DB operation — it `UPDATE status='archived', worker_pid=NULL` but never sends `SIGTERM` to the OS process. The worker stays alive as an orphan until it next calls `kanban_complete`/`kanban_block` and discovers its task was archived, burning API quota and compute.

Root cause: `archive_task()` was written as a counterpart to `delete_archived_task()` — a data-layer operation that only touches rows. The kill responsibility was never added.

Compare with `reclaim_task()` (L3273) which correctly snapshots `worker_pid+claim_lock` before the DB update and calls `_terminate_reclaimed_worker()` — sending `SIGTERM` → 5s wait → `SIGKILL` if needed.

## Fix

18 lines added to `archive_task()`, following the same order as `reclaim_task`:

1. **Snapshot** `worker_pid+claim_lock` via SELECT before the write_txn clears them
2. **Kill** via `_terminate_reclaimed_worker(pid, lock)` — same function, same SIGTERM→SIGKILL sequence
3. **Log** termination metadata (`prev_pid, terminated, sigkill, host_local`) in the 'archived' event payload

Non-running / non-local tasks are safe no-ops (`_terminate_reclaimed_worker` returns immediately when pid is None or claim_lock doesn't match the local host prefix).

## Risk

Low. Pattern is identical to `reclaim_task` (production-stable). No schema change, no API change, no test breakage.

## Related

- Original scratch-workspace fix: fc8afd500
- Orphaned-run closure: 8ef2ae650
- This is the third and final piece: orphaned-process termination