### PR TITLE
fix(cli): add timeout to git subprocess.run calls in stash management

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5841,6 +5841,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         capture_output=True,
         text=True,
         check=True,
+        timeout=30,
     )
     if not status.stdout.strip():
         return None
@@ -5854,10 +5855,11 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         cwd=cwd,
         capture_output=True,
         text=True,
+        timeout=30,
     )
     if unmerged.stdout.strip():
         print("→ Clearing unmerged index entries from a previous conflict...")
-        subprocess.run(git_cmd + ["reset"], cwd=cwd, capture_output=True)
+        subprocess.run(git_cmd + ["reset"], cwd=cwd, capture_output=True, timeout=30)
 
     from datetime import datetime, timezone
 
@@ -5869,6 +5871,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         git_cmd + ["stash", "push", "--include-untracked", "-m", stash_name],
         cwd=cwd,
         check=True,
+        timeout=60,
     )
     stash_ref = subprocess.run(
         git_cmd + ["rev-parse", "--verify", "refs/stash"],
@@ -5876,6 +5879,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         capture_output=True,
         text=True,
         check=True,
+        timeout=15,
     ).stdout.strip()
     return stash_ref
 
@@ -5889,6 +5893,7 @@ def _resolve_stash_selector(
         capture_output=True,
         text=True,
         check=True,
+        timeout=30,
     )
     for line in stash_list.stdout.splitlines():
         selector, _, commit = line.partition(" ")
@@ -5943,6 +5948,7 @@ def _restore_stashed_changes(
         cwd=cwd,
         capture_output=True,
         text=True,
+        timeout=60,
     )
 
     # Check for unmerged (conflicted) files — can happen even when returncode is 0
@@ -5951,6 +5957,7 @@ def _restore_stashed_changes(
         cwd=cwd,
         capture_output=True,
         text=True,
+        timeout=30,
     )
     has_conflicts = bool(unmerged.stdout.strip())
 
@@ -5978,6 +5985,7 @@ def _restore_stashed_changes(
             git_cmd + ["reset", "--hard", "HEAD"],
             cwd=cwd,
             capture_output=True,
+            timeout=30,
         )
         print("Working tree reset to clean state.")
         print(f"Restore your changes later with: git stash apply {stash_ref}")
@@ -6001,6 +6009,7 @@ def _restore_stashed_changes(
             cwd=cwd,
             capture_output=True,
             text=True,
+            timeout=30,
         )
         if drop.returncode != 0:
             print(
@@ -6053,6 +6062,7 @@ def _discard_stashed_changes(
         cwd=cwd,
         capture_output=True,
         text=True,
+        timeout=30,
     )
     if drop.returncode != 0:
         print(


### PR DESCRIPTION
## Summary

Adds `timeout` to 11 `subprocess.run()` calls in `hermes_cli/main.py` that execute git operations for stash management during `hermes update`.

## Functions Fixed

### `_stash_local_changes_if_needed` (5 calls)
| Call | Timeout | Rationale |
|------|---------|-----------|
| `git status --porcelain` | 30s | Local operation, fast |
| `git ls-files --unmerged` | 30s | Local operation, fast |
| `git reset` | 30s | Local operation, fast |
| `git stash push --include-untracked` | 60s | May collect many untracked files |
| `git rev-parse --verify refs/stash` | 15s | Local operation, instant |

### `_resolve_stash_selector` (1 call)
| Call | Timeout | Rationale |
|------|---------|-----------|
| `git stash list --format=%gd %H` | 30s | Local operation, fast |

### Restore flow (4 calls)
| Call | Timeout | Rationale |
|------|---------|-----------|
| `git stash apply` | 60s | May apply large diffs |
| `git diff --name-only --diff-filter=U` | 30s | Local operation, fast |
| `git reset --hard HEAD` | 30s | Local operation, fast |
| `git stash drop` | 30s | Local operation, fast |

### `_discard_stashed_changes` (1 call)
| Call | Timeout | Rationale |
|------|---------|-----------|
| `git stash drop` | 30s | Local operation, fast |

## Why this matters

These git operations run during `hermes update`. Without timeouts, a corrupted git state or unusual filesystem condition could cause the update to hang indefinitely. All operations are local (no network), so generous timeouts (15-60s) are more than sufficient.

## Test plan
- Syntax check passes on `hermes_cli/main.py`
- `hermes update` flow should work unchanged
- Stash management (local changes detection, apply, drop) should work as before
