### PR TITLE
feat(telegram): expose inline keyboard buttons via send_message tool

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -2846,3 +2846,142 @@ class TestSendTelegramThreadNotFoundRetry:
         finally:
             if media_path and os.path.exists(media_path):
                 os.unlink(media_path)
+
+
+class TestSendTelegramInlineKeyboard:
+    """Tests for the buttons parameter on _send_telegram (inline keyboard)."""
+
+    def test_buttons_schema_in_tool_definition(self):
+        """The send_message tool schema should include a 'buttons' parameter."""
+        from tools.send_message_tool import SEND_MESSAGE_SCHEMA
+        schema = SEND_MESSAGE_SCHEMA["parameters"]
+        assert "buttons" in schema["properties"]
+        btn_schema = schema["properties"]["buttons"]
+        assert btn_schema["type"] == "array"
+        assert "text" in btn_schema["items"]["properties"]
+        assert "callback_data" in btn_schema["items"]["properties"]
+
+    def test_send_telegram_with_buttons(self):
+        """Buttons should be converted to InlineKeyboardMarkup and passed as reply_markup."""
+        kwargs_seen = []
+
+        class FakeBot:
+            async def send_message(self, **kwargs):
+                kwargs_seen.append(kwargs)
+                return SimpleNamespace(message_id=1)
+
+        async def run_test():
+            with patch("telegram.Bot", return_value=FakeBot()):
+                return await _send_telegram(
+                    "fake-token", "-100123", "Choose an option:",
+                    buttons=[
+                        {"text": "✅ Approve", "callback_data": "approve:once"},
+                        {"text": "❌ Deny", "callback_data": "approve:deny"},
+                    ],
+                )
+
+        result = asyncio.run(run_test())
+        assert result["success"] is True
+        assert len(kwargs_seen) == 1
+        assert "reply_markup" in kwargs_seen[0]
+        markup = kwargs_seen[0]["reply_markup"]
+        # InlineKeyboardMarkup should have one row with two buttons
+        assert len(markup.inline_keyboard) == 1
+        assert len(markup.inline_keyboard[0]) == 2
+        assert markup.inline_keyboard[0][0].text == "✅ Approve"
+        assert markup.inline_keyboard[0][0].callback_data == "approve:once"
+        assert markup.inline_keyboard[0][1].text == "❌ Deny"
+        assert markup.inline_keyboard[0][1].callback_data == "approve:deny"
+
+    def test_send_telegram_without_buttons(self):
+        """Without buttons, no reply_markup should be set."""
+        kwargs_seen = []
+
+        class FakeBot:
+            async def send_message(self, **kwargs):
+                kwargs_seen.append(kwargs)
+                return SimpleNamespace(message_id=1)
+
+        async def run_test():
+            with patch("telegram.Bot", return_value=FakeBot()):
+                return await _send_telegram(
+                    "fake-token", "-100123", "Hello world",
+                )
+
+        result = asyncio.run(run_test())
+        assert result["success"] is True
+        assert "reply_markup" not in kwargs_seen[0]
+
+    def test_send_telegram_empty_buttons_list(self):
+        """Empty buttons list should not add reply_markup."""
+        kwargs_seen = []
+
+        class FakeBot:
+            async def send_message(self, **kwargs):
+                kwargs_seen.append(kwargs)
+                return SimpleNamespace(message_id=1)
+
+        async def run_test():
+            with patch("telegram.Bot", return_value=FakeBot()):
+                return await _send_telegram(
+                    "fake-token", "-100123", "Hello",
+                    buttons=[],
+                )
+
+        result = asyncio.run(run_test())
+        assert result["success"] is True
+        assert "reply_markup" not in kwargs_seen[0]
+
+    def test_send_telegram_buttons_with_invalid_entries(self):
+        """Buttons with missing fields should be filtered out."""
+        kwargs_seen = []
+
+        class FakeBot:
+            async def send_message(self, **kwargs):
+                kwargs_seen.append(kwargs)
+                return SimpleNamespace(message_id=1)
+
+        async def run_test():
+            with patch("telegram.Bot", return_value=FakeBot()):
+                return await _send_telegram(
+                    "fake-token", "-100123", "Choose:",
+                    buttons=[
+                        {"text": "Valid", "callback_data": "ok"},
+                        {"text": "Missing data"},  # no callback_data
+                        {"callback_data": "orphan"},  # no text
+                    ],
+                )
+
+        result = asyncio.run(run_test())
+        assert result["success"] is True
+        assert "reply_markup" in kwargs_seen[0]
+        markup = kwargs_seen[0]["reply_markup"]
+        # Only the valid button should remain
+        assert len(markup.inline_keyboard[0]) == 1
+        assert markup.inline_keyboard[0][0].text == "Valid"
+
+    def test_send_to_platform_passes_buttons_to_telegram(self):
+        """_send_to_platform should forward buttons to _send_telegram."""
+        from tools.send_message_tool import _send_to_platform
+
+        send_calls = []
+
+        async def mock_send_telegram(token, chat_id, message, **kwargs):
+            send_calls.append(kwargs)
+            return {"success": True, "message_id": 1}
+
+        async def run_test():
+            pconfig = SimpleNamespace(token="fake", extra={})
+            with patch("tools.send_message_tool._send_telegram", mock_send_telegram):
+                with patch("gateway.platforms.telegram.TelegramAdapter") as mock_adapter:
+                    mock_adapter.MAX_MESSAGE_LENGTH = 4096
+                    mock_adapter._message_thread_id_for_send = staticmethod(lambda x: None)
+                    with patch("tools.send_message_tool._send_to_platform", wraps=_send_to_platform):
+                        await _send_to_platform(
+                            Platform.TELEGRAM, pconfig, "-100123", "Pick one:",
+                            buttons=[{"text": "OK", "callback_data": "ok"}],
+                        )
+
+        asyncio.run(run_test())
+        assert len(send_calls) == 1
+        assert send_calls[0].get("buttons") == [{"text": "OK", "callback_data": "ok"}]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -148,6 +148,18 @@ SEND_MESSAGE_SCHEMA = {
             "message": {
                 "type": "string",
                 "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/report.pdf') in the message — the platform will deliver it as a native media attachment."
+            },
+            "buttons": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "text": {"type": "string", "description": "Button label shown to the user"},
+                        "callback_data": {"type": "string", "description": "Data sent back when the button is tapped (Telegram callback_data)"}
+                    },
+                    "required": ["text", "callback_data"]
+                },
+                "description": "Optional inline keyboard buttons (Telegram only). Each button has 'text' (label) and 'callback_data' (payload sent on tap). Buttons are arranged in a single row. Ignored on non-Telegram platforms."
             }
         },
         "required": []
@@ -178,6 +190,7 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
+    buttons = args.get("buttons")  # Optional inline keyboard buttons (Telegram only)
     if not target or not message:
         return tool_error("Both 'target' and 'message' are required when action='send'")
 
@@ -320,6 +333,7 @@ def _handle_send(args):
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document_attachments,
+                buttons=buttons,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -580,7 +594,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, buttons=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -665,6 +679,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 disable_link_previews=disable_link_previews,
                 force_document=force_document,
+                buttons=buttons if is_last else None,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -837,7 +852,7 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False, buttons=None):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -922,6 +937,20 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         text_kwargs = dict(thread_kwargs)
         if disable_link_previews:
             text_kwargs["disable_web_page_preview"] = True
+
+        # Build inline keyboard markup from buttons parameter (Telegram only).
+        # Each button becomes an InlineKeyboardButton in a single row.
+        if buttons and isinstance(buttons, list) and len(buttons) > 0:
+            try:
+                from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+                keyboard = InlineKeyboardMarkup([
+                    [InlineKeyboardButton(b["text"], callback_data=b["callback_data"])
+                     for b in buttons if isinstance(b, dict) and "text" in b and "callback_data" in b]
+                ])
+                if keyboard.inline_keyboard[0]:  # At least one valid button
+                    text_kwargs["reply_markup"] = keyboard
+            except Exception as kb_err:
+                logger.warning("send_message: failed to build inline keyboard: %s", kb_err)
 
         last_msg = None
         warnings = []


### PR DESCRIPTION
## Problem

When the agent needs user approval for multi-step workflows (e.g. `approve commit`, `approve push`), it can only send plain text via `send_message`. Users must manually type the exact approval phrase, which is error-prone and creates friction — especially on Telegram where inline keyboard buttons already exist for terminal command approvals.

## Solution

Add an optional `buttons` parameter to the `send_message` tool schema. Each button specifies `text` (label) and `callback_data` (payload sent on tap). When targeting Telegram, buttons are converted to `InlineKeyboardMarkup` and attached as `reply_markup`. Non-Telegram platforms silently ignore the parameter.

### Changes

- **`tools/send_message_tool.py`** — Added `buttons` array parameter to `SEND_MESSAGE_SCHEMA`. Updated `_handle_send`, `_send_to_platform`, and `_send_telegram` to forward and render inline keyboard buttons.
- **`tests/tools/test_send_message_tool.py`** — 6 new tests covering: schema validation, button rendering, no-buttons baseline, empty list, invalid entries filtering, and pass-through from `_send_to_platform`.

### Usage

```python
send_message(
    action="send",
    target="telegram",
    message="To continue, choose an option:",
    buttons=[
        {"text": "✅ Approve", "callback_data": "approve:once"},
        {"text": "❌ Deny", "callback_data": "approve:deny"},
    ]
)
```

Closes #42696
