### PR TITLE
fix(desktop): unmount disabled pane contents

### DIFF
--- a/apps/desktop/src/components/pane-shell/pane-shell.test.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { useEffect } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $paneStates, setPaneOpen, setPaneWidthOverride } from '@/store/panes'
 
@@ -34,6 +35,14 @@ function mockWidth(element: HTMLElement, width: number) {
       toJSON: () => ({})
     })
   })
+}
+
+function EffectProbe({ onMount }: { onMount: () => void }) {
+  useEffect(() => {
+    onMount()
+  }, [onMount])
+
+  return <span data-testid="pane-effect-child">child</span>
 }
 
 describe('PaneShell composition', () => {
@@ -144,6 +153,30 @@ describe('PaneShell composition', () => {
       </PaneShell>
     )
 
+    expect($paneStates.get().files?.open).toBe(true)
+  })
+
+  it('does not mount disabled pane children', () => {
+    const onMount = vi.fn()
+
+    setPaneOpen('files', true)
+
+    const rendered = render(
+      <PaneShell>
+        <Pane disabled={true} id="files" side="left" width="240px">
+          <EffectProbe onMount={onMount} />
+        </Pane>
+        <PaneMain>main</PaneMain>
+      </PaneShell>
+    )
+
+    const pane = rendered.container.querySelector('[data-pane-id="files"]')
+
+    expect(getColumnTemplate(gridContainer(rendered))).toEqual(['0px', 'minmax(0,1fr)'])
+    expect(pane).toBeInstanceOf(HTMLElement)
+    expect((pane as HTMLElement).getAttribute('aria-hidden')).toBe('true')
+    expect(rendered.queryByTestId('pane-effect-child')).toBeNull()
+    expect(onMount).not.toHaveBeenCalled()
     expect($paneStates.get().files?.open).toBe(true)
   })
 

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -566,7 +566,7 @@ export function Pane({
           />
         </div>
       )}
-      {children}
+      {!disabled && children}
     </div>
   )
 }


### PR DESCRIPTION
Disabled panes are route and feature gates: they keep their wrapper/grid slot so
the stored pane layout remains stable, but their contents should not stay active
while the pane is unavailable.

This changes the normal pane branch to skip mounting children while `disabled`
is true. Store-closed panes continue to preserve their contents, and
`forceCollapsed` + `hoverReveal` panes continue to render through the separate
overlay branch.

The original report identified the file tree's zero-size `PageLoader` animation
as the visible CPU source. Current `main` has since replaced that loader with a
tree skeleton, but the underlying lifecycle bug remains: disabled file-browser
and review panes still mount their hooks and subscriptions, and the newer
terminal pane still mounts `TerminalSlot`. That slot causes `PersistentTerminal`
to run its geometry `requestAnimationFrame` loop even when the pane has a zero-
sized track. Unmounting disabled pane contents clears the slot and stops that
loop; the persistent terminal workspace remains mounted outside the pane, so
live shells are preserved.

The regression test uses an effect probe to verify the lifecycle contract, not
only the pane's CSS/grid state.

Verification:

- `npm run test:ui -- src/components/pane-shell/pane-shell.test.tsx`
- `npm run typecheck`
- `npx eslint src/components/pane-shell/pane-shell.tsx src/components/pane-shell/pane-shell.test.tsx`
