### PR TITLE
fix(tools): harden spawn_local Windows job detachment

### DIFF
--- a/tests/tools/test_process_spawn_local_detached.py
+++ b/tests/tools/test_process_spawn_local_detached.py
@@ -1,0 +1,245 @@
+"""Behavioral tests for ProcessRegistry.spawn_local job-object detachment.
+
+The bug: a background process spawned via
+:meth:`ProcessRegistry.spawn_local` (the agent's ``terminal(background=true)``
+local path) was launched with only ``windows_hide_flags()``
+(``CREATE_NO_WINDOW``). That leaves the child inside the parent's Windows job
+object, so it is reaped if that job is torn down.
+
+The fix routes the spawn through ``windows_detach_popen_kwargs()`` (which adds
+``CREATE_BREAKAWAY_FROM_JOB`` on Windows and ``start_new_session=True`` on
+POSIX) with a breakaway-denied ``OSError`` retry that drops only the breakaway
+bit, mirroring ``hermes_cli/gateway_windows.py::_spawn_detached``.
+
+These tests drive the real ``spawn_local`` coroutine-free method with a mocked
+``subprocess.Popen`` and assert on the kwargs actually passed — not on source
+text. They run on any host: both ``process_registry._IS_WINDOWS`` and
+``hermes_cli._subprocess_compat.IS_WINDOWS`` are monkeypatched so each platform
+branch is exercised deterministically (the Win32 flag constants are plain ints
+defined unconditionally).
+
+Scope: this covers the standard pipe-backed (non-PTY) local background path.
+The ``use_pty=True`` branch spawns through pywinpty's own implementation and is
+out of scope here; it is a separate spawn path and is not touched by this fix.
+The native-Windows job-membership counterpart lives in
+``test_process_spawn_local_job_breakaway_win.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import hermes_cli._subprocess_compat as sc
+import tools.process_registry as pr
+from hermes_cli._subprocess_compat import (
+    windows_detach_flags,
+    windows_detach_flags_without_breakaway,
+)
+
+_BREAKAWAY = 0x01000000
+
+
+class _FakeProc:
+    """Minimal Popen stand-in. ``stdout=None`` makes the reader thread return
+    immediately, so no real I/O or process is involved."""
+
+    def __init__(self, pid: int = 4242):
+        self.pid = pid
+        self.stdout = None
+
+    def poll(self):
+        return None
+
+    def kill(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
+
+
+def _force_platform(monkeypatch, *, windows: bool):
+    monkeypatch.setattr(pr, "_IS_WINDOWS", windows)
+    monkeypatch.setattr(sc, "IS_WINDOWS", windows)
+
+
+def _quiet_registry(monkeypatch):
+    """Neutralize disk/OS/thread side effects so spawn_local exercises only the
+    spawn: no checkpoint write, no host-start-time probe, and a no-op reader
+    loop (the reader thread is not under test and would otherwise touch
+    attributes the fake proc doesn't have)."""
+    monkeypatch.setattr(pr.ProcessRegistry, "_write_checkpoint", lambda self: None)
+    monkeypatch.setattr(
+        pr.ProcessRegistry, "_safe_host_start_time", staticmethod(lambda pid: None)
+    )
+    monkeypatch.setattr(pr.ProcessRegistry, "_reader_loop", lambda self, session: None)
+    # _find_shell() probes candidate shells with its own subprocess.Popen calls;
+    # pin it so the recorder below captures only spawn_local's own spawn.
+    monkeypatch.setattr(pr, "_find_shell", lambda: "/bin/bash")
+    return pr.ProcessRegistry()
+
+
+def _install_popen(monkeypatch, side_effects):
+    """Patch subprocess.Popen with a recorder driven by ``side_effects`` (each
+    item is either an exception to raise or a proc to return)."""
+    calls = []
+
+    def fake_popen(argv, **kwargs):
+        calls.append((argv, kwargs))
+        effect = side_effects[min(len(calls) - 1, len(side_effects) - 1)]
+        if isinstance(effect, BaseException):
+            raise effect
+        return effect
+
+    monkeypatch.setattr(pr.subprocess, "Popen", fake_popen)
+    return calls
+
+
+def test_spawn_local_windows_retries_without_breakaway_on_oserror(monkeypatch, tmp_path):
+    _force_platform(monkeypatch, windows=True)
+    reg = _quiet_registry(monkeypatch)
+    calls = _install_popen(
+        monkeypatch, [OSError(5, "Access is denied"), _FakeProc()]
+    )
+
+    session = reg.spawn_local("echo hi", cwd=str(tmp_path))
+
+    assert len(calls) == 2, "restrictive-job OSError must trigger exactly one retry"
+    (argv1, kw1), (argv2, kw2) = calls
+
+    # argv is identical across primary and fallback. Do NOT pin the exact
+    # shell-flag layout ("-lic", "set +m; ...") — that is _find_shell's concern,
+    # not this fix's; assert only that the command reaches the shell.
+    assert argv1 == argv2
+    assert any("echo hi" in part for part in argv1), "command must reach the shell"
+
+    # Every non-creationflags kwarg is identical across the two attempts (only
+    # the breakaway bit in creationflags is allowed to differ).
+    assert set(kw1) - {"creationflags"} == set(kw2) - {"creationflags"}
+    for key in (set(kw1) | set(kw2)) - {"creationflags"}:
+        assert kw1[key] == kw2[key], f"{key} differs across retry"
+
+    # Stdio config is preserved on both attempts — process(action="poll")
+    # depends on the captured pipe.
+    for kw in (kw1, kw2):
+        assert kw["stdout"] is subprocess.PIPE
+        assert kw["stderr"] is subprocess.STDOUT
+        assert kw["stdin"] is subprocess.DEVNULL
+        assert kw["close_fds"] is True
+
+    # Primary carries breakaway; fallback drops only that bit. No session kwarg
+    # on the Windows branch, and never a preexec_fn.
+    assert kw1["creationflags"] == windows_detach_flags()
+    assert kw1["creationflags"] & _BREAKAWAY
+    assert kw2["creationflags"] == windows_detach_flags_without_breakaway()
+    assert not (kw2["creationflags"] & _BREAKAWAY)
+    # The two flag sets differ by *exactly* the breakaway bit — nothing else
+    # changes between the primary and the fallback.
+    assert kw1["creationflags"] ^ kw2["creationflags"] == _BREAKAWAY
+    for kw in (kw1, kw2):
+        assert "start_new_session" not in kw
+        assert "preexec_fn" not in kw
+
+    # The retry succeeded, so a real session is registered and returned.
+    assert session.pid == 4242
+    assert session.id in reg._running
+
+
+def test_spawn_local_windows_dual_failure_surfaces_to_caller(monkeypatch, tmp_path):
+    _force_platform(monkeypatch, windows=True)
+    reg = _quiet_registry(monkeypatch)
+    # Distinct exceptions so we can prove it is the *fallback's* failure that
+    # propagates — not the primary's, silently re-raised.
+    primary_exc = OSError(5, "primary breakaway denied")
+    fallback_exc = OSError(1, "fallback also failed")
+    calls = _install_popen(monkeypatch, [primary_exc, fallback_exc])
+
+    # Both attempts fail -> the failure is surfaced, not swallowed into a
+    # session that falsely claims the process started.
+    with pytest.raises(OSError) as excinfo:
+        reg.spawn_local("echo hi", cwd=str(tmp_path))
+
+    assert excinfo.value is fallback_exc, "the fallback's exception must propagate"
+    assert len(calls) == 2
+    assert reg._running == {}, "no session may be registered when the spawn failed"
+
+
+def test_spawn_local_windows_setup_failure_tree_kills_and_registers_no_session(
+    monkeypatch, tmp_path
+):
+    """A post-Popen setup failure on Windows must tree-kill the child, not just
+    proc.kill() it. The child has broken away from our job and owns descendants
+    (the shell's grandchildren), so a bare kill would leak them untracked."""
+    _force_platform(monkeypatch, windows=True)
+    reg = _quiet_registry(monkeypatch)
+    _install_popen(monkeypatch, [_FakeProc(pid=9999)])
+    # Sentinel host start time so we can prove the tree terminator receives the
+    # captured start time (its recycled-PID guard), not just the PID.
+    monkeypatch.setattr(
+        pr.ProcessRegistry, "_safe_host_start_time", staticmethod(lambda pid: 123456)
+    )
+
+    # Fail during post-Popen setup, BEFORE the session is registered.
+    def boom(*args, **kwargs):
+        raise RuntimeError("thread creation failed")
+
+    monkeypatch.setattr(pr.threading, "Thread", boom)
+
+    # Capture the start-time-validated tree terminator.
+    killed = {}
+    monkeypatch.setattr(
+        pr.ProcessRegistry,
+        "_terminate_host_pid",
+        classmethod(lambda cls, pid, expected=None: killed.update(pid=pid, expected=expected)),
+    )
+
+    with pytest.raises(RuntimeError, match="thread creation failed"):
+        reg.spawn_local("echo hi", cwd=str(tmp_path))
+
+    # Tree terminator invoked with BOTH the child pid and the captured start time.
+    assert killed == {"pid": 9999, "expected": 123456}
+    assert reg._running == {}, "no session may be registered after a setup failure"
+
+
+def test_spawn_local_windows_happy_path_single_spawn(monkeypatch, tmp_path):
+    _force_platform(monkeypatch, windows=True)
+    reg = _quiet_registry(monkeypatch)
+    calls = _install_popen(monkeypatch, [_FakeProc()])
+
+    reg.spawn_local("echo hi", cwd=str(tmp_path))
+
+    assert len(calls) == 1, "no retry when the primary spawn succeeds"
+    _, kw = calls[0]
+    assert kw["creationflags"] == windows_detach_flags()
+    assert kw["creationflags"] & _BREAKAWAY
+
+
+def test_spawn_local_posix_single_session_no_duplicate_no_preexec(monkeypatch, tmp_path):
+    _force_platform(monkeypatch, windows=False)
+    reg = _quiet_registry(monkeypatch)
+    calls = _install_popen(monkeypatch, [_FakeProc()])
+
+    # Would raise TypeError("multiple values for 'start_new_session'") if the
+    # helper's start_new_session collided with a hard-coded one.
+    reg.spawn_local("echo hi", cwd=str(tmp_path))
+
+    assert len(calls) == 1
+    _, kw = calls[0]
+    assert kw.get("start_new_session") is True
+    assert "creationflags" not in kw
+    assert "preexec_fn" not in kw
+
+
+def test_spawn_local_posix_oserror_is_not_retried(monkeypatch, tmp_path):
+    _force_platform(monkeypatch, windows=False)
+    reg = _quiet_registry(monkeypatch)
+    calls = _install_popen(monkeypatch, [OSError(2, "No such file")])
+
+    # On POSIX there is no breakaway bit to drop, so a genuine spawn OSError
+    # propagates immediately without a second attempt.
+    with pytest.raises(OSError):
+        reg.spawn_local("echo hi", cwd=str(tmp_path))
+
+    assert len(calls) == 1
+    assert reg._running == {}

--- a/tests/tools/test_process_spawn_local_job_breakaway_win.py
+++ b/tests/tools/test_process_spawn_local_job_breakaway_win.py
@@ -1,0 +1,206 @@
+"""Native-Windows integration test: spawn_local children break away from the
+parent job object.
+
+This is the real-OS counterpart to the mocked kwargs tests in
+``test_process_spawn_local_detached.py``. It stands up a controlled job object
+with ``JOB_OBJECT_LIMIT_BREAKAWAY_OK``, assigns the *current* (pytest) process
+to it, calls the real ``ProcessRegistry.spawn_local``, and asserts via
+``IsProcessInJob`` that the spawned child is NOT a member of that job — i.e. it
+used ``CREATE_BREAKAWAY_FROM_JOB`` and escaped.
+
+Adversarial contract:
+- Against pristine ``main`` (``windows_hide_flags()`` only), the child stays in
+  the controlled job and ``IsProcessInJob(child, job)`` is True -> this test
+  FAILS.
+- Against the fix, the child breaks away and ``IsProcessInJob(child, job)`` is
+  False -> this test PASSES.
+
+Isolation: assigning a process to a job object is irreversible for that
+process's lifetime, so this file must run in its OWN pytest process (it assigns
+the interpreter running it). Do not merge it into a shared test module.
+
+Scope: covers the standard pipe-backed (non-PTY) local background path only.
+``use_pty=True`` uses pywinpty's separate spawn implementation and is out of
+scope.
+
+Uses only the stdlib ``ctypes`` — no pywin32 / pywinpty dependency.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import sys
+import time
+
+import pytest
+
+import tools.process_registry as pr
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="native Windows job-object semantics"
+)
+
+
+def test_spawn_local_child_breaks_away_from_controlled_job(tmp_path):
+    from ctypes import wintypes
+
+    ULONG_PTR = ctypes.c_size_t
+
+    class JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", wintypes.LARGE_INTEGER),
+            ("PerJobUserTimeLimit", wintypes.LARGE_INTEGER),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ULONG_PTR),
+            ("MaximumWorkingSetSize", ULONG_PTR),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ULONG_PTR),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class IO_COUNTERS(ctypes.Structure):
+        _fields_ = [
+            ("ReadOperationCount", ctypes.c_ulonglong),
+            ("WriteOperationCount", ctypes.c_ulonglong),
+            ("OtherOperationCount", ctypes.c_ulonglong),
+            ("ReadTransferCount", ctypes.c_ulonglong),
+            ("WriteTransferCount", ctypes.c_ulonglong),
+            ("OtherTransferCount", ctypes.c_ulonglong),
+        ]
+
+    class JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", JOBOBJECT_BASIC_LIMIT_INFORMATION),
+            ("IoInfo", IO_COUNTERS),
+            ("ProcessMemoryLimit", ULONG_PTR),
+            ("JobMemoryLimit", ULONG_PTR),
+            ("PeakProcessMemoryUsed", ULONG_PTR),
+            ("PeakJobMemoryUsed", ULONG_PTR),
+        ]
+
+    JobObjectExtendedLimitInformation = 9
+    JOB_OBJECT_LIMIT_BREAKAWAY_OK = 0x00000800
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    PROCESS_TERMINATE = 0x0001
+
+    k32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    k32.CreateJobObjectW.argtypes = [wintypes.LPVOID, wintypes.LPCWSTR]
+    k32.CreateJobObjectW.restype = wintypes.HANDLE
+    k32.SetInformationJobObject.argtypes = [
+        wintypes.HANDLE, ctypes.c_int, wintypes.LPVOID, wintypes.DWORD
+    ]
+    k32.SetInformationJobObject.restype = wintypes.BOOL
+    k32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+    k32.AssignProcessToJobObject.restype = wintypes.BOOL
+    k32.IsProcessInJob.argtypes = [
+        wintypes.HANDLE, wintypes.HANDLE, ctypes.POINTER(wintypes.BOOL)
+    ]
+    k32.IsProcessInJob.restype = wintypes.BOOL
+    k32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    k32.OpenProcess.restype = wintypes.HANDLE
+    k32.GetCurrentProcess.argtypes = []
+    k32.GetCurrentProcess.restype = wintypes.HANDLE  # pseudo-handle, do not close
+    k32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    k32.TerminateProcess.restype = wintypes.BOOL
+    k32.CloseHandle.argtypes = [wintypes.HANDLE]
+    k32.CloseHandle.restype = wintypes.BOOL
+
+    def _is_in_job(proc_handle, job_handle) -> bool:
+        result = wintypes.BOOL()
+        if not k32.IsProcessInJob(proc_handle, job_handle, ctypes.byref(result)):
+            raise ctypes.WinError(ctypes.get_last_error())
+        return bool(result.value)
+
+    marker = "HERMES_BREAKAWAY_MARKER_42868"
+    job = k32.CreateJobObjectW(None, None)
+    if not job:
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    child_handle = None
+    session = None
+    reg = None
+    try:
+        # BREAKAWAY_OK is required: it is what lets a child that requests
+        # CREATE_BREAKAWAY_FROM_JOB actually escape (without it CreateProcess
+        # returns ERROR_ACCESS_DENIED, which is the fallback path — a different
+        # test). Build the info struct properly and size it via sizeof().
+        info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_BREAKAWAY_OK
+        if not k32.SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+
+        # Assign THIS process to the controlled job. If the environment forbids
+        # nesting (the interpreter is already in a job that disallows it), the
+        # test cannot be set up — skip rather than error.
+        if not k32.AssignProcessToJobObject(job, k32.GetCurrentProcess()):
+            err = ctypes.get_last_error()
+            pytest.skip(
+                f"cannot assign the test process to a controlled job "
+                f"(WinError {err}); nested job objects not permitted here"
+            )
+
+        # Guard against a vacuous test: if we are not actually in the job, a
+        # child "not in the job" proves nothing.
+        assert _is_in_job(k32.GetCurrentProcess(), job), (
+            "setup failed: pytest process is not in the controlled job"
+        )
+
+        reg = pr.ProcessRegistry()
+        # Long enough to stay alive while we query; the marker proves capture.
+        session = reg.spawn_local(f"echo {marker}; sleep 20", cwd=str(tmp_path))
+        assert session.pid, "spawn_local did not return a child pid"
+
+        # Captured output must still work over the pipe (the point of the
+        # non-PTY path) — poll the rolling buffer for the marker.
+        captured = ""
+        deadline = time.time() + 15.0
+        while time.time() < deadline:
+            captured = reg.read_log(session.id).get("output", "")
+            if marker in captured:
+                break
+            time.sleep(0.2)
+        assert marker in captured, (
+            f"marker not captured within timeout; buffer={captured!r}"
+        )
+
+        # The child must have broken away from the controlled job.
+        child_handle = k32.OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE,
+            False,
+            int(session.pid),
+        )
+        if not child_handle:
+            raise ctypes.WinError(ctypes.get_last_error())
+        assert _is_in_job(child_handle, job) is False, (
+            "child is still a member of the parent's job object — breakaway did "
+            "not take effect (this is the failure pristine main reproduces)"
+        )
+    finally:
+        # Cleanup order matters: run Hermes' /T tree termination FIRST so it can
+        # still find the shell's descendants; killing the shell directly first
+        # would orphan them. Only then fall back to a direct TerminateProcess on
+        # the child handle. Each handle is closed exactly once.
+        if reg is not None and session is not None:
+            try:
+                reg.kill_process(session.id)
+            except Exception:
+                pass
+        if child_handle:
+            try:
+                time.sleep(0.3)
+                # Only if kill_process did not already reap the child: a genuine
+                # last-resort fallback, not a second executioner.
+                if session is None or session.process is None or session.process.poll() is None:
+                    k32.TerminateProcess(child_handle, 1)
+            except Exception:
+                pass
+            finally:
+                k32.CloseHandle(child_handle)
+        k32.CloseHandle(job)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -42,7 +42,11 @@ import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import (
+    windows_detach_flags_without_breakaway,
+    windows_detach_popen_kwargs,
+    windows_hide_flags,
+)
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -766,21 +770,35 @@ class ProcessRegistry:
         # stdout is a pipe, hiding output from process(action="poll")).
         bg_env = _sanitize_subprocess_env(os.environ, env_vars)
         bg_env["PYTHONUNBUFFERED"] = "1"
-        _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
-        proc = subprocess.Popen(
-            [user_shell, "-lic", f"set +m; {command}"],
-            text=True,
-            cwd=session.cwd,
-            env=bg_env,
-            encoding="utf-8",
-            errors="replace",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.DEVNULL,
-            start_new_session=True,
-            **_popen_kwargs,
-        )
+        # Detach background children from the parent job/session. Restrictive
+        # Windows jobs can reject CREATE_BREAKAWAY_FROM_JOB, so mirror
+        # _spawn_detached and retry without only that bit. On POSIX, the helper
+        # supplies start_new_session=True.
+        popen_argv = [user_shell, "-lic", f"set +m; {command}"]
+        popen_common: Dict[str, Any] = {
+            "text": True,
+            "cwd": session.cwd,
+            "env": bg_env,
+            "encoding": "utf-8",
+            "errors": "replace",
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.STDOUT,
+            "stdin": subprocess.DEVNULL,
+            "close_fds": True,
+        }
+        try:
+            proc = subprocess.Popen(
+                popen_argv, **popen_common, **windows_detach_popen_kwargs()
+            )
+        except OSError:
+            if not _IS_WINDOWS:
+                raise
+            proc = subprocess.Popen(
+                popen_argv,
+                **popen_common,
+                creationflags=windows_detach_flags_without_breakaway(),
+            )
 
         session.process = proc
         session.pid = proc.pid
@@ -803,9 +821,13 @@ class ProcessRegistry:
 
             self._write_checkpoint()
         except Exception:
-            # Post-Popen setup failed — kill the orphaned subprocess (and any
-            # descendants spawned via setsid) before re-raising so they do not
-            # leak as untracked background processes.
+            # Post-Popen setup failed — terminate the child AND its descendants
+            # before re-raising so they do not leak as untracked background
+            # processes. The child now breaks away from our job object (see the
+            # spawn above), so a bare proc.kill() would only reap the shell and
+            # leave descendants running. Use POSIX process-group termination or
+            # the Windows start-time-validated tree terminator so descendants
+            # cannot escape untracked.
             try:
                 if not _IS_WINDOWS:
                     try:
@@ -814,7 +836,7 @@ class ProcessRegistry:
                     except (ProcessLookupError, PermissionError, OSError):
                         proc.kill()
                 else:
-                    proc.kill()
+                    self._terminate_host_pid(proc.pid, session.host_start_time)
             except Exception:
                 pass
             try:


### PR DESCRIPTION
## What does this PR do?

Uses Windows job breakaway for the primary `spawn_local` attempt so pipe-backed background children can survive owning-job teardown, while retaining a job-bound compatibility fallback when breakaway is denied.

`ProcessRegistry.spawn_local` (the pipe-backed, non-PTY local path) passed only `windows_hide_flags()` (`CREATE_NO_WINDOW`), leaving the child inside the parent's job object.

### Change

1. The primary spawn uses `windows_detach_popen_kwargs()`. On Windows it breaks the child away from the owning job (`CREATE_BREAKAWAY_FROM_JOB` plus detached flags) so it survives that job's teardown. On POSIX it is `start_new_session=True` (the session behavior current `main` already had, now supplied by the helper, so the hard-coded kwarg is dropped and there is no duplicate).
2. Fallback: if a restrictive job denies breakaway (`OSError`), retry once with `windows_detach_flags_without_breakaway()`. This preserves launch compatibility, but the child stays job-bound and cannot be guaranteed to survive the owning job's teardown.
3. POSIX errors and a Windows dual failure propagate, so `spawn_local` never registers a session that falsely claims a process started, and nothing (command, env, cwd) is logged.
4. The post-spawn setup-failure cleanup uses the start-time-validated tree terminator on Windows, since the detached child owns descendants that a bare `proc.kill()` would orphan. Adds `close_fds=True`.

Scope: the pipe-backed, non-PTY path only. `use_pty=True` (pywinpty) is untouched.

### Tests

- Mocked `Popen` behavioral suite: primary breakaway; breakaway-denied retry (argv and every non-`creationflags` kwarg preserved, and the flag sets differ by exactly the breakaway bit); dual-failure surfacing (the fallback's exception propagates and no session is registered); post-setup-failure tree-kill; POSIX single-session; POSIX error not retried.
- Native Windows integration (pure `ctypes`, no pywin32): assigns the test process to a `BREAKAWAY_OK` job and asserts the real `spawn_local` child is not a job member, with output capture verified. It passes on this branch and reproduces the failure on pristine `main`.
