### PR TITLE
fix(desktop): edit the default profile's SOUL.md from a single-profile setup

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -83,8 +83,9 @@ const stepThroughCells: Modifier = ({ containerNodeRect, draggingNodeRect, trans
 // Arc-Spaces-style profile rail at the sidebar foot: a default↔all toggle pinned
 // left, the colored named profiles scrolling between, and Manage pinned right.
 // The active profile pops in its own color — the "where am I" cue. Single-
-// profile users see only the "+" (create their first profile); everything else
-// appears once a second profile exists.
+// profile users see the "+" (create their first profile) and the Manage
+// overflow (edit the default profile's SOUL.md); the colored named squares
+// and the default↔all toggle only appear once a second profile exists.
 export function ProfileRail() {
   const { t } = useI18n()
   const p = t.profiles
@@ -268,9 +269,11 @@ export function ProfileRail() {
         </Tip>
       </div>
 
-      {multiProfile && (
-        <ProfilePill active={false} glyph="ellipsis" label={p.manageProfiles} onSelect={() => navigate(PROFILES_ROUTE)} />
-      )}
+      {/* Always reachable, even with only the default profile: the manage
+          overlay is the only place to edit a profile's SOUL.md, and a
+          single-profile user must be able to edit the default's persona
+          without first creating a throwaway second profile. */}
+      <ProfilePill active={false} glyph="ellipsis" label={p.manageProfiles} onSelect={() => navigate(PROFILES_ROUTE)} />
 
       {/* Land in the new profile on a fresh chat (selectProfile triggers the
           new-session reset), not stuck on the session you were just in. */}


### PR DESCRIPTION
## Summary

Bug 1 from the original PR — the only part still unfixed on `main`.

The "..." Manage-profiles overflow in the sidebar rail is the only UI that opens the profile manager (and thus the `SOUL.md` editor). It was gated behind `profiles.length > 1`, so a user with only the default profile couldn't edit the default's persona without first creating a throwaway second profile.

**Fix:** render the Manage overflow unconditionally in `profile-switcher.tsx`. The colored named squares and the default↔all toggle still only appear once a second profile exists.

## Scope trimmed per review

Rebased on latest `main` and reduced to just the `profile-switcher.tsx` change, per @OutThisLife's review:

- Dropped the Electron `main.cjs` change — superseded by `prepareProfileDeleteRequest()` / `teardownPoolBackendAndWait` on `main` (deterministic backend-exit wait instead of a fixed delay, plus primary-profile handling and `PROFILE_NAME_RE` validation).
- Dropped the `profiles.py` / `main.py` changes — covered by `main`'s existing `remove_error` + `RuntimeError` raise and `cmd_profile`'s catch.

## Test plan
- [x] Lint clean
- [ ] Manual (desktop, single default profile): the "..." overflow is visible and opens the SOUL.md editor for `default`.