### PR TITLE
fix(tests): use shutil.which and skip POSIX-only tests on Windows

### DIFF
--- a/tests/tools/test_search_hidden_dirs.py
+++ b/tests/tools/test_search_hidden_dirs.py
@@ -13,7 +13,9 @@ Fix: _search_files (find) and _search_with_grep both now exclude hidden
 directories, matching ripgrep's default behavior.
 """
 
+import shutil
 import subprocess
+import sys
 
 import pytest
 
@@ -41,6 +43,7 @@ def searchable_tree(tmp_path):
     return tmp_path / "skills"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="find is not available on Windows")
 class TestFindExcludesHiddenDirs:
     """_search_files uses find, which should exclude hidden directories."""
 
@@ -71,6 +74,7 @@ class TestFindExcludesHiddenDirs:
         assert "SKILL.md" in result.stdout
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="grep is not available on Windows")
 class TestGrepExcludesHiddenDirs:
     """_search_with_grep should exclude hidden directories."""
 
@@ -97,7 +101,7 @@ class TestRipgrepAlreadyExcludesHidden:
     """Verify ripgrep's default behavior is to skip hidden directories."""
 
     @pytest.mark.skipif(
-        subprocess.run(["which", "rg"], capture_output=True).returncode != 0,
+        shutil.which("rg") is None,
         reason="ripgrep not installed",
     )
     def test_rg_skips_hub_by_default(self, searchable_tree):
@@ -110,7 +114,7 @@ class TestRipgrepAlreadyExcludesHidden:
         assert "catalog.json" not in result.stdout
 
     @pytest.mark.skipif(
-        subprocess.run(["which", "rg"], capture_output=True).returncode != 0,
+        shutil.which("rg") is None,
         reason="ripgrep not installed",
     )
     def test_rg_finds_visible_content(self, searchable_tree):


### PR DESCRIPTION
## What does this PR do?

`test_search_hidden_dirs.py` crashes at collection time on Windows because `subprocess.run(["which", "rg"])` calls the Unix `which` command, which does not exist on Windows (`FileNotFoundError: [WinError 2]`). This prevents the entire test suite from running.

This PR replaces the Unix-only `which` with stdlib `shutil.which()` (as recommended by CONTRIBUTING.md rule #2) and adds platform skip markers for `find`/`grep` test classes that use other POSIX-only commands.

## Related Issue

No existing issue — discovered while setting up the dev environment on Windows.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/tools/test_search_hidden_dirs.py`:
  - Added `import shutil` and `import sys`
  - Replaced `subprocess.run(["which", "rg"], capture_output=True).returncode != 0` with `shutil.which("rg") is None` (lines 100, 113)
  - Added `@pytest.mark.skipif(sys.platform == "win32", reason="find is not available on Windows")` to `TestFindExcludesHiddenDirs`
  - Added `@pytest.mark.skipif(sys.platform == "win32", reason="grep is not available on Windows")` to `TestGrepExcludesHiddenDirs`

## How to Test

1. On a Windows machine, checkout this branch
2. Run `pytest tests/tools/test_search_hidden_dirs.py -v --timeout-method=thread`
3. Verify: 4 passed, 5 skipped, 0 errors

**Before this fix:**

ERROR collecting tests/tools/test_search_hidden_dirs.py FileNotFoundError: [WinError 2] The system cannot find the file specified


**After this fix:**

4 passed, 5 skipped in 0.79s

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10, Python 3.12.5

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no docs changes needed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

============================= test session starts ============================= platform win32 -- Python 3.12.5, pytest-9.0.2 tests/tools/test_search_hidden_dirs.py::TestFindExcludesHiddenDirs::test_find_skips_hub_cache_files SKIPPED tests/tools/test_search_hidden_dirs.py::TestFindExcludesHiddenDirs::test_find_skips_git_internals SKIPPED tests/tools/test_search_hidden_dirs.py::TestFindExcludesHiddenDirs::test_find_still_returns_visible_files SKIPPED tests/tools/test_search_hidden_dirs.py::TestGrepExcludesHiddenDirs::test_grep_skips_hub_cache SKIPPED tests/tools/test_search_hidden_dirs.py::TestGrepExcludesHiddenDirs::test_grep_still_finds_visible_content SKIPPED tests/tools/test_search_hidden_dirs.py::TestRipgrepAlreadyExcludesHidden::test_rg_skips_hub_by_default PASSED tests/tools/test_search_hidden_dirs.py::TestRipgrepAlreadyExcludesHidden::test_rg_finds_visible_content PASSED tests/tools/test_search_hidden_dirs.py::TestIgnoreFileWritten::test_write_index_cache_creates_ignore_file PASSED tests/tools/test_search_hidden_dirs.py::TestIgnoreFileWritten::test_write_index_cache_does_not_overwrite_existing_ignore PASSED ======================== 4 passed, 5 skipped in 0.79s =========================
