### PR TITLE
fix(cron): warn when agent.redact fails instead of silently passing

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1062,8 +1062,11 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             from agent.redact import redact_sensitive_text
             stdout = redact_sensitive_text(stdout)
             stderr = redact_sensitive_text(stderr)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "agent.redact failed — script output may contain secrets: %s",
+                exc,
+            )
 
         if result.returncode != 0:
             parts = [f"Script exited with code {result.returncode}"]

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -173,6 +173,32 @@ class TestRunJobScript:
         assert parsed["new_prs"][0]["number"] == 42
 
 
+    def test_script_redact_failure_warns_and_returns_output(self, cron_env, monkeypatch, caplog):
+        """If agent.redact fails, _run_job_script must warn but still return the script output."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "redact_fail.py"
+        script.write_text('print("secret: ABC123")\n')
+
+        def bad_redact(text):
+            raise RuntimeError("redact boom")
+
+        monkeypatch.setattr(
+            "agent.redact.redact_sensitive_text",
+            bad_redact,
+        )
+
+        with caplog.at_level("WARNING"):
+            success, output = _run_job_script(str(script))
+
+        assert success is True
+        assert output == "secret: ABC123"
+        assert any(
+            "agent.redact failed" in record.getMessage()
+            for record in caplog.records
+        )
+
+
 class TestBuildJobPromptWithScript:
     """Test that script output is injected into the prompt."""
 
@@ -540,3 +566,4 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+


### PR DESCRIPTION
## Summary

Replaces a silent `except Exception: pass` in `_run_job_script()` with a
`logger.warning` call. When `agent.redact` fails, the failure is now
surfaced in logs instead of being swallowed silently.

---

## Root cause

`_run_job_script()` in `cron/scheduler.py` runs a pre-run script and
redacts secrets from its stdout and stderr before injecting the output
into the job prompt. The redaction block at lines 1061-1066 is wrapped
in a broad `except Exception: pass` with no logging. If
`redact_sensitive_text` raises for any reason (import error, runtime bug,
missing dependency), the failure is invisible. The unredacted output then
flows into three places: the LLM prompt, `save_job_output()` on disk, and
`_deliver_result()` to the chat platform.

---

## Behavioral change

Before: any exception in `agent.redact.redact_sensitive_text` was silently
swallowed. Script output containing secrets could reach the LLM prompt,
disk storage, and chat delivery with no indication that redaction failed.

After: the exception is caught as `exc` and logged at WARNING level with
the message `"agent.redact failed — script output may contain secrets: %s"`.
The function continues and returns the unredacted output unchanged,
preserving the existing `(bool, str)` contract.

---

## What changed

**`cron/scheduler.py`**
- Replaced `except Exception: pass` with `except Exception as exc:` and
  a `logger.warning(...)` call matching the existing warning style in the file

**`tests/cron/test_cron_script.py`**
- Added `test_script_redact_failure_warns_and_returns_output` to
  `TestRunJobScript`: monkeypatches `redact_sensitive_text` to raise,
  verifies the function returns successfully and emits the expected warning

---

## What is NOT changed

- Job execution is not interrupted when redaction fails
- `_run_job_script()` return contract unchanged: `(bool, str)`
- No changes to `save_job_output()`, `_deliver_result()`, or prompt assembly
- `exc_info=True` intentionally omitted to match the warning style used
  across the rest of `scheduler.py`