### PR TITLE
fix: verify Photon sidecar setup runtime

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11595,7 +11595,9 @@ def main():
 
     # Execute the command
     if hasattr(args, "func"):
-        args.func(args)
+        result = args.func(args)
+        if isinstance(result, int) and not isinstance(result, bool):
+            sys.exit(result)
     else:
         parser.print_help()
 

--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -41,8 +41,8 @@ talks to it over loopback.
 ## First-time setup
 
 ```bash
-# One-shot setup: device login (opens browser) + project + user + sidecar deps
-hermes photon setup --phone +15551234567
+# One-shot setup: device login + project + user + sidecar runtime check
+hermes photon setup --phone +155****4567
 
 # Start the gateway
 hermes gateway start --platform photon
@@ -59,7 +59,9 @@ hermes gateway start --platform photon
    a user with that number already exists).
 5. **Print the assigned iMessage line** — the number you text to reach your
    agent.
-6. **Install the sidecar deps** (`spectrum-ts`).
+6. **Install and verify the sidecar deps** (`spectrum-ts`) under the
+   current Node runtime. If the import check fails, setup exits non-zero
+   instead of claiming Photon is ready.
 
 There is no separate `login` command; like every other Hermes channel,
 onboarding goes through one setup surface. Re-running `setup` reuses an
@@ -110,6 +112,7 @@ All env vars are documented in `plugin.yaml`. The most important:
 | `PHOTON_PROJECT_SECRET`   | from .env / auth.json      | Project secret                       |
 | `PHOTON_SIDECAR_PORT`     | 8789                       | Loopback port for the sidecar        |
 | `PHOTON_SIDECAR_AUTOSTART`| true                       | Spawn the sidecar on connect         |
+| `PHOTON_NODE_BIN`         | `which node`               | Override the Node binary used by the sidecar and setup/status probes |
 | `PHOTON_DASHBOARD_HOST`   | https://app.photon.codes   | Dashboard API host                   |
 | `PHOTON_SPECTRUM_HOST`    | https://spectrum.photon.codes | Spectrum API host                 |
 | `PHOTON_HOME_CHANNEL`     | your number (set by setup) | Default space for cron delivery — a space id, or a bare E.164 number (resolved to a DM) |

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -464,7 +464,9 @@ def gateway_setup() -> None:
         no_browser=False,
         skip_sidecar_install=False,
     )
-    _cmd_setup(args)
+    rc = _cmd_setup(args)
+    if rc != 0:
+        raise SystemExit(rc)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -15,6 +15,7 @@ gateway channel onboards through a single setup surface).
 Photon uses the spectrum-ts gRPC stream for inbound — there is no webhook
 to register, so there are no webhook subcommands.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -35,6 +36,7 @@ _SIDECAR_DIR = Path(__file__).parent / "sidecar"
 # ---------------------------------------------------------------------------
 # argparse wiring
 
+
 def register_cli(parser: argparse.ArgumentParser) -> None:
     """Wire up `hermes photon ...` subcommands."""
     subs = parser.add_subparsers(dest="photon_command", required=False)
@@ -43,26 +45,37 @@ def register_cli(parser: argparse.ArgumentParser) -> None:
         "setup",
         help="First-time setup (device login + project + user + sidecar runtime check)",
     )
-    p_setup.add_argument("--project-name", default=None,
-                         help="Project name (default: 'Hermes Agent')")
-    p_setup.add_argument("--phone", default=None,
-                         help="Your E.164 phone number (e.g. +155****4567)")
+    p_setup.add_argument(
+        "--project-name", default=None, help="Project name (default: 'Hermes Agent')"
+    )
+    p_setup.add_argument(
+        "--phone", default=None, help="Your E.164 phone number (e.g. +155****4567)"
+    )
     p_setup.add_argument("--first-name", default=None)
     p_setup.add_argument("--last-name", default=None)
     p_setup.add_argument("--email", default=None)
-    p_setup.add_argument("--no-browser", action="store_true",
-                         help="Don't try to open a browser for device login; print the URL only")
-    p_setup.add_argument("--skip-sidecar-install", action="store_true",
-                         help="Skip `npm install` inside the sidecar directory")
+    p_setup.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Don't try to open a browser for device login; print the URL only",
+    )
+    p_setup.add_argument(
+        "--skip-sidecar-install",
+        action="store_true",
+        help="Skip `npm install` inside the sidecar directory",
+    )
 
     subs.add_parser("status", help="Show login + project + sidecar runtime state")
-    subs.add_parser("install-sidecar", help="Run npm install and verify the sidecar runtime")
+    subs.add_parser(
+        "install-sidecar", help="Run npm install and verify the sidecar runtime"
+    )
 
     parser.set_defaults(func=dispatch)
 
 
 # ---------------------------------------------------------------------------
 # Dispatch
+
 
 def dispatch(args: argparse.Namespace) -> int:
     sub = getattr(args, "photon_command", None)
@@ -82,6 +95,7 @@ def dispatch(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 # Subcommand handlers
 
+
 def _run_device_login(args: argparse.Namespace) -> int:
     """Run the RFC 8628 device-code login flow and persist the token.
 
@@ -89,6 +103,7 @@ def _run_device_login(args: argparse.Namespace) -> int:
     no standalone ``hermes photon login`` command; Photon onboards
     through the single ``setup`` surface like every other channel.
     """
+
     def _print_code(code):
         target = code.verification_uri_complete or code.verification_uri
         print()
@@ -159,7 +174,9 @@ def _cmd_setup(args: argparse.Namespace) -> int:
         proj = photon_auth.ensure_spectrum_enabled(token, dashboard_id)
         spectrum_id = proj.get("spectrumProjectId")
         if not spectrum_id:
-            print("spectrum provisioning failed: no spectrum project id", file=sys.stderr)
+            print(
+                "spectrum provisioning failed: no spectrum project id", file=sys.stderr
+            )
             return 1
         spectrum_id = str(spectrum_id)
         secret = photon_auth.regenerate_project_secret(token, dashboard_id)
@@ -186,7 +203,9 @@ def _cmd_setup(args: argparse.Namespace) -> int:
     registered_phone = None
     registered_user_id = None
     if not phone:
-        print("      Skipped user registration (no phone given). Re-run with --phone later.")
+        print(
+            "      Skipped user registration (no phone given). Re-run with --phone later."
+        )
     else:
         # Name/email are optional and never prompted for — pass --first-name /
         # --email if you want them sent to the dashboard.
@@ -194,7 +213,8 @@ def _cmd_setup(args: argparse.Namespace) -> int:
         email = args.email
         try:
             user, created = photon_auth.register_user_if_absent(
-                spectrum_id, secret,
+                spectrum_id,
+                secret,
                 phone_number=phone,
                 first_name=first_name,
                 last_name=args.last_name,
@@ -231,13 +251,28 @@ def _cmd_setup(args: argparse.Namespace) -> int:
             print(f"      (could not fetch the assigned line: {e})", file=sys.stderr)
     if agent_number:
         print()
-        print(color("┌─ Your agent's iMessage number ───────────────────────────────", Colors.GREEN))
+        print(
+            color(
+                "┌─ Your agent's iMessage number ───────────────────────────────",
+                Colors.GREEN,
+            )
+        )
         print(
             color("│  📱 ", Colors.GREEN)
             + color(str(agent_number), Colors.GREEN, Colors.BOLD)
         )
-        print(color("│  Text this number from your phone to talk to your agent.", Colors.GREEN))
-        print(color("└──────────────────────────────────────────────────────────────", Colors.GREEN))
+        print(
+            color(
+                "│  Text this number from your phone to talk to your agent.",
+                Colors.GREEN,
+            )
+        )
+        print(
+            color(
+                "└──────────────────────────────────────────────────────────────",
+                Colors.GREEN,
+            )
+        )
     else:
         print("      No iMessage line assigned yet — check the Photon dashboard.")
     if registered_phone:
@@ -249,7 +284,9 @@ def _cmd_setup(args: argparse.Namespace) -> int:
                 dashboard_project_id=dashboard_id,
             )
         except Exception as e:
-            print(f"      (could not save Photon status metadata: {e})", file=sys.stderr)
+            print(
+                f"      (could not save Photon status metadata: {e})", file=sys.stderr
+            )
 
     # 6. Sidecar deps + runtime import check.
     if args.skip_sidecar_install:
@@ -480,6 +517,7 @@ def _install_sidecar() -> int:
 # project + user + sidecar flow as ``hermes photon setup`` with interactive
 # defaults (phone is prompted when stdin is a TTY).
 
+
 def gateway_setup() -> None:
     """Run Photon first-time setup from the `hermes gateway setup` wizard."""
     args = argparse.Namespace(
@@ -499,6 +537,7 @@ def gateway_setup() -> None:
 
 # ---------------------------------------------------------------------------
 # Small interactive helpers
+
 
 def _prompt(prompt: str, *, secret: bool = False) -> str:
     if not sys.stdin.isatty():

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -4,9 +4,9 @@
 
 Subcommands:
 
-    setup              full first-time setup (device login + project + user + sidecar)
-    status             show login + project + sidecar dep state
-    install-sidecar    npm install inside plugins/platforms/photon/sidecar/
+    setup              first-time setup + sidecar runtime verification
+    status             show login + project + sidecar runtime state
+    install-sidecar    npm install + sidecar runtime verification
 
 The device-code login runs automatically as the first step of ``setup``;
 there is no standalone ``login`` verb (matching how every other Hermes
@@ -41,7 +41,7 @@ def register_cli(parser: argparse.ArgumentParser) -> None:
 
     p_setup = subs.add_parser(
         "setup",
-        help="First-time setup (device login + project + user + sidecar)",
+        help="First-time setup (device login + project + user + sidecar runtime check)",
     )
     p_setup.add_argument("--project-name", default=None,
                          help="Project name (default: 'Hermes Agent')")
@@ -55,8 +55,8 @@ def register_cli(parser: argparse.ArgumentParser) -> None:
     p_setup.add_argument("--skip-sidecar-install", action="store_true",
                          help="Skip `npm install` inside the sidecar directory")
 
-    subs.add_parser("status", help="Show login + project + sidecar dep state")
-    subs.add_parser("install-sidecar", help="Run npm install inside the sidecar directory")
+    subs.add_parser("status", help="Show login + project + sidecar runtime state")
+    subs.add_parser("install-sidecar", help="Run npm install and verify the sidecar runtime")
 
     parser.set_defaults(func=dispatch)
 

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -46,7 +46,7 @@ def register_cli(parser: argparse.ArgumentParser) -> None:
     p_setup.add_argument("--project-name", default=None,
                          help="Project name (default: 'Hermes Agent')")
     p_setup.add_argument("--phone", default=None,
-                         help="Your E.164 phone number (e.g. +15551234567)")
+                         help="Your E.164 phone number (e.g. +155****4567)")
     p_setup.add_argument("--first-name", default=None)
     p_setup.add_argument("--last-name", default=None)
     p_setup.add_argument("--email", default=None)
@@ -178,7 +178,7 @@ def _cmd_setup(args: argparse.Namespace) -> int:
     # 4. Register the operator's phone number as a Spectrum user (idempotent).
     phone = args.phone or _prompt(
         color(
-            "[4/5] Your iMessage phone number (E.164, e.g. +15551234567): ",
+            "[4/5] Your iMessage phone number (E.164, e.g. +155****4567): ",
             Colors.CYAN,
         )
     )
@@ -251,11 +251,15 @@ def _cmd_setup(args: argparse.Namespace) -> int:
         except Exception as e:
             print(f"      (could not save Photon status metadata: {e})", file=sys.stderr)
 
-    # 6. Sidecar deps (spectrum-ts).
+    # 6. Sidecar deps + runtime import check.
     if args.skip_sidecar_install:
         print("[5/5] Skipping sidecar npm install (--skip-sidecar-install)")
+        print(
+            "      Sidecar runtime was not verified; run "
+            "`hermes photon install-sidecar` before declaring Photon ready."
+        )
     else:
-        print("[5/5] Installing Node sidecar deps (spectrum-ts)...")
+        print("[5/5] Installing and verifying Node sidecar deps (spectrum-ts)...")
         rc = _install_sidecar()
         if rc != 0:
             return rc
@@ -293,16 +297,92 @@ def _autoconfigure_access(phone: str) -> None:
             print(f"      could not set {key}: {e}", file=sys.stderr)
 
 
+def _resolve_node_bin() -> str | None:
+    configured = os.getenv("PHOTON_NODE_BIN")
+    if configured:
+        if shutil.which(configured) or Path(configured).exists():
+            return configured
+        return None
+    return shutil.which("node")
+
+
+def _run_sidecar_runtime_probe(node_bin: str) -> tuple[bool, str]:
+    """Verify the installed sidecar can load under the active Node runtime."""
+    check = subprocess.run(  # noqa: S603
+        [node_bin, "--check", "index.mjs"],
+        cwd=str(_SIDECAR_DIR),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check.returncode != 0:
+        return False, _summarize_probe_output(check)
+
+    # Node 18 exposes Blob/fetch but not global File. The sidecar polyfills
+    # File before importing spectrum-ts; the setup/status probe must exercise
+    # the same compatibility path so "setup complete" means the sidecar can
+    # actually start on this machine.
+    probe = """
+        import { File as NodeFile } from 'node:buffer';
+        if (typeof globalThis.File === 'undefined') globalThis.File = NodeFile;
+        const spectrum = await import('spectrum-ts');
+        const imessageProvider = await import('spectrum-ts/providers/imessage');
+        if (typeof spectrum.Spectrum !== 'function') {
+          throw new Error('spectrum-ts did not export Spectrum');
+        }
+        if (typeof imessageProvider.imessage !== 'function') {
+          throw new Error('spectrum-ts/providers/imessage did not export imessage');
+        }
+        console.log('ok');
+    """
+    runtime = subprocess.run(  # noqa: S603
+        [node_bin, "--input-type=module", "-e", probe],
+        cwd=str(_SIDECAR_DIR),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if runtime.returncode != 0:
+        return False, _summarize_probe_output(runtime)
+    return True, "ok"
+
+
+def _summarize_probe_output(proc: subprocess.CompletedProcess) -> str:
+    combined = "\n".join(
+        part.strip() for part in (proc.stdout, proc.stderr) if part and part.strip()
+    ).strip()
+    if not combined:
+        return f"node exited {proc.returncode}"
+    one_line = " ".join(combined.split())
+    return one_line[:700]
+
+
+def _sidecar_runtime_status() -> str:
+    node_bin = _resolve_node_bin()
+    if not node_bin:
+        return "✗ missing (install Node.js 18.17+ or set PHOTON_NODE_BIN)"
+    if not (_SIDECAR_DIR / "node_modules").exists():
+        return "✗ deps missing (run `hermes photon install-sidecar`)"
+    ok, detail = _run_sidecar_runtime_probe(node_bin)
+    return "✓ import OK" if ok else f"✗ {detail}"
+
+
 def _cmd_status(_args: argparse.Namespace) -> int:
     _refresh_status_numbers()
     # Defer the credential rows to auth.print_credential_summary — its emit
     # callback is the only sink that sees credential-derived strings, so
     # cli.py keeps zero taint flow according to CodeQL.
     photon_auth.print_credential_summary(print)
-    node_bin = os.getenv("PHOTON_NODE_BIN") or shutil.which("node")
+    # The non-credential rows live here so the helper stays purely about
+    # credentials.
+    node_bin = _resolve_node_bin()
     sidecar_installed = (_SIDECAR_DIR / "node_modules").exists()
-    print(f"  node binary         : {node_bin or '✗ missing (install Node 18+)'}")
-    print(f"  sidecar deps        : {'✓ installed' if sidecar_installed else '✗ run `hermes photon install-sidecar`'}")
+    print(f"  node binary         : {node_bin or '✗ missing (install Node.js 18.17+)'}")
+    print(
+        "  sidecar deps        : "
+        f"{'✓ installed' if sidecar_installed else '✗ run `hermes photon install-sidecar`'}"
+    )
+    print(f"  sidecar runtime     : {_sidecar_runtime_status()}")
     return 0
 
 
@@ -327,24 +407,39 @@ def _install_sidecar() -> int:
     npm = shutil.which("npm") or "npm"
     if not shutil.which(npm):
         print(
-            "npm is not on PATH. Install Node.js 18+ (https://nodejs.org/) "
+            "npm is not on PATH. Install Node.js 18.17+ (https://nodejs.org/) "
             "and re-run.",
             file=sys.stderr,
         )
         return 1
-    # Always pull the newest published spectrum-ts so every setup runs against
-    # the latest SDK. `spectrum-ts@latest` bumps package.json + package-lock.json
-    # to the current release before installing — a plain `npm install` would
-    # stay pinned to whatever the committed lockfile already resolved.
-    print(f"  $ cd {_SIDECAR_DIR} && {npm} install spectrum-ts@latest")
+    print(f"  $ cd {_SIDECAR_DIR} && {npm} install")
     proc = subprocess.run(  # noqa: S603
-        [npm, "install", "spectrum-ts@latest"],
+        [npm, "install"],
         cwd=str(_SIDECAR_DIR),
         check=False,
     )
     if proc.returncode != 0:
         print("npm install failed", file=sys.stderr)
-    return proc.returncode
+        return proc.returncode
+
+    node_bin = _resolve_node_bin()
+    if not node_bin:
+        print("Node.js disappeared after npm install", file=sys.stderr)
+        return 1
+    ok, detail = _run_sidecar_runtime_probe(node_bin)
+    if not ok:
+        print(
+            "sidecar runtime verification failed after npm install: " + detail,
+            file=sys.stderr,
+        )
+        print(
+            "Fix Node/dependency compatibility, then re-run "
+            "`hermes photon install-sidecar`.",
+            file=sys.stderr,
+        )
+        return 1
+    print("  ✓ sidecar runtime verified")
+    return 0
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -297,10 +297,17 @@ def _autoconfigure_access(phone: str) -> None:
             print(f"      could not set {key}: {e}", file=sys.stderr)
 
 
+_SIDECAR_RUNTIME_PROBE_TIMEOUT_SECONDS = 20
+
+
 def _resolve_node_bin() -> str | None:
     configured = os.getenv("PHOTON_NODE_BIN")
     if configured:
-        if shutil.which(configured) or Path(configured).exists():
+        resolved = shutil.which(configured)
+        if resolved:
+            return resolved
+        configured_path = Path(configured)
+        if configured_path.is_file() and os.access(configured_path, os.X_OK):
             return configured
         return None
     return shutil.which("node")
@@ -308,13 +315,19 @@ def _resolve_node_bin() -> str | None:
 
 def _run_sidecar_runtime_probe(node_bin: str) -> tuple[bool, str]:
     """Verify the installed sidecar can load under the active Node runtime."""
-    check = subprocess.run(  # noqa: S603
-        [node_bin, "--check", "index.mjs"],
-        cwd=str(_SIDECAR_DIR),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        check = subprocess.run(  # noqa: S603
+            [node_bin, "--check", "index.mjs"],
+            cwd=str(_SIDECAR_DIR),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=_SIDECAR_RUNTIME_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as e:
+        return False, _summarize_probe_timeout(e)
+    except OSError as e:
+        return False, _summarize_probe_error(e)
     if check.returncode != 0:
         return False, _summarize_probe_output(check)
 
@@ -335,16 +348,31 @@ def _run_sidecar_runtime_probe(node_bin: str) -> tuple[bool, str]:
         }
         console.log('ok');
     """
-    runtime = subprocess.run(  # noqa: S603
-        [node_bin, "--input-type=module", "-e", probe],
-        cwd=str(_SIDECAR_DIR),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        runtime = subprocess.run(  # noqa: S603
+            [node_bin, "--input-type=module", "-e", probe],
+            cwd=str(_SIDECAR_DIR),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=_SIDECAR_RUNTIME_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as e:
+        return False, _summarize_probe_timeout(e)
+    except OSError as e:
+        return False, _summarize_probe_error(e)
     if runtime.returncode != 0:
         return False, _summarize_probe_output(runtime)
     return True, "ok"
+
+
+def _summarize_probe_timeout(exc: subprocess.TimeoutExpired) -> str:
+    cmd = " ".join(str(part) for part in exc.cmd[:2]) if exc.cmd else "node"
+    return f"{cmd} timed out after {exc.timeout:g}s"
+
+
+def _summarize_probe_error(exc: OSError) -> str:
+    return f"node probe failed: {exc}"
 
 
 def _summarize_probe_output(proc: subprocess.CompletedProcess) -> str:

--- a/plugins/platforms/photon/plugin.yaml
+++ b/plugins/platforms/photon/plugin.yaml
@@ -39,8 +39,12 @@ optional_env:
     prompt: "Auto-start the sidecar?"
     password: false
   - name: PHOTON_NODE_BIN
-    description: "Path to the node binary (default: shutil.which('node'))"
+    description: "Path to the Node binary used by the sidecar and setup/status runtime probes (default: shutil.which('node'))"
     prompt: "Node executable path"
+    password: false
+  - name: PHOTON_MAX_INLINE_ATTACHMENT_BYTES
+    description: "Maximum inbound attachment/voice bytes the sidecar reads and base64-inlines on the NDJSON event (default 20 MB)"
+    prompt: "Max inline Photon attachment bytes"
     password: false
   - name: PHOTON_DASHBOARD_HOST
     description: "Photon Dashboard API host (default https://app.photon.codes)"

--- a/plugins/platforms/photon/sidecar/README.md
+++ b/plugins/platforms/photon/sidecar/README.md
@@ -9,9 +9,10 @@ The sidecar:
 - runs `Spectrum({ projectId, projectSecret, providers: [imessage.config()] })`
 - exposes a loopback-only HTTP control channel for the Python adapter
   to push send/typing requests (auth via `X-Hermes-Sidecar-Token`)
-- drains the inbound message stream so `spectrum-ts` keeps its
-  reconnect/heartbeat machinery alive (real inbound delivery is via
-  Photon's signed webhook hitting our Python aiohttp server)
+- streams inbound `app.messages` events to the Python adapter over
+  loopback `GET /inbound` (NDJSON); there is no Photon webhook in this
+  installed path
+- polyfills `globalThis.File` on Node 18 before importing `spectrum-ts`
 
 ## Install
 
@@ -20,8 +21,9 @@ cd plugins/platforms/photon/sidecar
 npm install
 ```
 
-The Hermes plugin's `hermes photon setup` command runs `npm install`
-here automatically.
+The Hermes plugin's `hermes photon setup` and `hermes photon install-sidecar`
+commands run `npm install` here, then verify that `index.mjs` and the
+`spectrum-ts` imports load under the active Node runtime.
 
 ## Run standalone
 
@@ -39,14 +41,7 @@ it by hand.
 
 ## Why a sidecar at all?
 
-Photon publishes webhooks (inbound) but their docs state explicitly:
-
-> Pass `space.id` to `Space.send(...)` from a separate `spectrum-ts`
-> SDK instance to reply.  No public HTTP send endpoint exists today.
-
-— https://photon.codes/docs/webhooks/events
-
-When Photon ships an HTTP send endpoint, the plan is to retire this
-sidecar entirely and call it directly from Python.  The plugin's
-outbound code path is already isolated behind a single helper
-(`_sidecar_send` in `adapter.py`) to make that swap a one-file change.
+Photon's `spectrum-ts` SDK is TypeScript-only and exposes the long-lived
+`app.messages` stream plus `space.send(...)` APIs Hermes needs. The Python
+gateway therefore supervises this sidecar and uses loopback HTTP for both
+directions instead of exposing a public webhook or direct HTTP send endpoint.

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -41,6 +41,14 @@
 
 import http from "node:http";
 import { once } from "node:events";
+import { File as NodeFile } from "node:buffer";
+
+// Node 18 exposes Blob/fetch but not global File. Recent spectrum-ts pulls
+// undici 7, which expects File during module import. Polyfill before the
+// lazy import so the sidecar can run on the Hermes container's Node 18.
+if (typeof globalThis.File === "undefined") {
+  globalThis.File = NodeFile;
+}
 
 const projectId = process.env.PHOTON_PROJECT_ID;
 const projectSecret = process.env.PHOTON_PROJECT_SECRET;

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@hermes-agent/photon-sidecar",
       "version": "0.2.0",
       "dependencies": {
-        "spectrum-ts": "^1.18.0"
+        "spectrum-ts": "1.18.0"
       },
       "engines": {
         "node": ">=18.17"
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.216.0.tgz",
-      "integrity": "sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -119,16 +119,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.216.0.tgz",
-      "integrity": "sha512-8SUzQY/aExKkz6Ab3vOf6gu690Xk4wHH90dGwXinejQzazn5HCIRR7yPVU/2fEuiZ73R92MU4qI3djHfYP7NJg==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.216.0",
+        "@opentelemetry/api-logs": "0.218.0",
         "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.216.0",
-        "@opentelemetry/otlp-transformer": "0.216.0",
-        "@opentelemetry/sdk-logs": "0.216.0"
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/sdk-logs": "0.218.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -138,14 +138,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.216.0.tgz",
-      "integrity": "sha512-DhWjvj0PUPFwFnhOEivpum8sJzj6FTuyx88zff+oHVLUhfd6cLyw4AIai/F4j0PZqYZBFuMT/OTMUd9wdXnBEQ==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.216.0",
-        "@opentelemetry/otlp-transformer": "0.216.0",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
         "@opentelemetry/resources": "2.7.1",
         "@opentelemetry/sdk-trace-base": "2.7.1"
       },
@@ -157,13 +157,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.216.0.tgz",
-      "integrity": "sha512-sSnvb5f+FYa4mfYxj03rmmUh+aDwo3jok62dgIWUDw8ZCUPzEbgtv/YhZyKUSlKNNey7Uc5xmJgmtTLLIV6UDQ==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-transformer": "0.216.0"
+        "@opentelemetry/otlp-transformer": "0.218.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -173,48 +173,23 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.216.0.tgz",
-      "integrity": "sha512-g4Rb6sAsxQAo11eDjixfKxelruBsQFdJ8Wo23FCj7D6OXbidgXMu2xaRSYs4RdlomzAXSJuc86RcS3xmE8A6uA==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.216.0",
+        "@opentelemetry/api-logs": "0.218.0",
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-logs": "0.216.0",
+        "@opentelemetry/sdk-logs": "0.218.0",
         "@opentelemetry/sdk-metrics": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1",
-        "protobufjs": "8.0.1"
+        "@opentelemetry/sdk-trace-base": "2.7.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/protobufjs": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
-      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
@@ -234,12 +209,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.216.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.216.0.tgz",
-      "integrity": "sha512-KB3rcwQuitq0JbbsCcNdqMhRJX3kArAYz/ovb0jGRaBQAIrt2roik3xQXuhYxS37zx0jSkUZcJu1z3Y2UCxbDA==",
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.216.0",
+        "@opentelemetry/api-logs": "0.218.0",
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -342,18 +317,18 @@
       }
     },
     "node_modules/@photon-ai/otel": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-0.1.1.tgz",
-      "integrity": "sha512-t/NVepO5+fHOLWDI+Eht+RC8PTik0wi7HQsKhU4yPqBjY5JncXmoBZLnWFvG+/qJ/pn6w+tveabKG9pykfkqKg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-0.1.2.tgz",
+      "integrity": "sha512-ekAwcChi/wgzcQj92okKGf4jgD2OwQ3WsQDJwCCnwREtKFDbePVdSlE/4BUw3oZTOgLDc+vSz/t9nWq7YZJLjA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/api-logs": "^0.216.0",
+        "@opentelemetry/api-logs": "^0.218.0",
         "@opentelemetry/context-async-hooks": "^2.7.1",
-        "@opentelemetry/exporter-logs-otlp-http": "^0.216.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.218.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
         "@opentelemetry/resources": "^2.7.1",
-        "@opentelemetry/sdk-logs": "^0.216.0",
+        "@opentelemetry/sdk-logs": "^0.218.0",
         "@opentelemetry/sdk-trace-base": "^2.7.1"
       },
       "engines": {
@@ -403,10 +378,9 @@
       }
     },
     "node_modules/@photon-ai/whatsapp-business/node_modules/protobufjs": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.4.2.tgz",
-      "integrity": "sha512-64rfNzkWOZAIazXzpBFPWq6F9up6gMvTzjE2oWIzApx2N/dqVUEE7+bCn2+40780dFVtKOUab8QfxJ6KJDWbqA==",
-      "hasInstallScript": true,
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
+      "integrity": "sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
@@ -479,15 +453,15 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@repeaterjs/repeater": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
-      "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.1.0.tgz",
+      "integrity": "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -1306,9 +1280,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
-      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1408,9 +1382,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -1614,9 +1588,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -1643,9 +1617,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
-      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -12,6 +12,6 @@
     "node": ">=18.17"
   },
   "dependencies": {
-    "spectrum-ts": "^1.18.0"
+    "spectrum-ts": "1.18.0"
   }
 }

--- a/tests/cli/test_main_exit_code.py
+++ b/tests/cli/test_main_exit_code.py
@@ -1,4 +1,5 @@
 """Tests for top-level CLI exit-code propagation."""
+
 from __future__ import annotations
 
 import sys

--- a/tests/cli/test_main_exit_code.py
+++ b/tests/cli/test_main_exit_code.py
@@ -1,0 +1,18 @@
+"""Tests for top-level CLI exit-code propagation."""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from hermes_cli import main as hermes_main
+
+
+def test_main_exits_with_integer_command_return(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["hermes", "version"])
+    monkeypatch.setattr(hermes_main, "cmd_version", lambda _args: 7)
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.main()
+
+    assert exc_info.value.code == 7

--- a/tests/plugins/platforms/photon/test_cli.py
+++ b/tests/plugins/platforms/photon/test_cli.py
@@ -5,6 +5,8 @@ import argparse
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from plugins.platforms.photon import cli as photon_cli
 
 
@@ -85,6 +87,20 @@ def test_install_sidecar_verifies_after_npm_success(monkeypatch, capsys) -> None
     captured = capsys.readouterr()
     assert rc == 0
     assert "sidecar runtime verified" in captured.out
+
+
+def test_gateway_setup_propagates_setup_failure(monkeypatch) -> None:
+    def fake_setup(args: argparse.Namespace) -> int:
+        assert args.photon_command == "setup"
+        assert args.skip_sidecar_install is False
+        return 7
+
+    monkeypatch.setattr(photon_cli, "_cmd_setup", fake_setup)
+
+    with pytest.raises(SystemExit) as exc_info:
+        photon_cli.gateway_setup()
+
+    assert exc_info.value.code == 7
 
 
 def test_status_prints_sidecar_runtime(monkeypatch, tmp_path: Path, capsys) -> None:

--- a/tests/plugins/platforms/photon/test_cli.py
+++ b/tests/plugins/platforms/photon/test_cli.py
@@ -1,0 +1,107 @@
+"""Tests for the Photon CLI setup/status helpers."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from plugins.platforms.photon import cli as photon_cli
+
+
+def test_sidecar_runtime_probe_polyfills_file_before_import(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(photon_cli, "_SIDECAR_DIR", tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(photon_cli.subprocess, "run", fake_run)
+
+    ok, detail = photon_cli._run_sidecar_runtime_probe("/usr/bin/node")
+
+    assert ok is True
+    assert detail == "ok"
+    assert calls[0] == ["/usr/bin/node", "--check", "index.mjs"]
+    assert calls[1][:3] == ["/usr/bin/node", "--input-type=module", "-e"]
+    probe_script = calls[1][3]
+    assert "File as NodeFile" in probe_script
+    assert "await import('spectrum-ts')" in probe_script
+    assert "spectrum-ts/providers/imessage" in probe_script
+
+
+def test_sidecar_runtime_probe_reports_node_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(photon_cli, "_SIDECAR_DIR", tmp_path)
+
+    def fake_run(args, **kwargs):
+        if "--check" in args:
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="syntax bad")
+        raise AssertionError("runtime import should not run after --check failure")
+
+    monkeypatch.setattr(photon_cli.subprocess, "run", fake_run)
+
+    ok, detail = photon_cli._run_sidecar_runtime_probe("node")
+
+    assert ok is False
+    assert "syntax bad" in detail
+
+
+def test_install_sidecar_fails_when_runtime_probe_fails(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(photon_cli.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def fake_run(args, **kwargs):
+        assert args == ["/usr/bin/npm", "install"]
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(photon_cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(photon_cli, "_run_sidecar_runtime_probe", lambda _node: (False, "File is not defined"))
+
+    rc = photon_cli._install_sidecar()
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "sidecar runtime verification failed" in captured.err
+    assert "File is not defined" in captured.err
+
+
+def test_install_sidecar_verifies_after_npm_success(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(photon_cli.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def fake_run(args, **kwargs):
+        assert args == ["/usr/bin/npm", "install"]
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(photon_cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(photon_cli, "_run_sidecar_runtime_probe", lambda _node: (True, "ok"))
+
+    rc = photon_cli._install_sidecar()
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "sidecar runtime verified" in captured.out
+
+
+def test_status_prints_sidecar_runtime(monkeypatch, tmp_path: Path, capsys) -> None:
+    sidecar_dir = tmp_path / "sidecar"
+    (sidecar_dir / "node_modules").mkdir(parents=True)
+    monkeypatch.setattr(photon_cli, "_SIDECAR_DIR", sidecar_dir)
+    monkeypatch.setattr(photon_cli, "_resolve_node_bin", lambda: "/usr/bin/node")
+    monkeypatch.setattr(photon_cli, "_sidecar_runtime_status", lambda: "✓ import OK")
+    monkeypatch.setattr(
+        photon_cli.photon_auth,
+        "print_credential_summary",
+        lambda emit: emit("Photon iMessage status\n  project key         : ✓ stored"),
+    )
+
+    rc = photon_cli._cmd_status(argparse.Namespace())
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "sidecar deps        : ✓ installed" in captured.out
+    assert "sidecar runtime     : ✓ import OK" in captured.out

--- a/tests/plugins/platforms/photon/test_cli.py
+++ b/tests/plugins/platforms/photon/test_cli.py
@@ -1,4 +1,5 @@
 """Tests for the Photon CLI setup/status helpers."""
+
 from __future__ import annotations
 
 import argparse
@@ -134,7 +135,11 @@ def test_install_sidecar_fails_when_runtime_probe_fails(monkeypatch, capsys) -> 
         return subprocess.CompletedProcess(args, 0)
 
     monkeypatch.setattr(photon_cli.subprocess, "run", fake_run)
-    monkeypatch.setattr(photon_cli, "_run_sidecar_runtime_probe", lambda _node: (False, "File is not defined"))
+    monkeypatch.setattr(
+        photon_cli,
+        "_run_sidecar_runtime_probe",
+        lambda _node: (False, "File is not defined"),
+    )
 
     rc = photon_cli._install_sidecar()
 
@@ -152,7 +157,9 @@ def test_install_sidecar_verifies_after_npm_success(monkeypatch, capsys) -> None
         return subprocess.CompletedProcess(args, 0)
 
     monkeypatch.setattr(photon_cli.subprocess, "run", fake_run)
-    monkeypatch.setattr(photon_cli, "_run_sidecar_runtime_probe", lambda _node: (True, "ok"))
+    monkeypatch.setattr(
+        photon_cli, "_run_sidecar_runtime_probe", lambda _node: (True, "ok")
+    )
 
     rc = photon_cli._install_sidecar()
 

--- a/tests/plugins/platforms/photon/test_cli.py
+++ b/tests/plugins/platforms/photon/test_cli.py
@@ -42,6 +42,7 @@ def test_sidecar_runtime_probe_reports_node_failure(
     monkeypatch.setattr(photon_cli, "_SIDECAR_DIR", tmp_path)
 
     def fake_run(args, **kwargs):
+        assert kwargs["timeout"] == photon_cli._SIDECAR_RUNTIME_PROBE_TIMEOUT_SECONDS
         if "--check" in args:
             return subprocess.CompletedProcess(args, 1, stdout="", stderr="syntax bad")
         raise AssertionError("runtime import should not run after --check failure")
@@ -52,6 +53,77 @@ def test_sidecar_runtime_probe_reports_node_failure(
 
     assert ok is False
     assert "syntax bad" in detail
+
+
+def test_sidecar_runtime_probe_reports_timeout(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(photon_cli, "_SIDECAR_DIR", tmp_path)
+
+    def fake_run(args, **kwargs):
+        raise subprocess.TimeoutExpired(args, kwargs["timeout"])
+
+    monkeypatch.setattr(photon_cli.subprocess, "run", fake_run)
+
+    ok, detail = photon_cli._run_sidecar_runtime_probe("node")
+
+    assert ok is False
+    assert "timed out after 20s" in detail
+
+
+def test_sidecar_runtime_probe_reports_os_error(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(photon_cli, "_SIDECAR_DIR", tmp_path)
+
+    def fake_run(args, **kwargs):
+        raise OSError("not executable")
+
+    monkeypatch.setattr(photon_cli.subprocess, "run", fake_run)
+
+    ok, detail = photon_cli._run_sidecar_runtime_probe("/tmp/node")
+
+    assert ok is False
+    assert "not executable" in detail
+
+
+def test_resolve_node_bin_rejects_non_executable_photon_node_bin(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    node_file = tmp_path / "node"
+    node_file.write_text("not executable")
+    monkeypatch.setenv("PHOTON_NODE_BIN", str(node_file))
+    monkeypatch.setattr(photon_cli.shutil, "which", lambda _name: None)
+
+    assert photon_cli._resolve_node_bin() is None
+
+
+def test_resolve_node_bin_rejects_directory_photon_node_bin(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    node_dir = tmp_path / "node"
+    node_dir.mkdir()
+    monkeypatch.setenv("PHOTON_NODE_BIN", str(node_dir))
+    monkeypatch.setattr(photon_cli.shutil, "which", lambda _name: None)
+
+    assert photon_cli._resolve_node_bin() is None
+
+
+def test_resolve_node_bin_accepts_executable_photon_node_bin(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    node_file = tmp_path / "node"
+    node_file.write_text("#!/bin/sh\n")
+    node_file.chmod(0o700)
+    monkeypatch.setenv("PHOTON_NODE_BIN", str(node_file))
+    monkeypatch.setattr(photon_cli.shutil, "which", lambda _name: None)
+
+    assert photon_cli._resolve_node_bin() == str(node_file)
 
 
 def test_install_sidecar_fails_when_runtime_probe_fails(monkeypatch, capsys) -> None:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -40,6 +40,11 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # downstream adapters (signal, etc.) expect.
 _PHONE_PLATFORMS = frozenset({"photon", "signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
+# Photon iMessage targets are opaque chat GUIDs like `any;-;+E164`
+# (DM) or `any;+;<guid>` (group). The channel directory lists those exact
+# values, so send_message must treat them as explicit IDs instead of trying
+# name resolution.
+_PHOTON_SPACE_TARGET_RE = re.compile(r"^\s*any;[+-];.+\s*$")
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -399,6 +404,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         topic = target_ref.strip()
         if topic:
             return topic, None, True
+    if platform_name == "photon":
+        match = _PHOTON_SPACE_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return target_ref.strip(), None, True
     if platform_name == "email":
         match = _EMAIL_TARGET_RE.fullmatch(target_ref)
         if match:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1,8 +1,9 @@
 """Send Message Tool -- cross-channel messaging via platform APIs.
 
-Sends a message to a user or channel on any connected messaging platform
-(Telegram, Discord, Slack). Supports listing available targets and resolving
-human-friendly channel names to IDs. Works in both CLI and gateway contexts.
+Sends a message to a user or channel on any connected messaging platform.
+Supports listing available targets, resolving human-friendly channel names to
+IDs, and explicit platform targets such as Photon E.164 numbers or `any;...`
+space ids. Works in both CLI and gateway contexts.
 """
 
 import asyncio
@@ -148,7 +149,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'ntfy:alerts-channel' (explicit ntfy topic), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'photon:+155****4567', 'photon:any;-;+155****4567', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'ntfy:alerts-channel' (explicit ntfy topic), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -59,7 +59,7 @@ hermes gateway setup
 
 ```bash
 # Device-code login + project + user + sidecar deps, all in one
-hermes photon setup --phone +15551234567
+hermes photon setup --phone +155****4567
 ```
 
 The setup, in order:
@@ -73,7 +73,10 @@ The setup, in order:
    user with that number already exists, so re-running is safe.
 5. **Prints your assigned iMessage line** — the number you text to reach
    your agent.
-6. **Runs `npm install`** inside the plugin's sidecar directory.
+6. **Runs `npm install`** inside the plugin's sidecar directory, then
+   verifies the sidecar entrypoint and `spectrum-ts` imports under the
+   current Node runtime. If that runtime check fails, setup exits
+   non-zero instead of claiming Photon is ready.
 
 Runtime credentials are written to `~/.hermes/.env`
 (`PHOTON_PROJECT_ID` = the Spectrum project id, `PHOTON_PROJECT_SECRET`),
@@ -98,7 +101,7 @@ Use `hermes pairing list` to see pending codes and approved users.
 **Pre-authorize specific numbers** (in `~/.hermes/.env`):
 
 ```bash
-PHOTON_ALLOWED_USERS=+15551234567,+15559876543
+PHOTON_ALLOWED_USERS=+155****4567,+155****6543
 ```
 
 **Open access** (dev only, in `~/.hermes/.env`):
@@ -174,8 +177,8 @@ Photon iMessage status
   dashboard project   : 3c90c3cc-0d44-4b50-...
   spectrum project id : sp-...
   project secret      : ✓ stored
-  my number           : +15551234567
-  assigned number     : +16282679185
+  my number           : +155****4567
+  assigned number     : +162****9185
   node binary         : /usr/bin/node
   sidecar deps        : ✓ installed
 ```
@@ -188,6 +191,11 @@ Common issues:
 - **`No iMessage line assigned yet`** — Spectrum is enabled but no line
   has been provisioned; re-run `hermes photon setup` or check the
   [dashboard][app].
+- **`sidecar runtime : ✗ ...`** — `npm install` completed, but the
+  sidecar cannot start under the current Node/dependency combination.
+  Re-run `hermes photon install-sidecar` after fixing the reported
+  Node/dependency issue; setup will not report success until this check
+  passes.
 - **Sidecar won't start** — confirm `node --version` is 18.17+ and that
   `hermes photon install-sidecar` completed without errors.
 

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -58,7 +58,7 @@ hermes gateway setup
 …or run the Photon setup directly (the wizard calls the same flow):
 
 ```bash
-# Device-code login + project + user + sidecar deps, all in one
+# Device-code login + project + user + sidecar runtime check
 hermes photon setup --phone +155****4567
 ```
 
@@ -181,6 +181,7 @@ Photon iMessage status
   assigned number     : +162****9185
   node binary         : /usr/bin/node
   sidecar deps        : ✓ installed
+  sidecar runtime     : ✓ import OK
 ```
 
 Common issues:
@@ -199,12 +200,13 @@ Common issues:
 - **Sidecar won't start** — confirm `node --version` is 18.17+ and that
   `hermes photon install-sidecar` completed without errors.
 
-## Limits today
+## Attachments & limits
 
-- **Inbound attachments are metadata-only.** Inbound events carry the
-  filename + MIME type; the agent sees a marker but can't yet read the
-  bytes. The SDK exposes attachment bytes via `content.read()`, so this
-  is a sidecar follow-up.
+- **Inbound attachments and voice notes are downloaded.** The sidecar reads
+  the bytes with `content.read()` and base64-inlines them on the NDJSON event;
+  the adapter caches them to Hermes' media cache so the agent can see images,
+  files, and voice notes. Media larger than `PHOTON_MAX_INLINE_ATTACHMENT_BYTES`
+  (default 20 MB), or any byte read that fails, falls back to a text marker.
 - **Outbound attachments are supported.** Hermes sends images, voice
   notes, video, and documents through spectrum-ts' `attachment()` /
   `voice()` content builders via the sidecar's `/send-attachment`
@@ -223,7 +225,8 @@ Common issues:
 | `PHOTON_SIDECAR_PORT`     | `8789`             | Loopback port for the sidecar control + inbound channel |
 | `PHOTON_SIDECAR_AUTOSTART`| `true`             | Whether the adapter spawns the sidecar     |
 | `PHOTON_NODE_BIN`         | `which node`       | Override the Node binary path              |
-| `PHOTON_HOME_CHANNEL`     | (unset)            | Default space id for cron / notifications  |
+| `PHOTON_MAX_INLINE_ATTACHMENT_BYTES` | `20971520` | Max inbound attachment/voice bytes the sidecar reads and inlines |
+| `PHOTON_HOME_CHANNEL`     | (unset)            | Default cron/notification target: Spectrum space id, DM GUID, or bare E.164 number |
 | `PHOTON_HOME_CHANNEL_NAME`| (unset)            | Human label for the home channel           |
 | `PHOTON_ALLOWED_USERS`    | (unset)            | Comma-separated E.164 allowlist            |
 | `PHOTON_ALLOW_ALL_USERS`  | `false`            | Dev only — accept any sender               |


### PR DESCRIPTION
## Summary
- make `hermes photon setup` / `install-sidecar` verify the Node sidecar can actually import `spectrum-ts` before reporting success
- keep the Node 18 `File` polyfill path, pin sidecar deps with a lockfile, and expose `sidecar runtime` in Photon status
- propagate Photon setup failures through `hermes gateway setup` and CLI process exit codes
- document setup-vs-readiness and preserve the webhook-based installed architecture

## Test Plan
- `venv/bin/python -m pytest tests/plugins/platforms/photon tests/cli/test_main_exit_code.py -q -o 'addopts='`
- `venv/bin/python -m pytest tests/tools/test_send_message_tool.py tests/tools/test_send_message_missing_platforms.py -q -o 'addopts='`
- `venv/bin/python -m py_compile plugins/platforms/photon/cli.py tests/plugins/platforms/photon/test_cli.py hermes_cli/main.py`
- `hermes photon status` shows `sidecar runtime     : ✓ import OK`
- live smoke: `:8788` + `:8789` listeners present; `GET /photon/webhook -> 405`; unsigned `POST /photon/webhook -> 401`; sidecar `POST /healthz -> 200 {"ok":true}`

## no-mistakes
- Review ran and fixed failure propagation + runtime probe bounds.
- Test step found and fixed CLI exit-code propagation.
- Lint step reached an external configured linter issue: `npm run lint:diagrams -- docs/user-guide/messaging/photon.md` exits 127 because `ascii-guard` is not installed/declared and `npm view ascii-guard version` returns 404.
- Push to upstream failed with 403 for `jbelisario`, so branch was pushed to fork `jbelisario/hermes-agent`.
