### PR TITLE
feat: add yazi path picker hotkey

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4951,6 +4951,88 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             _cprint(f"{_DIM}Failed to open external editor: {exc}{_RST}")
             return False
 
+    async def _pick_path_with_yazi(self, buffer=None) -> bool:
+        """Open yazi and insert the selected path(s) into the active input buffer."""
+        app = getattr(self, "_app", None)
+        if not app:
+            _cprint(f"{_DIM}Yazi path picker is only available inside the interactive CLI.{_RST}")
+            return False
+        if self._command_running:
+            _cprint(f"{_DIM}Wait for the current command to finish before opening yazi.{_RST}")
+            return False
+        if self._sudo_state or self._secret_state or self._approval_state or getattr(self, "_slash_confirm_state", None) or self._clarify_state:
+            _cprint(f"{_DIM}Finish the active prompt before opening yazi.{_RST}")
+            return False
+
+        target_buffer = buffer or getattr(app, "current_buffer", None)
+        if target_buffer is None:
+            _cprint(f"{_DIM}No active input buffer is available for yazi path insertion.{_RST}")
+            return False
+
+        yazi_bin = shutil.which("yazi")
+        if not yazi_bin:
+            _cprint(f"{_DIM}yazi is not installed or not on PATH.{_RST}")
+            return False
+
+        def _run_yazi() -> list[str]:
+            import subprocess
+
+            fd, chooser_path = tempfile.mkstemp(prefix="hermes-yazi-choice-", text=True)
+            os.close(fd)
+            try:
+                # yazi writes one selected path per line to --chooser-file.
+                # Empty file means the user cancelled or selected nothing.
+                subprocess.run([yazi_bin, "--chooser-file", chooser_path], check=False)
+                try:
+                    with open(chooser_path, "r", encoding="utf-8") as f:
+                        return [line.strip() for line in f if line.strip()]
+                except OSError:
+                    return []
+            finally:
+                try:
+                    os.unlink(chooser_path)
+                except OSError:
+                    pass
+
+        try:
+            from prompt_toolkit.application import run_in_terminal
+
+            was_visible = self._status_bar_visible
+            self._status_bar_visible = False
+            app.invalidate()
+            try:
+                selected_paths = await run_in_terminal(_run_yazi)
+            finally:
+                self._status_bar_visible = was_visible
+                app.invalidate()
+        except Exception as exc:
+            _cprint(f"{_DIM}Failed to open yazi: {exc}{_RST}")
+            return False
+
+        if not selected_paths:
+            return False
+
+        # Insert at the cursor, with light spacing so paths don't run into words.
+        insert_text = " ".join(selected_paths)
+        try:
+            before = target_buffer.document.text_before_cursor
+            after = target_buffer.document.text_after_cursor
+        except Exception:
+            before = getattr(target_buffer, "text", "")
+            after = ""
+        if before and not before[-1].isspace():
+            insert_text = " " + insert_text
+        if after and not after[0].isspace():
+            insert_text = insert_text + " "
+
+        try:
+            target_buffer.insert_text(insert_text)
+            app.invalidate()
+            return True
+        except Exception as exc:
+            _cprint(f"{_DIM}Failed to insert yazi selection: {exc}{_RST}")
+            return False
+
 
 
     def _install_tool_callbacks(self) -> None:
@@ -10985,6 +11067,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         def handle_open_in_editor(event):
             """Ctrl+G (or Alt+G in VSCode/Cursor) opens the current draft in an external editor."""
             cli_ref._open_external_editor(event.current_buffer)
+
+        # Ctrl+Y opens yazi and inserts selected path(s) at the current cursor.
+        # Alt+Y is a fallback for terminals/IDEs that intercept Ctrl chords.
+        _yazi_filter = Condition(
+            lambda: not self._clarify_state and not self._approval_state and not self._sudo_state and not self._secret_state
+        )
+
+        @kb.add('c-y', filter=_yazi_filter)
+        @kb.add('escape', 'y', filter=_yazi_filter)
+        def handle_yazi_path_picker(event):
+            """Ctrl+Y (or Alt+Y) opens yazi and inserts selected path(s)."""
+            event.app.create_background_task(cli_ref._pick_path_with_yazi(event.current_buffer))
 
         @kb.add('tab', eager=True)
         def handle_tab(event):

--- a/cli.py
+++ b/cli.py
@@ -8791,6 +8791,74 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
 
 
+    async def _pick_path_with_yazi(self, buffer=None) -> bool:
+        """Open yazi and insert selected paths into the active input buffer."""
+        app = getattr(self, "_app", None)
+        if not app:
+            _cprint(f"{_DIM}Yazi path picker is only available inside the interactive CLI.{_RST}")
+            return False
+        if self._command_running:
+            _cprint(f"{_DIM}Wait for the current command to finish before opening yazi.{_RST}")
+            return False
+        if self._sudo_state or self._secret_state or self._approval_state or getattr(self, "_slash_confirm_state", None) or self._clarify_state:
+            _cprint(f"{_DIM}Finish the active prompt before opening yazi.{_RST}")
+            return False
+        target_buffer = buffer or getattr(app, "current_buffer", None)
+        if target_buffer is None:
+            return False
+        yazi_bin = shutil.which("yazi")
+        if not yazi_bin:
+            _cprint(f"{_DIM}yazi is not installed or not on PATH.{_RST}")
+            return False
+
+        def _run_yazi() -> list[str]:
+            import subprocess
+            fd, chooser_path = tempfile.mkstemp(prefix="hermes-yazi-choice-", text=True)
+            os.close(fd)
+            try:
+                subprocess.run([yazi_bin, "--chooser-file", chooser_path], check=False)
+                with open(chooser_path, "r", encoding="utf-8") as f:
+                    paths = [line.rstrip("\r\n") for line in f]
+                return [path for path in paths if path]
+            except OSError:
+                return []
+            finally:
+                try:
+                    os.unlink(chooser_path)
+                except OSError:
+                    pass
+
+        try:
+            from prompt_toolkit.application import run_in_terminal
+            was_visible = self._status_bar_visible
+            self._status_bar_visible = False
+            app.invalidate()
+            try:
+                selected_paths = await run_in_terminal(_run_yazi)
+            finally:
+                self._status_bar_visible = was_visible
+                app.invalidate()
+        except Exception as exc:
+            _cprint(f"{_DIM}Failed to open yazi: {exc}{_RST}")
+            return False
+        if not selected_paths:
+            return False
+        insert_text = " ".join(selected_paths)
+        before = target_buffer.document.text_before_cursor
+        after = target_buffer.document.text_after_cursor
+        if before and not before[-1].isspace():
+            insert_text = " " + insert_text
+        if after and not after[0].isspace():
+            insert_text += " "
+        try:
+            target_buffer.insert_text(insert_text)
+            app.invalidate()
+            return True
+        except Exception as exc:
+            _cprint(f"{_DIM}Failed to insert yazi selection: {exc}{_RST}")
+            return False
+
+
     def _install_tool_callbacks(self) -> None:
         """Install tool callbacks that need the live prompt UI."""
         if getattr(self, "_tool_callbacks_installed", False):
@@ -18757,6 +18825,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         def handle_open_in_editor(event):
             """Ctrl+G (or Alt+G in VSCode/Cursor) opens the current draft in an external editor."""
             cli_ref._open_external_editor(event.current_buffer)
+
+        _yazi_filter = Condition(
+            lambda: not self._clarify_state and not self._approval_state and not self._sudo_state and not self._secret_state
+        )
+
+        @kb.add('c-y', filter=_yazi_filter)
+        @kb.add('escape', 'y', filter=_yazi_filter)
+        def handle_yazi_path_picker(event):
+            """Ctrl+Y (or Alt+Y) opens yazi and inserts selected paths."""
+            event.app.create_background_task(cli_ref._pick_path_with_yazi(event.current_buffer))
 
         # --- Ctrl+S prompt stash -------------------------------------------
         # Park a half-written draft, send something else, then bring the draft

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -60,6 +60,7 @@ TIPS = [
     "Tab accepts auto-suggestion ghost text or autocompletes slash commands.",
     "Type a new message while the agent is working to interrupt and redirect it.",
     "Alt+V pastes an image from your clipboard into the conversation.",
+    "Ctrl+Y opens yazi to pick file paths into the input buffer when yazi is installed. Alt+Y is the fallback.",
     "Pasting 5+ lines auto-saves to a file and inserts a compact reference instead.",
 
     # --- CLI Flags ---

--- a/tests/hermes_cli/test_yazi_path_picker.py
+++ b/tests/hermes_cli/test_yazi_path_picker.py
@@ -1,0 +1,88 @@
+import asyncio
+
+from cli import HermesCLI
+
+
+class FakeDocument:
+    def __init__(self, text: str, cursor_position: int):
+        self.text_before_cursor = text[:cursor_position]
+        self.text_after_cursor = text[cursor_position:]
+
+
+class FakeBuffer:
+    def __init__(self, text: str = "", cursor_position: int | None = None):
+        self.text = text
+        self.cursor_position = len(text) if cursor_position is None else cursor_position
+
+    @property
+    def document(self) -> FakeDocument:
+        return FakeDocument(self.text, self.cursor_position)
+
+    def insert_text(self, value: str) -> None:
+        self.text = self.text[:self.cursor_position] + value + self.text[self.cursor_position:]
+        self.cursor_position += len(value)
+
+
+class FakeApp:
+    def __init__(self, buffer: FakeBuffer):
+        self.current_buffer = buffer
+        self.invalidate_count = 0
+
+    def invalidate(self) -> None:
+        self.invalidate_count += 1
+
+
+def make_cli(buffer: FakeBuffer) -> HermesCLI:
+    cli = HermesCLI.__new__(HermesCLI)
+    setattr(cli, "_app", FakeApp(buffer))
+    cli._command_running = False
+    cli._sudo_state = None
+    cli._secret_state = None
+    cli._approval_state = None
+    cli._slash_confirm_state = None
+    cli._clarify_state = None
+    cli._status_bar_visible = True
+    return cli
+
+
+def test_yazi_path_picker_returns_false_when_yazi_missing(monkeypatch):
+    buffer = FakeBuffer("open")
+    cli = make_cli(buffer)
+    monkeypatch.setattr("cli.shutil.which", lambda name: None)
+
+    result = asyncio.run(cli._pick_path_with_yazi(buffer))
+
+    assert result is False
+    assert buffer.text == "open"
+
+
+def test_yazi_path_picker_inserts_selected_path_at_cursor(monkeypatch):
+    buffer = FakeBuffer("please inspect", cursor_position=len("please inspect"))
+    cli = make_cli(buffer)
+    monkeypatch.setattr("cli.shutil.which", lambda name: "/usr/bin/yazi")
+
+    async def fake_run_in_terminal(func):
+        return ["/tmp/example.c"]
+
+    monkeypatch.setattr("prompt_toolkit.application.run_in_terminal", fake_run_in_terminal)
+
+    result = asyncio.run(cli._pick_path_with_yazi(buffer))
+
+    assert result is True
+    assert buffer.text == "please inspect /tmp/example.c"
+
+
+def test_yazi_path_picker_preserves_spacing_around_inserted_path(monkeypatch):
+    buffer = FakeBuffer("before after", cursor_position=len("before "))
+    cli = make_cli(buffer)
+    monkeypatch.setattr("cli.shutil.which", lambda name: "/usr/bin/yazi")
+
+    async def fake_run_in_terminal(func):
+        return ["/tmp/example.c"]
+
+    monkeypatch.setattr("prompt_toolkit.application.run_in_terminal", fake_run_in_terminal)
+
+    result = asyncio.run(cli._pick_path_with_yazi(buffer))
+
+    assert result is True
+    assert buffer.text == "before /tmp/example.c after"

--- a/tests/hermes_cli/test_yazi_path_picker.py
+++ b/tests/hermes_cli/test_yazi_path_picker.py
@@ -1,0 +1,112 @@
+import asyncio
+from pathlib import Path
+
+from cli import HermesCLI
+
+
+class FakeDocument:
+    def __init__(self, text: str, cursor_position: int):
+        self.text_before_cursor = text[:cursor_position]
+        self.text_after_cursor = text[cursor_position:]
+
+
+class FakeBuffer:
+    def __init__(self, text: str = "", cursor_position: int | None = None):
+        self.text = text
+        self.cursor_position = len(text) if cursor_position is None else cursor_position
+
+    @property
+    def document(self) -> FakeDocument:
+        return FakeDocument(self.text, self.cursor_position)
+
+    def insert_text(self, value: str) -> None:
+        self.text = self.text[:self.cursor_position] + value + self.text[self.cursor_position:]
+        self.cursor_position += len(value)
+
+
+class FakeApp:
+    def __init__(self, buffer: FakeBuffer):
+        self.current_buffer = buffer
+        self.invalidate_count = 0
+
+    def invalidate(self) -> None:
+        self.invalidate_count += 1
+
+
+def make_cli(buffer: FakeBuffer) -> HermesCLI:
+    cli = HermesCLI.__new__(HermesCLI)
+    setattr(cli, "_app", FakeApp(buffer))
+    cli._command_running = False
+    cli._sudo_state = None
+    cli._secret_state = None
+    cli._approval_state = None
+    cli._slash_confirm_state = None
+    cli._clarify_state = None
+    cli._status_bar_visible = True
+    return cli
+
+
+def install_yazi_mocks(monkeypatch, chooser_content: str):
+    monkeypatch.setattr("cli.shutil.which", lambda name: "/usr/bin/yazi")
+    chooser_paths = []
+
+    def fake_subprocess_run(command, check):
+        assert command[:2] == ["/usr/bin/yazi", "--chooser-file"]
+        assert check is False
+        chooser_path = Path(command[2])
+        chooser_paths.append(chooser_path)
+        chooser_path.write_text(chooser_content, encoding="utf-8")
+
+    monkeypatch.setattr("subprocess.run", fake_subprocess_run)
+
+    async def fake_run_in_terminal(func):
+        return func()
+
+    monkeypatch.setattr("prompt_toolkit.application.run_in_terminal", fake_run_in_terminal)
+    return chooser_paths
+
+
+def test_yazi_path_picker_returns_false_when_yazi_missing(monkeypatch):
+    buffer = FakeBuffer("open")
+    cli = make_cli(buffer)
+    monkeypatch.setattr("cli.shutil.which", lambda name: None)
+
+    result = asyncio.run(cli._pick_path_with_yazi(buffer))
+
+    assert result is False
+    assert buffer.text == "open"
+
+
+def test_yazi_path_picker_inserts_selected_path_at_cursor(monkeypatch):
+    buffer = FakeBuffer("please inspect", cursor_position=len("please inspect"))
+    cli = make_cli(buffer)
+    chooser_paths = install_yazi_mocks(monkeypatch, "/tmp/example.c\n")
+
+    result = asyncio.run(cli._pick_path_with_yazi(buffer))
+
+    assert result is True
+    assert buffer.text == "please inspect /tmp/example.c"
+    assert chooser_paths and not chooser_paths[0].exists()
+
+
+def test_yazi_path_picker_preserves_spacing_around_inserted_path(monkeypatch):
+    buffer = FakeBuffer("before after", cursor_position=len("before "))
+    cli = make_cli(buffer)
+    chooser_paths = install_yazi_mocks(monkeypatch, "/tmp/example.c\n")
+
+    result = asyncio.run(cli._pick_path_with_yazi(buffer))
+
+    assert result is True
+    assert buffer.text == "before /tmp/example.c after"
+    assert chooser_paths and not chooser_paths[0].exists()
+
+
+def test_yazi_path_picker_preserves_whitespace_in_selected_paths(monkeypatch):
+    buffer = FakeBuffer()
+    cli = make_cli(buffer)
+    install_yazi_mocks(monkeypatch, " /tmp/leading  \n/tmp/trailing \n")
+
+    result = asyncio.run(cli._pick_path_with_yazi(buffer))
+
+    assert result is True
+    assert buffer.text == " /tmp/leading   /tmp/trailing "


### PR DESCRIPTION
## Summary
- Add Ctrl+Y / Alt+Y in the interactive CLI to open yazi when installed
- Insert selected path(s) into the current input buffer via yazi --chooser-file
- Treat yazi as an optional integration; if unavailable, show a non-fatal message
- Add a startup tip for discoverability

## Test Plan
- venv/bin/python -m py_compile cli.py hermes_cli/tips.py tests/hermes_cli/test_yazi_path_picker.py
- venv/bin/python -m pytest tests/hermes_cli/test_yazi_path_picker.py -q -o 'addopts='
- Manually tested Ctrl+Y in Hermes CLI on macOS