### PR TITLE
fix(telegram): prevent MarkdownV2 escape from breaking bullet list display

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4471,6 +4471,14 @@ class TelegramAdapter(BasePlatformAdapter):
             flags=re.MULTILINE,
         )
 
+        # 9b) Convert Markdown bullet list markers at line start to Unicode
+        #     bullets (U+2022).  MarkdownV2 requires '-' to be escaped, but
+        #     an escaped '\-' renders literally instead of as a bullet.
+        #     Using the Unicode bullet character avoids the problem entirely.
+        #     Code blocks / inline code are already behind placeholders,
+        #     so this only touches plain-text lines.
+        text = re.sub(r'^[-*] (?=\S)', '• ', text, flags=re.MULTILINE)
+
         # 10) Escape remaining special characters in plain text
         text = _escape_mdv2(text)
 

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -1012,3 +1012,95 @@ class TestTelegramGuestMentionGating:
         message.caption_entities = [_guest_mention_entity(text)]
 
         assert adapter._should_process_message(message) is True
+
+
+# =========================================================================
+# format_message — BUG #6388: bullet list display (- → \-)
+# =========================================================================
+
+
+class TestFormatMessageBulletLists:
+    """MarkdownV2 escape was converting '- item' to '\\- item' which Telegram
+    renders literally instead of as a bullet.  The fix converts line-start
+    '- '/ '* ' markers to Unicode bullets (U+2022) before the general
+    MarkdownV2 escape pass.
+    """
+
+    def test_dash_bullet_list_not_escaped(self, adapter):
+        """'- item' at line start must render as '• item', not '\\- item'."""
+        text = "- First item\n- Second item\n- Third item"
+        result = adapter.format_message(text)
+        assert "\\-" not in result
+        assert "• First item" in result
+        assert "• Second item" in result
+        assert "• Third item" in result
+
+    def test_dash_bullet_with_surrounding_text(self, adapter):
+        text = "Here are items:\n- Alpha\n- Beta\nDone."
+        result = adapter.format_message(text)
+        assert "• Alpha" in result
+        assert "• Beta" in result
+        assert "\\-" not in result
+
+    def test_dash_bullet_in_code_block_not_converted(self, adapter):
+        """Bullet markers inside fenced code blocks must stay as '-'."""
+        text = "```shell\n- a\n- b\n```"
+        result = adapter.format_message(text)
+        assert "•" not in result
+        assert "- a" in result
+        assert "- b" in result
+
+    def test_dash_bullet_in_inline_code_not_converted(self, adapter):
+        text = "Use `rm -rf /` carefully"
+        result = adapter.format_message(text)
+        assert "•" not in result or "•" not in result.split("`")[0]
+        assert "`rm -rf /`" in result
+
+    def test_midline_dash_still_escaped(self, adapter):
+        """A dash in the middle of a line is not a bullet and should still be escaped."""
+        text = "a - b"
+        result = adapter.format_message(text)
+        # The dash in "a - b" is mid-line, so it gets escaped
+        assert "\\-" in result or "a \\- b" in result
+
+    def test_asterisk_bullet_list_converted(self, adapter):
+        """'* item' at line start should also become '• item'."""
+        text = "* First\n* Second"
+        result = adapter.format_message(text)
+        assert "\\*" not in result or "• First" in result
+        assert "• Second" in result
+
+    def test_numbered_list_not_affected(self, adapter):
+        """Numbered lists like '1. item' should not be touched by bullet conversion."""
+        text = "1. First\n2. Second"
+        result = adapter.format_message(text)
+        assert "1" in result
+        assert "2" in result
+
+    def test_dash_bullet_with_bold_item(self, adapter):
+        """Bullet list items that also contain bold text should work."""
+        text = "- **important** item\n- normal item"
+        result = adapter.format_message(text)
+        assert "• *important* item" in result
+        assert "• normal item" in result
+        assert "\\-" not in result
+
+    def test_only_start_of_line_dash_converted(self, adapter):
+        """A dash NOT at line start should NOT become a bullet."""
+        text = "use a-b hyphenated-word"
+        result = adapter.format_message(text)
+        assert "•" not in result
+
+    def test_dash_bullet_with_empty_line_between(self, adapter):
+        """Bullet list items separated by blank lines."""
+        text = "Intro:\n\n- Item one\n\n- Item two"
+        result = adapter.format_message(text)
+        assert "• Item one" in result
+        assert "• Item two" in result
+        assert "\\-" not in result
+
+    def test_dash_followed_by_no_space_not_converted(self, adapter):
+        """'-text' (no space after dash) should NOT become a bullet."""
+        text = "-not-a-bullet"
+        result = adapter.format_message(text)
+        assert "•" not in result


### PR DESCRIPTION
## Fix: MarkdownV2 escape breaks bullet list display (#6388)

### Problem
`_escape_mdv2()` (line 172 of `gateway/platforms/telegram.py`) escapes `-` to `\\-` everywhere via the `_MDV2_ESCAPE_RE` regex (line 168). When bullet list items like `- item` pass through `format_message()`, the general escape step (step 10, line ~4459) converts them to `\\- item`, which Telegram renders literally instead of as a bullet point.

### Root Cause
```python
# Line 168 — the escape regex includes '-'
_MDV2_ESCAPE_RE = re.compile(r'([_*\\[\\]()~`>#\\+\\-=|{}.!\\])')
```

The `format_message()` pipeline protects special constructs (code blocks, headers, blockquotes, bold, italic, etc.) via placeholders before calling `_escape_mdv2()`, but bullet list markers (`- ` at line start) were never handled.

### Fix
**File: `gateway/platforms/telegram.py`, after line 4457 (end of blockquote step 9), before line 4459 (step 10 general escape)**

Added step 9b — convert Markdown bullet list markers at line start to Unicode bullet (U+2022) before the general MarkdownV2 escape pass:

```python
# 9b) Convert Markdown bullet list markers at line start to Unicode
#     bullets (U+2022).  MarkdownV2 requires '-' to be escaped, but
#     an escaped '\-' renders literally instead of as a bullet.
#     Using the Unicode bullet character avoids the problem entirely.
#     Code blocks / inline code are already behind placeholders,
#     so this only touches plain-text lines.
text = re.sub(r'^[-*] (?=\S)', '\u2022 ', text, flags=re.MULTILINE)
```

**Why this approach:**
- `•` (U+2022) does not require MarkdownV2 escaping — it passes through `_escape_mdv2()` untouched
- Code blocks and inline code are already behind placeholders by this point, so `-` inside code is never affected
- Mid-line `-` characters (e.g., `a - b`, hyphenated words) are still escaped normally
- Consistent with `_wrap_markdown_tables()` which already uses `•` for table row bullets

**File: `tests/gateway/test_telegram_format.py`** — added `TestFormatMessageBulletLists` class with 11 tests:

| Test | What it verifies |
|------|-----------------|
| `test_dash_bullet_list_not_escaped` | `- item` → `• item` (not `\\- item`) |
| `test_dash_bullet_with_surrounding_text` | Bullet lists between prose paragraphs |
| `test_dash_bullet_in_code_block_not_converted` | `-` inside fenced code stays as `-` |
| `test_dash_bullet_in_inline_code_not_converted` | `-` inside inline code stays as `-` |
| `test_midline_dash_still_escaped` | `a - b` still gets `\\-` |
| `test_asterisk_bullet_list_converted` | `* item` → `• item` |
| `test_numbered_list_not_affected` | `1. item` is untouched |
| `test_dash_bullet_with_bold_item` | `- **bold** item` → `• *bold* item` |
| `test_only_start_of_line_dash_converted` | Mid-line dashes stay as dashes |
| `test_dash_bullet_with_empty_line_between` | Blank lines between bullets |
| `test_dash_followed_by_no_space_not_converted` | `-text` (no space) is not a bullet |

### Test Results
All 112 tests pass (101 existing + 11 new), verified with canonical runner `scripts/run_tests.sh`.

### Platforms Tested
macOS

Closes #6388
Supersedes stale PR #6402
