### PR TITLE
Fix Windows Python 3.14 updates and pytest timeout handling

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6866,10 +6866,11 @@ def _install_python_dependencies_with_optional_fallback(
     ``_quarantine_running_hermes_exe`` for the rationale.
     """
     scripts_dir = _venv_scripts_dir() if _is_windows() else None
+    install_env = _augment_install_env_for_windows_py314(env)
 
     def _install(args: list[str]) -> None:
         _run_quarantined_install(
-            install_cmd_prefix + args, env=env, scripts_dir=scripts_dir
+            install_cmd_prefix + args, env=install_env, scripts_dir=scripts_dir
         )
 
     try:
@@ -6910,7 +6911,33 @@ def _install_python_dependencies_with_optional_fallback(
     # stage. Reinstall with --reinstall to force resolution if anything is
     # missing, then re-verify so the failure surfaces here instead of
     # downstream.
-    _verify_core_dependencies_installed(install_cmd_prefix, env=env, group=group)
+    _verify_core_dependencies_installed(install_cmd_prefix, env=install_env, group=group)
+
+
+def _augment_install_env_for_windows_py314(
+    env: dict[str, str] | None,
+) -> dict[str, str] | None:
+    """Add Windows/Python 3.14 install workarounds for native Rust deps.
+
+    `pywinpty` 2.x still falls back to a source build on CPython 3.14 because
+    upstream does not publish cp314 wheels. PyO3 rejects 3.14 by default even
+    though the stable ABI build path works on this machine, so `hermes update`
+    can fail during `pip install -e .` after an otherwise-successful code pull.
+
+    Setting `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` suppresses that guard and
+    lets maturin build against the stable ABI. We scope it narrowly to Windows
+    on Python 3.14+ so normal installs stay unchanged elsewhere.
+    """
+    if not _is_windows():
+        return env
+    if sys.version_info < (3, 14):
+        return env
+
+    merged = dict(os.environ)
+    if env:
+        merged.update(env)
+    merged.setdefault("PYO3_USE_ABI3_FORWARD_COMPATIBILITY", "1")
+    return merged
 
 
 def _verify_core_dependencies_installed(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -533,6 +533,11 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
         "(only for tests that genuinely need real os.kill / subprocess "
         "behaviour — e.g. PTY tests that signal their own child).",
     )
+    # pytest-timeout's SIGALRM mode is POSIX-only. The project-wide addopts use
+    # `--timeout-method=signal`; normalize that to `thread` on Windows so the
+    # suite can run under native CPython without per-invocation overrides.
+    if sys.platform == "win32" and getattr(config.option, "timeout_method", None) == "signal":
+        config.option.timeout_method = "thread"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -448,6 +448,56 @@ def test_install_with_optional_fallback_honors_custom_group(monkeypatch):
     ]
 
 
+def test_install_with_optional_fallback_enables_pyo3_abi3_on_windows_py314(monkeypatch):
+    calls = []
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(hermes_main.sys, "version_info", (3, 14, 4))
+    monkeypatch.setattr(
+        hermes_main,
+        "_load_installable_optional_extras",
+        lambda group="all": [],
+    )
+    monkeypatch.setattr(hermes_main, "_verify_core_dependencies_installed", lambda *args, **kwargs: None)
+
+    def fake_run_quarantined_install(cmd, **kwargs):
+        calls.append((cmd, kwargs.get("env")))
+
+    monkeypatch.setattr(hermes_main, "_run_quarantined_install", fake_run_quarantined_install)
+
+    hermes_main._install_python_dependencies_with_optional_fallback(
+        ["uv", "pip"],
+        env={"VIRTUAL_ENV": "C:\\venv"},
+    )
+
+    assert calls, "expected at least one install attempt"
+    assert calls[0][1]["PYO3_USE_ABI3_FORWARD_COMPATIBILITY"] == "1"
+    assert calls[0][1]["VIRTUAL_ENV"] == "C:\\venv"
+
+
+def test_install_with_optional_fallback_leaves_env_unchanged_off_windows(monkeypatch):
+    calls = []
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: False)
+    monkeypatch.setattr(
+        hermes_main,
+        "_load_installable_optional_extras",
+        lambda group="all": [],
+    )
+    monkeypatch.setattr(hermes_main, "_verify_core_dependencies_installed", lambda *args, **kwargs: None)
+
+    def fake_run_quarantined_install(cmd, **kwargs):
+        calls.append(kwargs.get("env"))
+
+    monkeypatch.setattr(hermes_main, "_run_quarantined_install", fake_run_quarantined_install)
+
+    base_env = {"VIRTUAL_ENV": "/tmp/venv"}
+    hermes_main._install_python_dependencies_with_optional_fallback(
+        ["uv", "pip"],
+        env=base_env,
+    )
+
+    assert calls == [base_env]
+
+
 def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch, capsys):
     """Long quiet installs should emit periodic heartbeat lines."""
 

--- a/tests/test_windows_pytest_timeout_config.py
+++ b/tests/test_windows_pytest_timeout_config.py
@@ -1,0 +1,37 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import SimpleNamespace
+
+
+_CONFTEST_PATH = Path(__file__).with_name("conftest.py")
+_SPEC = spec_from_file_location("tests_conftest_module", _CONFTEST_PATH)
+assert _SPEC and _SPEC.loader
+_CONFTEST = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_CONFTEST)
+
+
+class _FakeConfig:
+    def __init__(self, timeout_method: str):
+        self.option = SimpleNamespace(timeout_method=timeout_method)
+        self.markers: list[tuple[str, str]] = []
+
+    def addinivalue_line(self, name: str, value: str) -> None:
+        self.markers.append((name, value))
+
+
+def test_pytest_configure_switches_timeout_method_on_windows(monkeypatch):
+    config = _FakeConfig("signal")
+    monkeypatch.setattr(_CONFTEST.sys, "platform", "win32", raising=False)
+
+    _CONFTEST.pytest_configure(config)
+
+    assert config.option.timeout_method == "thread"
+
+
+def test_pytest_configure_keeps_timeout_method_on_non_windows(monkeypatch):
+    config = _FakeConfig("signal")
+    monkeypatch.setattr(_CONFTEST.sys, "platform", "linux", raising=False)
+
+    _CONFTEST.pytest_configure(config)
+
+    assert config.option.timeout_method == "signal"


### PR DESCRIPTION
## Summary
- enable `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` automatically during Windows Python 3.14+ update installs so `pywinpty` source builds stop breaking `hermes update`
- thread the adjusted install environment through the dependency verification/repair path as well
- normalize `pytest-timeout` from `signal` to `thread` on Windows in `tests/conftest.py` and add a regression test for the hook

## Validation
- `python -m pytest tests/hermes_cli/test_update_autostash.py -k "pyo3_abi3 or leaves_env_unchanged_off_windows or honors_custom_group" -q`
- `python -m pytest tests/test_windows_pytest_timeout_config.py -q`
- `python -m pytest tests/hermes_cli/test_setup_agent_settings.py -q`
- `python -c "from hermes_cli.main import _install_python_dependencies_with_optional_fallback, PROJECT_ROOT; import os; _install_python_dependencies_with_optional_fallback([str(PROJECT_ROOT.parent / 'bin' / 'uv.exe'),'pip'], env={**os.environ, 'VIRTUAL_ENV': str(PROJECT_ROOT / 'venv')})"`

## Context
- reproduced from a native Windows Python 3.14.4 install where `hermes update` pulled new code and then failed at `uv pip install -e .` while rebuilding `pywinpty`.
