### PR TITLE
fix(desktop): prefer text over images on paste to fix macOS clipboard PDF flavor

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -469,6 +469,28 @@ export function ChatBar({
   }
 
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
+    // Check text first — on macOS, copying plain text always includes a
+    // PDF/image flavor in the clipboard.  If we check images first, that
+    // ghost flavor is extracted as a blank image and the text is lost.
+    // See https://github.com/NousResearch/hermes-agent/issues/42827
+    const pastedText = event.clipboardData.getData('text').trim()
+
+    if (pastedText) {
+      if (DATA_IMAGE_URL_RE.test(pastedText)) {
+        event.preventDefault()
+
+        return
+      }
+
+      event.preventDefault()
+      document.execCommand('insertText', false, pastedText)
+      const nextDraft = composerPlainText(event.currentTarget)
+      draftRef.current = nextDraft
+      aui.composer().setText(nextDraft)
+
+      return
+    }
+
     const imageBlobs = extractClipboardImageBlobs(event.clipboardData)
 
     if (imageBlobs.length > 0) {
@@ -485,29 +507,8 @@ export function ChatBar({
       return
     }
 
-    // Trim surrounding whitespace so a copy that dragged along leading/trailing
-    // blank lines (common when selecting from terminals, code blocks, web pages)
-    // doesn't dump multiline padding into the composer. Internal newlines are
-    // preserved — only the edges are cleaned up.
-    const pastedText = event.clipboardData.getData('text').trim()
-
-    if (!pastedText) {
-      event.preventDefault()
-
-      return
-    }
-
-    if (DATA_IMAGE_URL_RE.test(pastedText)) {
-      event.preventDefault()
-
-      return
-    }
-
+    // No text and no images — swallow the paste to avoid inserting nothing.
     event.preventDefault()
-    document.execCommand('insertText', false, pastedText)
-    const nextDraft = composerPlainText(event.currentTarget)
-    draftRef.current = nextDraft
-    aui.composer().setText(nextDraft)
   }
 
   const [trigger, setTrigger] = useState<TriggerState | null>(null)

--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -66,6 +66,32 @@ describe('extractClipboardImageBlobs', () => {
 
     expect(extractClipboardImageBlobs(clipboard)).toEqual([image])
   })
+  it('extracts image blobs from macOS clipboard that also has text', () => {
+    // macOS clipboard always includes a PDF/image flavor alongside text.
+    // The caller (handlePaste) must check text FIRST — this test documents
+    // why: extractClipboardImageBlobs WILL return the ghost image.
+    // See https://github.com/NousResearch/hermes-agent/issues/42827
+    const ghostImage = new File([new Uint8Array([0xff, 0xd8])], 'clip.png', {
+      type: 'image/png',
+      lastModified: 1_700_000_000_002
+    })
+
+    const clipboard = {
+      files: { length: 0, item: () => null },
+      getData: (type: string) => (type === 'text/plain' ? 'hello world' : ''),
+      items: [
+        {
+          kind: 'file',
+          type: 'image/png',
+          getAsFile: () => ghostImage
+        }
+      ]
+    } as unknown as DataTransfer
+
+    // extractClipboardImageBlobs returns the ghost image — it doesn't know
+    // about text priority.  The caller must prefer text when available.
+    expect(extractClipboardImageBlobs(clipboard)).toEqual([ghostImage])
+  })
 })
 
 describe('blobDedupeKey', () => {


### PR DESCRIPTION
## Problem

On macOS, copying **plain text** (Cmd+C from Terminal, VS Code, any app) and pasting into the Hermes Desktop composer (Cmd+V) inserts a **blank/black image placeholder** instead of the text.

Root cause: macOS's clipboard always includes a PDF/image flavor alongside the text flavor. The composer's `handlePaste` checked for image blobs **before** checking for text, so the ghost image was extracted first and the paste was treated as an image attachment — the text was silently dropped.

## Fix

Reorder `handlePaste` to check for text content **first**:

- If the clipboard has text → insert as text (most common case: user copied text)
- If no text but has image blobs → attach as image (screenshot paste)
- If neither → swallow the paste event

This matches the expected UX: if you copied text, you get text; if you took a screenshot (no text on clipboard), you get the image.

## Testing

- Added a test documenting the macOS clipboard behavior: `extractClipboardImageBlobs` correctly returns the ghost image from a clipboard that also has text — confirming the caller must check text first
- All 9 tests in `text-utils.test.ts` pass

Closes #42827
