### PR TITLE
fix(streaming): cut off silent hangs before stale timeout

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1694,6 +1694,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
     first_delta_fired = {"done": False}
     deltas_were_sent = {"yes": False}  # Track if any deltas were fired (for fallback)
+    first_stream_event_seen = {"yes": False}
     # Wall-clock timestamp of the last real streaming chunk.  The outer
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
@@ -1754,6 +1755,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 api_kwargs=stream_kwargs,
             )
         )
+        first_stream_event_seen["yes"] = False
         # Reset stale-stream timer so the detector measures from this
         # attempt's start, not a previous attempt's last chunk.
         last_chunk_time["t"] = time.time()
@@ -1793,6 +1795,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         reasoning_parts: list = []
         usage_obj = None
         for chunk in stream:
+            first_stream_event_seen["yes"] = True
             last_chunk_time["t"] = time.time()
             agent._touch_activity("receiving stream response")
 
@@ -2439,6 +2442,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         else:
             _stream_stale_timeout = _stream_stale_timeout_base
 
+    # Generic chat-completions first-event watchdog. Only enable it when the
+    # agent actually has fallback providers to escape to; otherwise a slow but
+    # healthy upstream would be penalized with no alternate route available.
+    _stream_ttfb_enabled = (
+        getattr(agent, "api_mode", None) not in {"codex_responses", "anthropic_messages"}
+        and bool(getattr(agent, "_fallback_chain", []))
+        and not (agent.base_url and is_local_endpoint(agent.base_url))
+    )
+    _stream_ttfb_timeout = _env_float("HERMES_STREAM_TTFB_TIMEOUT_SECONDS", 30.0)
+    if _stream_ttfb_timeout <= 0:
+        _stream_ttfb_enabled = False
+
     t = threading.Thread(target=_call, daemon=True)
     t.start()
     _last_heartbeat = time.time()
@@ -2466,6 +2481,36 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # but delivering no real chunks.  Kill the client so the
         # inner retry loop can start a fresh connection.
         _stale_elapsed = time.time() - last_chunk_time["t"]
+        if (
+            _stream_ttfb_enabled
+            and not first_stream_event_seen["yes"]
+            and _stale_elapsed > _stream_ttfb_timeout
+        ):
+            logger.warning(
+                "Streaming provider emitted no events within %.0fs "
+                "(threshold %.0fs, provider=%s, model=%s). Killing "
+                "connection so retries/fallback can continue.",
+                _stale_elapsed,
+                _stream_ttfb_timeout,
+                agent.provider or "unknown",
+                api_kwargs.get("model", "unknown"),
+            )
+            agent._buffer_status(
+                f"⚠️ No stream events from provider in {int(_stale_elapsed)}s "
+                f"(model: {api_kwargs.get('model', 'unknown')}). Reconnecting."
+            )
+            try:
+                _close_request_client_once("stream_ttfb_kill")
+            except Exception:
+                pass
+            try:
+                agent._replace_primary_openai_client(reason="stream_ttfb_pool_cleanup")
+            except Exception:
+                pass
+            last_chunk_time["t"] = time.time()
+            agent._touch_activity(
+                f"stream killed after {int(_stale_elapsed)}s with no first event"
+            )
         if _stale_elapsed > _stream_stale_timeout:
             _est_ctx = estimate_request_context_tokens(api_kwargs)
             logger.warning(

--- a/tests/agent/test_stream_ttfb_watchdog.py
+++ b/tests/agent/test_stream_ttfb_watchdog.py
@@ -1,0 +1,190 @@
+"""Regression tests for the generic streaming first-event watchdog."""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+
+# Stub optional heavy imports so run_agent imports cleanly in isolation.
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+
+def _make_agent(tmp_path, monkeypatch, *, fallback_model):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            provider="openrouter",
+            base_url="https://integrate.api.nvidia.com/v1",
+            model="deepseek-v4",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+            platform="cli",
+        )
+
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    monkeypatch.setattr(agent, "_emit_status", lambda *a, **k: None)
+    monkeypatch.setattr(agent, "_buffer_status", lambda *a, **k: None)
+    monkeypatch.setattr(agent, "_replace_primary_openai_client", lambda *a, **k: None)
+    return agent
+
+
+def _chunk(*, content=None, finish_reason=None):
+    delta = SimpleNamespace(
+        content=content,
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=None,
+    )
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="deepseek-v4", usage=None)
+
+
+class _HangingStream:
+    response = None
+
+    def __init__(self, stop_flag):
+        self._stop_flag = stop_flag
+
+    def __iter__(self):
+        deadline = time.time() + 30
+        while time.time() < deadline and not self._stop_flag["flag"]:
+            time.sleep(0.02)
+        raise httpx.RemoteProtocolError("connection closed")
+
+
+class _DelayedFirstEventStream:
+    response = None
+
+    def __init__(self, delay_seconds):
+        self._delay_seconds = delay_seconds
+
+    def __iter__(self):
+        time.sleep(self._delay_seconds)
+        yield _chunk(content="hello")
+        yield _chunk(finish_reason="stop")
+
+
+class _EarlyKeepaliveThenContentStream:
+    response = None
+
+    def __init__(self, post_keepalive_delay):
+        self._post_keepalive_delay = post_keepalive_delay
+
+    def __iter__(self):
+        yield SimpleNamespace(choices=[], model="deepseek-v4", usage=None)
+        time.sleep(self._post_keepalive_delay)
+        yield _chunk(content="hello")
+        yield _chunk(finish_reason="stop")
+
+
+def _install_stream_clients(agent, stream_factories):
+    closes = []
+    streams = iter(stream_factories)
+
+    def _make_client(**kwargs):
+        stream = next(streams)
+        return SimpleNamespace(
+            _stream=stream,
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **_kwargs: stream)
+            ),
+        )
+
+    def _close(client, reason=None):
+        closes.append(reason)
+        stop_flag = getattr(getattr(client, "_stream", None), "_stop_flag", None)
+        if stop_flag is not None:
+            stop_flag["flag"] = True
+
+    agent._create_request_openai_client = _make_client
+    agent._abort_request_openai_client = _close
+    agent._close_request_openai_client = _close
+    return closes
+
+
+def test_generic_stream_ttfb_kills_hanging_attempt_and_retries(
+    tmp_path, monkeypatch
+):
+    agent = _make_agent(
+        tmp_path,
+        monkeypatch,
+        fallback_model=[{"provider": "openrouter", "model": "gemma4:31b"}],
+    )
+    monkeypatch.setenv("HERMES_STREAM_TTFB_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+
+    stop_flag = {"flag": False}
+    closes = _install_stream_clients(
+        agent,
+        [_HangingStream(stop_flag), _DelayedFirstEventStream(0.05)],
+    )
+
+    t0 = time.time()
+    resp = agent._interruptible_streaming_api_call(
+        {"model": agent.model, "messages": []}
+    )
+    elapsed = time.time() - t0
+
+    assert resp.choices[0].message.content == "hello"
+    assert "stream_ttfb_kill" in closes
+    assert elapsed < 15, f"generic stream TTFB watchdog took {elapsed:.1f}s"
+
+
+def test_generic_stream_ttfb_stays_disabled_without_fallback(
+    tmp_path, monkeypatch
+):
+    agent = _make_agent(tmp_path, monkeypatch, fallback_model=None)
+    monkeypatch.setenv("HERMES_STREAM_TTFB_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+    closes = _install_stream_clients(agent, [_DelayedFirstEventStream(1.3)])
+
+    resp = agent._interruptible_streaming_api_call(
+        {"model": agent.model, "messages": []}
+    )
+
+    assert resp.choices[0].message.content == "hello"
+    assert "stream_ttfb_kill" not in closes
+
+
+def test_generic_stream_ttfb_does_not_kill_after_first_event(
+    tmp_path, monkeypatch
+):
+    agent = _make_agent(
+        tmp_path,
+        monkeypatch,
+        fallback_model=[{"provider": "openrouter", "model": "gemma4:31b"}],
+    )
+    monkeypatch.setenv("HERMES_STREAM_TTFB_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+    closes = _install_stream_clients(
+        agent, [_EarlyKeepaliveThenContentStream(1.3)]
+    )
+
+    resp = agent._interruptible_streaming_api_call(
+        {"model": agent.model, "messages": []}
+    )
+
+    assert resp.choices[0].message.content == "hello"
+    assert "stream_ttfb_kill" not in closes


### PR DESCRIPTION
## Summary
- add a generic first-event watchdog to the chat-completions streaming poll loop when fallback providers are configured
- kill silent hanging stream attempts early so the existing retry and fallback path can continue
- cover hang-then-retry, no-fallback, and keepalive-first cases with focused watchdog tests

## Testing
- pytest -o addopts='' tests/agent/test_stream_ttfb_watchdog.py
- pytest -o addopts='' tests/agent/test_codex_ttfb_watchdog.py
- ruff check agent/chat_completion_helpers.py tests/agent/test_stream_ttfb_watchdog.py
- git diff --check HEAD^ HEAD

Closes #42776