### PR TITLE
fix(gemini): preserve native resource model ids

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -82,6 +82,14 @@ def bare_gemini_model_id(model: str) -> str:
     return name
 
 
+def _gemini_model_resource_name(model: str) -> str:
+    """Return the Gemini REST resource name for a bare or native model id."""
+    model_name = bare_gemini_model_id(model)
+    if model_name.startswith(("models/", "tunedModels/")):
+        return model_name
+    return f"models/{model_name}"
+
+
 def gemini_requires_tool_call_ids(model: str) -> bool:
     """Gemini 3+ needs explicit functionCall/functionResponse ids so replayed parallel tool calls
     pair with their responses; 2.x rejects the field.
@@ -114,7 +122,12 @@ def probe_gemini_tier(
     headers = {"Content-Type": "application/json", "X-Goog-Api-Client": _API_CLIENT}
     try:
         with httpx.Client(timeout=timeout) as client:
-            resp = client.post(f"{base}/models/{model}:generateContent", params={"key": key}, json=payload, headers=headers)
+            resp = client.post(
+                f"{base}/{_gemini_model_resource_name(model)}:generateContent",
+                params={"key": key},
+                json=payload,
+                headers=headers,
+            )
     except Exception as exc:
         logger.debug("probe_gemini_tier: network error: %s", exc)
         return "unknown"
@@ -662,7 +675,7 @@ class GeminiNativeClient:
             top_p=top_p, stop=stop, thinking_config=extra.get("thinking_config") or extra.get("thinkingConfig"), model=model,
         )
         model = bare_gemini_model_id(model)
-        url = f"{self.base_url}/models/{model}:"
+        url = f"{self.base_url}/{_gemini_model_resource_name(model)}:"
         if stream:
             return self._stream_completion(model, url + "streamGenerateContent?alt=sse", request, timeout)
         response = self._http.post(url + "generateContent", json=request, headers=self._headers(), timeout=timeout)

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -59,6 +59,14 @@ def bare_gemini_model_id(model: str) -> str:
     return name
 
 
+def _gemini_model_resource_name(model: str) -> str:
+    """Return the Gemini REST resource name for a bare or native model id."""
+    model_name = bare_gemini_model_id(model)
+    if model_name.startswith(("models/", "tunedModels/")):
+        return model_name
+    return f"models/{model_name}"
+
+
 def is_native_gemini_base_url(base_url: str) -> bool:
     """Return True when the endpoint speaks Gemini's native REST API."""
     normalized = str(base_url or "").strip().rstrip("/").lower()
@@ -94,7 +102,7 @@ def probe_gemini_tier(
     if normalized_base.lower().endswith("/openai"):
         normalized_base = normalized_base[: -len("/openai")]
 
-    url = f"{normalized_base}/models/{model}:generateContent"
+    url = f"{normalized_base}/{_gemini_model_resource_name(model)}:generateContent"
     payload = {
         "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
         "generationConfig": {"maxOutputTokens": 1},
@@ -1012,7 +1020,7 @@ class GeminiNativeClient:
         if stream:
             return self._stream_completion(model=model, request=request, timeout=timeout)
 
-        url = f"{self.base_url}/models/{model}:generateContent"
+        url = f"{self.base_url}/{_gemini_model_resource_name(model)}:generateContent"
         response = self._http.post(url, json=request, headers=self._headers(), timeout=timeout)
         if response.status_code != 200:
             raise gemini_http_error(response)
@@ -1028,7 +1036,7 @@ class GeminiNativeClient:
         return translate_gemini_response(payload, model=model)
 
     def _stream_completion(self, *, model: str, request: Dict[str, Any], timeout: Any = None) -> Iterator[_GeminiStreamChunk]:
-        url = f"{self.base_url}/models/{model}:streamGenerateContent?alt=sse"
+        url = f"{self.base_url}/{_gemini_model_resource_name(model)}:streamGenerateContent?alt=sse"
         stream_headers = dict(self._headers())
         stream_headers["Accept"] = "text/event-stream"
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -316,6 +316,101 @@ def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatc
     assert response.choices[0].message.content == "hello"
 
 
+_MODEL_RESOURCE_CASES = [
+    pytest.param("gemini-2.5-flash", "models/gemini-2.5-flash", id="bare"),
+    pytest.param(
+        "google/gemini-2.0-flash", "models/gemini-2.0-flash", id="google-prefix"
+    ),
+    pytest.param(
+        "gemini/gemini-2.0-flash", "models/gemini-2.0-flash", id="gemini-prefix"
+    ),
+    pytest.param("models/gemini-2.5-flash", "models/gemini-2.5-flash", id="models"),
+    pytest.param(
+        "tunedModels/custom-gemini-model",
+        "tunedModels/custom-gemini-model",
+        id="tuned-models",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("path", "suffix"),
+    [
+        pytest.param("probe", ":generateContent", id="probe"),
+        pytest.param("sync", ":generateContent", id="sync"),
+        pytest.param(
+            "stream",
+            ":streamGenerateContent?alt=sse",
+            id="stream",
+        ),
+    ],
+)
+@pytest.mark.parametrize(("model", "resource_name"), _MODEL_RESOURCE_CASES)
+def test_gemini_native_paths_build_model_resource_url(
+    monkeypatch, path, suffix, model, resource_name
+):
+    from agent.gemini_native_adapter import GeminiNativeClient, probe_gemini_tier
+
+    recorded = {}
+
+    class RecordingHTTP:
+        status_code = 200
+
+        def post(self, url, **kwargs):
+            recorded["url"] = url
+            return DummyResponse(
+                payload={
+                    "candidates": [
+                        {
+                            "content": {"parts": [{"text": "ok"}]},
+                            "finishReason": "STOP",
+                        }
+                    ],
+                    "usageMetadata": {
+                        "promptTokenCount": 1,
+                        "candidatesTokenCount": 1,
+                        "totalTokenCount": 2,
+                    },
+                }
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+        def stream(self, method, url, **kwargs):
+            recorded["url"] = url
+            return self
+
+        def iter_text(self):
+            yield 'data: {"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}\n\n'
+
+        def close(self):
+            return None
+
+    http = RecordingHTTP()
+    if path == "probe":
+        monkeypatch.setattr(
+            "agent.gemini_native_adapter.httpx.Client", lambda **kwargs: http
+        )
+        assert probe_gemini_tier("AIza-test", model=model) == "paid"
+    else:
+        client = GeminiNativeClient(api_key="AIza-test", http_client=http)
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=path == "stream",
+        )
+        if path == "stream":
+            list(response)
+
+    assert recorded["url"] == (
+        f"https://generativelanguage.googleapis.com/v1beta/{resource_name}{suffix}"
+    )
+
+
 
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -156,6 +156,98 @@ def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatc
     assert response.choices[0].message.content == "hello"
 
 
+_MODEL_RESOURCE_CASES = [
+    pytest.param("gemini-2.5-flash", "models/gemini-2.5-flash", id="bare"),
+    pytest.param(
+        "google/gemini-2.0-flash", "models/gemini-2.0-flash", id="self-prefix"
+    ),
+    pytest.param("models/gemini-2.5-flash", "models/gemini-2.5-flash", id="models"),
+    pytest.param(
+        "tunedModels/custom-gemini-model",
+        "tunedModels/custom-gemini-model",
+        id="tuned-models",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("path", "suffix"),
+    [
+        pytest.param("probe", ":generateContent", id="probe"),
+        pytest.param("sync", ":generateContent", id="sync"),
+        pytest.param(
+            "stream",
+            ":streamGenerateContent?alt=sse",
+            id="stream",
+        ),
+    ],
+)
+@pytest.mark.parametrize(("model", "resource_name"), _MODEL_RESOURCE_CASES)
+def test_gemini_native_paths_build_model_resource_url(
+    monkeypatch, path, suffix, model, resource_name
+):
+    from agent.gemini_native_adapter import GeminiNativeClient, probe_gemini_tier
+
+    recorded = {}
+
+    class RecordingHTTP:
+        status_code = 200
+
+        def post(self, url, **kwargs):
+            recorded["url"] = url
+            return DummyResponse(
+                payload={
+                    "candidates": [
+                        {
+                            "content": {"parts": [{"text": "ok"}]},
+                            "finishReason": "STOP",
+                        }
+                    ],
+                    "usageMetadata": {
+                        "promptTokenCount": 1,
+                        "candidatesTokenCount": 1,
+                        "totalTokenCount": 2,
+                    },
+                }
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+        def stream(self, method, url, **kwargs):
+            recorded["url"] = url
+            return self
+
+        def iter_text(self):
+            yield 'data: {"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}\n\n'
+
+        def close(self):
+            return None
+
+    http = RecordingHTTP()
+    if path == "probe":
+        monkeypatch.setattr(
+            "agent.gemini_native_adapter.httpx.Client", lambda **kwargs: http
+        )
+        assert probe_gemini_tier("AIza-test", model=model) == "paid"
+    else:
+        client = GeminiNativeClient(api_key="AIza-test", http_client=http)
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=path == "stream",
+        )
+        if path == "stream":
+            list(response)
+
+    assert recorded["url"] == (
+        f"https://generativelanguage.googleapis.com/v1beta/{resource_name}{suffix}"
+    )
+
+
 
 
 


### PR DESCRIPTION
## Summary

- Preserve Gemini native resource-style model IDs such as `models/...` and `tunedModels/...` instead of prefixing them again with `models/`.
- Compose resource-name construction with the existing `bare_gemini_model_id()` provider-prefix normalization.
- Reuse the same builder for tier probing, non-streaming requests, and streaming requests.
- Add focused parameterized regression coverage for bare IDs, `google/` and `gemini/` self-prefixes, and native `models/...` / `tunedModels/...` resource IDs across all three URL paths.

## Conflict refresh

Refreshed onto canonical `main` at `93ed11379b6a7203f87ca8a9cb3e4e33dda4e6a7`. The old patch conflicted only with later Gemini 3 helper additions in `agent/gemini_native_adapter.py`; the refresh keeps those current-main behaviors and applies the resource-name normalization as a separate narrow helper. The test file's earlier suite pruning is respected: this update adds only the compact behavior matrix rather than restoring deleted broad tests.

## Validation

- Baseline RED on current `main` with the parameterized regression matrix: `8 failed, 7 passed`; every failure was an expected double-prefix resource URL case.
- After the production fix: focused matrix `15 passed`.
- Full adapter test file in an isolated `dev` environment: `33 passed`.
- Ruff check on both changed files: passed.
- `git diff --check`: passed.

## Duplicate check

Immediately before publication, live canonical `main` still constructed `models/tunedModels/...` in probe, sync, and stream paths. Live open/recently closed PR searches for `models/tunedModels`, `bare_gemini_model_id`, and `native resource` found no materially equivalent active fix; merged #36141 only strips self-provider prefixes and does not preserve native resource paths.

## Browser/Playwright status

Not applicable: this patch changes Python Gemini provider URL construction only and is covered by mocked HTTP unit tests; it has no browser-visible UI path.
