### PR TITLE
fix(cron): write consistent status doc for empty script output in non-no_agent path

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1527,7 +1527,13 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         return False, blocked_doc, "", str(block_exc)
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
-        return True, "", SILENT_MARKER, None
+        silent_doc = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+            "Script produced no output — agent skipped.\n"
+        )
+        return True, silent_doc, SILENT_MARKER, None
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2122,6 +2122,25 @@ class TestRunJobWakeGate:
         assert "Script gate returned `wakeAgent=false`" in doc
         agent_cls.assert_not_called()
 
+    def test_empty_script_output_returns_nonempty_doc(self):
+        """When the script produces no output, run_job returns a non-empty
+        status doc (not a blank string) so the run log file is consistent
+        with the wakeAgent=false path.  Regression test for #42851."""
+        from cron.scheduler import SILENT_MARKER
+        import cron.scheduler as scheduler
+
+        with patch.object(scheduler, "_run_job_script",
+                          return_value=(True, "")), \
+             patch("run_agent.AIAgent") as agent_cls:
+            success, doc, final, err = scheduler.run_job(self._make_job())
+
+        assert success is True
+        assert err is None
+        assert final == SILENT_MARKER
+        assert doc  # must be non-empty
+        assert "no output" in doc.lower() or "produced no output" in doc.lower()
+        agent_cls.assert_not_called()
+
     def test_wake_true_runs_agent_with_injected_output(self):
         """When the script returns {wakeAgent: true, data: ...}, the agent is
         invoked and the data line still shows up in the prompt."""


### PR DESCRIPTION
fix(cron): write consistent status doc for empty script output in non-no_agent path

## What does this PR do?

When a cron job's pre-check script produces no output (empty stdout) in the
default (non-no_agent) path, `run_job` returned an empty string as the output
doc. This created an empty `.md` file under `cron/output/<job-id>/`, making the
run log ambiguous — the user cannot tell whether the job ran successfully and
skipped intentionally, or something went wrong.

The `wakeAgent=false` path already writes a proper status doc. This fix adds
the same treatment to the empty-output path so both silent outcomes produce
consistent, non-empty run logs.

## Related Issue

Fixes #42851

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: When the script returns empty stdout and `prompt is
  None`, return a `silent_doc` with job metadata and "Script produced no
  output — agent skipped." status instead of an empty string.
- `tests/cron/test_scheduler.py`: Add
  `TestRunJobWakeGate::test_empty_script_output_returns_nonempty_doc` —
  verifies that empty script output produces a non-empty status doc with
  the expected status message, consistent with the `wakeAgent=false` path.

## How to Test

1. Configure a `no_agent=False` cron job with a script that prints nothing.
2. Run `hermes cron run <job_id>`.
3. Inspect the latest run log in `~/.hermes/cron/output/<job-id>/`.
4. The file should contain job metadata and "Script produced no output — agent
   skipped." — not be empty.
5. Run `pytest tests/cron/test_scheduler.py::TestRunJobWakeGate -v` to verify
   both the new and existing tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/ -q` and all tests pass (2 pre-existing failures unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cron/scheduler.py::run_job` (no_agent empty-output path + non-no_agent empty-output path)
- Blast radius: LOW — only affects the silent-run doc generation; no control-flow or delivery changes
- Related patterns: The `wakeAgent=false` path at line 1495 already writes a status doc; this fix mirrors that pattern
