### PR TITLE
fix(agent): historicalize persisted compaction handoffs

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -113,6 +113,16 @@ _FALLBACK_TURN_MAX_CHARS = 700
 
 
 _PATH_MENTION_RE = re.compile(r"(?:/|~/?|[A-Za-z]:\\)[^\s`'\")\]}<>]+")
+_SUMMARY_SECTION_CANONICAL_TO_HISTORICAL = (
+    ("## Active Task", "## Historical Task (prior session)"),
+    ("## In Progress", "## Previous In-Flight Work"),
+    ("## Pending User Asks", "## Previous Pending User Asks"),
+    ("## Remaining Work", "## Previous Work State"),
+)
+_SUMMARY_SECTION_HISTORICAL_TO_CANONICAL = tuple(
+    (historical, canonical)
+    for canonical, historical in _SUMMARY_SECTION_CANONICAL_TO_HISTORICAL
+)
 
 
 def _dedupe_append(items: list[str], value: str, *, limit: int) -> None:
@@ -1577,10 +1587,50 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 return text[len(prefix):].lstrip()
         return text
 
+    @staticmethod
+    def _rewrite_summary_section_headers(
+        summary: str,
+        replacements: tuple[tuple[str, str], ...],
+    ) -> str:
+        """Rewrite exact summary section headings line-by-line.
+
+        The summarizer still thinks in canonical sections (``## Active Task``,
+        ``## Remaining Work``), but the persisted handoff shown to the model on
+        a later resumed turn must read as historical context, not as a fresh
+        checklist of work to continue.
+        """
+        text = summary or ""
+        for old, new in replacements:
+            text = re.sub(
+                rf"(?m)^{re.escape(old)}(?=\s*$)",
+                new,
+                text,
+            )
+        return text
+
+    @classmethod
+    def _canonicalize_handoff_summary_sections(cls, summary: str) -> str:
+        """Restore persisted historical headings to canonical internal names."""
+        return cls._rewrite_summary_section_headers(
+            summary,
+            _SUMMARY_SECTION_HISTORICAL_TO_CANONICAL,
+        )
+
+    @classmethod
+    def _historicalize_handoff_summary_sections(cls, summary: str) -> str:
+        """Rewrite live-sounding headings before persisting a handoff."""
+        return cls._rewrite_summary_section_headers(
+            summary,
+            _SUMMARY_SECTION_CANONICAL_TO_HISTORICAL,
+        )
+
     @classmethod
     def _with_summary_prefix(cls, summary: str) -> str:
         """Normalize summary text to the current compaction handoff format."""
-        text = cls._strip_summary_prefix(summary)
+        text = cls._canonicalize_handoff_summary_sections(
+            cls._strip_summary_prefix(summary)
+        )
+        text = cls._historicalize_handoff_summary_sections(text)
         return f"{SUMMARY_PREFIX}\n{text}" if text else SUMMARY_PREFIX
 
     @staticmethod
@@ -1601,7 +1651,8 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         for idx in range(end - 1, start - 1, -1):
             content = messages[idx].get("content")
             if cls._is_context_summary_content(content):
-                return idx, cls._strip_summary_prefix(_content_text_for_contains(content))
+                body = cls._strip_summary_prefix(_content_text_for_contains(content))
+                return idx, cls._canonicalize_handoff_summary_sections(body)
         return None, ""
 
     # ------------------------------------------------------------------

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -85,3 +85,35 @@ def test_handoff_in_protected_head_populates_previous_summary_before_update():
     assert compressor._previous_summary == old_summary
     assert seen_turns
     assert all(old_summary not in str(msg.get("content", "")) for msg in seen_turns)
+
+
+def test_compress_persists_historical_handoff_headings_without_mutating_internal_summary():
+    """The transcript-facing handoff should read as historical context, while
+    ``_previous_summary`` stays canonical for the next iterative update."""
+    compressor = _compressor()
+    canonical_summary = (
+        "## Active Task\n"
+        "User asked: 'task A'\n\n"
+        "## In Progress\n"
+        "Running tests.\n\n"
+        "## Pending User Asks\n"
+        "Answer task A.\n\n"
+        "## Remaining Work\n"
+        "Need final reply.\n"
+    )
+
+    with patch("agent.context_compressor.call_llm", return_value=_response(canonical_summary)):
+        out = compressor.compress(_messages_with_handoff("older summary"))
+
+    persisted_summary = next(
+        msg["content"] for msg in out if msg.get("role") in {"user", "assistant"}
+        and isinstance(msg.get("content"), str)
+        and msg["content"].startswith(SUMMARY_PREFIX)
+        and "task A" in msg["content"]
+    )
+    assert "## Historical Task (prior session)" in persisted_summary
+    assert "## Previous In-Flight Work" in persisted_summary
+    assert "## Previous Pending User Asks" in persisted_summary
+    assert "## Previous Work State" in persisted_summary
+    assert "## Active Task\nUser asked:" not in persisted_summary
+    assert compressor._previous_summary == canonical_summary.strip()

--- a/tests/agent/test_resume_stale_active_task.py
+++ b/tests/agent/test_resume_stale_active_task.py
@@ -87,6 +87,8 @@ def test_resumed_stale_handoff_gets_renormalized_to_current_prefix():
     assert "resume exactly" not in renormalized.lower()
     assert renormalized.startswith(SUMMARY_PREFIX)
     assert "wins" in renormalized.lower()
+    assert "## Historical Task (prior session)" in renormalized
+    assert "## Active Task\nUser asked:" not in renormalized
 
 
 def test_legacy_prefix_handoff_also_renormalized():
@@ -97,6 +99,7 @@ def test_legacy_prefix_handoff_also_renormalized():
     assert renormalized.startswith(SUMMARY_PREFIX)
     assert LEGACY_SUMMARY_PREFIX not in renormalized
     assert "task A" in renormalized
+    assert "## Historical Task (prior session)" in renormalized
 
 
 def test_inherited_handoff_detected_in_resumed_protected_head():
@@ -117,9 +120,43 @@ def test_inherited_handoff_detected_in_resumed_protected_head():
     )
     assert idx == 1, "handoff in protected head must be found"
     assert "task A" in body
+    assert "## Active Task" in body
     # The detected body is stripped of the prefix (treated as state, not a
     # standalone instruction message).
     assert not body.startswith(SUMMARY_PREFIX)
+
+
+def test_historical_handoff_headings_are_restored_for_iterative_updates():
+    """Persisted historical headings must map back to canonical internal
+    names when a resumed lineage rehydrates the prior summary."""
+    persisted = (
+        f"{SUMMARY_PREFIX}\n"
+        "## Historical Task (prior session)\n"
+        "User asked: 'task A'\n\n"
+        "## Previous In-Flight Work\n"
+        "Running tests.\n\n"
+        "## Previous Pending User Asks\n"
+        "Answer task A.\n\n"
+        "## Previous Work State\n"
+        "Need final reply.\n"
+    )
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": persisted},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "Unrelated task B"},
+    ]
+
+    idx, body = ContextCompressor._find_latest_context_summary(
+        messages, 1, len(messages)
+    )
+
+    assert idx == 1
+    assert "## Active Task" in body
+    assert "## In Progress" in body
+    assert "## Pending User Asks" in body
+    assert "## Remaining Work" in body
+    assert "Historical Task (prior session)" not in body
 
 
 def test_historical_prefixed_handoff_detected_and_stripped():


### PR DESCRIPTION
## What does this PR do?

This hardens context-compaction handoffs so resumed or idle-reset conversations do not see live-sounding persisted headings like `## Active Task` and continue stale work from an old session. Persisted summaries now use explicitly historical section names in the transcript, while resume-time rehydration converts them back to the canonical internal headings the iterative compressor expects.

## Related Issue

Fixes #42812

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`: rewrite persisted handoff headings from canonical active names to explicit historical names before prefixing the compaction summary, and canonicalize those headings again when a resumed session rehydrates the summary for iterative updates.
- `tests/agent/test_resume_stale_active_task.py`: add resume-path regressions proving historicalized handoffs are restored to canonical internal headings while old prefixes still normalize correctly.
- `tests/agent/test_context_compressor_summary_continuity.py`: add coverage that the transcript-facing handoff is historicalized without mutating the compressor's internal `_previous_summary` state.

## How to Test

1. Run `pytest tests/agent/test_resume_stale_active_task.py tests/agent/test_context_compressor_summary_continuity.py -q` and confirm the new stale-handoff regressions pass.
2. Create or load a conversation with a compaction handoff, then verify the persisted handoff text now uses `## Historical Task (prior session)`, `## Previous In-Flight Work`, `## Previous Pending User Asks`, and `## Previous Work State` instead of the live-sounding headings.
3. Re-run compaction on that resumed transcript and verify iterative summary state still restores to canonical internal headings, so the compressor updates the prior summary instead of treating the historical headings as a brand-new user instruction.
4. Optionally run the broader compressor-focused subset used here: `pytest tests/agent/test_compress_focus.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_compression_logging_session_context.py tests/agent/test_compressor_historical_media.py tests/agent/test_compressor_image_tokens.py tests/agent/test_context_compressor.py tests/agent/test_context_compressor_cross_session_guard.py tests/agent/test_context_compressor_summary_continuity.py tests/agent/test_context_compressor_temporal_anchoring.py tests/agent/test_context_engine.py tests/agent/test_context_engine_host_contract.py tests/agent/test_last_total_tokens.py tests/agent/test_memory_provider.py tests/agent/test_resume_stale_active_task.py tests/agent/test_summary_prefix_semantics.py tests/agent/test_turn_context.py tests/gateway/test_compress_command.py tests/gateway/test_compress_focus.py tests/gateway/test_compress_plugin_engine.py tests/gateway/test_compression_concurrent_sessions.py tests/gateway/test_session_hygiene.py tests/gateway/test_usage_command.py -q`.

## What platforms tested on

- macOS 15 / darwin-arm64 (local worktree)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted regressions passed: `pytest tests/agent/test_resume_stale_active_task.py tests/agent/test_context_compressor_summary_continuity.py -q`
- The required broad local command `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` stopped early on an unrelated shared-venv import error: `ModuleNotFoundError: No module named 'fastapi'` while collecting `tests/hermes_cli/test_dashboard_auth_401_reauth.py`.
- The mechanical compressor-covering subset completed and our changed-module tests passed, but several unrelated pre-existing tests failed under the sandbox when they instantiated `AIAgent` and tried to open `/Users/kon5i/.hermes/logs/agent.log` (`PermissionError: [Errno 1] Operation not permitted`).

<!-- autocontrib:worker-id=issue-new-80f65f8e kind=pr-open -->