### PR TITLE
fix(desktop): persist zoom level across restarts

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -60,6 +60,13 @@ const {
   resolveReadableFileForIpc,
   resolveTimeoutMs
 } = require('./hardening.cjs')
+const {
+  ZOOM_STATE_FILE_NAME,
+  ZOOM_STORAGE_KEY,
+  normalizeZoomState,
+  serializeZoomState,
+  shouldHandleZoomShortcut
+} = require('./zoom-state.cjs')
 
 let nodePty = null
 
@@ -3254,57 +3261,81 @@ function installPreviewShortcut(window) {
   })
 }
 
-// Zoom level is persisted in the renderer's own localStorage (per-origin,
-// survives reloads/restarts) rather than a main-process JSON file. The main
-// process owns setZoomLevel, so we mirror each change into localStorage and
-// read it back on did-finish-load to re-apply after reloads or crash recovery.
-const ZOOM_STORAGE_KEY = 'hermes:desktop:zoomLevel'
+// Persist zoom in main-process userData so it survives restarts, renderer
+// origin/storage resets, app moves, and older builds that wrote ui-zoom.json.
+// localStorage remains as a fallback/mirror for compatibility with 0.15.x.
+function zoomStatePath() {
+  return path.join(app.getPath('userData'), ZOOM_STATE_FILE_NAME)
+}
 
-function clampZoomLevel(value) {
-  if (!Number.isFinite(value)) return 0
-  return Math.min(Math.max(value, -9), 9)
+function readPersistedZoomStateFromFile() {
+  try {
+    const statePath = zoomStatePath()
+    if (!fs.existsSync(statePath)) return null
+    return normalizeZoomState(JSON.parse(fs.readFileSync(statePath, 'utf8')))
+  } catch (error) {
+    rememberLog(`[zoom] read failed: ${error?.message || error}`)
+    return null
+  }
+}
+
+function writePersistedZoomLevel(zoomLevel) {
+  const next = serializeZoomState(zoomLevel)
+  try {
+    const statePath = zoomStatePath()
+    fs.mkdirSync(path.dirname(statePath), { recursive: true })
+    fs.writeFileSync(statePath, `${JSON.stringify(next, null, 2)}\n`, 'utf8')
+  } catch (error) {
+    rememberLog(`[zoom] file persist failed: ${error?.message || error}`)
+  }
+  return next
 }
 
 function setAndPersistZoomLevel(window, zoomLevel) {
   if (!window || window.isDestroyed()) return
-  const next = clampZoomLevel(zoomLevel)
-  window.webContents.setZoomLevel(next)
+  const next = writePersistedZoomLevel(zoomLevel)
+  window.webContents.setZoomLevel(next.level)
   window.webContents
-    .executeJavaScript(`try { localStorage.setItem(${JSON.stringify(ZOOM_STORAGE_KEY)}, ${JSON.stringify(String(next))}) } catch {}`)
-    .catch(error => rememberLog(`[zoom] persist failed: ${error?.message || error}`))
+    .executeJavaScript(`try { localStorage.setItem(${JSON.stringify(ZOOM_STORAGE_KEY)}, ${JSON.stringify(String(next.level))}) } catch {}`)
+    .catch(error => rememberLog(`[zoom] localStorage persist failed: ${error?.message || error}`))
 }
 
 function restorePersistedZoomLevel(window) {
   if (!window || window.isDestroyed()) return
+
+  const fileState = readPersistedZoomStateFromFile()
+  if (fileState) {
+    window.webContents.setZoomLevel(fileState.level)
+    return
+  }
+
   window.webContents
     .executeJavaScript(`(() => { try { return localStorage.getItem(${JSON.stringify(ZOOM_STORAGE_KEY)}) } catch { return null } })()`)
     .then(stored => {
       if (stored == null || !window || window.isDestroyed()) return
-      const level = clampZoomLevel(Number(stored))
-      window.webContents.setZoomLevel(level)
+      const state = normalizeZoomState(stored)
+      if (!state) return
+      writePersistedZoomLevel(state.level)
+      window.webContents.setZoomLevel(state.level)
     })
-    .catch(error => rememberLog(`[zoom] restore failed: ${error?.message || error}`))
+    .catch(error => rememberLog(`[zoom] localStorage restore failed: ${error?.message || error}`))
 }
 
 function installZoomShortcuts(window) {
   // Override Ctrl/Cmd + +/-/0 with half the default zoom step (0.1 vs 0.2).
-  // The menu items handle this on macOS (where the menu is always present),
-  // but on Linux/Windows the menu is null and Chromium's default handler
-  // would use the full 0.2 step, so we intercept here for consistency.
+  // Cmd++ often arrives as Cmd+Shift+= on macOS keyboard layouts; handle that
+  // explicitly so Chromium's transient default zoom path cannot bypass persist.
   const ZOOM_STEP = 0.1
   window.webContents.on('before-input-event', (event, input) => {
-    const mod = IS_MAC ? input.meta : input.control
-    if (!mod || input.alt || input.shift) return
+    const action = shouldHandleZoomShortcut(input, IS_MAC)
+    if (!action) return
 
-    const key = input.key
-    if (key === '0') {
-      event.preventDefault()
+    event.preventDefault()
+    if (action === 'reset') {
       setAndPersistZoomLevel(window, 0)
-    } else if (key === '=' || key === '+') {
-      event.preventDefault()
+    } else if (action === 'in') {
       setAndPersistZoomLevel(window, window.webContents.getZoomLevel() + ZOOM_STEP)
-    } else if (key === '-') {
-      event.preventDefault()
+    } else if (action === 'out') {
       setAndPersistZoomLevel(window, window.webContents.getZoomLevel() - ZOOM_STEP)
     }
   })

--- a/apps/desktop/electron/zoom-state.cjs
+++ b/apps/desktop/electron/zoom-state.cjs
@@ -1,0 +1,89 @@
+'use strict'
+
+const ZOOM_STORAGE_KEY = 'hermes:desktop:zoomLevel'
+const ZOOM_STATE_FILE_NAME = 'ui-zoom.json'
+const MIN_ZOOM_LEVEL = -9
+const MAX_ZOOM_LEVEL = 9
+const DEFAULT_ZOOM_LEVEL = 0
+
+function finiteNumber(value) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+function clampZoomLevel(value) {
+  const number = finiteNumber(value)
+  if (number == null) return DEFAULT_ZOOM_LEVEL
+  return Math.min(Math.max(number, MIN_ZOOM_LEVEL), MAX_ZOOM_LEVEL)
+}
+
+function zoomLevelToFactor(level) {
+  return Math.pow(1.2, clampZoomLevel(level))
+}
+
+function zoomFactorToLevel(factor) {
+  const number = finiteNumber(factor)
+  if (number == null || number <= 0) return DEFAULT_ZOOM_LEVEL
+  return clampZoomLevel(Math.log(number) / Math.log(1.2))
+}
+
+function normalizeZoomState(raw) {
+  if (raw == null) return null
+
+  if (typeof raw === 'number' || typeof raw === 'string') {
+    const level = finiteNumber(raw)
+    return level == null ? null : serializeZoomState(level)
+  }
+
+  if (typeof raw !== 'object') return null
+
+  const level = finiteNumber(raw.level ?? raw.zoomLevel)
+  if (level != null) return serializeZoomState(level)
+
+  const factor = finiteNumber(raw.factor ?? raw.zoomFactor)
+  if (factor != null && factor > 0) return serializeZoomState(zoomFactorToLevel(factor))
+
+  const percent = finiteNumber(raw.percent ?? raw.zoomPercent)
+  if (percent != null && percent > 0) return serializeZoomState(zoomFactorToLevel(percent / 100))
+
+  return null
+}
+
+function serializeZoomState(level) {
+  const nextLevel = clampZoomLevel(level)
+  const factor = zoomLevelToFactor(nextLevel)
+  return {
+    version: 1,
+    level: Number(nextLevel.toFixed(4)),
+    factor: Number(factor.toFixed(4)),
+    percent: Math.round(factor * 100)
+  }
+}
+
+function shouldHandleZoomShortcut(input, isMac) {
+  if (!input || input.type === 'keyUp') return false
+
+  const mod = isMac ? input.meta : input.control
+  if (!mod || input.alt) return false
+
+  const key = String(input.key || '')
+  if (key === '0') return !input.shift ? 'reset' : false
+  if (key === '-' || key === '_') return 'out'
+  if (key === '=' || key === '+') return 'in'
+
+  return false
+}
+
+module.exports = {
+  DEFAULT_ZOOM_LEVEL,
+  MAX_ZOOM_LEVEL,
+  MIN_ZOOM_LEVEL,
+  ZOOM_STATE_FILE_NAME,
+  ZOOM_STORAGE_KEY,
+  clampZoomLevel,
+  normalizeZoomState,
+  serializeZoomState,
+  shouldHandleZoomShortcut,
+  zoomFactorToLevel,
+  zoomLevelToFactor
+}

--- a/apps/desktop/electron/zoom-state.test.cjs
+++ b/apps/desktop/electron/zoom-state.test.cjs
@@ -1,0 +1,50 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  clampZoomLevel,
+  normalizeZoomState,
+  serializeZoomState,
+  shouldHandleZoomShortcut,
+  zoomFactorToLevel,
+  zoomLevelToFactor
+} = require('./zoom-state.cjs')
+
+test('clampZoomLevel accepts finite numbers and clamps Electron bounds', () => {
+  assert.equal(clampZoomLevel(0.5), 0.5)
+  assert.equal(clampZoomLevel(999), 9)
+  assert.equal(clampZoomLevel(-999), -9)
+  assert.equal(clampZoomLevel('nope'), 0)
+})
+
+test('zoom factor conversion round-trips practical UI scales', () => {
+  const level = zoomFactorToLevel(1.5)
+  assert.equal(Math.round(zoomLevelToFactor(level) * 100), 150)
+})
+
+test('normalizeZoomState reads current level schema', () => {
+  assert.deepEqual(normalizeZoomState({ level: 0.5 }), serializeZoomState(0.5))
+})
+
+test('normalizeZoomState migrates old factor and percent schemas', () => {
+  assert.equal(normalizeZoomState({ factor: 1.5 }).percent, 150)
+  assert.equal(normalizeZoomState({ percent: 150 }).percent, 150)
+})
+
+test('normalizeZoomState tolerates localStorage string level fallback', () => {
+  assert.deepEqual(normalizeZoomState('0.25'), serializeZoomState(0.25))
+  assert.equal(normalizeZoomState('wat'), null)
+})
+
+test('shouldHandleZoomShortcut catches Cmd/Ctrl plus even when + requires Shift', () => {
+  assert.equal(shouldHandleZoomShortcut({ meta: true, key: '=', shift: true }, true), 'in')
+  assert.equal(shouldHandleZoomShortcut({ meta: true, key: '+', shift: true }, true), 'in')
+  assert.equal(shouldHandleZoomShortcut({ control: true, key: '=' }, false), 'in')
+})
+
+test('shouldHandleZoomShortcut distinguishes reset/out and ignores alt/plain input', () => {
+  assert.equal(shouldHandleZoomShortcut({ meta: true, key: '0' }, true), 'reset')
+  assert.equal(shouldHandleZoomShortcut({ meta: true, key: '-' }, true), 'out')
+  assert.equal(shouldHandleZoomShortcut({ meta: true, alt: true, key: '=' }, true), false)
+  assert.equal(shouldHandleZoomShortcut({ key: '=' }, true), false)
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/zoom-state.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary
- persist Electron zoom level in the main-process userData directory via `ui-zoom.json`
- migrate existing localStorage/factor/percent zoom state into the new schema
- handle Cmd/Ctrl +/-/0 shortcuts in main process so zoom changes are saved consistently

## Tests
- `PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH" node --test electron/zoom-state.test.cjs`
- `PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH" npm run test:desktop:platforms`
- `PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH" npm exec -- eslint electron/main.cjs electron/zoom-state.cjs electron/zoom-state.test.cjs --quiet`

Note: full `npm run lint -- --quiet` currently fails on unrelated pre-existing sort/curly issues in `src/` files.
