### PR TITLE
fix(gateway): select macOS launchd domain from manager

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3067,12 +3067,35 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
+def _launchd_manager_name() -> str | None:
+    """Return launchd's current manager name when available (Aqua, Background, etc.)."""
+    try:
+        proc = subprocess.Popen(
+            ["launchctl", "managername"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        stdout, _ = proc.communicate(timeout=10)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    manager = stdout.strip()
+    return manager or None
+
+
 def _launchd_domain() -> str:
-    # The `user/<uid>` domain (vs the older `gui/<uid>`) is reachable from
-    # non-Aqua/background sessions (SSH, headless, login items) and is the only
-    # one that supports service management on macOS 26+. `gui/<uid>` returns
-    # error 125 ("Domain does not support specified action") there. See #23387.
-    return f"user/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    # LaunchAgents installed from an interactive macOS login session live in
+    # gui/<uid>. Background/non-Aqua sessions on macOS 26+ need user/<uid>.
+    # Pick from the live launchd manager instead of hardcoding either side;
+    # hardcoding user/<uid> broke Aqua upgrades where the existing gateway was
+    # still loaded under gui/<uid> (#40831, #42524), while hardcoding gui/<uid>
+    # breaks the non-Aqua case fixed by #40581.
+    uid = os.getuid()  # windows-footgun: ok — POSIX launchd helper, never invoked on Windows
+    if _launchd_manager_name() == "Aqua":
+        return f"gui/{uid}"
+    return f"user/{uid}"
 
 
 # On macOS, exit code 125 ("Domain does not support specified action") and

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -679,9 +679,34 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
-    def test_launchd_domain_uses_user_domain(self):
-        # The user/<uid> domain (not gui/<uid>) is the one reachable from
-        # non-Aqua/background sessions on macOS 26+ (issue #23387).
+    def test_launchd_domain_uses_gui_domain_in_aqua_session(self, monkeypatch):
+        class FakePopen:
+            returncode = 0
+
+            def communicate(self, timeout=None):
+                return "Aqua\n", ""
+
+        monkeypatch.setattr(gateway_cli.subprocess, "Popen", lambda *args, **kwargs: FakePopen())
+
+        assert gateway_cli._launchd_domain() == f"gui/{os.getuid()}"
+
+    def test_launchd_domain_uses_user_domain_outside_aqua(self, monkeypatch):
+        class FakePopen:
+            returncode = 0
+
+            def communicate(self, timeout=None):
+                return "Background\n", ""
+
+        monkeypatch.setattr(gateway_cli.subprocess, "Popen", lambda *args, **kwargs: FakePopen())
+
+        assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
+
+    def test_launchd_domain_defaults_to_user_when_manager_unknown(self, monkeypatch):
+        def fake_popen(*args, **kwargs):
+            raise FileNotFoundError("launchctl")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "Popen", fake_popen)
+
         assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
 
     def test_launchctl_domain_unsupported_recognizes_macos26_codes(self):


### PR DESCRIPTION
## What does this PR do?

Fixes macOS gateway service management in Aqua login sessions after #40581 changed launchd operations to always target `user/<uid>`.

`user/<uid>` is correct for non-Aqua/background launchd managers, but Aqua LaunchAgents are commonly loaded under `gui/<uid>`. On those hosts, `hermes gateway start` / `restart` / `stop` looks in the wrong domain, reports the service as unloaded, then tries to bootstrap into `user/<uid>` and can hit `launchctl` exit 5 before falling back to an unsupervised detached process.

This PR selects the launchd domain from the live manager name:

- `launchctl managername == Aqua` → `gui/<uid>`
- any other/unknown manager → `user/<uid>`

That preserves the non-Aqua macOS 26 behavior from #40581 while restoring Aqua-session management.

## Related Issue

Fixes #40831
Refs #42524

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/gateway.py`
  - Add `_launchd_manager_name()` helper.
  - Make `_launchd_domain()` choose `gui/<uid>` for Aqua managers and `user/<uid>` otherwise.
- `tests/hermes_cli/test_gateway_service.py`
  - Replace the hardcoded `user/<uid>` regression test with coverage for Aqua, non-Aqua, and unknown-manager fallback.

## How to Test

1. On a macOS Aqua session:
   ```bash
   launchctl managername
   # Aqua
   ```
2. Verify the helper selects the existing Aqua LaunchAgent domain:
   ```bash
   uv run python - <<'PY'
   import hermes_cli.gateway as g
   print(g._launchd_manager_name())
   print(g._launchd_domain())
   PY
   # Aqua
   # gui/501
   ```
3. Run focused regression tests:
   ```bash
   uv run --with pytest --with pytest-xdist --with pyyaml \
     python -m pytest tests/hermes_cli/test_gateway_service.py \
     -k 'launchd_domain or launchd_start_reloads or launchd_restart or launchd_stop or launchd_install_falls_back' \
     -q -o 'addopts='
   ```

Result:

```text
15 passed, 132 deselected in 0.49s
```

Also ran:

```bash
git diff --check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Aqua manager

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

From a macOS Aqua host before the fix, `hermes gateway restart` targeted `user/501` even though the LaunchAgent was loaded under `gui/501`, leading to `Could not find service`, `Bootstrap failed: 5: Input/output error`, and detached fallback.

With the branch checked out locally:

```text
manager Aqua
domain gui/501
```
