### PR TITLE
feat(terminal): auto-rewrite bare commands to rtk equivalents

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2065,6 +2065,20 @@ def terminal_tool(
                     "status": "blocked"
                 }, ensure_ascii=False)
 
+        # Rewrite bare commands (find, grep, cat, ls, …) to their rtk equivalents
+        # so token-heavy output is automatically filtered regardless of whether the
+        # model remembered to prefix with rtk.
+        try:
+            import subprocess as _sp
+            _rewritten = _sp.run(
+                ["rtk", "rewrite", command],
+                capture_output=True, text=True, timeout=2,
+            )
+            if _rewritten.returncode == 0 and _rewritten.stdout.strip():
+                command = _rewritten.stdout.strip()
+        except Exception:
+            pass  # rtk not available or timed out — run original command as-is
+
         # Prepare command for execution
         pty_disabled_reason = None
         effective_pty = pty


### PR DESCRIPTION
## Problem

Hermes workers frequently invoke shell commands like `find`, `grep`, `cat`, `ls` without the `rtk` prefix, causing unfiltered, token-heavy output to flood the model context. This happens even when workers know about RTK — under cognitive load or mid-task re-orientation, they skip the prefix.

### Evidence from worker logs (pigwars board, last 24h)

| Command | Bare calls | Notable cost |
|---------|-----------|--------------|
| `find` | 60 | 2× timeout `[exit 124]` at 10s and 15s |
| `ls` | 19 | — |
| `grep` | 13 | — |
| `cat` | 5 | Large Unity YAML files read unfiltered |

Examples of costly bare calls:
```bash
find /home/charles -path "*/Pigs/Base/PigAnimController*" ... → 15.3s [exit 124]
find /mnt/data /home/charles -name "PigAnimController*"    → 10.4s [exit 124]
find /home/charles -path "*/AnimationViewer3D.cs"          → 19.1s
cat PigAnimController.controller                           → large YAML, unfiltered
```

## Fix

A single 14-line block in `terminal_tool()`, injected just before the command reaches `env.execute()`:

```python
try:
    import subprocess as _sp
    _rewritten = _sp.run(
        ["rtk", "rewrite", command],
        capture_output=True, text=True, timeout=2,
    )
    if _rewritten.returncode == 0 and _rewritten.stdout.strip():
        command = _rewritten.stdout.strip()
except Exception:
    pass  # rtk not available or timed out — run original command as-is
```

`rtk rewrite` is the single source of truth for command rewrites (it already powers the Claude Code `PreToolUse` hook). It exits 0 + prints the rewritten command when a rewrite is possible, exits 1 with no output otherwise — so commands with no RTK equivalent (`python3`, `git`, `blender`, …) are passed through unchanged.

### Rewrite examples

```
find /home -name '*.cs'        → rtk find /home -name '*.cs'
grep -rn foo /mnt/data         → rtk grep -rn foo /mnt/data
cat /tmp/large_file.yaml       → rtk read /tmp/large_file.yaml
ls -la /some/dir               → rtk ls -la /some/dir
cd /foo && find . -name '*.py' → cd /foo && rtk find . -name '*.py'
python3 script.py              → (unchanged, exit 1)
git log --oneline              → rtk git log --oneline
```

## Properties

- **Transparent**: workers don't need to change anything. Commands with no RTK equivalent are untouched.
- **Safe fallback**: the entire block is wrapped in `try/except` — if `rtk` is not installed or times out (2s hard cap), the original command runs as-is.
- **Backend-agnostic**: applies to all terminal backends (local, Docker, SSH, Modal, Singularity) since the rewrite happens in the Python process before the command is handed to the backend.
- **No duplication**: commands already prefixed with `rtk` are passed to `rtk rewrite` too — `rtk rewrite "rtk find ..."` is a no-op (exits 1), so double-wrapping cannot occur.

## Test plan

- [ ] Worker runs `find /home -name '*.py'` — verify it executes as `rtk find` and output is filtered
- [ ] Worker runs `python3 script.py` — verify it passes through unchanged
- [ ] `rtk` binary absent from PATH — verify worker commands still execute normally (no crash)
- [ ] Worker explicitly uses `rtk find` — verify no double-wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)