### PR TITLE
fix: show account limits for persisted usage

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7983,7 +7983,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         which would otherwise early-return before any credits showed.
         """
         if not self.agent:
-            if not self._print_nous_credits_block():
+            shown = self._show_persisted_session_usage()
+            credits_shown = self._print_nous_credits_block()
+            if not shown and not credits_shown:
                 print("(._.) No active agent -- send a message first.")
             return
 
@@ -8103,6 +8105,70 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # into stream-retry events, credential rotations, etc.
             # Console quietness is enforced by hermes_logging not
             # installing a console StreamHandler in non-verbose mode.
+
+    def _show_persisted_session_usage(self) -> bool:
+        """Render persisted session usage when /usage runs without a live agent.
+
+        Desktop/TUI slash commands may run in a worker process that resumes the
+        session but does not construct or share the active ``AIAgent``.  The
+        live-agent path above remains authoritative for context-window details;
+        this fallback shows the best persisted DB snapshot instead of the
+        misleading "No active agent" message after a real turn completed.
+        """
+        session_id = getattr(self, "session_id", None)
+        session_db = getattr(self, "_session_db", None)
+        if not session_id or session_db is None:
+            return False
+        try:
+            row = session_db.get_session(session_id)
+        except Exception:
+            logger.debug("Failed to load persisted usage for session %s", session_id, exc_info=True)
+            return False
+        if not row:
+            return False
+
+        input_tokens = int(row.get("input_tokens") or 0)
+        output_tokens = int(row.get("output_tokens") or 0)
+        cache_read_tokens = int(row.get("cache_read_tokens") or 0)
+        cache_write_tokens = int(row.get("cache_write_tokens") or 0)
+        reasoning_tokens = int(row.get("reasoning_tokens") or 0)
+        calls = int(row.get("api_call_count") or 0)
+        total = input_tokens + output_tokens
+        if calls <= 0 and total <= 0:
+            return False
+
+        model = row.get("model") or getattr(self, "model", None) or "unknown"
+        msg_count = int(row.get("message_count") or len(getattr(self, "conversation_history", []) or []))
+        cost_status = row.get("cost_status")
+        cost_source = row.get("cost_source")
+        actual_cost = row.get("actual_cost_usd")
+        estimated_cost = row.get("estimated_cost_usd")
+
+        print("  📊 Persisted Session Token Usage")
+        print(f"  {'─' * 40}")
+        print(f"  Model:                     {model}")
+        print(f"  Input tokens:              {input_tokens:>10,}")
+        print(f"  Cache read tokens:         {cache_read_tokens:>10,}")
+        print(f"  Cache write tokens:        {cache_write_tokens:>10,}")
+        print(f"  Output tokens:             {output_tokens:>10,}")
+        if reasoning_tokens:
+            print(f"  ↳ Reasoning (subset):      {reasoning_tokens:>10,}")
+        print(f"  Total tokens:              {total:>10,}")
+        print(f"  API calls:                 {calls:>10,}")
+        if cost_status:
+            print(f"  Cost status:              {str(cost_status):>10}")
+        if cost_source:
+            print(f"  Cost source:              {str(cost_source):>10}")
+        if actual_cost is not None:
+            print(f"  Total cost:               ${float(actual_cost):>10.4f}")
+        elif estimated_cost is not None:
+            print(f"  Total cost:              ~${float(estimated_cost):>10.4f}")
+        else:
+            print(f"  Total cost:              {'n/a':>10}")
+        print(f"  {'─' * 40}")
+        print(f"  Messages:         {msg_count}")
+        print("  Note:             persisted DB snapshot; live context details unavailable")
+        return True
 
     def _print_nous_credits_block(self) -> bool:
         """Print the Nous credits magnitudes + monthly-grant gauge when a Nous account

--- a/cli.py
+++ b/cli.py
@@ -7984,8 +7984,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """
         if not self.agent:
             shown = self._show_persisted_session_usage()
+            limits_shown = self._print_account_limits()
             credits_shown = self._print_nous_credits_block()
-            if not shown and not credits_shown:
+            if not shown and not limits_shown and not credits_shown:
                 print("(._.) No active agent -- send a message first.")
             return
 
@@ -8067,26 +8068,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Account limits -- fetched off-thread with a hard timeout so slow
         # provider APIs don't hang the prompt.
-        provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
-        base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
-        api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
-        # Lazy import — pulls the OpenAI SDK chain, only needed here.
-        from agent.account_usage import fetch_account_usage, render_account_usage_lines
-        account_snapshot = None
-        if provider:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
-                try:
-                    account_snapshot = _pool.submit(
-                        fetch_account_usage, provider,
-                        base_url=base_url, api_key=api_key,
-                    ).result(timeout=10.0)
-                except (concurrent.futures.TimeoutError, Exception):
-                    account_snapshot = None
-        account_lines = [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
-        if account_lines:
-            print()
-            for line in account_lines:
-                print(line)
+        self._print_account_limits(
+            provider=getattr(agent, "provider", None) or getattr(self, "provider", None),
+            base_url=getattr(agent, "base_url", None) or getattr(self, "base_url", None),
+            api_key=getattr(agent, "api_key", None) or getattr(self, "api_key", None),
+        )
 
         # Nous credits magnitudes + monthly-grant gauge (agent-independent — also
         # runs at the no-agent / no-calls early-returns above). See the helper.
@@ -8106,6 +8092,71 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # Console quietness is enforced by hermes_logging not
             # installing a console StreamHandler in non-verbose mode.
 
+    def _persisted_usage_session_row(self) -> Optional[Dict[str, Any]]:
+        session_id = getattr(self, "session_id", None)
+        session_db = getattr(self, "_session_db", None)
+        if not session_id or session_db is None:
+            return None
+        try:
+            row = session_db.get_session(session_id)
+        except Exception:
+            logger.debug("Failed to load persisted usage for session %s", session_id, exc_info=True)
+            return None
+        return row or None
+
+    def _usage_account_provider_from_row(self, row: Optional[Dict[str, Any]]) -> Optional[str]:
+        candidates = [
+            getattr(self, "provider", None),
+            getattr(self, "requested_provider", None),
+            (row or {}).get("billing_provider") if isinstance(row, dict) else None,
+            CLI_CONFIG.get("model", {}).get("provider") if isinstance(CLI_CONFIG.get("model"), dict) else None,
+        ]
+        model = str((row or {}).get("model") or getattr(self, "model", "") or "").lower()
+        if "codex" in model or model.startswith("gpt-5"):
+            candidates.append("openai-codex")
+        for provider in candidates:
+            provider_str = str(provider or "").strip()
+            if provider_str and provider_str.lower() not in {"auto", "custom"}:
+                return provider_str
+        return None
+
+    def _print_account_limits(
+        self,
+        provider: Optional[str] = None,
+        *,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ) -> bool:
+        """Print provider account limits for /usage without requiring a live agent."""
+        row = None
+        if not provider:
+            row = self._persisted_usage_session_row()
+            provider = self._usage_account_provider_from_row(row)
+        if not provider or str(provider).strip().lower() in {"auto", "custom"}:
+            return False
+
+        # Lazy import — pulls the OpenAI SDK chain, only needed here.
+        from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+        account_snapshot = None
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
+            try:
+                account_snapshot = _pool.submit(
+                    fetch_account_usage,
+                    provider,
+                    base_url=base_url if base_url is not None else getattr(self, "base_url", None),
+                    api_key=api_key if api_key is not None else getattr(self, "api_key", None),
+                ).result(timeout=10.0)
+            except (concurrent.futures.TimeoutError, Exception):
+                account_snapshot = None
+        account_lines = [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
+        if not account_lines:
+            return False
+        print()
+        for line in account_lines:
+            print(line)
+        return True
+
     def _show_persisted_session_usage(self) -> bool:
         """Render persisted session usage when /usage runs without a live agent.
 
@@ -8115,15 +8166,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         this fallback shows the best persisted DB snapshot instead of the
         misleading "No active agent" message after a real turn completed.
         """
-        session_id = getattr(self, "session_id", None)
-        session_db = getattr(self, "_session_db", None)
-        if not session_id or session_db is None:
-            return False
-        try:
-            row = session_db.get_session(session_id)
-        except Exception:
-            logger.debug("Failed to load persisted usage for session %s", session_id, exc_info=True)
-            return False
+        row = self._persisted_usage_session_row()
         if not row:
             return False
 

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -607,6 +607,7 @@ class TestCLIUsageReport:
             }
         )
         cli_obj._print_nous_credits_block = lambda: False
+        cli_obj._print_account_limits = lambda: False
 
         cli_obj._show_usage()
         output = capsys.readouterr().out
@@ -632,12 +633,74 @@ class TestCLIUsageReport:
             }
         )
         cli_obj._print_nous_credits_block = lambda: False
+        cli_obj._print_account_limits = lambda: False
 
         cli_obj._show_usage()
         output = capsys.readouterr().out
 
         assert "No active agent -- send a message first" in output
         assert "Persisted Session Token Usage" not in output
+
+    def test_show_usage_without_live_agent_prints_account_limits(self, capsys, monkeypatch):
+        cli_obj = _make_cli(model="gpt-5.5")
+        cli_obj.provider = "openai-codex"
+        cli_obj.base_url = None
+        cli_obj.api_key = None
+        cli_obj.session_id = "session-usage-limits"
+        cli_obj._session_db = SimpleNamespace(
+            get_session=lambda session_id: {
+                "id": session_id,
+                "model": "gpt-5.5",
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "api_call_count": 1,
+                "message_count": 2,
+            }
+        )
+        cli_obj._print_nous_credits_block = lambda: False
+        monkeypatch.setattr(
+            "agent.account_usage.fetch_account_usage",
+            lambda provider, **kwargs: SimpleNamespace(provider=provider),
+        )
+        monkeypatch.setattr(
+            "agent.account_usage.render_account_usage_lines",
+            lambda snapshot: [
+                "Account limits",
+                "Provider: openai-codex",
+                "Weekly: 80% remaining (20% used) • resets Jun 10 12:00 UTC",
+            ],
+        )
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "Persisted Session Token Usage" in output
+        assert "Account limits" in output
+        assert "Provider: openai-codex" in output
+        assert "resets Jun 10" in output
+        assert "No active agent" not in output
+
+    def test_show_usage_without_live_agent_skips_missing_account_limits(self, capsys, monkeypatch):
+        cli_obj = _make_cli(model="gpt-5.5")
+        cli_obj.provider = "openai-codex"
+        cli_obj.session_id = "empty-session"
+        cli_obj._session_db = SimpleNamespace(
+            get_session=lambda session_id: {
+                "id": session_id,
+                "model": "gpt-5.5",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "api_call_count": 0,
+            }
+        )
+        cli_obj._print_nous_credits_block = lambda: False
+        monkeypatch.setattr("agent.account_usage.fetch_account_usage", lambda provider, **kwargs: None)
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "No active agent -- send a message first" in output
+        assert "Account limits" not in output
 
 
 class TestStatusBarWidthSource:

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -586,6 +586,59 @@ class TestCLIUsageReport:
         assert "n/a" in output
         assert "Pricing unknown for glm-5" in output
 
+    def test_show_usage_without_live_agent_uses_persisted_session_snapshot(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-usage-fallback"
+        cli_obj._session_db = SimpleNamespace(
+            get_session=lambda session_id: {
+                "id": session_id,
+                "model": "gpt-5.5",
+                "input_tokens": 1234,
+                "output_tokens": 567,
+                "cache_read_tokens": 100,
+                "cache_write_tokens": 25,
+                "reasoning_tokens": 42,
+                "api_call_count": 3,
+                "message_count": 6,
+                "estimated_cost_usd": 0.0123,
+                "actual_cost_usd": None,
+                "cost_status": "estimated",
+                "cost_source": "pricing",
+            }
+        )
+        cli_obj._print_nous_credits_block = lambda: False
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "Persisted Session Token Usage" in output
+        assert "No active agent" not in output
+        assert "gpt-5.5" in output
+        assert "1,234" in output
+        assert "567" in output
+        assert "API calls:" in output
+        assert "3" in output
+        assert "persisted DB snapshot" in output
+
+    def test_show_usage_without_live_agent_keeps_no_agent_message_when_no_snapshot(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "empty-session"
+        cli_obj._session_db = SimpleNamespace(
+            get_session=lambda session_id: {
+                "id": session_id,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "api_call_count": 0,
+            }
+        )
+        cli_obj._print_nous_credits_block = lambda: False
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "No active agent -- send a message first" in output
+        assert "Persisted Session Token Usage" not in output
+
 
 class TestStatusBarWidthSource:
     """Ensure status bar fragments don't overflow the terminal width."""


### PR DESCRIPTION
## Summary
- follow-up to #42772: Desktop/TUI `/usage` no-live-agent fallback now also prints provider Account limits
- extracts live `/usage` account-limit fetch/render into a shared `_print_account_limits()` helper
- keeps the provider API fetch off-thread with the existing 10s timeout behavior
- infers provider from live agent, CLI state/config, persisted billing provider, or Codex-like model names when no live agent exists

Fixes #42904.
Related to #42772.

## Notes
This branch is stacked on the current #42772 fallback commit because #42772 is still open. If #42772 merges first, this follow-up can be rebased down to just `fb9b95208`.

## Test Plan
- `uv run --with pytest python -m pytest tests/cli/test_cli_status_bar.py -q -o 'addopts='` (41 passed)
