### PR TITLE
Defensive think-tag scrubber in stream consumer (think msg leak)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -461,11 +461,18 @@ def strip_think_blocks(agent, content: str) -> str:
       3. Stray orphan open/close tags that slip through.
       4. Tag variants: any tag whose name contains one of the keywords
          ``think``, ``thinking``, ``reasoning``, ``thought``, or
-         ``REASONING_SCRATCHPAD`` as a substring, case-insensitive.
-         This covers canonical tags (``<think>``, ``<thinking>``, …) and
-         model-name-prefixed/suffixed forms such as ``<M2_7think>``,
-         ``<M2_7_thinking>``, ``<M2_7reasoning>``, ``<deepseek_thought>``
-         (Jun 9 2026 "/think msg issue").
+         ``REASONING_SCRATCHPAD`` AS A DISTINCT TAG-NAME COMPONENT,
+         case-insensitive.  The keyword must be at the start of the tag,
+         or immediately preceded by a non-letter character (digit,
+         underscore, dash, ``/`` for closing tags, …), AND immediately
+         followed by a word boundary.  This covers canonical tags
+         (``<think>``, ``<thinking>``, …) and model-name-prefixed/
+         suffixed forms such as ``<M2_7think>``, ``<M2_7_thinking>``,
+         ``<M2_7reasoning>``, ``<deepseek_thought>`` while excluding
+         false positives like ``<overthink>``, ``<mythinking>``,
+         ``<rethink>``, ``<doublethink>`` where ``think`` is embedded
+         inside a regular English word (Jun 9 2026 "/think msg issue";
+         refined after maintainer review).
 
     Additionally strips standalone tool-call XML blocks that some open
     models (notably Gemma variants on OpenRouter) emit inside assistant
@@ -490,9 +497,18 @@ def strip_think_blocks(agent, content: str) -> str:
     #    the open tag (e.g. <M2_7think>…</think> is intentionally matched).
     #    Jun 9 2026: added to fix the "/think msg issue" where prefixed tags
     #    leaked raw reasoning to the user.
+    #    The keyword is anchored as a distinct tag-name component
+    #    (preceded by start-of-tag or a non-letter, followed by \b) so we
+    #    do not match <overthink>, <mythinking>, <rethink>, etc.  See
+    #    docstring point 4.
     _THINK_KW = r'(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)'
+    # Tag-name component: optional prefix that ends in a non-letter
+    # (digit/underscore/dash, etc. — the kinds of chars that appear in
+    # model prefixes like "M2_7", "deepseek_"), then the keyword, then
+    # a word boundary so "think" in "thinkx" is not treated as a tag.
+    _THINK_TAG_BODY = rf'(?:[^>]*[^A-Za-z>])?{_THINK_KW}\b'
     content = re.sub(
-        rf'<[^>]*{_THINK_KW}[^>]*>.*?</[^>]*{_THINK_KW}[^>]*>',
+        rf'<{_THINK_TAG_BODY}[^>]*>.*?</{_THINK_TAG_BODY}[^>]*>',
         '',
         content,
         flags=re.DOTALL | re.IGNORECASE,
@@ -525,17 +541,18 @@ def strip_think_blocks(agent, content: str) -> str:
     #    (start of text, or after a newline) with no matching close.
     #    Strip from the tag to end of string.  Fixes #8878 / #9568
     #    (MiniMax M2.7 leaking raw reasoning into assistant content).
-    #    Tag-name is permissive (keyword-as-substring) per Jun 9 2026 fix.
+    #    Tag-name is anchored as a distinct component (see _THINK_TAG_BODY)
+    #    so <overthink>x</overthink>-style false positives are not matched.
     content = re.sub(
-        rf'(?:^|\n)[ \t]*<[^>]*{_THINK_KW}[^>]*\b[^>]*>.*$',
+        rf'(?:^|\n)[ \t]*<{_THINK_TAG_BODY}[^>]*>.*$',
         '',
         content,
         flags=re.DOTALL | re.IGNORECASE,
     )
     # 3. Stray orphan open/close tags that slipped through.
-    #    Tag-name is permissive (keyword-as-substring) per Jun 9 2026 fix.
+    #    Tag-name is anchored as a distinct component (see _THINK_TAG_BODY).
     content = re.sub(
-        rf'</?[^>]*{_THINK_KW}[^>]*>\s*',
+        rf'</?{_THINK_TAG_BODY}[^>]*>\s*',
         '',
         content,
         flags=re.IGNORECASE,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -459,9 +459,13 @@ def strip_think_blocks(agent, content: str) -> str:
          ``gateway/stream_consumer.py``'s filter so models that mention
          ``<think>`` in prose aren't over-stripped.
       3. Stray orphan open/close tags that slip through.
-      4. Tag variants: ``<think>``, ``<thinking>``, ``<reasoning>``,
-         ``<REASONING_SCRATCHPAD>``, ``<thought>`` (Gemma 4), all
-         case-insensitive.
+      4. Tag variants: any tag whose name contains one of the keywords
+         ``think``, ``thinking``, ``reasoning``, ``thought``, or
+         ``REASONING_SCRATCHPAD`` as a substring, case-insensitive.
+         This covers canonical tags (``<think>``, ``<thinking>``, …) and
+         model-name-prefixed/suffixed forms such as ``<M2_7think>``,
+         ``<M2_7_thinking>``, ``<M2_7reasoning>``, ``<deepseek_thought>``
+         (Jun 9 2026 "/think msg issue").
 
     Additionally strips standalone tool-call XML blocks that some open
     models (notably Gemma variants on OpenRouter) emit inside assistant
@@ -479,14 +483,20 @@ def strip_think_blocks(agent, content: str) -> str:
     """
     if not content:
         return ""
-    # 1. Closed tag pairs — case-insensitive for all variants so
-    #    mixed-case tags (<THINK>, <Thinking>) don't slip through to
-    #    the unterminated-tag pass and take trailing content with them.
-    content = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thinking>.*?</thinking>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
+    # 1. Closed tag pairs — permissive tag-name matching so model-name
+    #    prefixed/suffixed variants (e.g. <M2_7think>, <deepseek_thought>)
+    #    are caught.  Both the open and close tag must contain the same
+    #    keyword as a substring; the close tag need not be identical to
+    #    the open tag (e.g. <M2_7think>…</think> is intentionally matched).
+    #    Jun 9 2026: added to fix the "/think msg issue" where prefixed tags
+    #    leaked raw reasoning to the user.
+    _THINK_KW = r'(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)'
+    content = re.sub(
+        rf'<[^>]*{_THINK_KW}[^>]*>.*?</[^>]*{_THINK_KW}[^>]*>',
+        '',
+        content,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
     # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
     #     generic tag names first — they have no attribute gating since
     #     a literal <tool_call> in prose is already vanishingly rare.
@@ -515,15 +525,17 @@ def strip_think_blocks(agent, content: str) -> str:
     #    (start of text, or after a newline) with no matching close.
     #    Strip from the tag to end of string.  Fixes #8878 / #9568
     #    (MiniMax M2.7 leaking raw reasoning into assistant content).
+    #    Tag-name is permissive (keyword-as-substring) per Jun 9 2026 fix.
     content = re.sub(
-        r'(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$',
+        rf'(?:^|\n)[ \t]*<[^>]*{_THINK_KW}[^>]*\b[^>]*>.*$',
         '',
         content,
         flags=re.DOTALL | re.IGNORECASE,
     )
     # 3. Stray orphan open/close tags that slipped through.
+    #    Tag-name is permissive (keyword-as-substring) per Jun 9 2026 fix.
     content = re.sub(
-        r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*',
+        rf'</?[^>]*{_THINK_KW}[^>]*>\s*',
         '',
         content,
         flags=re.IGNORECASE,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -47,6 +47,55 @@ _NEW_SEGMENT = object()
 _COMMENTARY = object()
 
 
+# ── Defensive think-tag scrubber ─────────────────────────────────────────
+# Jun 9 2026: added to plug the /think msg leak.  The stateful scrubber
+# upstream (_filter_and_accumulate) and the agent-level strip_think_blocks
+# both have hardcoded tag lists that miss model-name-prefixed variants
+# (e.g. </M2_7think>, </deepseek_thought>) — and the orphan-pass regex
+# requires trailing whitespace, so an orphan close glued to surrounding
+# text slips through.  This module-level scrubber runs on the *visible*
+# text right before each platform send, catches anything tag-shaped that
+# the upstream paths missed, and is idempotent.
+_THINK_KW = r'(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)'
+_THINK_CLOSED_PAIR_RE = re.compile(
+    rf'<[^>]*{_THINK_KW}[^>]*>.*?</[^>]*{_THINK_KW}[^>]*>',
+    re.DOTALL | re.IGNORECASE,
+)
+_THINK_TAG_RE = re.compile(
+    rf'<[^>]*{_THINK_KW}[^>]*>',
+    re.IGNORECASE,
+)
+
+
+def scrub_thinking_tags_in_prose(text: str) -> str:
+    """Remove any residual think-tag characters from user-visible prose.
+
+    Defensive safety-net pass: runs AFTER all upstream stateful scrubbing
+    and the agent-level strip_think_blocks.  Catches three classes of leak:
+
+      1. Model-prefixed tag variants the hardcoded tag lists miss
+         (e.g. </M2_7think>, </deepseek_thought>).
+      2. Orphan close tags attached to surrounding text without trailing
+         whitespace (the upstream orphan-pass regex requires ``\\s*``).
+      3. Anything else that ends up looking like a think-tag in the
+         final visible text, regardless of why.
+
+    The pattern is intentionally permissive — any tag whose name
+    contains a known reasoning keyword as a substring, case-insensitive —
+    and runs without block-boundary checks.  False positives (a model
+    legitimately using ``<thinkful>``-style names in prose) are vastly
+    less harmful than false negatives (a literal think-tag close
+    leaking raw reasoning to the user).
+
+    Idempotent: running twice produces the same output as running once.
+    """
+    if not text:
+        return ""
+    text = _THINK_CLOSED_PAIR_RE.sub("", text)
+    text = _THINK_TAG_RE.sub("", text)
+    return text
+
+
 @dataclass
 class StreamConsumerConfig:
     """Runtime config for a single stream consumer instance."""
@@ -701,6 +750,8 @@ class GatewayStreamConsumer:
         Returns the message_id so callers can thread subsequent chunks.
         """
         text = self._clean_for_display(text)
+        # Defensive think-tag scrub — see scrub_thinking_tags_in_prose.
+        text = scrub_thinking_tags_in_prose(text)
         if not text.strip():
             return reply_to_id
         try:
@@ -767,6 +818,8 @@ class GatewayStreamConsumer:
         Retries each chunk once on flood-control failures with a short delay.
         """
         final_text = self._clean_for_display(text)
+        # Defensive think-tag scrub — see scrub_thinking_tags_in_prose.
+        final_text = scrub_thinking_tags_in_prose(final_text)
         continuation = self._continuation_text(final_text)
         self._fallback_final_send = False
         if not continuation.strip():
@@ -1154,6 +1207,10 @@ class GatewayStreamConsumer:
         # Media files are delivered as native attachments after the stream
         # finishes (via _deliver_media_from_response in gateway/run.py).
         text = self._clean_for_display(text)
+        # Defensive: scrub any think-tag characters the upstream scrubbers
+        # missed (model-prefixed variants, orphan closes glued to text, …).
+        # Jun 9 2026 — see scrub_thinking_tags_in_prose docstring.
+        text = scrub_thinking_tags_in_prose(text)
         # A bare streaming cursor is not meaningful user-visible content and
         # can render as a stray tofu/white-box message on some clients.
         visible_without_cursor = text

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -57,12 +57,19 @@ _COMMENTARY = object()
 # text right before each platform send, catches anything tag-shaped that
 # the upstream paths missed, and is idempotent.
 _THINK_KW = r'(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)'
+# Tag-name component: optional prefix that ends in a non-letter
+# (digit/underscore/dash, etc. — the kinds of chars that appear in model
+# prefixes like "M2_7", "deepseek_"), then the keyword, then a word
+# boundary so "think" in "thinkx" is not treated as a tag.  Same anchor
+# as agent/agent_runtime_helpers.py:strip_think_blocks so the two
+# scrubbers agree on what counts as a think-tag.
+_THINK_TAG_BODY = rf'(?:[^>]*[^A-Za-z>])?{_THINK_KW}\b'
 _THINK_CLOSED_PAIR_RE = re.compile(
-    rf'<[^>]*{_THINK_KW}[^>]*>.*?</[^>]*{_THINK_KW}[^>]*>',
+    rf'<{_THINK_TAG_BODY}[^>]*>.*?</{_THINK_TAG_BODY}[^>]*>',
     re.DOTALL | re.IGNORECASE,
 )
 _THINK_TAG_RE = re.compile(
-    rf'<[^>]*{_THINK_KW}[^>]*>',
+    rf'<{_THINK_TAG_BODY}[^>]*>',
     re.IGNORECASE,
 )
 
@@ -80,12 +87,15 @@ def scrub_thinking_tags_in_prose(text: str) -> str:
       3. Anything else that ends up looking like a think-tag in the
          final visible text, regardless of why.
 
-    The pattern is intentionally permissive — any tag whose name
-    contains a known reasoning keyword as a substring, case-insensitive —
-    and runs without block-boundary checks.  False positives (a model
-    legitimately using ``<thinkful>``-style names in prose) are vastly
-    less harmful than false negatives (a literal think-tag close
-    leaking raw reasoning to the user).
+    The pattern matches any tag whose name contains a known reasoning
+    keyword AS A DISTINCT TAG-NAME COMPONENT (start-of-tag or preceded
+    by a non-letter; followed by a word boundary).  This catches model
+    prefixes like ``<M2_7think>`` and ``<deepseek_thought>`` while
+    excluding English-word substrings like ``<overthink>`` and
+    ``<mythinking>``.  False positives (a model legitimately using a
+    tag like ``<thinkful>`` in prose) are vastly less harmful than
+    false negatives (a literal think-tag close leaking raw reasoning
+    to the user); when in doubt, scrub.
 
     Idempotent: running twice produces the same output as running once.
     """

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -204,6 +204,59 @@ class TestScrubThinkingTagsInProse:
         assert "visible" not in result  # also between two close tags → scrubbed
         assert "more" in result
 
+    # ── Model-prefixed variants with attributes / mixed suffixes ──
+
+    def test_model_prefixed_with_attribute(self):
+        """Model-prefixed tags carrying XML attributes are still stripped.
+
+        The non-letter boundary check accepts a space (between the keyword
+        and the attribute) as a valid separator.
+        """
+        assert scrub_thinking_tags_in_prose(
+            "<" + "M2_7think attr=\"x\">reasoning"
+            + "<" + "/M2_7think>kept"
+        ) == "kept"
+
+    def test_model_prefixed_underscore_keyword_with_attribute(self):
+        assert scrub_thinking_tags_in_prose(
+            "<" + "M2_7_thinking attr=\"x\">reasoning"
+            + "<" + "/M2_7_thinking>kept"
+        ) == "kept"
+
+    # ── Substring-in-English-word tags: must NOT be stripped ──
+    # These tags contain the keyword as a substring inside a real English
+    # word, not as a distinct tag-name component.  The June 9 2026
+    # permissive regex <[^>]*think[^>]*> over-matched these; the
+    # maintainer-requested refinement anchors the keyword to a non-letter
+    # (or start-of-tag) boundary, excluding them.
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "overthink",
+            "mythinking",
+            "rethink",
+            "doublethink",
+            "unthinking",
+            "thinkx",   # keyword followed by a word char → \b fails
+        ],
+    )
+    def test_english_word_substring_preserved(self, tag):
+        """Tags where 'think' is embedded in an English word are kept as-is.
+
+        The reasoning: 'overthink', 'mythinking', 'rethink' etc. are
+        extremely unlikely to be model-prefixed think-tag variants, and
+        stripping them would silently mutilate user-visible prose.
+        """
+        s = f"<{tag}>x</{tag}>visible"
+        # The whole thing should pass through unchanged.
+        assert scrub_thinking_tags_in_prose(s) == s
+
+    def test_english_word_substring_prose_preserved(self):
+        """Prose that mentions 'overthink' etc. is left alone."""
+        s = "Let me <overthink> this for a moment."
+        assert scrub_thinking_tags_in_prose(s) == s
+
 
 # ── Integration: _send_or_edit strips MEDIA: ─────────────────────────────
 

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from gateway.stream_consumer import (
+    GatewayStreamConsumer,
+    StreamConsumerConfig,
+    scrub_thinking_tags_in_prose,
+)
 
 
 # ── _clean_for_display unit tests ────────────────────────────────────────
@@ -83,6 +87,122 @@ class TestCleanForDisplay:
         # "MEDIA:" in upper case without a path won't match \S+ (space follows)
         # But "media:" is lowercase so won't match either
         assert result == text
+
+
+# ── scrub_thinking_tags_in_prose unit tests ──────────────────────────────
+# Jun 9 2026: defensive scrubber for the "/think msg issue" — catches
+# model-prefixed think-tag variants and orphan closes attached to
+# surrounding text without trailing whitespace that the upstream
+# stateful scrubber misses.  See gateway/stream_consumer.py for context.
+
+
+class TestScrubThinkingTagsInProse:
+    """Defensive think-tag scrubber runs on visible text right before send."""
+
+    # ── Model-prefixed variants: the actual bug ──
+
+    def test_model_prefixed_orphan_close_attached(self):
+        """The literal-tag-leak case: orphan close glued to text, no space."""
+        assert scrub_thinking_tags_in_prose(
+            "Hello" + "<" + "/M2_7think>world"
+        ) == "Helloworld"
+
+    def test_model_prefixed_orphan_close_deepseek(self):
+        assert scrub_thinking_tags_in_prose(
+            "Hello" + "<" + "/deepseek_thought>world"
+        ) == "Helloworld"
+
+    def test_model_prefixed_orphan_close_underscore_variant(self):
+        assert scrub_thinking_tags_in_prose(
+            "text" + "<" + "/M2_7_thinking>more"
+        ) == "textmore"
+
+    def test_model_prefixed_closed_pair(self):
+        assert scrub_thinking_tags_in_prose(
+            "<" + "M2_7think>reasoning" + "<" + "/M2_7think>visible"
+        ) == "visible"
+
+    def test_model_prefixed_open_tag_alone(self):
+        """Bare open tag (no close) is also removed."""
+        assert scrub_thinking_tags_in_prose(
+            "before " + "<" + "M2_7think> after"
+        ) == "before  after"
+
+    # ── Canonical (known) tag forms still work ──
+
+    @pytest.mark.parametrize(
+        "tag",
+        ["think", "thinking", "reasoning", "thought", "REASONING_SCRATCHPAD"],
+    )
+    def test_canonical_closed_pair(self, tag):
+        s = f"<{tag}>x</{tag}>Hello"
+        assert scrub_thinking_tags_in_prose(s) == "Hello"
+
+    def test_canonical_orphan_close_attached(self):
+        assert scrub_thinking_tags_in_prose(
+            "Hello" + "<" + "/think>world"
+        ) == "Helloworld"
+
+    # ── Preservation: must NOT touch unrelated text ──
+
+    def test_plain_text_passthrough(self):
+        assert scrub_thinking_tags_in_prose("Hello world!") == "Hello world!"
+
+    def test_comparison_operator_preserved(self):
+        assert scrub_thinking_tags_in_prose("2 < 5 is true") == "2 < 5 is true"
+
+    def test_html_unrelated_tag_preserved(self):
+        assert scrub_thinking_tags_in_prose(
+            "Click <a href='x'>here</a> please"
+        ) == "Click <a href='x'>here</a> please"
+
+    def test_self_closing_div_preserved(self):
+        assert scrub_thinking_tags_in_prose(
+            "Before<br/>after"
+        ) == "Before<br/>after"
+
+    # ── Idempotency & edge cases ──
+
+    def test_idempotent(self):
+        """Running twice produces the same output as running once."""
+        text = "Hello" + "<" + "/M2_7think>world" + "<" + "deepseek_thought>x" + "<" + "/deepseek_thought>plain"
+        once = scrub_thinking_tags_in_prose(text)
+        twice = scrub_thinking_tags_in_prose(once)
+        assert once == twice
+
+    def test_empty_string(self):
+        assert scrub_thinking_tags_in_prose("") == ""
+
+    def test_none_safe(self):
+        # Guards against accidental None leakage from upstream scrub paths.
+        assert scrub_thinking_tags_in_prose("") == ""  # empty string is the safe contract
+
+    def test_case_insensitive(self):
+        s = "<THINK>x</Think>Hello"
+        assert scrub_thinking_tags_in_prose(s) == "Hello"
+
+    def test_mixed_known_and_prefixed_in_one_string(self):
+        """Closed pairs, prefixed pairs, and orphan closes all collapse.
+
+        The text BETWEEN two orphan closes is treated as leaked reasoning
+        and stripped along with the tags — that's the defensive behavior.
+        """
+        s = (
+            "<think>reasoning</think>kept"
+            + "<" + "/M2_7think>leaked"
+            + "visible" + "<" + "/deepseek_thought>more"
+        )
+        result = scrub_thinking_tags_in_prose(s)
+        # All tag-shaped content is gone.
+        assert "<think>" not in result
+        assert "M2_7" not in result
+        assert "deepseek" not in result
+        # The reasoning that leaked between two orphan closes is also gone.
+        assert "leaked" not in result
+        # The visible prose before and after is preserved.
+        assert "kept" in result
+        assert "visible" not in result  # also between two close tags → scrubbed
+        assert "more" in result
 
 
 # ── Integration: _send_or_edit strips MEDIA: ─────────────────────────────


### PR DESCRIPTION
## Problem

The gateway's `GatewayStreamConsumer` and the agent-level `strip_think_blocks` both have hardcoded tag-name lists. Model-name-prefixed think-tag variants (e.g. closing tags like `M2_7think`, `deepseek_thought`, `M2_7_thinking`) and orphan closes attached to surrounding text without trailing whitespace slip through and leak raw reasoning to the user. This is the recurring "/think msg issue" reported on Discord and Telegram since May 2026.

## Root cause

Three places, three drift patterns:

1. `agent/agent_runtime_helpers.py:strip_think_blocks` — orphan-pass regex required trailing whitespace, so an orphan close glued to surrounding text (`Hello` + close-tag + `world`) was not caught.
2. `gateway/stream_consumer.py:_OPEN_THINK_TAGS / _CLOSE_THINK_TAGS` — hardcoded list of 5 names (think, thinking, reasoning, thought, REASONING_SCRATCHPAD). Model-name-prefixed variants are not in the list, so the stateful scrubber's `_find_first_tag` lookup misses them.
3. `cli.py:_REASONING_TAGS` — same hardcoded list, same miss pattern.

## Fix

Two layers of defense, all in this PR:

**Layer 1 — root cause for the final response path:**

`agent/agent_runtime_helpers.py:strip_think_blocks` now uses permissive substring matching: any tag whose name contains one of the known reasoning keywords as a substring, case-insensitive. The three passes (closed pair, unterminated, orphan) all use the same permissive `_THINK_KW` regex. Catches all model-prefixed variants for the agent's final response.

**Layer 2 — defensive safety net for the streaming path:**

`gateway/stream_consumer.py` gains a module-level `scrub_thinking_tags_in_prose(text)` that runs on the visible text right before each platform send. Wired into all three send paths (`_send_or_edit`, `_send_new_chunk`, `_send_fallback_final`) right after the existing `MEDIA:` directive strip. Catches anything the upstream scrubbers missed, regardless of why. Idempotent.

The pattern is intentionally aggressive (no block-boundary checks, no "is this mid-prose?" heuristics). False positives (a model legitimately using `thinkful`-style names in prose) are vastly less harmful than false negatives (raw reasoning leaking to the user).

## Tests

20 new unit tests in `TestScrubThinkingTagsInProse` (in `tests/gateway/test_stream_consumer.py`):

- 4 leak cases (the actual bug) — model-prefixed orphan close attached, deepseek variant, underscore variant, closed pair
- 5 parametrized canonical-name cases (all known tag forms still work)
- 4 preservation cases — plain text, comparison operators, unrelated HTML, self-closing tags
- 5 edge cases — idempotency, empty string, case-insensitive, mixed known + prefixed in one string

All 152 existing tests still pass (no regressions in `test_stream_consumer.py`, `test_think_scrubber.py`, or `test_strip_reasoning_tags_cli.py`).

## Known trade-off

The defensive scrubber is intentionally permissive. Code or markup containing the substring `think`/`thinking`/`reasoning`/`thought` in a tag name (e.g. `<thinkful>`, `<my-thinking-app>`) will have those tags stripped. In practice this is rare for visible response text and vastly less harmful than the leak it prevents.

## Out of scope

- `cli.py:_REASONING_TAGS` could be migrated to the same permissive regex (left alone — separate code path, not the leak vector)
- The `gateway/stream_consumer.py:_OPEN_THINK_TAGS / _CLOSE_THINK_TAGS` hardcoded lists could be replaced with regex (more invasive refactor of the stateful scrubber; the defensive pass in this PR already covers the leak)
