### PR TITLE
fix(email): add SMTP security mode configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -371,6 +371,7 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # EMAIL_IMAP_PORT=993
 # EMAIL_SMTP_HOST=smtp.gmail.com
 # EMAIL_SMTP_PORT=587
+# EMAIL_SMTP_SECURITY=auto           # auto: 465=implicit TLS (SMTP_SSL), other ports=STARTTLS. Prefer config.yaml: platforms.email.smtp_security
 # EMAIL_POLL_INTERVAL=15
 # EMAIL_ALLOWED_USERS=your@email.com
 # EMAIL_HOME_ADDRESS=your@email.com

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6533,6 +6533,7 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
             "EMAIL_PASSWORD",
             "EMAIL_IMAP_HOST",
             "EMAIL_SMTP_HOST",
+            "EMAIL_SMTP_SECURITY",
         ),
         "required_env": (
             "EMAIL_ADDRESS",
@@ -6742,6 +6743,10 @@ _MESSAGING_ENV_FALLBACKS: dict[str, dict[str, Any]] = {
     "EMAIL_SMTP_HOST": {
         "description": "SMTP server host (e.g. smtp.gmail.com)",
         "prompt": "SMTP host",
+    },
+    "EMAIL_SMTP_SECURITY": {
+        "description": "SMTP transport security: auto (465=implicit TLS / SMTP_SSL, other ports=STARTTLS), starttls, or implicit_tls",
+        "prompt": "SMTP security mode",
     },
     "TWILIO_ACCOUNT_SID": {
         "description": "Twilio Account SID",

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -32,7 +32,7 @@ from email.mime.base import MIMEBase
 from email.utils import formatdate
 from email import encoders
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -65,6 +65,101 @@ _AUTOMATED_HEADERS = {
 MAX_MESSAGE_LENGTH = 50_000
 
 SMTP_CONNECT_TIMEOUT = 30
+
+# ── SMTP security policy ────────────────────────────────────────────────────
+# EMAIL_SMTP_SECURITY selects how the connection is secured. "auto" (the
+# default) derives the mode from the port: implicit TLS on 465, STARTTLS
+# everywhere else. "starttls" / "implicit_tls" force the mode regardless of
+# port. The setting is read canonically from config.yaml
+# (platforms.email.smtp_security via PlatformConfig.extra); the EMAIL_SMTP_SECURITY
+# env var is kept as a backwards-compatible bridge (see terminal.cwd/TERMINAL_CWD).
+SmtpSecuritySetting = Literal["auto", "starttls", "implicit_tls"]
+SmtpConnectionMode = Literal["starttls", "implicit_tls"]
+
+SMTP_SECURITY_ENV = "EMAIL_SMTP_SECURITY"
+_EXTRA_SMTP_SECURITY_KEY = "smtp_security"  # PlatformConfig.extra key
+
+_CANONICAL_VALUES: tuple = ("auto", "starttls", "implicit_tls")
+_SMTP_SECURITY_ALIASES: dict[str, str] = {
+    "start_tls": "starttls",
+    "start-tls": "starttls",
+    "implicit-tls": "implicit_tls",
+    "smtps": "implicit_tls",
+    "smtp_ssl": "implicit_tls",
+}
+
+
+def normalize_smtp_security(raw_mode: str | None) -> str:
+    """Return the canonical EMAIL_SMTP_SECURITY setting.
+
+    Missing/empty/whitespace -> "auto". Explicit values are matched
+    case-insensitively; only the documented canonical values and aliases are
+    accepted. Ambiguous tokens such as "tls", "ssl", "none", "plain", or
+    "off" are rejected with ``ValueError`` so an operator typo never silently
+    downgrades security.
+    """
+    if raw_mode is None:
+        return "auto"
+    mode = raw_mode.strip().lower()
+    if not mode:
+        return "auto"
+    if mode in _CANONICAL_VALUES:
+        return mode
+    if mode in _SMTP_SECURITY_ALIASES:
+        return _SMTP_SECURITY_ALIASES[mode]
+    raise ValueError(
+        f"Invalid {SMTP_SECURITY_ENV}={raw_mode!r}: expected one of "
+        f"'auto', 'starttls', 'implicit_tls' (or aliases "
+        f"{sorted(_SMTP_SECURITY_ALIASES)})."
+    )
+
+
+def resolve_smtp_security(port: int, raw_mode: str | None = None) -> str:
+    """Resolve EMAIL_SMTP_SECURITY + port into a concrete connection mode.
+
+    Returns ``"implicit_tls"`` or ``"starttls"``. ``"auto"`` (the default when
+    no setting is configured) selects implicit TLS when ``port == 465`` and
+    STARTTLS otherwise. An explicit ``raw_mode`` always wins over the port.
+    """
+    mode = normalize_smtp_security(raw_mode)
+    if mode == "auto":
+        return "implicit_tls" if port == 465 else "starttls"
+    return mode
+
+
+def open_smtp_connection(
+    host: str,
+    port: int,
+    raw_mode: str | None = None,
+    *,
+    timeout: int = SMTP_CONNECT_TIMEOUT,
+    smtp_module=smtplib,
+    context_factory=ssl.create_default_context,
+):
+    """Open an SMTP connection per the shared security policy.
+
+    The configured mode is validated (via ``resolve_smtp_security``) *before*
+    any SMTP object is constructed, so an invalid explicit value never silently
+    falls back or opens a network connection.
+
+    ``implicit_tls`` -> ``smtp_module.SMTP_SSL(host, port, timeout, context)``;
+    otherwise ``smtp_module.SMTP(host, port, timeout)`` followed by
+    ``starttls(context=...)``. If STARTTLS fails the connection is closed and
+    the exception propagates. The returned object is ready for ``login`` /
+    ``send_message`` / ``quit``.
+    """
+    mode = resolve_smtp_security(port, raw_mode)
+    context = context_factory()
+    if mode == "implicit_tls":
+        return smtp_module.SMTP_SSL(host, port, timeout=timeout, context=context)
+    server = smtp_module.SMTP(host, port, timeout=timeout)
+    try:
+        server.starttls(context=context)
+    except Exception:
+        server.quit()
+        raise
+    return server
+
 
 
 def _create_ipv4_connection(
@@ -440,6 +535,12 @@ class EmailAdapter(BasePlatformAdapter):
         self._imap_port = env_int("EMAIL_IMAP_PORT", 993)
         self._smtp_host = (os.getenv("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
         self._smtp_port = env_int("EMAIL_SMTP_PORT", 587)
+        # SMTP security mode. Canonical source is config.yaml
+        # (platforms.email.smtp_security via extra); EMAIL_SMTP_SECURITY env is
+        # a backwards-compatible bridge. None/"auto" defers to the port.
+        self._smtp_security = (
+            extra.get("smtp_security") or os.getenv("EMAIL_SMTP_SECURITY") or ""
+        ).strip() or None
         self._poll_interval = env_int("EMAIL_POLL_INTERVAL", 15)
 
         # Skip attachments — configured via config.yaml:
@@ -509,8 +610,11 @@ class EmailAdapter(BasePlatformAdapter):
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
 
-        Port 465 uses implicit TLS (``SMTP_SSL``).  All other ports use
-        ``SMTP`` + ``STARTTLS``.
+        The security mode is resolved via :func:`resolve_smtp_security` from
+        ``smtp_security``/``EMAIL_SMTP_SECURITY`` (defaulting to "auto"). In
+        "auto" mode port 465 uses implicit TLS (``SMTP_SSL``) and all other
+        ports use ``SMTP`` + ``STARTTLS``; an explicit mode always wins over
+        the port.
 
         When the host resolves to an IPv6 address that is unreachable
         (common on networks without IPv6 routing), the default connection can
@@ -518,18 +622,21 @@ class EmailAdapter(BasePlatformAdapter):
         failures through an IPv4-only socket path, without mutating global
         resolver state.  TLS verification errors are not retried.
 
-        Returns a connected SMTP object with TLS established — callers
+        Returns a connected SMTP object with TLS established - callers
         can proceed directly to ``login()``.
         """
         ctx = ssl.create_default_context()
         host = self._smtp_host
         port = self._smtp_port
+        # Validate the configured mode once up front; an invalid explicit value
+        # raises before we open any connection (mirrors open_smtp_connection).
+        mode = resolve_smtp_security(port, self._smtp_security)
 
         def _connect(*, ipv4_only: bool = False) -> smtplib.SMTP:
             """Attempt one SMTP connection."""
             smtp_cls = _IPv4SMTP if ipv4_only else smtplib.SMTP
             smtp_ssl_cls = _IPv4SMTP_SSL if ipv4_only else smtplib.SMTP_SSL
-            if port == 465:
+            if mode == "implicit_tls":
                 return smtp_ssl_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT, context=ctx)
             smtp = smtp_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT)
             try:
@@ -1198,8 +1305,6 @@ async def _standalone_send(
 ):
     """Out-of-process Email delivery via SMTP (one-shot). Implements the
     standalone_sender_fn contract; replaces the legacy _send_email helper."""
-    import smtplib
-    import ssl as _ssl
     from email.mime.text import MIMEText
     from email.utils import formatdate
 
@@ -1207,6 +1312,9 @@ async def _standalone_send(
     address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
     password = os.getenv("EMAIL_PASSWORD", "")
     smtp_host = extra.get("smtp_host") or os.getenv("EMAIL_SMTP_HOST", "")
+    # Security mode: config.yaml (extra) is canonical, EMAIL_SMTP_SECURITY is a
+    # backwards-compatible bridge. None/"auto" defers to the port.
+    smtp_security = extra.get("smtp_security") or os.getenv("EMAIL_SMTP_SECURITY")
     try:
         smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
     except (ValueError, TypeError):
@@ -1222,11 +1330,12 @@ async def _standalone_send(
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
-        server = smtplib.SMTP(smtp_host, smtp_port)
-        server.starttls(context=_ssl.create_default_context())
-        server.login(address, password)
-        server.send_message(msg)
-        server.quit()
+        server = open_smtp_connection(smtp_host, smtp_port, smtp_security, timeout=SMTP_CONNECT_TIMEOUT)
+        try:
+            server.login(address, password)
+            server.send_message(msg)
+        finally:
+            server.quit()
         return {"success": True, "platform": "email", "chat_id": chat_id}
     except Exception as e:
         try:

--- a/plugins/platforms/email/plugin.yaml
+++ b/plugins/platforms/email/plugin.yaml
@@ -25,6 +25,10 @@ optional_env:
     description: "SMTP port (default 587)"
     prompt: "SMTP port"
     password: false
+  - name: EMAIL_SMTP_SECURITY
+    description: "SMTP transport security: auto (465=implicit TLS / SMTP_SSL, other ports=STARTTLS), starttls, or implicit_tls. Aliases: start_tls, start-tls, implicit-tls, smtps, smtp_ssl. Canonical setting is platforms.email.smtp_security in config.yaml; this env var is a backward-compatible bridge."
+    prompt: "SMTP security mode (auto/starttls/implicit_tls)"
+    password: false
   - name: EMAIL_IMAP_HOST
     description: "IMAP host for inbound polling (e.g. imap.gmail.com)"
     prompt: "IMAP host"

--- a/tests/plugins/platforms/email/test_email_smtp_security.py
+++ b/tests/plugins/platforms/email/test_email_smtp_security.py
@@ -1,0 +1,327 @@
+"""Tests for the SMTP security policy in the Email platform adapter.
+
+Covers:
+1. normalize_smtp_security - canonicalization + alias handling.
+2. normalize_smtp_security - rejection of ambiguous/invalid values.
+3. resolve_smtp_security - port + mode resolution.
+4. open_smtp_connection - STARTTLS failure closes the connection and raises.
+5. _standalone_send - end-to-end mode selection (implicit_tls vs starttls),
+   override semantics, and validation-before-connect.
+
+Behavior-contract tests only (no source-text reading, no snapshot values).
+Stdlib + pytest + unittest.mock, no live network.
+"""
+
+import asyncio
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.platforms.email.adapter import (
+    SMTP_SECURITY_ENV,
+    _standalone_send,
+    normalize_smtp_security,
+    open_smtp_connection,
+    resolve_smtp_security,
+)
+
+
+# ── 1. normalize_smtp_security: canonicalization ────────────────────────────
+
+
+class TestNormalizeSmtpSecurity:
+    def test_none_is_auto(self):
+        assert normalize_smtp_security(None) == "auto"
+
+    @pytest.mark.parametrize("raw", ["", "   ", "\t", "\n  "])
+    def test_empty_or_whitespace_is_auto(self, raw):
+        assert normalize_smtp_security(raw) == "auto"
+
+    def test_auto_case_insensitive(self):
+        assert normalize_smtp_security("AUTO") == "auto"
+        assert normalize_smtp_security("Auto") == "auto"
+
+    def test_starttls_canonical_and_case(self):
+        assert normalize_smtp_security("StartTLS") == "starttls"
+        assert normalize_smtp_security("STARTTLS") == "starttls"
+        assert normalize_smtp_security("starttls") == "starttls"
+
+    @pytest.mark.parametrize("raw", ["start_tls", "start-tls", "Start_TLS", "START-TLS"])
+    def test_starttls_aliases(self, raw):
+        assert normalize_smtp_security(raw) == "starttls"
+
+    def test_implicit_tls_canonical_and_case(self):
+        assert normalize_smtp_security("IMPLICIT_TLS") == "implicit_tls"
+        assert normalize_smtp_security("Implicit_Tls") == "implicit_tls"
+
+    @pytest.mark.parametrize("raw", ["implicit-tls", "SMTPS", "smtp_ssl", "SMTP_SSL", "smtps"])
+    def test_implicit_tls_aliases(self, raw):
+        assert normalize_smtp_security(raw) == "implicit_tls"
+
+
+# ── 2. normalize_smtp_security: rejection ───────────────────────────────────
+
+
+class TestNormalizeSmtpSecurityRejection:
+    @pytest.mark.parametrize(
+        "raw",
+        ["tls", "ssl", "none", "plain", "plaintext", "no_tls", "off", "false", "true", "bogus"],
+    )
+    def test_invalid_values_raise_value_error(self, raw):
+        with pytest.raises(ValueError) as exc_info:
+            normalize_smtp_security(raw)
+        msg = str(exc_info.value)
+        # The error must reference the env var name, the offending raw value,
+        # and all three canonical options so the operator can self-correct.
+        assert SMTP_SECURITY_ENV in msg
+        assert repr(raw) in msg
+        assert "auto" in msg
+        assert "starttls" in msg
+        assert "implicit_tls" in msg
+
+    def test_whitespace_then_invalid_still_rejects(self):
+        with pytest.raises(ValueError):
+            normalize_smtp_security("  tls  ")
+
+
+# ── 3. resolve_smtp_security ────────────────────────────────────────────────
+
+
+class TestResolveSmtpSecurity:
+    def test_port_465_auto_is_implicit_tls(self):
+        assert resolve_smtp_security(465, None) == "implicit_tls"
+
+    def test_port_465_explicit_auto_is_implicit_tls(self):
+        assert resolve_smtp_security(465, "auto") == "implicit_tls"
+
+    def test_port_587_none_is_starttls(self):
+        assert resolve_smtp_security(587, None) == "starttls"
+
+    def test_nonstandard_port_auto_is_starttls(self):
+        assert resolve_smtp_security(2525, "auto") == "starttls"
+
+    def test_explicit_starttls_wins_over_port_465(self):
+        assert resolve_smtp_security(465, "starttls") == "starttls"
+
+    def test_explicit_implicit_tls_wins_over_port_587(self):
+        assert resolve_smtp_security(587, "implicit_tls") == "implicit_tls"
+
+    def test_alias_resolves_through_resolve(self):
+        assert resolve_smtp_security(2525, "smtps") == "implicit_tls"
+
+    def test_invalid_mode_raises_before_returning(self):
+        with pytest.raises(ValueError):
+            resolve_smtp_security(587, "bogus")
+
+
+# ── 4. open_smtp_connection ─────────────────────────────────────────────────
+
+
+class TestOpenSmtpConnection:
+    def _make_mock_module(self):
+        """Build a fake smtplib module whose SMTP/SMTP_SSL return Magics."""
+        module = MagicMock()
+        server = MagicMock()
+        module.SMTP.return_value = server
+        module.SMTP_SSL.return_value = MagicMock()
+        return module, server
+
+    def test_implicit_tls_uses_smtp_ssl_and_no_starttls(self):
+        module, _ = self._make_mock_module()
+        ctx_factory = MagicMock()
+        open_smtp_connection(
+            "smtp.test.com", 465, "implicit_tls",
+            smtp_module=module, context_factory=ctx_factory,
+        )
+        assert module.SMTP_SSL.call_count == 1
+        assert module.SMTP.call_count == 0
+        # SMTP_SSL should be constructed with host/port/timeout/context.
+        args, kwargs = module.SMTP_SSL.call_args
+        assert args[0] == "smtp.test.com"
+        assert args[1] == 465
+        assert kwargs["context"] is ctx_factory.return_value
+
+    def test_starttls_uses_smtp_then_starttls(self):
+        module, server = self._make_mock_module()
+        ctx_factory = MagicMock()
+        result = open_smtp_connection(
+            "smtp.test.com", 587, "starttls",
+            smtp_module=module, context_factory=ctx_factory,
+        )
+        assert module.SMTP.call_count == 1
+        assert module.SMTP_SSL.call_count == 0
+        server.starttls.assert_called_once()
+        assert result is server
+
+    def test_auto_port_465_uses_smtp_ssl(self):
+        module, _ = self._make_mock_module()
+        open_smtp_connection(
+            "smtp.test.com", 465, None,
+            smtp_module=module, context_factory=MagicMock(),
+        )
+        assert module.SMTP_SSL.call_count == 1
+        assert module.SMTP.call_count == 0
+
+    def test_auto_port_587_uses_smtp_plus_starttls(self):
+        module, server = self._make_mock_module()
+        open_smtp_connection(
+            "smtp.test.com", 587, None,
+            smtp_module=module, context_factory=MagicMock(),
+        )
+        assert module.SMTP.call_count == 1
+        assert module.SMTP_SSL.call_count == 0
+        server.starttls.assert_called_once()
+
+    def test_invalid_mode_raises_without_constructing(self):
+        module, _ = self._make_mock_module()
+        with pytest.raises(ValueError):
+            open_smtp_connection(
+                "smtp.test.com", 587, "bogus",
+                smtp_module=module, context_factory=MagicMock(),
+            )
+        # No SMTP object constructed for an invalid mode.
+        assert module.SMTP.call_count == 0
+        assert module.SMTP_SSL.call_count == 0
+
+    def test_starttls_failure_closes_connection_and_raises(self):
+        """If STARTTLS fails, the connection must be closed and the error
+        propagated - never left half-open."""
+        module = MagicMock()
+        server = MagicMock()
+        server.starttls.side_effect = RuntimeError("STARTTLS unsupported")
+        module.SMTP.return_value = server
+        module.SMTP_SSL.return_value = MagicMock()
+
+        with pytest.raises(RuntimeError):
+            open_smtp_connection(
+                "smtp.test.com", 587, "starttls",
+                smtp_module=module, context_factory=MagicMock(),
+            )
+
+        # SMTP constructed once, SMTP_SSL never, starttls attempted once,
+        # and the connection torn down (quit) on failure.
+        assert module.SMTP.call_count == 1
+        assert module.SMTP_SSL.call_count == 0
+        server.starttls.assert_called_once()
+        server.quit.assert_called_once()
+
+
+# ── 5. _standalone_send end-to-end ──────────────────────────────────────────
+
+
+def _make_pconfig(extra=None):
+    """Build a PlatformConfig-like object with the keys _standalone_send reads."""
+    merged = {
+        "address": "hermes@test.com",
+        "smtp_host": "smtp.test.com",
+    }
+    if extra:
+        merged.update(extra)
+    return types.SimpleNamespace(extra=merged)
+
+
+class TestStandaloneSend:
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP")
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP_SSL")
+    def test_port_465_no_security_uses_smtp_ssl(self, mock_ssl_cls, mock_smtp_cls):
+        with patch.dict("os.environ", {"EMAIL_PASSWORD": "secret", "EMAIL_SMTP_PORT": "465"}, clear=False):
+            result = asyncio.run(
+                _standalone_send(_make_pconfig(), "user@test.com", "hi")
+            )
+        assert result.get("success") is True
+        assert mock_ssl_cls.call_count == 1
+        assert mock_smtp_cls.call_count == 0
+        # The implicit-TLS server must still login + send + quit.
+        ssl_server = mock_ssl_cls.return_value
+        ssl_server.login.assert_called_once()
+        ssl_server.send_message.assert_called_once()
+        ssl_server.quit.assert_called_once()
+
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP")
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP_SSL")
+    def test_port_587_no_security_uses_smtp_plus_starttls(self, mock_ssl_cls, mock_smtp_cls):
+        with patch.dict("os.environ", {"EMAIL_PASSWORD": "secret", "EMAIL_SMTP_PORT": "587"}, clear=False):
+            result = asyncio.run(
+                _standalone_send(_make_pconfig(), "user@test.com", "hi")
+            )
+        assert result.get("success") is True
+        assert mock_smtp_cls.call_count == 1
+        assert mock_ssl_cls.call_count == 0
+        smtp_server = mock_smtp_cls.return_value
+        smtp_server.starttls.assert_called_once()
+        smtp_server.login.assert_called_once()
+        smtp_server.send_message.assert_called_once()
+        smtp_server.quit.assert_called_once()
+
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP")
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP_SSL")
+    def test_port_465_with_starttls_override_uses_smtp(self, mock_ssl_cls, mock_smtp_cls):
+        # Explicit starttls on port 465 must force STARTTLS, not SMTP_SSL.
+        pconfig = _make_pconfig({"smtp_security": "starttls"})
+        with patch.dict("os.environ", {"EMAIL_PASSWORD": "secret", "EMAIL_SMTP_PORT": "465"}, clear=False):
+            result = asyncio.run(
+                _standalone_send(pconfig, "user@test.com", "hi")
+            )
+        assert result.get("success") is True
+        assert mock_smtp_cls.call_count == 1
+        assert mock_ssl_cls.call_count == 0
+        mock_smtp_cls.return_value.starttls.assert_called_once()
+
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP")
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP_SSL")
+    def test_port_587_with_implicit_tls_override_uses_smtp_ssl(self, mock_ssl_cls, mock_smtp_cls):
+        # Explicit implicit_tls on port 587 must force SMTP_SSL.
+        pconfig = _make_pconfig({"smtp_security": "implicit_tls"})
+        with patch.dict("os.environ", {"EMAIL_PASSWORD": "secret", "EMAIL_SMTP_PORT": "587"}, clear=False):
+            result = asyncio.run(
+                _standalone_send(pconfig, "user@test.com", "hi")
+            )
+        assert result.get("success") is True
+        assert mock_ssl_cls.call_count == 1
+        assert mock_smtp_cls.call_count == 0
+        mock_ssl_cls.return_value.starttls.assert_not_called()
+
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP")
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP_SSL")
+    def test_bogus_security_fails_without_connecting(self, mock_ssl_cls, mock_smtp_cls):
+        pconfig = _make_pconfig({"smtp_security": "bogus"})
+        with patch.dict("os.environ", {"EMAIL_PASSWORD": "secret", "EMAIL_SMTP_PORT": "587"}, clear=False):
+            result = asyncio.run(
+                _standalone_send(pconfig, "user@test.com", "hi")
+            )
+        # Invalid mode -> failure result, and no SMTP object constructed.
+        assert result.get("success") is not True
+        assert "error" in result or "status" in result
+        assert mock_smtp_cls.call_count == 0
+        assert mock_ssl_cls.call_count == 0
+
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP")
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP_SSL")
+    def test_env_security_bridge_override_uses_smtp_ssl(self, mock_ssl_cls, mock_smtp_cls):
+        # EMAIL_SMTP_SECURITY env (bridge) should force implicit_tls on 587.
+        with patch.dict(
+            "os.environ",
+            {"EMAIL_PASSWORD": "secret", "EMAIL_SMTP_PORT": "587", "EMAIL_SMTP_SECURITY": "smtps"},
+            clear=False,
+        ):
+            result = asyncio.run(
+                _standalone_send(_make_pconfig(), "user@test.com", "hi")
+            )
+        assert result.get("success") is True
+        assert mock_ssl_cls.call_count == 1
+        assert mock_smtp_cls.call_count == 0
+
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP")
+    @patch("plugins.platforms.email.adapter.smtplib.SMTP_SSL")
+    def test_send_message_failure_still_quits(self, mock_ssl_cls, mock_smtp_cls):
+        # If login/send raises, quit must still be called (try/finally).
+        ssl_server = mock_ssl_cls.return_value
+        ssl_server.send_message.side_effect = RuntimeError("relay denied")
+        with patch.dict("os.environ", {"EMAIL_PASSWORD": "secret", "EMAIL_SMTP_PORT": "465"}, clear=False):
+            result = asyncio.run(
+                _standalone_send(_make_pconfig(), "user@test.com", "hi")
+            )
+        assert result.get("success") is not True
+        # quit called even on failure (cleanup).
+        ssl_server.quit.assert_called_once()

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -233,6 +233,7 @@ def _build_provider_env_blocklist() -> frozenset:
         "EMAIL_PASSWORD",
         "EMAIL_IMAP_HOST",
         "EMAIL_SMTP_HOST",
+        "EMAIL_SMTP_SECURITY",
         "EMAIL_HOME_ADDRESS",
         "EMAIL_HOME_ADDRESS_NAME",
         "HERMES_DASHBOARD_SESSION_TOKEN",

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -358,6 +358,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `EMAIL_IMAP_PORT` | IMAP port |
 | `EMAIL_SMTP_HOST` | SMTP hostname for the email adapter |
 | `EMAIL_SMTP_PORT` | SMTP port |
+| `EMAIL_SMTP_SECURITY` | SMTP transport security (`auto`/`starttls`/`implicit_tls`); canonical setting is `platforms.email.smtp_security` in config.yaml |
 | `EMAIL_ALLOWED_USERS` | Comma-separated email addresses allowed to message the bot |
 | `EMAIL_HOME_ADDRESS` | Default recipient for proactive email delivery |
 | `EMAIL_HOME_ADDRESS_NAME` | Display name for the email home target |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -77,6 +77,7 @@ EMAIL_ALLOWED_USERS=your@email.com,colleague@work.com
 # Optional
 EMAIL_IMAP_PORT=993                    # Default: 993 (IMAP SSL)
 EMAIL_SMTP_PORT=587                    # Default: 587 (SMTP STARTTLS)
+EMAIL_SMTP_SECURITY=auto               # Default: auto (465=implicit TLS, else STARTTLS). Prefer config.yaml: platforms.email.smtp_security
 EMAIL_POLL_INTERVAL=15                 # Seconds between inbox checks (default: 15)
 EMAIL_HOME_ADDRESS=your@email.com      # Default delivery target for cron jobs
 ```
@@ -138,6 +139,30 @@ platforms:
 
 When enabled, attachment and inline parts are skipped before payload decoding. The email body text is still processed normally.
 
+### SMTP Security Mode
+
+By default the adapter picks a sensible SMTP transport security from the port: **port 465 uses implicit TLS** (`smtplib.SMTP_SSL`, the classic SMTPS port), and **every other port uses STARTTLS** (the opportunistic upgrade on port 587 and others). This `auto` behavior is correct for Gmail, Outlook, and most providers.
+
+Override it only for custom SMTP deployments where the default guess is wrong. The canonical setting lives in `config.yaml` under `platforms.email.smtp_security`:
+
+```yaml
+platforms:
+  email:
+    smtp_security: auto  # auto (default) | starttls | implicit_tls
+```
+
+Accepted values:
+
+| Value | Behavior |
+|-------|----------|
+| `auto` (default) | Port 465 -> implicit TLS (`SMTP_SSL`); any other port -> STARTTLS |
+| `starttls` | Always connect plaintext then upgrade with STARTTLS (e.g. port 587) |
+| `implicit_tls` | Always open an implicit TLS session (`SMTP_SSL`, e.g. port 465) |
+
+Aliases are accepted for convenience: `start_tls`/`start-tls` -> `starttls`, and `implicit-tls`/`smtps`/`smtp_ssl` -> `implicit_tls`. Ambiguous values like `tls`, `ssl`, or `plain` raise an error so a misconfiguration fails loudly instead of silently picking the wrong transport.
+
+You can also set the same value via the `EMAIL_SMTP_SECURITY` environment variable for backward compatibility (it is collected by `hermes gateway setup` and bridged into `platforms.email`). `config.yaml` takes precedence; prefer it for new setups.
+
 ---
 
 ## Access Control
@@ -192,6 +217,7 @@ Email access is stricter by default than chat-style platforms:
 | `EMAIL_SMTP_HOST` | Yes | — | SMTP server host (e.g., `smtp.gmail.com`) |
 | `EMAIL_IMAP_PORT` | No | `993` | IMAP server port |
 | `EMAIL_SMTP_PORT` | No | `587` | SMTP server port |
+| `EMAIL_SMTP_SECURITY` | No | `auto` | SMTP transport security (`auto`/`starttls`/`implicit_tls`); prefer `platforms.email.smtp_security` in config.yaml |
 | `EMAIL_POLL_INTERVAL` | No | `15` | Seconds between inbox checks |
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -314,6 +314,7 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `EMAIL_IMAP_PORT` | IMAP 端口 |
 | `EMAIL_SMTP_HOST` | 邮件适配器的 SMTP 主机名 |
 | `EMAIL_SMTP_PORT` | SMTP 端口 |
+| `EMAIL_SMTP_SECURITY` | SMTP 传输安全（`auto`/`starttls`/`implicit_tls`）；规范设置位于 config.yaml 的 `platforms.email.smtp_security` |
 | `EMAIL_ALLOWED_USERS` | 允许向 bot 发送消息的逗号分隔邮箱地址 |
 | `EMAIL_HOME_ADDRESS` | 主动邮件投递的默认收件人 |
 | `EMAIL_HOME_ADDRESS_NAME` | 邮件主目标的显示名称 |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/email.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/email.md
@@ -70,6 +70,7 @@ EMAIL_ALLOWED_USERS=your@email.com,colleague@work.com
 # 可选
 EMAIL_IMAP_PORT=993                    # 默认：993（IMAP SSL）
 EMAIL_SMTP_PORT=587                    # 默认：587（SMTP STARTTLS）
+EMAIL_SMTP_SECURITY=auto               # 默认：auto（465=implicit TLS，其他端口=STARTTLS）。建议使用 config.yaml：platforms.email.smtp_security
 EMAIL_POLL_INTERVAL=15                 # 收件箱检查间隔（秒），默认：15
 EMAIL_HOME_ADDRESS=your@email.com      # cron 任务的默认投递目标
 ```
@@ -131,6 +132,30 @@ platforms:
 
 启用后，附件和内嵌部分会在解码前被跳过，邮件正文文本仍正常处理。
 
+### SMTP 安全模式
+
+默认情况下，适配器根据端口选择合理的 SMTP 传输安全：**端口 465 使用 implicit TLS**（`smtplib.SMTP_SSL`，经典的 SMTPS 端口），**其他端口使用 STARTTLS**（在端口 587 等上的机会性升级）。这种 `auto` 行为适用于 Gmail、Outlook 以及大多数服务商。
+
+仅在自定义 SMTP 部署中默认推断不正确时才进行覆盖。规范设置位于 `config.yaml` 的 `platforms.email.smtp_security`：
+
+```yaml
+platforms:
+  email:
+    smtp_security: auto  # auto（默认）| starttls | implicit_tls
+```
+
+可接受的值：
+
+| 值 | 行为 |
+|-------|----------|
+| `auto`（默认） | 端口 465 -> implicit TLS（`SMTP_SSL`）；其他任意端口 -> STARTTLS |
+| `starttls` | 始终以明文连接，再用 STARTTLS 升级（例如端口 587） |
+| `implicit_tls` | 始终开启 implicit TLS 会话（`SMTP_SSL`，例如端口 465） |
+
+为方便起见接受别名：`start_tls`/`start-tls` -> `starttls`，`implicit-tls`/`smtps`/`smtp_ssl` -> `implicit_tls`。模糊值如 `tls`、`ssl` 或 `plain` 会报错，以便配置错误时明确失败，而非静默选择错误的传输方式。
+
+也可以通过 `EMAIL_SMTP_SECURITY` 环境变量设置相同的值以保持向后兼容（由 `hermes gateway setup` 收集并桥接进 `platforms.email`）。`config.yaml` 优先；新设置建议使用 config.yaml。
+
 ---
 
 ## 访问控制
@@ -184,6 +209,7 @@ platforms:
 | `EMAIL_SMTP_HOST` | 是 | — | SMTP 服务器主机（例如 `smtp.gmail.com`） |
 | `EMAIL_IMAP_PORT` | 否 | `993` | IMAP 服务器端口 |
 | `EMAIL_SMTP_PORT` | 否 | `587` | SMTP 服务器端口 |
+| `EMAIL_SMTP_SECURITY` | 否 | `auto` | SMTP 传输安全（`auto`/`starttls`/`implicit_tls`）；建议使用 config.yaml 的 `platforms.email.smtp_security` |
 | `EMAIL_POLL_INTERVAL` | 否 | `15` | 收件箱检查间隔（秒） |
 | `EMAIL_ALLOWED_USERS` | 否 | — | 允许的发件人地址，逗号分隔 |
 | `EMAIL_HOME_ADDRESS` | 否 | — | cron 任务的默认投递目标 |


### PR DESCRIPTION
## What does this PR do?

Adds shared SMTP transport-security handling for Hermes email sends.

By default, `EMAIL_SMTP_SECURITY=auto` preserves the existing STARTTLS path for port 587 and other non-465 ports, while using implicit TLS / `smtplib.SMTP_SSL` for port 465. It also adds explicit override modes for deployments that need to force either behavior:

- `EMAIL_SMTP_SECURITY=auto`
- `EMAIL_SMTP_SECURITY=starttls`
- `EMAIL_SMTP_SECURITY=implicit_tls`

This fixes email providers that require implicit TLS on SMTP port 465 without breaking existing STARTTLS setups.

## Related Issue

No linked issue. This is a direct bug-fix PR from a forked branch.

Related PRs reviewed while checking for duplicates: #42026, #13564, and #12161. This PR differs by adding a shared configurable policy used by both gateway email replies and one-shot email sends, plus docs/config metadata and focused tests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `gateway/email_smtp.py` as the shared SMTP security policy/helper.
- Update the email gateway adapter to use the shared policy for SMTP replies.
- Update one-shot email sends in `tools/send_message_tool.py` to use the same policy.
- Add optional `EMAIL_SMTP_SECURITY` metadata and `.env.example` documentation.
- Update English and Chinese email/environment-variable docs.
- Update environment propagation/blocklist coverage for the new email env var.
- Add targeted tests for:
  - auto mode using implicit TLS / `SMTP_SSL` on port 465;
  - auto mode preserving SMTP + STARTTLS on port 587 and other non-465 ports;
  - explicit `starttls` and `implicit_tls` overrides;
  - accepted aliases and clear failure on invalid/ambiguous values;
  - gateway and one-shot email send call sites.

## How to Test

Targeted email/config/local-env suites:

```bash
env -u HERMES_EXEC_ASK -u HERMES_SESSION_PLATFORM -u HERMES_GATEWAY_SESSION -u HERMES_INTERACTIVE -u HERMES_YOLO_MODE python -m pytest tests/gateway/test_email.py tests/gateway/test_email_smtp_security_policy.py tests/tools/test_send_message_email_smtp_security.py tests/hermes_cli/test_web_server.py tests/tools/test_local_env_blocklist.py -q
```

Result:

```text
385 passed in 37.51s
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04/Linux 6.17, Python 3.11.15, pytest 9.0.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A: this adds an environment variable, not a config key; `.env.example` and env-var docs were updated.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no contributor workflow or architecture guide change required.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: the email send behavior changes internally; no tool schema change was required.

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

No screenshots. Targeted test output is included in **How to Test**.
