### PR TITLE
fix(todo): keep active step ahead of pending rows

### DIFF
--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -14,8 +14,9 @@ class TestWriteAndRead:
         ]
         result = store.write(items)
         assert len(result) == 2
-        assert result[0]["id"] == "1"
-        assert result[1]["status"] == "in_progress"
+        assert result[0]["id"] == "2"
+        assert result[0]["status"] == "in_progress"
+        assert result[1]["id"] == "1"
 
     def test_read_returns_copy(self):
         store = TodoStore()
@@ -32,8 +33,21 @@ class TestWriteAndRead:
             {"id": "1", "content": "Latest version", "status": "in_progress"},
         ])
         assert result == [
-            {"id": "2", "content": "Other task", "status": "pending"},
             {"id": "1", "content": "Latest version", "status": "in_progress"},
+            {"id": "2", "content": "Other task", "status": "pending"},
+        ]
+
+    def test_write_moves_active_item_before_earlier_pending_step(self):
+        store = TodoStore()
+        result = store.write([
+            {"id": "1", "content": "Already done", "status": "completed"},
+            {"id": "2", "content": "Verify freed space", "status": "pending"},
+            {"id": "3", "content": "Move archives to Trash", "status": "in_progress"},
+        ])
+        assert result == [
+            {"id": "1", "content": "Already done", "status": "completed"},
+            {"id": "3", "content": "Move archives to Trash", "status": "in_progress"},
+            {"id": "2", "content": "Verify freed space", "status": "pending"},
         ]
 
 
@@ -96,6 +110,23 @@ class TestMergeMode:
         )
         items = store.read()
         assert len(items) == 2
+
+    def test_merge_reorders_active_item_ahead_of_earlier_pending_step(self):
+        store = TodoStore()
+        store.write([
+            {"id": "1", "content": "Completed", "status": "completed"},
+            {"id": "2", "content": "Verify freed space", "status": "pending"},
+            {"id": "3", "content": "Move archives to Trash", "status": "pending"},
+        ])
+        result = store.write(
+            [{"id": "3", "status": "in_progress"}],
+            merge=True,
+        )
+        assert result == [
+            {"id": "1", "content": "Completed", "status": "completed"},
+            {"id": "3", "content": "Move archives to Trash", "status": "in_progress"},
+            {"id": "2", "content": "Verify freed space", "status": "pending"},
+        ]
 
 
 class TestTodoToolFunction:

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -57,7 +57,9 @@ class TodoStore:
         """
         if not merge:
             # Replace mode: new list entirely
-            self._items = [self._validate(t) for t in self._dedupe_by_id(todos)]
+            self._items = self._normalize_order(
+                [self._validate(t) for t in self._dedupe_by_id(todos)]
+            )
         else:
             # Merge mode: update existing items by id, append new ones
             existing = {item["id"]: item for item in self._items}
@@ -87,7 +89,7 @@ class TodoStore:
                 if current["id"] not in seen:
                     rebuilt.append(current)
                     seen.add(current["id"])
-            self._items = rebuilt
+            self._items = self._normalize_order(rebuilt)
         # Bound total item count so a replayed/oversized list can't grow the
         # re-injection block without limit. Keep the highest-priority head
         # (list order is priority).
@@ -182,6 +184,31 @@ class TodoStore:
             item_id = str(item.get("id", "")).strip() or "?"
             last_index[item_id] = i
         return [todos[i] for i in sorted(last_index.values())]
+
+    @staticmethod
+    def _normalize_order(items: List[Dict[str, str]]) -> List[Dict[str, str]]:
+        """Lift the active step ahead of any earlier unfinished placeholders."""
+        active_index = next(
+            (i for i, item in enumerate(items) if item["status"] == "in_progress"),
+            None,
+        )
+        if active_index is None:
+            return items
+
+        pending_index = next(
+            (
+                i for i, item in enumerate(items[:active_index])
+                if item["status"] == "pending"
+            ),
+            None,
+        )
+        if pending_index is None:
+            return items
+
+        normalized = items.copy()
+        active_item = normalized.pop(active_index)
+        normalized.insert(pending_index, active_item)
+        return normalized
 
 
 def todo_tool(


### PR DESCRIPTION
## What does this PR do?

Fixes the todo ordering edge case behind #42649 where Hermes can persist a later `in_progress` step while an earlier visible step still remains `pending` after a blocked action or replan.

The `todo` store now normalizes writes so the active step is lifted into the first unfinished slot. That keeps the visible sequence aligned with execution without changing completed work.

## Related Issue

Fixes #42649

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- normalize `TodoStore.write()` output so a single active `in_progress` item no longer sits behind earlier `pending` rows
- apply the same normalization to both replace writes and merge updates
- add regression coverage for replace-mode and merge-mode out-of-order todo snapshots
- update existing todo-store expectations to assert the new ordering invariant

## How to Test

Targeted local validation:

- `uv run --frozen pytest -o addopts='' tests/tools/test_todo_tool.py tests/agent/test_display_todo_progress.py`
- `uv run --frozen ruff check tools/todo_tool.py tests/tools/test_todo_tool.py tests/agent/test_display_todo_progress.py`
- `git diff --check HEAD^ HEAD`

## Notes

This is intentionally separate from #42669. That PR fixes archived todo rendering semantics in Desktop; this one fixes the underlying todo ordering invariant so downstream UIs stop showing a later active step after an earlier pending one.
