### PR TITLE
fix(terminal): ignore docker config JSON on local backend

### DIFF
--- a/tests/tools/test_terminal_docker_config_parsing.py
+++ b/tests/tools/test_terminal_docker_config_parsing.py
@@ -1,0 +1,27 @@
+import pytest
+
+from tools.terminal_tool import _get_env_config
+
+
+def test_local_backend_ignores_malformed_docker_json_env(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", "not json")
+    monkeypatch.setenv("TERMINAL_DOCKER_ENV", "not json")
+    monkeypatch.setenv("TERMINAL_DOCKER_EXTRA_ARGS", "not json")
+    monkeypatch.setenv("TERMINAL_DOCKER_FORWARD_ENV", "not json")
+
+    config = _get_env_config()
+
+    assert config["env_type"] == "local"
+    assert config["docker_volumes"] == []
+    assert config["docker_env"] == {}
+    assert config["docker_extra_args"] == []
+    assert config["docker_forward_env"] == []
+
+
+def test_docker_backend_still_rejects_malformed_docker_json_env(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", "not json")
+
+    with pytest.raises(ValueError, match="TERMINAL_DOCKER_VOLUMES"):
+        _get_env_config()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1048,9 +1048,19 @@ def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    env_type = (os.getenv("TERMINAL_ENV", "local") or "local").strip().lower()
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    is_docker_backend = env_type == "docker"
+    mount_docker_cwd = is_docker_backend and os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    docker_forward_env = []
+    docker_volumes = []
+    docker_env = {}
+    docker_extra_args = []
+    if is_docker_backend:
+        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
+        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
+        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
+        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
 
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, and everything else starts in the backend's default
@@ -1094,7 +1104,7 @@ def _get_env_config() -> Dict[str, Any]:
         "env_type": env_type,
         "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
         "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
-        "docker_forward_env": _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON"),
+        "docker_forward_env": docker_forward_env,
         "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
         "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
         "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
@@ -1122,10 +1132,10 @@ def _get_env_config() -> Dict[str, Any]:
         "container_memory": _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120"),     # MB (default 5GB)
         "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
-        "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
-        "docker_env": _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON"),
+        "docker_volumes": docker_volumes,
+        "docker_env": docker_env,
         "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_extra_args": _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON"),
+        "docker_extra_args": docker_extra_args,
         # Cross-process container reuse (issue #20561).  The docs claim
         # "ONE long-lived container shared across sessions" — this toggle
         # makes that real by probing for a labeled container at startup and


### PR DESCRIPTION
## Summary
- parse Docker-only JSON env vars only when TERMINAL_ENV is docker
- keep local backend terminal commands from crashing on malformed TERMINAL_DOCKER_* values
- add regression coverage for local ignore and Docker rejection behavior

Fixes #42725.

## Verification
- uv run --with pytest --with pytest-timeout pytest -q tests/tools/test_terminal_docker_config_parsing.py tests/tools/test_terminal_none_command_guard.py

## Notes
- Branch is based on the fork main because the agent token lacks GitHub workflow scope for pushing upstream workflow history changes.
