### PR TITLE
fix(terminal): guard Docker env var parsing against non-Docker backends

### DIFF
--- a/tests/tools/test_parse_env_var.py
+++ b/tests/tools/test_parse_env_var.py
@@ -105,3 +105,66 @@ class TestImportTimeEnvParsing:
                 assert mod.DISK_USAGE_WARNING_THRESHOLD_GB == 500.0
         finally:
             importlib.reload(_tt_mod)
+
+
+class TestDockerEnvVarIsolation:
+    """Docker-specific env vars should not crash non-Docker backends (#42725)."""
+
+    def test_local_backend_ignores_invalid_docker_volumes(self):
+        """Invalid TERMINAL_DOCKER_VOLUMES should not crash local backend."""
+        with patch.dict("os.environ", {
+            "TERMINAL_ENV": "local",
+            "TERMINAL_DOCKER_VOLUMES": "None",  # Invalid JSON
+        }, clear=False):
+            config = _tt_mod._get_env_config()
+            assert config["env_type"] == "local"
+            assert config["docker_volumes"] == []
+
+    def test_ssh_backend_ignores_invalid_docker_env(self):
+        """Invalid TERMINAL_DOCKER_ENV should not crash SSH backend."""
+        with patch.dict("os.environ", {
+            "TERMINAL_ENV": "ssh",
+            "TERMINAL_DOCKER_ENV": "invalid",
+        }, clear=False):
+            config = _tt_mod._get_env_config()
+            assert config["env_type"] == "ssh"
+            assert config["docker_env"] == {}
+
+    def test_local_backend_ignores_invalid_docker_extra_args(self):
+        """Invalid TERMINAL_DOCKER_EXTRA_ARGS should not crash local backend."""
+        with patch.dict("os.environ", {
+            "TERMINAL_ENV": "local",
+            "TERMINAL_DOCKER_EXTRA_ARGS": "not-json",
+        }, clear=False):
+            config = _tt_mod._get_env_config()
+            assert config["env_type"] == "local"
+            assert config["docker_extra_args"] == []
+
+    def test_local_backend_ignores_invalid_docker_forward_env(self):
+        """Invalid TERMINAL_DOCKER_FORWARD_ENV should not crash local backend."""
+        with patch.dict("os.environ", {
+            "TERMINAL_ENV": "local",
+            "TERMINAL_DOCKER_FORWARD_ENV": "broken",
+        }, clear=False):
+            config = _tt_mod._get_env_config()
+            assert config["env_type"] == "local"
+            assert config["docker_forward_env"] == []
+
+    def test_docker_backend_still_parses_valid_volumes(self):
+        """Docker backend should still parse valid TERMINAL_DOCKER_VOLUMES."""
+        with patch.dict("os.environ", {
+            "TERMINAL_ENV": "docker",
+            "TERMINAL_DOCKER_VOLUMES": '["/host:/container"]',
+        }, clear=False):
+            config = _tt_mod._get_env_config()
+            assert config["env_type"] == "docker"
+            assert config["docker_volumes"] == ["/host:/container"]
+
+    def test_docker_backend_still_rejects_invalid_volumes(self):
+        """Docker backend should raise on invalid TERMINAL_DOCKER_VOLUMES."""
+        with patch.dict("os.environ", {
+            "TERMINAL_ENV": "docker",
+            "TERMINAL_DOCKER_VOLUMES": "not-json",
+        }, clear=False):
+            with pytest.raises(ValueError, match="TERMINAL_DOCKER_VOLUMES"):
+                _tt_mod._get_env_config()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1110,7 +1110,9 @@ def _get_env_config() -> Dict[str, Any]:
         "env_type": env_type,
         "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
         "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
-        "docker_forward_env": _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON"),
+        # Docker-specific JSON config: only parse when backend is actually docker
+        # to avoid crashing non-Docker backends on malformed env vars (#42725)
+        "docker_forward_env": _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON") if env_type == "docker" else [],
         "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
         "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
         "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
@@ -1138,10 +1140,12 @@ def _get_env_config() -> Dict[str, Any]:
         "container_memory": _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120"),     # MB (default 5GB)
         "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
-        "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
-        "docker_env": _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON"),
+        # Docker-specific JSON config: only parse when backend is actually docker
+        # to avoid crashing non-Docker backends on malformed env vars (#42725)
+        "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON") if env_type == "docker" else [],
+        "docker_env": _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON") if env_type == "docker" else {},
         "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_extra_args": _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON"),
+        "docker_extra_args": _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON") if env_type == "docker" else [],
         # Cross-process container reuse (issue #20561).  The docs claim
         # "ONE long-lived container shared across sessions" — this toggle
         # makes that real by probing for a labeled container at startup and


### PR DESCRIPTION
## What does this PR do?

Fixes a P1 bug where invalid JSON in Docker-specific environment variables (e.g., `TERMINAL_DOCKER_VOLUMES=None`) crashes **all** terminal and code execution tools — even when the terminal backend is `local` and Docker is completely irrelevant to the setup.

The root cause: `_get_env_config()` in `tools/terminal_tool.py` eagerly parses `TERMINAL_DOCKER_VOLUMES`, `TERMINAL_DOCKER_ENV`, `TERMINAL_DOCKER_EXTRA_ARGS`, and `TERMINAL_DOCKER_FORWARD_ENV` with `json.loads` regardless of the active backend. When any of these contain invalid JSON, `_parse_env_var()` raises `ValueError`, making the agent completely inoperable.

The fix: only parse Docker-specific JSON env vars when `env_type == "docker"`. For non-Docker backends (`local`, `ssh`, `modal`, `singularity`, `daytona`), skip parsing entirely and use safe defaults (`[]`, `{}`).

This brings `terminal_tool.py` in line with `gateway/run.py:2191`, which already has this guard.

## Related Issue

Fixes #42725

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py`: Added `if env_type == "docker"` guard to 4 Docker-specific JSON parsing lines in `_get_env_config()`
- `tests/tools/test_parse_env_var.py`: Added `TestDockerEnvVarIsolation` class with 6 tests covering:
  - Non-Docker backends ignore invalid Docker env vars (4 tests)
  - Docker backend still parses valid values correctly (1 test)
  - Docker backend still raises on invalid values (1 test)

## How to Test

1. Set invalid Docker env var with local backend:
   ```bash
   export TERMINAL_DOCKER_VOLUMES=None
   export TERMINAL_ENV=local
   ```
2. Start Hermes and run any `terminal()` or `execute_code()` call
3. **Before fix**: `ValueError: Invalid value for TERMINAL_DOCKER_VOLUMES: 'None'`
4. **After fix**: Commands execute normally, Docker config is `[]`

Run the test suite:
```bash
pytest tests/tools/test_parse_env_var.py::TestDockerEnvVarIsolation -v
# 6 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/tools/test_parse_env_var.py tests/tools/test_terminal_config_env_sync.py -v` and all 27 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — no documentation updates needed (internal bug fix, no new config keys)
- [x] N/A — no `cli-config.yaml.example` changes
- [x] N/A — no `CONTRIBUTING.md` or `AGENTS.md` changes
- [x] N/A — no cross-platform impact (fix applies to all platforms equally)
- [x] N/A — no tool description/schema changes

Created with: Hermes Agent