### PR TITLE
fix(cli): clarify /new, /start, /reset command descriptions

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -63,9 +63,9 @@ class CommandDef:
 
 COMMAND_REGISTRY: list[CommandDef] = [
     # Session
-    CommandDef("start", "Acknowledge platform start pings without a reply", "Session",
+    CommandDef("start", "Internal: acknowledge Telegram bot launch pings (not a user command)", "Session",
                gateway_only=True),
-    CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
+    CommandDef("new", "Discard current conversation and start fresh (clears history + session ID)", "Session",
                aliases=("reset",), args_hint="[name]"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),


### PR DESCRIPTION
## What does this PR do?

Fixes user confusion about three CLI commands that appear similar in help output.

**The problem**: Users see `/new`, `/start`, and `/reset` in help and think they all do the same thing.

**The reality**:
- `/start` is a Telegram platform ping (not a user command) — just acknowledges bot launches without replying
- `/new` is the actual user command to discard current conversation and start fresh
- `/reset` is just an alias of `/new` (same command, same behavior)

**The fix**: Update descriptions to make the distinction clear:
- `/start`: "Internal: acknowledge Telegram bot launch pings (not a user command)"
- `/new`: "Discard current conversation and start fresh (clears history + session ID)"

This prevents new users from being confused about which command to use when they want to reset their conversation.

## Related Issue

Fixes #42829

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/commands.py`: Updated descriptions for `/start` and `/new` in `COMMAND_REGISTRY`

## How to Test

1. Run Hermes CLI
2. Type `/help` or press `/` to see command list
3. Verify `/start` now shows: "Internal: acknowledge Telegram bot launch pings (not a user command)"
4. Verify `/new` now shows: "Discard current conversation and start fresh (clears history + session ID)"
5. Verify `/new` still shows "(alias: `/reset`)" in the help output

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls)
- [x] My PR contains **only** changes related to this fix
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — no README/docs updates (command descriptions are inline)
- [x] N/A — no `cli-config.yaml.example` changes
- [x] N/A — no `CONTRIBUTING.md` or `AGENTS.md` changes
- [x] N/A — no cross-platform impact
- [x] N/A — no tool description/schema changes

Created with: Hermes Agent