### PR TITLE
fix: disable voice beeps by default

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9005,10 +9005,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             from hermes_cli.config import load_config
             voice_cfg = load_config().get("voice", {})
             if isinstance(voice_cfg, dict):
-                return bool(voice_cfg.get("beep_enabled", True))
+                return bool(voice_cfg.get("beep_enabled", False))
         except Exception:
             pass
-        return True
+        return False
 
     def _enable_voice_mode(self):
         """Enable voice mode after checking requirements."""

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1628,7 +1628,7 @@ DEFAULT_CONFIG = {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
         "auto_tts": False,
-        "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
+        "beep_enabled": False,        # Play record start/stop beeps in CLI voice mode
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
     },

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -245,16 +245,16 @@ def _debug(msg: str) -> None:
 
 
 def _beeps_enabled() -> bool:
-    """CLI parity: voice.beep_enabled in config.yaml (default True)."""
+    """CLI parity: voice.beep_enabled in config.yaml (default False)."""
     try:
         from hermes_cli.config import load_config
 
         voice_cfg = load_config().get("voice", {})
         if isinstance(voice_cfg, dict):
-            return bool(voice_cfg.get("beep_enabled", True))
+            return bool(voice_cfg.get("beep_enabled", False))
     except Exception:
         pass
-    return True
+    return False
 
 
 def _play_beep(frequency: int, count: int = 1) -> None:

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -939,9 +939,9 @@ class TestVoiceBeepConfigReal:
     """Tests the CLI voice beep toggle."""
 
     @patch("hermes_cli.config.load_config", return_value={"voice": {}})
-    def test_beeps_enabled_by_default(self, _cfg):
+    def test_beeps_disabled_by_default(self, _cfg):
         cli = _make_voice_cli()
-        assert cli._voice_beeps_enabled() is True
+        assert cli._voice_beeps_enabled() is False
 
     @patch("hermes_cli.config.load_config", return_value={"voice": {"beep_enabled": False}})
     def test_beeps_can_be_disabled(self, _cfg):

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -168,7 +168,7 @@ voice:
   record_key: "ctrl+b"
   max_recording_seconds: 120
   auto_tts: false
-  beep_enabled: true
+  beep_enabled: false
   silence_threshold: 200
   silence_duration: 3.0
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1370,7 +1370,7 @@ voice:
   record_key: "ctrl+b"         # Push-to-talk key inside the CLI
   max_recording_seconds: 120    # Hard stop for long recordings
   auto_tts: false               # Enable spoken replies automatically when /voice on
-  beep_enabled: true            # Play record start/stop beeps in CLI voice mode
+  beep_enabled: false           # Play record start/stop beeps in CLI voice mode
   silence_threshold: 200        # RMS threshold for speech detection
   silence_duration: 3.0         # Seconds of silence before auto-stop
 ```

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -389,7 +389,7 @@ voice:
   record_key: "ctrl+b"            # Key to start/stop recording
   max_recording_seconds: 120       # Maximum recording length
   auto_tts: false                  # Auto-enable TTS when voice mode starts
-  beep_enabled: true               # Play record start/stop beeps
+  beep_enabled: false              # Play record start/stop beeps
   silence_threshold: 200           # RMS level (0-32767) below which counts as silence
   silence_duration: 3.0            # Seconds of silence before auto-stop
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/use-voice-mode-with-hermes.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/use-voice-mode-with-hermes.md
@@ -164,7 +164,7 @@ voice:
   record_key: "ctrl+b"
   max_recording_seconds: 120
   auto_tts: false
-  beep_enabled: true
+  beep_enabled: false
   silence_threshold: 200
   silence_duration: 3.0
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1272,7 +1272,7 @@ voice:
   record_key: "ctrl+b"         # CLI 内的按键通话键
   max_recording_seconds: 120    # 长录音的硬停止
   auto_tts: false               # /voice on 时自动启用口语回复
-  beep_enabled: true            # 在 CLI 语音模式中播放录音开始/停止提示音
+  beep_enabled: false           # 在 CLI 语音模式中播放录音开始/停止提示音
   silence_threshold: 200        # 语音检测的 RMS 阈值
   silence_duration: 3.0         # 自动停止前的静默秒数
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/voice-mode.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/voice-mode.md
@@ -389,7 +389,7 @@ voice:
   record_key: "ctrl+b"            # 开始/停止录音的按键
   max_recording_seconds: 120       # 最大录音时长
   auto_tts: false                  # 启用语音模式时自动开启 TTS
-  beep_enabled: true               # 播放录音开始/结束提示音
+  beep_enabled: false              # 播放录音开始/结束提示音
   silence_threshold: 200           # 静音判定的 RMS 电平（0-32767）
   silence_duration: 3.0            # 自动停止前的静音秒数
 


### PR DESCRIPTION
## Summary
- Disable CLI voice start/stop beeps by default so voice mode is quiet out of the box
- Keep the existing `voice.beep_enabled` override for anyone who wants the cues back
- Update tests and docs in English and zh-Hans

## Test Plan
- `pytest -q tests/hermes_cli/test_voice_wrapper.py tests/tools/test_voice_cli_integration.py`
