### PR TITLE
fix(cron): run no-agent scripts from workdir

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -954,7 +954,7 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(script_path: str, *, cwd: str | None = None) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -976,6 +976,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         script_path: Path to the script.  Relative paths are resolved
             against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
             are also validated to ensure they stay within the scripts dir.
+        cwd: Optional subprocess working directory.  When omitted, scripts
+            run from their own directory to preserve existing pre-check
+            behaviour.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -1007,6 +1010,12 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         return False, f"Script path is not a file: {path}"
 
     script_timeout = _get_script_timeout()
+    run_cwd = path.parent
+    if cwd:
+        run_cwd_path = Path(cwd).expanduser()
+        if not run_cwd_path.is_dir():
+            return False, f"Working directory not found: {run_cwd_path}"
+        run_cwd = run_cwd_path.resolve()
 
     # Pick an interpreter by extension.  Bash for .sh/.bash, Python for
     # everything else.  We deliberately do NOT honour the file's own
@@ -1050,7 +1059,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             capture_output=True,
             text=True,
             timeout=script_timeout,
-            cwd=str(path.parent),
+            cwd=str(run_cwd),
             env=run_env,
             **popen_kwargs,
         )
@@ -1387,22 +1396,10 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # paths. For no_agent jobs this is just the subprocess cwd (not an
         # agent TERMINAL_CWD bridge).
         _job_workdir = (job.get("workdir") or "").strip() or None
-        _prior_cwd = None
-        if _job_workdir and Path(_job_workdir).is_dir():
-            _prior_cwd = os.getcwd()
-            try:
-                os.chdir(_job_workdir)
-            except OSError:
-                _prior_cwd = None
+        if _job_workdir and not Path(_job_workdir).is_dir():
+            _job_workdir = None
 
-        try:
-            ok, output = _run_job_script(script_path)
-        finally:
-            if _prior_cwd is not None:
-                try:
-                    os.chdir(_prior_cwd)
-                except OSError:
-                    pass
+        ok, output = _run_job_script(script_path, cwd=_job_workdir)
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -210,6 +210,37 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in doc
 
 
+def test_run_job_no_agent_uses_configured_workdir_for_script_cwd(hermes_env):
+    """no_agent scripts should run from the job workdir when one is configured."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    workdir = hermes_env / "project"
+    workdir.mkdir()
+    (workdir / "marker.txt").write_text("from workdir\n")
+
+    script_path = hermes_env / "scripts" / "read_marker.py"
+    script_path.write_text(
+        "from pathlib import Path\n"
+        "print(Path('marker.txt').read_text().strip())\n"
+    )
+
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="read_marker.py",
+        no_agent=True,
+        deliver="local",
+        workdir=str(workdir),
+    )
+    success, doc, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert "from workdir" in final_response
+    assert "from workdir" in doc
+
+
 def test_run_job_no_agent_empty_output_is_silent(hermes_env):
     """Empty stdout → SILENT_MARKER, which suppresses delivery downstream."""
     from cron.jobs import create_job


### PR DESCRIPTION
## Summary

- Run cron `no_agent` scripts from the job's configured `workdir` when one is present.
- Preserve the existing `_run_job_script()` default of running scripts from `HERMES_HOME/scripts`.
- Add a regression test proving a no-agent script can read a relative file from the configured workdir.

## Validation

- Failed first: `.venv/bin/python -m pytest tests/cron/test_cron_no_agent.py -k workdir -q` failed because `run_job(job)` returned `success=False`.
- `.venv/bin/python -m pytest tests/cron/test_cron_no_agent.py -k workdir -q` (passed after fix)
- `.venv/bin/python -m pytest tests/cron/test_cron_no_agent.py -q` (19 passed)
- `.venv/bin/python -m pytest tests/cron/test_cron_workdir.py -q` (21 passed)
- `.venv/bin/python -m pytest tests/cron/test_cron_script.py::TestRunJobScript tests/cron/test_cron_script.py::TestBuildJobPromptWithScript -q` (10 passed)
- `HERMES_DISABLE_LAZY_INSTALLS=1 .venv/bin/python -m pytest tests/cron/test_cron_no_agent.py tests/cron/test_cron_script.py tests/cron/test_cron_workdir.py -q` (76 passed)
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python scripts/check-windows-footguns.py --all` (612 files scanned)
- `git diff --check`

Note: the same three-file pytest command without `HERMES_DISABLE_LAZY_INSTALLS=1` timed out in an unrelated lazy dependency install path in `TestRunJobEnvVarCleanup`; disabling lazy installs is the repo-supported switch for avoiding runtime package installs during unit tests.

## Sprint Gates

- Branch created from latest `upstream/main` (`f6416f50fced55260144a702e06ec5026c2dcffd`).
- Repo-local git identity: `qdivan / 77005282+qdivan@users.noreply.github.com`.
- Duplicate open PR check: no active duplicate found in the batched open PR list.
- Candidate review: PASS.
- Patch review: PASS twice; second review after docstring update.
