### PR TITLE
fix(tools): count non-overlapping occurrences in V4A patch validation

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -463,9 +463,24 @@ class TestCountOccurrences:
     def test_basic(self):
         from tools.patch_parser import _count_occurrences
         assert _count_occurrences("aaa", "a") == 3
-        assert _count_occurrences("aaa", "aa") == 2
         assert _count_occurrences("hello world", "xyz") == 0
         assert _count_occurrences("", "x") == 0
+
+    def test_counts_non_overlapping_matches(self):
+        """The helper is documented to count *non-overlapping* occurrences,
+        and the ambiguity check in ``_validate_operations`` relies on that:
+        a self-overlapping context hint that occurs exactly once must count
+        as 1, otherwise an unambiguous addition-only hunk is spuriously
+        rejected as "ambiguous" (the ``start = pos + 1`` overlap bug)."""
+        from tools.patch_parser import _count_occurrences
+        # Self-overlapping patterns that occur exactly once non-overlapping.
+        assert _count_occurrences("aaa", "aa") == 1
+        # A short divider hint sitting inside a longer rule: one location.
+        assert _count_occurrences("-----", "---") == 1
+        assert _count_occurrences("ababa", "aba") == 1
+        # Genuine non-overlapping repeats are still counted.
+        assert _count_occurrences("aaaa", "aa") == 2
+        assert _count_occurrences("xx.xx", "xx") == 2
 
 
 class TestParseErrorSignalling:

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -233,7 +233,10 @@ def _count_occurrences(text: str, pattern: str) -> int:
         if pos == -1:
             break
         count += 1
-        start = pos + 1
+        # Advance past the whole match so occurrences are counted
+        # non-overlapping (as documented). ``max(1, ...)`` keeps an empty
+        # pattern from looping forever.
+        start = pos + max(1, len(pattern))
     return count
 
 


### PR DESCRIPTION
## What & why

`_count_occurrences` (`tools/patch_parser.py`) is documented to count **non-overlapping** occurrences, and `_validate_operations` uses `occurrences > 1` to decide whether an addition-only hunk's `context_hint` is ambiguous. The loop advanced the cursor with `start = pos + 1`, so it counted *overlapping* matches: a self-overlapping hint that appears exactly once (e.g. a short divider `---` sitting inside a longer rule `-----`) was counted multiple times, and the otherwise-valid patch was rejected with "context hint is ambiguous".

Fix advances past the whole match (`start = pos + max(1, len(pattern))`); `max(1, …)` keeps an empty pattern from looping forever. The existing `TestCountOccurrences.test_basic` assertion that encoded the overlapping behaviour (`n("aaa","aa") == 2`) is corrected, and a focused regression test is added.

## How to test

```bash
pytest tests/tools/test_patch_parser.py
```

## Platforms

macOS (pure-Python, no platform-specific behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
