### PR TITLE
fix(cron): reject zero-length durations instead of looping forever

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -200,8 +200,13 @@ def parse_duration(s: str) -> int:
         raise ValueError(f"Invalid duration: '{s}'. Use format like '30m', '2h', or '1d'")
     
     value = int(match.group(1))
+    if value <= 0:
+        raise ValueError(
+            f"Duration must be positive: '{s}'. "
+            "A zero interval would re-fire on every scheduler tick."
+        )
     unit = match.group(2)[0]  # First char: m, h, or d
-    
+
     multipliers = {'m': 1, 'h': 60, 'd': 1440}
     return value * multipliers[unit]
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -62,6 +62,17 @@ class TestParseDuration:
         with pytest.raises(ValueError):
             parse_duration("m30")
 
+    def test_zero_duration_raises(self):
+        """A zero duration is degenerate: as an interval it produces a job
+        that is always immediately due and re-fires every scheduler tick.
+        It must be rejected at parse time rather than silently accepted."""
+        with pytest.raises(ValueError):
+            parse_duration("0m")
+        with pytest.raises(ValueError):
+            parse_duration("0h")
+        with pytest.raises(ValueError):
+            parse_duration("0d")
+
 
 # =========================================================================
 # parse_schedule
@@ -104,6 +115,12 @@ class TestParseSchedule:
     def test_invalid_schedule_raises(self):
         with pytest.raises(ValueError):
             parse_schedule("not_a_schedule")
+
+    def test_zero_interval_raises(self):
+        """'every 0m' would build an interval job that is always due and
+        re-fires on every tick (runaway agent runs); reject it."""
+        with pytest.raises(ValueError):
+            parse_schedule("every 0m")
 
     def test_invalid_cron_raises(self):
         pytest.importorskip("croniter")


### PR DESCRIPTION
## What & why

`parse_duration` accepted `"0m"`/`"0h"`/`"0d"` and returned `0`. For an interval schedule (`every 0m`), `parse_schedule` then built `{"kind":"interval","minutes":0}`; `compute_next_run` returns `now + 0min = now`, so the job is perpetually due and the scheduler re-fires it on every tick — an unbounded stream of agent runs (API-budget burn / delivery flooding) until an operator deletes it.

Reject `value <= 0` in `parse_duration` so `every 0m` fails fast at create/update time with a clear error (the cron tool already surfaces `ValueError`). A zero one-shot duration is likewise rejected, which is harmless.

This is a robustness / DoS-hardening fix (per the SECURITY.md note, availability hardening, not the load-bearing isolation boundary).

## How to test

```bash
pytest tests/cron/test_jobs.py
```

## Platforms

macOS (pure-Python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
