### PR TITLE
fix(tools): retry Telegram 504 / gateway-timeout sends

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -982,6 +982,38 @@ class TestSendTelegramHtmlDetection:
         sleep_mock.assert_awaited_once()
 
 
+class TestTelegramRetryDelay:
+    """``_telegram_retry_delay`` decides whether a failed Telegram send is
+    retried. A 504 / "Gateway Timeout" is a transient upstream error that
+    must be retried like the other 5xx responses it enumerates; the broad
+    ``"timeout" in text`` check must not shadow the ``"gateway timeout"`` /
+    ``"504"`` branch (which was previously dead code)."""
+
+    def test_gateway_timeout_is_retried(self):
+        from tools.send_message_tool import _telegram_retry_delay
+        assert _telegram_retry_delay(Exception("Gateway Timeout"), 0) == 1.0
+        assert _telegram_retry_delay(Exception("504 Gateway Timeout"), 1) == 2.0
+
+    def test_other_transient_5xx_still_retried(self):
+        from tools.send_message_tool import _telegram_retry_delay
+        assert _telegram_retry_delay(Exception("502 Bad Gateway"), 0) == 1.0
+        assert _telegram_retry_delay(Exception("503 Service Unavailable"), 2) == 4.0
+        assert _telegram_retry_delay(Exception("429 Too Many Requests"), 1) == 2.0
+
+    def test_client_side_timeout_not_retried(self):
+        from tools.send_message_tool import _telegram_retry_delay
+        # A bare read/connect timeout may already have reached Telegram, so
+        # re-sending risks a duplicate message — do not retry.
+        assert _telegram_retry_delay(Exception("Read timed out"), 0) is None
+        assert _telegram_retry_delay(Exception("Connection timeout"), 0) is None
+
+    def test_retry_after_takes_precedence(self):
+        from tools.send_message_tool import _telegram_retry_delay
+        exc = Exception("flood")
+        exc.retry_after = 7
+        assert _telegram_retry_delay(exc, 3) == 7.0
+
+
 class TestSendTelegramThreadIdMapping:
     """General-topic mapping in _send_telegram (issue #22267).
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -89,8 +89,11 @@ def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
             return 1.0
 
     text = str(exc).lower()
-    if "timed out" in text or "timeout" in text:
-        return None
+    # Retry transient upstream errors (5xx / rate limiting) with exponential
+    # backoff. This is checked BEFORE the generic timeout bail-out below:
+    # a 504 "Gateway Timeout" contains the substring "timeout", so the
+    # generic check would otherwise shadow this branch and the 504/gateway
+    # timeout cases would never be retried.
     if (
         "bad gateway" in text
         or "502" in text
@@ -102,6 +105,10 @@ def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
         or "504" in text
     ):
         return float(2 ** attempt)
+    # A bare client-side read/connect timeout is not safely retryable: the
+    # request may already have reached Telegram, so re-sending risks a dup.
+    if "timed out" in text or "timeout" in text:
+        return None
     return None
 
 


### PR DESCRIPTION
## What & why

`_telegram_retry_delay` checked `"timed out" in text or "timeout" in text` and returned `None` (no retry) **before** the branch listing `"gateway timeout"` / `"504"` as retryable. Because a 504 message contains the substring `"timeout"`, that retryable branch was dead code: transient Telegram **504 Gateway Timeout** responses were surfaced as hard send failures, while every other 5xx (502/503) and 429 were retried with exponential backoff.

Evaluate the retryable 5xx/429/gateway-timeout block first, then fall back to the generic timeout bail-out (which still covers genuine client-side read/connect timeouts, where re-sending could duplicate the message).

## How to test

```bash
pytest tests/tools/test_send_message_tool.py
```

## Platforms

macOS (pure-Python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
