### PR TITLE
fix(tools): count file lines newline-agnostically in read_file

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -300,6 +300,44 @@ def file_ops(mock_env):
     return ShellFileOperations(mock_env)
 
 
+class _RealShellEnv:
+    """A terminal env whose ``execute`` runs the command in a real shell,
+    so read_file's shell pipeline (wc -c / head -c / sed / line count) is
+    exercised end-to-end against an actual file on disk."""
+
+    def __init__(self, cwd):
+        self.cwd = str(cwd)
+
+    def execute(self, command, **kwargs):
+        import subprocess
+        proc = subprocess.run(
+            command, shell=True, cwd=self.cwd,
+            capture_output=True, text=True,
+        )
+        return {"output": proc.stdout, "returncode": proc.returncode}
+
+
+def test_read_file_counts_final_line_without_trailing_newline(tmp_path):
+    """A file whose last line has no trailing newline must report the correct
+    total_lines so the truncation hint is right. `wc -l` counts newline
+    characters and undercounts such files by one; for a 501-line file read
+    in 500-line pages that made `truncated` False and silently dropped the
+    last (unterminated) line from the model's view."""
+    target = tmp_path / "noeol.txt"
+    # 501 logical lines, NO trailing newline on the last one.
+    target.write_text("\n".join(f"line{i}" for i in range(1, 502)))
+
+    ops = ShellFileOperations(_RealShellEnv(tmp_path))
+    result = ops.read_file(str(target), offset=1, limit=500)
+
+    assert result.error is None
+    assert result.total_lines == 501
+    # The 501st line is past the first page, so the read must be truncated
+    # and a continuation hint emitted.
+    assert result.truncated is True
+    assert result.hint is not None
+
+
 class TestShellFileOpsHelpers:
     def test_normalize_read_pagination_clamps_invalid_values(self):
         assert normalize_read_pagination(offset=0, limit=0) == (1, 1)
@@ -394,7 +432,7 @@ class TestShellFileOpsHelpers:
                 return {"output": "print('ok')\n", "returncode": 0}
             if command.startswith("sed -n"):
                 return {"output": leaked, "returncode": 0}
-            if command.startswith("wc -l"):
+            if command.startswith("awk"):
                 return {"output": "1\n", "returncode": 0}
             return {"output": "", "returncode": 0}
 

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -284,7 +284,7 @@ class TestPaginationBounds:
                 return MagicMock(exit_code=0, stdout="line1\nline2\n")
             if command.startswith("sed -n"):
                 return MagicMock(exit_code=0, stdout="line1\n")
-            if command.startswith("wc -l"):
+            if command.startswith("awk"):
                 return MagicMock(exit_code=0, stdout="2")
             return MagicMock(exit_code=0, stdout="")
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1017,12 +1017,15 @@ class ShellFileOperations(FileOperations):
         if offset == 1:
             read_output, _ = _strip_bom(read_output)
         
-        # Get total line count
-        wc_cmd = f"wc -l < {self._escape_shell_arg(path)}"
-        wc_result = self._exec(wc_cmd)
-        wc_output = _strip_terminal_fence_leaks(wc_result.stdout)
+        # Get total line count. ``awk 'END{print NR}'`` counts logical lines
+        # including a final line with no trailing newline; ``wc -l`` counts
+        # newline characters and would undercount such files by one, yielding
+        # a wrong total and a wrong/absent truncation hint.
+        count_cmd = f"awk 'END{{print NR}}' {self._escape_shell_arg(path)}"
+        count_result = self._exec(count_cmd)
+        count_output = _strip_terminal_fence_leaks(count_result.stdout)
         try:
-            total_lines = int(wc_output.strip())
+            total_lines = int(count_output.strip())
         except ValueError:
             total_lines = 0
         


### PR DESCRIPTION
## What & why

`read_file` derived `total_lines` from `wc -l`, which counts newline characters, not logical lines. A file whose last line has no trailing newline (common for source/config files) was reported one line short. That value feeds `truncated = total_lines > end_line` and the continuation hint, so on a file landing exactly on the page boundary the read was marked complete and the final un-terminated line was silently dropped from the model's view (the `sed` content was correct; only the metadata was wrong).

Use `awk 'END{print NR}'`, which counts the final line with no trailing newline. Mocks that simulated the line-count command are updated to match.

## How to test

```bash
pytest tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py
```

## Platforms

macOS, Linux, WSL2 — `awk 'END{print NR}'` is POSIX and runs through the same shell the function already uses for `wc -c` / `sed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
