### PR TITLE
fix(providers): bound the /models catalog response size in fetch_models

### DIFF
--- a/providers/base.py
+++ b/providers/base.py
@@ -17,6 +17,11 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Upper bound on a /models catalog response. A model list is small JSON even
+# for providers with thousands of models; this only exists so a misconfigured
+# or hostile catalog endpoint can't stream an unbounded body into memory.
+_MAX_MODELS_RESPONSE_BYTES = 16 * 1024 * 1024  # 16 MiB
+
 # Sentinel for "omit temperature entirely" (Kimi: server manages it)
 OMIT_TEMPERATURE = object()
 
@@ -204,9 +209,33 @@ class ProviderProfile:
         for k, v in self.default_headers.items():
             req.add_header(k, v)
 
+        # Bound the response so a misconfigured/hostile catalog endpoint
+        # can't force an unbounded in-memory buffer. A timeout limits
+        # wall-clock, not size. Oversized responses fall back to the static
+        # model list (return None), matching the documented contract.
+        max_bytes = _MAX_MODELS_RESPONSE_BYTES
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                data = json.loads(resp.read().decode())
+                content_length = resp.headers.get("Content-Length")
+                if content_length is not None:
+                    try:
+                        if int(content_length) > max_bytes:
+                            logger.debug(
+                                "fetch_models(%s): catalog response too large "
+                                "(Content-Length=%s > %d)",
+                                self.name, content_length, max_bytes,
+                            )
+                            return None
+                    except (TypeError, ValueError):
+                        pass
+                raw = resp.read(max_bytes + 1)
+            if len(raw) > max_bytes:
+                logger.debug(
+                    "fetch_models(%s): catalog response exceeded %d bytes",
+                    self.name, max_bytes,
+                )
+                return None
+            data = json.loads(raw.decode())
             items = data if isinstance(data, list) else data.get("data", [])
             return [m["id"] for m in items if isinstance(m, dict) and "id" in m]
         except Exception as exc:

--- a/tests/providers/test_fetch_models_size_limit.py
+++ b/tests/providers/test_fetch_models_size_limit.py
@@ -1,0 +1,69 @@
+"""Regression tests for ProviderProfile.fetch_models response-size bounding.
+
+fetch_models() probes a provider's /models endpoint. The endpoint URL comes
+from operator/config (base_url/models_url, e.g. a self-hosted or community
+relay), so a misconfigured or hostile catalog endpoint must not be able to
+force the process to buffer an unbounded body into memory. A timeout bounds
+wall-clock, not size — the response itself has to be capped.
+"""
+
+import json
+
+import providers.base as pbase
+from providers.base import ProviderProfile
+
+
+class _FakeResp:
+    """Minimal stand-in for an http.client.HTTPResponse context manager."""
+
+    def __init__(self, body: bytes, content_length=None):
+        self._body = body
+        self.headers = {}
+        if content_length is not None:
+            self.headers["Content-Length"] = str(content_length)
+
+    def read(self, n=-1):
+        if n is None or n < 0:
+            return self._body
+        return self._body[:n]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _patch_urlopen(monkeypatch, resp):
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda req, timeout=None: resp
+    )
+
+
+def _profile():
+    return ProviderProfile(name="test", base_url="https://api.example.test/v1")
+
+
+def test_small_response_returns_model_ids(monkeypatch):
+    body = json.dumps({"data": [{"id": "m1"}, {"id": "m2"}]}).encode()
+    _patch_urlopen(monkeypatch, _FakeResp(body))
+    assert _profile().fetch_models() == ["m1", "m2"]
+
+
+def test_oversized_body_is_rejected(monkeypatch):
+    # Cap to a tiny value so we don't allocate megabytes in the test.
+    monkeypatch.setattr(pbase, "_MAX_MODELS_RESPONSE_BYTES", 32)
+    body = json.dumps({"data": [{"id": "x" * 200}]}).encode()
+    assert len(body) > 32
+    # No Content-Length header → the post-read length guard must catch it.
+    _patch_urlopen(monkeypatch, _FakeResp(body))
+    assert _profile().fetch_models() is None
+
+
+def test_oversized_content_length_header_is_rejected(monkeypatch):
+    monkeypatch.setattr(pbase, "_MAX_MODELS_RESPONSE_BYTES", 32)
+    # Small body, but the server advertises a huge Content-Length.
+    _patch_urlopen(
+        monkeypatch, _FakeResp(b'{"data": []}', content_length=10_000_000)
+    )
+    assert _profile().fetch_models() is None


### PR DESCRIPTION
## What & why

`ProviderProfile.fetch_models` did `json.loads(resp.read().decode())` with no size limit. The endpoint URL comes from the provider profile's `base_url`/`models_url`, which is operator/config-controlled (e.g. a self-hosted or community OpenAI-compatible relay). A misconfigured or compromised endpoint could stream a multi-hundred-MB body within the request timeout and force the CLI/gateway to buffer and JSON-parse an unbounded blob (memory spike / OOM); a timeout bounds wall-clock, not size.

Check `Content-Length` and cap the read at `_MAX_MODELS_RESPONSE_BYTES` (16 MiB), returning `None` on an oversized response so callers degrade gracefully to the static fallback model list — mirroring the existing bounded-download pattern in `tools/vision_tools.py`.

Robustness / DoS-hardening fix.

## How to test

```bash
pytest tests/providers/test_fetch_models_size_limit.py
```

## Platforms

macOS (stdlib `urllib`, no platform-specific behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
