### PR TITLE
Fix LINE ready auto-push and group mention gate

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -16,10 +16,11 @@ expired, or rejected by the API.
 **Slow-LLM postback button (optional).** When the LLM is still running past
 ``slow_response_threshold`` seconds (default 45, leaving 15s margin on the
 60s reply-token TTL), we burn the original reply token to send a Template
-Buttons bubble — the user taps it later to receive the cached answer via a
-*fresh* reply token (also free). State machine: PENDING → READY → DELIVERED,
-with ERROR for cancelled runs. Set the threshold to 0 to disable the
-button and always Push-fallback instead.
+Buttons bubble. When the answer becomes ready we proactively Push the final
+response back to the chat; if that Push fails, the existing button still lets
+the user fetch the cached answer via a *fresh* reply token. State machine:
+PENDING → READY → DELIVERED, with ERROR for cancelled runs. Set the
+threshold to 0 to disable the button and always Push-fallback instead.
 
 **Three-allowlist gating.** Separate allowlists for users (U-prefixed),
 groups (C-prefixed), and rooms (R-prefixed). ``LINE_ALLOW_ALL_USERS=true``
@@ -938,13 +939,6 @@ class LineAdapter(BasePlatformAdapter):
         chat_id, chat_type = _resolve_chat(source)
         user_id = source.get("userId", "") or chat_id
 
-        # Stash the reply token for outbound use.
-        if chat_id and reply_token:
-            self._reply_tokens[chat_id] = (
-                reply_token,
-                time.time() + LINE_REPLY_TOKEN_TTL_SECONDS,
-            )
-
         # Handle media inbound — fetch the binary, cache it, and surface a
         # vision-tool-friendly local path on the MessageEvent.
         media_urls: List[str] = []
@@ -968,6 +962,39 @@ class LineAdapter(BasePlatformAdapter):
             text = f"[location: {title} {address}]".strip()
         else:
             text = f"[unsupported message type: {msg_type}]"
+
+        # Mention gate for group/room:
+        # - allow when text starts with @hermes / ＠hermes (case-insensitive), OR
+        # - allow when LINE mention metadata includes @all / isSelf.
+        # DM bypasses this gate.
+        source_type = (source.get("type") or "").lower()
+        if source_type in {"group", "room"}:
+            if msg_type != "text":
+                logger.info("LINE: mention gate skip (group non-text), chat=%s", chat_id)
+                return
+
+            text_for_gate = text.strip()
+            has_prefix_mention = bool(
+                re.match(r"^[＠@]\s*hermes\b", text_for_gate, flags=re.IGNORECASE)
+            )
+            mention = msg.get("mention") or {}
+            mentionees = mention.get("mentionees") or []
+            has_true_mention = any(
+                isinstance(m, dict) and (m.get("isSelf") is True or m.get("type") == "all")
+                for m in mentionees
+            )
+            if not (has_prefix_mention or has_true_mention):
+                logger.info("LINE: mention gate skip (group text without mention), chat=%s", chat_id)
+                return
+
+        # Stash the reply token for outbound use only after this message has
+        # passed gating, so unrelated group chatter cannot overwrite the token
+        # for an in-flight mentioned request.
+        if chat_id and reply_token:
+            self._reply_tokens[chat_id] = (
+                reply_token,
+                time.time() + LINE_REPLY_TOKEN_TTL_SECONDS,
+            )
 
         # Best-effort typing indicator (DM only).
         if chat_type == "dm" and self._client:
@@ -1092,14 +1119,46 @@ class LineAdapter(BasePlatformAdapter):
         if _is_system_bypass(content):
             return await self._send_text_chunks(chat_id, content, force_push=False)
 
-        # If the chat has a PENDING postback button outstanding, route the
-        # response into the cache for the user to fetch via tap.
+        # If the chat has a PENDING postback button outstanding, cache the
+        # response immediately and then proactively push it to the chat. If the
+        # push fails, keep the READY cache entry so the existing postback button
+        # still works as a manual fallback.
         pending_rid = self._pending_buttons.get(chat_id)
         if pending_rid:
             self._cache.set_ready(pending_rid, content)
+            await self._push_cached_response(chat_id, pending_rid)
             return SendResult(success=True, message_id=pending_rid)
 
         return await self._send_text_chunks(chat_id, content, force_push=False)
+
+    async def _push_cached_response(self, chat_id: str, request_id: str) -> bool:
+        """Push a cached READY response to chat; keep cache as fallback on failure."""
+        entry = self._cache.get(request_id)
+        if not self._client or not entry or entry.state is not State.READY:
+            return False
+
+        payload = entry.payload or ""
+        chunks = split_for_line(strip_markdown_preserving_urls(str(payload)))
+        messages = [_text_message(c) for c in chunks][:LINE_MAX_MESSAGES_PER_CALL]
+        if not messages:
+            self._cache.mark_delivered(request_id)
+            self._pending_buttons.pop(chat_id, None)
+            return True
+
+        try:
+            await self._client.push(chat_id, messages)
+            self._cache.mark_delivered(request_id)
+            self._pending_buttons.pop(chat_id, None)
+            logger.info("LINE: auto-pushed ready response for chat %s (rid=%s)", chat_id, request_id)
+            return True
+        except Exception as exc:
+            logger.warning(
+                "LINE: auto-push ready response failed for chat %s (rid=%s): %s",
+                chat_id,
+                request_id,
+                exc,
+            )
+            return False
 
     async def _send_text_chunks(
         self,

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -324,6 +324,43 @@ class TestSendRouting:
         assert not _is_system_bypass("Hello world")
         assert not _is_system_bypass("")
 
+    def test_group_fullwidth_prefix_mention_reaches_handler(self, adapter):
+        adapter.handle_message = AsyncMock()
+        event = {
+            "replyToken": "rtok",
+            "source": {"type": "group", "groupId": "Cchat", "userId": "Uuser"},
+            "message": {"id": "m1", "type": "text", "text": "＠hermes 幫我整理"},
+        }
+        asyncio.run(adapter._handle_message_event(event))
+        adapter.handle_message.assert_awaited_once()
+
+    def test_group_text_without_mention_is_ignored(self, adapter):
+        adapter.handle_message = AsyncMock()
+        event = {
+            "replyToken": "rtok",
+            "source": {"type": "group", "groupId": "Cchat", "userId": "Uuser"},
+            "message": {"id": "m2", "type": "text", "text": "幫我整理"},
+        }
+        asyncio.run(adapter._handle_message_event(event))
+        adapter.handle_message.assert_not_awaited()
+
+    def test_ignored_group_chatter_does_not_overwrite_reply_token(self, adapter):
+        adapter.handle_message = AsyncMock()
+        mention_event = {
+            "replyToken": "rtok-mention",
+            "source": {"type": "group", "groupId": "Cchat", "userId": "Uuser"},
+            "message": {"id": "m3", "type": "text", "text": "＠hermes 幫我整理"},
+        }
+        ignored_event = {
+            "replyToken": "rtok-ignored",
+            "source": {"type": "group", "groupId": "Cchat", "userId": "Uuser"},
+            "message": {"id": "m4", "type": "text", "text": "路過聊天"},
+        }
+        asyncio.run(adapter._handle_message_event(mention_event))
+        asyncio.run(adapter._handle_message_event(ignored_event))
+        assert adapter._reply_tokens["Cchat"][0] == "rtok-mention"
+        assert adapter.handle_message.await_count == 1
+
     def test_send_uses_reply_when_token_present(self, adapter):
         import time as _time
         adapter._reply_tokens["Uchat"] = ("rt-token", _time.time() + 30)
@@ -355,17 +392,28 @@ class TestSendRouting:
         assert not result.success
         assert "network" in result.error
 
-    def test_send_pending_button_caches_response(self, adapter):
+    def test_send_pending_button_auto_pushes_ready_response(self, adapter):
         # Simulate that the slow-LLM postback button has fired.
         rid = adapter._cache.register_pending("Uchat")
         adapter._pending_buttons["Uchat"] = rid
         result = asyncio.run(adapter.send("Uchat", "the answer"))
         assert result.success
-        # Response must have been cached, not pushed/replied.
         adapter._client.reply.assert_not_called()
-        adapter._client.push.assert_not_called()
+        adapter._client.push.assert_called_once()
+        assert adapter._cache.get(rid).state is State.DELIVERED
+        assert "Uchat" not in adapter._pending_buttons
+
+    def test_send_pending_button_keeps_ready_cache_when_auto_push_fails(self, adapter):
+        rid = adapter._cache.register_pending("Uchat")
+        adapter._pending_buttons["Uchat"] = rid
+        adapter._client.push.side_effect = RuntimeError("network")
+        result = asyncio.run(adapter.send("Uchat", "the answer"))
+        assert result.success
+        adapter._client.reply.assert_not_called()
+        adapter._client.push.assert_called_once()
         assert adapter._cache.get(rid).state is State.READY
         assert adapter._cache.get(rid).payload == "the answer"
+        assert adapter._pending_buttons["Uchat"] == rid
 
     def test_send_system_bypass_skips_postback_cache(self, adapter):
         # Even with a pending button, system busy-acks must surface visibly.


### PR DESCRIPTION
Summary
- auto-push LINE slow-response answers as soon as the cached response becomes READY
- keep the existing postback button as a manual fallback if the proactive push fails
- backport the live LINE group mention gate hotfix so source also accepts full-width `＠hermes` prefix mentions while staying prefix-only in group/room chats
- add regression tests for both behaviors

Problem
In LINE group chats, `＠hermes ...` could be ignored because the source tree was missing the live mention-gate hotfix. Separately, once the slow-response button fired, users had to tap a second time after the answer was ready because the adapter only cached the final response and never proactively delivered it.

What changed
1. Group/room mention gate
   - accepts `@hermes` and `＠hermes` at message start (case-insensitive)
   - still allows explicit LINE mention metadata (`isSelf` / `@all`)
   - keeps strict prefix-only gating to avoid noisy group activation

2. Slow-response completion delivery
   - when a pending slow-response request becomes READY, cache it and immediately push the final answer back to the same LINE chat
   - if that proactive push fails, leave the cache entry in READY and keep the postback button mapping so the existing manual fetch path still works

Tests
- `env -u LINE_PUBLIC_URL -u LINE_HOME_CHANNEL -u LINE_PORT -u LINE_CHANNEL_ACCESS_TOKEN -u LINE_CHANNEL_SECRET /opt/hermes/.venv/bin/pytest -q -o addopts='' tests/gateway/test_line_plugin.py`
- `python3 -m py_compile plugins/platforms/line/adapter.py tests/gateway/test_line_plugin.py`

Notes
- I had to unset local LINE env vars while running the test file because this workstation injects runtime LINE config into the shell and those values change a few environment-dependent expectations in the existing test suite.
