### PR TITLE
fix(desktop): show clear message for file browser in remote gateway mode

### DIFF
--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -8,6 +8,7 @@ import { useI18n } from '@/i18n'
 import { Loader } from '@/components/ui/loader'
 import { Tip } from '@/components/ui/tooltip'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
+import { isRemoteGateway } from '@/lib/media'
 import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
@@ -304,7 +305,7 @@ interface FileTreeBodyProps {
   openState: ReturnType<typeof useProjectTree>['openState']
 }
 
-function FileTreeBody({
+export function FileTreeBody({
   collapseNonce,
   cwd,
   data,
@@ -322,6 +323,10 @@ function FileTreeBody({
 
   if (!cwd) {
     return <EmptyState body={r.noProjectBody} title={r.noProjectTitle} />
+  }
+
+  if (isRemoteGateway()) {
+    return <EmptyState body={r.remoteGatewayBody} title={r.remoteGatewayTitle} />
   }
 
   if (error) {

--- a/apps/desktop/src/app/right-sidebar/remote-gateway.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/remote-gateway.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $connection } from '@/store/session'
+
+import { FileTreeBody } from './index'
+
+describe('FileTreeBody remote gateway guard', () => {
+  afterEach(() => {
+    $connection.set(null)
+  })
+
+  it('shows remote gateway message when connected to a remote gateway', () => {
+    $connection.set({ mode: 'remote' } as never)
+
+    render(
+      <FileTreeBody
+        collapseNonce={0}
+        cwd="/root/hermes"
+        data={[]}
+        error={null}
+        loading={false}
+        onActivateFile={() => {}}
+        onActivateFolder={() => {}}
+        onLoadChildren={() => {}}
+        onNodeOpenChange={() => {}}
+        openState={{}}
+      />
+    )
+
+    expect(screen.getByText('Remote gateway')).toBeTruthy()
+    expect(screen.getByText(/File browser is not available/)).toBeTruthy()
+  })
+
+  it('shows unreadable error in local mode when error is present', () => {
+    $connection.set({ mode: 'local' } as never)
+
+    render(
+      <FileTreeBody
+        collapseNonce={0}
+        cwd="/some/path"
+        data={[]}
+        error="ENOENT"
+        loading={false}
+        onActivateFile={() => {}}
+        onActivateFolder={() => {}}
+        onLoadChildren={() => {}}
+        onNodeOpenChange={() => {}}
+        openState={{}}
+      />
+    )
+
+    expect(screen.getByText('Unreadable')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1509,6 +1509,8 @@ export const en: Translations = {
     noProjectBody: 'Set a working directory from the status bar to browse files.',
     unreadableTitle: 'Unreadable',
     unreadableBody: error => `Could not read this folder (${error}).`,
+    remoteGatewayTitle: 'Remote gateway',
+    remoteGatewayBody: 'File browser is not available when connected to a remote gateway.',
     emptyTitle: 'Empty',
     emptyBody: 'This folder is empty.',
     treeErrorTitle: 'Tree error',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1652,6 +1652,8 @@ export const ja = defineLocale({
     noProjectBody: 'ステータスバーから作業ディレクトリを設定してファイルを閲覧してください。',
     unreadableTitle: '読み取り不可',
     unreadableBody: error => `このフォルダーを読み取れませんでした (${error})。`,
+    remoteGatewayTitle: 'リモートゲートウェイ',
+    remoteGatewayBody: 'リモートゲートウェイに接続中はファイルブラウザをご利用いただけません。',
     emptyTitle: '空',
     emptyBody: 'このフォルダーは空です。',
     treeErrorTitle: 'ツリーエラー',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1181,6 +1181,8 @@ export interface Translations {
     noProjectBody: string
     unreadableTitle: string
     unreadableBody: (error: string) => string
+    remoteGatewayTitle: string
+    remoteGatewayBody: string
     emptyTitle: string
     emptyBody: string
     treeErrorTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1613,6 +1613,8 @@ export const zhHant = defineLocale({
     noProjectBody: '從狀態列設定工作目錄後即可瀏覽檔案。',
     unreadableTitle: '無法讀取',
     unreadableBody: error => `無法讀取此資料夾 (${error})。`,
+    remoteGatewayTitle: '遠端閘道',
+    remoteGatewayBody: '連接到遠端閘道時，檔案瀏覽器不可用。',
     emptyTitle: '空資料夾',
     emptyBody: '此資料夾是空的。',
     treeErrorTitle: '檔案樹錯誤',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1690,6 +1690,8 @@ export const zh: Translations = {
     noProjectBody: '从状态栏设置工作目录后即可浏览文件。',
     unreadableTitle: '无法读取',
     unreadableBody: error => `无法读取此文件夹 (${error})。`,
+    remoteGatewayTitle: '远程网关',
+    remoteGatewayBody: '连接到远程网关时，文件浏览器不可用。',
     emptyTitle: '空文件夹',
     emptyBody: '此文件夹为空。',
     treeErrorTitle: '文件树错误',


### PR DESCRIPTION
## Problem

When Hermes Desktop connects to a **remote gateway** (e.g. via Tailscale or SSH tunnel), the right sidebar file browser shows "Unreadable — Could not read this folder (ENOENT)". The file browser reads the remote backend's working directory path on the **local** machine's filesystem, where it doesn't exist.

**Reproduction:**
1. Set up Hermes Desktop to connect to a remote gateway
2. Connect successfully — chat works against the remote backend
3. Open the file browser pane in the right sidebar
4. The header shows the remote backend's cwd (e.g. `/root/hermes/...` on the server)
5. The tree area shows "UNREADABLE — Could not read this folder (ENOENT)"

## Fix

Added a remote gateway detection check in `FileTreeBody` using the existing `isRemoteGateway()` utility. When connected to a remote gateway, the file browser now shows a clear "Remote gateway — File browser is not available when connected to a remote gateway" message instead of the confusing ENOENT error.

**Changes:**
- `apps/desktop/src/app/right-sidebar/index.tsx` — Added `isRemoteGateway()` check before the error state in `FileTreeBody`
- `apps/desktop/src/i18n/types.ts` — Added `remoteGatewayTitle` and `remoteGatewayBody` type definitions
- `apps/desktop/src/i18n/{en,zh,zh-hant,ja}.ts` — Added localized strings for all 4 supported languages
- `apps/desktop/src/app/right-sidebar/remote-gateway.test.tsx` — Added 2 tests for the remote gateway guard

**Tests:** 12 tests passing (2 new + 10 existing)

Fixes #42878
