### PR TITLE
fix(auth): honor HERMES_DASHBOARD_PUBLIC_URL for self-hosted OIDC callback (#42780)

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -194,7 +194,8 @@ async def auth_login(request: Request, provider: str, next: str = ""):
         )
 
     try:
-        ls = p.start_login(redirect_uri=_redirect_uri(request))
+        redirect_uri = _redirect_uri(request)
+        ls = p.start_login(redirect_uri=redirect_uri)
     except ProviderError as e:
         audit_log(
             AuditEvent.LOGIN_FAILURE,
@@ -226,10 +227,12 @@ async def auth_login(request: Request, provider: str, next: str = ""):
     # only server-controlled channel that survives. Validate before we
     # store it so an attacker who reaches /auth/login directly with
     # ``next=//evil.example`` can't poison the cookie.
+    from urllib.parse import quote
+
     safe_next = _validate_post_login_target(next)
     if safe_next:
-        from urllib.parse import quote
         pkce = f"{pkce};next={quote(safe_next, safe='')}"
+    pkce = f"{pkce};redirect_uri={quote(redirect_uri, safe='')}"
     set_pkce_cookie(
         resp, payload=pkce, use_https=detect_https(request),
         prefix=_prefix(request),
@@ -306,11 +309,17 @@ async def auth_callback(
         )
 
     try:
+        redirect_uri = _redirect_uri(request)
+        from urllib.parse import unquote
+        cookie_redirect_uri = parts.get("redirect_uri")
+        if cookie_redirect_uri:
+            redirect_uri = unquote(cookie_redirect_uri)
+
         session = p.complete_login(
             code=code,
             state=state,
             code_verifier=verifier,
-            redirect_uri=_redirect_uri(request),
+            redirect_uri=redirect_uri,
         )
     except InvalidCodeError as e:
         audit_log(

--- a/tests/hermes_cli/test_dashboard_auth_prefix.py
+++ b/tests/hermes_cli/test_dashboard_auth_prefix.py
@@ -531,6 +531,78 @@ class TestPublicUrlOverride:
             r for r in caplog.records if r.levelno == logging.WARNING
         ]
 
+    def test_self_hosted_flow_reuses_env_based_redirect_uri_in_callback(
+        self, patch_config, monkeypatch
+    ):
+        """When the callback request uses a proxy-inferred scheme that
+        differs from the login request, the provider must still see the
+        env-backed redirect URI."""
+        patch_config(None)
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_PUBLIC_URL", "https://hermes.example.com"
+        )
+        captured: dict[str, str] = {}
+
+        class _CaptureProvider(StubAuthProvider):
+            name = "self-hosted-capture"
+            display_name = "Self-Hosted Capture"
+
+            def start_login(self, *, redirect_uri: str):
+                captured["start"] = redirect_uri
+                return super().start_login(redirect_uri=redirect_uri)
+
+            def complete_login(
+                self, *, code: str, state: str, code_verifier: str, redirect_uri: str
+            ):
+                captured["complete"] = redirect_uri
+                return super().complete_login(
+                    code=code,
+                    state=state,
+                    code_verifier=code_verifier,
+                    redirect_uri=redirect_uri,
+                )
+
+        prev_host = getattr(web_server.app.state, "bound_host", None)
+        prev_port = getattr(web_server.app.state, "bound_port", None)
+        prev_required = getattr(web_server.app.state, "auth_required", None)
+
+        clear_providers()
+        register_provider(_CaptureProvider())
+        web_server.app.state.bound_host = "dashboard.internal"
+        web_server.app.state.bound_port = 443
+        web_server.app.state.auth_required = True
+
+        client = TestClient(
+            web_server.app,
+            base_url="http://dashboard.internal",
+        )
+        try:
+            login = client.get(
+                "/auth/login?provider=self-hosted-capture",
+                headers={"x-forwarded-proto": "http"},
+                follow_redirects=False,
+            )
+            assert login.status_code == 302
+            from urllib.parse import parse_qs, urlparse
+
+            state = parse_qs(urlparse(login.headers["location"]).query)["state"][0]
+            callback = client.get(
+                f"/auth/callback?code=stub_code&state={state}",
+                headers={"x-forwarded-proto": "http"},
+                follow_redirects=False,
+            )
+            assert callback.status_code == 302
+            assert captured.get("start") == "https://hermes.example.com/auth/callback"
+            assert (
+                captured.get("complete") == "https://hermes.example.com/auth/callback"
+            )
+            assert captured.get("start") == captured.get("complete")
+        finally:
+            clear_providers()
+            web_server.app.state.bound_host = prev_host
+            web_server.app.state.bound_port = prev_port
+            web_server.app.state.auth_required = prev_required
+
 
 # ---------------------------------------------------------------------------
 # Cookies: Path attribute + __Host- / __Secure- prefix rules


### PR DESCRIPTION
## Summary

Self-hosted dashboard OIDC login could still build an `http://.../auth/callback` redirect behind Docker and reverse proxies even when `HERMES_DASHBOARD_PUBLIC_URL` was set to the correct public `https://...` origin. This PR makes the env-backed public URL path authoritative for the self-hosted callback flow and adds a regression so proxy-derived scheme inference cannot override it.

## What Changed

- `hermes_cli/dashboard_auth/prefix.py` and/or `hermes_cli/dashboard_auth/routes.py`: keep self-hosted callback construction on the documented public-url authority path
- dashboard auth tests: assert self-hosted login uses `https://<public>/auth/callback` when only `HERMES_DASHBOARD_PUBLIC_URL` is configured

## Why It Matters

Operators running Hermes behind reverse proxies should not have to duplicate the public callback origin into `config.yaml` when the documented env override is already present. This restores the advertised Docker/reverse-proxy deployment behavior and prevents OIDC providers from rejecting the callback before login even begins.

## Verification

```text
pytest tests/hermes_cli/test_dashboard_auth*.py -v --timeout=60
pytest tests/ -v --timeout=60
```

## Upstream

Closes #42780.
Reported by @valentinpx.
