### PR TITLE
feat(hooks): expose parent_session_id on shell-hook payload

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -528,14 +528,6 @@ def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
         "tool_name": kwargs.get("tool_name"),
         "tool_input": kwargs.get("args") if isinstance(kwargs.get("args"), dict) else None,
         "session_id": kwargs.get("session_id") or kwargs.get("parent_session_id") or "",
-        # Distinct lineage field: when a session_id rotates (e.g. context
-        # compression forks a child session, see conversation_compression.py),
-        # `session_id` carries the rotated head while `parent_session_id`
-        # carries the session it continues from. Exposing it as its own field
-        # — rather than only collapsing it into `session_id` above — lets hook
-        # consumers stitch a single logical conversation across the rotation
-        # instead of seeing it as disconnected sessions. None when not a
-        # continuation.
         "parent_session_id": kwargs.get("parent_session_id") or None,
         "cwd": cwd,
         "extra": extras,

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -528,6 +528,15 @@ def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
         "tool_name": kwargs.get("tool_name"),
         "tool_input": kwargs.get("args") if isinstance(kwargs.get("args"), dict) else None,
         "session_id": kwargs.get("session_id") or kwargs.get("parent_session_id") or "",
+        # Distinct lineage field: when a session_id rotates (e.g. context
+        # compression forks a child session, see conversation_compression.py),
+        # `session_id` carries the rotated head while `parent_session_id`
+        # carries the session it continues from. Exposing it as its own field
+        # — rather than only collapsing it into `session_id` above — lets hook
+        # consumers stitch a single logical conversation across the rotation
+        # instead of seeing it as disconnected sessions. None when not a
+        # continuation.
+        "parent_session_id": kwargs.get("parent_session_id") or None,
         "cwd": cwd,
         "extra": extras,
     }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -201,6 +201,7 @@ AUTHOR_MAP = {
     "ali.zakaee.1997@gmail.com": "ITheEqualizer",
     "copii.list@gmail.com": "stremtec",
     "solaiagent@gmail.com": "solaitken",
+    "solaitken@users.noreply.github.com": "solaitken",
     "cryptoworlldz@gmail.com": "worlldz",
     "prostoandrei9@gmail.com": "vladkvlchk",
     "116314616+ThyFriendlyFox@users.noreply.github.com": "ThyFriendlyFox",

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -142,7 +142,6 @@ class TestSerializePayload:
         assert payload["tool_name"] == "terminal"
         assert payload["tool_input"] == {"command": "ls"}
         assert payload["session_id"] == "sess-1"
-        # no rotation: parent_session_id is absent -> exposed as null
         assert payload["parent_session_id"] is None
         assert "cwd" in payload
         # task_id / tool_call_id end up under extra
@@ -162,13 +161,9 @@ class TestSerializePayload:
         )
         payload = json.loads(raw)
         assert payload["session_id"] == "p-1"
-        # the lineage is also surfaced through the distinct field
         assert payload["parent_session_id"] == "p-1"
 
     def test_parent_session_id_exposed_alongside_rotated_head(self):
-        # Compression rotation: session_id is the new (child) head, while
-        # parent_session_id names the session it continues from. Both are
-        # visible so a hook can stitch them into one logical conversation.
         raw = shell_hooks._serialize_payload(
             "on_session_start",
             {"session_id": "child-2", "parent_session_id": "root-1"},

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -142,6 +142,8 @@ class TestSerializePayload:
         assert payload["tool_name"] == "terminal"
         assert payload["tool_input"] == {"command": "ls"}
         assert payload["session_id"] == "sess-1"
+        # no rotation: parent_session_id is absent -> exposed as null
+        assert payload["parent_session_id"] is None
         assert "cwd" in payload
         # task_id / tool_call_id end up under extra
         assert payload["extra"]["task_id"] == "t-1"
@@ -160,6 +162,20 @@ class TestSerializePayload:
         )
         payload = json.loads(raw)
         assert payload["session_id"] == "p-1"
+        # the lineage is also surfaced through the distinct field
+        assert payload["parent_session_id"] == "p-1"
+
+    def test_parent_session_id_exposed_alongside_rotated_head(self):
+        # Compression rotation: session_id is the new (child) head, while
+        # parent_session_id names the session it continues from. Both are
+        # visible so a hook can stitch them into one logical conversation.
+        raw = shell_hooks._serialize_payload(
+            "on_session_start",
+            {"session_id": "child-2", "parent_session_id": "root-1"},
+        )
+        payload = json.loads(raw)
+        assert payload["session_id"] == "child-2"
+        assert payload["parent_session_id"] == "root-1"
 
     def test_unserialisable_extras_stringified(self):
         class Weird:

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -104,8 +104,7 @@ class TestHooksTest:
             "hook_event_name", "tool_name", "tool_input",
             "session_id", "parent_session_id", "cwd", "extra",
         }
-        # parent_session_id is exposed top-level and still routed to
-        # session_id as a fallback (matches runtime)
+        # parent_session_id routed to session_id and exposed top-level (matches runtime)
         assert seen["session_id"] == "parent-sess"
         assert seen["parent_session_id"] == "parent-sess"
         assert "parent_session_id" not in seen["extra"]

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -102,10 +102,12 @@ class TestHooksTest:
         # Same top-level keys _serialize_payload produces at runtime
         assert set(seen.keys()) == {
             "hook_event_name", "tool_name", "tool_input",
-            "session_id", "cwd", "extra",
+            "session_id", "parent_session_id", "cwd", "extra",
         }
-        # parent_session_id was routed to top-level session_id (matches runtime)
+        # parent_session_id is exposed top-level and still routed to
+        # session_id as a fallback (matches runtime)
         assert seen["session_id"] == "parent-sess"
+        assert seen["parent_session_id"] == "parent-sess"
         assert "parent_session_id" not in seen["extra"]
         # subagent_stop has no tool, so tool_name / tool_input are null
         assert seen["tool_name"] is None


### PR DESCRIPTION
## Summary
- expose `parent_session_id` as a distinct top-level field on the shell-hook stdin payload
- additive and non-breaking: `null` when the turn is not a continuation

## Why
When a `session_id` rotates mid-process — context compression forks a child session (`agent/conversation_compression.py` creates it with `parent_session_id=old_session_id`) — `_serialize_payload` only surfaced the rotated head:

```python
"session_id": kwargs.get("session_id") or kwargs.get("parent_session_id") or "",
```

`parent_session_id` was already a recognized kwarg (it is in `_TOP_LEVEL_PAYLOAD_KEYS`) but was only collapsed into `session_id` as a fallback, never exposed on its own. Hook consumers saw a single logical conversation as disconnected sessions across each compression boundary and could not stitch them.

Unlike Claude Code / Codex (where `session_id` stays stable across compaction so no lineage is needed), Hermes rotates the id, so the lineage has to be visible for a hook consumer to behave correctly. This continues the payload-alignment work from #39939 (transcript_path).

Closes #42939

## Changes
- `agent/shell_hooks.py`: add `parent_session_id` to the payload dict in `_serialize_payload` (`kwargs.get("parent_session_id") or None`), with a comment explaining the rotation/lineage semantics.
- `tests/agent/test_shell_hooks.py`: assert the field is `null` with no rotation, equals the parent when only `parent_session_id` is supplied, and is exposed alongside the rotated head when both are present.

## Tests
- `python3 -m pytest tests/agent/test_shell_hooks.py -q -o addopts=` — 54 passed
- `python3 -m py_compile agent/shell_hooks.py tests/agent/test_shell_hooks.py` — clean
