### PR TITLE
fix(kanban): make protocol_violation failure_limit configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2025,6 +2025,12 @@ DEFAULT_CONFIG = {
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.
         "failure_limit": 2,
+        # Failure limit for protocol-violation and systemic crashes.
+        # Protocol violations (API timeouts, network errors) are often
+        # transient — a higher limit gives the provider time to recover
+        # before auto-blocking the task. Set to 1 for the legacy
+        # one-crash-and-block behavior.
+        "protocol_violation_failure_limit": 3,
         # Worker stdout/stderr logs rotate at spawn time. Defaults preserve
         # the historical 2 MiB + one-backup behavior; long-running workers can
         # raise these to keep more early failure evidence.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4815,6 +4815,12 @@ DEFAULT_FAILURE_LIMIT = 2
 # Legacy alias — callers / tests still reference the old name.
 DEFAULT_SPAWN_FAILURE_LIMIT = DEFAULT_FAILURE_LIMIT
 
+# Failure limit for protocol-violation and systemic crashes. Protocol
+# violations (API timeouts, network errors) are often transient — a higher
+# limit gives the provider time to recover before auto-blocking the task.
+# Overridable via ``kanban.protocol_violation_failure_limit`` in config.yaml.
+DEFAULT_PROTOCOL_VIOLATION_FAILURE_LIMIT = 3
+
 # Max bytes to keep in a single worker log file. The dispatcher truncates
 # and rotates on spawn if the file is larger than this at spawn time.
 DEFAULT_LOG_ROTATE_BYTES = 2 * 1024 * 1024   # 2 MiB
@@ -5593,11 +5599,20 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # ready → blocked with a ``gave_up`` event on top of the ``crashed``
     # event we already emitted.
     #
-    # Protocol-violation crashes force an immediate trip (failure_limit=1)
-    # because clean-exit-without-transition is deterministic: the next
-    # respawn will do exactly the same thing. Better to surface to a
-    # human with a clear reason than to loop ``DEFAULT_FAILURE_LIMIT``
-    # times first.
+    # Protocol-violation and systemic crashes use a configurable failure
+    # limit (default 3) to give transient provider errors time to recover
+    # before auto-blocking.  Override via
+    # ``kanban.protocol_violation_failure_limit`` in config.yaml; set to 1
+    # for the legacy one-crash-and-block behavior.
+    pv_limit: int = DEFAULT_PROTOCOL_VIOLATION_FAILURE_LIMIT
+    try:
+        from hermes_cli.config import load_config
+        _kanban_cfg = (load_config().get("kanban") or {})
+        _pv_cfg = _kanban_cfg.get("protocol_violation_failure_limit")
+        if _pv_cfg is not None:
+            pv_limit = max(1, int(_pv_cfg))
+    except Exception:
+        pass
     auto_blocked: list[str] = []
     if crash_details:
         # Fingerprint errors to detect systemic failures.
@@ -5615,7 +5630,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 conn, tid,
                 error=error_text,
                 outcome="crashed",
-                failure_limit=1 if (protocol_violation or is_systemic) else None,
+                failure_limit=pv_limit if (protocol_violation or is_systemic) else None,
                 release_claim=False,
                 end_run=False,
                 event_payload_extra={"pid": pid, "claimer": claimer},

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -546,10 +546,16 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
 def test_detect_crashed_workers_systemic_failure_fast_block(
     kanban_home, monkeypatch,
 ):
-    """When many tasks crash with the same error, trip the breaker faster."""
+    """When many tasks crash with the same error, the breaker trips after
+    ``protocol_violation_failure_limit`` consecutive crashes (default 3)."""
     import hermes_cli.kanban_db as _kb
 
     monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    # Use limit=1 to reproduce legacy one-crash-and-block behavior.
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"protocol_violation_failure_limit": 1}},
+    )
 
     with kb.connect() as conn:
         task_ids = []
@@ -571,6 +577,75 @@ def test_detect_crashed_workers_systemic_failure_fast_block(
             task = kb.get_task(conn, tid)
             assert task.status == "blocked", (
                 f"task {tid} should be blocked (systemic), got {task.status}"
+            )
+
+
+def test_detect_crashed_workers_systemic_respects_configurable_limit(
+    kanban_home, monkeypatch,
+):
+    """Systemic crashes use ``protocol_violation_failure_limit`` (default 3)
+    instead of the old hardcoded limit of 1."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+    with kb.connect() as conn:
+        task_ids = []
+        for i in range(4):
+            tid = kb.create_task(conn, title=f"pv-{i}", assignee="a")
+            host = _kb._claimer_id().split(":", 1)[0]
+            conn.execute(
+                "UPDATE tasks SET status='running', worker_pid=?, "
+                "claim_lock=? WHERE id=?",
+                (70000 + i, f"{host}:w{i}", tid),
+            )
+            task_ids.append(tid)
+        conn.commit()
+
+        # First crash — tasks stay ready (limit is 3, failures now 1).
+        crashed = kb.detect_crashed_workers(conn)
+        assert len(crashed) == 4
+        for tid in task_ids:
+            task = kb.get_task(conn, tid)
+            assert task.status == "ready", (
+                f"task {tid} should be ready after 1 crash, got {task.status}"
+            )
+            assert task.consecutive_failures == 1
+
+
+def test_detect_crashed_workers_pv_limit_from_config(
+    kanban_home, monkeypatch,
+):
+    """``kanban.protocol_violation_failure_limit`` overrides the default."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"protocol_violation_failure_limit": 1}},
+    )
+
+    with kb.connect() as conn:
+        task_ids = []
+        for i in range(3):
+            tid = kb.create_task(conn, title=f"cfg-{i}", assignee="a")
+            host = _kb._claimer_id().split(":", 1)[0]
+            conn.execute(
+                "UPDATE tasks SET status='running', worker_pid=?, "
+                "claim_lock=? WHERE id=?",
+                (60000 + i, f"{host}:w{i}", tid),
+            )
+            task_ids.append(tid)
+        conn.commit()
+
+        # With config limit=1 and 3+ same-fingerprint crashes (systemic),
+        # a single crash should block all tasks.
+        crashed = kb.detect_crashed_workers(conn)
+        assert len(crashed) == 3
+        for tid in task_ids:
+            task = kb.get_task(conn, tid)
+            assert task.status == "blocked", (
+                f"task {tid} should be blocked (config limit=1), got {task.status}"
             )
 
 


### PR DESCRIPTION
## Problem

`detect_crashed_workers()` hardcodes `failure_limit=1` for protocol-violation and systemic crashes:

```python
failure_limit=1 if (protocol_violation or is_systemic) else None,
```

This means a single transient API timeout permanently blocks the task with `gave_up`, regardless of the `kanban.failure_limit` config setting. Protocol violations (ReadTimeout, APITimeoutError, network errors) are often temporary — a provider may be degraded for a few minutes and recover.

## Fix

Add `kanban.protocol_violation_failure_limit` config key (default 3) that controls how many consecutive crashes trigger auto-block for protocol-violation and systemic failures.

- **Default 3**: gives transient errors time to recover before blocking
- **Set to 1**: restores legacy one-crash-and-block behavior
- **Floor of 1**: prevents misconfiguration from disabling the breaker entirely

## Changes

- `hermes_cli/config.py`: Add `protocol_violation_failure_limit: 3` under `kanban` section
- `hermes_cli/kanban_db.py`: Add `DEFAULT_PROTOCOL_VIOLATION_FAILURE_LIMIT = 3` constant; read config in `detect_crashed_workers()`; replace hardcoded `1` with configurable value
- `tests/hermes_cli/test_kanban_db.py`: Update existing systemic test to use config mock; add tests for configurable limit and config override

## Testing

```
tests/hermes_cli/test_kanban_db.py::test_detect_crashed_workers_systemic_failure_fast_block PASSED
tests/hermes_cli/test_kanban_db.py::test_detect_crashed_workers_systemic_respects_configurable_limit PASSED
tests/hermes_cli/test_kanban_db.py::test_detect_crashed_workers_pv_limit_from_config PASSED
tests/hermes_cli/test_kanban_db.py::test_detect_crashed_workers_isolated_failure_normal_retry PASSED
```

Full kanban test suite: 216 passed.

Closes #42924
