### PR TITLE
fix(dashboard): restore chat autoscroll routing

### DIFF
--- a/tests/hermes_cli/test_dashboard_chat_scroll_contract.py
+++ b/tests/hermes_cli/test_dashboard_chat_scroll_contract.py
@@ -1,0 +1,57 @@
+"""Guard the dashboard chat scroll contract.
+
+The embedded dashboard chat is a PTY-backed view of ``hermes --tui``. The
+browser host must not invent a second transcript history, or the TUI loses its
+sticky-tail and "pause auto-follow while reviewing history" behavior.
+
+This regression test intentionally inspects ``web/src/pages/ChatPage.tsx``
+directly because the repo currently has no lightweight frontend interaction
+harness for the embedded xterm bridge. The contract we care about is narrow:
+
+1. browser-side xterm scrollback stays disabled
+2. wheel gestures are routed back into the TUI's existing Shift+Up/Down path
+3. the browser host does not call ``term.scrollLines(...)`` locally
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHAT_PAGE = _REPO_ROOT / "web" / "src" / "pages" / "ChatPage.tsx"
+
+
+def _chat_page_source() -> str:
+    return _CHAT_PAGE.read_text(encoding="utf-8")
+
+
+def _wheel_handler_block(source: str) -> str:
+    match = re.search(
+        r"term\.attachCustomWheelEventHandler\(\(ev\) => \{(?P<body>.*?)\n    \}\);",
+        source,
+        re.DOTALL,
+    )
+    assert match, "ChatPage must define a custom wheel handler for the embedded TUI bridge"
+    return match.group("body")
+
+
+def test_dashboard_chat_disables_browser_scrollback() -> None:
+    source = _chat_page_source()
+    assert "scrollback: 0," in source, "dashboard xterm must not keep its own scrollback buffer"
+
+
+def test_dashboard_chat_routes_wheel_to_tui_scroll_keys() -> None:
+    body = _wheel_handler_block(_chat_page_source())
+
+    assert '"\\x1b[1;2A"' in body, "wheel-up must map to the TUI's Shift+Up scroll input"
+    assert '"\\x1b[1;2B"' in body, "wheel-down must map to the TUI's Shift+Down scroll input"
+    assert "ws.send(seq);" in body, "wheel handler must forward scroll input through the PTY websocket"
+    assert "ev.preventDefault();" in body, "wheel handler must stop browser-native scrolling"
+    assert "ev.stopPropagation();" in body, "wheel handler must not leak wheel events to outer panes"
+
+
+def test_dashboard_chat_does_not_scroll_browser_xterm_locally() -> None:
+    body = _wheel_handler_block(_chat_page_source())
+    assert "scrollLines" not in body, "wheel handler must not bypass the inner TUI with local xterm scrollback"

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -318,9 +318,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // is false; enabling it gives users a single-action selection
       // path on top of the modifier-based bypass above.
       rightClickSelectsWord: true,
-      // Browser-embedded chat runs the TUI in inline mode. Keep transcript
-      // history in xterm.js so the browser wheel can scroll it directly.
-      scrollback: 5000,
+      // Keep the browser xterm as a display/input bridge only. The embedded
+      // Hermes TUI already owns transcript history, sticky tail-following,
+      // and "pause auto-follow when the user scrolls up" semantics.
+      scrollback: 0,
       theme: terminalTheme,
     });
     termRef.current = term;
@@ -423,16 +424,29 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     fitRef.current = fit;
     term.loadAddon(fit);
 
-    // Dashboard chat should scroll the browser-side transcript, not send
-    // mouse-wheel protocol bytes through the PTY.
+    // Let the inner Hermes TUI own transcript scrolling. Browser-side
+    // scrollback breaks the TUI's sticky-tail behavior and drifts from the
+    // terminal's own notion of whether the user is reviewing history.
     term.attachCustomWheelEventHandler((ev) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        return false;
+      }
+
       const delta = ev.deltaY;
       if (!delta) {
         return false;
       }
 
+      // Shift+Up / Shift+Down are the TUI's known-good line scroll inputs.
+      // Routing wheel gestures through them preserves the transcript's
+      // existing sticky-at-tail rules instead of inventing a second one.
       const step = Math.max(1, Math.round(Math.abs(delta) / 50));
-      term.scrollLines(delta > 0 ? step : -step);
+      const seq = delta > 0 ? "\x1b[1;2B" : "\x1b[1;2A";
+
+      for (let i = 0; i < step; i += 1) {
+        ws.send(seq);
+      }
 
       ev.preventDefault();
       ev.stopPropagation();


### PR DESCRIPTION
## Summary
- restore the embedded dashboard chat to browserless xterm scrollback
- route wheel input back through the inner TUI's existing Shift+Up/Shift+Down scroll path
- add a narrow regression test that guards the ChatPage scroll contract

## Testing
- `uv run --frozen --extra dev pytest tests/hermes_cli/test_dashboard_chat_scroll_contract.py`
- `uv run --frozen --extra dev ruff check tests/hermes_cli/test_dashboard_chat_scroll_contract.py`
- `cd web && node /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/web/node_modules/eslint/bin/eslint.js src/pages/ChatPage.tsx`
- `git diff --check`

## Notes
- `eslint` reports 2 pre-existing `react-hooks/exhaustive-deps` warnings in `ChatPage.tsx`, but no errors.
