### PR TITLE
fix(feishu): parse CardKit 2.0 user_dsl for interactive card messages

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -934,6 +934,20 @@ def _normalize_share_chat_message(payload: Dict[str, Any]) -> FeishuNormalizedMe
 
 def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -> FeishuNormalizedMessage:
     card_payload = payload.get("card") if isinstance(payload.get("card"), dict) else payload
+
+    # CardKit 2.0: real content lives in user_dsl (JSON string),
+    # not in elements (v1 fallback, often empty placeholder text).
+    # Parse user_dsl and inject its elements so the standard extractor picks them up.
+    _user_dsl_raw = card_payload.get("user_dsl")
+    if isinstance(_user_dsl_raw, str) and _user_dsl_raw.strip():
+        try:
+            _user_dsl = json.loads(_user_dsl_raw)
+            _body = _user_dsl.get("body") or _user_dsl
+            if isinstance(_body, dict) and _body.get("elements"):
+                card_payload["elements"] = _body["elements"]
+        except (json.JSONDecodeError, TypeError, ValueError):
+            pass
+
     title = _first_non_empty_text(
         _find_header_title(card_payload),
         payload.get("title"),


### PR DESCRIPTION
## Problem

CardKit 2.0 interactive cards store their real content in the `user_dsl` field (a JSON string) rather than in `elements` (v1 fallback structure, often showing "请升级至最新版本客户端" or empty placeholder text).

Currently `_normalize_interactive_message` only extracts text from `elements`, so agents see empty/fallback content instead of the actual card content (tables, lists, buttons, color markers, etc.).

## Solution

Before the standard card text extraction, check for `user_dsl` on the card payload. If present as a JSON string, parse it and inject its `body.elements` into `card_payload["elements"]` so the existing extraction logic picks them up.

## Changes

`gateway/platforms/feishu.py` — +14 lines in `_normalize_interactive_message()`.

## Testing

- Parsed CardKit 2.0 cards with markdown tables, lists, `<hr>` separators, bold/color markers — all extracted correctly.
- Falls back to existing behavior when `user_dsl` is absent or unparseable (no breakage for v1 cards).
- Gracefully handles `json.JSONDecodeError`, `TypeError`, `ValueError` on malformed payloads.