### PR TITLE
fix(skills): render darwinian-evolver prompt templates in a Jinja2 sandbox

### DIFF
--- a/optional-skills/research/darwinian-evolver/scripts/parrot_openrouter.py
+++ b/optional-skills/research/darwinian-evolver/scripts/parrot_openrouter.py
@@ -17,6 +17,7 @@ import sys
 from pathlib import Path
 
 import jinja2
+from jinja2.sandbox import SandboxedEnvironment
 from openai import OpenAI
 
 # Vendored problem types from upstream (AGPL — only run via subprocess in production)
@@ -57,12 +58,21 @@ def _prompt_llm(prompt: str) -> str:
         return f"<LLM_ERROR: {type(e).__name__}: {e}>"
 
 
+# The evolution loop stores raw model output as the next organism's
+# prompt_template (see ImproveParrotMutator.mutate), then renders it every
+# generation. Render through a sandboxed environment so a model-derived
+# template containing a Jinja2 gadget (``{{ ''.__class__... }}``) cannot
+# execute arbitrary Python on the host (SSTI -> RCE). The sandbox still
+# allows ordinary ``{{ phrase }}`` / attribute substitution.
+_SANDBOX = SandboxedEnvironment(autoescape=False)
+
+
 class ParrotOrganism(Organism):
     prompt_template: str
 
     def run(self, phrase: str) -> str:
         try:
-            prompt = jinja2.Template(self.prompt_template).render(phrase=phrase)
+            prompt = _SANDBOX.from_string(self.prompt_template).render(phrase=phrase)
         except jinja2.exceptions.TemplateError as e:
             return f"Error rendering prompt: {e}"
         if not prompt:
@@ -104,7 +114,7 @@ template in the LAST triple-backtick block of your response.
         learning_log_entries: list[LearningLogEntry],
     ) -> list[ParrotOrganism]:
         fc = failure_cases[0]
-        prompt = jinja2.Template(self.IMPROVEMENT_PROMPT_TEMPLATE).render(
+        prompt = _SANDBOX.from_string(self.IMPROVEMENT_PROMPT_TEMPLATE).render(
             organism=organism, failure_case=fc
         )
         try:

--- a/tests/skills/test_darwinian_evolver_skill.py
+++ b/tests/skills/test_darwinian_evolver_skill.py
@@ -87,6 +87,21 @@ def test_parrot_script_has_error_swallowing() -> None:
     assert "LLM_ERROR" in src, "_prompt_llm should swallow provider errors and tag them"
 
 
+def test_parrot_script_sandboxes_jinja() -> None:
+    """The mutator stores the model's output verbatim as the next organism's
+    ``prompt_template`` and that template is rendered each generation. A bare
+    ``jinja2.Template(...).render()`` of model-derived text is a Server-Side
+    Template Injection -> RCE sink, so the driver must render through a
+    sandboxed Jinja2 environment instead."""
+    src = (SKILL_DIR / "scripts" / "parrot_openrouter.py").read_text()
+    assert "SandboxedEnvironment" in src, (
+        "parrot driver must render templates with jinja2.sandbox.SandboxedEnvironment"
+    )
+    assert "jinja2.Template(" not in src, (
+        "bare jinja2.Template render is unsafe for model-derived templates (SSTI->RCE)"
+    )
+
+
 def test_skill_calls_out_agpl(frontmatter) -> None:
     """The upstream tool is AGPL-3.0. The skill MUST flag this so users don't
     import it into MIT-licensed code by accident."""


### PR DESCRIPTION
## What & why

`ParrotOrganism.run()` and `ImproveParrotMutator.mutate()` rendered prompt templates with the **unsandboxed** `jinja2.Template(...).render()`. The evolution loop stores the model's raw output verbatim as the next organism's `prompt_template` (`mutate()`: `new_tpl = parts[-2].strip()`) and renders it every generation, so a model-derived template containing a Jinja2 gadget — e.g. `{{ ''.__class__.__mro__[1].__subclasses__() }}` — executes arbitrary Python on the host. That is an SSTI → RCE primitive driven by whatever model endpoint the operator points the evolver at.

Render through a module-level `jinja2.sandbox.SandboxedEnvironment` instead. The sandbox blocks dunder/gadget access (raising `SecurityError`, a subclass of the `TemplateError` already caught in `run()`, so the failure stays graceful) while still allowing ordinary `{{ phrase }}` / public-attribute substitution.

Defense-in-depth / latent-RCE hardening in an optional research skill (the threat requires the operator to point the evolver at a malicious/compromised model).

## How to test

```bash
pytest tests/skills/test_darwinian_evolver_skill.py
```

The new `test_parrot_script_sandboxes_jinja` asserts the driver uses `SandboxedEnvironment` and no longer calls bare `jinja2.Template(`. Mechanism verified independently: `SandboxedEnvironment(autoescape=False)` renders `{{ phrase }}` normally and raises `SecurityError` on the `__class__.__mro__...__subclasses__()` gadget.

## Platforms

macOS (pure-Python; the skill itself is gated `[linux, macos]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
