### PR TITLE
feat: add /exit-restricted slash command to reset iteration budget

### DIFF
--- a/agent/iteration_budget.py
+++ b/agent/iteration_budget.py
@@ -48,6 +48,17 @@ class IterationBudget:
             if self._used > 0:
                 self._used -= 1
 
+    def reset(self) -> None:
+        """Reset the used counter to zero.
+
+        Called between user turns so that a budget exhausted in a prior
+        turn does not permanently block the next turn.  The ``max_total``
+        cap is preserved — this only clears the accumulated ``_used``
+        count.  See ``/exit-restricted`` (issue #42824).
+        """
+        with self._lock:
+            self._used = 0
+
     @property
     def used(self) -> int:
         with self._lock:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7059,6 +7059,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "stop":
             return await self._handle_stop_command(event)
         
+        if canonical == "exit-restricted":
+            return await self._handle_exit_restricted_command(event)
+        
         if canonical == "reasoning":
             return await self._handle_reasoning_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -608,6 +608,57 @@ class GatewaySlashCommandsMixin:
 
         return t("gateway.stop.no_active")
 
+    async def _handle_exit_restricted_command(self, event: MessageEvent) -> str:
+        """Handle /exit-restricted — reset iteration budget and restore full tool access.
+
+        When an agent exhausts its iteration budget within a turn (default 90
+        iterations), the budget counter accumulates but never resets between
+        turns because the gateway caches agent instances.  This leaves the agent
+        in "restricted mode" where only housekeeping tools (memory, todo,
+        skill_manage, session_search) are available.
+
+        This command resets the iteration budget counter so the next turn has
+        the full budget available, restoring normal tool access.
+        See issue #42824.
+        """
+        from gateway.run import _AGENT_PENDING_SENTINEL
+        source = event.source
+        session_entry = self.session_store.get_or_create_session(source)
+        session_key = session_entry.session_key
+
+        # Try running agent first (mid-turn), then cached agent (between turns)
+        agent = self._running_agents.get(session_key)
+        if not agent or agent is _AGENT_PENDING_SENTINEL:
+            _cache_lock = getattr(self, "_agent_cache_lock", None)
+            _cache = getattr(self, "_agent_cache", None)
+            if _cache_lock and _cache is not None:
+                with _cache_lock:
+                    cached = _cache.get(session_key)
+                    if cached:
+                        agent = cached[0] if isinstance(cached, tuple) else cached
+
+        if not agent:
+            return "No active agent found for this session."
+
+        # Reset iteration budget
+        budget_reset = False
+        if hasattr(agent, "iteration_budget") and agent.iteration_budget:
+            agent.iteration_budget.reset()
+            budget_reset = True
+
+        # Reset budget-related flags
+        if hasattr(agent, "_budget_exhausted_injected"):
+            agent._budget_exhausted_injected = False
+        if hasattr(agent, "_budget_grace_call"):
+            agent._budget_grace_call = False
+
+        if budget_reset:
+            return (
+                f"✅ Restricted mode cleared. Iteration budget reset "
+                f"({agent.iteration_budget.max_total} iterations available)."
+            )
+        return "No iteration budget found on the active agent."
+
     async def _handle_platform_command(self, event: MessageEvent) -> str:
         """Handle ``/platform list|pause|resume [name]`` — surface and
         manually control failed/paused gateway adapters.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -93,6 +93,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",
                cli_only=True, aliases=("snap",), args_hint="[create|restore <id>|prune]"),
     CommandDef("stop", "Kill all running background processes", "Session"),
+    CommandDef("exit-restricted", "Reset restricted mode and restore full tool access", "Session",
+               aliases=("unrestrict",)),
     CommandDef("approve", "Approve a pending dangerous command", "Session",
                gateway_only=True, args_hint="[session|always]"),
     CommandDef("deny", "Deny a pending dangerous command", "Session",

--- a/tests/gateway/test_exit_restricted_command.py
+++ b/tests/gateway/test_exit_restricted_command.py
@@ -1,0 +1,157 @@
+"""Tests for /exit-restricted gateway command (issue #42824).
+
+Verifies that the /exit-restricted slash command resets the iteration budget
+on a cached agent, clearing restricted mode and restoring full tool access
+for the next turn.
+"""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.iteration_budget import IterationBudget
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str = "/exit-restricted") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=_make_source(),
+        message_id="m1",
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._is_user_authorized = lambda _source: True
+    return runner
+
+
+def _make_mock_agent(max_iterations: int = 90) -> MagicMock:
+    """Create a minimal mock agent with iteration budget."""
+    agent = MagicMock()
+    agent.max_iterations = max_iterations
+    agent.iteration_budget = IterationBudget(max_total=max_iterations)
+    agent._budget_exhausted_injected = False
+    agent._budget_grace_call = False
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_exit_restricted_resets_cached_agent_budget():
+    """When an agent is cached with an exhausted budget, /exit-restricted resets it."""
+    runner = _make_runner()
+    source = _make_source()
+    sk = build_session_key(source)
+
+    # Create a cached agent with exhausted budget
+    agent = _make_mock_agent(max_iterations=90)
+    for _ in range(90):
+        agent.iteration_budget.consume()
+    assert agent.iteration_budget.remaining == 0
+
+    # Set up the session store mock to return a session entry
+    session_entry = SimpleNamespace(session_key=sk)
+    runner.session_store.get_or_create_session.return_value = session_entry
+
+    # Put the agent in the cache
+    runner._agent_cache[sk] = (agent, "timestamp")
+
+    # Run the handler
+    result = await runner._handle_exit_restricted_command(_make_event())
+
+    # Budget should be reset
+    assert agent.iteration_budget.used == 0
+    assert agent.iteration_budget.remaining == 90
+    assert "✅ Restricted mode cleared" in result
+
+
+@pytest.mark.asyncio
+async def test_exit_restricted_resets_running_agent_budget():
+    """When an agent is mid-turn, /exit-restricted resets its budget."""
+    runner = _make_runner()
+    source = _make_source()
+    sk = build_session_key(source)
+
+    agent = _make_mock_agent(max_iterations=90)
+    for _ in range(90):
+        agent.iteration_budget.consume()
+
+    session_entry = SimpleNamespace(session_key=sk)
+    runner.session_store.get_or_create_session.return_value = session_entry
+
+    # Put the agent in running agents (mid-turn)
+    runner._running_agents[sk] = agent
+
+    result = await runner._handle_exit_restricted_command(_make_event())
+
+    assert agent.iteration_budget.used == 0
+    assert agent.iteration_budget.remaining == 90
+    assert "✅ Restricted mode cleared" in result
+
+
+@pytest.mark.asyncio
+async def test_exit_restricted_resets_budget_flags():
+    """Budget-related flags must be cleared alongside the counter."""
+    runner = _make_runner()
+    source = _make_source()
+    sk = build_session_key(source)
+
+    agent = _make_mock_agent()
+    for _ in range(90):
+        agent.iteration_budget.consume()
+    agent._budget_exhausted_injected = True
+    agent._budget_grace_call = True
+
+    session_entry = SimpleNamespace(session_key=sk)
+    runner.session_store.get_or_create_session.return_value = session_entry
+
+    runner._agent_cache[sk] = (agent, "timestamp")
+
+    await runner._handle_exit_restricted_command(_make_event())
+
+    assert agent._budget_exhausted_injected is False
+    assert agent._budget_grace_call is False
+    assert agent.iteration_budget.used == 0
+
+
+@pytest.mark.asyncio
+async def test_exit_restricted_no_active_agent():
+    """When no agent exists, return an informative message."""
+    runner = _make_runner()
+    source = _make_source()
+    sk = build_session_key(source)
+
+    session_entry = SimpleNamespace(session_key=sk)
+    runner.session_store.get_or_create_session.return_value = session_entry
+
+    result = await runner._handle_exit_restricted_command(_make_event())
+
+    assert "No active agent" in result

--- a/tests/run_agent/test_iteration_budget_race.py
+++ b/tests/run_agent/test_iteration_budget_race.py
@@ -104,3 +104,79 @@ def test_iteration_budget_remaining():
     assert budget.remaining == 2
     budget.refund()
     assert budget.remaining == 3
+
+
+def test_iteration_budget_reset_clears_used():
+    """reset() must clear the used counter back to zero.
+
+    This is the core fix for issue #42824: when an agent exhausts its
+    iteration budget, the counter persists across turns because the gateway
+    caches agent instances.  reset() clears the counter so the next turn
+    has the full budget available.
+    """
+    from run_agent import IterationBudget
+
+    budget = IterationBudget(max_total=90)
+
+    # Exhaust the budget
+    for _ in range(90):
+        budget.consume()
+    assert budget.used == 90
+    assert budget.remaining == 0
+
+    # Reset should clear the counter
+    budget.reset()
+    assert budget.used == 0
+    assert budget.remaining == 90
+
+    # Should be able to consume again
+    assert budget.consume() is True
+    assert budget.used == 1
+
+
+def test_iteration_budget_reset_preserves_max_total():
+    """reset() must not change the max_total cap."""
+    from run_agent import IterationBudget
+
+    budget = IterationBudget(max_total=42)
+    budget.consume()
+    budget.consume()
+    budget.reset()
+    assert budget.max_total == 42
+    assert budget.remaining == 42
+
+
+def test_iteration_budget_reset_is_thread_safe():
+    """reset() must be safe to call while other threads consume/refund."""
+    from concurrent.futures import ThreadPoolExecutor
+    from run_agent import IterationBudget
+
+    budget = IterationBudget(max_total=1000)
+    errors = []
+
+    def consumer():
+        try:
+            for _ in range(200):
+                budget.consume()
+        except Exception as exc:
+            errors.append(exc)
+
+    def resetter():
+        try:
+            for _ in range(50):
+                budget.reset()
+        except Exception as exc:
+            errors.append(exc)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [
+            executor.submit(consumer),
+            executor.submit(consumer),
+            executor.submit(resetter),
+            executor.submit(resetter),
+        ]
+        for f in futures:
+            f.result()
+
+    assert not errors, f"Thread safety violation: {errors}"
+    assert 0 <= budget.used <= budget.max_total


### PR DESCRIPTION
## Summary

Adds a new `/exit-restricted` slash command (alias: `/unrestrict`) that resets an agent's iteration budget, restoring full tool access after hitting the iteration limit.

## Problem

When an agent exhausts its iteration budget within a turn (default 90 iterations), the budget counter persists across turns because the gateway caches agent instances. This leaves the agent in "restricted mode" where only housekeeping tools (`memory`, `todo`, `skill_manage`, `session_search`) are available.

The only current workaround is `/new` (losing all session context) or `/restart` (restarting the entire gateway process). Neither is acceptable for long-lived sessions.

## Solution

1. **`IterationBudget.reset()`** — New method that clears the `_used` counter back to zero, giving the next turn a full budget.

2. **`/exit-restricted` command** — Looks up the running or cached agent for the session, calls `budget.reset()`, and clears the `_budget_exhausted_injected` and `_budget_grace_call` flags.

3. **Thread-safe** — `reset()` acquires the same lock as `consume()`/`refund()` to prevent data races.

## Changes

| File | Change |
|------|--------|
| `agent/iteration_budget.py` | Added `reset()` method |
| `hermes_cli/commands.py` | Registered `/exit-restricted` with alias `/unrestrict` |
| `gateway/run.py` | Added dispatch for `exit-restricted` canonical |
| `gateway/slash_commands.py` | Implemented `_handle_exit_restricted_command()` handler |
| `tests/run_agent/test_iteration_budget_race.py` | 3 tests: reset clears used, preserves max, thread-safe |
| `tests/gateway/test_exit_restricted_command.py` | 4 tests: cached agent, running agent, flags, no-agent |

## Testing

All 12 tests pass:

```
tests/run_agent/test_iteration_budget_race.py — 8 passed
tests/gateway/test_exit_restricted_command.py — 4 passed
```

Fixes #42824