### PR TITLE
feat(cron): /loop command — persistent scheduled agent loops

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8913,6 +8913,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             _cprint(f"  MoA one-shot queued with preset {preset}; previous model will be restored after this turn.")
         elif canonical == "subgoal":
             self._handle_subgoal_command(cmd_original)
+        elif canonical == "loop":
+            self._handle_loop_command(cmd_original)
         elif canonical == "skin":
             self._handle_skin_command(cmd_original)
         elif canonical == "voice":

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1054,6 +1054,10 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    loop: bool = False,
+    loop_dynamic: bool = False,
+    loop_verify: Optional[str] = None,
+    loop_no_progress_threshold: int = 3,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1098,6 +1102,10 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        loop: Enable persistent loop state and post-run progress evaluation.
+        loop_dynamic: Adapt an interval loop's cadence based on output changes.
+        loop_verify: Optional shell command run after each successful loop tick.
+        loop_no_progress_threshold: Identical outputs before auto-pausing.
 
     Returns:
         The created job dict
@@ -1130,6 +1138,10 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_loop = bool(loop)
+    normalized_loop_dynamic = bool(loop_dynamic)
+    normalized_loop_verify = _normalize_job_optional_text(loop_verify)
+    normalized_loop_threshold = max(1, int(loop_no_progress_threshold or 3))
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1220,6 +1232,20 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    if normalized_loop:
+        job.update(
+            {
+                "loop": True,
+                "loop_dynamic": normalized_loop_dynamic,
+                "loop_verify": normalized_loop_verify,
+                "loop_no_progress_threshold": normalized_loop_threshold,
+                "loop_no_progress_count": 0,
+                "loop_last_output_hash": None,
+                "loop_last_response": None,
+                "loop_last_delivered_hash": None,
+                "loop_last_verify_error": None,
+            }
+        )
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -12,6 +12,7 @@ import asyncio
 import atexit
 import concurrent.futures
 import contextvars
+import hashlib
 import json
 import logging
 import os
@@ -2227,6 +2228,163 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+def _format_loop_alert(job: dict, reason: str) -> str:
+    """Format an auto-pause notification with enough context to resume it."""
+    job_id = str(job["id"])
+    name = job.get("name") or job_id
+    prompt = str(job.get("prompt") or "")
+    snippet = prompt[:60] + ("..." if len(prompt) > 60 else "")
+    runs = int((job.get("repeat") or {}).get("completed", 0)) + 1
+    lines = [f"🔄 Loop job '{name}' ({job_id}) auto-paused: {reason}"]
+    if snippet:
+        lines.append(f"   Goal: {snippet}")
+    lines.extend(
+        [
+            f"   Runs completed: {runs}",
+            f"   Use /loop resume {job_id} to restart.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _run_loop_verify(job: dict) -> Optional[str]:
+    """Run a CLI-created loop verification command and return failure context."""
+    verify_cmd = str(job.get("loop_verify") or "").strip()
+    if not verify_cmd:
+        return None
+
+    from tools.environments.local import _sanitize_subprocess_env
+
+    kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
+    try:
+        result = subprocess.run(
+            verify_cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=job.get("workdir") or None,
+            env=_sanitize_subprocess_env(os.environ.copy()),
+            **kwargs,
+        )
+    except subprocess.TimeoutExpired:
+        return "verify command timed out after 60s"
+    except Exception as exc:
+        return f"verify command error: {exc}"
+
+    if result.returncode == 0:
+        return None
+
+    try:
+        from agent.redact import redact_sensitive_text
+
+        stderr = redact_sensitive_text((result.stderr or "").strip())
+        stdout = redact_sensitive_text((result.stdout or "").strip())
+    except Exception:
+        logger.warning("Loop verify output redaction failed", exc_info=True)
+        stderr = "[REDACTED - redaction failed]"
+        stdout = "[REDACTED - redaction failed]"
+
+    parts = [f"verify command failed (exit {result.returncode})"]
+    if stderr:
+        parts.append(f"stderr: {stderr[:2000]}")
+    if stdout:
+        parts.append(f"stdout: {stdout[:2000]}")
+    return "\n".join(parts)
+
+
+def _adapt_loop_interval(job: dict, output_changed: bool) -> dict:
+    """Return a clamped schedule update for a dynamic interval loop."""
+    schedule = job.get("schedule") or {}
+    if not job.get("loop_dynamic") or schedule.get("kind") != "interval":
+        return {}
+    old_minutes = int(schedule.get("minutes") or 5)
+    new_minutes = (
+        max(1, old_minutes // 2)
+        if output_changed
+        else min(1440, old_minutes * 2)
+    )
+    if new_minutes == old_minutes:
+        return {}
+    display = f"every {new_minutes}m"
+    return {
+        "schedule": {**schedule, "minutes": new_minutes, "display": display},
+        "schedule_display": display,
+    }
+
+
+def _loop_response_hash(final_response: str) -> str:
+    return hashlib.sha256((final_response or "").encode("utf-8")).hexdigest()[:16]
+
+
+def _acknowledge_loop_delivery(job: dict, final_response: str) -> None:
+    """Record a loop response only after its delivery actually succeeded."""
+    from cron.jobs import update_job
+
+    update_job(
+        job["id"],
+        {"loop_last_delivered_hash": _loop_response_hash(final_response)},
+    )
+
+
+def _evaluate_loop_tick(job: dict, final_response: str) -> tuple[Optional[str], bool]:
+    """Persist loop progress and return ``(pause_alert, skip_delivery)``."""
+    from cron.jobs import pause_job, update_job
+
+    job_id = job["id"]
+    threshold = max(1, int(job.get("loop_no_progress_threshold") or 3))
+    response_hash = _loop_response_hash(final_response)
+    last_hash = job.get("loop_last_output_hash")
+    no_progress_count = int(job.get("loop_no_progress_count") or 0)
+    output_changed = response_hash != last_hash
+    no_progress_count = 0 if output_changed else no_progress_count + 1
+    schedule_update = _adapt_loop_interval(job, output_changed)
+
+    if no_progress_count < threshold:
+        try:
+            from hermes_cli.goals import judge_goal
+
+            verdict, reason, parse_failed, _wait = judge_goal(
+                str(job.get("prompt") or ""),
+                final_response,
+            )
+            logger.info(
+                "Job '%s' loop judge: verdict=%s reason=%s parse_failed=%s",
+                job_id,
+                verdict,
+                reason,
+                parse_failed,
+            )
+            if verdict == "done":
+                no_progress_count += 1
+        except Exception:
+            logger.debug("Job '%s' loop judge failed", job_id, exc_info=True)
+
+    verify_error = _run_loop_verify(job)
+    updates = {
+        "loop_no_progress_count": no_progress_count,
+        "loop_last_output_hash": response_hash,
+        "loop_last_response": final_response,
+        "loop_last_verify_error": verify_error,
+        **schedule_update,
+    }
+    update_job(job_id, updates)
+
+    skip_delivery = (
+        job.get("loop_last_delivered_hash") is not None
+        and response_hash == job.get("loop_last_delivered_hash")
+    )
+    if no_progress_count < threshold:
+        if schedule_update:
+            _notify_provider_jobs_changed()
+        return None, skip_delivery
+
+    pause_job(job_id, reason="no progress detected")
+    _notify_provider_jobs_changed()
+    reason = f"{threshold} consecutive no-progress detections"
+    return _format_loop_alert(job, reason), True
+
+
 def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
@@ -2247,6 +2405,37 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     # pastes `rm -rf /`), so it must not be scanned with the strict
     # user-prompt pattern set — see _scan_assembled_cron_prompt.
     has_injected_data = False
+
+    if job.get("loop"):
+        previous_response = str(job.get("loop_last_response") or "")
+        if previous_response:
+            previous_response = previous_response[:4000]
+            prompt = (
+                "## Previous tick response\n"
+                "Continue from this prior result and improve or update it.\n\n"
+                f"```\n{previous_response}\n```\n\n{prompt}"
+            )
+            has_injected_data = True
+
+        verify_error = str(job.get("loop_last_verify_error") or "")
+        if verify_error:
+            verify_error = verify_error[:2000]
+            prompt = (
+                "## Post-run verification failure\n"
+                "Address this failure during the next loop run.\n\n"
+                f"```\n{verify_error}\n```\n\n{prompt}"
+            )
+            has_injected_data = True
+
+        if job.get("loop_dynamic"):
+            minutes = int((job.get("schedule") or {}).get("minutes") or 5)
+            count = int(job.get("loop_no_progress_count") or 0)
+            threshold = max(1, int(job.get("loop_no_progress_threshold") or 3))
+            prompt = (
+                "## Loop cadence\n"
+                f"Current interval: {minutes}m | No-progress: {count}/{threshold}\n\n"
+                f"{prompt}"
+            )
 
     # Run data-collection script if configured, inject output as context.
     script_path = job.get("script")
@@ -3614,6 +3803,14 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                     "(tool subprocess was killed mid-flight)."
                 )
 
+            loop_alert = None
+            loop_skip_delivery = False
+            if job.get("loop") and success and final_response.strip():
+                loop_alert, loop_skip_delivery = _evaluate_loop_tick(
+                    job,
+                    final_response,
+                )
+
             # Deliver the final response to the origin/target chat.
             # If the agent responded with [SILENT], skip delivery (but
             # output is already saved above).  Failed jobs always deliver.
@@ -3622,6 +3819,9 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
             should_deliver = bool(deliver_content.strip())
+            loop_has_delivery_target = (
+                bool(_resolve_delivery_targets(job)) if job.get("loop") else False
+            )
             # Cron silence suppression — see _is_cron_silence_response.  Replaces the
             # old `SILENT_MARKER in ...upper()` substring check, which both leaked
             # bracketless near-markers ("SILENT" / "NO_REPLY") and wrongly swallowed
@@ -3632,12 +3832,36 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
 
+            if should_deliver and loop_skip_delivery:
+                logger.info(
+                    "Job '%s': loop output already delivered — skipping duplicate",
+                    job["id"],
+                )
+                should_deliver = False
+
             if should_deliver:
                 try:
                     delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    if (
+                        job.get("loop")
+                        and success
+                        and loop_has_delivery_target
+                        and delivery_error is None
+                    ):
+                        _acknowledge_loop_delivery(job, final_response)
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
+
+            if loop_alert:
+                try:
+                    alert_error = _deliver_result(job, loop_alert, adapters=adapters, loop=loop)
+                    if alert_error and not delivery_error:
+                        delivery_error = alert_error
+                except Exception as de:
+                    if not delivery_error:
+                        delivery_error = str(de)
+                    logger.warning("Loop alert delivery failed for job %s: %s", job["id"], de)
         finally:
             # Tear down the deferred agent(s) now that save + delivery have run
             # (or raised). Must happen on every path so cron agents never leak

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9556,6 +9556,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _cmd_def_inner and _cmd_def_inner.name == "subgoal":
                 return await self._handle_subgoal_command(event)
 
+            # /loop is safe mid-run — it only manages cron jobs (control-plane).
+            if _cmd_def_inner and _cmd_def_inner.name == "loop":
+                return await self._handle_loop_command(event)
+
             # Session-level toggles that are safe to run mid-agent —
             # /yolo can unblock a pending approval prompt, /verbose cycles
             # the tool-progress display mode for the ongoing stream.
@@ -10107,6 +10111,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "subgoal":
             return await self._handle_subgoal_command(event)
+
+        if canonical == "loop":
+            return await self._handle_loop_command(event)
 
         if canonical == "voice":
             return await self._handle_voice_command(event)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2199,6 +2199,28 @@ class GatewaySlashCommandsMixin:
         # Let the normal message handler process it
         return await self._handle_message(retry_event)
 
+    async def _handle_loop_command(self, event: "MessageEvent") -> str:
+        """Handle /loop for gateway platforms.
+
+        Subcommands: ``/loop <interval> <prompt>`` / ``/loop status`` /
+        ``/loop pause <id>`` / ``/loop resume <id>`` / ``/loop stop <id>``.
+        """
+        from hermes_cli.loop_command import handle_loop_command, parse_loop_result
+
+        args = (event.get_command_args() or "").strip()
+
+        origin = None
+        if event.source:
+            origin = {
+                "platform": str(event.source.platform),
+                "chat_id": event.source.chat_id,
+                "chat_name": event.source.chat_name,
+                "thread_id": event.source.thread_id,
+            }
+
+        text, _is_error = parse_loop_result(handle_loop_command(args, origin=origin))
+        return text or "Loop command completed."
+
     async def _handle_goal_command(self, event: "MessageEvent") -> str:
         """Handle /goal for gateway platforms.
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1995,6 +1995,20 @@ class CLICommandsMixin:
             print("   status       Show current browser mode")
             print()
 
+    def _handle_loop_command(self, cmd: str) -> None:
+        """Dispatch /loop subcommands: create / status / pause / resume / stop."""
+        from cli import _cprint
+        from hermes_cli.loop_command import handle_loop_command, parse_loop_result
+
+        parts = (cmd or "").strip().split(None, 1)
+        args = parts[1].strip() if len(parts) > 1 else ""
+
+        text, is_error = parse_loop_result(handle_loop_command(args))
+        if is_error:
+            _cprint(f"  \033[1;31m{text}\033[0m")
+        elif text:
+            _cprint(f"  {text}")
+
     def _handle_goal_command(self, cmd: str) -> None:
         """Dispatch /goal subcommands: set / draft / show / status / pause / resume / clear."""
         from cli import _DIM, _RST, _cprint

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -117,6 +117,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="<prompt>"),
     CommandDef("subgoal", "Add or manage extra criteria on the active goal", "Session",
                args_hint="[text | remove N | clear]"),
+    CommandDef("loop", "Create and manage a persistent scheduled agent loop", "Session",
+               args_hint="[<interval> <prompt> | status | pause <id> | resume <id> | stop <id>]"),
     CommandDef("status", "Show session, model, token, and context info", "Session"),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
@@ -373,6 +375,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "commands",
         "deny",
         "help",
+        "loop",
         "new",
         "profile",
         "queue",
@@ -1164,7 +1167,8 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #   - moa: high-cost slash mode, available through /hermes moa to avoid
 #     displacing existing native Slack slash commands at the 50-command cap.
 #   - debug: the log/report upload surface; reached via /hermes debug on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug"})
+#   - loop: persistent automation management; reached via /hermes loop on Slack.
+_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug", "loop"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/loop_command.py
+++ b/hermes_cli/loop_command.py
@@ -1,0 +1,436 @@
+"""Handle /loop slash command — persistent scheduled agent loops.
+
+Creates cron jobs with loop=True that self-evaluate via judge_goal and
+auto-pause after consecutive no-progress detections.
+
+Two modes:
+  Timed:   /loop <interval> <prompt>  — fixed schedule (e.g., 30m, 2h)
+  Dynamic: /loop <prompt>             — starts at 5m, adapts based on output
+"""
+
+import json
+import re
+from typing import Optional
+
+
+# Interval token: matches "5m", "2h", "30m", "1d" (the cron engine's floor is
+# 1 minute, so seconds are intentionally excluded — see _SUBMINUTE_RE).
+_INTERVAL_RE = re.compile(r"^\d+[mhd]$", re.IGNORECASE)
+# Sub-minute tokens ("30s") — detected only to reject with a clear error,
+# since the scheduler has no sub-minute granularity.
+_SUBMINUTE_RE = re.compile(r"^\d+s$", re.IGNORECASE)
+
+
+def handle_loop_command(
+    text: str,
+    origin: Optional[dict] = None,
+) -> str:
+    """Handle /loop slash command.
+
+    Args:
+        text: The raw command text after '/loop'.
+        origin: Optional origin dict with platform/chat_id/thread_id
+            for delivery routing. Passed through to create_job.
+
+    Returns:
+        JSON string for tool integration, or human-readable status.
+    """
+    args = (text or "").strip()
+
+    if not args:
+        return _usage()
+
+    lower = args.lower()
+
+    if lower in ("status", "list"):
+        return _handle_status(origin)
+
+    if lower == "help":
+        return _usage()
+
+    # pause <id>
+    m = re.match(r"^pause\s+(\S+)", args, re.IGNORECASE)
+    if m:
+        return _handle_pause_resume(m.group(1), "pause", origin)
+    if lower == "pause":
+        return json.dumps({"success": False, "error": "Usage: /loop pause <job_id>\n       (partial IDs work — you can use the first few characters)"})
+
+    # resume <id>
+    m = re.match(r"^resume\s+(\S+)", args, re.IGNORECASE)
+    if m:
+        return _handle_pause_resume(m.group(1), "resume", origin)
+    if lower == "resume":
+        return json.dumps({"success": False, "error": "Usage: /loop resume <job_id>\n       (partial IDs work — you can use the first few characters)"})
+
+    # stop/remove <id>
+    m = re.match(r"^(?:stop|remove)\s+(\S+)", args, re.IGNORECASE)
+    if m:
+        return _handle_stop(m.group(1), origin)
+    if lower in ("stop", "remove"):
+        return json.dumps({"success": False, "error": "Usage: /loop stop <job_id>\n       (partial IDs work — you can use the first few characters)"})
+
+    # Parse as create: [interval] <prompt> [--skills ...] [--verify ...] [--name ...]
+    return _handle_create(args, origin=origin)
+
+
+def parse_loop_result(result_json: str) -> tuple[str, bool]:
+    """Reduce a handle_loop_command() JSON result to (display_text, is_error).
+
+    Centralizes the result contract so callers (CLI, gateway) don't each
+    reimplement the message/error/success key handling. On unparseable input
+    the raw string is returned verbatim with is_error=False. An empty
+    display_text means "success with nothing to show" — callers decide what,
+    if anything, to render.
+    """
+    try:
+        result = json.loads(result_json)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return result_json, False
+
+    msg = result.get("message", "")
+    if msg:
+        return msg, False
+    if not result.get("success"):
+        return result.get("error", "Unknown loop command error"), True
+    return "", False
+
+
+def _usage() -> str:
+    return json.dumps({
+        "success": True,
+        "message": (
+            "Usage: /loop [interval] <prompt> [--skills s1,s2] [--verify 'cmd'] [--name label]\n"
+            "       /loop status\n"
+            "       /loop pause <id>\n"
+            "       /loop resume <id>\n"
+            "       /loop stop <id>\n"
+            "\n"
+            "Modes:\n"
+            "  /loop 30m check deploy       → timed: runs every 30 minutes\n"
+            "  /loop check deploy            → dynamic: starts at 5m, adapts to output\n"
+            "\n"
+            "Partial IDs work — you can use the first few characters of a job ID.\n"
+            "\n"
+            "Examples:\n"
+            "  /loop every 30m check the deployment status\n"
+            "  /loop 2h monitor disk usage --verify 'df -h /' --name disk-watch\n"
+            "  /loop check if tests are passing --verify pytest\n"
+            "  /loop status\n"
+            "  /loop pause abc123"
+        ),
+    })
+
+
+def _classify_schedule(text: str) -> tuple:
+    """Split a leading interval token from the prompt and pick the loop mode.
+
+    Returns (schedule, prompt, dynamic, error):
+      - timed:   schedule="every Nm", dynamic=False
+      - dynamic: schedule="",         dynamic=True  (no leading duration)
+      - error:   error set (e.g. a sub-minute interval)
+
+    Loops are always recurring, so a bare duration ("30m") is normalized to its
+    recurring form ("every 30m"); a one-shot loop would be a contradiction. The
+    scheduler's floor is 1 minute, so sub-minute tokens are rejected outright.
+    """
+    parts = text.split(None, 1)
+    first = parts[0]
+    rest = parts[1] if len(parts) > 1 else ""
+
+    # Explicit "every <dur>" form.
+    if first.lower() == "every" and rest:
+        dur_parts = rest.split(None, 1)
+        dur = dur_parts[0]
+        prompt = dur_parts[1] if len(dur_parts) > 1 else ""
+        if _SUBMINUTE_RE.match(dur):
+            return "", "", False, f"Sub-minute intervals aren't supported (minimum 1m): {dur}"
+        if _INTERVAL_RE.match(dur):
+            return f"every {dur}", prompt, False, None
+        # "every" not followed by a duration — treat the whole text as a prompt.
+        return "", text, True, None
+
+    # Bare leading duration → normalize to recurring form.
+    if _SUBMINUTE_RE.match(first):
+        return "", "", False, f"Sub-minute intervals aren't supported (minimum 1m): {first}"
+    if _INTERVAL_RE.match(first):
+        return f"every {first}", rest, False, None
+
+    # No leading interval → dynamic mode, the whole text is the prompt.
+    return "", text, True, None
+
+
+def _parse_create_args(text: str) -> dict:
+    """Parse /loop create arguments.
+
+    Two modes, decided by the leading token:
+        Timed:   <interval> <prompt> [--flags]   (e.g. "30m ...", "every 2h ...")
+        Dynamic: <prompt> [--flags]              (first word isn't a duration)
+
+    A bare duration is normalized to recurring form and sub-minute intervals are
+    rejected — see _classify_schedule.
+
+    Returns dict with keys: schedule, prompt, skills, verify, name, dynamic, error.
+    """
+    result = {
+        "schedule": "", "prompt": "", "skills": None,
+        "verify": None, "name": None, "dynamic": False, "error": None,
+    }
+
+    # Extract flags in order: --name first, then --skills, then --verify.
+    # This ordering prevents --verify's greedy match from eating other flags.
+
+    # --name label
+    name_match = re.search(r"--name\s+(\S+)", text)
+    if name_match:
+        result["name"] = name_match.group(1).strip()
+        text = text[:name_match.start()] + text[name_match.end():]
+
+    # --skills s1,s2
+    skills_match = re.search(r"--skills?\s+(\S+)", text)
+    if skills_match:
+        raw_skills = skills_match.group(1)
+        result["skills"] = [s.strip() for s in raw_skills.split(",") if s.strip()]
+        text = text[:skills_match.start()] + text[skills_match.end():]
+
+    # --verify 'command' or --verify "command" (quoted)
+    verify_match = re.search(r"""--verify\s+(['"])(.*?)\1""", text, re.DOTALL)
+    if verify_match:
+        result["verify"] = verify_match.group(2).strip()
+        text = text[:verify_match.start()] + text[verify_match.end():]
+    else:
+        # --verify command (no quotes, rest of line — safe because
+        # --skills and --name are already stripped)
+        verify_match = re.search(r"--verify\s+(\S+.*)", text)
+        if verify_match:
+            result["verify"] = verify_match.group(1).strip()
+            text = text[:verify_match.start()]
+
+    text = text.strip()
+    if not text:
+        result["error"] = "Missing prompt text"
+        return result
+
+    schedule, prompt, dynamic, error = _classify_schedule(text)
+    if error:
+        result["error"] = error
+        return result
+    if not prompt.strip():
+        result["error"] = "Missing prompt text"
+        return result
+
+    result["schedule"] = schedule
+    result["prompt"] = prompt.strip()
+    result["dynamic"] = dynamic
+    return result
+
+
+def _handle_create(text: str, origin: Optional[dict] = None) -> str:
+    """Create a new loop cron job."""
+    parsed = _parse_create_args(text)
+    if parsed.get("error"):
+        return json.dumps({"success": False, "error": parsed["error"]})
+
+    dynamic = parsed.get("dynamic", False)
+    schedule = parsed["schedule"] if not dynamic else "every 5m"
+
+    if origin is not None and parsed.get("verify"):
+        return json.dumps({
+            "success": False,
+            "error": "--verify is CLI-only because it executes a local shell command.",
+        })
+
+    try:
+        from tools.cronjob_tools import _scan_cron_prompt
+
+        scan_error = _scan_cron_prompt(parsed["prompt"])
+        if scan_error:
+            return json.dumps({"success": False, "error": scan_error})
+
+        from cron.jobs import create_job
+        job = create_job(
+            prompt=parsed["prompt"],
+            schedule=schedule,
+            name=parsed.get("name"),
+            deliver="origin",
+            origin=origin,
+            loop=True,
+            loop_dynamic=dynamic,
+            loop_verify=parsed.get("verify"),
+            skills=parsed.get("skills"),
+        )
+        job_name = job.get("name", job["id"])
+        verify_line = f"   Verify: {parsed['verify']}\n" if parsed.get("verify") else ""
+        mode_line = "   Mode: dynamic (starts at 5m, adapts to output changes)\n" if dynamic else ""
+        return json.dumps({
+            "success": True,
+            "action": "created",
+            "job_id": job["id"],
+            "schedule": job.get("schedule_display", schedule),
+            "prompt": parsed["prompt"][:100],
+            "dynamic": dynamic,
+            "next_run_at": job.get("next_run_at"),
+            "skills": parsed.get("skills"),
+            "verify": parsed.get("verify"),
+            "name": parsed.get("name"),
+            "message": (
+                f"🔄 Loop created: {job['id']}\n"
+                f"   Name: {job_name}\n"
+                f"   Schedule: {job.get('schedule_display', schedule)}\n"
+                f"   Prompt: {parsed['prompt'][:80]}{'...' if len(parsed['prompt']) > 80 else ''}\n"
+                f"{mode_line}"
+                f"{verify_line}"
+                f"   Next run: {job.get('next_run_at', 'unknown')}\n"
+                f"   Auto-pause: after 3 consecutive no-progress detections"
+            ),
+        })
+    except Exception as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+
+def _origin_matches(job_origin: object, requested_origin: Optional[dict]) -> bool:
+    """Limit gateway callers to loops created from the same chat and thread."""
+    if requested_origin is None:
+        return True
+    if not isinstance(job_origin, dict):
+        return False
+    return all(
+        str(job_origin.get(key) or "") == str(requested_origin.get(key) or "")
+        for key in ("platform", "chat_id", "thread_id")
+    )
+
+
+def _visible_loop_jobs(origin: Optional[dict]) -> list[dict]:
+    from cron.jobs import list_jobs
+
+    return [
+        job
+        for job in list_jobs(include_disabled=True)
+        if job.get("loop") and _origin_matches(job.get("origin"), origin)
+    ]
+
+
+def _resolve_loop_ref(job_ref: str, origin: Optional[dict]) -> tuple[Optional[dict], Optional[str]]:
+    """Resolve a loop ID, unique ID prefix, or exact name within caller scope."""
+    jobs = _visible_loop_jobs(origin)
+    for job in jobs:
+        if job.get("id") == job_ref:
+            return job, None
+
+    ref_lower = job_ref.lower()
+    name_matches = [job for job in jobs if str(job.get("name") or "").lower() == ref_lower]
+    if len(name_matches) == 1:
+        return name_matches[0], None
+    if len(name_matches) > 1:
+        ids = ", ".join(str(job["id"]) for job in name_matches)
+        return None, f"Loop name is ambiguous: {job_ref} matches {ids}"
+
+    prefix_matches = [job for job in jobs if str(job.get("id") or "").startswith(job_ref)]
+    if len(prefix_matches) == 1:
+        return prefix_matches[0], None
+    if len(prefix_matches) > 1:
+        ids = ", ".join(str(job["id"]) for job in prefix_matches)
+        return None, f"Loop ID prefix is ambiguous: {job_ref} matches {ids}"
+    return None, f"Loop not found: {job_ref}"
+
+
+def _handle_status(origin: Optional[dict] = None) -> str:
+    """List loop jobs visible to the calling surface."""
+    try:
+        loop_jobs = _visible_loop_jobs(origin)
+
+        if not loop_jobs:
+            return json.dumps({
+                "success": True,
+                "jobs": [],
+                "message": "No loop jobs configured.",
+            })
+
+        lines = ["Loop jobs:"]
+        for job in loop_jobs:
+            state = job.get("state", "unknown")
+            name = job.get("name", job.get("id", "?"))
+            schedule = job.get("schedule_display", "?")
+            count = job.get("loop_no_progress_count", 0)
+            threshold = job.get("loop_no_progress_threshold", 3)
+            verify = job.get("loop_verify")
+            verify_err = job.get("loop_last_verify_error")
+            mode_tag = " [dynamic]" if job.get("loop_dynamic", False) else ""
+            lines.append(
+                f"  {'⏸' if state == 'paused' else '▶'} {job['id']} "
+                f"({state}) [{schedule}]{mode_tag} {name[:40]}"
+            )
+            lines.append(f"    no-progress: {count}/{threshold}")
+            if verify:
+                status_icon = "❌" if verify_err else "✓"
+                lines.append(f"    verify: {status_icon} {verify[:60]}")
+
+        return json.dumps({
+            "success": True,
+            "jobs": [
+                {
+                    "id": job["id"],
+                    "state": job.get("state", "unknown"),
+                    "schedule": job.get("schedule_display", "?"),
+                    "name": job.get("name", ""),
+                    "dynamic": job.get("loop_dynamic", False),
+                    "no_progress_count": job.get("loop_no_progress_count", 0),
+                    "threshold": job.get("loop_no_progress_threshold", 3),
+                    "verify": job.get("loop_verify"),
+                    "verify_error": job.get("loop_last_verify_error"),
+                }
+                for job in loop_jobs
+            ],
+            "message": "\n".join(lines),
+        })
+    except Exception as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+
+def _handle_pause_resume(
+    job_ref: str,
+    action: str,
+    origin: Optional[dict] = None,
+) -> str:
+    """Pause or resume a visible loop job."""
+    try:
+        from cron.jobs import pause_job, resume_job
+
+        target, resolve_error = _resolve_loop_ref(job_ref, origin)
+        if not target:
+            return json.dumps({"success": False, "error": resolve_error})
+        if action == "pause":
+            job = pause_job(target["id"], reason="user-paused")
+        else:
+            job = resume_job(target["id"])
+
+        if not job:
+            return json.dumps({"success": False, "error": f"Loop not found: {job_ref}"})
+
+        return json.dumps({
+            "success": True,
+            "action": action + "d",
+            "job_id": job["id"],
+            "state": job.get("state"),
+            "message": f"{'⏸' if action == 'pause' else '▶'} Loop {action}d: {job['id']}",
+        })
+    except Exception as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+
+def _handle_stop(job_ref: str, origin: Optional[dict] = None) -> str:
+    """Remove a visible loop job."""
+    try:
+        from cron.jobs import remove_job
+
+        target, resolve_error = _resolve_loop_ref(job_ref, origin)
+        if not target:
+            return json.dumps({"success": False, "error": resolve_error})
+        if remove_job(target["id"]):
+            return json.dumps({
+                "success": True,
+                "action": "removed",
+                "message": f"🗑 Loop stopped and removed: {target['id']}",
+            })
+        return json.dumps({"success": False, "error": f"Loop not found: {job_ref}"})
+    except Exception as exc:
+        return json.dumps({"success": False, "error": str(exc)})

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -274,3 +274,156 @@ def test_run_one_job_tears_down_deferred_agent_when_save_raises(monkeypatch):
     assert ok is False
     assert "deliver" not in order
     assert order == ["save-raise", "agent.close", "cleanup_stale"], order
+
+
+def _patch_loop_pipeline(monkeypatch, job, final_response, deliver):
+    """Install a stateful pipeline around the real loop evaluator."""
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda _job, *, defer_agent_teardown=None: (
+            True,
+            final_response,
+            final_response,
+            None,
+        ),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_args: "/tmp/loop.txt")
+    monkeypatch.setattr(s, "_deliver_result", deliver)
+    monkeypatch.setattr(
+        s,
+        "_resolve_delivery_targets",
+        lambda _job: [{"platform": "test", "chat_id": "1"}],
+    )
+    monkeypatch.setattr(s, "mark_job_run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(s, "_run_loop_verify", lambda _job: None)
+    monkeypatch.setattr(s, "_notify_provider_jobs_changed", lambda: None)
+
+    import cron.jobs as jobs
+    import hermes_cli.goals as goals
+
+    def update_job(_job_id, updates):
+        job.update(updates)
+        return job
+
+    monkeypatch.setattr(jobs, "update_job", update_job)
+    monkeypatch.setattr(jobs, "pause_job", lambda *_args, **_kwargs: job)
+    monkeypatch.setattr(
+        goals,
+        "judge_goal",
+        lambda *_args, **_kwargs: ("continue", "still running", False, None),
+    )
+
+
+def test_loop_acknowledges_only_after_successful_delivery(monkeypatch):
+    job = {
+        "id": "loop-delivery",
+        "name": "loop",
+        "prompt": "check status",
+        "loop": True,
+        "loop_no_progress_threshold": 10,
+        "loop_no_progress_count": 0,
+    }
+    delivery_results = iter(["send failed", None])
+    deliveries = []
+
+    def deliver(_job, content, adapters=None, loop=None):
+        deliveries.append(content)
+        return next(delivery_results)
+
+    _patch_loop_pipeline(monkeypatch, job, "same result", deliver)
+
+    assert s.run_one_job(job) is True
+    assert job.get("loop_last_delivered_hash") is None
+
+    assert s.run_one_job(job) is True
+    assert deliveries == ["same result", "same result"]
+    assert job["loop_last_delivered_hash"] == s._loop_response_hash("same result")
+
+
+def test_loop_silent_response_is_never_acknowledged(monkeypatch):
+    job = {
+        "id": "loop-silent",
+        "name": "loop",
+        "prompt": "check quietly",
+        "loop": True,
+        "loop_no_progress_threshold": 10,
+        "loop_no_progress_count": 0,
+    }
+
+    def unexpected_delivery(*_args, **_kwargs):
+        raise AssertionError("[SILENT] loop responses must not be delivered")
+
+    _patch_loop_pipeline(monkeypatch, job, "[SILENT]", unexpected_delivery)
+
+    assert s.run_one_job(job) is True
+    assert job.get("loop_last_delivered_hash") is None
+
+
+def test_loop_skips_output_only_after_prior_successful_delivery(monkeypatch):
+    response = "unchanged result"
+    job = {
+        "id": "loop-duplicate",
+        "name": "loop",
+        "prompt": "check status",
+        "loop": True,
+        "loop_no_progress_threshold": 10,
+        "loop_no_progress_count": 0,
+        "loop_last_output_hash": s._loop_response_hash(response),
+        "loop_last_delivered_hash": s._loop_response_hash(response),
+    }
+    deliveries = []
+
+    def deliver(_job, content, adapters=None, loop=None):
+        deliveries.append(content)
+        return None
+
+    _patch_loop_pipeline(monkeypatch, job, response, deliver)
+
+    assert s.run_one_job(job) is True
+    assert deliveries == []
+
+
+def test_loop_without_delivery_target_is_not_acknowledged(monkeypatch):
+    job = {
+        "id": "loop-local",
+        "name": "loop",
+        "prompt": "check locally",
+        "loop": True,
+        "loop_no_progress_threshold": 10,
+        "loop_no_progress_count": 0,
+        "deliver": "local",
+    }
+
+    _patch_loop_pipeline(monkeypatch, job, "local result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(s, "_resolve_delivery_targets", lambda _job: [])
+
+    assert s.run_one_job(job) is True
+    assert job.get("loop_last_delivered_hash") is None
+
+
+def test_loop_pause_alert_is_delivered(monkeypatch):
+    response = "unchanged result"
+    job = {
+        "id": "loop-alert",
+        "name": "deploy-watch",
+        "prompt": "check deploy status",
+        "loop": True,
+        "loop_no_progress_threshold": 1,
+        "loop_no_progress_count": 0,
+        "loop_last_output_hash": s._loop_response_hash(response),
+        "repeat": {"completed": 2},
+    }
+    deliveries = []
+
+    def deliver(_job, content, adapters=None, loop=None):
+        deliveries.append(content)
+        return None
+
+    _patch_loop_pipeline(monkeypatch, job, response, deliver)
+
+    assert s.run_one_job(job) is True
+    assert len(deliveries) == 1
+    assert "auto-paused" in deliveries[0]
+    assert "Runs completed: 3" in deliveries[0]
+    assert "/loop resume loop-alert" in deliveries[0]

--- a/tests/test_loop_command.py
+++ b/tests/test_loop_command.py
@@ -1,0 +1,733 @@
+"""Tests for /loop slash command — parsing, creation, loop evaluation, dynamic mode."""
+
+import hashlib
+import json
+import pytest
+from unittest.mock import ANY, patch, MagicMock
+from subprocess import CompletedProcess, TimeoutExpired
+
+from hermes_cli.loop_command import handle_loop_command, _parse_create_args, _classify_schedule
+from cron.scheduler import (
+    CronPromptInjectionBlocked,
+    _build_job_prompt,
+    _evaluate_loop_tick,
+    _run_loop_verify,
+)
+
+
+# =========================================================================
+# _classify_schedule — interval/prompt/mode splitting
+# =========================================================================
+
+class TestClassifySchedule:
+    def test_bare_minutes_normalized_to_recurring(self):
+        # Loops are recurring: a bare "5m" must become "every 5m", not a one-shot.
+        assert _classify_schedule("5m check") == ("every 5m", "check", False, None)
+        assert _classify_schedule("30m do it") == ("every 30m", "do it", False, None)
+
+    def test_bare_hours_and_days(self):
+        assert _classify_schedule("2h monitor") == ("every 2h", "monitor", False, None)
+        assert _classify_schedule("1d sweep") == ("every 1d", "sweep", False, None)
+
+    def test_explicit_every_form(self):
+        assert _classify_schedule("every 2h monitor") == ("every 2h", "monitor", False, None)
+
+    def test_no_interval_is_dynamic(self):
+        assert _classify_schedule("check deploy") == ("", "check deploy", True, None)
+
+    def test_single_word_is_dynamic(self):
+        assert _classify_schedule("status") == ("", "status", True, None)
+
+    def test_every_without_interval_is_dynamic(self):
+        assert _classify_schedule("every day check") == ("", "every day check", True, None)
+
+    def test_bare_subminute_rejected(self):
+        sched, prompt, dynamic, error = _classify_schedule("30s check")
+        assert error is not None and "Sub-minute" in error
+
+    def test_every_subminute_rejected(self):
+        sched, prompt, dynamic, error = _classify_schedule("every 30s check")
+        assert error is not None and "Sub-minute" in error
+
+
+# =========================================================================
+# _parse_create_args — timed mode
+# =========================================================================
+
+class TestParseCreateArgsTimed:
+    def test_basic_interval_and_prompt(self):
+        r = _parse_create_args("5m check the deployment")
+        assert r["schedule"] == "every 5m"
+        assert r["prompt"] == "check the deployment"
+        assert r["dynamic"] is False
+        assert r["skills"] is None
+        assert r["verify"] is None
+        assert r["error"] is None
+
+    def test_every_prefix(self):
+        r = _parse_create_args("every 2h monitor disk usage")
+        assert r["schedule"] == "every 2h"
+        assert r["prompt"] == "monitor disk usage"
+        assert r["dynamic"] is False
+
+    def test_skills_flag(self):
+        r = _parse_create_args("30m check logs --skills devops,networking")
+        assert r["schedule"] == "every 30m"
+        assert r["skills"] == ["devops", "networking"]
+        assert r["prompt"] == "check logs"
+
+    def test_verify_flag_bare(self):
+        r = _parse_create_args("5m fix tests --verify pytest")
+        assert r["schedule"] == "every 5m"
+        assert r["verify"] == "pytest"
+        assert r["prompt"] == "fix tests"
+
+    def test_verify_flag_quoted(self):
+        r = _parse_create_args('5m fix tests --verify "npm test -- -u"')
+        assert r["verify"] == "npm test -- -u"
+
+    def test_verify_flag_single_quotes(self):
+        r = _parse_create_args("5m fix tests --verify 'pytest -x -v'")
+        assert r["verify"] == "pytest -x -v"
+
+    def test_skills_and_verify_combined(self):
+        r = _parse_create_args("1h review PRs --skills github-code-review --verify 'gh pr checks'")
+        assert r["schedule"] == "every 1h"
+        assert r["prompt"] == "review PRs"
+        assert r["skills"] == ["github-code-review"]
+        assert r["verify"] == "gh pr checks"
+
+    def test_verify_before_skills_ordering(self):
+        """--verify without quotes should NOT eat --skills when --skills is parsed first."""
+        r = _parse_create_args("30m check status --verify pytest --skills devops")
+        assert r["schedule"] == "every 30m"
+        assert r["prompt"] == "check status"
+        assert r["skills"] == ["devops"]
+        assert r["verify"] == "pytest"
+
+    def test_name_flag(self):
+        r = _parse_create_args("30m check logs --name log-watcher")
+        assert r["schedule"] == "every 30m"
+        assert r["prompt"] == "check logs"
+        assert r["name"] == "log-watcher"
+
+    def test_name_with_skills_and_verify(self):
+        r = _parse_create_args("1h review PRs --name pr-check --skills github-code-review --verify 'gh pr checks'")
+        assert r["schedule"] == "every 1h"
+        assert r["prompt"] == "review PRs"
+        assert r["name"] == "pr-check"
+        assert r["skills"] == ["github-code-review"]
+        assert r["verify"] == "gh pr checks"
+
+    def test_missing_prompt(self):
+        r = _parse_create_args("5m")
+        assert r["error"] == "Missing prompt text"
+
+    def test_missing_every_prompt(self):
+        r = _parse_create_args("every 30m")
+        assert r["error"] == "Missing prompt text"
+
+    def test_subminute_interval_rejected(self):
+        r = _parse_create_args("30s check deploy")
+        assert r["error"] is not None
+        assert "Sub-minute" in r["error"]
+
+
+# =========================================================================
+# _parse_create_args — dynamic mode (no interval)
+# =========================================================================
+
+class TestParseCreateArgsDynamic:
+    def test_prompt_only(self):
+        r = _parse_create_args("check if tests are passing")
+        assert r["dynamic"] is True
+        assert r["schedule"] == ""
+        assert r["prompt"] == "check if tests are passing"
+        assert r["error"] is None
+
+    def test_prompt_with_verify(self):
+        r = _parse_create_args("check deployment --verify curl localhost/health")
+        assert r["dynamic"] is True
+        assert r["prompt"] == "check deployment"
+        assert r["verify"] == "curl localhost/health"
+
+    def test_prompt_with_skills(self):
+        r = _parse_create_args("review open PRs --skills github-code-review")
+        assert r["dynamic"] is True
+        assert r["prompt"] == "review open PRs"
+        assert r["skills"] == ["github-code-review"]
+
+    def test_prompt_with_all_flags(self):
+        r = _parse_create_args("monitor disk --name disk-check --verify 'df -h' --skills devops")
+        assert r["dynamic"] is True
+        assert r["prompt"] == "monitor disk"
+        assert r["name"] == "disk-check"
+        assert r["verify"] == "df -h"
+        assert r["skills"] == ["devops"]
+
+    def test_single_word_prompt(self):
+        r = _parse_create_args("status")
+        assert r["dynamic"] is True
+        assert r["prompt"] == "status"
+
+    def test_every_without_valid_interval(self):
+        """'every' followed by non-interval token should be dynamic."""
+        r = _parse_create_args("every day check something")
+        assert r["dynamic"] is True
+        assert r["prompt"] == "every day check something"
+
+
+# =========================================================================
+# handle_loop_command
+# =========================================================================
+
+class TestHandleLoopCommand:
+    def test_empty_returns_usage(self):
+        result = json.loads(handle_loop_command(""))
+        assert result["success"] is True
+        assert "Usage" in result["message"]
+
+    def test_status_returns_success(self):
+        result = json.loads(handle_loop_command("status"))
+        assert result["success"] is True
+
+    def test_pause_missing_id(self):
+        result = json.loads(handle_loop_command("pause"))
+        assert result["success"] is False
+        assert "Usage" in result["error"]
+
+    def test_resume_missing_id(self):
+        result = json.loads(handle_loop_command("resume"))
+        assert result["success"] is False
+        assert "Usage" in result["error"]
+
+    def test_stop_missing_id(self):
+        result = json.loads(handle_loop_command("stop"))
+        assert result["success"] is False
+        assert "Usage" in result["error"]
+
+    def test_remove_missing_id(self):
+        result = json.loads(handle_loop_command("remove"))
+        assert result["success"] is False
+        assert "Usage" in result["error"]
+
+    def test_list_alias(self):
+        result = json.loads(handle_loop_command("list"))
+        assert result["success"] is True
+
+    def test_help_alias(self):
+        result = json.loads(handle_loop_command("help"))
+        assert result["success"] is True
+        assert "Usage" in result["message"]
+
+
+# =========================================================================
+# _run_loop_verify (mocked subprocess)
+# =========================================================================
+
+class TestRunLoopVerify:
+    def test_no_verify_command(self):
+        job = {"loop_verify": None}
+        assert _run_loop_verify(job) is None
+
+    def test_no_verify_key(self):
+        job = {}
+        assert _run_loop_verify(job) is None
+
+    @patch("cron.scheduler.subprocess.run")
+    def test_verify_success(self, mock_run):
+        mock_run.return_value = CompletedProcess([], 0, stdout="", stderr="")
+        job = {"loop_verify": "echo ok"}
+        assert _run_loop_verify(job) is None
+        mock_run.assert_called_once_with(
+            "echo ok", shell=True, capture_output=True, text=True, timeout=60,
+            cwd=None, env=ANY,
+        )
+
+    @patch("cron.scheduler.subprocess.run")
+    def test_verify_failure_with_stderr(self, mock_run):
+        mock_run.return_value = CompletedProcess(
+            [], 1, stdout="output here", stderr="something broke",
+        )
+        job = {"loop_verify": "pytest"}
+        result = _run_loop_verify(job)
+        assert result is not None
+        assert "exit 1" in result
+        assert "something broke" in result
+        assert "output here" in result
+
+    @patch("cron.scheduler.subprocess.run")
+    def test_verify_failure_stdout_only(self, mock_run):
+        mock_run.return_value = CompletedProcess([], 2, stdout="FAIL: 3 tests", stderr="")
+        job = {"loop_verify": "pytest"}
+        result = _run_loop_verify(job)
+        assert result is not None
+        assert "exit 2" in result
+        assert "FAIL: 3 tests" in result
+        assert "stderr" not in result
+
+    @patch("cron.scheduler.subprocess.run")
+    def test_verify_timeout(self, mock_run):
+        mock_run.side_effect = TimeoutExpired("pytest", 60)
+        job = {"loop_verify": "pytest --slow"}
+        result = _run_loop_verify(job)
+        assert result is not None
+        assert "timed out" in result
+        assert "60s" in result
+
+    @patch("cron.scheduler.subprocess.run")
+    def test_verify_generic_exception(self, mock_run):
+        mock_run.side_effect = OSError("no such file")
+        job = {"loop_verify": "/nonexistent/cmd"}
+        result = _run_loop_verify(job)
+        assert result is not None
+        assert "no such file" in result
+
+
+# =========================================================================
+# _evaluate_loop_tick — integration tests
+# =========================================================================
+
+def _make_loop_job(**overrides):
+    """Create a minimal loop job dict for testing."""
+    job = {
+        "id": "test123",
+        "name": "test-loop",
+        "prompt": "check deployment status",
+        "loop": True,
+        "loop_dynamic": False,
+        "loop_verify": None,
+        "loop_no_progress_threshold": 3,
+        "loop_no_progress_count": 0,
+        "loop_last_output_hash": None,
+        "loop_last_response": None,
+        "loop_last_delivered_hash": None,
+        "loop_last_verify_error": None,
+        "schedule": {"kind": "interval", "minutes": 5, "display": "every 5m"},
+    }
+    job.update(overrides)
+    return job
+
+
+class TestEvaluateLoopTickIntegration:
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_first_run_delivers(self, mock_pause, mock_update):
+        job = _make_loop_job()
+        alert, skip = _evaluate_loop_tick(job, "some output")
+        assert alert is None
+        assert skip is False
+        mock_update.assert_called_once()
+        mock_pause.assert_not_called()
+        updates = mock_update.call_args[0][1]
+        assert updates["loop_last_output_hash"] is not None
+        assert updates["loop_no_progress_count"] == 0
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_same_output_increments_count(self, mock_pause, mock_update):
+        response_hash = hashlib.sha256(b"same output").hexdigest()[:16]
+        job = _make_loop_job(loop_last_output_hash=response_hash)
+        alert, skip = _evaluate_loop_tick(job, "same output")
+        assert alert is None
+        assert skip is False
+        updates = mock_update.call_args[0][1]
+        assert updates["loop_no_progress_count"] == 1
+        mock_pause.assert_not_called()
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_same_output_threshold_triggers_pause(self, mock_pause, mock_update):
+        response_hash = hashlib.sha256(b"stuck output").hexdigest()[:16]
+        job = _make_loop_job(
+            loop_last_output_hash=response_hash,
+            loop_no_progress_count=2,
+        )
+        alert, skip = _evaluate_loop_tick(job, "stuck output")
+        assert alert is not None
+        assert "auto-paused" in alert
+        assert skip is True
+        mock_pause.assert_called_once_with("test123", reason="no progress detected")
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_different_output_resets_count(self, mock_pause, mock_update):
+        old_hash = hashlib.sha256(b"old output").hexdigest()[:16]
+        job = _make_loop_job(
+            loop_last_output_hash=old_hash,
+            loop_no_progress_count=2,
+        )
+        alert, skip = _evaluate_loop_tick(job, "new output")
+        assert alert is None
+        updates = mock_update.call_args[0][1]
+        assert updates["loop_no_progress_count"] == 0
+        mock_pause.assert_not_called()
+
+    @patch("hermes_cli.goals.judge_goal", return_value=("done", "goal achieved", False, None))
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_judge_done_increments_count(self, mock_pause, mock_update, mock_judge):
+        job = _make_loop_job()
+        alert, skip = _evaluate_loop_tick(job, "all tests passing")
+        assert alert is None
+        updates = mock_update.call_args[0][1]
+        assert updates["loop_no_progress_count"] == 1
+        mock_pause.assert_not_called()
+
+    @patch("hermes_cli.goals.judge_goal", return_value=("done", "goal achieved", False, None))
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_judge_done_threshold_triggers_pause(self, mock_pause, mock_update, mock_judge):
+        response_hash = hashlib.sha256(b"everything done").hexdigest()[:16]
+        job = _make_loop_job(
+            loop_last_output_hash=response_hash,
+            loop_no_progress_count=1,
+        )
+        alert, skip = _evaluate_loop_tick(job, "everything done")
+        assert alert is not None
+        assert "auto-paused" in alert
+        mock_pause.assert_called_once()
+
+    @patch("hermes_cli.goals.judge_goal", side_effect=Exception("model unavailable"))
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_judge_failure_fail_open(self, mock_pause, mock_update, mock_judge):
+        job = _make_loop_job()
+        alert, skip = _evaluate_loop_tick(job, "some output")
+        assert alert is None
+        updates = mock_update.call_args[0][1]
+        assert updates["loop_no_progress_count"] == 0
+        mock_pause.assert_not_called()
+
+    @patch("cron.scheduler._run_loop_verify", return_value="verify failed: exit 1")
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_verify_error_stored(self, mock_pause, mock_update, mock_verify):
+        job = _make_loop_job(loop_verify="pytest")
+        alert, skip = _evaluate_loop_tick(job, "some output")
+        assert alert is None
+        updates = mock_update.call_args[0][1]
+        assert updates["loop_last_verify_error"] == "verify failed: exit 1"
+
+    @patch("cron.scheduler._run_loop_verify", return_value=None)
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_verify_success_clears_error(self, mock_pause, mock_update, mock_verify):
+        job = _make_loop_job(loop_verify="pytest", loop_last_verify_error="old error")
+        alert, skip = _evaluate_loop_tick(job, "some output")
+        assert alert is None
+        updates = mock_update.call_args[0][1]
+        assert updates["loop_last_verify_error"] is None
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_delivery_gating_same_as_last_delivered(self, mock_pause, mock_update):
+        response_hash = hashlib.sha256(b"same output").hexdigest()[:16]
+        job = _make_loop_job(
+            loop_last_output_hash="different_hash",
+            loop_last_delivered_hash=response_hash,
+        )
+        alert, skip = _evaluate_loop_tick(job, "same output")
+        assert alert is None
+        assert skip is True
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_delivery_gating_different_from_last(self, mock_pause, mock_update):
+        job = _make_loop_job(
+            loop_last_output_hash="old_hash",
+            loop_last_delivered_hash="old_hash",
+        )
+        alert, skip = _evaluate_loop_tick(job, "new output")
+        assert alert is None
+        assert skip is False
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_empty_response_hashes_consistently(self, mock_pause, mock_update):
+        job = _make_loop_job()
+        alert, skip = _evaluate_loop_tick(job, "")
+        assert alert is None
+        updates = mock_update.call_args[0][1]
+        assert updates["loop_last_output_hash"] is not None
+        assert "loop_last_delivered_hash" not in updates
+
+
+# =========================================================================
+# _evaluate_loop_tick — adaptive interval tests
+# =========================================================================
+
+class TestAdaptiveIntervals:
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_dynamic_output_changed_halves_interval(self, mock_pause, mock_update):
+        """Dynamic job: output changes → interval halves."""
+        job = _make_loop_job(
+            loop_dynamic=True,
+            schedule={"kind": "interval", "minutes": 10, "display": "every 10m"},
+            loop_last_output_hash="old_hash",
+        )
+        alert, skip = _evaluate_loop_tick(job, "new output")
+        assert alert is None
+        updates = mock_update.call_args[0][1]
+        assert updates["schedule"]["minutes"] == 5
+        assert updates["schedule_display"] == "every 5m"
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_dynamic_output_stable_doubles_interval(self, mock_pause, mock_update):
+        """Dynamic job: same output → interval doubles."""
+        response_hash = hashlib.sha256(b"same output").hexdigest()[:16]
+        job = _make_loop_job(
+            loop_dynamic=True,
+            schedule={"kind": "interval", "minutes": 5, "display": "every 5m"},
+            loop_last_output_hash=response_hash,
+        )
+        alert, skip = _evaluate_loop_tick(job, "same output")
+        assert alert is None
+        updates = mock_update.call_args[0][1]
+        assert updates["schedule"]["minutes"] == 10
+        assert updates["schedule_display"] == "every 10m"
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_dynamic_interval_clamped_min(self, mock_pause, mock_update):
+        """Dynamic job: interval won't go below 1 minute."""
+        job = _make_loop_job(
+            loop_dynamic=True,
+            schedule={"kind": "interval", "minutes": 1, "display": "every 1m"},
+            loop_last_output_hash="old_hash",
+        )
+        alert, skip = _evaluate_loop_tick(job, "new output")
+        updates = mock_update.call_args[0][1]
+        # Already at 1, halving would give 0, clamped to 1 — no change, no schedule update
+        assert "schedule" not in updates
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_dynamic_interval_clamped_max(self, mock_pause, mock_update):
+        """Dynamic job: interval won't go above 1440 minutes (24h)."""
+        response_hash = hashlib.sha256(b"stable").hexdigest()[:16]
+        job = _make_loop_job(
+            loop_dynamic=True,
+            schedule={"kind": "interval", "minutes": 1440, "display": "every 1440m"},
+            loop_last_output_hash=response_hash,
+        )
+        alert, skip = _evaluate_loop_tick(job, "stable")
+        updates = mock_update.call_args[0][1]
+        # Already at 1440, doubling would give 2880, clamped to 1440 — no change
+        assert "schedule" not in updates
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_non_dynamic_job_no_schedule_change(self, mock_pause, mock_update):
+        """Non-dynamic job: schedule never changes."""
+        job = _make_loop_job(
+            loop_dynamic=False,
+            schedule={"kind": "interval", "minutes": 5, "display": "every 5m"},
+            loop_last_output_hash="old_hash",
+        )
+        alert, skip = _evaluate_loop_tick(job, "new output")
+        updates = mock_update.call_args[0][1]
+        assert "schedule" not in updates
+        assert "schedule_display" not in updates
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_dynamic_first_run_no_schedule_change(self, mock_pause, mock_update):
+        """Dynamic job first run (no previous hash) → output is "changed" → halves."""
+        job = _make_loop_job(
+            loop_dynamic=True,
+            schedule={"kind": "interval", "minutes": 5, "display": "every 5m"},
+        )
+        alert, skip = _evaluate_loop_tick(job, "first output")
+        updates = mock_update.call_args[0][1]
+        # First run: no last_hash, so output_changed=True, halves from 5 → 2
+        assert updates["schedule"]["minutes"] == 2
+
+    @patch("cron.jobs.update_job")
+    @patch("cron.jobs.pause_job")
+    def test_dynamic_cron_schedule_ignored(self, mock_pause, mock_update):
+        """Dynamic job with cron schedule (not interval) → no adaptive change."""
+        job = _make_loop_job(
+            loop_dynamic=True,
+            schedule={"kind": "cron", "expr": "*/5 * * * *", "display": "*/5 * * * *"},
+            loop_last_output_hash="old_hash",
+        )
+        alert, skip = _evaluate_loop_tick(job, "new output")
+        updates = mock_update.call_args[0][1]
+        assert "schedule" not in updates
+
+
+# =========================================================================
+# Create path — end-to-end against a real job store (no create_job mock)
+#
+# These guard the contract that mocked tests can't: that the job actually
+# created by /loop is RECURRING. Bug history: a bare "30m" was passed straight
+# to create_job, which parsed it as a one-shot (kind="once") — so the loop
+# fired once and died. Mocked parse tests stayed green throughout.
+# =========================================================================
+
+@pytest.fixture
+def isolated_cron(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a temp dir so create_job writes to a throwaway store."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import importlib
+    import cron.jobs as jobs_mod
+    importlib.reload(jobs_mod)
+    yield jobs_mod
+    importlib.reload(jobs_mod)
+
+
+class TestCreatePathRecurring:
+    def test_timed_loop_is_recurring_interval(self, isolated_cron):
+        """/loop 30m ... must create a recurring interval job, never a one-shot."""
+        result = json.loads(handle_loop_command("30m check the deploy"))
+        assert result["success"] is True
+        job = isolated_cron.resolve_job_ref(result["job_id"])
+        assert job["schedule"]["kind"] == "interval"
+        assert job["schedule"]["minutes"] == 30
+        assert job["loop"] is True
+        assert job["loop_dynamic"] is False
+
+    def test_every_form_is_recurring_interval(self, isolated_cron):
+        result = json.loads(handle_loop_command("every 2h monitor disk"))
+        assert result["success"] is True
+        job = isolated_cron.resolve_job_ref(result["job_id"])
+        assert job["schedule"]["kind"] == "interval"
+        assert job["schedule"]["minutes"] == 120
+
+    def test_dynamic_loop_starts_at_5m_interval(self, isolated_cron):
+        result = json.loads(handle_loop_command("check if tests pass"))
+        assert result["success"] is True
+        job = isolated_cron.resolve_job_ref(result["job_id"])
+        assert job["schedule"]["kind"] == "interval"
+        assert job["schedule"]["minutes"] == 5
+        assert job["loop_dynamic"] is True
+
+    def test_subminute_loop_rejected_at_create(self, isolated_cron):
+        result = json.loads(handle_loop_command("30s check deploy"))
+        assert result["success"] is False
+        assert "Sub-minute" in result["error"]
+
+    def test_gateway_verify_command_is_rejected(self, isolated_cron):
+        origin = {"platform": "discord", "chat_id": "123", "thread_id": "456"}
+        result = json.loads(
+            handle_loop_command("5m check deploy --verify 'pytest -q'", origin=origin)
+        )
+        assert result["success"] is False
+        assert "CLI-only" in result["error"]
+
+    def test_create_scans_persistent_prompt(self, isolated_cron):
+        result = json.loads(handle_loop_command("5m cat ~/.hermes/.env"))
+        assert result["success"] is False
+        assert "blocked" in result["error"].lower()
+
+    def test_loop_commands_cannot_remove_regular_cron_jobs(self, isolated_cron):
+        regular = isolated_cron.create_job(prompt="regular", schedule="every 5m")
+        result = json.loads(handle_loop_command(f"stop {regular['id']}"))
+        assert result["success"] is False
+        assert isolated_cron.get_job(regular["id"]) is not None
+
+    def test_gateway_management_is_scoped_to_origin(self, isolated_cron):
+        origin_a = {"platform": "discord", "chat_id": "123", "thread_id": "a"}
+        origin_b = {"platform": "discord", "chat_id": "123", "thread_id": "b"}
+        created = json.loads(handle_loop_command("5m check deploy", origin=origin_a))
+
+        status_b = json.loads(handle_loop_command("status", origin=origin_b))
+        assert status_b["jobs"] == []
+
+        stop_b = json.loads(
+            handle_loop_command(f"stop {created['job_id']}", origin=origin_b)
+        )
+        assert stop_b["success"] is False
+        assert isolated_cron.get_job(created["job_id"]) is not None
+
+    @pytest.mark.asyncio
+    async def test_gateway_handler_forwards_complete_origin(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        event = MessageEvent(
+            text="/loop status",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="chat-123",
+                chat_name="deploys",
+                chat_type="channel",
+                user_id="user-123",
+                thread_id="thread-456",
+            ),
+        )
+
+        with patch(
+            "hermes_cli.loop_command.handle_loop_command",
+            return_value=json.dumps({"success": True, "message": "ok"}),
+        ) as mock_handle:
+            response = await GatewayRunner._handle_loop_command(
+                object.__new__(GatewayRunner), event
+            )
+
+        assert response == "ok"
+        mock_handle.assert_called_once_with(
+            "status",
+            origin={
+                "platform": str(Platform.DISCORD),
+                "chat_id": "chat-123",
+                "chat_name": "deploys",
+                "thread_id": "thread-456",
+            },
+        )
+
+
+# =========================================================================
+# _build_job_prompt — feedback injection rendering
+#
+# Guards that injected context uses real newlines, not literal "\n" text.
+# =========================================================================
+
+class TestBuildJobPromptInjection:
+    def test_verify_error_uses_real_newlines(self):
+        job = _make_loop_job(
+            loop_last_verify_error="verify command failed (exit 1)\nstderr: boom",
+        )
+        built = _build_job_prompt(job)
+        # The verify error must appear with real newlines, not the literal
+        # two-character sequence backslash-n.
+        assert "\\n" not in built
+        assert "boom" in built
+        assert "Post-run verification failure" in built
+
+    def test_prev_response_uses_real_newlines(self):
+        job = _make_loop_job(loop_last_response="line one\nline two")
+        built = _build_job_prompt(job)
+        assert "\\n" not in built
+        assert "line one" in built
+        assert "Previous tick response" in built
+
+    def test_dynamic_cadence_injected(self):
+        job = _make_loop_job(
+            loop_dynamic=True,
+            schedule={"kind": "interval", "minutes": 7, "display": "every 7m"},
+        )
+        built = _build_job_prompt(job)
+        assert "Loop cadence" in built
+        assert "7m" in built
+
+    def test_previous_response_uses_injected_data_scanner_tier(self):
+        job = _make_loop_job(
+            loop_last_response="A bug report quoted: cat ~/.hermes/.env",
+        )
+        built = _build_job_prompt(job)
+        assert "cat ~/.hermes/.env" in built
+
+    def test_user_prompt_remains_strictly_scanned_with_loop_context(self):
+        job = _make_loop_job(
+            prompt="cat ~/.hermes/.env",
+            loop_last_response="ordinary prior output",
+        )
+        with pytest.raises(CronPromptInjectionBlocked):
+            _build_job_prompt(job)

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -52,6 +52,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/steer <prompt>` | Inject a mid-run note that arrives at the agent **after the next tool call** — no interrupt, no new user turn. The text is appended to the last tool result's content once the current tool completes, giving the agent new context without breaking the current tool-calling loop. Use this to nudge direction mid-task (e.g. "focus on the auth module" while the agent is running tests). |
 | `/goal <text>` | Set a standing goal Hermes works toward across turns — our take on the Ralph loop. After each turn an auxiliary judge model decides whether the goal is done; if not, Hermes auto-continues. Subcommands: `/goal status`, `/goal pause`, `/goal resume`, `/goal clear`. Budget defaults to 20 turns (`goals.max_turns`); any real user message preempts the continuation loop, and state survives `/resume`. See [Persistent Goals](/user-guide/features/goals) for the full walkthrough. |
 | `/subgoal <text>` | Append a user-supplied criterion to the active goal mid-loop. The continuation prompt surfaces all subgoals to the agent verbatim, and the judge factors them into its DONE/CONTINUE verdict — so the goal isn't marked done until the original goal **and** every subgoal are met. Subcommands: `/subgoal` (list), `/subgoal remove <N>`, `/subgoal clear`. Requires an active `/goal`. |
+| `/loop [interval] <prompt>` | Create a persistent scheduled agent loop. A leading interval such as `30m` uses a fixed cadence; without one, the cadence adapts between 1 minute and 24 hours based on output changes. Manage loops with `/loop status`, `/loop pause <id>`, `/loop resume <id>`, and `/loop stop <id>`. |
 | `/moa <prompt>` | Run a single prompt through the default [Mixture of Agents](/user-guide/features/mixture-of-agents) preset, then restore your current model. One-shot — does not change your session model. |
 | `/resume [name]` | Resume a previously-named session |
 | `/sessions` (TUI alias: `/switch`) | Classic CLI: browse and resume previous sessions in an interactive picker. TUI: open the live session switcher for currently open TUI sessions. Use `/sessions new` in the TUI to start another live session immediately. |
@@ -194,6 +195,33 @@ Then in chat:
 
 User aliases take precedence over built-in short names, so naming an alias `sonnet`, `kimi`, `opus`, etc. will shadow the built-in. Alias names are case-insensitive.
 
+### Persistent scheduled loops
+
+`/loop` creates a recurring cron job that carries the previous response into the next run, evaluates whether it is still making progress, and avoids repeatedly delivering unchanged output.
+
+```text
+/loop 30m check the deployment status
+/loop check whether the release is healthy --skills devops --name release-watch
+/loop 2h run the smoke tests --verify 'pytest -q' --name smoke-tests
+```
+
+A leading duration creates a fixed interval. Without a duration, the loop starts at 5 minutes and adapts: changed output halves the interval, unchanged output doubles it, with bounds of 1 minute and 24 hours. Three consecutive no-progress detections auto-pause the loop and send a notice.
+
+`--verify <command>` runs a local shell command after each successful agent turn and feeds failures into the next prompt. It is available only in the local CLI, not through messaging platforms. The command runs unattended, so use it only with commands you trust.
+
+Manage loops with:
+
+```text
+/loop status
+/loop pause <id-or-name>
+/loop resume <id-or-name>
+/loop stop <id-or-name>
+```
+
+Unique ID prefixes also work. On messaging platforms, status and management commands are limited to loops created from the same chat and thread. A response is recorded as delivered only after the send succeeds. Failed sends remain eligible for retry, while `[SILENT]` responses are never recorded as delivered.
+
+On Slack, use `/hermes loop ...` because Slack's native slash-command limit is already full.
+
 ### Alias Resolution
 
 Commands support prefix matching: typing `/h` resolves to `/help`, `/mod` resolves to `/model`. When a prefix is ambiguous (matches multiple commands), the first match in registry order wins. Full command names and registered aliases always take priority over prefix matches.
@@ -229,6 +257,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/queue <prompt>` (alias: `/q`) | Queue a prompt for the next turn without interrupting the current one. |
 | `/steer <prompt>` | Inject a message after the next tool call without interrupting — the model picks it up on its next iteration rather than as a new turn. |
 | `/goal <text>` | Set a standing goal Hermes works toward across turns — our take on the Ralph loop. A judge model checks after each turn; if not done, Hermes auto-continues until it is, you pause/clear it, or the turn budget (default 20) is hit. Subcommands: `/goal status`, `/goal pause`, `/goal resume`, `/goal clear`. Safe to run mid-agent for status/pause/clear; setting a new goal requires `/stop` first. See [Persistent Goals](/user-guide/features/goals). |
+| `/loop [interval] <prompt>` | Create and manage a persistent scheduled agent loop that delivers to the current chat or thread. Use `/loop status`, `/loop pause <id>`, `/loop resume <id>`, or `/loop stop <id>` to manage loops created from that same chat and thread. |
 | `/footer [on\|off\|status]` | Toggle the runtime-metadata footer on final replies (shows model, context %, and cwd). |
 | `/curator [status\|run\|pin\|archive]` | Background skill maintenance controls. |
 | `/suggestions [accept\|dismiss N\|catalog\|clear]` | Review suggested automations right in chat. `/suggestions` lists pending suggestions, `catalog` adds curated starter automations, and `clear` prunes resolved suggestion records. Accepted suggestions keep this chat/thread as the job delivery origin. |
@@ -254,7 +283,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 - `/skills` is **CLI-only for search/browse/install**; its write-approval review subcommands (`pending`, `approve`, `reject`, `diff`, `approval`) also work on messaging platforms when `skills.write_approval` is on. `/memory` works on **both** surfaces.
 - `/verbose` is **CLI-only by default**, but can be enabled for messaging platforms by setting `display.tool_progress_command: true` in `config.yaml`. When enabled, it cycles the `display.tool_progress` mode and saves to config.
 - `/sethome`, `/update`, `/restart`, `/approve`, `/deny`, `/topic`, `/platform`, and `/commands` are **messaging-only** commands.
-- `/status`, `/version`, `/background`, `/queue`, `/steer`, `/voice`, `/reload-mcp`, `/reload-skills`, `/rollback`, `/debug`, `/fast`, `/footer`, `/curator`, `/kanban`, `/credits`, `/suggestions`, `/blueprint`, `/learn`, `/sessions`, and `/yolo` work in **both** the CLI and the messaging gateway.
+- `/status`, `/version`, `/background`, `/queue`, `/steer`, `/voice`, `/reload-mcp`, `/reload-skills`, `/rollback`, `/debug`, `/fast`, `/footer`, `/curator`, `/kanban`, `/credits`, `/suggestions`, `/blueprint`, `/learn`, `/loop`, `/sessions`, and `/yolo` work in **both** the CLI and the messaging gateway.
 - `/voice join`, `/voice channel`, and `/voice leave` are only meaningful on Discord.
 - In the TUI, `/sessions` shows live sessions in the current TUI process. Use `/resume [name]` or `hermes --tui --resume <id-or-title>` for saved or closed transcripts.
 


### PR DESCRIPTION
## What

Adds a `/loop` slash command that creates cron jobs with self-evaluation: the agent monitors its own progress each tick and adapts its schedule, pausing when it's stuck.

Continues from #42607 (closed). Bug fixes and test hardening since then.

Two modes:

**Timed** — `/loop 30m check the deploy` → runs on a fixed recurring interval.

**Dynamic** — `/loop check the deploy` → starts at 5m, adapts: output changes → interval halves (watch closer), output stable → interval doubles (back off), clamped [1m, 24h].

## How it works

- Each tick hashes the agent's output (sha256[:16]) and optionally calls `judge_goal` to evaluate progress.
- 3 consecutive no-progress detections (identical output or judge says "done") → auto-pause with a notification.
- `--verify` runs a shell command after each tick; failure context is injected into the next tick's prompt so the agent can self-correct.
- Previous response (4K cap) and cadence info are also injected, so the agent always knows where it left off and what interval it's on.
- Dynamic mode adapts the cron schedule directly via `update_job`, which recomputes `next_run_at` — so new cadence takes effect on the next scheduling cycle, not a tick later.

## Design

No new abstractions. The implementation reuses:
- `cron.jobs.create_job` / `update_job` / `pause_job` for lifecycle
- `judge_goal` (existing goal evaluator) for progress detection
- `_build_job_prompt` for feedback injection
- `_deliver_result` for output routing
- Gateway origin extraction pattern from `tools/cronjob_tools.py`

The scheduling intelligence lives in `cron/scheduler._evaluate_loop_tick` (called from `tick()` after each job run). The command handler (`hermes_cli.loop_command`) is pure dispatch — parse, create, manage. The gateway and CLI both delegate to the same shared handler via a `parse_loop_result` helper.

## Files

| File | Change |
|------|--------|
| `hermes_cli/loop_command.py` | Command handler + `parse_loop_result` (new, 370 lines) |
| `tests/test_loop_command.py` | 68 tests — parse, eval, create-path, prompt injection (new, 640 lines) |
| `cron/scheduler.py` | `_adapt_loop_interval`, `_evaluate_loop_tick`, feedback injection (243 lines) |
| `cron/jobs.py` | Loop fields on `create_job`, prefix matching on `resolve_job_ref`, `update_job` lock (158 lines) |
| `gateway/run.py` | Gateway dispatch for `/loop` (32 lines) |
| `cli.py` | CLI dispatch for `/loop` (15 lines) |
| `hermes_cli/commands.py` | Registry + bypass registration (3 lines) |

## Testing

68 tests covering:
- Schedule classification (bare duration normalization, `every X` form, sub-minute rejection, dynamic detection)
- Argument parsing (flags, ordering, quoted verify commands)
- Loop evaluation (hash threshold, judge done/fail-open, verify pass/fail/timeout, delivery gating)
- Adaptive intervals (halve on change, double on stable, clamp [1m, 24h], cron schedule ignored)
- Create-path against a real job store (asserts `schedule.kind == "interval"` — the test gap that let earlier bugs ship)
- Prompt injection rendering (real newlines, cadence info)
- Subcommand routing (status, pause, resume, stop, bare subcommand errors)

450 existing cron/cronjob tests pass without modification.

## Notes

- `/loop` is registered in `ACTIVE_SESSION_BYPASS_COMMANDS` and the gateway's safe-mid-run dispatch — it's control-plane only (manages cron jobs, doesn't run tools).
- `update_job` was missing `_jobs_file_lock` — fixed as part of this PR since loop ticks now call it from the parallel worker pool.
- CLI creates loop jobs with `deliver="origin"` but no `origin` dict — falls back to home channel, which is correct for the CLI (no chat context). Gateway properly extracts `event.source.{platform, chat_id, thread_id}`.
