### PR TITLE
fix(tui): use CPU-adaptive default for RPC thread pool workers

### DIFF
--- a/tests/tui_gateway/test_rpc_pool_default.py
+++ b/tests/tui_gateway/test_rpc_pool_default.py
@@ -1,0 +1,65 @@
+"""Tests for tui_gateway.server RPC pool worker default (issue #42942)."""
+
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+class TestRpcPoolWorkerDefault:
+    """Verify the RPC thread pool uses a CPU-adaptive default instead of hardcoded 4."""
+
+    def test_default_is_cpu_adaptive(self):
+        """_DEFAULT_RPC_POOL_WORKERS must be >= 8 and scale with CPU count."""
+        import tui_gateway.server as server_mod
+
+        expected = max(8, min(32, (os.cpu_count() or 4) * 2))
+        assert server_mod._DEFAULT_RPC_POOL_WORKERS == expected
+
+    def test_default_at_least_8(self):
+        """Even on a 1-core machine the default must be >= 8."""
+        import tui_gateway.server as server_mod
+
+        assert server_mod._DEFAULT_RPC_POOL_WORKERS >= 8
+
+    def test_default_at_most_32(self):
+        """The default must not exceed 32 to avoid excessive threads."""
+        import tui_gateway.server as server_mod
+
+        assert server_mod._DEFAULT_RPC_POOL_WORKERS <= 32
+
+    def test_env_var_override_still_works(self):
+        """HERMES_TUI_RPC_POOL_WORKERS env var must override the default."""
+        # We can't easily test the module-level code after import, but we can
+        # verify the fallback constant is used correctly by checking the pool.
+        import tui_gateway.server as server_mod
+
+        # The pool was created at import time. Verify it exists and has workers.
+        pool = server_mod._pool
+        assert pool is not None
+        assert pool._max_workers >= 2
+
+    def test_pool_created_with_reasonable_workers(self):
+        """The pool must have been created with a reasonable number of workers."""
+        import tui_gateway.server as server_mod
+
+        pool = server_mod._pool
+        # Should be between 2 and 32
+        assert 2 <= pool._max_workers <= 32
+
+    def test_default_formula_matches_cpu_count(self):
+        """The formula max(8, min(32, cpu_count * 2)) produces correct values."""
+        cpu = os.cpu_count() or 4
+        expected = max(8, min(32, cpu * 2))
+
+        # On typical machines:
+        # 1 core -> max(8, min(32, 2)) = 8
+        # 2 cores -> max(8, min(32, 4)) = 8
+        # 4 cores -> max(8, min(32, 8)) = 8
+        # 8 cores -> max(8, min(32, 16)) = 16
+        # 16 cores -> max(8, min(32, 32)) = 32
+        # 32+ cores -> max(8, min(32, 64)) = 32
+        import tui_gateway.server as server_mod
+
+        assert server_mod._DEFAULT_RPC_POOL_WORKERS == expected

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -184,12 +184,13 @@ _LONG_HANDLERS = frozenset(
     }
 )
 
+_DEFAULT_RPC_POOL_WORKERS = max(8, min(32, (os.cpu_count() or 4) * 2))
 try:
     _rpc_pool_workers = max(
-        2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS") or "4")
+        2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS") or str(_DEFAULT_RPC_POOL_WORKERS))
     )
 except (ValueError, TypeError):
-    _rpc_pool_workers = 4
+    _rpc_pool_workers = _DEFAULT_RPC_POOL_WORKERS
 _pool = concurrent.futures.ThreadPoolExecutor(
     max_workers=_rpc_pool_workers,
     thread_name_prefix="tui-rpc",


### PR DESCRIPTION
## What does this PR do?

Changes the TUI RPC thread pool default from a hardcoded 4 workers to a CPU-adaptive value (`max(8, min(32, cpu_count * 2))`). This prevents WS heartbeat starvation when multiple agent sessions run concurrent long tool calls.

## Related Issue

Fixes #42942

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: Replace hardcoded default `4` with CPU-adaptive formula `max(8, min(32, (os.cpu_count() or 4) * 2))`. The `HERMES_TUI_RPC_POOL_WORKERS` env var still overrides the default.
- `tests/tui_gateway/test_rpc_pool_default.py`: 6 tests verifying the default formula bounds, CPU scaling, and pool creation.

## How to Test

1. Run `pytest tests/tui_gateway/test_rpc_pool_default.py -v` — all 6 tests should pass
2. Start the TUI and verify the pool uses the new default: `python -c "import tui_gateway.server; print(tui_gateway.server._DEFAULT_RPC_POOL_WORKERS)"` should show a value ≥ 8
3. Set `HERMES_TUI_RPC_POOL_WORKERS=16` in `~/.hermes/.env` and restart — the pool should use 16 workers

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `tui_gateway/server.py` ThreadPoolExecutor initialization (module-level, line 187)
- Callers: `_pool` used by `_dispatch()` for all WS JSON-RPC method handlers
- Blast radius: LOW — only changes the default value, env var override preserved
- Related patterns: other `HERMES_TUI_*` env vars in the same file follow the same pattern
