### PR TITLE
feat(hooks): expose parent_session_id in shell-hook payload

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -476,6 +476,7 @@ def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
         "tool_name": kwargs.get("tool_name"),
         "tool_input": kwargs.get("args") if isinstance(kwargs.get("args"), dict) else None,
         "session_id": kwargs.get("session_id") or kwargs.get("parent_session_id") or "",
+        "parent_session_id": kwargs.get("parent_session_id"),
         "cwd": cwd,
         "extra": extras,
     }

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -160,6 +160,24 @@ class TestSerializePayload:
         )
         payload = json.loads(raw)
         assert payload["session_id"] == "p-1"
+        assert payload["parent_session_id"] == "p-1"
+
+    def test_parent_session_id_exposed_alongside_session_id(self):
+        raw = shell_hooks._serialize_payload(
+            "subagent_stop",
+            {"session_id": "new-s", "parent_session_id": "old-s"},
+        )
+        payload = json.loads(raw)
+        assert payload["session_id"] == "new-s"
+        assert payload["parent_session_id"] == "old-s"
+
+    def test_parent_session_id_null_when_absent(self):
+        raw = shell_hooks._serialize_payload(
+            "pre_tool_call", {"session_id": "s-1"},
+        )
+        payload = json.loads(raw)
+        assert payload["session_id"] == "s-1"
+        assert payload["parent_session_id"] is None
 
     def test_unserialisable_extras_stringified(self):
         class Weird:


### PR DESCRIPTION
## Problem

When context compression forks a child session (`agent/conversation_compression.py` creates a continuation with `parent_session_id=old_session_id`), the shell-hook payload only exposes the rotated head. `_serialize_payload` collapses `parent_session_id` into `session_id` as a fallback but never surfaces it as its own field.

A hook consumer therefore sees a single logical conversation as a sequence of disconnected `session_id`s across each compression boundary, with no way to stitch them back together.

## Solution

Add `parent_session_id` as a distinct top-level field on the shell-hook JSON payload. This is **additive** — the field is `null` when absent, so existing consumers are unaffected. The `session_id` fallback logic is preserved.

**Before:**
```json
{"session_id": "new-session", ...}
```

**After:**
```json
{"session_id": "new-session", "parent_session_id": "old-session", ...}
```

When no compression has occurred, `parent_session_id` is `null`.

## Changes

- `agent/shell_hooks.py`: Add `"parent_session_id": kwargs.get("parent_session_id")` to payload dict in `_serialize_payload()` (+1 line)
- `tests/agent/test_shell_hooks.py`: 3 new tests (+18 lines)
  - `test_parent_session_id_used_when_no_session_id`: Updated to verify the field is present
  - `test_parent_session_id_exposed_alongside_session_id`: Both fields present
  - `test_parent_session_id_null_when_absent`: Field is null when not in kwargs

Closes #42939
