### PR TITLE
fix: recover wedged Telegram polling

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1023,6 +1023,47 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
 
+    async def _polling_liveness_watchdog(self) -> None:
+        """Recover PTB polling when it reports running but stops consuming updates."""
+        interval = int(os.getenv("HERMES_TELEGRAM_LIVENESS_INTERVAL", "15") or "15")
+        consecutive_pending = 0
+        while not self.has_fatal_error:
+            await asyncio.sleep(max(5, interval))
+            if self._webhook_mode or not self._app or not self._app.updater or not self._bot:
+                continue
+            try:
+                info = await self._bot.get_webhook_info()
+                pending = int(getattr(info, "pending_update_count", 0) or 0)
+            except Exception as exc:
+                logger.debug("[%s] Telegram liveness probe failed: %s", self.name, exc)
+                continue
+            if pending <= 0:
+                consecutive_pending = 0
+                continue
+            consecutive_pending += 1
+            if consecutive_pending < 2:
+                continue
+            logger.warning(
+                "[%s] Telegram polling liveness detected %d pending update(s) not being consumed; restarting polling only",
+                self.name, pending,
+            )
+            consecutive_pending = 0
+            try:
+                if self._app.updater.running:
+                    await self._app.updater.stop()
+            except Exception:
+                logger.debug("[%s] Telegram liveness updater.stop failed", self.name, exc_info=True)
+            await self._drain_polling_connections()
+            try:
+                await self._app.updater.start_polling(
+                    allowed_updates=Update.ALL_TYPES,
+                    drop_pending_updates=False,
+                    error_callback=self._polling_error_callback_ref,
+                )
+                logger.info("[%s] Telegram polling liveness restart complete", self.name)
+            except Exception as exc:
+                logger.warning("[%s] Telegram liveness polling restart failed: %s", self.name, exc)
+
     async def _verify_polling_after_reconnect(self) -> None:
         """Heartbeat probe scheduled after a successful reconnect.
 
@@ -1641,8 +1682,6 @@ class TelegramAdapter(BasePlatformAdapter):
                         await asyncio.sleep(wait)
                     else:
                         raise
-            await self._app.start()
-
             # Decide between webhook and polling mode
             webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
 
@@ -1716,9 +1755,20 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=True,
+                    drop_pending_updates=False,
                     error_callback=_polling_error_callback,
                 )
+
+            # Match python-telegram-bot run_polling lifecycle: initialize,
+            # start updater polling/webhook, then start the application so
+            # update processing is attached to the active updater.
+            await self._app.start()
+            logger.info(
+                "[%s] Telegram application started (updater_running=%s, running=%s)",
+                self.name,
+                bool(getattr(self._app.updater, "running", False)),
+                bool(getattr(self._app, "running", False)),
+            )
             
             # Register bot commands so Telegram shows a hint menu when users type /
             # List is derived from the central COMMAND_REGISTRY — adding a new
@@ -1766,6 +1816,10 @@ class TelegramAdapter(BasePlatformAdapter):
             self._mark_connected()
             mode = "webhook" if self._webhook_mode else "polling"
             logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
+            if not self._webhook_mode:
+                live_task = asyncio.ensure_future(self._polling_liveness_watchdog())
+                self._background_tasks.add(live_task)
+                live_task.add_done_callback(self._background_tasks.discard)
 
             # Set up DM topics (Bot API 9.4 — Private Chat Topics)
             # Runs after connection is established so the bot can call createForumTopic.


### PR DESCRIPTION
## Summary

Fix Telegram polling getting into a silent wedged state where the gateway logs `Connected to Telegram (polling mode)` but incoming DMs remain queued in Telegram Bot API and never reach Hermes handlers.

This changes the polling lifecycle to match python-telegram-bot's `run_polling()` ordering, avoids dropping pending updates on startup, and adds a lightweight liveness watchdog that restarts only Telegram polling when Bot API reports queued updates that are not being consumed.

## Field reproduction

Observed on a self-hosted Hermes gateway on macOS with Telegram polling mode enabled:

1. Start Hermes Gateway via launchd.
2. Logs show Telegram successfully connected:
   - `Connected to Telegram (polling mode)`
   - `✓ telegram connected`
   - `Gateway running with 1 platform(s)`
3. Send a DM to the bot from Telegram Desktop/mobile.
4. Telegram client shows delivered/read check marks.
5. Hermes logs no `inbound message`, no auth rejection, and no polling error.
6. `getWebhookInfo` reports `pending_update_count=1`.
7. A manual Bot API `getUpdates?timeout=0&limit=3` returns the queued message while the gateway process is still running, proving Hermes is not actively consuming updates despite reporting connected.

Example diagnostic output from the affected host:

```text
getWebhookInfo: pending_update_count=1
manual getUpdates returned update_id=751241211 with the DM text
Hermes process still running
No inbound message in gateway.log
```

This lines up with the failure mode described in #42909: Telegram connects and polls according to startup logs, but incoming DMs produce no gateway activity.

## Root cause hypothesis

The adapter was starting `Application.start()` before `Updater.start_polling()`. In the affected environment, this allowed the application/gateway to report connected while no active long-poll consumer was actually draining Telegram updates.

A secondary issue is that initial polling used `drop_pending_updates=True`, so watchdog or launchd restarts could discard the exact queued message that proved the poller was wedged.

## Changes

- Start Telegram polling/webhook before `Application.start()`, matching PTB's normal `run_polling()` lifecycle.
- Use `drop_pending_updates=False` for initial polling startup so recovery restarts do not discard queued user messages.
- Add `_polling_liveness_watchdog()` for polling mode:
  - probes `get_webhook_info()` every `HERMES_TELEGRAM_LIVENESS_INTERVAL` seconds, default 15;
  - requires two consecutive probes with pending updates before acting;
  - restarts only PTB polling, not the full Hermes gateway;
  - preserves queued updates with `drop_pending_updates=False`.
- Log `updater_running` and application `running` state after startup to make this class of issue visible in future reports.

## Verification

Verified on the affected self-hosted macOS gateway:

Before the fix:

```text
pending_update_count=1
manual getUpdates returned the DM
no inbound message logged
```

After the lifecycle change:

```text
Telegram application started (updater_running=True, running=True)
inbound message: platform=telegram ... msg='Good'
response ready: platform=telegram ... time=3.6s
```

A second message was also consumed and answered without restart:

```text
inbound message: platform=telegram ... msg='A breve ti mando anche la cena di stasera'
response ready: platform=telegram ... time=5.4s
pending_update_count=0
```

Local validation:

```bash
python -m py_compile gateway/platforms/telegram.py
git diff --check
```

## Notes

This PR intentionally does not change webhook mode behavior beyond moving `Application.start()` after webhook startup as part of the same PTB lifecycle ordering. The liveness watchdog only runs when not in webhook mode.

Fixes #42909.
