### PR TITLE
fix(tui): increase WS write timeout from 10s to 30s for Windows ProactorEventLoop

### DIFF
--- a/tests/tui_gateway/test_ws_write_timeout.py
+++ b/tests/tui_gateway/test_ws_write_timeout.py
@@ -1,0 +1,61 @@
+"""Tests for tui_gateway.ws — WebSocket transport write timeout."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestWSWriteTimeout:
+    """Verify the write timeout constant and timeout-triggered closure."""
+
+    def test_timeout_constant_is_30s(self):
+        """_WS_WRITE_TIMEOUT_S must be 30 s — 10 s was too aggressive on Windows."""
+        from tui_gateway.ws import _WS_WRITE_TIMEOUT_S
+
+        assert _WS_WRITE_TIMEOUT_S == 30.0
+
+    def test_write_marks_transport_closed_on_timeout(self):
+        """A write that times out must close the transport so subsequent writes fail."""
+        from tui_gateway.ws import WSTransport
+
+        mock_ws = MagicMock()
+        loop = asyncio.new_event_loop()
+        try:
+            transport = WSTransport(mock_ws, loop, peer="test:1234")
+            assert not transport._closed
+
+            # Simulate: get_running_loop returns a DIFFERENT loop → off-loop path
+            other_loop = asyncio.new_event_loop()
+            try:
+                with (
+                    patch("asyncio.get_running_loop", return_value=other_loop),
+                    patch(
+                        "agent.async_utils.safe_schedule_threadsafe",
+                        return_value=None,
+                    ),
+                ):
+                    result = transport.write({"method": "test"})
+            finally:
+                other_loop.close()
+
+            assert result is False
+            assert transport._closed is True
+        finally:
+            loop.close()
+
+    def test_write_returns_false_after_closed(self):
+        """Once closed, write() returns False without attempting I/O."""
+        from tui_gateway.ws import WSTransport
+
+        mock_ws = MagicMock()
+        loop = asyncio.new_event_loop()
+        try:
+            transport = WSTransport(mock_ws, loop, peer="test:1234")
+            transport._closed = True
+            assert transport.write({"method": "test"}) is False
+        finally:
+            loop.close()

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -35,8 +35,10 @@ _log = logging.getLogger(__name__)
 
 # Max seconds a pool-dispatched handler will block waiting for the event loop
 # to flush a WS frame before we mark the transport dead. Protects handler
-# threads from a wedged socket.
-_WS_WRITE_TIMEOUT_S = 10.0
+# threads from a wedged socket.  10 s was too aggressive on Windows
+# ProactorEventLoop where scheduling latency from worker threads is higher;
+# large tool outputs routinely exceeded that window under load (#42938).
+_WS_WRITE_TIMEOUT_S = 30.0
 _WS_LOG_PAYLOAD_PREVIEW = 240
 
 # Keep starlette optional at import time; handle_ws uses the real class when


### PR DESCRIPTION
## What does this PR do?

Increases the WebSocket write timeout in `tui_gateway/ws.py` from 10 s to 30 s to prevent spurious disconnections on Windows ProactorEventLoop under heavy tool usage.

## Related Issue

Fixes #42938

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/ws.py`: Increased `_WS_WRITE_TIMEOUT_S` from 10.0 to 30.0 with comment explaining the Windows ProactorEventLoop scheduling latency rationale
- `tests/tui_gateway/test_ws_write_timeout.py`: Added 3 tests — constant value assertion, timeout-triggered closure behavior, and closed-transport guard

## How to Test

1. Run `pytest tests/tui_gateway/test_ws_write_timeout.py -v` — all 3 tests should pass
2. On Windows: launch Hermes Desktop, execute a heavy multi-session workload (concurrent tool calls, long pip install) and verify WS connections no longer drop every 2-3 hours
3. On any platform: verify `_WS_WRITE_TIMEOUT_S == 30.0` by importing from `tui_gateway.ws`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tui_gateway/test_ws_write_timeout.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tui_gateway/ws.py` (WSTransport.write — callers: handle_ws, dispatch handler threads)
- Blast radius: LOW — single constant change, no control-flow modification
- Related patterns: `_WS_WRITE_TIMEOUT_S` is only used at line 100 in `fut.result(timeout=...)` — no other consumers
