### PR TITLE
fix(desktop): keep retrying remote backends after in-app update (#42354)

### DIFF
--- a/apps/desktop/electron/desktop-remote-reconnect.cjs
+++ b/apps/desktop/electron/desktop-remote-reconnect.cjs
@@ -1,0 +1,124 @@
+/**
+ * desktop-remote-reconnect.cjs
+ *
+ * Focused utilities for remote-backend reconnect behavior used by
+ * electron/main.cjs: bounded remote startup probing and recovery-state
+ * accounting for transient /api/status misses.
+ *
+ * Kept as a pure module so we can unit-test timing, threshold, and state
+ * transitions with deterministic clocks instead of booting the Electron shell.
+ */
+
+const DEFAULT_REMOTE_PROBE_TIMEOUT_MS = 90_000
+const DEFAULT_REMOTE_PROBE_INITIAL_DELAY_MS = 500
+const DEFAULT_REMOTE_PROBE_MAX_DELAY_MS = 2_000
+const DEFAULT_REMOTE_PROBE_MAX_ATTEMPTS = 16
+const DEFAULT_REMOTE_REVALIDATE_FAILURE_LIMIT = 3
+const DEFAULT_REMOTE_REVALIDATE_FAILURE_WINDOW_MS = 20_000
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function toPositiveInteger(value, fallback) {
+  return Number.isFinite(value) && value > 0 ? Math.trunc(value) : fallback
+}
+
+function backoffDelay(attempt, initialDelayMs, maxDelayMs) {
+  const capped = Math.pow(2, Math.max(0, attempt - 1))
+  return Math.min(initialDelayMs * capped, maxDelayMs)
+}
+
+async function waitForRemoteHermes(baseUrl, token, options = {}) {
+  const fetcher = options.fetcher
+  if (typeof fetcher !== 'function') {
+    throw new Error('waitForRemoteHermes requires a fetcher function')
+  }
+
+  const timeoutMs = toPositiveInteger(options.timeoutMs, DEFAULT_REMOTE_PROBE_TIMEOUT_MS)
+  const maxAttempts = toPositiveInteger(options.maxAttempts, DEFAULT_REMOTE_PROBE_MAX_ATTEMPTS)
+  const initialDelayMs = toPositiveInteger(options.initialDelayMs, DEFAULT_REMOTE_PROBE_INITIAL_DELAY_MS)
+  const maxDelayMs = toPositiveInteger(options.maxDelayMs, DEFAULT_REMOTE_PROBE_MAX_DELAY_MS)
+  const deadline = Date.now() + timeoutMs
+  const wait = options.sleep || sleep
+  let attempts = 0
+  let lastError = null
+
+  while (Date.now() < deadline) {
+    try {
+      await fetcher(`${baseUrl}/api/status`, token, options.fetcherOptions)
+      return
+    } catch (error) {
+      lastError = error
+      attempts += 1
+
+      if (attempts >= maxAttempts) {
+        break
+      }
+
+      const delay = backoffDelay(attempts, initialDelayMs, maxDelayMs)
+      const remainingMs = deadline - Date.now()
+      if (remainingMs <= delay) {
+        break
+      }
+      await wait(delay)
+    }
+  }
+
+  const message = lastError?.message || 'timeout'
+  throw new Error(`Remote Hermes backend did not become ready after ${attempts} attempts: ${message}`)
+}
+
+function createRemoteRevalidateState() {
+  return {
+    failures: 0,
+    windowStartedAt: 0
+  }
+}
+
+function resetRemoteRevalidateState(state) {
+  if (!state) return
+  state.failures = 0
+  state.windowStartedAt = 0
+}
+
+function recordRemoteRevalidateFailure(state, options = {}) {
+  if (!state) {
+    throw new Error('recordRemoteRevalidateFailure requires a state object')
+  }
+
+  const now = toPositiveInteger(options.now, Date.now())
+  const failureLimit = toPositiveInteger(options.failureLimit, DEFAULT_REMOTE_REVALIDATE_FAILURE_LIMIT)
+  const failureWindowMs = toPositiveInteger(options.failureWindowMs, DEFAULT_REMOTE_REVALIDATE_FAILURE_WINDOW_MS)
+  const inWindow = state.failures > 0 && state.windowStartedAt > 0 && now - state.windowStartedAt <= failureWindowMs
+
+  if (!inWindow) {
+    state.failures = 1
+    state.windowStartedAt = now
+    return { failures: 1, shouldReset: false }
+  }
+
+  state.failures += 1
+  return {
+    failures: state.failures,
+    shouldReset: state.failures >= failureLimit
+  }
+}
+
+function shouldRemoteRevalidateKeepState(state) {
+  return state && state.failures > 0
+}
+
+module.exports = {
+  createRemoteRevalidateState,
+  DEFAULT_REMOTE_PROBE_INITIAL_DELAY_MS,
+  DEFAULT_REMOTE_PROBE_MAX_ATTEMPTS,
+  DEFAULT_REMOTE_PROBE_MAX_DELAY_MS,
+  DEFAULT_REMOTE_PROBE_TIMEOUT_MS,
+  DEFAULT_REMOTE_REVALIDATE_FAILURE_LIMIT,
+  DEFAULT_REMOTE_REVALIDATE_FAILURE_WINDOW_MS,
+  recordRemoteRevalidateFailure,
+  resetRemoteRevalidateState,
+  shouldRemoteRevalidateKeepState,
+  waitForRemoteHermes
+}

--- a/apps/desktop/electron/desktop-remote-reconnect.test.cjs
+++ b/apps/desktop/electron/desktop-remote-reconnect.test.cjs
@@ -1,0 +1,109 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  createRemoteRevalidateState,
+  recordRemoteRevalidateFailure,
+  resetRemoteRevalidateState,
+  shouldRemoteRevalidateKeepState,
+  waitForRemoteHermes
+} = require('./desktop-remote-reconnect.cjs')
+
+async function withFakeNow(startMs, fn) {
+  const realNow = Date.now
+  let nowMs = startMs
+  Date.now = () => nowMs
+  try {
+    await fn({
+      advance(ms) {
+        nowMs += ms
+      }
+    })
+  } finally {
+    Date.now = realNow
+  }
+}
+
+test('waitForRemoteHermes retries transient probe failures before succeeding', async () => {
+  await withFakeNow(10_000, async clock => {
+    const sleeps = []
+    let attempts = 0
+
+    await waitForRemoteHermes('https://gw.example.com', 'tok', {
+      fetcher: async () => {
+        attempts += 1
+        if (attempts < 3) {
+          throw new Error(`miss ${attempts}`)
+        }
+      },
+      maxAttempts: 5,
+      timeoutMs: 90_000,
+      sleep: async ms => {
+        sleeps.push(ms)
+        clock.advance(ms)
+      }
+    })
+
+    assert.equal(attempts, 3)
+    assert.deepEqual(sleeps, [500, 1_000])
+  })
+})
+
+test('waitForRemoteHermes fails after the bounded retry budget', async () => {
+  await withFakeNow(20_000, async clock => {
+    const sleeps = []
+
+    await assert.rejects(
+      () =>
+        waitForRemoteHermes('https://gw.example.com', 'tok', {
+          fetcher: async () => {
+            throw new Error('still restarting')
+          },
+          maxAttempts: 3,
+          timeoutMs: 90_000,
+          sleep: async ms => {
+            sleeps.push(ms)
+            clock.advance(ms)
+          }
+        }),
+      /after 3 attempts: still restarting/
+    )
+
+    assert.deepEqual(sleeps, [500, 1_000])
+  })
+})
+
+test('recordRemoteRevalidateFailure only resets after repeated misses in one window', () => {
+  const state = createRemoteRevalidateState()
+
+  assert.equal(shouldRemoteRevalidateKeepState(state), false)
+  assert.deepEqual(recordRemoteRevalidateFailure(state, { now: 1_000 }), {
+    failures: 1,
+    shouldReset: false
+  })
+  assert.equal(shouldRemoteRevalidateKeepState(state), true)
+  assert.deepEqual(recordRemoteRevalidateFailure(state, { now: 5_000 }), {
+    failures: 2,
+    shouldReset: false
+  })
+  assert.deepEqual(recordRemoteRevalidateFailure(state, { now: 9_000 }), {
+    failures: 3,
+    shouldReset: true
+  })
+
+  resetRemoteRevalidateState(state)
+  assert.equal(shouldRemoteRevalidateKeepState(state), false)
+})
+
+test('recordRemoteRevalidateFailure starts a fresh window after the retry budget expires', () => {
+  const state = createRemoteRevalidateState()
+
+  assert.deepEqual(recordRemoteRevalidateFailure(state, { now: 1_000 }), {
+    failures: 1,
+    shouldReset: false
+  })
+  assert.deepEqual(recordRemoteRevalidateFailure(state, { now: 30_000 }), {
+    failures: 1,
+    shouldReset: false
+  })
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -127,6 +127,13 @@ const {
   resolveRequestedPathForIpc,
   resolveTimeoutMs
 } = require('./hardening.cjs')
+const {
+  createRemoteRevalidateState,
+  recordRemoteRevalidateFailure,
+  resetRemoteRevalidateState,
+  shouldRemoteRevalidateKeepState,
+  waitForRemoteHermes: waitForRemoteHermesWithBackoff
+} = require('./desktop-remote-reconnect.cjs')
 
 let nodePty = null
 let nodePtyDir = null
@@ -792,6 +799,7 @@ const POOL_IDLE_MS = Math.max(60_000, Number(process.env.HERMES_DESKTOP_POOL_IDL
 // killing one to honor the soft cap would abort a running agent.
 const POOL_KEEPALIVE_FRESH_MS = 90_000
 let poolIdleReaper = null
+const REMOTE_REVALIDATE_FAILURE_KEEP_MS = 120_000
 // Auto-reload budget for renderer crashes. A deterministic startup crash would
 // otherwise loop forever (reload → crash → reload), pinning CPU and spamming
 // logs. Allow a few reloads per rolling window, then stop and leave the dead
@@ -813,6 +821,7 @@ let backendStartFailure = null
 let bootstrapAbortController = null
 let connectionConfigCache = null
 let connectionConfigCacheMtime = null
+const remoteRevalidateStates = new Map() // baseUrl -> { failures, windowStartedAt }
 const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
@@ -3918,6 +3927,29 @@ function closePreviewWatchers() {
   }
 }
 
+function canonicalRemoteBaseUrl(baseUrl) {
+  return String(baseUrl || '').replace(/\/+$/, '')
+}
+
+function trimRemoteRevalidateStates(now = Date.now()) {
+  for (const [key, state] of remoteRevalidateStates.entries()) {
+    const ageMs = now - (state.windowStartedAt || 0)
+    if (!shouldRemoteRevalidateKeepState(state) || !state.windowStartedAt || ageMs > REMOTE_REVALIDATE_FAILURE_KEEP_MS) {
+      remoteRevalidateStates.delete(key)
+    }
+  }
+}
+
+function remoteRevalidateStateFor(baseUrl) {
+  const normalized = canonicalRemoteBaseUrl(baseUrl)
+  const existing = remoteRevalidateStates.get(normalized)
+  if (existing) return existing
+
+  const next = createRemoteRevalidateState()
+  remoteRevalidateStates.set(normalized, next)
+  return next
+}
+
 async function waitForHermes(baseUrl, token) {
   const deadline = Date.now() + 45_000
   let lastError = null
@@ -3933,6 +3965,19 @@ async function waitForHermes(baseUrl, token) {
   }
 
   throw new Error(`Hermes backend did not become ready: ${lastError?.message || 'timeout'}`)
+}
+
+async function waitForRemoteHermes(baseUrl, token) {
+  try {
+    await waitForRemoteHermesWithBackoff(baseUrl, token, {
+      fetcher: fetchJson,
+      maxAttempts: 16,
+      timeoutMs: 90_000,
+      fetcherOptions: {}
+    })
+  } catch (error) {
+    throw new Error(`Hermes remote backend did not become ready: ${error.message}`)
+  }
 }
 
 function getWindowButtonPosition() {
@@ -5207,6 +5252,7 @@ function resetHermesConnection() {
   stopBackendChild(hermesProcess)
 
   hermesProcess = null
+  remoteRevalidateStates.clear()
   resetBootProgressForReconnect()
 }
 
@@ -5345,7 +5391,7 @@ async function spawnPoolBackend(profile, entry) {
   // tolerate.
   const remote = await resolveRemoteBackend(profile)
   if (remote) {
-    await waitForHermes(remote.baseUrl, remote.token)
+    await waitForRemoteHermes(remote.baseUrl, remote.token)
     return {
       ...remote,
       profile,
@@ -5540,7 +5586,7 @@ async function startHermes() {
     const remote = await resolveRemoteBackend(primaryProfileKey())
     if (remote) {
       await advanceBootProgress('backend.remote', `Connecting to remote Hermes backend at ${remote.baseUrl}`, 24)
-      await waitForHermes(remote.baseUrl, remote.token)
+      await waitForRemoteHermes(remote.baseUrl, remote.token)
       updateBootProgress({
         phase: 'backend.ready',
         message: 'Remote Hermes backend is ready',
@@ -6126,14 +6172,24 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
   }
 
   const base = conn.baseUrl.replace(/\/+$/, '')
+  trimRemoteRevalidateStates()
+  const state = remoteRevalidateStateFor(base)
   try {
     await fetchPublicJson(`${base}/api/status`, { timeoutMs: 2_500 })
+    resetRemoteRevalidateState(state)
     return { ok: true, rebuilt: false }
   } catch {
-    // Unreachable remote: drop the stale cache so the renderer's next reconnect
-    // tick rebuilds a fresh, reachable descriptor. resetHermesConnection only
-    // nulls connectionPromise for a remote (no child to SIGTERM).
-    rememberLog('Cached remote Hermes backend failed liveness probe; dropping stale connection.')
+    const failure = recordRemoteRevalidateFailure(state)
+    if (!failure.shouldReset) {
+      rememberLog(
+        `Cached remote Hermes backend failed liveness probe (${failure.failures}/3); preserving cached connection during restart window.`
+      )
+      return { ok: true, rebuilt: false }
+    }
+
+    // Repeated misses across the same short window mean the cached remote is
+    // genuinely stale, so let the next reconnect rebuild from config.
+    rememberLog('Cached remote Hermes backend failed repeated liveness probes; dropping stale connection.')
     resetHermesConnection()
     return { ok: true, rebuilt: true }
   }


### PR DESCRIPTION
## Summary

When Hermes Desktop updated itself while attached to a remote backend, the updater handoff could leave the app unable to recover the remote connection automatically even though the backend stayed healthy. This PR keeps remote-mode reconnect intent alive across the update restart path and prevents a transient probe miss from permanently dropping the connection.

## What Changed

- Desktop Electron reconnect/update flow: preserve remote backend config through update restart and keep bounded reconnect attempts alive after handoff
- focused Electron tests: cover transient remote probe failure followed by automatic reconnect success

## Why It Matters

Remote-backend users expect in-app updates to be seamless. Requiring a full manual relaunch after every update is avoidable friction and makes the remote mode feel less reliable than the bundled local backend path.

## Verification

```text
node --test apps/desktop/electron/connection-config.test.cjs apps/desktop/electron/desktop-remote-reconnect.test.cjs
```

`apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx` still has pre-existing failures on the unchanged `origin/main` renderer path and is not covered by this diff.

## Upstream

Closes #42354.
Reported by @BigDon86.
