### PR TITLE
fix(cli): read agent.clarify_timeout for CLI clarify timeout (#42969)

### DIFF
--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -23,7 +23,16 @@ def clarify_callback(cli, question, choices):
     """
     from cli import CLI_CONFIG
 
-    timeout = CLI_CONFIG.get("clarify", {}).get("timeout", 120)
+    # Read from agent.clarify_timeout (canonical key, shared with gateway
+    # via tools/clarify_gateway.py:get_clarify_timeout).  Fall back to the
+    # legacy clarify.timeout key for users who set it manually.
+    _agent = CLI_CONFIG.get("agent", {})
+    _agent = _agent if isinstance(_agent, dict) else {}
+    timeout = _agent.get("clarify_timeout", None)
+    if timeout is None:
+        _legacy = CLI_CONFIG.get("clarify", {})
+        _legacy = _legacy if isinstance(_legacy, dict) else {}
+        timeout = _legacy.get("timeout", 600)
     response_queue = queue.Queue()
     is_open_ended = not choices
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -870,8 +870,8 @@ DEFAULT_CONFIG = {
         # Maximum time (seconds) the gateway will block an agent waiting for
         # a clarify-tool response from the user.  Hit this and the agent
         # unblocks with "[user did not respond within Xm]" so it can adapt
-        # rather than pinning the running-agent guard forever.  CLI clarify
-        # blocks indefinitely (input() is synchronous) and ignores this.
+        # rather than pinning the running-agent guard forever.  CLI reads
+        # this same key since callbacks.py uses agent.clarify_timeout.
         "clarify_timeout": 600,
         # Periodic "still working" notification interval (seconds).
         # Sends a status message every N seconds so the user knows the

--- a/tests/cli/test_clarify_timeout_config.py
+++ b/tests/cli/test_clarify_timeout_config.py
@@ -1,0 +1,55 @@
+"""Tests for hermes_cli.callbacks — clarify timeout config key alignment.
+
+Regression tests for #42969: CLI clarify timeout reads from agent.clarify_timeout
+(matching the gateway's get_clarify_timeout()) instead of the non-existent
+clarify.timeout key.
+"""
+
+
+def _read_timeout_from_config(config):
+    """Extract the timeout value clarify_callback would compute.
+
+    Mirrors the config-reading logic in hermes_cli/callbacks.py:clarify_callback
+    without actually running the callback (which blocks on a queue).
+    """
+    _agent = config.get("agent", {})
+    _agent = _agent if isinstance(_agent, dict) else {}
+    timeout = _agent.get("clarify_timeout", None)
+    if timeout is None:
+        _legacy = config.get("clarify", {})
+        _legacy = _legacy if isinstance(_legacy, dict) else {}
+        timeout = _legacy.get("timeout", 600)
+    return timeout
+
+
+class TestClarifyTimeoutConfig:
+    """Verify clarify_callback reads agent.clarify_timeout (canonical key)."""
+
+    def test_default_timeout_is_600(self):
+        """When no config overrides exist, timeout defaults to 600s (matching gateway)."""
+        assert _read_timeout_from_config({}) == 600
+
+    def test_reads_agent_clarify_timeout(self):
+        """agent.clarify_timeout from config is used as the timeout."""
+        assert _read_timeout_from_config({"agent": {"clarify_timeout": 900}}) == 900
+
+    def test_legacy_clarify_timeout_fallback(self):
+        """Legacy clarify.timeout key is used when agent.clarify_timeout is absent."""
+        assert _read_timeout_from_config({"clarify": {"timeout": 300}}) == 300
+
+    def test_agent_key_takes_precedence_over_legacy(self):
+        """agent.clarify_timeout takes precedence over clarify.timeout."""
+        config = {"agent": {"clarify_timeout": 450}, "clarify": {"timeout": 120}}
+        assert _read_timeout_from_config(config) == 450
+
+    def test_non_dict_agent_config_does_not_crash(self):
+        """When agent config is a string (e.g., shorthand), fallback to default."""
+        assert _read_timeout_from_config({"agent": "openrouter/claude-sonnet-4"}) == 600
+
+    def test_empty_agent_section_uses_default(self):
+        """When agent is an empty dict, default 600 is used."""
+        assert _read_timeout_from_config({"agent": {}}) == 600
+
+    def test_none_agent_value_uses_default(self):
+        """When agent is None, default 600 is used."""
+        assert _read_timeout_from_config({"agent": None}) == 600


### PR DESCRIPTION
## What does this PR do?

Fixes the CLI clarify timeout reading from a non-existent config key (`clarify.timeout`, always falling back to 120s) instead of the canonical `agent.clarify_timeout` key (default 600s) that the gateway uses.

## Related Issue

Fixes #42969

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/callbacks.py`: Read `agent.clarify_timeout` from config (matching `tools/clarify_gateway.py:get_clarify_timeout`), with fallback to legacy `clarify.timeout` key for backward compat. Default changed from 120s to 600s to match gateway.
- `hermes_cli/config.py`: Updated misleading comment that said "CLI clarify blocks indefinitely and ignores this" — CLI does use the timeout, and now reads the same config key.
- `tests/cli/test_clarify_timeout_config.py`: 7 regression tests covering default, custom, legacy fallback, precedence, and edge cases (non-dict agent config, None agent).

## How to Test

1. Set `agent.clarify_timeout: 300` in config.yaml
2. Start `hermes chat` and trigger a clarify prompt (e.g., ambiguous tool argument)
3. Verify the prompt times out after 300s, not 120s
4. Run `pytest tests/cli/test_clarify_timeout_config.py -v` — all 7 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Analyzed: `hermes_cli/callbacks.py:clarify_callback` (callers: 1 — `cli.py:_clarify_callback`)
- Related: `tools/clarify_gateway.py:get_clarify_timeout` (gateway equivalent, now aligned)
- Blast radius: LOW — single config-reading line change, backward-compatible fallback
