### PR TITLE
fix(desktop): refresh cached session messages when externally updated

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -463,6 +463,32 @@ export function useSessionActions({
         clearComposerDraft()
         clearComposerAttachments()
 
+        // Check if the stored session was updated externally (e.g. via
+        // Telegram, Discord, or another Desktop instance). If the stored
+        // message_count differs from the cached messages, refetch so the
+        // user sees the latest turns without restarting the app (#42962).
+        try {
+          const stored = $sessions.get().find(s => s.id === storedSessionId)
+          const cachedMsgCount = cachedState.messages?.length ?? 0
+
+          if (stored && stored.message_count !== cachedMsgCount) {
+            const fresh = await getSessionMessages(storedSessionId, sessionProfile)
+
+            if (isCurrentResume()) {
+              const freshMessages = preserveLocalAssistantErrors(
+                toChatMessages(fresh.messages),
+                $messages.get()
+              )
+
+              if (!chatMessageArraysEquivalent($messages.get(), freshMessages)) {
+                setMessages(freshMessages)
+              }
+            }
+          }
+        } catch {
+          // Non-fatal: the cached view is still usable.
+        }
+
         try {
           const usage = await requestGateway<UsageStats>('session.usage', { session_id: cachedRuntimeId })
 


### PR DESCRIPTION
## Problem

Hermes Desktop does not refresh an already-open conversation when the same stored session is updated from another frontend (Telegram, Discord, CLI/TUI, etc.). The new messages are correctly persisted to `state.db`, but the Desktop chat view shows stale cached messages until the app is restarted.

**Reproduction:**
1. Open a session in Desktop
2. Resume the same session from Telegram and have a conversation
3. Return to Desktop — the Telegram-added turns are missing
4. Restart Desktop — the turns now appear

## Fix

Add a freshness check in the cached session resume path of `use-session-actions.ts`. When a cached session is resumed, compare the stored session's `message_count` against the cached messages length. If they differ, fetch the latest messages from the API and update the view.

This is a minimal, non-intrusive change:
- Only triggers when `message_count` actually changed (zero overhead for normal use)
- Wrapped in try/catch so a fetch failure degrades gracefully to the cached view
- Respects the `isCurrentResume()` guard to avoid stale updates from abandoned requests
- Uses the same `preserveLocalAssistantErrors` + `toChatMessages` pipeline as the normal resume path

## Testing

Manual verification:
1. Open a session in Desktop
2. Send a message to the same session via Telegram
3. Click the session in Desktop sidebar — the Telegram message should now appear without restarting

Fixes #42962
