### PR TITLE
fix(agent): normalize provider to lowercase in _pool_may_recover_from…

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -260,7 +260,7 @@ def _pool_may_recover_from_rate_limit(
         return False
     # CloudCode / Gemini CLI quotas are account-wide — all pool entries share
     # the same throttle window, so rotation can't recover.  Prefer fallback.
-    if provider == "google-gemini-cli" or str(base_url or "").startswith("cloudcode-pa://"):
+    if (provider or "").strip().lower() == "google-gemini-cli" or str(base_url or "").startswith("cloudcode-pa://"):
         return False
     return len(pool.entries()) > 1
 

--- a/tests/agent/test_gemini_fast_fallback.py
+++ b/tests/agent/test_gemini_fast_fallback.py
@@ -76,3 +76,14 @@ def test_conversation_loop_resolves_pool_helper_through_run_agent_module():
 
     assert "_ra()._pool_may_recover_from_rate_limit(" in source
     assert "pool_may_recover = _pool_may_recover_from_rate_limit(" not in source
+
+
+def test_gemini_cli_provider_case_insensitive():
+    # Provider names from config may arrive in mixed case; the guard must
+    # treat Google-Gemini-CLI and GOOGLE-GEMINI-CLI the same as google-gemini-cli.
+    for variant in ("Google-Gemini-CLI", "GOOGLE-GEMINI-CLI", "Google-gemini-cli"):
+        assert _pool_may_recover_from_rate_limit(
+            _pool(entries=3),
+            provider=variant,
+            base_url="https://generativelanguage.googleapis.com",
+        ) is False, f"Expected False for provider={variant!r}"


### PR DESCRIPTION
## Summary

Normalizes `provider` to lowercase before comparing against
`"google-gemini-cli"` in `_pool_may_recover_from_rate_limit()`. Provider
names from config may arrive in mixed case and previously bypassed the
guard entirely.

---

## Root cause

`_pool_may_recover_from_rate_limit()` uses a direct equality check
`provider == "google-gemini-cli"` with no normalization. Any case
variation (`Google-Gemini-CLI`, `GOOGLE-GEMINI-CLI`) causes the guard to
return `False`, so the credential pool burns through its retry budget on
a 429 that rotation cannot recover from, instead of triggering fallback
immediately.

---

## Behavioral change

Before: `provider = "Google-Gemini-CLI"` bypassed the guard, causing
unnecessary pool rotation under an account-wide quota.

After: `provider` is normalized with `(provider or "").strip().lower()`
before comparison. All case variants now correctly skip rotation and
trigger immediate fallback.

---

## What changed

**`run_agent.py`**: replaced `provider == "google-gemini-cli"` with
`(provider or "").strip().lower() == "google-gemini-cli"` (line 263)

**`tests/agent/test_gemini_fast_fallback.py`**: added
`test_gemini_cli_provider_case_insensitive` covering three mixed-case
variants.

---

## What is NOT changed

- `base_url` branch behavior unchanged
- All existing 7 tests pass without modification