### PR TITLE
fix(desktop): parse BOM-prefixed connection config

### DIFF
--- a/apps/desktop/electron/connection-config.cjs
+++ b/apps/desktop/electron/connection-config.cjs
@@ -142,6 +142,75 @@ function normAuthMode(mode) {
   return mode === 'oauth' ? 'oauth' : 'token'
 }
 
+// Windows PowerShell 5.1's Set-Content emits UTF-8 with a BOM by default. If a
+// user or repair script rewrites connection.json that way, plain JSON.parse()
+// sees the leading U+FEFF and throws. Strip only the leading JSON BOM; leave
+// all other content byte-for-byte for normal JSON validation.
+function stripJsonBom(raw) {
+  const text = String(raw ?? '')
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text
+}
+
+function parseJsonWithOptionalBom(raw) {
+  return JSON.parse(stripJsonBom(raw))
+}
+
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+// Validate + normalize the per-profile remote overrides map read from disk.
+function sanitizeConnectionProfiles(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return {}
+  }
+
+  const out = {}
+  for (const [name, entry] of Object.entries(raw)) {
+    if (!entry || typeof entry !== 'object') {
+      continue
+    }
+    if (name !== 'default' && !PROFILE_NAME_RE.test(name)) {
+      continue
+    }
+
+    const cleaned = { mode: entry.mode === 'remote' ? 'remote' : 'local' }
+    const url = String(entry.url || '').trim()
+    if (url) {
+      cleaned.url = url
+    }
+    cleaned.authMode = normAuthMode(entry.authMode)
+    if (entry.token && typeof entry.token === 'object') {
+      cleaned.token = entry.token
+    }
+    out[name] = cleaned
+  }
+
+  return out
+}
+
+function defaultDesktopConnectionConfig() {
+  return { mode: 'local', remote: {}, profiles: {} }
+}
+
+function parseDesktopConnectionConfig(raw) {
+  try {
+    const parsed = parseJsonWithOptionalBom(raw)
+
+    if (parsed && typeof parsed === 'object') {
+      const remote = parsed.remote && typeof parsed.remote === 'object' ? parsed.remote : {}
+      remote.authMode = remote.authMode === 'oauth' ? 'oauth' : 'token'
+      return {
+        mode: parsed.mode === 'remote' ? 'remote' : 'local',
+        remote,
+        profiles: sanitizeConnectionProfiles(parsed.profiles)
+      }
+    }
+  } catch {
+    // Missing or malformed connection settings should fall back to local.
+  }
+
+  return defaultDesktopConnectionConfig()
+}
+
 /**
  * Select a profile's explicit remote override from a connection config, or null
  * when it has none (so the caller falls back to env → global remote → local).
@@ -280,9 +349,13 @@ module.exports = {
   cookiesHaveLiveSession,
   normAuthMode,
   normalizeRemoteBaseUrl,
+  parseDesktopConnectionConfig,
+  parseJsonWithOptionalBom,
   pathWithGlobalRemoteProfile,
   profileRemoteOverride,
   resolveAuthMode,
   resolveTestWsUrl,
+  sanitizeConnectionProfiles,
+  stripJsonBom,
   tokenPreview
 }

--- a/apps/desktop/electron/connection-config.test.cjs
+++ b/apps/desktop/electron/connection-config.test.cjs
@@ -24,10 +24,13 @@ const {
   cookiesHaveLiveSession,
   normAuthMode,
   normalizeRemoteBaseUrl,
+  parseDesktopConnectionConfig,
+  parseJsonWithOptionalBom,
   pathWithGlobalRemoteProfile,
   profileRemoteOverride,
   resolveAuthMode,
   resolveTestWsUrl,
+  stripJsonBom,
   tokenPreview
 } = require('./connection-config.cjs')
 
@@ -45,6 +48,46 @@ test('normAuthMode coerces to token unless explicitly oauth', () => {
   assert.equal(normAuthMode('token'), 'token')
   assert.equal(normAuthMode(undefined), 'token')
   assert.equal(normAuthMode('weird'), 'token')
+})
+
+test('stripJsonBom removes only a leading UTF-8 BOM decoded as U+FEFF', () => {
+  assert.equal(stripJsonBom('\ufeff{"mode":"remote"}'), '{"mode":"remote"}')
+  assert.equal(stripJsonBom('{"mode":"remote"}'), '{"mode":"remote"}')
+  assert.equal(stripJsonBom('{"value":"\ufeffkept-inside"}'), '{"value":"\ufeffkept-inside"}')
+})
+
+test('parseJsonWithOptionalBom parses BOM-prefixed JSON for readJson callers', () => {
+  assert.deepEqual(parseJsonWithOptionalBom('\ufeff{"schemaVersion":1,"pinnedCommit":"abc1234"}'), {
+    schemaVersion: 1,
+    pinnedCommit: 'abc1234'
+  })
+})
+
+test('parseDesktopConnectionConfig keeps a BOM-prefixed remote config remote', () => {
+  const raw =
+    '\ufeff' +
+    JSON.stringify({
+      mode: 'remote',
+      remote: { url: 'https://gw.example.com', authMode: 'oauth' },
+      profiles: {
+        coder: { mode: 'remote', url: 'https://coder.example.com', authMode: 'token' },
+        'bad name': { mode: 'remote', url: 'https://bad.example.com' }
+      }
+    })
+  const parsed = parseDesktopConnectionConfig(raw)
+
+  assert.equal(parsed.mode, 'remote')
+  assert.deepEqual(parsed.remote, { url: 'https://gw.example.com', authMode: 'oauth' })
+  assert.deepEqual(parsed.profiles, {
+    coder: { mode: 'remote', url: 'https://coder.example.com', authMode: 'token' }
+  })
+})
+
+test('parseDesktopConnectionConfig still falls back to local for malformed JSON', () => {
+  const fallback = { mode: 'local', remote: {}, profiles: {} }
+
+  assert.deepEqual(parseDesktopConnectionConfig(' {"mode":"remote"'), fallback)
+  assert.deepEqual(parseDesktopConnectionConfig(' \ufeff{"mode":"remote"}'), fallback)
 })
 
 // --- profileRemoteOverride ---

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -85,6 +85,8 @@ const {
   cookiesHaveLiveSession,
   normAuthMode,
   normalizeRemoteBaseUrl,
+  parseDesktopConnectionConfig,
+  parseJsonWithOptionalBom,
   pathWithGlobalRemoteProfile,
   profileRemoteOverride,
   resolveAuthMode,
@@ -2387,7 +2389,7 @@ fi
 
 function readJson(filePath) {
   try {
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    return parseJsonWithOptionalBom(fs.readFileSync(filePath, 'utf8'))
   } catch {
     return null
   }
@@ -4342,38 +4344,6 @@ function decryptDesktopSecret(secret) {
   return value
 }
 
-// Validate + normalize the per-profile remote overrides map read from disk.
-// Drops malformed names/entries and keeps only the recognized fields so a
-// hand-edited or stale connection.json can't inject junk into resolution.
-function sanitizeConnectionProfiles(raw) {
-  if (!raw || typeof raw !== 'object') {
-    return {}
-  }
-
-  const out = {}
-  for (const [name, entry] of Object.entries(raw)) {
-    if (!entry || typeof entry !== 'object') {
-      continue
-    }
-    if (name !== 'default' && !PROFILE_NAME_RE.test(name)) {
-      continue
-    }
-
-    const cleaned = { mode: entry.mode === 'remote' ? 'remote' : 'local' }
-    const url = String(entry.url || '').trim()
-    if (url) {
-      cleaned.url = url
-    }
-    cleaned.authMode = normAuthMode(entry.authMode)
-    if (entry.token && typeof entry.token === 'object') {
-      cleaned.token = entry.token
-    }
-    out[name] = cleaned
-  }
-
-  return out
-}
-
 function readDesktopConnectionConfig() {
   // Check if file changed on disk since last read (e.g. modified by another
   // process or an external tool).  Our own writes update the cache inline
@@ -4389,27 +4359,11 @@ function readDesktopConnectionConfig() {
     return connectionConfigCache
   }
 
-  let config = { mode: 'local', remote: {}, profiles: {} }
+  let config = parseDesktopConnectionConfig(null)
 
   try {
     const raw = fs.readFileSync(DESKTOP_CONNECTION_CONFIG_PATH, 'utf8')
-    const parsed = JSON.parse(raw)
-
-    if (parsed && typeof parsed === 'object') {
-      const remote = parsed.remote && typeof parsed.remote === 'object' ? parsed.remote : {}
-      // authMode lives on the remote sub-object: 'oauth' (cookie + ws-ticket)
-      // or 'token' (legacy static session token). Default to 'token' for
-      // backward compatibility with configs written before OAuth support.
-      remote.authMode = remote.authMode === 'oauth' ? 'oauth' : 'token'
-      config = {
-        mode: parsed.mode === 'remote' ? 'remote' : 'local',
-        remote,
-        // Per-profile remote overrides: each profile may point at its own
-        // backend (local spawn or its own remote URL). Preserved verbatim so
-        // profileRemoteOverride() can resolve them; normalized lazily on save.
-        profiles: sanitizeConnectionProfiles(parsed.profiles)
-      }
-    }
+    config = parseDesktopConnectionConfig(raw)
   } catch {
     // Missing or malformed connection settings should fall back to local.
   }


### PR DESCRIPTION
## Summary
- add a BOM-tolerant JSON parser and extracted desktop connection config parser seam
- route main.cjs connection-config and bootstrap-marker JSON parsing through the BOM-tolerant parser
- add regression coverage for BOM-prefixed remote connection config plus malformed JSON fallback behavior

## Verification
- node --test electron/connection-config.test.cjs
- node --check electron/connection-config.cjs && node --check electron/connection-config.test.cjs && node --check electron/main.cjs
- npx eslint electron/connection-config.cjs electron/connection-config.test.cjs electron/main.cjs
- git diff --check -- apps/desktop/electron/connection-config.cjs apps/desktop/electron/connection-config.test.cjs apps/desktop/electron/main.cjs
- npm run test:desktop:platforms

Kanban: t_9eddd0de