### PR TITLE
feat(models): add anthropic/claude-fable-5 to openrouter + nous curated lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -33,6 +33,7 @@ COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Anthropic
+    ("anthropic/claude-fable-5",               ""),
     ("anthropic/claude-opus-4.8",              ""),
     ("anthropic/claude-opus-4.8-fast",         "2x price, higher output speed"),
     ("anthropic/claude-sonnet-4.6",            ""),
@@ -154,6 +155,7 @@ def _xai_curated_models() -> list[str]:
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
         # Anthropic
+        "anthropic/claude-fable-5",
         "anthropic/claude-opus-4.8",
         "anthropic/claude-sonnet-4.6",
         "anthropic/claude-haiku-4.5",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-09T05:57:24Z",
+  "updated_at": "2026-06-09T17:20:16Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -12,6 +12,10 @@
         "note": "Descriptions drive picker badges. Live /api/v1/models filters curated ids by tool-calling support and free pricing."
       },
       "models": [
+        {
+          "id": "anthropic/claude-fable-5",
+          "description": ""
+        },
         {
           "id": "anthropic/claude-opus-4.8",
           "description": ""
@@ -144,6 +148,9 @@
         "note": "Free-tier gating is determined live via Portal pricing (partition_nous_models_by_tier), not this manifest."
       },
       "models": [
+        {
+          "id": "anthropic/claude-fable-5"
+        },
         {
           "id": "anthropic/claude-opus-4.8"
         },


### PR DESCRIPTION
## Summary
`anthropic/claude-fable-5` is now the top entry in the OpenRouter and Nous Portal curated model lists, so it shows above `claude-opus-4.8` in `/model` and `hermes model`.

## Changes
- `hermes_cli/models.py`: insert `anthropic/claude-fable-5` above `anthropic/claude-opus-4.8` in `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]`
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py` to match

## Validation
- `tests/hermes_cli/test_model_catalog.py` — 28 passed (manifest back in sync)
- `tests/hermes_cli/test_models.py` + `tests/test_empty_model_fallback.py` — 117 passed (membership `>= N` invariants hold; Nous silent-default override still resolves to a non-flagship entry, unaffected by the new `[0]`)

## Infographic

![nous-helvetica](https://v3b.fal.media/files/b/0a9da114/31LWiJvb74w8yUEmdw-BW_rInulvWU.png)
