### PR TITLE
fix(tui): extend websocket write timeout on Windows

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -87,3 +87,11 @@ def test_ws_disconnect_preserves_and_repoints_reconnectable_session(monkeypatch)
         assert server._sessions["plain"]["transport"] is server._detached_ws_transport
     finally:
         server._sessions.clear()
+
+
+def test_ws_write_timeout_is_longer_on_windows(monkeypatch):
+    monkeypatch.setattr(ws_mod.sys, "platform", "win32")
+    assert ws_mod._default_ws_write_timeout_s() == 30.0
+
+    monkeypatch.setattr(ws_mod.sys, "platform", "linux")
+    assert ws_mod._default_ws_write_timeout_s() == 10.0

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -27,16 +27,23 @@ import asyncio
 import json
 import logging
 import socket
+import sys
 from typing import Any
 
 from tui_gateway import server
 
 _log = logging.getLogger(__name__)
 
+def _default_ws_write_timeout_s() -> float:
+    # Windows ProactorEventLoop can take longer to run a thread-safe callback
+    # when the loop is under heavy stream-output load.
+    return 30.0 if sys.platform == "win32" else 10.0
+
+
 # Max seconds a pool-dispatched handler will block waiting for the event loop
 # to flush a WS frame before we mark the transport dead. Protects handler
 # threads from a wedged socket.
-_WS_WRITE_TIMEOUT_S = 10.0
+_WS_WRITE_TIMEOUT_S = _default_ws_write_timeout_s()
 _WS_LOG_PAYLOAD_PREVIEW = 240
 
 # Keep starlette optional at import time; handle_ws uses the real class when


### PR DESCRIPTION
## Summary

Issue #42938 reports repeated Windows Desktop/TUI websocket disconnects where worker-thread sends hit `TimeoutError` after the fixed 10s wait, mark the transport closed, and trigger backend restarts.

This keeps the existing fail-closed behavior for real send failures and wedged sockets, but gives Windows ProactorEventLoop more room to schedule the cross-thread send under heavy stream-output load:

- Windows: 30s
- Other platforms: unchanged 10s

This is intentionally conservative: it does not turn sends into fire-and-forget or allow multiple pending websocket writes to accumulate/reorder.

## Verification

- `uv run ruff check tui_gateway/ws.py tests/test_tui_gateway_ws.py`
- `uv run --extra dev pytest tests/test_tui_gateway_ws.py -q`

## Review note

Codex adversarial review was attempted through the cron gate but degraded after retries with `401 Unauthorized` from the configured API key. Manual review focused on preserving ordered writes and existing fatal behavior for actual send failures.