### PR TITLE
fix(auth): use OpenRouter pool with configured base URL

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1316,7 +1316,7 @@ def resolve_runtime_provider(
             or env_openrouter_base_url
         )
         if cfg_base_url and cfg_provider in {"auto", "custom"}:
-            has_custom_endpoint = True
+            has_custom_endpoint = not base_url_host_matches(cfg_base_url, "openrouter.ai")
         has_runtime_override = bool(explicit_api_key or explicit_base_url)
         should_use_pool = (
             requested_provider in {"openrouter", "auto"}

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -27,6 +27,40 @@ def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
     assert resolved["source"] == "manual"
 
 
+def test_resolve_runtime_provider_uses_openrouter_pool_with_config_base_url(monkeypatch):
+    class _Entry:
+        access_token = "pool-openrouter-token"
+        source = "manual"
+        base_url = "https://openrouter.ai/api/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "auto",
+            "base_url": "https://openrouter.ai/api/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+
+    resolved = rp.resolve_runtime_provider(requested="auto")
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "pool-openrouter-token"
+    assert resolved["credential_pool"] is not None
+    assert resolved["source"] == "manual"
+
+
 def test_resolve_runtime_provider_anthropic_pool_respects_config_base_url(monkeypatch):
     class _Entry:
         access_token = "pool-token"


### PR DESCRIPTION
## Summary
- allow OpenRouter credential-pool resolution when model.base_url is the canonical OpenRouter endpoint under provider auto/custom
- keep custom endpoint protection for non-OpenRouter base URLs
- add regression coverage for auto provider + OpenRouter base URL + no env key

## Test Plan
- python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q

Closes #42835