### PR TITLE
fix(tui): dedicated WS write executor with keep-alive on event-loop stall

### DIFF
--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -34,9 +34,35 @@ from tui_gateway import server
 
 _log = logging.getLogger(__name__)
 
-# Max seconds a pool-dispatched handler will block waiting for the event loop
-# to flush a WS frame before we mark the transport dead. Protects handler
-# threads from a wedged socket.
+# ── Write completion executor ────────────────────────────────────────────
+# RPC pool workers call write() which schedules _safe_send on the event
+# loop.  Rather than blocking the RPC worker on fut.result(), we offload
+# the blocking wait to a dedicated *write executor*.  This keeps the RPC
+# pool free for computation while a small dedicated pool handles I/O
+# completion monitoring.
+#
+#                     ┌──────────────────┐
+#  RPC pool worker ──►│ schedule on loop │──► returns immediately
+#    (32 threads)     │ submit to write  │    (RPC worker freed)
+#                     │   executor       │
+#                     └──────┬───────────┘
+#                            │
+#              ┌─────────────▼─────────────┐
+#              │  write executor (2 thr)   │
+#              │  fut.result(timeout=10)   │
+#              │  on timeout → keep alive  │
+#              │  (no _closed; _safe_send  │
+#              │  catches real errors)     │
+#              └───────────────────────────┘
+#
+_WRITE_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=2,
+    thread_name_prefix="tui-ws-write",
+)
+
+# Max seconds the write executor will wait for the event loop to flush a
+# frame before logging. Aligned with upstream's 10s — _safe_send handles
+# real socket errors.
 _WS_WRITE_TIMEOUT_S = 10.0
 _WS_LOG_PAYLOAD_PREVIEW = 240
 
@@ -51,17 +77,15 @@ except ImportError:  # pragma: no cover - starlette is a required install path
 class WSTransport:
     """Per-connection WS transport.
 
-    ``write`` is safe to call from any thread *other than* the event loop
-    thread that owns the socket. Pool workers (the only real caller) run in
-    their own threads, so marshalling onto the loop via
-    :func:`asyncio.run_coroutine_threadsafe` + ``future.result()`` is correct
-    and deadlock-free there.
+    ``write`` is safe to call from any thread.  From the event loop thread
+    we use fire-and-forget (``create_task``).  From worker threads we
+    schedule ``_safe_send`` on the event loop and then offload the
+    blocking ``fut.result()`` wait to the module-level ``_WRITE_EXECUTOR``
+    so the calling thread (typically an RPC pool worker) is never blocked
+    by I/O completion.
 
-    When called from the loop thread itself (e.g. by ``handle_ws`` for an
-    inline response) the same call would deadlock: we'd schedule work onto
-    the loop we're currently blocking. We detect that case and fire-and-
-    forget instead. Callers that need to know when the bytes are on the wire
-    should use :meth:`write_async` from the loop thread.
+    Callers that need to know when the bytes are on the wire should use
+    :meth:`write_async` from the loop thread.
     """
 
     def __init__(
@@ -76,7 +100,16 @@ class WSTransport:
         self._peer = peer
         self._closed = False
 
+    # ── public API ───────────────────────────────────────────────────
+
     def write(self, obj: dict) -> bool:
+        """Enqueue *obj* for delivery.  Never blocks the calling thread.
+
+        From the event loop thread: fires and forgets via ``create_task``.
+        From any other thread: schedules ``_safe_send`` on the event loop
+        and submits the ``fut.result()`` wait to ``_WRITE_EXECUTOR`` so
+        the caller returns immediately.
+        """
         if self._closed:
             return False
 
@@ -88,36 +121,29 @@ class WSTransport:
             on_loop = False
 
         if on_loop:
-            # Fire-and-forget — don't block the loop waiting on itself.
             self._loop.create_task(self._safe_send(line))
             return True
 
+        # Worker thread path: schedule on event loop, offload the wait.
+        # PR #42983: offload fut.result() to _WRITE_EXECUTOR so RPC pool
+        # workers are never blocked by I/O completion. Keep upstream's
+        # "loop stalled, keep transport alive" semantics on timeout (no
+        # _closed latch here — _safe_send catches real socket errors).
         try:
             from agent.async_utils import safe_schedule_threadsafe
+
             fut = safe_schedule_threadsafe(self._safe_send(line), self._loop)
             if fut is None:
                 self._closed = True
                 return False
-            fut.result(timeout=_WS_WRITE_TIMEOUT_S)
-            return not self._closed
-        except concurrent.futures.TimeoutError:  # builtin TimeoutError on 3.11+
-            # The event loop is stalled (GIL-heavy agent turn, delegation
-            # running N children), NOT the socket dead. The send coroutine is
-            # already scheduled and will flush once the loop breathes — latching
-            # _closed here permanently silenced live windows after one slow
-            # write (the "subagent window shows zero streaming" bug). Unblock
-            # the worker thread and keep the transport alive; _safe_send latches
-            # on a real socket error when the frame actually fails.
-            _log.warning(
-                "ws write slow (loop stalled >%ss) peer=%s — frame left in flight",
-                _WS_WRITE_TIMEOUT_S, self._peer,
-            )
-            return not self._closed
+            _WRITE_EXECUTOR.submit(self._await_write, fut)
+            return True
         except Exception as exc:
-            self._closed = True
             _log.warning(
-                "ws write failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
+                "ws schedule failed peer=%s error_type=%s error=%s",
+                self._peer,
+                type(exc).__name__,
+                exc,
             )
             return False
 
@@ -128,6 +154,31 @@ class WSTransport:
         await self._safe_send(json.dumps(obj, ensure_ascii=False))
         return not self._closed
 
+    # ── internals ────────────────────────────────────────────────────
+
+    def _await_write(self, fut: concurrent.futures.Future) -> None:
+        """Block on *fut* in a write-executor thread.
+
+        Called by ``_WRITE_EXECUTOR``. If the event loop cannot flush the
+        frame within ``_WS_WRITE_TIMEOUT_S`` we log and let the transport
+        stay alive — the frame was already scheduled and will flush once
+        the loop breathes. Latching ``_closed`` here would permanently
+        silence live windows after a single slow write (the "subagent
+        window zero streaming" bug); ``_safe_send`` catches real socket
+        errors. This is upstream's keep-alive semantics (06-12).
+        """
+        try:
+            fut.result(timeout=_WS_WRITE_TIMEOUT_S)
+        except concurrent.futures.TimeoutError:
+            _log.warning(
+                "ws write slow (loop stalled >%ss) peer=%s — frame left in flight",
+                _WS_WRITE_TIMEOUT_S,
+                self._peer,
+            )
+        except Exception:
+            # _safe_send already logged + set self._closed.
+            pass
+
     async def _safe_send(self, line: str) -> None:
         try:
             await self._ws.send_text(line)
@@ -135,7 +186,9 @@ class WSTransport:
             self._closed = True
             _log.warning(
                 "ws send failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
+                self._peer,
+                type(exc).__name__,
+                exc,
             )
 
     def close(self) -> None:


### PR DESCRIPTION
## What does this PR do?

Replaces the synchronous `fut.result(timeout=10)` call in `WSTransport.write()` with a module-level `_WRITE_EXECUTOR` (2 threads) that offloads the blocking I/O completion wait. After this change, `write()` never blocks the calling thread — RPC pool workers return immediately after scheduling the send, and the dedicated write executor handles timeout detection independently.

### Architecture

```
Before:
  RPC worker → schedule on event loop → fut.result(timeout=10) ← BLOCKED up to 10s

After:
  RPC worker → schedule on event loop → _WRITE_EXECUTOR.submit() ← returns immediately
                                               │
                          ┌────────────────────┘
                          ▼
               _WRITE_EXECUTOR (2 threads, separate from RPC pool)
               └─ fut.result(timeout=10) → log warn on timeout (keep-alive)
```

### Why this matters

On Windows ProactorEventLoop under heavy tool usage (multiple concurrent sessions, 60s+ terminal calls), the event loop can be saturated to the point where `fut.result(timeout=10)` still times out — each timeout wastes an RPC pool worker for 10s and can cascade into WS disconnections (see #42938, #42942).

With this change:

- **RPC pool never blocked by I/O** — tool execution throughput is decoupled from WS write latency
- **Timeout detection preserved** — `_WRITE_EXECUTOR`'s `_await_write()` logs a warning on 10s timeout and lets the transport stay alive; the frame was already scheduled and will flush once the loop breathes. `_safe_send` still latches `_closed` on a real socket error (this resolves the "subagent window zero streaming" bug differently from a hard mark-dead: keep windows alive, let `_safe_send` catch actual errors).
- **2-thread overhead** — minimal; write completion monitoring is purely I/O-bound
- **Callers unaffected** — all existing callers of `write()` ignore the return value

### Re-rebase note (2026-06-13)

This PR was re-rebased onto `origin/main` at `7d183f649` (368 commits newer than the original base `92e8d84`). Resolution adopted: **keep `_WRITE_EXECUTOR` + accept upstream's "loop stalled, keep alive" semantics + keep 10s timeout** (no data supports 30s). All three existing ws tests pass, including `test_ws_write_loop_stall_does_not_latch_transport` which guards the keep-alive behavior.

### Related Issues

Fixes #42938, #42942

### Type of Change

- [x] Bug fix

### Changes Made

- `tui_gateway/ws.py`: Added `_WRITE_EXECUTOR` (module-level `ThreadPoolExecutor(max_workers=2)`)
- `tui_gateway/ws.py`: `WSTransport.write()` now submits to `_WRITE_EXECUTOR` instead of blocking
- `tui_gateway/ws.py`: Added `WSTransport._await_write()` for timeout-aware I/O completion monitoring (keep-alive on timeout)
- `tui_gateway/ws.py`: Updated docstrings to document the new architecture

### How to Test

1. Start Hermes Desktop on Windows
2. Execute a heavy multi-session workload (concurrent tool calls, long pip install, file operations)
3. Verify WS connections no longer drop with `ws write failed ... TimeoutError`
4. Verify timeout warning is logged but transport stays alive: block the event loop >10s and confirm no `_closed` latch (subagent window keeps streaming)

### Checklist

- [x] I've read the Contributing Guide
- [x] My commit follows Conventional Commits
- [x] I've checked for existing PRs
- [x] No new dependencies
- [x] No API changes
- [x] I've tested on my platform: Windows 11 (ProactorEventLoop)
