### PR TITLE
fix(cli): respect explicit terminal.cwd for local backend

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -570,15 +570,17 @@ def load_cli_config() -> Dict[str, Any]:
     
     # CWD resolution for CLI/TUI. The gateway has its own config bridge in
     # gateway/run.py but may lazily import cli.py (triggering this code).
-    # Local backend: always os.getcwd(). Use `cd /dir && hermes` to control it.
+    # Local backend with placeholder: resolve to os.getcwd().
+    # Local backend with explicit path: keep as-is.
     # Non-local with placeholder: pop so terminal_tool uses its per-backend default.
     # Non-local with explicit path: keep as-is.
     _CWD_PLACEHOLDERS = (".", "auto", "cwd")
     effective_backend = terminal_config.get("env_type", "local")
 
     if effective_backend == "local":
-        terminal_config["cwd"] = os.getcwd()
-        defaults["terminal"]["cwd"] = terminal_config["cwd"]
+        if terminal_config.get("cwd") in _CWD_PLACEHOLDERS or not terminal_config.get("cwd"):
+            terminal_config["cwd"] = os.getcwd()
+            defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)
     

--- a/tests/cli/test_cwd_env_respect.py
+++ b/tests/cli/test_cwd_env_respect.py
@@ -1,22 +1,22 @@
 """Tests for CLI/TUI CWD resolution in load_cli_config().
 
 Rules:
-- Local backend CLI/TUI: always os.getcwd(), ignoring config and inherited env.
+- Local backend with placeholder: resolve to os.getcwd().
+- Local backend with explicit path: keep as-is.
 - Non-local with placeholder: pop cwd for backend default.
 - Non-local with explicit path: keep as-is.
 """
 
 
-_CWD_PLACEHOLDERS = (".", "auto", "cwd")
-
-
 def _resolve_cwd(terminal_config: dict, defaults: dict, env: dict):
     """Mirror the CWD resolution logic from cli.py load_cli_config()."""
+    _CWD_PLACEHOLDERS = (".", "auto", "cwd")
     effective_backend = terminal_config.get("env_type", "local")
 
     if effective_backend == "local":
-        terminal_config["cwd"] = "/fake/getcwd"
-        defaults["terminal"]["cwd"] = terminal_config["cwd"]
+        if terminal_config.get("cwd") in _CWD_PLACEHOLDERS or not terminal_config.get("cwd"):
+            terminal_config["cwd"] = "/fake/getcwd"
+            defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)
 
@@ -32,19 +32,19 @@ def _resolve_cwd(terminal_config: dict, defaults: dict, env: dict):
 
 
 class TestLocalBackendCli:
-    """Local backend always uses os.getcwd()."""
+    """Local backend respects explicit paths, resolves placeholders to os.getcwd()."""
 
-    def test_explicit_config_ignored(self):
+    def test_explicit_config_preserved(self):
         env = {}
         tc = {"cwd": "/explicit/path", "env_type": "local"}
         d = {"terminal": {"cwd": "/explicit/path"}}
-        assert _resolve_cwd(tc, d, env) == "/fake/getcwd"
+        assert _resolve_cwd(tc, d, env) == "/explicit/path"
 
-    def test_inherited_env_overwritten(self):
+    def test_inherited_env_preserved_with_explicit_config(self):
         env = {"TERMINAL_CWD": "/parent/hermes"}
         tc = {"cwd": "/home/user", "env_type": "local"}
         d = {"terminal": {"cwd": "/home/user"}}
-        assert _resolve_cwd(tc, d, env) == "/fake/getcwd"
+        assert _resolve_cwd(tc, d, env) == "/home/user"
 
     def test_placeholder_resolved(self):
         env = {}
@@ -56,6 +56,18 @@ class TestLocalBackendCli:
         env = {"TERMINAL_CWD": "/stale/value"}
         tc = {"cwd": ".", "env_type": "local"}
         d = {"terminal": {"cwd": "."}}
+        assert _resolve_cwd(tc, d, env) == "/fake/getcwd"
+
+    def test_empty_cwd_resolved(self):
+        env = {}
+        tc = {"cwd": "", "env_type": "local"}
+        d = {"terminal": {"cwd": ""}}
+        assert _resolve_cwd(tc, d, env) == "/fake/getcwd"
+
+    def test_missing_cwd_resolved(self):
+        env = {}
+        tc = {"env_type": "local"}
+        d = {"terminal": {}}
         assert _resolve_cwd(tc, d, env) == "/fake/getcwd"
 
 
@@ -91,9 +103,10 @@ class TestGatewayLazyImport:
         result = _resolve_cwd(tc, d, env)
         assert result == "/home/user/project"
 
-    def test_cli_overwrites_stale_env(self):
+    def test_cli_preserves_stale_env_with_explicit_config(self):
         env = {"TERMINAL_CWD": "/stale/from/dotenv"}
         tc = {"cwd": "/home/user", "env_type": "local"}
         d = {"terminal": {"cwd": "/home/user"}}
         result = _resolve_cwd(tc, d, env)
-        assert result == "/fake/getcwd"
+        # Explicit config path is preserved; CLI bridges it to env
+        assert result == "/home/user"


### PR DESCRIPTION
## What does this PR do?

Respects explicit `terminal.cwd` config values for the local backend instead of unconditionally overwriting them with `os.getcwd()`. Placeholder values (`.`, `auto`, `cwd`) and missing/empty cwd still resolve to the process launch directory, preserving the existing default behavior.

## Related Issue

Fixes #42961

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: Added placeholder check before overwriting `terminal.cwd` for local backend — explicit paths are now preserved
- `tests/cli/test_cwd_env_respect.py`: Updated test assertions to verify explicit paths are preserved; added edge-case tests for empty and missing cwd

## How to Test

1. Set `terminal.cwd` to an explicit path: `hermes config set terminal.cwd ~/Documents/MyProject`
2. Launch Hermes from a different directory (e.g., `cd /tmp && hermes`)
3. Start a new session and run `pwd` via the terminal tool
4. Observe: returns `~/Documents/MyProject`, not `/tmp`
5. Verify placeholder behavior: set `terminal.cwd` to `.` and confirm it resolves to the launch directory

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cli.py::load_cli_config()` (CWD resolution block, lines 570-583)
- Blast radius: LOW — isolated to terminal config initialization; no control flow changes to other modules
- Related patterns: `terminal.cwd` is bridged to `TERMINAL_CWD` env var for tool execution; non-local backends already respect explicit paths via the `elif` branch
