### PR TITLE
fix(desktop): prevent sidebar section header overlap

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -924,7 +924,12 @@ export function ChatSidebar({
             onTogglePin={pinSession}
             open={agentsOpen}
             pinned={false}
-            rootClassName="min-h-0 flex-1 p-0"
+            // Keep the flexible recents section at least as tall as its own
+            // header. With min-h-0, a short window plus fixed messaging/platform
+            // sections can squeeze this flex item below the header height; the
+            // visible header then bleeds into the following Discord/Telegram
+            // header and the two labels overlap.
+            rootClassName="min-h-[2.125rem] flex-1 p-0"
             sessions={displayAgentSessions}
             sortable={!showAllProfiles && agentSessions.length > 1}
             workingSessionIdSet={workingSessionIdSet}


### PR DESCRIPTION
## Summary

- Prevent the Desktop sidebar recents section from shrinking below its section header height
- Avoid visual overlap between the `SESSIONS` header and following messaging platform headers such as `DISCORD`

Fixes #42987

## Test Plan

- [x] `npm run type-check`
- [x] `npm run build`
- [x] `npx eslint src/app/chat/sidebar/index.tsx`
- [x] Browser DOM reproduction on macOS:
  - With the fix, `SESSIONS` and `DISCORD` headers are separated.
  - Forcing the recents section back to `min-height: 0` reproduces the overlap.

## Notes

I did not replace the installed macOS app bundle. This PR is intended to land the fix upstream so it arrives through the normal release/update path.
