### PR TITLE
fix(models): omit sampling params for claude-fable-5

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -77,16 +77,17 @@ ADAPTIVE_EFFORT_MAP = {
 # xhigh as a distinct level between high and max; older adaptive-thinking
 # models (4.6) reject it with a 400.  Keep this substring list in sync with
 # the Anthropic migration guide as new model families ship.
-_XHIGH_EFFORT_SUBSTRINGS = ("4-7", "4.7", "4-8", "4.8")
+_XHIGH_EFFORT_SUBSTRINGS = ("4-7", "4.7", "4-8", "4.8", "fable")
 
 # Models where extended thinking is deprecated/removed (4.6+ behavior: adaptive
 # is the only supported mode; 4.7 additionally forbids manual thinking entirely
 # and drops temperature/top_p/top_k).
-_ADAPTIVE_THINKING_SUBSTRINGS = ("4-6", "4.6", "4-7", "4.7", "4-8", "4.8")
+_ADAPTIVE_THINKING_SUBSTRINGS = ("4-6", "4.6", "4-7", "4.7", "4-8", "4.8", "fable")
 
 # Models where temperature/top_p/top_k return 400 if set to non-default values.
-# This is the Opus 4.7 contract; future 4.x+ models are expected to follow it.
-_NO_SAMPLING_PARAMS_SUBSTRINGS = ("4-7", "4.7", "4-8", "4.8")
+# This is the Opus 4.7 contract; Opus 4.8 and Fable 5 follow it (Fable 5
+# returns "`temperature` is deprecated for this model" if sent).
+_NO_SAMPLING_PARAMS_SUBSTRINGS = ("4-7", "4.7", "4-8", "4.8", "fable")
 _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
 
 # ── Max output token limits per Anthropic model ───────────────────────
@@ -94,6 +95,8 @@ _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
 # max_tokens as a mandatory field.  Previously we hardcoded 16384, which
 # starves thinking-enabled models (thinking tokens count toward the limit).
 _ANTHROPIC_OUTPUT_LIMITS = {
+    # Claude Fable 5
+    "claude-fable-5":    128_000,
     # Claude 4.8
     "claude-opus-4-8":   128_000,
     # Claude 4.7

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1188,6 +1188,8 @@ class TestBuildAnthropicKwargs:
         # params through its signature, we exercise the strip behavior by
         # calling the internal predicate directly.
         from agent.anthropic_adapter import _forbids_sampling_params
+        assert _forbids_sampling_params("claude-fable-5") is True
+        assert _forbids_sampling_params("anthropic/claude-fable-5") is True
         assert _forbids_sampling_params("claude-opus-4-8") is True
         assert _forbids_sampling_params("claude-opus-4-8-fast") is True
         assert _forbids_sampling_params("claude-opus-4-7") is True


### PR DESCRIPTION
## What

`claude-fable-5` was added to the curated model picker lists in #42979, but selecting it crashes every request: the API rejects it with `400 BadRequestError: \`temperature\` is deprecated for this model`, and the conversation loop exhausts its retries and gives up.

The cause is that the parameter-gating substring lists in `agent/anthropic_adapter.py` only match version-number patterns (`4-7`, `4.7`, `4-8`, `4.8`), so the new `fable` naming scheme slips past `_forbids_sampling_params()` and `temperature` gets sent.

## Why these three lists

Per Anthropic's docs, Fable 5 follows the full Opus 4.7+ request contract:

- `temperature`/`top_p`/`top_k` are removed (400 if sent) → added to `_NO_SAMPLING_PARAMS_SUBSTRINGS` — **this is the crash fix**
- adaptive thinking is the only on-mode (`budget_tokens` 400s) → added to `_ADAPTIVE_THINKING_SUBSTRINGS`
- `xhigh` effort is supported → added to `_XHIGH_EFFORT_SUBSTRINGS`

Also registered Fable 5's 128K output limit in `_ANTHROPIC_OUTPUT_LIMITS`.

Matching on `"fable"` covers both `claude-fable-5` and `anthropic/claude-fable-5` (OpenRouter form).

## How to test

1. `hermes config set model.default claude-fable-5` (or pick it from `/model` — it's in the curated list since #42979)
2. Send the agent any message.
3. **Before:** every request fails with `anthropic.BadRequestError: 400 … \`temperature\` is deprecated for this model`, followed by `Invalid API response (retry N/3)` until the loop gives up.
4. **After:** responses come back normally.

Unit coverage added in `tests/agent/test_anthropic_adapter.py::test_forbids_sampling_params` (`claude-fable-5` and `anthropic/claude-fable-5` both gate as True).

## Platforms tested

macOS (Apple Silicon, Python 3.11) — reproduced the crash live against the Anthropic API, applied the patch, and verified the gateway runs clean on `claude-fable-5`. The change is pure Python string matching, no platform-specific surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)