### PR TITLE
feat(commands): support description overrides via config.yaml

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -378,6 +378,24 @@ def should_bypass_active_session(command_name: str | None) -> bool:
     return resolve_command(command_name) is not None if command_name else False
 
 
+def _resolve_description_overrides() -> dict[str, str]:
+    """Return command description overrides from ``commands.descriptions`` in config.
+
+    Users can customise slash-command descriptions (e.g. for locale
+    preferences) without modifying source code.  Returns an empty dict on
+    any error so callers degrade gracefully.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        descs = cfg.get("commands", {}).get("descriptions")
+        if isinstance(descs, dict):
+            return {str(k): str(v) for k, v in descs.items()}
+    except Exception:
+        pass
+    return {}
+
+
 def _resolve_config_gates() -> set[str]:
     """Return canonical names of commands whose ``gateway_config_gate`` is truthy.
 
@@ -431,6 +449,7 @@ def _requires_argument(args_hint: str) -> bool:
 def gateway_help_lines() -> list[str]:
     """Generate gateway help text lines from the registry."""
     overrides = _resolve_config_gates()
+    desc_overrides = _resolve_description_overrides()
     lines: list[str] = []
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
@@ -443,7 +462,8 @@ def gateway_help_lines() -> list[str]:
                 continue
             alias_parts.append(f"`/{a}`")
         alias_note = f" (alias: {', '.join(alias_parts)})" if alias_parts else ""
-        lines.append(f"`/{cmd.name}{args}` -- {cmd.description}{alias_note}")
+        desc = desc_overrides.get(cmd.name, cmd.description)
+        lines.append(f"`/{cmd.name}{args}` -- {desc}{alias_note}")
     return lines
 
 
@@ -494,6 +514,7 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     because plugins may not provide a no-arg usage fallback.
     """
     overrides = _resolve_config_gates()
+    desc_overrides = _resolve_description_overrides()
     result: list[tuple[str, str]] = []
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
@@ -503,7 +524,8 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
         # the menu hurts discoverability (issue #24312).
         tg_name = _sanitize_telegram_name(cmd.name)
         if tg_name:
-            result.append((tg_name, cmd.description))
+            desc = desc_overrides.get(cmd.name, cmd.description)
+            result.append((tg_name, desc))
     for name, description, args_hint in _iter_plugin_command_entries():
         if _requires_argument(args_hint):
             continue

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2439,6 +2439,13 @@ DEFAULT_CONFIG = {
     "paste_collapse_char_threshold": 2000,
 
 
+    # Command description overrides — allow users to customise slash-command
+    # descriptions in their preferred language without modifying source code.
+    # Example: {"new": "开始新会话", "help": "显示帮助信息"}
+    "commands": {
+        "descriptions": {},  # dict mapping canonical command name -> custom description
+    },
+
     # Config schema version - bump this when adding new required fields
     "_config_version": 28,
 }

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -190,6 +190,7 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("display", "show_reasoning"),
         ("privacy", "redact_pii"),
         ("tts", "provider"),
+        ("commands", "descriptions"),
     ]
 
     for section, key in interesting_paths:

--- a/tests/hermes_cli/test_command_description_override.py
+++ b/tests/hermes_cli/test_command_description_override.py
@@ -1,0 +1,109 @@
+"""Tests for command description overrides via config.yaml (issue #13107)."""
+
+import pytest
+from unittest.mock import patch
+
+
+class TestResolveDescriptionOverrides:
+    """Tests for _resolve_description_overrides()."""
+
+    def test_returns_empty_dict_when_no_config(self):
+        from hermes_cli.commands import _resolve_description_overrides
+        with patch("hermes_cli.config.read_raw_config", side_effect=Exception("no config")):
+            result = _resolve_description_overrides()
+            assert result == {}
+
+    def test_returns_overrides_from_config(self):
+        from hermes_cli.commands import _resolve_description_overrides
+        with patch("hermes_cli.config.read_raw_config", return_value={
+            "commands": {"descriptions": {"new": "开始新会话", "help": "帮助"}}
+        }):
+            result = _resolve_description_overrides()
+            assert result == {"new": "开始新会话", "help": "帮助"}
+
+    def test_returns_empty_when_descriptions_is_none(self):
+        from hermes_cli.commands import _resolve_description_overrides
+        with patch("hermes_cli.config.read_raw_config", return_value={
+            "commands": {"descriptions": None}
+        }):
+            result = _resolve_description_overrides()
+            assert result == {}
+
+    def test_returns_empty_when_commands_missing(self):
+        from hermes_cli.commands import _resolve_description_overrides
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            result = _resolve_description_overrides()
+            assert result == {}
+
+    def test_coerces_non_string_values(self):
+        from hermes_cli.commands import _resolve_description_overrides
+        with patch("hermes_cli.config.read_raw_config", return_value={
+            "commands": {"descriptions": {42: True}}
+        }):
+            result = _resolve_description_overrides()
+            assert result == {"42": "True"}
+
+
+class TestTelegramBotCommandsOverrides:
+    """Tests for telegram_bot_commands() with description overrides."""
+
+    def test_override_appears_in_telegram_commands(self):
+        from hermes_cli.commands import telegram_bot_commands
+
+        with patch("hermes_cli.config.read_raw_config", return_value={
+            "commands": {"descriptions": {"new": "开始新会话"}}
+        }):
+            cmds = telegram_bot_commands()
+            new_entry = next(((n, d) for n, d in cmds if n == "new"), None)
+            assert new_entry is not None
+            assert new_entry[1] == "开始新会话"
+
+    def test_default_description_when_no_override(self):
+        from hermes_cli.commands import telegram_bot_commands, COMMAND_REGISTRY
+
+        default_desc = next(c.description for c in COMMAND_REGISTRY if c.name == "help")
+
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            cmds = telegram_bot_commands()
+            help_entry = next(((n, d) for n, d in cmds if n == "help"), None)
+            assert help_entry is not None
+            assert help_entry[1] == default_desc
+
+    def test_override_does_not_affect_unrelated_commands(self):
+        from hermes_cli.commands import telegram_bot_commands, COMMAND_REGISTRY
+
+        default_help_desc = next(c.description for c in COMMAND_REGISTRY if c.name == "help")
+
+        with patch("hermes_cli.config.read_raw_config", return_value={
+            "commands": {"descriptions": {"new": "custom new"}}
+        }):
+            cmds = telegram_bot_commands()
+            help_entry = next(((n, d) for n, d in cmds if n == "help"), None)
+            assert help_entry is not None
+            assert help_entry[1] == default_help_desc
+
+
+class TestGatewayHelpLinesOverrides:
+    """Tests for gateway_help_lines() with description overrides."""
+
+    def test_override_appears_in_help_lines(self):
+        from hermes_cli.commands import gateway_help_lines
+
+        with patch("hermes_cli.config.read_raw_config", return_value={
+            "commands": {"descriptions": {"new": "开始新会话"}}
+        }):
+            lines = gateway_help_lines()
+            new_line = next((l for l in lines if l.startswith("`/new")), None)
+            assert new_line is not None
+            assert "开始新会话" in new_line
+
+    def test_default_description_in_help_when_no_override(self):
+        from hermes_cli.commands import gateway_help_lines, COMMAND_REGISTRY
+
+        default_desc = next(c.description for c in COMMAND_REGISTRY if c.name == "help")
+
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            lines = gateway_help_lines()
+            help_line = next((l for l in lines if l.startswith("`/help")), None)
+            assert help_line is not None
+            assert default_desc in help_line


### PR DESCRIPTION
## Problem

All slash-command descriptions in COMMAND_REGISTRY are hardcoded in English. When platforms like Telegram or Discord register bot commands, all users see English descriptions regardless of locale. Users who prefer other languages cannot customise these descriptions without modifying source code — which doesn't survive upgrades.

## Solution

Add a `commands.descriptions` config section that allows users to override slash-command descriptions by canonical name. Overrides apply to:

- **Telegram BotCommand menu** — `telegram_bot_commands()` reads overrides when building `(name, description)` pairs
- **Gateway /help output** — `gateway_help_lines()` reads overrides when generating help text lines

Config example:

```yaml
commands:
  descriptions:
    new: "开始新会话"
    help: "显示帮助信息"
    background: "在后台运行任务"
```

### Changes

| File | Change |
|------|--------|
| `hermes_cli/config.py` | Add `commands.descriptions` to DEFAULT_CONFIG |
| `hermes_cli/commands.py` | Add `_resolve_description_overrides()` helper; wire into `telegram_bot_commands()` and `gateway_help_lines()` |
| `hermes_cli/dump.py` | Add `commands.descriptions` to `interesting_paths` for `hermes config display` |
| `tests/hermes_cli/test_command_description_override.py` | 10 tests: helper, Telegram override, help override, fallback, coercion |

### Design decisions

- **Local import pattern** — `read_raw_config` is imported locally in the helper, matching the existing `_resolve_config_gates()` pattern. Mock target is the definition site (`hermes_cli.config.read_raw_config`).
- **Graceful fallback** — invalid config (non-dict, missing section) returns empty dict; callers degrade to default descriptions.
- **Per-command granularity** — only commands with explicit overrides are affected; all others keep their hardcoded English descriptions.

### Test results

```
10 passed in 0.74s
144 passed in 3.85s  (existing test_commands.py — zero regressions)
```

Closes #13107
