### PR TITLE
Handle memory quota overflow retries with store-state guard

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1293,7 +1293,17 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     # Memory: distinguish "store full" from real errors.
     if tool_name == "memory":
         if isinstance(data, dict):
-            if data.get("success") is False and "exceed the limit" in data.get("error", ""):
+            error_details = data.get("error_details")
+            structured_quota = (
+                data.get("error_code") == "memory_quota_exceeded"
+                or (
+                    isinstance(error_details, dict)
+                    and error_details.get("code") == "memory_quota_exceeded"
+                )
+            )
+            if data.get("success") is False and (
+                structured_quota or "exceed the limit" in data.get("error", "")
+            ):
                 return True, " [full]"
 
     # Structured error in JSON result (any tool that surfaces {"error": ...}).
@@ -1506,5 +1516,4 @@ def get_cute_tool_message(
 # =========================================================================
 # Honcho session line (one-liner with clickable OSC 8 hyperlink)
 # =========================================================================
-
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -165,6 +165,24 @@ def _ra():
     return run_agent
 
 
+def _memory_current_state_token(agent, function_name: str, function_args: dict) -> str | None:
+    if function_name != "memory":
+        return None
+    memory_store = getattr(agent, "_memory_store", None)
+    if memory_store is None or not hasattr(memory_store, "stat"):
+        return None
+    store = function_args.get("store") or function_args.get("target") or "memory"
+    try:
+        stat = memory_store.stat(store)
+    except Exception:
+        return None
+    if isinstance(stat, dict):
+        token = stat.get("store_state_token")
+        if isinstance(token, str):
+            return token
+    return None
+
+
 def _is_interpreter_shutdown_submit_error(exc: RuntimeError) -> bool:
     return "cannot schedule new futures after interpreter shutdown" in str(exc)
 
@@ -440,7 +458,11 @@ def _run_agent_tool_execution_middleware(
         guardrail_decision = None
         if block_message is None:
             guardrail_decision = agent._tool_guardrails.before_call(
-                function_name, final_args
+                function_name,
+                final_args,
+                current_store_state_token=_memory_current_state_token(
+                    agent, function_name, final_args
+                ),
             )
             if guardrail_decision.allows_execution:
                 guardrail_decision = None

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -176,9 +176,12 @@ def _memory_current_state_token(agent, function_name: str, function_args: dict) 
         stat = memory_store.stat(store)
     except Exception:
         return None
-    if isinstance(stat, dict):
+    # Only a successful, authentic token may refresh observed store state.
+    # Failed/empty fabricated stats must return None so before_call keeps the
+    # previously observed token (and any armed same-state skip).
+    if isinstance(stat, dict) and stat.get("success") is True:
         token = stat.get("store_state_token")
-        if isinstance(token, str):
+        if isinstance(token, str) and token:
             return token
     return None
 

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -194,7 +194,7 @@ class ToolCallSignature:
 class ToolGuardrailDecision:
     """Decision returned by the tool-call guardrail controller."""
 
-    action: str = "allow"  # allow | warn | block | halt
+    action: str = "allow"  # allow | warn | skip | block | halt
     code: str = "allow"
     message: str = ""
     tool_name: str = ""
@@ -235,6 +235,72 @@ def canonical_tool_args(args: Mapping[str, Any]) -> str:
     )
 
 
+def _canonical_memory_text(value: Any) -> dict[str, Any]:
+    normalized = str(value).strip()
+    return {"hash": _sha256(normalized), "chars": len(normalized)}
+
+
+def _canonical_memory_operation(operation: Any) -> dict[str, Any]:
+    if not isinstance(operation, Mapping):
+        return {"invalid_type": type(operation).__name__}
+    normalized: dict[str, Any] = {
+        "action": str(operation.get("action") or "").strip(),
+    }
+    for field in ("content", "old_text"):
+        if field in operation and operation.get(field) is not None:
+            normalized[field] = _canonical_memory_text(operation.get(field))
+    if operation.get("entry_id") is not None:
+        normalized["entry_id"] = str(operation.get("entry_id"))
+    return normalized
+
+
+def canonical_memory_args(args: Mapping[str, Any]) -> str:
+    """Canonicalize memory writes without retaining raw memory content."""
+    normalized: dict[str, Any] = {
+        "store": str(args.get("store") or args.get("target") or "memory").strip(),
+    }
+    if args.get("action") is not None:
+        normalized["action"] = str(args.get("action") or "").strip()
+    for field in ("content", "old_text"):
+        if field in args and args.get(field) is not None:
+            normalized[field] = _canonical_memory_text(args.get(field))
+    if args.get("entry_id") is not None:
+        normalized["entry_id"] = str(args.get("entry_id"))
+    operations = args.get("operations")
+    if isinstance(operations, list):
+        normalized["operations"] = [
+            _canonical_memory_operation(operation) for operation in operations
+        ]
+    return canonical_tool_args(normalized)
+
+
+def tool_call_signature(
+    tool_name: str, args: Mapping[str, Any] | None
+) -> ToolCallSignature:
+    coerced = _coerce_args(args)
+    if tool_name == "memory":
+        return ToolCallSignature(
+            tool_name=tool_name,
+            args_hash=_sha256(canonical_memory_args(coerced)),
+        )
+    return ToolCallSignature.from_call(tool_name, coerced)
+
+
+def _memory_store_from_args(args: Mapping[str, Any]) -> str:
+    return str(args.get("store") or args.get("target") or "memory")
+
+
+def _memory_quota_error(data: Mapping[str, Any]) -> bool:
+    details = data.get("error_details")
+    return (
+        data.get("error_code") == "memory_quota_exceeded"
+        or (
+            isinstance(details, Mapping)
+            and details.get("code") == "memory_quota_exceeded"
+        )
+    )
+
+
 def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]:
     """Safety-fallback classifier used only when callers don't pass ``failed``.
 
@@ -260,7 +326,10 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
     if tool_name == "memory":
         data = safe_json_loads(result)
         if isinstance(data, dict):
-            if data.get("success") is False and "exceed the limit" in data.get("error", ""):
+            if data.get("success") is False and (
+                _memory_quota_error(data)
+                or "exceed the limit" in data.get("error", "")
+            ):
                 return True, " [full]"
 
     lower = result[:500].lower()
@@ -281,6 +350,10 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._memory_quota_failures: dict[
+            tuple[ToolCallSignature, str, str], ToolGuardrailDecision
+        ] = {}
+        self._observed_memory_store_states: dict[str, str] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
         # Per-turn runaway-loop cap counters. Reset every turn (this method
         # runs at the start of each run_conversation), so the caps bound a
@@ -292,8 +365,15 @@ class ToolCallGuardrailController:
     def halt_decision(self) -> ToolGuardrailDecision | None:
         return self._halt_decision
 
-    def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
-        signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
+    def before_call(
+        self,
+        tool_name: str,
+        args: Mapping[str, Any] | None,
+        *,
+        current_store_state_token: str | None = None,
+    ) -> ToolGuardrailDecision:
+        args = _coerce_args(args)
+        signature = tool_call_signature(tool_name, args)
 
         # ── Per-turn runaway-loop caps ──────────────────────────────────
         # These are hard ceilings on how many times a runaway-prone tool may
@@ -301,10 +381,32 @@ class ToolCallGuardrailController:
         # of hard_stop_enabled (which only governs the per-turn loop detector).
         # We block BEFORE the call runs once the count is already at the cap,
         # then increment for an allowed call so the (cap+1)-th is refused.
-        cap_block = self._check_loop_cap(tool_name, _coerce_args(args), signature)
+        cap_block = self._check_loop_cap(tool_name, args, signature)
         if cap_block is not None:
             return cap_block
 
+        if tool_name == "memory":
+            store = _memory_store_from_args(args)
+            if current_store_state_token is not None:
+                self._observed_memory_store_states[store] = current_store_state_token
+            observed_token = self._observed_memory_store_states.get(store)
+            if observed_token is not None:
+                previous = self._memory_quota_failures.get(
+                    (signature, store, observed_token)
+                )
+                if previous is not None:
+                    return ToolGuardrailDecision(
+                        action="skip",
+                        code=previous.code,
+                        message=(
+                            "This memory write already exceeded quota for the current "
+                            "store state. Remove memory, shorten the write, or wait for "
+                            "the store state to change before retrying."
+                        ),
+                        tool_name=tool_name,
+                        count=previous.count,
+                        signature=signature,
+                    )
         if not self.config.hard_stop_enabled:
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -356,7 +458,41 @@ class ToolCallGuardrailController:
         failed: bool | None = None,
     ) -> ToolGuardrailDecision:
         args = _coerce_args(args)
-        signature = ToolCallSignature.from_call(tool_name, args)
+        signature = tool_call_signature(tool_name, args)
+        data = safe_json_loads(result or "")
+        if (
+            tool_name == "memory"
+            and isinstance(data, dict)
+            and data.get("success") is False
+            and _memory_quota_error(data)
+        ):
+            args_store = _memory_store_from_args(args)
+            store = str(data.get("store") or data.get("target") or args_store)
+            token = str(
+                data.get("store_state_token")
+                or self._observed_memory_store_states.get(store)
+                or ""
+            )
+            if token:
+                self._observed_memory_store_states[store] = token
+                self._observed_memory_store_states[args_store] = token
+            decision = ToolGuardrailDecision(
+                action="warn",
+                code="memory_quota_exceeded_non_retryable",
+                message=(
+                    "Shorten the memory content, remove existing memory first, "
+                    "or skip the write. Retrying this memory call unchanged cannot "
+                    "succeed while the store state is unchanged."
+                ),
+                tool_name=tool_name,
+                count=1,
+                signature=signature,
+            )
+            if token:
+                self._memory_quota_failures[(signature, store, token)] = decision
+                self._memory_quota_failures[(signature, args_store, token)] = decision
+            self._no_progress.pop(signature, None)
+            return decision
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
 
@@ -408,6 +544,16 @@ class ToolCallGuardrailController:
                 )
 
             return ToolGuardrailDecision(tool_name=tool_name, count=exact_count, signature=signature)
+
+        if tool_name == "memory" and isinstance(data, dict):
+            store = str(
+                data.get("store")
+                or data.get("target")
+                or _memory_store_from_args(args)
+            )
+            token = data.get("store_state_token")
+            if token is not None:
+                self._observed_memory_store_states[store] = str(token)
 
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -67,6 +67,15 @@ class TestDetectToolFailureMemory:
         result = json.dumps({"success": False, "error": "would exceed the limit"})
         assert _detect_tool_failure("memory", result) == (True, " [full]")
 
+    def test_structured_memory_quota_error_returns_full_suffix(self):
+        result = json.dumps({
+            "success": False,
+            "error": "Memory quota rejected this write.",
+            "error_code": "memory_quota_exceeded",
+            "error_details": {"code": "memory_quota_exceeded", "operation": "batch"},
+        })
+        assert _detect_tool_failure("memory", result) == (True, " [full]")
+
     def test_memory_other_error_returns_specific_message(self):
         # An error that's NOT a "full" overflow falls through to the
         # structured-error path and surfaces the actual message.

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -11,6 +11,20 @@ from agent.tool_guardrails import (
 )
 
 
+def _memory_quota_result(*, store_state_token: str = "opaque:A", operation: str = "batch"):
+    return json.dumps({
+        "success": False,
+        "store": "memory",
+        "store_state_token": store_state_token,
+        "error": "Memory quota rejected this write.",
+        "error_code": "memory_quota_exceeded",
+        "error_details": {
+            "code": "memory_quota_exceeded",
+            "operation": operation,
+        },
+    })
+
+
 def test_tool_call_signature_hashes_canonical_nested_unicode_args_without_exposing_raw_args():
     args_a = {
         "z": [{"β": "☤", "a": 1}],
@@ -79,6 +93,100 @@ def test_default_repeated_identical_failed_call_warns_without_blocking():
     assert {d.code for d in decisions[1:]} == {"repeated_exact_failure_warning"}
     assert controller.before_call("web_search", args).action == "allow"
     assert controller.halt_decision is None
+
+
+def test_memory_quota_failure_skips_identical_batch_under_same_store_state():
+    controller = ToolCallGuardrailController()
+    args = {
+        "target": "memory",
+        "operations": [
+            {"action": "remove", "old_text": "obsolete"},
+            {"action": "add", "content": "replacement fact"},
+        ],
+    }
+
+    assert controller.before_call(
+        "memory", args, current_store_state_token="opaque:A"
+    ).action == "allow"
+    first = controller.after_call("memory", args, _memory_quota_result(), failed=True)
+    skipped = controller.before_call(
+        "memory", args, current_store_state_token="opaque:A"
+    )
+
+    assert first.action == "warn"
+    assert first.code == "memory_quota_exceeded_non_retryable"
+    assert skipped.action == "skip"
+    assert skipped.code == "memory_quota_exceeded_non_retryable"
+    assert skipped.allows_execution is False
+    assert skipped.should_halt is False
+
+
+def test_memory_quota_batch_retry_allows_changed_operations_or_store_state():
+    controller = ToolCallGuardrailController()
+    original = {
+        "target": "memory",
+        "operations": [{"action": "add", "content": "oversized fact"}],
+    }
+    changed = {
+        "target": "memory",
+        "operations": [{"action": "add", "content": "short"}],
+    }
+
+    controller.before_call("memory", original, current_store_state_token="opaque:A")
+    controller.after_call("memory", original, _memory_quota_result(), failed=True)
+
+    assert controller.before_call(
+        "memory", changed, current_store_state_token="opaque:A"
+    ).action == "allow"
+    assert controller.before_call(
+        "memory", original, current_store_state_token="opaque:B"
+    ).action == "allow"
+
+
+def test_memory_batch_signature_normalizes_key_order_without_exposing_content():
+    controller = ToolCallGuardrailController()
+    first_args = {
+        "target": "memory",
+        "operations": [{"action": "add", "content": "private fact   "}],
+    }
+    reordered_args = {
+        "operations": [{"content": "private fact", "action": "add"}],
+        "target": "memory",
+    }
+
+    controller.before_call("memory", first_args, current_store_state_token="opaque:A")
+    decision = controller.after_call(
+        "memory", first_args, _memory_quota_result(), failed=True
+    )
+    skipped = controller.before_call(
+        "memory", reordered_args, current_store_state_token="opaque:A"
+    )
+
+    assert skipped.action == "skip"
+    assert "private fact" not in json.dumps(decision.to_metadata())
+
+
+def test_memory_batch_retry_allows_unicode_variant_with_different_serialized_length():
+    controller = ToolCallGuardrailController()
+    decomposed = {
+        "target": "memory",
+        "operations": [{"action": "add", "content": "e\u0301"}],
+    }
+    composed = {
+        "target": "memory",
+        "operations": [{"action": "add", "content": "é"}],
+    }
+
+    controller.before_call("memory", decomposed, current_store_state_token="opaque:A")
+    controller.after_call("memory", decomposed, _memory_quota_result(), failed=True)
+
+    assert controller.before_call(
+        "memory", composed, current_store_state_token="opaque:A"
+    ).action == "allow"
+
+
+def test_structured_memory_quota_failure_classifier_uses_error_code():
+    assert classify_tool_failure("memory", _memory_quota_result()) == (True, " [full]")
 
 
 def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution():

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -189,6 +189,24 @@ def test_structured_memory_quota_failure_classifier_uses_error_code():
     assert classify_tool_failure("memory", _memory_quota_result()) == (True, " [full]")
 
 
+def test_legacy_memory_overflow_string_does_not_arm_same_state_skip():
+    controller = ToolCallGuardrailController()
+    args = {"target": "memory", "action": "add", "content": "too big"}
+    legacy = json.dumps({
+        "success": False,
+        "error": "Memory at 40/50 chars. Adding this entry would exceed the limit.",
+    })
+
+    assert controller.before_call(
+        "memory", args, current_store_state_token="opaque:A"
+    ).action == "allow"
+    decision = controller.after_call("memory", args, legacy, failed=True)
+    assert decision.code != "memory_quota_exceeded_non_retryable"
+    assert controller.before_call(
+        "memory", args, current_store_state_token="opaque:A"
+    ).action == "allow"
+
+
 def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -207,6 +207,21 @@ def test_legacy_memory_overflow_string_does_not_arm_same_state_skip():
     ).action == "allow"
 
 
+def test_none_current_token_keeps_armed_same_state_skip():
+    """A failed stat must not clear observed state or disarm the firebreak."""
+    controller = ToolCallGuardrailController()
+    args = {"target": "memory", "action": "add", "content": "too big"}
+
+    controller.before_call("memory", args, current_store_state_token="opaque:A")
+    controller.after_call("memory", args, _memory_quota_result(), failed=True)
+
+    skipped = controller.before_call(
+        "memory", args, current_store_state_token=None
+    )
+    assert skipped.action == "skip"
+    assert skipped.code == "memory_quota_exceeded_non_retryable"
+
+
 def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -18,6 +18,15 @@ class _FakeMemoryStore:
         return {"success": True, "store": target, "store_state_token": self.token}
 
 
+class _FailingMemoryStore:
+    def stat(self, target: str):
+        return {
+            "success": False,
+            "store": target,
+            "error": f"Could not read {target}",
+        }
+
+
 def _make_tool_defs(*names: str) -> list[dict]:
     return [
         {
@@ -372,6 +381,15 @@ def test_sequential_memory_call_passes_current_store_state_token_to_guardrail():
     before_call.assert_called_once_with(
         "memory", args, current_store_state_token="opaque:seq"
     )
+
+
+def test_failed_memory_stat_passes_none_token_without_fabricating_empty_state():
+    from agent.tool_executor import _memory_current_state_token
+
+    agent = SimpleNamespace(_memory_store=_FailingMemoryStore())
+    assert _memory_current_state_token(
+        agent, "memory", {"target": "memory", "action": "add", "content": "x"}
+    ) is None
 
 
 def test_concurrent_memory_call_passes_current_store_state_token_to_guardrail():

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -8,6 +8,16 @@ from unittest.mock import MagicMock, patch
 from run_agent import AIAgent
 
 
+class _FakeMemoryStore:
+    def __init__(self, token: str):
+        self.token = token
+        self.stat_targets = []
+
+    def stat(self, target: str):
+        self.stat_targets.append(target)
+        return {"success": True, "store": target, "store_state_token": self.token}
+
+
 def _make_tool_defs(*names: str) -> list[dict]:
     return [
         {
@@ -339,6 +349,81 @@ def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
     mock_hfc.assert_not_called()
     assert "plugin policy" in messages[0]["content"]
     assert agent._tool_guardrails.before_call("web_search", args).action == "allow"
+
+
+def test_sequential_memory_call_passes_current_store_state_token_to_guardrail():
+    agent = _make_agent("memory")
+    agent._memory_store = _FakeMemoryStore("opaque:seq")
+    before_call = MagicMock(wraps=agent._tool_guardrails.before_call)
+    agent._tool_guardrails.before_call = before_call
+    args = {
+        "target": "memory",
+        "operations": [{"action": "add", "content": "hello"}],
+    }
+    tc = _mock_tool_call("memory", json.dumps(args), "c-memory-seq")
+    messages = []
+
+    with patch("tools.memory_tool.memory_tool", return_value=json.dumps({"success": True})):
+        agent._execute_tool_calls_sequential(
+            SimpleNamespace(content="", tool_calls=[tc]), messages, "task-1"
+        )
+
+    assert agent._memory_store.stat_targets == ["memory"]
+    before_call.assert_called_once_with(
+        "memory", args, current_store_state_token="opaque:seq"
+    )
+
+
+def test_concurrent_memory_call_passes_current_store_state_token_to_guardrail():
+    agent = _make_agent("memory")
+    agent._memory_store = _FakeMemoryStore("opaque:conc")
+    before_call = MagicMock(wraps=agent._tool_guardrails.before_call)
+    agent._tool_guardrails.before_call = before_call
+    args = {"store": "user", "action": "add", "content": "hello"}
+    tc = _mock_tool_call("memory", json.dumps(args), "c-memory-conc")
+    messages = []
+
+    with patch.object(agent, "_invoke_tool", return_value=json.dumps({"success": True})):
+        agent._execute_tool_calls_concurrent(
+            SimpleNamespace(content="", tool_calls=[tc]), messages, "task-1"
+        )
+
+    assert agent._memory_store.stat_targets == ["user"]
+    before_call.assert_called_once_with(
+        "memory", args, current_store_state_token="opaque:conc"
+    )
+
+
+def test_same_state_memory_quota_retry_is_skipped_without_halting():
+    agent = _make_agent("memory")
+    agent._memory_store = _FakeMemoryStore("opaque:A")
+    args = {
+        "target": "memory",
+        "operations": [{"action": "add", "content": "oversized fact"}],
+    }
+    quota_result = json.dumps({
+        "success": False,
+        "store": "memory",
+        "store_state_token": "opaque:A",
+        "error": "Memory quota rejected this write.",
+        "error_code": "memory_quota_exceeded",
+        "error_details": {"code": "memory_quota_exceeded", "operation": "batch"},
+    })
+    agent._tool_guardrails.before_call(
+        "memory", args, current_store_state_token="opaque:A"
+    )
+    agent._tool_guardrails.after_call("memory", args, quota_result, failed=True)
+    tc = _mock_tool_call("memory", json.dumps(args), "c-memory-skip")
+    messages = []
+
+    with patch("tools.memory_tool.memory_tool", return_value="SHOULD_NOT_RUN") as memory_call:
+        agent._execute_tool_calls_sequential(
+            SimpleNamespace(content="", tool_calls=[tc]), messages, "task-1"
+        )
+
+    memory_call.assert_not_called()
+    assert "memory_quota_exceeded_non_retryable" in messages[0]["content"]
+    assert agent._tool_guardrail_halt_decision is None
 
 
 def test_default_run_conversation_warns_without_guardrail_halt():

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -248,9 +248,9 @@ def test_relay_rewrite_precedes_sequential_policy_approval_checkpoint_and_dispat
 
     original_before_call = agent._tool_guardrails.before_call
 
-    def observe_guardrail(name, args):
+    def observe_guardrail(name, args, **kwargs):
         observed["guardrail"].append((name, dict(args)))
-        return original_before_call(name, args)
+        return original_before_call(name, args, **kwargs)
 
     def relay_execute(name, args, callback, **kwargs):
         del name, args, kwargs

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -174,6 +174,24 @@ class TestMemoryQuotaMetadata:
         assert composed["usage"]["current_chars"] == 1
         assert decomposed["store_state_token"] != composed["store_state_token"]
 
+    def test_stat_unreadable_file_returns_error_without_state_token(self, store, monkeypatch):
+        store.add("memory", "entry one")
+        path = store._path_for("memory")
+        real = Path.read_text
+
+        def flaky(self, *a, **k):
+            if self == path:
+                raise OSError("transient: file temporarily unavailable")
+            return real(self, *a, **k)
+
+        monkeypatch.setattr(Path, "read_text", flaky)
+        result = store.stat("memory")
+
+        assert result["success"] is False
+        assert "store_state_token" not in result
+        assert "Could not read" in result["error"]
+        assert result["store"] == "memory"
+
     def test_success_response_keeps_terminal_contract_with_store_state(self, store):
         result = store.add("memory", "entry one")
 

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -143,6 +143,99 @@ class TestMemoryStoreAdd:
         assert "Blocked" in result["error"]
 
 
+class TestMemoryQuotaMetadata:
+    def test_stat_reports_opaque_store_state_without_exposing_entries(self, store):
+        store.add("memory", "entry one")
+
+        first = store.stat("memory")
+        repeated = store.stat("memory")
+
+        assert first["success"] is True
+        assert first["store"] == "memory"
+        assert first["store_state_token"].startswith("opaque:")
+        assert repeated["store_state_token"] == first["store_state_token"]
+        assert "entries" not in first
+        assert first["usage"] == {
+            "current_chars": len("entry one"),
+            "limit_chars": store.memory_char_limit,
+            "remaining_chars": store.memory_char_limit - len("entry one"),
+            "quota_unit": "serialized_chars",
+        }
+
+    def test_stat_token_tracks_exact_serialized_unicode_state(self, store):
+        path = store._path_for("memory")
+        path.write_text("e\u0301", encoding="utf-8")
+        decomposed = store.stat("memory")
+
+        path.write_text("é", encoding="utf-8")
+        composed = store.stat("memory")
+
+        assert decomposed["usage"]["current_chars"] == 2
+        assert composed["usage"]["current_chars"] == 1
+        assert decomposed["store_state_token"] != composed["store_state_token"]
+
+    def test_success_response_keeps_terminal_contract_with_store_state(self, store):
+        result = store.add("memory", "entry one")
+
+        assert result["success"] is True
+        assert result["done"] is True
+        assert result["store"] == "memory"
+        assert result["store_state_token"].startswith("opaque:")
+        assert "entries" not in result
+
+    def test_add_overflow_returns_structured_quota_state(self, store):
+        store.memory_char_limit = 40
+        store.add("memory", "x" * 35)
+
+        result = store.add("memory", "y" * 20)
+
+        assert result["success"] is False
+        assert result["store"] == "memory"
+        assert result["error_code"] == "memory_quota_exceeded"
+        assert result["error_details"] == {
+            "code": "memory_quota_exceeded",
+            "operation": "add",
+        }
+        assert result["store_state_token"].startswith("opaque:")
+        assert result["quota_usage"]["current_chars"] == 35
+        assert result["quota_usage"]["remaining_chars"] == 5
+        assert result["quota_usage"]["attempted_total_chars"] > 40
+        assert result["quota_usage"]["over_by_chars"] > 0
+
+    def test_replace_overflow_returns_structured_quota_state(self, store):
+        store.memory_char_limit = 80
+        store.add("memory", "alpha " + "x" * 20)
+        store.add("memory", "beta " + "y" * 20)
+
+        result = store.replace("memory", "alpha", "alpha " + "z" * 70)
+
+        assert result["success"] is False
+        assert result["error_code"] == "memory_quota_exceeded"
+        assert result["error_details"] == {
+            "code": "memory_quota_exceeded",
+            "operation": "replace",
+        }
+        assert result["store_state_token"].startswith("opaque:")
+        assert result["quota_usage"]["attempted_total_chars"] > 80
+
+    def test_batch_overflow_returns_structured_quota_state_without_mutating(self, store):
+        store.add("memory", "keep")
+        before = store.stat("memory")
+        operations = [{"action": "add", "content": "q" * 600}]
+
+        result = store.apply_batch("memory", operations)
+
+        assert result["success"] is False
+        assert result["error_code"] == "memory_quota_exceeded"
+        assert result["error_details"] == {
+            "code": "memory_quota_exceeded",
+            "operation": "batch",
+        }
+        assert result["store_state_token"] == before["store_state_token"]
+        assert result["quota_usage"]["attempted_total_chars"] > store.memory_char_limit
+        assert store.memory_entries == ["keep"]
+
+
 class TestMemoryStoreReplace:
     def test_replace_entry(self, store):
         store.add("memory", "Python 3.11 project")

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -201,6 +201,9 @@ class TestMemoryQuotaMetadata:
         assert result["quota_usage"]["remaining_chars"] == 5
         assert result["quota_usage"]["attempted_total_chars"] > 40
         assert result["quota_usage"]["over_by_chars"] > 0
+        assert "current_entries" in result
+        assert "Consolidate now" in result["error"]
+        assert "retry this add" in result["error"]
 
     def test_replace_overflow_returns_structured_quota_state(self, store):
         store.memory_char_limit = 80
@@ -234,6 +237,113 @@ class TestMemoryQuotaMetadata:
         assert result["store_state_token"] == before["store_state_token"]
         assert result["quota_usage"]["attempted_total_chars"] > store.memory_char_limit
         assert store.memory_entries == ["keep"]
+
+
+class TestMemoryQuotaSameStateRetryGuard:
+    """End-to-end #35121 firebreak: MemoryStore tokens + guardrail skip."""
+
+    def test_add_overflow_remove_then_same_add_is_allowed(self, store):
+        from agent.tool_guardrails import ToolCallGuardrailController
+
+        store.memory_char_limit = 60
+        store.add("memory", "STALE:" + "a" * 20)
+        store.add("memory", "KEEP:" + "b" * 20)
+
+        controller = ToolCallGuardrailController()
+        new_fact = "NEW:" + "c" * 25
+        add_args = {"target": "memory", "action": "add", "content": new_fact}
+
+        token_before = store.stat("memory")["store_state_token"]
+        assert controller.before_call(
+            "memory", add_args, current_store_state_token=token_before
+        ).action == "allow"
+        overflow = store.add("memory", new_fact)
+        assert overflow["success"] is False
+        assert overflow["error_code"] == "memory_quota_exceeded"
+        assert "Consolidate now" in overflow["error"]
+        assert "current_entries" in overflow
+        warn = controller.after_call(
+            "memory", add_args, json.dumps(overflow), failed=True
+        )
+        assert warn.action == "warn"
+        assert warn.code == "memory_quota_exceeded_non_retryable"
+
+        identical = controller.before_call(
+            "memory",
+            add_args,
+            current_store_state_token=store.stat("memory")["store_state_token"],
+        )
+        assert identical.action == "skip"
+        assert identical.should_halt is False
+
+        remove_args = {"target": "memory", "action": "remove", "old_text": "STALE:"}
+        assert controller.before_call(
+            "memory",
+            remove_args,
+            current_store_state_token=store.stat("memory")["store_state_token"],
+        ).action == "allow"
+        removed = store.remove("memory", "STALE:")
+        assert removed["success"] is True
+        controller.after_call(
+            "memory", remove_args, json.dumps(removed), failed=False
+        )
+        assert removed["store_state_token"] != token_before
+
+        allowed = controller.before_call(
+            "memory",
+            add_args,
+            current_store_state_token=removed["store_state_token"],
+        )
+        assert allowed.action == "allow"
+        retry = store.add("memory", new_fact)
+        assert retry["success"] is True
+        assert new_fact in store.memory_entries
+
+    def test_post_cap_quota_overflow_still_skips_identical_retry(self, store):
+        from agent.tool_guardrails import ToolCallGuardrailController
+
+        store.memory_char_limit = 50
+        store.add("memory", "x" * 40)
+        controller = ToolCallGuardrailController()
+        # Burn the consolidation budget with distinct overflowing writes so the
+        # next identical write is the first time this signature hits the cap.
+        for i in range(store._MAX_CONSOLIDATION_FAILURES_PER_TURN):
+            args = {"target": "memory", "action": "add", "content": f"y{i}" + "z" * 20}
+            token = store.stat("memory")["store_state_token"]
+            assert controller.before_call(
+                "memory", args, current_store_state_token=token
+            ).action == "allow"
+            result = store.add("memory", args["content"])
+            assert result["error_code"] == "memory_quota_exceeded"
+            controller.after_call("memory", args, json.dumps(result), failed=True)
+
+        final_args = {
+            "target": "memory",
+            "action": "add",
+            "content": "post-cap" + "z" * 20,
+        }
+        token = store.stat("memory")["store_state_token"]
+        assert controller.before_call(
+            "memory", final_args, current_store_state_token=token
+        ).action == "allow"
+        capped = store.add("memory", final_args["content"])
+        assert capped["done"] is True
+        assert capped["error_code"] == "memory_quota_exceeded"
+        assert capped["store_state_token"].startswith("opaque:")
+        assert "continue with your reply" in capped["error"]
+        recorded = controller.after_call(
+            "memory", final_args, json.dumps(capped), failed=True
+        )
+        assert recorded.code == "memory_quota_exceeded_non_retryable"
+
+        skipped = controller.before_call(
+            "memory",
+            final_args,
+            current_store_state_token=capped["store_state_token"],
+        )
+        assert skipped.action == "skip"
+        assert skipped.code == "memory_quota_exceeded_non_retryable"
+        assert skipped.should_halt is False
 
 
 class TestMemoryStoreReplace:
@@ -298,6 +408,30 @@ class TestMemoryConsolidationGracefulDegrade:
         assert "current_entries" not in r
         assert "continue with your reply" in r["error"]
 
+    def test_add_overflow_degrades_after_cap(self, store):
+        # Fill near the 500-char user/memory limit so add() overflows.
+        store.add("memory", "x" * 200)
+        store.add("memory", "y" * 200)
+        cap = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
+        big = "z" * 200
+        for _ in range(cap):
+            r = store.add("memory", big)
+            assert r["success"] is False
+            assert "retry this add" in r["error"]  # still instructs in-turn retry
+        r = store.add("memory", big)
+        assert r["success"] is False
+        assert r["done"] is True
+        assert "continue with your reply" in r["error"]
+        # Cap response is terminal, but keep identity fields so the same-state
+        # retry guard can still recognize this as a deterministic quota miss.
+        assert r["error_code"] == "memory_quota_exceeded"
+        assert r["error_details"]["code"] == "memory_quota_exceeded"
+        assert r["store"] == "memory"
+        assert r["target"] == "memory"
+        assert isinstance(r["store_state_token"], str)
+        assert r["store_state_token"].startswith("opaque:")
+        assert "current_entries" not in r
+        assert "retry this add" not in r["error"]
 
     def test_apply_batch_failures_count_toward_budget(self, store):
         """apply_batch is the primary at-capacity consolidation path; its

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,6 +23,7 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
+import hashlib
 import json
 import logging
 import time
@@ -387,6 +388,101 @@ class MemoryStore:
             return self.user_char_limit
         return self.memory_char_limit
 
+    @staticmethod
+    def _serialized_char_count(entries: List[str]) -> int:
+        return len(ENTRY_DELIMITER.join(entries)) if entries else 0
+
+    def _store_state_token_for_entries(self, target: str, entries: List[str]) -> str:
+        payload = json.dumps(
+            {
+                "store": target,
+                "entries": entries,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return "opaque:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def _store_state_token(self, target: str) -> str:
+        return self._store_state_token_for_entries(target, self._entries_for(target))
+
+    def _quota_usage(
+        self,
+        target: str,
+        *,
+        current_chars: int,
+        attempted_total_chars: int,
+        extra: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        limit = self._char_limit(target)
+        payload: Dict[str, Any] = {
+            "current_chars": current_chars,
+            "limit_chars": limit,
+            "remaining_chars": max(0, limit - current_chars),
+            "attempted_total_chars": attempted_total_chars,
+            "over_by_chars": max(0, attempted_total_chars - limit),
+            "quota_unit": "serialized_chars",
+        }
+        if extra:
+            payload.update(extra)
+        return payload
+
+    def _quota_failure(
+        self,
+        target: str,
+        *,
+        operation: str,
+        error: str,
+        attempted_total_chars: int,
+        extra: Dict[str, Any] | None = None,
+        quota_extra: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        entries = self._entries_for(target)
+        current = self._char_count(target)
+        response: Dict[str, Any] = {
+            "success": False,
+            "target": target,
+            "store": target,
+            "error": error,
+            "error_code": "memory_quota_exceeded",
+            "error_details": {
+                "code": "memory_quota_exceeded",
+                "operation": operation,
+            },
+            "store_state_token": self._store_state_token_for_entries(target, entries),
+            "current_entries": entries,
+            "usage": f"{current:,}/{self._char_limit(target):,}",
+            "quota_usage": self._quota_usage(
+                target,
+                current_chars=current,
+                attempted_total_chars=attempted_total_chars,
+                extra=quota_extra,
+            ),
+        }
+        if extra:
+            response.update(extra)
+        return self._consolidation_failure(response)
+
+    def stat(self, target: str) -> Dict[str, Any]:
+        """Return current usage and opaque state without exposing entries."""
+        with self._file_lock(self._path_for(target)):
+            entries = list(dict.fromkeys(self._read_file(self._path_for(target))))
+        current = self._serialized_char_count(entries)
+        limit = self._char_limit(target)
+        return {
+            "success": True,
+            "target": target,
+            "store": target,
+            "store_state_token": self._store_state_token_for_entries(target, entries),
+            "usage": {
+                "current_chars": current,
+                "limit_chars": limit,
+                "remaining_chars": max(0, limit - current),
+                "quota_unit": "serialized_chars",
+            },
+        }
+
     def add(self, target: str, content: str) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
         content = content.strip()
@@ -427,18 +523,25 @@ class MemoryStore:
 
             if new_total > limit:
                 current = self._char_count(target)
-                return self._consolidation_failure({
-                    "success": False,
-                    "error": (
+                delimiter_chars = len(ENTRY_DELIMITER) if entries else 0
+                max_add_chars = max(0, limit - current - delimiter_chars)
+                return self._quota_failure(
+                    target,
+                    operation="add",
+                    error=(
                         f"Memory at {current:,}/{limit:,} chars. "
                         f"Adding this entry ({len(content)} chars) would exceed the limit. "
                         f"Consolidate now: use 'replace' to merge overlapping entries into "
                         f"shorter ones or 'remove' stale or less important entries (see "
                         f"current_entries below), then retry this add — all in this turn."
                     ),
-                    "current_entries": entries,
-                    "usage": f"{current:,}/{limit:,}",
-                })
+                    attempted_total_chars=new_total,
+                    quota_extra={
+                        "new_entry_chars": len(content),
+                        "max_add_chars": max_add_chars,
+                        "min_chars_to_free": max(0, new_total - limit),
+                    },
+                )
 
             entries.append(content)
             self._set_entries(target, entries)
@@ -498,18 +601,30 @@ class MemoryStore:
             new_total = len(ENTRY_DELIMITER.join(test_entries))
 
             if new_total > limit:
-                current = self._char_count(target)
-                return self._consolidation_failure({
-                    "success": False,
-                    "error": (
+                old_entry_chars = len(entries[idx])
+                new_entry_chars = len(new_content)
+                return self._quota_failure(
+                    target,
+                    operation="replace",
+                    error=(
                         f"Replacement would put memory at {new_total:,}/{limit:,} chars. "
                         f"Shorten the new content, or 'remove' other stale or less important "
                         f"entries to make room (see current_entries below), then retry — all "
                         f"in this turn."
                     ),
-                    "current_entries": entries,
-                    "usage": f"{current:,}/{limit:,}",
-                })
+                    attempted_total_chars=new_total,
+                    extra={
+                        "replacement": {
+                            "old_entry_chars": old_entry_chars,
+                            "new_entry_chars": new_entry_chars,
+                            "delta_chars": new_entry_chars - old_entry_chars,
+                            "max_replacement_chars": max(
+                                0,
+                                limit - (self._char_count(target) - old_entry_chars),
+                            ),
+                        },
+                    },
+                )
 
             entries[idx] = new_content
             self._set_entries(target, entries)
@@ -650,17 +765,17 @@ class MemoryStore:
             # Budget check against the FINAL state only.
             new_total = len(ENTRY_DELIMITER.join(working)) if working else 0
             if new_total > limit:
-                current = self._char_count(target)
-                return self._consolidation_failure({
-                    "success": False,
-                    "error": (
+                return self._quota_failure(
+                    target,
+                    operation="batch",
+                    error=(
                         f"After applying all {len(operations)} operations, memory would be at "
                         f"{new_total:,}/{limit:,} chars -- over the limit. Remove or shorten more "
                         f"entries in the same batch (see current_entries below), then retry."
                     ),
-                    "current_entries": self._entries_for(target),
-                    "usage": f"{current:,}/{limit:,}",
-                })
+                    attempted_total_chars=new_total,
+                    quota_extra={"operation_count": len(operations)},
+                )
 
             # Commit.
             self._set_entries(target, working)
@@ -720,6 +835,8 @@ class MemoryStore:
             "success": True,
             "done": True,
             "target": target,
+            "store": target,
+            "store_state_token": self._store_state_token(target),
             "usage": f"{pct}% — {current:,}/{limit:,} chars",
             "entry_count": len(entries),
         }
@@ -1234,7 +1351,6 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
 
 
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -190,7 +190,9 @@ class MemoryStore:
         self._consolidation_failures += 1
         if self._consolidation_failures <= self._MAX_CONSOLIDATION_FAILURES_PER_TURN:
             return response
-        return {
+        # Terminal "stop retrying" message, but keep quota identity fields so the
+        # same-store-state guardrail can still skip an identical write (#35121).
+        degraded: Dict[str, Any] = {
             "success": False,
             "done": True,
             "error": (
@@ -200,6 +202,16 @@ class MemoryStore:
                 "in a later turn."
             ),
         }
+        for key in (
+            "store",
+            "target",
+            "error_code",
+            "error_details",
+            "store_state_token",
+        ):
+            if key in response:
+                degraded[key] = response[key]
+        return degraded
 
     def load_from_disk(self):
         """Load entries from MEMORY.md and USER.md, capture system prompt snapshot.

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -477,9 +477,27 @@ class MemoryStore:
         return self._consolidation_failure(response)
 
     def stat(self, target: str) -> Dict[str, Any]:
-        """Return current usage and opaque state without exposing entries."""
-        with self._file_lock(self._path_for(target)):
-            entries = list(dict.fromkeys(self._read_file(self._path_for(target))))
+        """Return current usage and opaque state without exposing entries.
+
+        An unreadable on-disk file is NOT an empty store. Returning a fabricated
+        empty-state token would let the same-store-state retry guard overwrite a
+        real observed token and briefly re-allow identical quota retries
+        (#35121).
+        """
+        path = self._path_for(target)
+        with self._file_lock(path):
+            entries, read_ok = self._read_entries_checked(path)
+        if not read_ok:
+            return {
+                "success": False,
+                "target": target,
+                "store": target,
+                "error": (
+                    f"Could not read {path.name} to compute store state "
+                    "(temporarily locked, permission change, invalid encoding, "
+                    "or filesystem error). No state token is returned."
+                ),
+            }
         current = self._serialized_char_count(entries)
         limit = self._char_limit(target)
         return {


### PR DESCRIPTION
## Summary

Part of #35121.

This PR adds a deterministic firebreak for memory quota retry loops on current `main`: the built-in `memory` tool returns structured quota/state metadata, and the agent skips an identical write only when the observed store state is unchanged.

This is a clean rebuild on current upstream `main`, not a mechanical conflict resolution of the earlier branch. It preserves the existing consolidation-failure cap, atomic batch behavior, and terminal success-response contract.

## Behavior

- Add, replace, and final atomic-batch quota overflow return `error_code = "memory_quota_exceeded"`, structured quota usage, and an opaque `store_state_token`.
- Successful memory responses remain terminal and include `store` plus `store_state_token`; `MemoryStore.stat()` exposes current state/usage without exposing entries.
- Memory-write signatures hash content rather than retaining it, preserve batch operation order, normalize key order/trailing whitespace, and distinguish serialized Unicode variants that can differ in quota cost.
- A structured quota failure is recorded by `(signature, store, store_state_token)`.
- An identical write against the same store state becomes a synthetic non-executing, non-halting `skip`.
- Changed arguments or changed store state remain executable.
- Non-quota failures continue through the existing bounded consolidation-failure path.
- Sequential and concurrent tool execution refresh the current store token before guardrail preflight.
- Structured and legacy quota failures continue to render as `[full]`.

## Review feedback addressed

- Covers `operations -> apply_batch()` final-budget overflow and includes a repeated-identical-batch regression test.
- Integrates with current `main` behavior instead of preserving the conflicting historical implementation.
- Preserves the existing cross-action consolidation cap for non-quota failures.

## Validation

TDD evidence:

- Baseline relevant suite on current upstream `main`: `131 passed`.
- New regression tests before implementation: `13 failed, 131 passed` for the expected missing behavior.
- Unicode correctness follow-up before implementation: `2 failed` for the expected normalization defect.
- Focused final suite: `146 passed`.
- Wider memory/agent/runtime suite: `221 passed in 6.88s`.
- Ruff lint across all 8 changed files: `All checks passed!`.
- `git diff --check`: passed.

`ruff format --check` is not applied as a repository gate here because these pre-existing files are not Ruff-formatted and it requests whole-file rewrites unrelated to this fix.

## One-time branch governance exception

- Existing PR head: `codex/memory-overflow-retry-guard-pr1`
- Current remote SHA: `62a4a0ae31784fcaf03ac6bc719f73401e6ec8cc`
- Approved target SHA: `e99e2ca237da368649f5f26117d392c5227777ad`
- Reason: this open upstream PR predates the current branch grammar, and GitHub cannot retarget an existing pull request head. The implementation was rebuilt on a compliant local candidate branch and this exception only updates the existing PR head.
- Scope: one force-with-lease update to the existing fork branch; no protected branch or runtime pointer is changed.
- Expiry: when PR #43001 is merged or closed, or 2026-08-15, whichever comes first.
- Rollback: restore remote SHA `62a4a0ae31784fcaf03ac6bc719f73401e6ec8cc` with an exact force-with-lease if the update itself must be reverted.
- Approver: repository owner authorization in this Codex task on 2026-07-15.
