### PR TITLE
fix(email): use BODY.PEEK[] to avoid marking messages as read

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -383,7 +383,7 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -895,6 +895,36 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(results[0]["sender_addr"], "john@test.com")
         self.assertEqual(results[0]["sender_name"], "John Doe")
 
+    def test_fetch_uses_body_peek_to_preserve_unseen_flag(self):
+        """IMAP fetch must use BODY.PEEK[] to avoid marking messages as read."""
+        adapter = self._make_adapter()
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        mock_imap = MagicMock()
+        fetch_calls = []
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                fetch_calls.append(args)
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            adapter._fetch_new_messages()
+
+        # Verify BODY.PEEK[] is used instead of RFC822 to avoid setting \\Seen
+        self.assertEqual(len(fetch_calls), 1)
+        self.assertIn("BODY.PEEK[]", fetch_calls[0][1])
+        self.assertNotIn("RFC822", fetch_calls[0][1])
+
 
 class TestPollLoop(unittest.TestCase):
     """Test the async polling loop."""


### PR DESCRIPTION
## What does this PR do?

Fixes the Email gateway IMAP polling silently marking unread messages as read. The `FETCH (RFC822)` command sets the `\Seen` flag on Gmail and other IMAP servers, so simply running the Email gateway marks every new email as read before Hermes even decides whether to process it. Switching to `FETCH (BODY.PEEK[])` retrieves the full message without modifying flags.

## Related Issue

Fixes #42997

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/email.py`: Replace `(RFC822)` with `(BODY.PEEK[])` in `_fetch_new_messages()` IMAP fetch to avoid setting the `\Seen` flag
- `tests/gateway/test_email.py`: Add `test_fetch_uses_body_peek_to_preserve_unseen_flag` to verify the fetch uses `BODY.PEEK[]` and does not contain `RFC822`

## How to Test

1. Configure the Email gateway with a Gmail account and `EMAIL_IMAP_HOST=imap.gmail.com`
2. Send a test email to the configured mailbox
3. Verify the email remains **unread** in Gmail after the gateway polls
4. Run `pytest tests/gateway/test_email.py -v` — all 61 tests should pass, including the new `test_fetch_uses_body_peek_to_preserve_unseen_flag`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_email.py -v` and all 61 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (IMAP protocol behavior is server-side)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `gateway/platforms/email.py` `_fetch_new_messages()` — single call site for `imap.uid("fetch", ...)`
- Blast radius: LOW — single-line change, IMAP fetch argument only, no control flow change
- Related patterns: `BODY.PEEK[]` is the standard IMAP "peek" fetch that avoids side effects; used by all well-behaved IMAP clients
