### PR TITLE
fix(discord): process concurrent voice utterances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -317,6 +317,11 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # Named VOICE_TOOLS_OPENAI_KEY to avoid interference with OpenRouter.
 # Get at: https://platform.openai.com/api-keys
 # VOICE_TOOLS_OPENAI_KEY=
+#
+# Discord live voice transcripts are posted to the linked side text channel
+# directly by the gateway by default. Set true only if every transcript snippet
+# should also become an agent turn.
+# HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS=false
 
 # =============================================================================
 # SLACK INTEGRATION

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -699,6 +699,7 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#   voice_transcript_agent_turns: false  # Post live voice transcripts directly; true also invokes agent per snippet
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -922,6 +922,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if plat == Platform.DISCORD and "voice_transcript_agent_turns" in platform_cfg:
+                    bridged["voice_transcript_agent_turns"] = platform_cfg["voice_transcript_agent_turns"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12198,6 +12198,17 @@ class GatewayRunner:
         recent_store[key] = recent[-5:]
         return False
 
+    def _discord_voice_transcript_agent_turns_enabled(self) -> bool:
+        """Whether Discord voice transcript snippets should invoke the agent."""
+        env_value = os.getenv("HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS")
+        if env_value is not None:
+            return is_truthy_value(env_value, default=False)
+
+        config = getattr(self, "config", None)
+        platform_cfg = getattr(config, "platforms", {}).get(Platform.DISCORD) if config else None
+        extra = getattr(platform_cfg, "extra", {}) if platform_cfg else {}
+        return is_truthy_value(extra.get("voice_transcript_agent_turns"), default=False)
+
     async def _handle_voice_channel_input(
         self, guild_id: int, user_id: int, transcript: str
     ):
@@ -12244,6 +12255,10 @@ class GatewayRunner:
             )
             return
 
+        reset_timeout = getattr(adapter, "_reset_voice_timeout", None)
+        if callable(reset_timeout):
+            reset_timeout(guild_id)
+
         # Show transcript in text channel (after auth, with mention sanitization)
         try:
             channel = adapter._client.get_channel(text_ch_id)
@@ -12252,6 +12267,11 @@ class GatewayRunner:
                 await channel.send(f"**[Voice]** <@{user_id}>: {safe_text}")
         except Exception:
             pass
+
+        # LLMs/agents orchestrate reasoning-heavy work; the deterministic
+        # gateway runtime executes repeatable transcript posting by default.
+        if not self._discord_voice_transcript_agent_turns_enabled():
+            return
 
         # Build a synthetic MessageEvent and feed through the normal pipeline
         # Use SimpleNamespace as raw_message so _get_guild_id() can extract

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -181,6 +181,7 @@ class VoiceReceiver:
 
     SILENCE_THRESHOLD = 1.5    # seconds of silence → end of utterance
     MIN_SPEECH_DURATION = 0.5  # minimum seconds to process (skip noise)
+    MAX_UTTERANCE_DURATION = 30.0  # bound hot-path audio buffers during long monologues
     SAMPLE_RATE = 48000        # Discord native rate
     CHANNELS = 2               # Discord sends stereo
 
@@ -478,7 +479,11 @@ class VoiceReceiver:
                 # 48kHz, 16-bit, stereo = 192000 bytes/sec
                 buf_duration = len(buf) / (self.SAMPLE_RATE * self.CHANNELS * 2)
 
-                if silence_duration >= self.SILENCE_THRESHOLD and buf_duration >= self.MIN_SPEECH_DURATION:
+                utterance_complete = (
+                    silence_duration >= self.SILENCE_THRESHOLD
+                    or buf_duration >= self.MAX_UTTERANCE_DURATION
+                )
+                if utterance_complete and buf_duration >= self.MIN_SPEECH_DURATION:
                     user_id = ssrc_user_map.get(ssrc, 0)
                     if not user_id:
                         # SSRC not mapped (SPEAKING event missing after bot rejoin).
@@ -576,6 +581,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
+    VOICE_ACTIVITY_TIMEOUT_REFRESH = 30.0
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
@@ -595,6 +601,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
         self._voice_sources: Dict[int, Dict[str, Any]] = {}  # guild_id -> linked text channel source metadata
         self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
+        self._voice_activity_timeout_resets: Dict[int, float] = {}  # guild_id -> monotonic timestamp
         # Phase 2: voice listening
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
@@ -2154,6 +2161,9 @@ class DiscordAdapter(BasePlatformAdapter):
             task = self._voice_timeout_tasks.pop(guild_id, None)
             if task:
                 task.cancel()
+            resets = getattr(self, "_voice_activity_timeout_resets", None)
+            if resets is not None:
+                resets.pop(guild_id, None)
             self._voice_text_channels.pop(guild_id, None)
             self._voice_sources.pop(guild_id, None)
 
@@ -2252,9 +2262,24 @@ class DiscordAdapter(BasePlatformAdapter):
         task = self._voice_timeout_tasks.pop(guild_id, None)
         if task:
             task.cancel()
+        resets = getattr(self, "_voice_activity_timeout_resets", None)
+        if resets is None:
+            resets = {}
+            self._voice_activity_timeout_resets = resets
+        resets[guild_id] = time.monotonic()
         self._voice_timeout_tasks[guild_id] = asyncio.ensure_future(
             self._voice_timeout_handler(guild_id)
         )
+
+    def _note_voice_activity(self, guild_id: int) -> None:
+        """Refresh the inactivity timer for inbound audio without timer churn."""
+        resets = getattr(self, "_voice_activity_timeout_resets", None)
+        if resets is None:
+            resets = {}
+            self._voice_activity_timeout_resets = resets
+        now = time.monotonic()
+        if now - resets.get(guild_id, 0.0) >= self.VOICE_ACTIVITY_TIMEOUT_REFRESH:
+            self._reset_voice_timeout(guild_id)
 
     async def _voice_timeout_handler(self, guild_id: int) -> None:
         """Auto-disconnect after VOICE_TIMEOUT seconds of inactivity."""
@@ -2382,6 +2407,8 @@ class DiscordAdapter(BasePlatformAdapter):
                         pass
 
                 completed = receiver.check_silence()
+                if receiver._last_packet_time:
+                    self._note_voice_activity(guild_id)
                 # Voice inputs always originate from a specific guild
                 # (guild_id is in scope). Pass it so role checks are
                 # guild-scoped and not cross-guild.
@@ -2393,6 +2420,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         is_dm=False,
                     ):
                         continue
+                    self._note_voice_activity(guild_id)
                     await self._process_voice_input(guild_id, user_id, pcm_data)
         except asyncio.CancelledError:
             pass

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -605,6 +605,10 @@ class DiscordAdapter(BasePlatformAdapter):
         # Phase 2: voice listening
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
+        self._voice_input_tasks: Dict[int, set[asyncio.Task]] = {}  # guild_id -> in-flight STT/callback work
+        self._voice_input_semaphore: Optional[asyncio.Semaphore] = None
+        self._voice_input_concurrency = max(1, int(os.getenv("HERMES_DISCORD_VOICE_STT_CONCURRENCY", "3")))
+        self._voice_input_max_pending = max(1, int(os.getenv("HERMES_DISCORD_VOICE_STT_MAX_PENDING", "12")))
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
         # Phase 3: continuous voice mixer (ambient idle bed + ducked speech).
@@ -2145,6 +2149,8 @@ class DiscordAdapter(BasePlatformAdapter):
             listen_task = self._voice_listen_tasks.pop(guild_id, None)
             if listen_task:
                 listen_task.cancel()
+            for task in list(getattr(self, "_voice_input_tasks", {}).pop(guild_id, set())):
+                task.cancel()
 
             # Tear down the mixer (stops the continuous outgoing stream).
             if getattr(self, "_voice_mixers", None) is not None:
@@ -2421,11 +2427,62 @@ class DiscordAdapter(BasePlatformAdapter):
                     ):
                         continue
                     self._note_voice_activity(guild_id)
-                    await self._process_voice_input(guild_id, user_id, pcm_data)
+                    self._schedule_voice_input_processing(guild_id, user_id, pcm_data)
         except asyncio.CancelledError:
             pass
         except Exception as e:
             logger.error("Voice listen loop error: %s", e, exc_info=True)
+
+    def _schedule_voice_input_processing(self, guild_id: int, user_id: int, pcm_data: bytes) -> bool:
+        """Schedule PCM->WAV->STT->callback work without blocking voice polling.
+
+        Live meetings can produce completed utterances from several speakers in
+        the same silence-check tick.  Running each STT path inline makes later
+        speakers wait behind earlier speakers and pauses silence detection.
+        Keep the listener cheap: fan out completed chunks, cap concurrency, and
+        bound pending work per guild so STT backlog cannot grow forever.
+        """
+        tasks_by_guild = getattr(self, "_voice_input_tasks", None)
+        if tasks_by_guild is None:
+            tasks_by_guild = {}
+            self._voice_input_tasks = tasks_by_guild
+
+        tasks = tasks_by_guild.setdefault(guild_id, set())
+        for task in list(tasks):
+            if task.done():
+                tasks.discard(task)
+
+        max_pending = max(1, int(getattr(self, "_voice_input_max_pending", 12)))
+        if len(tasks) >= max_pending:
+            logger.warning(
+                "Dropping Discord voice utterance for guild=%d user=%d: STT backlog full (%d)",
+                guild_id, user_id, len(tasks),
+            )
+            return False
+
+        async def _runner():
+            semaphore = getattr(self, "_voice_input_semaphore", None)
+            if semaphore is None:
+                concurrency = max(1, int(getattr(self, "_voice_input_concurrency", 3)))
+                semaphore = asyncio.Semaphore(concurrency)
+                self._voice_input_semaphore = semaphore
+            async with semaphore:
+                await self._process_voice_input(guild_id, user_id, pcm_data)
+
+        task = asyncio.create_task(_runner())
+        tasks.add(task)
+
+        def _done(done_task: asyncio.Task) -> None:
+            tasks.discard(done_task)
+            try:
+                done_task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                logger.warning("Discord voice input task failed: %s", exc, exc_info=True)
+
+        task.add_done_callback(_done)
+        return True
 
     async def _process_voice_input(self, guild_id: int, user_id: int, pcm_data: bytes):
         """Convert PCM -> WAV -> STT -> callback."""

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -32,6 +32,22 @@ def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monk
     assert config.stt_enabled is False
 
 
+def test_load_gateway_config_bridges_discord_voice_transcript_agent_turns(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.dump({"discord": {"voice_transcript_agent_turns": True}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.DISCORD].extra["voice_transcript_agent_turns"] is True
+
+
 @pytest.mark.asyncio
 async def test_enrich_message_with_transcription_surfaces_path_when_stt_disabled():
     from gateway.run import GatewayRunner

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -919,18 +919,41 @@ class TestVoiceChannelCommands:
         await runner._handle_voice_channel_input(111, 42, "Hello")
 
     @pytest.mark.asyncio
-    async def test_input_creates_event_and_dispatches(self, runner):
-        """Voice input creates synthetic event and calls handle_message."""
+    async def test_input_posts_transcript_without_agent_by_default(self, runner, monkeypatch):
+        """Voice input posts transcript text without calling the agent by default."""
         from gateway.config import Platform
+        monkeypatch.delenv("HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS", raising=False)
         mock_adapter = AsyncMock()
         mock_adapter._voice_text_channels = {111: 123}
         mock_adapter._voice_sources = {}
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
         await runner._handle_voice_channel_input(111, 42, "Hello from VC")
+        mock_channel.send.assert_called_once()
+        mock_adapter.handle_message.assert_not_called()
+        mock_adapter._reset_voice_timeout.assert_called_once_with(111)
+
+    @pytest.mark.asyncio
+    async def test_input_opt_in_agent_dispatch(self, runner, monkeypatch):
+        """Voice transcript snippets can still dispatch to the agent when opted in."""
+        from gateway.config import Platform
+        monkeypatch.setenv("HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS", "true")
+        mock_adapter = AsyncMock()
+        mock_adapter._voice_text_channels = {111: 123}
+        mock_adapter._voice_sources = {}
+        mock_channel = AsyncMock()
+        mock_adapter._client = MagicMock()
+        mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
+        mock_adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        await runner._handle_voice_channel_input(111, 42, "Hello from VC")
+
         mock_adapter.handle_message.assert_called_once()
         event = mock_adapter.handle_message.call_args[0][0]
         assert event.text == "Hello from VC"
@@ -939,9 +962,37 @@ class TestVoiceChannelCommands:
         assert event.source.chat_type == "channel"
 
     @pytest.mark.asyncio
-    async def test_input_reuses_bound_source_metadata(self, runner):
+    async def test_input_config_opt_in_agent_dispatch(self, runner, monkeypatch):
+        """Config can opt Discord voice transcript snippets into agent turns."""
+        from gateway.config import Platform, PlatformConfig
+        monkeypatch.delenv("HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS", raising=False)
+        runner.config = SimpleNamespace(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    extra={"voice_transcript_agent_turns": True},
+                )
+            }
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter._voice_text_channels = {111: 123}
+        mock_adapter._voice_sources = {}
+        mock_channel = AsyncMock()
+        mock_adapter._client = MagicMock()
+        mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
+        mock_adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        await runner._handle_voice_channel_input(111, 42, "Config opt in")
+
+        mock_adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_input_reuses_bound_source_metadata(self, runner, monkeypatch):
         """Voice input should share the linked text channel session metadata."""
         from gateway.config import Platform
+        monkeypatch.setenv("HERMES_DISCORD_VOICE_TRANSCRIPT_AGENT_TURNS", "true")
 
         bound_source = SessionSource(
             chat_id="123",
@@ -958,6 +1009,7 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
 
@@ -980,6 +1032,7 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
         await runner._handle_voice_channel_input(111, 42, "Test transcript")
@@ -999,13 +1052,14 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
 
         await runner._handle_voice_channel_input(111, 42, "Hello from VC")
         await runner._handle_voice_channel_input(111, 42, "Hello from VC")
 
-        mock_adapter.handle_message.assert_called_once()
+        mock_adapter.handle_message.assert_not_called()
         mock_channel.send.assert_called_once()
 
     @pytest.mark.asyncio
@@ -1019,13 +1073,14 @@ class TestVoiceChannelCommands:
         mock_channel = AsyncMock()
         mock_adapter._client = MagicMock()
         mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter._reset_voice_timeout = MagicMock()
         mock_adapter.handle_message = AsyncMock()
         runner.adapters[Platform.DISCORD] = mock_adapter
 
         await runner._handle_voice_channel_input(111, 42, "This is a test of the voice system")
         await runner._handle_voice_channel_input(111, 42, "This is a test for the voice system")
 
-        mock_adapter.handle_message.assert_called_once()
+        mock_adapter.handle_message.assert_not_called()
         mock_channel.send.assert_called_once()
 
     # -- _get_guild_id --
@@ -1343,6 +1398,23 @@ class TestVoiceReceiverThreadSafety:
         t1.join()
         t2.join()
         assert len(errors) == 0, f"Race detected: {errors[:3]}"
+
+    def test_completed_utterance_buffer_is_cleared(self):
+        """A completed utterance is returned once and then dropped."""
+        receiver = self._make_receiver()
+        receiver.map_ssrc(100, 42)
+        with receiver._lock:
+            receiver._buffers[100].extend(b"\x00" * 192000)
+            receiver._last_packet_time[100] = time.monotonic() - (
+                receiver.SILENCE_THRESHOLD + 0.1
+            )
+
+        completed = receiver.check_silence()
+
+        assert completed == [(42, b"\x00" * 192000)]
+        assert receiver._buffers[100] == bytearray()
+        assert 100 not in receiver._last_packet_time
+        assert receiver.check_silence() == []
 
 
 # =====================================================================

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -2900,6 +2900,67 @@ class TestUDPKeepalive:
             DiscordAdapter._KEEPALIVE_INTERVAL = original_interval
 
 
+class TestVoiceListenLoopConcurrency:
+    """Completed utterances from multiple speakers should not queue serially."""
+
+    @pytest.mark.asyncio
+    async def test_simultaneous_speaker_utterances_start_processing_concurrently(self):
+        """Three completed speakers should enter STT processing before any one finishes.
+
+        Regression coverage for live meetings where the transcript lagged far
+        behind when several people talked at once.  The listener loop should
+        keep extraction cheap and fan out completed utterances instead of
+        awaiting each PCM->WAV/STT/callback path inline.
+        """
+        import asyncio
+        from plugins.platforms.discord.adapter import DiscordAdapter
+        from gateway.config import PlatformConfig, Platform
+
+        class FakeReceiver:
+            def __init__(self):
+                self._running = True
+                self._last_packet_time = {1: time.monotonic()}
+                self._calls = 0
+
+            def check_silence(self):
+                self._calls += 1
+                self._running = False
+                return [
+                    (101, b"a" * 96000),
+                    (102, b"b" * 96000),
+                    (103, b"c" * 96000),
+                ]
+
+        adapter = object.__new__(DiscordAdapter)
+        adapter.platform = Platform.DISCORD
+        adapter.config = PlatformConfig(enabled=True, extra={})
+        adapter._client = SimpleNamespace(get_guild=lambda _guild_id: None)
+        adapter._voice_clients = {}
+        adapter._voice_receivers = {111: FakeReceiver()}
+        adapter._is_allowed_user = MagicMock(return_value=True)
+        adapter._note_voice_activity = MagicMock()
+
+        started = set()
+        all_started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def fake_process(guild_id, user_id, pcm_data):
+            started.add(user_id)
+            if len(started) == 3:
+                all_started.set()
+            await release.wait()
+
+        adapter._process_voice_input = fake_process
+
+        task = asyncio.create_task(adapter._voice_listen_loop(111))
+        try:
+            await asyncio.wait_for(all_started.wait(), timeout=1.0)
+            assert started == {101, 102, 103}
+        finally:
+            release.set()
+            await asyncio.wait_for(task, timeout=1.0)
+
+
 # =====================================================================
 # BasePlatformAdapter._should_auto_tts_for_chat — gate for auto-TTS
 # on voice input. Regression test for Issue #16007.


### PR DESCRIPTION
## Summary
- Keep Discord voice silence polling cheap by scheduling completed utterances into bounded background STT tasks instead of awaiting each speaker inline.
- Add per-guild in-flight task tracking, global STT concurrency cap (`HERMES_DISCORD_VOICE_STT_CONCURRENCY`, default 3), and bounded pending backlog (`HERMES_DISCORD_VOICE_STT_MAX_PENDING`, default 12).
- Cancel pending voice input tasks on voice leave.
- Add a regression test proving three simultaneous speaker utterances all enter processing before any one finishes.

## Root cause
When `receiver.check_silence()` returned completed utterances for multiple speakers, `_voice_listen_loop()` processed them serially with `await _process_voice_input(...)`. PCM->WAV, STT, transcript posting, and optional callback latency for speaker 1 blocked speaker 2/3, and also paused further silence polling while STT was in flight.

## Tests
- RED verified first: new concurrency regression timed out on the old serial implementation.
- `python -m py_compile plugins/platforms/discord/adapter.py`
- `python -m pytest tests/gateway/test_voice_command.py::TestUDPKeepalive tests/gateway/test_voice_command.py::TestVoiceListenLoopConcurrency -q -o 'addopts='`
- `python -m pytest tests/gateway/test_voice_command.py tests/gateway/test_discord_opus.py tests/integration/test_voice_channel_flow.py -q -o 'addopts='`

Result: `168 passed, 22 skipped`.

## Notes
This builds on the prior Discord voice transcription fix branch/runtime worktree because upstream PR #42611 is still unmerged.