### PR TITLE
fix(desktop): render user prompts in full

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -74,7 +74,6 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Loader } from '@/components/ui/loader'
 import type { HermesGateway } from '@/hermes'
-import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { LinkifiedText } from '@/lib/external-link'
@@ -748,32 +747,6 @@ const UserMessage: FC<{
     return messageAttachmentRefs(custom.attachmentRefs)
   })
 
-  // Sticky human bubbles clamp to ~2 lines with a soft fade so a long prompt
-  // doesn't dominate the viewport while the response streams underneath; the
-  // clamp lifts on hover / focus (see styles.css). We measure the *unclamped*
-  // inner wrapper so the ResizeObserver only fires on real content / width
-  // changes, not on every frame while the outer max-height animates open.
-  const clampInnerRef = useRef<HTMLDivElement | null>(null)
-  const [bodyClamped, setBodyClamped] = useState(false)
-
-  const measureClamp = useCallback(() => {
-    const inner = clampInnerRef.current
-    const outer = inner?.parentElement
-
-    if (!inner || !outer) {
-      return
-    }
-
-    const styles = getComputedStyle(inner)
-    const lineHeight = parseFloat(styles.lineHeight) || 1.5 * parseFloat(styles.fontSize) || 20
-    const fullHeight = inner.scrollHeight
-
-    outer.style.setProperty('--human-msg-full', `${fullHeight}px`)
-    setBodyClamped(fullHeight > lineHeight * 2 + 1)
-  }, [])
-
-  useResizeObserver(measureClamp, clampInnerRef)
-
   const hasBody = messageText.trim().length > 0
   const isLatestUser = messageId === latestUserId
   const showStop = isLatestUser && threadRunning && Boolean(onCancel)
@@ -796,11 +769,7 @@ const UserMessage: FC<{
         // Render the user's text through a minimal markdown pipeline:
         // backtick `code` and ``` fenced ``` blocks, with directive chips
         // (`@file:` etc.) still resolved inside the plain-text spans.
-        <div className="sticky-human-clamp" data-clamped={bodyClamped ? 'true' : undefined}>
-          <div ref={clampInnerRef}>
-            <UserMessageText className="wrap-anywhere" text={messageText} />
-          </div>
-        </div>
+        <UserMessageText className="wrap-anywhere" text={messageText} />
       )}
     </>
   )

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -826,31 +826,6 @@ canvas {
   font-size: var(--conversation-text-font-size);
 }
 
-/* Sticky human bubbles clamp to ~2 lines with a soft bottom fade so a long
-   prompt doesn't dominate the viewport. The clamp lifts on focus only (clicking
-   opens the edit composer, which shows the full text) — not on hover, so the
-   bubble doesn't jump as the pointer passes over it. --human-msg-full is the
-   measured content height (set in UserMessage) so it animates to the real
-   height instead of overshooting the cap. */
-.sticky-human-clamp {
-  cursor: pointer;
-  max-height: calc(2 * var(--dt-line-height) * var(--conversation-text-font-size) + 0.15rem);
-  overflow: hidden;
-  transition: max-height 0.08s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.sticky-human-clamp[data-clamped='true'] {
-  -webkit-mask-image: linear-gradient(to bottom, #000 55%, transparent);
-  mask-image: linear-gradient(to bottom, #000 55%, transparent);
-}
-
-.composer-human-message:focus-within .sticky-human-clamp {
-  max-height: min(var(--human-msg-full, 24rem), 24rem);
-  overflow-y: auto;
-  -webkit-mask-image: none;
-  mask-image: none;
-}
-
 /* The thread renders items in natural document flow (padding spacers, not
    transforms) and @tanstack/react-virtual already adjusts scrollTop itself
    when an off-screen turn is measured and its real height differs from the


### PR DESCRIPTION
## Summary
- remove the two-line clamp wrapper from Desktop user message bubbles
- remove the fade/mask CSS and clamped-height measurement for submitted prompts
- render user-authored prompt text at its natural height, matching Codex app behavior

Closes #42992

## Test Plan
- [x] `npm run type-check`
- [x] `npx eslint src/components/assistant-ui/thread.tsx --quiet`
- [x] `npm run build`

Note: full `npm run lint -- --quiet` currently fails on pre-existing unrelated lint issues in other files on `main`; the touched file passes targeted ESLint.