### PR TITLE
fix(telegram): start polling before PTB app

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1641,8 +1641,6 @@ class TelegramAdapter(BasePlatformAdapter):
                         await asyncio.sleep(wait)
                     else:
                         raise
-            await self._app.start()
-
             # Decide between webhook and polling mode
             webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
 
@@ -1716,9 +1714,17 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=True,
+                    drop_pending_updates=False,
                     error_callback=_polling_error_callback,
                 )
+
+            # Match python-telegram-bot's run_polling lifecycle: initialize,
+            # start polling/webhook, then start the application so the update
+            # processor is attached after the updater is actively receiving.
+            app = self._app
+            if app is None:
+                raise RuntimeError("Telegram application was not initialized")
+            await app.start()
             
             # Register bot commands so Telegram shows a hint menu when users type /
             # List is derived from the central COMMAND_REGISTRY — adding a new
@@ -1781,6 +1787,23 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
             
         except Exception as e:
+            app = self._app
+            if app is not None:
+                try:
+                    updater = getattr(app, "updater", None)
+                    if updater and getattr(updater, "running", False):
+                        await updater.stop()
+                    if getattr(app, "running", False):
+                        await app.stop()
+                    shutdown = getattr(app, "shutdown", None)
+                    if shutdown:
+                        await shutdown()
+                except Exception:
+                    logger.debug(
+                        "[%s] Telegram startup cleanup failed (non-fatal)",
+                        self.name,
+                        exc_info=True,
+                    )
             self._release_platform_lock()
             message = f"Telegram startup failed: {e}"
             self._set_fatal_error("telegram_connect_error", message, retryable=True)

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -288,6 +288,122 @@ async def test_connect_clears_webhook_before_polling(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_connect_starts_polling_before_application_without_dropping_updates(monkeypatch):
+    """Initial polling startup must match PTB's run_polling lifecycle.
+
+    Starting the PTB application before the updater can leave Hermes reporting
+    "Connected to Telegram" while no long-poll consumer drains incoming DMs.
+    Dropping pending updates on the same startup then discards the queued DM
+    that would prove the poller was wedged.
+    """
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.delenv("TELEGRAM_WEBHOOK_URL", raising=False)
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    calls = []
+    start_polling_kwargs = {}
+
+    async def fake_start_polling(**kwargs):
+        calls.append("start_polling")
+        start_polling_kwargs.update(kwargs)
+
+    async def fake_app_start():
+        calls.append("app_start")
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=fake_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(
+        delete_webhook=AsyncMock(),
+        set_my_commands=AsyncMock(),
+    )
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(side_effect=fake_app_start),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert calls[:2] == ["start_polling", "app_start"]
+    assert start_polling_kwargs["drop_pending_updates"] is False
+
+
+@pytest.mark.asyncio
+async def test_connect_cleans_up_polling_when_application_start_fails(monkeypatch):
+    """A post-polling app.start failure must not leave getUpdates running."""
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.delenv("TELEGRAM_WEBHOOK_URL", raising=False)
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    release = MagicMock()
+    monkeypatch.setattr("gateway.status.release_scoped_lock", release)
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(
+        delete_webhook=AsyncMock(),
+        set_my_commands=AsyncMock(),
+    )
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(side_effect=RuntimeError("app start failed")),
+        stop=AsyncMock(),
+        shutdown=AsyncMock(),
+        running=False,
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter.fatal_error_code == "telegram_connect_error"
+    updater.start_polling.assert_awaited_once()
+    updater.stop.assert_awaited_once()
+    app.shutdown.assert_awaited_once()
+    release.assert_called()
+
+
+@pytest.mark.asyncio
 async def test_disconnect_skips_inactive_updater_and_app(monkeypatch):
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
 


### PR DESCRIPTION
## Summary
- Align Telegram polling startup with python-telegram-bot's lifecycle by starting the updater before `Application.start()`
- Preserve queued incoming DMs on polling startup with `drop_pending_updates=False`
- Clean up a started updater/application if startup fails after polling begins, so retries do not leave a second `getUpdates` consumer behind

Fixes #42909.

Supersedes the narrow lifecycle/drop-pending portion of closed, unmerged #42959 without adding the unproven polling watchdog from that attempt.

Related open overlap: #29033 covers the `drop_pending_updates=False` startup-loss piece only. This PR keeps that fix and adds the PTB startup lifecycle ordering plus post-polling startup cleanup needed for #42909's "connected but not consuming DMs" failure mode.

## Root cause
Hermes initialized and started the PTB application before starting polling. That differed from PTB's own `run_polling()` lifecycle (`initialize -> updater.start_polling -> app.start`) and could leave the gateway reporting “Connected to Telegram” while the updater was not yet the active update consumer. On startup, Hermes also used `drop_pending_updates=True`, discarding the queued DM that would otherwise be processed after the poller attached.

## Verification
- RED: `python -m pytest tests/gateway/test_telegram_conflict.py::test_connect_starts_polling_before_application_without_dropping_updates -q` failed before the fix with `['app_start', 'start_polling'] != ['start_polling', 'app_start']`
- RED: `python -m pytest tests/gateway/test_telegram_conflict.py::test_connect_cleans_up_polling_when_application_start_fails -q` failed before cleanup with `updater.stop` awaited 0 times
- GREEN: `python -m pytest tests/gateway/test_telegram_conflict.py::test_connect_starts_polling_before_application_without_dropping_updates tests/gateway/test_telegram_conflict.py::test_connect_cleans_up_polling_when_application_start_fails -q` passed
- `scripts/run_tests.sh tests/gateway/test_telegram_conflict.py tests/gateway/test_telegram_channel_posts.py` passed, 12 tests
- `scripts/run_tests.sh tests/gateway/test_telegram*.py` passed, 567 tests
- `python -m ruff check gateway/platforms/telegram.py tests/gateway/test_telegram_conflict.py` passed
- `python -m py_compile gateway/platforms/telegram.py tests/gateway/test_telegram_conflict.py && git diff --check` passed
- Fresh adversarial autoreview after cleanup fix: no blocking findings

## Notes
No live Telegram token was used. The behavior is covered with mocked PTB lifecycle tests around the gateway integration boundary.
