### PR TITLE
fix(desktop): increase user message bubble clamp from 2 to 4 lines

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -769,7 +769,7 @@ const UserMessage: FC<{
     const fullHeight = inner.scrollHeight
 
     outer.style.setProperty('--human-msg-full', `${fullHeight}px`)
-    setBodyClamped(fullHeight > lineHeight * 2 + 1)
+    setBodyClamped(fullHeight > lineHeight * 4 + 1)
   }, [])
 
   useResizeObserver(measureClamp, clampInnerRef)

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -827,14 +827,16 @@ canvas {
 }
 
 /* Sticky human bubbles clamp to ~2 lines with a soft bottom fade so a long
-   prompt doesn't dominate the viewport. The clamp lifts on focus only (clicking
+   prompt doesn't dominate the viewport.  The clamp lifts on focus only (clicking
    opens the edit composer, which shows the full text) — not on hover, so the
-   bubble doesn't jump as the pointer passes over it. --human-msg-full is the
+   bubble doesn't jump as the pointer passes over it.  Up to four lines are
+   visible before the fade kicks in, so short multi-line prompts (numbered
+   lists, two-question prompts) stay fully readable.  --human-msg-full is the
    measured content height (set in UserMessage) so it animates to the real
    height instead of overshooting the cap. */
 .sticky-human-clamp {
   cursor: pointer;
-  max-height: calc(2 * var(--dt-line-height) * var(--conversation-text-font-size) + 0.15rem);
+  max-height: calc(4 * var(--dt-line-height) * var(--conversation-text-font-size) + 0.15rem);
   overflow: hidden;
   transition: max-height 0.08s cubic-bezier(0.4, 0, 0.2, 1);
 }


### PR DESCRIPTION
## Problem

In Hermes Desktop, the user message bubble in the chat thread clamps content to 2 visual lines via the `.sticky-human-clamp` CSS class. Multi-line prompts (numbered lists, two-question messages) have their 3rd+ lines hidden behind a fade mask, even though the agent received and answered the full text.

This creates confusion — users think their prompt was truncated or lost.

**Reported in:** #42992

## Root Cause

The CSS `max-height` was calculated as:
```css
max-height: calc(2 * var(--dt-line-height) * var(--conversation-text-font-size) + 0.15rem);
```

And the JS threshold for applying the fade mask was:
```js
setBodyClamped(fullHeight > lineHeight * 2 + 1)
```

Both limited visibility to exactly 2 lines.

## Fix

Increase the clamp from 2 to 4 lines in both the CSS `max-height` calculation and the JS `bodyClamped` threshold. This keeps short multi-line prompts fully readable while still clamping genuinely long messages that would dominate the viewport.

**Files changed:**
- `apps/desktop/src/styles.css` — `max-height` calc: `2 *` → `4 *`, updated comment
- `apps/desktop/src/components/assistant-ui/thread.tsx` — threshold: `lineHeight * 2` → `lineHeight * 4`

## Testing

- Verified that a 3-line user message is now fully visible without clicking
- Verified that long messages (10+ lines) still clamp with the fade mask
- Verified that clicking to edit still expands to full height
