### PR TITLE
fix(cli): resolve qwen-oauth and google-gemini-cli logout from config fallback

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6123,9 +6123,21 @@ def _logout_default_provider_from_config() -> Optional[str]:
     config.yaml still selected an OAuth provider such as openai-codex for the
     agent model: there was no active auth provider to target, so logout printed
     "No provider is currently logged in" and never reset model.provider.
+
+    This also covers OAuth providers whose tokens live outside auth.json
+    entirely (qwen-oauth in the Qwen CLI credential file, google-gemini-cli in
+    the Google OAuth store). Selecting them via `hermes model` sets
+    model.provider without writing active_provider, so the config fallback is
+    the only way logout can find the target.
     """
     provider = _get_config_provider()
-    if provider in {"nous", "openai-codex", "xai-oauth"}:
+    if provider in {
+        "nous",
+        "openai-codex",
+        "xai-oauth",
+        "qwen-oauth",
+        "google-gemini-cli",
+    }:
         return provider
     return None
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -860,6 +860,62 @@ def test_logout_clears_stale_active_codex_without_provider_credentials(tmp_path,
     assert "provider: auto" in config_text
 
 
+def test_logout_defaults_to_configured_qwen_oauth_when_no_active_provider(tmp_path, monkeypatch, capsys):
+    """Bare `hermes logout` should target configured Qwen OAuth if auth has no active provider.
+
+    Selecting Qwen OAuth via `hermes model` sets model.provider without writing
+    auth.json.active_provider (its tokens live in the Qwen CLI credential file),
+    so logout must fall back to the config provider to reset the agent model.
+    """
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}, "credential_pool": {}})
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  default: qwen3-coder-plus\n"
+        "  provider: qwen-oauth\n"
+        "  base_url: https://portal.qwen.ai/v1\n"
+    )
+
+    from types import SimpleNamespace
+    from hermes_cli.auth import logout_command
+
+    logout_command(SimpleNamespace(provider=None))
+
+    out = capsys.readouterr().out
+    assert "Logged out of Qwen OAuth." in out
+    config_text = (hermes_home / "config.yaml").read_text()
+    assert "provider: auto" in config_text
+
+
+def test_logout_defaults_to_configured_gemini_cli_when_no_active_provider(tmp_path, monkeypatch, capsys):
+    """Bare `hermes logout` should target configured Google Gemini OAuth if auth has no active provider.
+
+    Selecting Gemini OAuth via `hermes model` sets model.provider without writing
+    auth.json.active_provider (its tokens live in the Google OAuth store), so
+    logout must fall back to the config provider to reset the agent model.
+    """
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}, "credential_pool": {}})
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  default: gemini-3-flash-preview\n"
+        "  provider: google-gemini-cli\n"
+        "  base_url: cloudcode-pa://google\n"
+    )
+
+    from types import SimpleNamespace
+    from hermes_cli.auth import logout_command
+
+    logout_command(SimpleNamespace(provider=None))
+
+    out = capsys.readouterr().out
+    assert "Logged out of Google Gemini (OAuth)." in out
+    config_text = (hermes_home / "config.yaml").read_text()
+    assert "provider: auto" in config_text
+
+
 def test_reset_config_provider_uses_atomic_yaml_write(tmp_path, monkeypatch):
     """Logout config reset should delegate the YAML write atomically."""
     hermes_home = tmp_path / "hermes"


### PR DESCRIPTION
## What does this PR do?

`hermes logout` resolves its target as
`provider_id or active_provider or _logout_default_provider_from_config()`.
The config fallback only recognized `nous`, `openai-codex`, and `xai-oauth`.

When Qwen OAuth or Google Gemini OAuth is selected via `hermes model`, the flow
sets `model.provider` but not `auth.json.active_provider` (their tokens live
outside `auth.json` — in the Qwen CLI credential file / Google OAuth store).
So with no active provider, `hermes logout` printed
`No provider is currently logged in.` and never reset `model.provider`.

This adds `qwen-oauth` and `google-gemini-cli` to the fallback set, mirroring
how `openai-codex` and `xai-oauth` are already handled. Both are already in
`PROVIDER_REGISTRY`, so `_should_reset_config_provider_on_logout` resets the
config once the target resolves — no other changes needed.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py` — `_logout_default_provider_from_config()`: add
  `qwen-oauth` and `google-gemini-cli` to the fallback provider set.
- `tests/hermes_cli/test_auth_commands.py` — two regression tests covering
  bare `hermes logout` with config provider set and no active provider.

## How to Test

1. Set `model.provider: qwen-oauth` (or `google-gemini-cli`) in `config.yaml`
   with `auth.json` having no `active_provider`.
2. Run `hermes logout`.
3. Before: `No provider is currently logged in.` (config untouched).
   After: `Logged out of Qwen OAuth.` and `model.provider` reset to `auto`.

### Tests

    $ python -m pytest tests/hermes_cli/test_auth_commands.py -q
    52 passed

    $ python -m pytest tests/hermes_cli/test_auth_commands.py -k logout -q
    5 passed

New tests:
- `test_logout_defaults_to_configured_qwen_oauth_when_no_active_provider`
- `test_logout_defaults_to_configured_gemini_cli_when_no_active_provider`

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] All tests pass
- [x] I've added tests for my changes