### PR TITLE
fix(openrouter): never send reasoning field for adaptive Anthropic models

### DIFF
--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -117,19 +117,25 @@ class OpenRouterProfile(ProviderProfile):
         """
         extra_body: dict[str, Any] = {}
         if supports_reasoning:
-            if reasoning_config is not None:
-                cfg = dict(reasoning_config)
-                # Reasoning-mandatory Anthropic models (Claude 4.6+ / fable /
-                # future named models) have no "off" switch. Forwarding
-                # ``{enabled: false}`` makes OpenRouter emit Anthropic's manual
-                # ``thinking: {type: "disabled"}``, which those models reject
-                # with a non-retryable HTTP 400. Omit reasoning entirely so the
-                # model falls back to its default (adaptive) thinking instead.
-                disabling = cfg.get("enabled") is False or cfg.get("effort") == "none"
-                if disabling and _anthropic_reasoning_is_mandatory(model):
-                    pass  # leave reasoning unset → adaptive default
-                else:
-                    extra_body["reasoning"] = cfg
+            # Reasoning-mandatory Anthropic models (Claude 4.6+ / fable /
+            # future named models) use *adaptive* thinking: the model decides
+            # how much to think, and OpenRouter ignores ``reasoning.effort`` for
+            # them entirely. Sending any ``reasoning`` field is therefore both
+            # pointless and actively harmful:
+            #   - ``{enabled: false}`` → OpenRouter emits Anthropic's manual
+            #     ``thinking: {type: "disabled"}``, which these models 400 on.
+            #   - any enabled form, on a tool-continuation turn whose prior
+            #     assistant tool_call carries no thinking block (chat_completions
+            #     never replays signed thinking blocks), ALSO makes OpenRouter
+            #     emit ``thinking: {type: "disabled"}`` → the same 400 on every
+            #     turn after the first tool call.
+            # The only reliable behavior is to omit ``reasoning`` and let the
+            # model default to adaptive. See hermes-agent#42991 (disable case)
+            # and the tool-replay follow-up.
+            if _anthropic_reasoning_is_mandatory(model):
+                pass  # omit reasoning entirely → adaptive default
+            elif reasoning_config is not None:
+                extra_body["reasoning"] = dict(reasoning_config)
             else:
                 extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
 

--- a/tests/providers/test_profile_wiring.py
+++ b/tests/providers/test_profile_wiring.py
@@ -124,11 +124,11 @@ class TestOpenRouterProfileParity:
     def test_reasoning_full_config(self, transport):
         rc = {"enabled": True, "effort": "high"}
         legacy = transport.build_kwargs(
-            model="anthropic/claude-sonnet-4.6", messages=_msgs(), tools=None,
+            model="deepseek/deepseek-chat", messages=_msgs(), tools=None,
             provider_profile=get_provider_profile("openrouter"), supports_reasoning=True, reasoning_config=rc,
         )
         profile = transport.build_kwargs(
-            model="anthropic/claude-sonnet-4.6", messages=_msgs(), tools=None,
+            model="deepseek/deepseek-chat", messages=_msgs(), tools=None,
             provider_profile=get_provider_profile("openrouter"),
             supports_reasoning=True, reasoning_config=rc,
         )
@@ -136,11 +136,11 @@ class TestOpenRouterProfileParity:
 
     def test_default_reasoning(self, transport):
         legacy = transport.build_kwargs(
-            model="anthropic/claude-sonnet-4.6", messages=_msgs(), tools=None,
+            model="deepseek/deepseek-chat", messages=_msgs(), tools=None,
             provider_profile=get_provider_profile("openrouter"), supports_reasoning=True,
         )
         profile = transport.build_kwargs(
-            model="anthropic/claude-sonnet-4.6", messages=_msgs(), tools=None,
+            model="deepseek/deepseek-chat", messages=_msgs(), tools=None,
             provider_profile=get_provider_profile("openrouter"),
             supports_reasoning=True,
         )

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -218,15 +218,27 @@ class TestOpenRouterProfile:
             )
             assert eb["reasoning"] == {"enabled": False}, (model, eb)
 
-    def test_reasoning_enabled_unaffected_for_mandatory_anthropic(self):
-        """Enabling reasoning on a mandatory model still forwards the config."""
+    def test_reasoning_omitted_for_mandatory_anthropic_even_when_enabled(self):
+        """Reasoning-mandatory Anthropic models (4.6+/fable) use adaptive
+        thinking — OpenRouter ignores reasoning.effort for them, and sending any
+        reasoning field makes OpenRouter emit thinking.type.disabled on
+        tool-continuation turns (whose assistant tool_calls carry no thinking
+        block), 400ing every turn after the first tool call. The profile must
+        omit reasoning entirely so the model defaults to adaptive.
+        """
         p = get_provider_profile("openrouter")
-        eb, _ = p.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "medium"},
-            supports_reasoning=True,
-            model="anthropic/claude-fable-5",
-        )
-        assert eb["reasoning"] == {"enabled": True, "effort": "medium"}
+        for cfg in (
+            {"enabled": True, "effort": "medium"},
+            {"enabled": True, "effort": "xhigh"},
+            {"effort": "high"},
+            {"enabled": True},
+        ):
+            eb, _ = p.build_api_kwargs_extras(
+                reasoning_config=cfg,
+                supports_reasoning=True,
+                model="anthropic/claude-fable-5",
+            )
+            assert "reasoning" not in eb, (cfg, eb)
 
     def test_default_reasoning(self):
         p = get_provider_profile("openrouter")

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -160,7 +160,7 @@ class TestOpenRouterParity:
         """OpenRouter passes the FULL reasoning_config dict, not just effort."""
         rc = {"enabled": True, "effort": "high"}
         kw = transport.build_kwargs(
-            model="anthropic/claude-sonnet-4.6",
+            model="deepseek/deepseek-chat",
             messages=_simple_messages(),
             tools=None,
             provider_profile=get_provider_profile("openrouter"),
@@ -169,10 +169,24 @@ class TestOpenRouterParity:
         )
         assert kw["extra_body"]["reasoning"] == rc
 
+    def test_reasoning_omitted_for_mandatory_anthropic(self, transport):
+        """Adaptive-thinking Anthropic models (4.6+/fable) get NO reasoning
+        field — sending one makes OpenRouter emit thinking.type.disabled on
+        tool-replay turns, which the model 400s on."""
+        kw = transport.build_kwargs(
+            model="anthropic/claude-sonnet-4.6",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("openrouter"),
+            supports_reasoning=True,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert "reasoning" not in kw.get("extra_body", {})
+
     def test_default_reasoning_when_no_config(self, transport):
         """When supports_reasoning=True but no config, adds default."""
         kw = transport.build_kwargs(
-            model="anthropic/claude-sonnet-4.6",
+            model="deepseek/deepseek-chat",
             messages=_simple_messages(),
             tools=None,
             provider_profile=get_provider_profile("openrouter"),


### PR DESCRIPTION
## Summary

Fable-5 (and any Claude 4.6+ adaptive model) over OpenRouter now survives tool-continuation turns instead of dying with `thinking.type.disabled` on every turn after the first tool call.

**Root cause (the part #42991 missed):** #42991 only omitted `reasoning` when it was being *disabled*. But the real failure also happens with reasoning **enabled**: `chat_completions` never replays signed thinking blocks, so the prior assistant `tool_call` in history carries no thinking. When the next request still asks for reasoning, OpenRouter resolves the mismatch ("reasoning requested, but the assistant turn has none") by emitting Anthropic `thinking: {type: "disabled"}` — which adaptive models reject. So the first turn succeeds and every turn after the first tool call 400s. The logs show exactly this: API call #1 OK, call #2 (the tool replay) 400, `provider_name: Amazon Bedrock`.

OpenRouter ignores `reasoning.effort` for adaptive Anthropic models anyway (the model self-decides how much to think), so the field is pointless on every turn and harmful on tool-replay turns.

## Changes

- `plugins/model-providers/openrouter/__init__.py`: omit the `reasoning` field entirely for reasoning-mandatory Anthropic models (4.6+/fable), regardless of enabled/disabled. Legacy Anthropic + all non-Anthropic models unchanged.
- tests: assert omission across enabled/disabled/effort variants; parity tests switched to a non-Anthropic reasoning model (deepseek) since Anthropic 4.6+ no longer carries a `reasoning` field.

## Validation

Live, through the real transport+profile path, replaying a `user → assistant(tool_call) → tool` history on `anthropic/claude-fable-5` with reasoning enabled:

| | Before | After |
|---|---|---|
| extra_body | `{reasoning: {enabled: true, effort: medium}}` | `None` (no reasoning field) |
| tool-replay turn | HTTP 400 `thinking.type.disabled` | HTTP 200 |
| adaptive thinking | n/a (request died) | still happens (model-decided) |

Tests: `tests/providers/` + `test_run_agent.py::TestBuildApiKwargs` + `test_anthropic_adapter.py` + transports/aux suites — all green (288 + 536 passed across the runs).

Builds on #42991 (merged).