### PR TITLE
fix(cron): remove racy _hermes_home global write in profile job context

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -241,23 +241,27 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
 
     Cron jobs are stored and scheduled by the profile running the scheduler, but
     an individual job can opt into a different runtime profile. While active,
-    the scheduler's test/override hook and a context-local Hermes home override
-    both point at the resolved profile directory so _get_hermes_home(),
-    .env/config loading, script resolution, AIAgent construction, and downstream
-    get_hermes_home() callers agree on the same home.
+    a context-local Hermes home override (via ContextVar set_hermes_home_override)
+    scopes _get_hermes_home(), .env/config loading, script resolution,
+    AIAgent construction, and downstream get_hermes_home() callers to the
+    profile directory.
+
+    Each job runs inside ctx.run() (see tick()), so ContextVar mutations are
+    isolated to that job's context copy and never leak to parallel-pool threads.
+    The former module-level _hermes_home global write has been removed: it was
+    the only cross-context contaminant and caused parallel jobs to resolve
+    scripts against the profile's scripts/ directory.
 
     Some existing provider/config paths still load profile .env values through
     os.environ, so profile jobs also snapshot and restore the process
     environment on exit. tick() runs profile jobs sequentially to keep that
-    temporary mutation isolated from other scheduled jobs.
+    temporary os.environ mutation isolated from other scheduled jobs.
     """
     raw_profile = str(profile or "").strip()
     if not raw_profile:
         yield None
         return
 
-    global _hermes_home
-    prior_override = _hermes_home
     env_snapshot = os.environ.copy()
 
     from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
@@ -278,7 +282,6 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
     override_token = None
     try:
         override_token = set_hermes_home_override(profile_home)
-        _hermes_home = profile_home
         logger.info(
             "Job '%s': using Hermes profile '%s' (%s)",
             job_id,
@@ -287,7 +290,6 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
         )
         yield normalized_profile
     finally:
-        _hermes_home = prior_override
         if override_token is not None:
             reset_hermes_home_override(override_token)
         # Delta-based restore: remove added keys, restore changed keys.
@@ -2135,12 +2137,17 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 return False
 
         # Partition due jobs: jobs with a per-job workdir and/or profile touch
-        # process-global runtime state inside run_job. Workdir jobs temporarily
-        # set os.environ["TERMINAL_CWD"]; profile jobs use a context-local
-        # Hermes home override, scheduler _hermes_home hook, and temporary
-        # profile .env load into os.environ with snapshot/restore. They MUST run
-        # sequentially to avoid corrupting each other. Jobs without either field
-        # stay parallel-safe.
+        # process-global os.environ inside run_job. Workdir jobs temporarily set
+        # os.environ["TERMINAL_CWD"]; profile jobs load their .env into os.environ
+        # with snapshot/restore. Both MUST run sequentially to prevent concurrent
+        # os.environ mutations from corrupting each other. Jobs without either
+        # field are parallel-safe.
+        #
+        # Note: profile jobs previously also wrote a module-level _hermes_home
+        # global which leaked to parallel-pool threads. That write has been
+        # removed; the ContextVar set by set_hermes_home_override() inside
+        # ctx.run() now provides correct per-job isolation without any global
+        # mutation.
         sequential_jobs = [
             j for j in due_jobs
             if (j.get("workdir") or "").strip() or (j.get("profile") or "").strip()

--- a/tests/cron/test_cron_profile.py
+++ b/tests/cron/test_cron_profile.py
@@ -447,3 +447,73 @@ class TestTickProfilePartition:
             assert seq_thread.startswith("cron-seq"), seq_thread
         par_thread = next(t for job_id, t in calls if job_id == "c")
         assert par_thread.startswith("cron-parallel"), par_thread
+
+
+class TestProfileHomeThreadIsolation:
+    """Regression tests for the race where a profile job's home leaked to
+    parallel-pool threads via the module-level _hermes_home global.
+
+    When a profile job (sequential pool) runs at the same time as a non-profile
+    job (parallel pool), the parallel job must still resolve scripts and config
+    from the default HERMES_HOME, not from the profile's home directory.
+    """
+
+    def test_parallel_thread_sees_default_home_during_profile_job(
+        self, tmp_path, monkeypatch
+    ):
+        """A parallel job must see the default HERMES_HOME even while a profile
+        job's ContextVar override is active on another thread."""
+        import contextvars
+        import threading
+        import cron.scheduler as sched
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        default_home = tmp_path / "default"
+        profile_home = tmp_path / "profile"
+        default_home.mkdir()
+        profile_home.mkdir()
+
+        # Leave _hermes_home=None so the ContextVar / env-var path is exercised.
+        monkeypatch.setattr(sched, "_hermes_home", None)
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+        seen_in_parallel: list = []
+        profile_active = threading.Event()
+        parallel_done = threading.Event()
+
+        def profile_job():
+            # Mirror the real execution model: run inside ctx.run() and set
+            # the ContextVar within that context, as _job_profile_context does.
+            ctx = contextvars.copy_context()
+
+            def _inner():
+                token = set_hermes_home_override(profile_home)
+                try:
+                    profile_active.set()   # signal: override active on this thread
+                    parallel_done.wait(timeout=5)
+                finally:
+                    reset_hermes_home_override(token)
+
+            ctx.run(_inner)
+
+        def parallel_job():
+            profile_active.wait(timeout=5)
+            # Must resolve the default home, not the profile home
+            seen_in_parallel.append(sched._get_hermes_home())
+            parallel_done.set()
+
+        t1 = threading.Thread(target=profile_job, name="seq-profile")
+        t2 = threading.Thread(target=parallel_job, name="parallel-job")
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        assert len(seen_in_parallel) == 1, "parallel job did not run"
+        assert seen_in_parallel[0] == default_home, (
+            f"Parallel job saw {seen_in_parallel[0]!r} instead of "
+            f"{default_home!r} — profile home leaked across threads"
+        )


### PR DESCRIPTION
## Problem

`_job_profile_context()` writes `global _hermes_home = profile_home` before yielding. Because `_hermes_home` is a module-level global shared across all threads, parallel-pool jobs (those without a `profile` field) read `_get_hermes_home()` and receive the profile home instead of the default HERMES_HOME. This causes script path resolution to point at the profile's `scripts/` directory, producing `Script not found` errors for unrelated parallel jobs that fire at the same tick.

The sequential pool only prevents **profile jobs from racing each other**. It does not prevent the parallel pool from reading the contaminated global.

## Root Cause

The global write predates the introduction of `set_hermes_home_override()` (ContextVar, commit `544406ef2`). When the ContextVar was added to replace the `os.environ["HERMES_HOME"]` mutation, the `_hermes_home` global write was retained as a belt-and-suspenders fallback — but it became redundant once `ctx.run()` was in place.

Each job runs via `ctx.run(_process_job, j)` (verified in `tick()`). ContextVar mutations inside `ctx.run()` are scoped to that job's context copy and are never visible to other threads' contexts. `_get_hermes_home()` already falls through to `get_hermes_home()` which reads the ContextVar correctly — so the global write only adds cross-thread contamination without adding correctness.

## Fix

Remove the three lines that wrote to the module global:

```python
# removed from _job_profile_context():
global _hermes_home
_hermes_home = profile_home          # in try block
_hermes_home = prior_override        # in finally block
```

`_hermes_home: Path | None = None` is preserved as a module-level variable for test monkeypatching compatibility (`patch("cron.scheduler._hermes_home", ...)`).

The sequential pool is retained — it still prevents concurrent `os.environ` mutations between profile and workdir jobs.

The docstring and tick() partition comment are updated to reflect that the sequential pool is now retained solely for `os.environ` isolation, not for `_hermes_home`.

## Test

Adds `TestProfileHomeThreadIsolation` with a concurrent regression test:

- A profile thread sets the ContextVar override inside `ctx.run()` (mirroring the real execution path)
- A parallel thread concurrently calls `_get_hermes_home()`
- The parallel thread must resolve the default HERMES_HOME, not the profile home

```
21 passed in 0.70s  (20 existing + 1 new)
```

## Commit history context

| Commit | Effect |
|---|---|
| `bb9ecb217` | Initial profile support: wrote both `os.environ["HERMES_HOME"]` and `_hermes_home` |
| `544406ef2` | Replaced env var write with ContextVar; kept global write as "belt-and-suspenders" |
| `9c48d47aa` | Added os.environ snapshot/restore; global write remained |
| this PR | Remove global write — ContextVar alone is sufficient via `ctx.run()` |