### PR TITLE
fix(desktop): pass owning profile when exporting a session

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -74,7 +74,7 @@ function useSessionActions({ sessionId, title, pinned = false, profile, onPin, o
       label: r.export,
       onSelect: () => {
         triggerHaptic('selection')
-        void exportSession(sessionId, { title })
+        void exportSession(sessionId, { profile, title })
       }
     },
     {

--- a/apps/desktop/src/lib/session-export.test.ts
+++ b/apps/desktop/src/lib/session-export.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getSessionMessages } from '@/hermes'
+
+import { exportSession } from './session-export'
+
+vi.mock('@/hermes', () => ({
+  getSessionMessages: vi.fn()
+}))
+
+const mockedGetSessionMessages = vi.mocked(getSessionMessages)
+
+describe('exportSession', () => {
+  beforeEach(() => {
+    mockedGetSessionMessages.mockReset()
+    mockedGetSessionMessages.mockResolvedValue({ messages: [] } as never)
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock')
+    globalThis.URL.revokeObjectURL = vi.fn()
+    vi.spyOn(HTMLElement.prototype, 'click').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // Regression: a session owned by another profile (Command Center's all-profile
+  // list passes the whole session object) must read from that profile's backend,
+  // not the active gateway profile's — otherwise the transcript 404s or comes
+  // back wrong. getSessionMessages takes the owning profile to route the read.
+  it('forwards the owning profile from the session object', async () => {
+    await exportSession('s1', { session: { id: 's1', profile: 'work' } as never, title: 'Demo' })
+
+    expect(mockedGetSessionMessages).toHaveBeenCalledWith('s1', 'work')
+  })
+
+  it('prefers an explicitly passed profile (sidebar action menu path)', async () => {
+    await exportSession('s1', { profile: 'work', title: 'Demo' })
+
+    expect(mockedGetSessionMessages).toHaveBeenCalledWith('s1', 'work')
+  })
+
+  it('omits the profile for current/default-profile sessions', async () => {
+    await exportSession('s1', { title: 'Demo' })
+
+    expect(mockedGetSessionMessages).toHaveBeenCalledWith('s1', undefined)
+  })
+})

--- a/apps/desktop/src/lib/session-export.ts
+++ b/apps/desktop/src/lib/session-export.ts
@@ -7,6 +7,7 @@ interface ExportSessionParams {
   sessionId: string
   title?: string | null
   session?: SessionInfo
+  profile?: string | null
 }
 
 function sanitizeFilenamePart(value: string) {
@@ -31,7 +32,8 @@ export async function exportSession(sessionId: string, params: Omit<ExportSessio
   }
 
   try {
-    const { messages } = await getSessionMessages(sessionId)
+    const profile = params.profile ?? params.session?.profile
+    const { messages } = await getSessionMessages(sessionId, profile)
 
     const payload = {
       exported_at: new Date().toISOString(),


### PR DESCRIPTION
## What does this PR do?

`exportSession()` always called `getSessionMessages(sessionId)` without the
owning profile. When a session belongs to another profile — Command Center's
all-profile list, or the sidebar under a non-active profile — the read hit the
active gateway profile's backend instead, returning a 404 or the wrong
transcript. `getSessionMessages(id, profile?)` documents that the owning profile
must be passed for non-current/default profiles, so this forwards it — matching
the existing `renameSession`/`deleteSession` convention.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/session-export.ts` — add `profile` to
  `ExportSessionParams`; resolve `params.profile ?? params.session?.profile` and
  pass it to `getSessionMessages`.
- `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx` — forward the
  existing `profile` prop into the export call.
- `apps/desktop/src/lib/session-export.test.ts` — new regression tests.

## How to Test

1. Configure two profiles; open Command Center's all-profiles session list.
2. Export a session owned by a non-active profile.
3. Before: request omits `?profile=` → 404 / wrong transcript.
   After: owning profile is forwarded → correct transcript exports.

Automated (run inside `apps/desktop`):

```
npm run test:ui -- src/lib/session-export.test.ts
#   Test Files  1 passed (1)
#   Tests       3 passed (3)

npm run type-check    # tsc -b  → exit 0
npm run lint          # eslint  → clean (exit 0)
```

Full desktop `test:ui` suite: this change adds +3 passing tests and introduces
0 new failures (verified against a clean baseline; the remaining failures are
pre-existing and unrelated to session export).

## Checklist

- [x] Commit messages follow Conventional Commits (`fix(desktop): …`)
- [x] PR contains only changes related to this fix
- [x] I've added tests for my change
- [ ] `pytest tests/ -q` — N/A (desktop-only TypeScript change)
- [ ] Cross-platform impact — N/A (renderer logic, no OS-specific code)
- [ ] Docs update — N/A