### PR TITLE
fix(email): use BODY.PEEK[] in IMAP fetch to preserve unread state

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -383,7 +383,7 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -895,6 +895,40 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(results[0]["sender_addr"], "john@test.com")
         self.assertEqual(results[0]["sender_name"], "John Doe")
 
+    def test_fetch_uses_body_peek_to_preserve_unread(self):
+        """UID FETCH must use BODY.PEEK[] instead of RFC822 to avoid
+        implicitly setting the \\Seen flag on polled messages (#42997)."""
+        adapter = self._make_adapter()
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        mock_imap = MagicMock()
+        fetch_calls = []
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                fetch_calls.append(args)
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        # Verify BODY.PEEK[] is used, not RFC822
+        self.assertTrue(len(fetch_calls) > 0, "Expected at least one fetch call")
+        fetch_arg = fetch_calls[0][-1]  # last positional arg is the fetch spec
+        self.assertIn("BODY.PEEK", fetch_arg, f"Expected BODY.PEEK but got: {fetch_arg}")
+        self.assertNotIn("RFC822", fetch_arg, "RFC822 must not be used (sets \\Seen flag)")
+
+
 
 class TestPollLoop(unittest.TestCase):
     """Test the async polling loop."""


### PR DESCRIPTION
## What does this PR do?

Changes the Email gateway's IMAP UID FETCH from `(RFC822)` to `(BODY.PEEK[])` so that polling for new messages does not implicitly set the `\Seen` flag on Gmail and other IMAP servers.

## Related Issue

Fixes #42997

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/email.py`: Changed `imap.uid("fetch", uid, "(RFC822)")` to `imap.uid("fetch", uid, "(BODY.PEEK[])")` in `_fetch_new_messages()` — the `BODY.PEEK[]` fetch item returns the same raw message data without triggering the implicit `\Seen` flag that `RFC822` causes on servers like Gmail.
- `tests/gateway/test_email.py`: Added `test_fetch_uses_body_peek_to_preserve_unread` to verify the UID FETCH call uses `BODY.PEEK[]` and not `RFC822`.

## How to Test

1. Run `pytest tests/gateway/test_email.py -x -q` — all 61 tests pass (60 existing + 1 new).
2. The new test `test_fetch_uses_body_peek_to_preserve_unread` captures the actual fetch argument passed to `imap.uid()` and asserts it contains `BODY.PEEK` and not `RFC822`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `EmailAdapter._fetch_new_messages()` (single call site in `gateway/platforms/email.py:386`)
- Blast radius: LOW — only affects IMAP message fetching behavior; returns identical raw email data
- Related patterns: IMAP `BODY.PEEK[]` is the standard non-destructive alternative to `RFC822` per RFC 3501 §6.4.5
