### PR TITLE
fix(email): use BODY.PEEK[] to avoid marking messages as read on Gmail

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -383,7 +383,7 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 


### PR DESCRIPTION
## Summary

Fixes #42997 — Email gateway IMAP polling marks unread Gmail messages as read.

## Problem

On Gmail and other IMAP servers, fetching `RFC822` is not a peek operation and implicitly sets the `\\Seen` flag. This causes the Email gateway to mark incoming mailbox messages as read during polling, even before Hermes decides whether the sender is allowed or whether the message should be ignored.

## Solution

Change the IMAP fetch command from `(RFC822)` to `(BODY.PEEK[])`, which preserves the existing raw-message parsing behavior while avoiding the implicit `\\Seen` side effect.

## Changes

- `gateway/platforms/email.py:386` — Changed `imap.uid("fetch", uid, "(RFC822)")` to `imap.uid("fetch", uid, "(BODY.PEEK[])")`

## Testing

- All 60 existing email gateway tests pass
- Syntax validation: `python -m py_compile gateway/platforms/email.py` ✓
- Local validation: Replacing `(RFC822)` with `(BODY.PEEK[])` verified with IMAP fetch operation

## Notes

The adapter tracks processed UIDs in memory during the process lifetime. Changing to `BODY.PEEK[]` means unread messages stay unread as intended. On gateway restart, the adapter seeds `_seen_uids` from existing `ALL` messages during `connect()`, so it still skips pre-existing messages without needing to mark them read.
