### PR TITLE
fix(gateway/email): use BODY.PEEK[] instead of RFC822 to avoid marking messages as read

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -383,7 +383,7 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -278,8 +278,13 @@ class EmailAdapter(BasePlatformAdapter):
 
         IMAP UIDs are monotonically increasing integers. When the set grows
         beyond the cap, we keep only the highest half — old UIDs are safe to
-        drop because new messages always have higher UIDs and IMAP's UNSEEN
-        flag prevents re-delivery regardless.
+        drop because new messages always have higher UIDs.  Note: since we
+        use BODY.PEEK[] (which does not set ``\\Seen``), this set is the
+        **sole** deduplication mechanism — a trimmed UID that remains
+        UNSEEN could be re-fetched if enough higher-UID messages arrive
+        within a single long-lived session.  On reconnect, ``connect()``
+        reseeds from ``search ALL``, so only in-session redelivery is
+        possible.
         """
         if len(self._seen_uids) <= self._seen_uids_max:
             return

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -895,6 +895,42 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(results[0]["sender_addr"], "john@test.com")
         self.assertEqual(results[0]["sender_name"], "John Doe")
 
+    def test_fetch_uses_body_peek_not_rfc822(self):
+        """_fetch_new_messages must use BODY.PEEK[] to avoid marking messages as read.
+
+        RFC822 fetch implicitly sets \\Seen on Gmail and other IMAP servers,
+        which marks emails as read even when Hermes discards them (non-allowlisted
+        sender, automated sender filter, etc.). BODY.PEEK[] returns the same
+        raw bytes without the \\Seen side effect.
+        """
+        adapter = self._make_adapter()
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        mock_imap = MagicMock()
+        fetch_calls = []
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"42"])
+            if command == "fetch":
+                fetch_calls.append(args)
+                return ("OK", [(b"42", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(fetch_calls), 1)
+        self.assertIn("BODY.PEEK[]", fetch_calls[0][1])
+        self.assertNotIn("RFC822", fetch_calls[0][1])
+
 
 class TestPollLoop(unittest.TestCase):
     """Test the async polling loop."""


### PR DESCRIPTION
## Problem

The Email gateway adapter polls IMAP for unread messages using `UID FETCH ... (RFC822)`. On Gmail and other IMAP servers, fetching `RFC822` is not a peek operation and implicitly sets the `\Seen` flag. As a result, simply running the Hermes Email gateway marks incoming mailbox messages as read — even when Hermes discards them (non-allowlisted sender, automated sender filter, etc.).

## Fix

Replace `(RFC822)` with `(BODY.PEEK[])` in the IMAP UID FETCH call. `BODY.PEEK[]` returns the same raw message bytes without the `\Seen` side effect, preserving the mailbox read/unread state as intended.

The response parsing at `msg_data[0][1]` works identically with both — no downstream changes needed.

## Testing

- Added regression test `test_fetch_uses_body_peek_not_rfc822` that verifies the IMAP fetch call uses `BODY.PEEK[]` and not `RFC822`
- All 61 existing email adapter tests pass

## Files Changed

- `gateway/platforms/email.py` — single-line fix: `(RFC822)` → `(BODY.PEEK[])`
- `tests/gateway/test_email.py` — new regression test

Fixes #42997
