### PR TITLE
fix(whatsapp): expose inbound video cache paths

### DIFF
--- a/tests/gateway/test_whatsapp_inbound_video_paths.py
+++ b/tests/gateway/test_whatsapp_inbound_video_paths.py
@@ -1,0 +1,76 @@
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+def _make_runner() -> "GatewayRunner":  # type: ignore[name-defined]
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+    return runner
+
+
+def _video_event(
+    *,
+    text: str = "[video received]",
+    path: str = "/tmp/cache_12345_clip.mp4",
+) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.VIDEO,
+        source=SessionSource(platform=Platform.WHATSAPP, chat_id="1", chat_type="dm"),
+        media_urls=[path],
+        media_types=["video/mp4"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_video_attachment_adds_agent_visible_path_note():
+    runner = _make_runner()
+    source = SessionSource(platform=Platform.WHATSAPP, chat_id="1", chat_type="dm")
+    event = _video_event()
+
+    with patch(
+        "tools.credential_files.to_agent_visible_cache_path",
+        side_effect=lambda p: p,
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "video attachment" in result.lower()
+    assert "/tmp/cache_12345_clip.mp4" in result
+    assert "[video received]" in result
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_video_attachment_uses_display_name_without_cache_prefix():
+    runner = _make_runner()
+    source = SessionSource(platform=Platform.WHATSAPP, chat_id="1", chat_type="dm")
+    event = _video_event(path="/tmp/video_abcd1234_demo reel.mp4")
+
+    with patch(
+        "tools.credential_files.to_agent_visible_cache_path",
+        side_effect=lambda p: f"/agent{p}",
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "demo reel.mp4" in result
+    assert "/agent/tmp/video_abcd1234_demo reel.mp4" in result


### PR DESCRIPTION
## What does this PR do?

Narrow the WhatsApp media bug in #19105 to one upstream-safe fix: when an inbound WhatsApp video arrives with a bridge-cached local file, Hermes now prepends an agent-visible file-path note before the original placeholder/body text. That gives the model a real path it can reason about or pass to media tools instead of seeing only placeholder text such as `[video received]`.

## Related Issue

Refs #19105

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/run.py`: add inbound `MessageType.VIDEO` context notes that expose the cached video path through `to_agent_visible_cache_path()` and preserve the original user-visible placeholder/body text.
- `tests/gateway/test_whatsapp_inbound_video_paths.py`: cover the new inbound video note and the display-name/path translation behavior.

## How to Test

1. Run `pytest tests/gateway/test_whatsapp_inbound_video_paths.py -q`.
2. Run `pytest tests/gateway/test_telegram_audio_vs_voice.py -q` to confirm the adjacent audio/document preprocessing path still behaves correctly.
3. Run `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`. In this worker environment the broad suite stops early in `tests/hermes_cli/test_dashboard_auth_401_reauth.py` with `ModuleNotFoundError: No module named "fastapi"`, before reaching a meaningful verdict on unrelated areas.

## What platforms tested on

- macOS on darwin-arm64 (local worker environment)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Local covering tests passed: `tests/gateway/test_whatsapp_inbound_video_paths.py` and `tests/gateway/test_telegram_audio_vs_voice.py`.
- `ruff check gateway/run.py tests/gateway/test_whatsapp_inbound_video_paths.py` passed, and `ruff format --check tests/gateway/test_whatsapp_inbound_video_paths.py` reported the new file already formatted.
- `git diff --check` passed.
- `python scripts/check-windows-footguns.py` reported no staged files to scan in this environment.

<!-- autocontrib:worker-id=issue-new-3a59cdbb kind=pr-open -->