### PR TITLE
feat: add goal-mode indicator to desktop status bar

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -31,6 +31,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
+  setGoalActive,
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
@@ -673,6 +674,17 @@ export function useMessageStream({
 
           if (typeof payload?.fast === 'boolean') {
             setCurrentFastMode(payload.fast)
+          }
+
+          if (typeof payload?.goal_active === 'boolean') {
+            setGoalActive(payload.goal_active)
+
+            if (sessionId) {
+              updateSessionState(sessionId, state => ({
+                ...state,
+                goalActive: payload.goal_active ?? state.goalActive
+              }))
+            }
           }
 
           if (typeof payload?.yolo === 'boolean') {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -34,6 +34,7 @@ import {
   setCurrentServiceTier,
   setCurrentUsage,
   setFreshDraftReady,
+  setGoalActive,
   setIntroSeed,
   setMessages,
   setSelectedStoredSessionId,
@@ -212,12 +213,12 @@ function patchSessionWorkspace(sessionId: string, cwd: string | undefined) {
 
 function applyRuntimeInfo(
   info: SessionCreateResponse['info'] | undefined
-): Partial<Pick<ClientSessionState, 'branch' | 'cwd'>> | null {
+): Partial<Pick<ClientSessionState, 'branch' | 'cwd' | 'goalActive'>> | null {
   if (!info) {
     return null
   }
 
-  const sessionState: Partial<Pick<ClientSessionState, 'branch' | 'cwd'>> = {}
+  const sessionState: Partial<Pick<ClientSessionState, 'branch' | 'cwd' | 'goalActive'>> = {}
 
   reportBackendContract(info.desktop_contract)
 
@@ -261,6 +262,11 @@ function applyRuntimeInfo(
 
   if (typeof info.yolo === 'boolean') {
     setYoloActive(info.yolo)
+  }
+
+  if (typeof info.goal_active === 'boolean') {
+    setGoalActive(info.goal_active)
+    sessionState.goalActive = info.goal_active
   }
 
   if (info.usage) {
@@ -311,6 +317,7 @@ export function useSessionActions({
       })
       setSessionStartedAt(null)
       setTurnStartedAt(null)
+      setGoalActive(false)
       // New chats inherit the current workspace.
       setCurrentCwd(getRememberedWorkspaceCwd())
       setCurrentBranch('')

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -5,7 +5,15 @@ import type { ChatMessage } from '@/lib/chat-messages'
 import { preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { setMutableRef } from '@/lib/mutable-ref'
-import { $busy, $messages, noteSessionActivity, setSessionAttention, setSessionWorking, setTurnStartedAt } from '@/store/session'
+import {
+  $busy,
+  $messages,
+  noteSessionActivity,
+  setGoalActive,
+  setSessionAttention,
+  setSessionWorking,
+  setTurnStartedAt
+} from '@/store/session'
 
 import type { ClientSessionState } from '../../types'
 
@@ -127,6 +135,7 @@ export function useSessionStateCache({
     setBusy(pending.state.busy)
     setMutableRef(busyRef, pending.state.busy)
     setAwaitingResponse(pending.state.awaitingResponse)
+    setGoalActive(pending.state.goalActive)
     // Mirror the focused session's per-session turn clock into the global
     // atom the statusbar timer reads. Keeps a backgrounded turn's elapsed
     // time intact on focus instead of zeroing it (the "timer restarts" bug).

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -13,6 +13,7 @@ import {
   Command,
   Hash,
   Loader2,
+  Pin,
   Sparkles,
   Zap,
   ZapFilled
@@ -33,6 +34,7 @@ import {
   $currentProvider,
   $currentReasoningEffort,
   $currentUsage,
+  $goalActive,
   $sessionStartedAt,
   $turnStartedAt,
   $workingSessionIds,
@@ -91,6 +93,7 @@ export function useStatusbarItems({
   const copy = t.shell.statusbar
   const activeSessionId = useStore($activeSessionId)
   const yoloActive = useStore($yoloActive)
+  const goalActive = useStore($goalActive)
   const busy = useStore($busy)
   const currentFastMode = useStore($currentFastMode)
   const currentModel = useStore($currentModel)
@@ -396,6 +399,15 @@ export function useStatusbarItems({
         id: 'session-timer',
         label: copy.session,
         title: copy.runtimeSessionElapsed,
+        variant: 'text'
+      },
+      {
+        className: 'bg-(--chrome-action-hover) px-1 text-foreground',
+        hidden: !goalActive,
+        icon: <Pin className="size-3.5 shrink-0" />,
+        id: 'goal',
+        label: copy.goal || 'Goal',
+        title: copy.goalActive || 'Goal mode active',
         variant: 'text'
       },
       {

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -109,6 +109,7 @@ export interface ClientSessionState {
   sawAssistantPayload: boolean
   pendingBranchGroup: string | null
   interrupted: boolean
+  goalActive: boolean
   /** A blocking clarify prompt is waiting on the user for this session. Drives
    *  the sidebar "needs input" indicator; cleared when the turn resumes/ends. */
   needsInput: boolean

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1483,6 +1483,8 @@ export const en: Translations = {
       runtimeSessionElapsed: 'Runtime session elapsed',
       yoloOn: 'YOLO on — auto-approving dangerous commands. Click to turn off. Shift+click toggles it globally.',
       yoloOff: 'YOLO off — click to auto-approve dangerous commands. Shift+click toggles it globally.',
+      goal: 'Goal',
+      goalActive: 'Goal mode active — Hermes is working toward a standing goal.',
       modelNone: 'none',
       noModel: 'no model',
       switchModel: 'Switch model',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1626,6 +1626,8 @@ export const ja = defineLocale({
       runtimeSessionElapsed: 'ランタイムセッション経過時間',
       yoloOn: 'YOLO オン — 危険なコマンドを自動承認中。クリックでオフに。Shift+クリックで全体に切り替え。',
       yoloOff: 'YOLO オフ — クリックで危険なコマンドを自動承認。Shift+クリックで全体に切り替え。',
+      goal: '目標',
+      goalActive: '目標モード有効 — Hermes は設定された目標に向けて作業中です。',
       modelNone: 'なし',
       noModel: 'モデルなし',
       switchModel: 'モデルを切り替え',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1155,6 +1155,8 @@ export interface Translations {
       runtimeSessionElapsed: string
       yoloOn: string
       yoloOff: string
+      goal: string
+      goalActive: string
       modelNone: string
       noModel: string
       switchModel: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1587,6 +1587,8 @@ export const zhHant = defineLocale({
       runtimeSessionElapsed: '執行時工作階段已用時間',
       yoloOn: 'YOLO 已開啟 — 自動核准危險指令。點擊關閉。Shift+點擊可全域切換。',
       yoloOff: 'YOLO 已關閉 — 點擊自動核准危險指令。Shift+點擊可全域切換。',
+      goal: '目標',
+      goalActive: '目標模式已啟用 — Hermes 正在朝著既定目標工作。',
       modelNone: '無',
       noModel: '無模型',
       switchModel: '切換模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1664,6 +1664,8 @@ export const zh: Translations = {
       runtimeSessionElapsed: '运行时会话已用时间',
       yoloOn: 'YOLO 已开启 - 自动批准危险命令。点击关闭。Shift+点击可全局切换。',
       yoloOff: 'YOLO 已关闭 - 点击自动批准危险命令。Shift+点击可全局切换。',
+      goal: '目标',
+      goalActive: '目标模式已激活 — Hermes 正在朝着既定目标工作。',
       modelNone: '无',
       noModel: '无模型',
       switchModel: '切换模型',

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -45,6 +45,7 @@ export type GatewayEventPayload = {
   service_tier?: string
   fast?: boolean
   yolo?: boolean
+  goal_active?: boolean
   running?: boolean
   cwd?: string
   branch?: string

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -46,6 +46,7 @@ export function createClientSessionState(
     sawAssistantPayload: false,
     pendingBranchGroup: null,
     interrupted: false,
+    goalActive: false,
     needsInput: false,
     turnStartedAt: null
   }

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -117,6 +117,7 @@ export const $currentProvider = atom('')
 export const $currentReasoningEffort = atom('')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(false)
+export const $goalActive = atom(false)
 // Effective approval-bypass state mirrored from the gateway (session.info).
 // Persistence lives in the backend config (approvals.mode), so this is a plain
 // reflection of the truth the gateway reports rather than its own store.
@@ -162,6 +163,7 @@ export const setCurrentProvider = (next: Updater<string>) => updateAtom($current
 export const setCurrentReasoningEffort = (next: Updater<string>) => updateAtom($currentReasoningEffort, next)
 export const setCurrentServiceTier = (next: Updater<string>) => updateAtom($currentServiceTier, next)
 export const setCurrentFastMode = (next: Updater<boolean>) => updateAtom($currentFastMode, next)
+export const setGoalActive = (next: Updater<boolean>) => updateAtom($goalActive, next)
 export const setYoloActive = (next: Updater<boolean>) => updateAtom($yoloActive, next)
 
 export const setCurrentCwd = (next: Updater<string>) => {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -305,6 +305,8 @@ export interface SessionInfo {
   /** Handoff lifecycle: 'pending' | 'in_progress' | 'completed' | 'failed'. */
   handoff_state?: null | string
   handoff_error?: null | string
+  goal_active?: boolean
+  goal_text?: string
   /** Owning profile name, set by the cross-profile aggregator
    *  (`/api/profiles/sessions`). Absent on legacy single-profile responses,
    *  which the UI treats as the default profile. */
@@ -349,6 +351,7 @@ export interface SessionRuntimeInfo {
   cwd?: string
   desktop_contract?: number
   fast?: boolean
+  goal_active?: boolean
   model?: string
   personality?: string
   provider?: string

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5503,6 +5503,15 @@ async def get_session_detail(session_id: str, profile: Optional[str] = None):
             raise HTTPException(status_code=404, detail="Session not found")
         if profile:
             session["profile"] = _cron_profile_home(profile)[0]
+        # Enrich with goal state
+        try:
+            from hermes_cli.goals import load_goal
+            goal_state = load_goal(sid or session_id)
+            session["goal_active"] = goal_state is not None and goal_state.status == "active"
+            session["goal_text"] = (goal_state.goal if goal_state else "") or ""
+        except Exception:
+            session["goal_active"] = False
+            session["goal_text"] = ""
         return session
     finally:
         db.close()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2033,12 +2033,25 @@ def _session_info(agent, session: dict | None = None) -> dict:
         yolo = bool(_YOLO_MODE_FROZEN) or session_yolo or _get_approval_mode() == "off"
     except Exception:
         yolo = False
+    # Check if goal mode is active for this session
+    goal_active = False
+    try:
+        from hermes_cli.goals import GoalManager
+
+        session_key = (session or {}).get("session_key")
+        if session_key:
+            goal_mgr = GoalManager(session_id=session_key)
+            goal_active = goal_mgr.is_active()
+    except Exception:
+        pass
+
     info: dict = {
         "model": getattr(agent, "model", ""),
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
         "yolo": yolo,
+        "goal_active": goal_active,
         "tools": {},
         "skills": {},
         "cwd": cwd,
@@ -5118,6 +5131,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                                     sid,
                                     {"kind": "goal", "text": verdict_msg},
                                 )
+                                _emit("session.info", sid, _session_info(agent, session))
                             if decision.get("should_continue"):
                                 cont_prompt = decision.get("continuation_prompt") or ""
                                 if cont_prompt:
@@ -7115,6 +7129,17 @@ def _(rid, params: dict) -> dict:
         name = resolved
     session = _sessions.get(params.get("session_id", ""))
 
+    def _emit_current_session_info() -> None:
+        if not session:
+            return
+        agent = session.get("agent")
+        if agent is None:
+            return
+        try:
+            _emit("session.info", params.get("session_id", ""), _session_info(agent, session))
+        except Exception:
+            pass
+
     qcmds = _load_cfg().get("quick_commands", {})
     if name in qcmds:
         qc = qcmds[name]
@@ -7266,10 +7291,12 @@ def _(rid, params: dict) -> dict:
             return _ok(rid, {"type": "exec", "output": mgr.status_line()})
         if lower == "pause":
             state = mgr.pause(reason="user-paused")
+            _emit_current_session_info()
             out = "No goal set." if state is None else f"⏸ Goal paused: {state.goal}"
             return _ok(rid, {"type": "exec", "output": out})
         if lower == "resume":
             state = mgr.resume()
+            _emit_current_session_info()
             if state is None:
                 return _ok(rid, {"type": "exec", "output": "No goal to resume."})
             return _ok(
@@ -7285,6 +7312,7 @@ def _(rid, params: dict) -> dict:
         if lower in {"clear", "stop", "done"}:
             had = mgr.has_goal()
             mgr.clear()
+            _emit_current_session_info()
             return _ok(
                 rid,
                 {
@@ -7298,6 +7326,7 @@ def _(rid, params: dict) -> dict:
             state = mgr.set(arg)
         except ValueError as exc:
             return _err(rid, 4004, f"invalid goal: {exc}")
+        _emit_current_session_info()
 
         notice = (
             f"⊙ Goal set ({state.max_turns}-turn budget): {state.goal}\n"
@@ -8151,6 +8180,8 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
                 agent.service_tier = "priority"
             elif mode in {"normal", "off"}:
                 agent.service_tier = None
+            _emit("session.info", sid, _session_info(agent, session))
+        elif name == "goal" and agent:
             _emit("session.info", sid, _session_info(agent, session))
         elif name == "reload-mcp" and agent and hasattr(agent, "reload_mcp_tools"):
             agent.reload_mcp_tools()


### PR DESCRIPTION
## What does this PR do?

Adds a **"Goal"** label with subtle highlight in the desktop status bar when goal mode is active (via /goal). Mirrors the goal-mode badge that Codex shows.

When a user sets a goal with /goal, the backend emits a session.info event with goal_active: true, and the desktop frontend displays **Goal** session timer.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

### Backend
- `tui_gateway/server.py` — _session_info() reports goal_active via GoalManager.is_active(); _mirror_slash_side_effects emits session.info after /goal; goal set/resume/clear handlers emit immediately; goal judge verdict re-emits on completion
- `hermes_cli/web_server.py` — REST endpoint GET /api/sessions/{id} returns goal_active + goal_text

### Frontend (desktop)
- `store/session.ts` — $goalActive atom + setGoalActive()
- `use-message-stream.ts` — handles goal_active from session.info events
- `use-session-actions.ts`, `use-session-state-cache.ts` — preserves goal state across session switches
- `use-statusbar-items.tsx` — renders **Goal** text with bg-(--chrome-action-hover) highlight
- `app/types.ts`, `types/hermes.ts`, `lib/chat-messages.ts`, `lib/chat-runtime.ts` — type plumbing
- `i18n/types.ts`, `i18n/en.ts`, `i18n/ja.ts`, `i18n/zh.ts`, `i18n/zh-hant.ts` — all 4 locales

## How to Test

1. Start Hermes Desktop
2. Type /goal `keep working until you count till 20 and print it in chat`
3. Status bar shows a **Goal** label with highlight, next to session timer.
4. Goal loop runs; after completion the label disappears

## Checklist

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits (feat(desktop): ...)
- [x] My PR contains only changes related to this feature
- [ ] I have run pytest tests/ -q and all tests pass
- [ ] I have added tests for my changes
- [x] I have tested on my platform: macOS

## Screenshots
<img width="1172" height="251" alt="Screenshot 2026-06-09 at 12 05 18 PM" src="https://github.com/user-attachments/assets/2fb89d6f-0e72-4179-999c-9fad8807508d" />


Status bar shows Goal text with highlight, right of session timer. Hidden when no goal is set. This only displays when the chat window pertaining to it selected, if switched to another chat window, this doesn't appear.