### PR TITLE
fix: add NVIDIA NIM X-API-Key header support in model probe

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3239,10 +3239,15 @@ def probe_api_models(
         candidates.append((alternate_base, True))
 
     tried: list[str] = []
+    from utils import base_url_host_matches
     headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
+    # NVIDIA NIM endpoints require X-API-Key header instead of Bearer
+    _is_nvidia = base_url_host_matches(normalized, "integrate.api.nvidia.com")
     if api_key and api_mode == "anthropic_messages":
         headers["x-api-key"] = api_key
         headers["anthropic-version"] = "2023-06-01"
+    elif api_key and _is_nvidia:
+        headers["X-API-Key"] = api_key
     elif api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     if normalized.startswith(COPILOT_BASE_URL):


### PR DESCRIPTION
## Summary

The model validation probe ( in ) only sent standard  headers, but NVIDIA's  endpoint requires the  header for authentication.

This caused 401 failures during model validation, breaking:
-  switching for NVIDIA models
- Interactive  picker for NVIDIA models

## Fix

Added NVIDIA endpoint detection in  that sends the correct  header, following the existing pattern for Anthropic ( + ) and Copilot special-casing.

## Testing

Verified the probe now successfully returns the model list from  including , and the full  switch flow works:

