### PR TITLE
fix(providers): default MiniMax API-key overlays to /anthropic base (#42235)

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -120,6 +120,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     "minimax": HermesOverlay(
         transport="anthropic_messages",
         base_url_env_var="MINIMAX_BASE_URL",
+        # MiniMax serves the Anthropic Messages API under /anthropic; the bare
+        # models.dev base (/v1) is OpenAI-only and 404s the anthropic transport.
+        # Mirror minimax-oauth. MINIMAX_BASE_URL still overrides at resolution.
+        base_url_override="https://api.minimax.io/anthropic",
     ),
     "minimax-oauth": HermesOverlay(
         transport="anthropic_messages",
@@ -129,6 +133,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     "minimax-cn": HermesOverlay(
         transport="anthropic_messages",
         base_url_env_var="MINIMAX_CN_BASE_URL",
+        base_url_override="https://api.minimaxi.com/anthropic",
     ),
     "deepseek": HermesOverlay(
         transport="openai_chat",

--- a/tests/providers/test_minimax_anthropic_base.py
+++ b/tests/providers/test_minimax_anthropic_base.py
@@ -1,0 +1,40 @@
+"""Regression: MiniMax API-key overlays must use the /anthropic base.
+
+`anthropic_messages` transport POSTs to `{base}/v1/messages`. MiniMax serves
+that only under `/anthropic`; the bare `/v1` host is OpenAI-only and 404s the
+Anthropic transport. Any overlay that forces anthropic_messages for MiniMax
+must therefore pin a `base_url_override` ending in `/anthropic`.
+
+Guards against the regression where `minimax` / `minimax-cn` shipped no
+override and fell back to the models.dev `/v1` base → 404 page not found.
+"""
+import pytest
+
+from hermes_cli.providers import HERMES_OVERLAYS
+
+
+@pytest.mark.parametrize(
+    "provider_id, expected_base",
+    [
+        ("minimax", "https://api.minimax.io/anthropic"),
+        ("minimax-oauth", "https://api.minimax.io/anthropic"),
+        ("minimax-cn", "https://api.minimaxi.com/anthropic"),
+    ],
+)
+def test_minimax_overlay_pins_anthropic_base(provider_id, expected_base):
+    ov = HERMES_OVERLAYS[provider_id]
+    assert ov.transport == "anthropic_messages"
+    assert ov.base_url_override == expected_base, (
+        f"{provider_id!r} forces anthropic_messages but base_url_override="
+        f"{ov.base_url_override!r}; the anthropic transport 404s on the /v1 "
+        f"OpenAI path. Expected {expected_base!r}."
+    )
+
+
+def test_no_minimax_overlay_falls_back_to_v1():
+    """Any minimax-family anthropic overlay must NOT rely on the /v1 default."""
+    for pid, ov in HERMES_OVERLAYS.items():
+        if "minimax" in pid and ov.transport == "anthropic_messages":
+            assert ov.base_url_override.endswith("/anthropic"), (
+                f"{pid!r} would resolve to the models.dev /v1 base and 404."
+            )


### PR DESCRIPTION
## What
The `minimax` and `minimax-cn` provider overlays force `transport="anthropic_messages"` but ship **no** `base_url_override`, so `get_provider_def()` falls back to the models.dev base `https://api.minimax.io/v1`. The Anthropic Messages transport then POSTs to `{base}/v1/messages` on a host that only serves MiniMax's OpenAI-compatible path → **`HTTP 404: 404 page not found`** on every call.

`minimax-oauth` already pins `.../anthropic`. This mirrors it for the API-key variants.

Fixes #42235.

## Change
```diff
 "minimax": HermesOverlay(
     transport="anthropic_messages",
     base_url_env_var="MINIMAX_BASE_URL",
+    base_url_override="https://api.minimax.io/anthropic",
 ),
 "minimax-cn": HermesOverlay(
     transport="anthropic_messages",
     base_url_env_var="MINIMAX_CN_BASE_URL",
+    base_url_override="https://api.minimaxi.com/anthropic",
 ),
```
`MINIMAX_BASE_URL` / `MINIMAX_CN_BASE_URL` still override at resolution (env wins), so custom/self-hosted bases are unaffected — only the broken default changes.

## Verification
- **Live:** `MiniMax-M3` (API key) → `POST https://api.minimax.io/anthropic/v1/messages` → **200**; the same call on `/v1` → **404 page not found**.
- **Regression test** `tests/providers/test_minimax_anthropic_base.py`: pins every minimax-family `anthropic_messages` overlay to an `/anthropic` base. **Fails before this change** (`minimax`, `minimax-cn`), **passes after** — `4 passed`.

Reported + diagnosed in #42235.
