### PR TITLE
Add durable profile-agent orchestration via agent_control

### DIFF
--- a/acp_adapter/client.py
+++ b/acp_adapter/client.py
@@ -1,0 +1,448 @@
+"""Small JSON-RPC client for driving Hermes ACP sessions.
+
+This module is intentionally transport-level and dependency-light: it speaks
+newline-delimited JSON-RPC over ``hermes acp`` stdio without importing the ACP
+Python package.  It is used by orchestration tools that need to command another
+Hermes profile as a real persistent agent rather than as an in-process
+``delegate_task`` child.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+
+_AUTH_METHOD_ENV = "HERMES_ACP_AUTH_METHOD"
+
+
+def _select_auth_method_id(
+    initialize_result: dict[str, Any],
+    preferred_method: str | None = None,
+) -> str | None:
+    """Choose the ACP auth method id to acknowledge, if the server advertises one."""
+    preferred = (preferred_method or os.environ.get(_AUTH_METHOD_ENV, "")).strip().lower()
+    auth_methods = (
+        initialize_result.get("authMethods")
+        or initialize_result.get("auth_methods")
+        or []
+    )
+    if not isinstance(auth_methods, list):
+        return None
+
+    method_ids: list[str] = []
+    for method in auth_methods:
+        if not isinstance(method, dict):
+            continue
+        raw_id = str(method.get("id") or "").strip()
+        if raw_id:
+            method_ids.append(raw_id)
+
+    if not method_ids:
+        return None
+
+    if preferred:
+        for method_id in method_ids:
+            if method_id.lower() == preferred:
+                return method_id
+
+    return method_ids[0]
+
+
+def resolve_hermes_bin() -> str:
+    """Resolve the Hermes executable used for ACP subprocesses."""
+    explicit = os.environ.get("HERMES_BIN", "").strip()
+    if explicit:
+        return explicit
+
+    which_hermes = shutil.which("hermes")
+    if which_hermes:
+        return which_hermes
+
+    # Developer checkout fallback: run the current interpreter against the CLI
+    # package.  This keeps tests and editable installs useful even before the
+    # console script is on PATH.
+    return sys.executable
+
+
+def build_hermes_acp_command(profile: str, hermes_bin: str | None = None) -> list[str]:
+    """Return the argv used to start a Hermes ACP server for *profile*."""
+    resolved = hermes_bin or resolve_hermes_bin()
+    profile = (profile or "default").strip() or "default"
+
+    if Path(resolved).name.startswith("python"):
+        cmd = [resolved, "-m", "hermes_cli.main"]
+    else:
+        cmd = [resolved]
+
+    cmd.extend(["-p", profile])
+    cmd.append("acp")
+    return cmd
+
+
+def build_hermes_acp_env(
+    *,
+    hermes_bin: str | None = None,
+    use_profile_toolsets: bool = True,
+    extra_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Return the environment for an agent-control ACP subprocess."""
+    env = os.environ.copy()
+    if use_profile_toolsets:
+        env["HERMES_ACP_USE_PROFILE_TOOLSETS"] = "1"
+
+    # When running from a source checkout before the console script is
+    # installed, the fallback command is ``python -m hermes_cli.main``.  The
+    # controlled agent may run in an arbitrary project cwd, so preserve this
+    # checkout on PYTHONPATH for that child process.
+    resolved = hermes_bin or resolve_hermes_bin()
+    if Path(resolved).name.startswith("python"):
+        project_root = str(Path(__file__).resolve().parent.parent)
+        existing = env.get("PYTHONPATH", "")
+        paths = [project_root]
+        if existing:
+            paths.append(existing)
+        env["PYTHONPATH"] = os.pathsep.join(paths)
+
+    env.update(extra_env or {})
+    return env
+
+
+class HermesACPClient:
+    """Line-oriented JSON-RPC client for one Hermes profile."""
+
+    def __init__(
+        self,
+        profile: str,
+        cwd: str | None = None,
+        *,
+        hermes_bin: str | None = None,
+        approval_policy: str = "deny",
+        use_profile_toolsets: bool = True,
+        extra_env: dict[str, str] | None = None,
+    ):
+        self.profile = (profile or "default").strip() or "default"
+        self.cwd = cwd or str(Path.home())
+        self.hermes_bin = hermes_bin
+        self.approval_policy = approval_policy
+        self.use_profile_toolsets = use_profile_toolsets
+        self.extra_env = dict(extra_env or {})
+        self.proc: Optional[subprocess.Popen[str]] = None
+        self._lock = threading.Lock()
+        self._next_id = 0
+        self._messages: "queue.Queue[dict[str, Any]]" = queue.Queue()
+        self._stderr_tail: list[str] = []
+        self.notifications: list[dict[str, Any]] = []
+        self.session_id: str | None = None
+
+    # ---- process and IO -------------------------------------------------
+
+    def _start(self) -> None:
+        if self.proc is not None and self.proc.poll() is None:
+            return
+        self.proc = None
+        cmd = build_hermes_acp_command(self.profile, self.hermes_bin)
+        env = build_hermes_acp_env(
+            hermes_bin=self.hermes_bin,
+            use_profile_toolsets=self.use_profile_toolsets,
+            extra_env=self.extra_env,
+        )
+        self.proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            cwd=self.cwd,
+            env=env,
+        )
+        threading.Thread(target=self._read_stdout, daemon=True).start()
+        threading.Thread(target=self._read_stderr, daemon=True).start()
+
+    def _read_stdout(self) -> None:
+        if not self.proc or self.proc.stdout is None:
+            return
+        for line in self.proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                self._messages.put(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    def _read_stderr(self) -> None:
+        if not self.proc or self.proc.stderr is None:
+            return
+        for line in self.proc.stderr:
+            self._stderr_tail.append(line.rstrip())
+            if len(self._stderr_tail) > 80:
+                self._stderr_tail.pop(0)
+
+    def _write_message(self, payload: dict[str, Any]) -> None:
+        self._start()
+        assert self.proc is not None and self.proc.stdin is not None
+        with self._lock:
+            self.proc.stdin.write(json.dumps(payload) + "\n")
+            self.proc.stdin.flush()
+
+    def _respond_to_server_request(self, message: dict[str, Any]) -> None:
+        """Best-effort response to server-initiated JSON-RPC requests.
+
+        The important case is ACP permission requests.  If we do not answer,
+        the target agent can hang waiting for a decision.  Agent-control runs
+        default to fail-closed, so unknown permission requests are denied.
+        """
+        req_id = message.get("id")
+        if req_id is None or not message.get("method"):
+            return
+
+        method = str(message.get("method") or "")
+        lowered = method.replace("/", "_").replace("-", "_").lower()
+        if "permission" in lowered:
+            if str(self.approval_policy).lower() in {"allow", "allow_once", "once"}:
+                result = {"outcome": {"outcome": "selected", "optionId": "allow_once"}}
+            else:
+                result = {"outcome": {"outcome": "cancelled"}}
+            self._write_message({"jsonrpc": "2.0", "id": req_id, "result": result})
+            return
+
+        self._write_message(
+            {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {
+                    "code": -32601,
+                    "message": f"Method not found: {method}",
+                },
+            }
+        )
+
+    def _send_rpc_raw(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        timeout: float = 120.0,
+    ) -> Any:
+        self._start()
+        assert self.proc is not None
+
+        with self._lock:
+            self._next_id += 1
+            req_id = self._next_id
+            payload = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "method": method,
+                "params": params or {},
+            }
+            assert self.proc.stdin is not None
+            self.proc.stdin.write(json.dumps(payload) + "\n")
+            self.proc.stdin.flush()
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.proc.poll() is not None:
+                break
+            try:
+                message = self._messages.get(timeout=0.1)
+            except queue.Empty:
+                continue
+
+            if message.get("id") == req_id:
+                if "error" in message:
+                    raise RuntimeError(f"ACP error for {method}: {message['error']}")
+                return message.get("result")
+
+            if message.get("id") is not None and message.get("method"):
+                self._respond_to_server_request(message)
+                continue
+
+            self.notifications.append(message)
+
+        stderr_text = "\n".join(self._stderr_tail).strip()
+        if self.proc.poll() is not None:
+            raise RuntimeError(stderr_text or f"ACP process exited during {method}.")
+        raise TimeoutError(f"Timeout waiting for {method} response.")
+
+    def _send_rpc(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        timeout: float = 120.0,
+    ) -> dict[str, Any]:
+        result = self._send_rpc_raw(method, params=params, timeout=timeout)
+        return result if isinstance(result, dict) else {"value": result}
+
+    # ---- ACP calls ------------------------------------------------------
+
+    def initialize(self) -> dict[str, Any]:
+        return self._send_rpc(
+            "initialize",
+            {
+                "protocolVersion": 1,
+                "clientCapabilities": {},
+                "clientInfo": {
+                    "name": "hermes-agent-control",
+                    "version": "1.0",
+                },
+            },
+            timeout=30.0,
+        )
+
+    def maybe_authenticate(self, initialize_result: dict[str, Any]) -> str | None:
+        method_id = _select_auth_method_id(initialize_result)
+        if not method_id:
+            return None
+        self._send_rpc(
+            "authenticate",
+            {"methodId": method_id, "args": {}},
+            timeout=30.0,
+        )
+        return method_id
+
+    def connect(self) -> str | None:
+        init_result = self.initialize()
+        return self.maybe_authenticate(init_result)
+
+    def new_session(self, cwd: str | None = None) -> str:
+        result = self._send_rpc(
+            "session/new",
+            {"cwd": cwd or self.cwd, "mcpServers": []},
+            timeout=30.0,
+        )
+        session_id = str(result.get("sessionId") or result.get("session_id") or "").strip()
+        if not session_id:
+            raise RuntimeError("session/new returned no sessionId.")
+        self.session_id = session_id
+        return session_id
+
+    def load_session(self, session_id: str, cwd: str | None = None) -> str:
+        result = self._send_rpc_raw(
+            "session/load",
+            {"sessionId": session_id, "cwd": cwd or self.cwd, "mcpServers": []},
+            timeout=30.0,
+        )
+        if result is None:
+            raise RuntimeError(f"session/load could not find sessionId: {session_id}")
+        self.session_id = session_id
+        return session_id
+
+    def resume_session(self, session_id: str, cwd: str | None = None) -> str:
+        result = self._send_rpc(
+            "session/resume",
+            {"sessionId": session_id, "cwd": cwd or self.cwd, "mcpServers": []},
+            timeout=30.0,
+        )
+        resumed_id = str(result.get("sessionId") or result.get("session_id") or session_id).strip()
+        if not resumed_id:
+            raise RuntimeError("session/resume returned no sessionId.")
+        self.session_id = resumed_id
+        return resumed_id
+
+    def fork_session(self, session_id: str, cwd: str | None = None) -> str:
+        result = self._send_rpc(
+            "session/fork",
+            {"sessionId": session_id, "cwd": cwd or self.cwd, "mcpServers": []},
+            timeout=30.0,
+        )
+        new_id = str(result.get("sessionId") or result.get("session_id") or "").strip()
+        if not new_id:
+            raise RuntimeError("session/fork returned no sessionId.")
+        self.session_id = new_id
+        return new_id
+
+    def cancel(self, session_id: str) -> None:
+        self._send_rpc("session/cancel", {"sessionId": session_id}, timeout=15.0)
+
+    def prompt(self, session_id: str, text: str, timeout: float = 600.0) -> dict[str, Any]:
+        self._start()
+        assert self.proc is not None and self.proc.stdin is not None
+
+        with self._lock:
+            self._next_id += 1
+            req_id = self._next_id
+            payload = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": text}],
+                },
+            }
+            self.proc.stdin.write(json.dumps(payload) + "\n")
+            self.proc.stdin.flush()
+
+        text_parts: list[str] = []
+        updates: list[dict[str, Any]] = []
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.proc.poll() is not None:
+                break
+            try:
+                message = self._messages.get(timeout=0.1)
+            except queue.Empty:
+                continue
+
+            if message.get("id") is not None and message.get("method"):
+                self._respond_to_server_request(message)
+                continue
+
+            if message.get("method") == "session/update":
+                params = message.get("params") or {}
+                update = params.get("update") or {}
+                if isinstance(update, dict):
+                    updates.append(update)
+                    kind = update.get("sessionUpdate") or update.get("session_update")
+                    if kind == "agent_message_chunk":
+                        content = update.get("content") or {}
+                        if isinstance(content, dict) and content.get("type") == "text":
+                            text_parts.append(str(content.get("text") or ""))
+                continue
+
+            if message.get("id") != req_id:
+                self.notifications.append(message)
+                continue
+
+            if "error" in message:
+                raise RuntimeError(f"ACP error for session/prompt: {message['error']}")
+
+            result = message.get("result", {}) or {}
+            if isinstance(result, dict) and not text_parts:
+                for block in result.get("content", []) or []:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text_parts.append(str(block.get("text") or ""))
+            return {
+                "stop_reason": result.get("stopReason") or result.get("stop_reason"),
+                "text": "".join(text_parts),
+                "content": result.get("content", []) if isinstance(result, dict) else [],
+                "usage": result.get("usage", {}) if isinstance(result, dict) else {},
+                "updates": updates,
+            }
+
+        stderr_text = "\n".join(self._stderr_tail).strip()
+        if self.proc.poll() is not None:
+            raise RuntimeError(stderr_text or "ACP process exited during session/prompt.")
+        raise TimeoutError(f"Timeout ({timeout}s) waiting for session/prompt response.")
+
+    def close(self) -> None:
+        if not self.proc:
+            return
+        self.proc.terminate()
+        try:
+            self.proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait()
+        finally:
+            self.proc = None

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -155,6 +155,42 @@ def _expand_acp_enabled_toolsets(
     return expanded
 
 
+def _split_toolset_env(value: str | None) -> List[str]:
+    raw = str(value or "").strip()
+    if not raw:
+        return []
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _resolve_acp_base_toolsets(config: dict[str, Any]) -> List[str]:
+    """Return the base ACP toolsets for a new session.
+
+    Normal editor ACP sessions keep the focused ``hermes-acp`` surface. The
+    agent-control client sets ``HERMES_ACP_USE_PROFILE_TOOLSETS=1`` so peer
+    profiles run with their configured CLI toolsets instead of being flattened
+    into the editor default.
+    """
+    explicit = _split_toolset_env(os.environ.get("HERMES_ACP_TOOLSETS"))
+    if explicit:
+        return explicit
+
+    if _env_truthy("HERMES_ACP_USE_PROFILE_TOOLSETS"):
+        try:
+            from hermes_cli.tools_config import _get_platform_tools
+
+            resolved = sorted(_get_platform_tools(config, "cli"))
+            if resolved:
+                return resolved
+        except Exception:
+            logger.debug("Failed to resolve profile CLI toolsets for ACP", exc_info=True)
+
+    return ["hermes-acp"]
+
+
 def _clear_task_cwd(task_id: str) -> None:
     """Remove task-specific cwd overrides for an ACP session."""
     if not task_id:
@@ -599,11 +635,12 @@ class SessionManager:
             for name, cfg in (config.get("mcp_servers") or {}).items()
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
+        base_toolsets = _resolve_acp_base_toolsets(config)
 
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                base_toolsets,
                 mcp_server_names=configured_mcp_servers,
             ),
             "quiet_mode": True,

--- a/agent/orchestration.py
+++ b/agent/orchestration.py
@@ -1,0 +1,785 @@
+"""Durable control plane for orchestrating Hermes profiles as peer agents."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from acp_adapter.client import HermesACPClient
+from hermes_constants import get_default_hermes_root, get_hermes_home
+from hermes_cli.profiles import validate_profile_name
+
+
+DEFAULT_LEASE_SECONDS = 900.0
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _row_to_dict(row: sqlite3.Row | None) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    return dict(row)
+
+
+def _normalize_profile(profile: str | None) -> str:
+    normalized = (profile or "default").strip() or "default"
+    validate_profile_name(normalized)
+    return normalized
+
+
+def _normalize_cwd(cwd: str | None) -> str:
+    normalized = os.path.abspath(os.path.expanduser(cwd or os.getcwd()))
+    if not os.path.isdir(normalized):
+        raise FileNotFoundError(f"Working directory does not exist: {normalized}")
+    return normalized
+
+
+class AgentControlStore:
+    """SQLite-backed handles, runs, and cross-process leases."""
+
+    def __init__(self, db_path: str | Path | None = None):
+        self.db_path = Path(db_path) if db_path is not None else get_hermes_home() / "agent-control.db"
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, timeout=30.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS agent_handles (
+                    id TEXT PRIMARY KEY,
+                    profile TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    cwd TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'idle',
+                    idempotency_key TEXT UNIQUE,
+                    lease_owner TEXT,
+                    lease_until REAL,
+                    last_run_id TEXT,
+                    last_response TEXT,
+                    last_error TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_agent_handles_profile
+                    ON agent_handles(profile);
+                CREATE INDEX IF NOT EXISTS idx_agent_handles_status
+                    ON agent_handles(status);
+
+                CREATE TABLE IF NOT EXISTS agent_session_leases (
+                    profile TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    handle_id TEXT,
+                    lease_owner TEXT NOT NULL,
+                    lease_until REAL NOT NULL,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY (profile, session_id)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_agent_session_leases_until
+                    ON agent_session_leases(lease_until);
+
+                CREATE TABLE IF NOT EXISTS agent_runs (
+                    id TEXT PRIMARY KEY,
+                    handle_id TEXT NOT NULL REFERENCES agent_handles(id) ON DELETE CASCADE,
+                    profile TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    prompt TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    stop_reason TEXT,
+                    response TEXT,
+                    error TEXT,
+                    usage_json TEXT,
+                    started_at REAL NOT NULL,
+                    finished_at REAL,
+                    updated_at REAL NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_agent_runs_handle
+                    ON agent_runs(handle_id, started_at DESC);
+                CREATE INDEX IF NOT EXISTS idx_agent_runs_status
+                    ON agent_runs(status);
+                """
+            )
+
+    def refresh_expired_leases(self) -> int:
+        now = _now()
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            expired = conn.execute(
+                """
+                SELECT id, last_run_id
+                FROM agent_handles
+                WHERE lease_until IS NOT NULL
+                  AND lease_until < ?
+                  AND status = 'running'
+                """,
+                (now,),
+            ).fetchall()
+            cur = conn.execute(
+                """
+                UPDATE agent_handles
+                SET lease_owner = NULL, lease_until = NULL, status = 'error',
+                    last_error = 'agent_control lease expired', updated_at = ?
+                WHERE lease_until IS NOT NULL
+                  AND lease_until < ?
+                  AND status = 'running'
+                """,
+                (now, now),
+            )
+            for row in expired:
+                run_id = row["last_run_id"]
+                if not run_id:
+                    continue
+                conn.execute(
+                    """
+                    UPDATE agent_runs
+                    SET status = 'error', error = 'agent_control lease expired',
+                        finished_at = ?, updated_at = ?
+                    WHERE id = ? AND status = 'running'
+                    """,
+                    (now, now, run_id),
+                )
+            conn.execute("DELETE FROM agent_session_leases WHERE lease_until < ?", (now,))
+            return int(cur.rowcount or 0)
+
+    def create_handle(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        cwd: str,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        handle_id = f"agent-{uuid.uuid4().hex[:12]}"
+        now = _now()
+        with self._connect() as conn:
+            if idempotency_key:
+                existing = conn.execute(
+                    "SELECT * FROM agent_handles WHERE idempotency_key = ?",
+                    (idempotency_key,),
+                ).fetchone()
+                if existing is not None:
+                    return dict(existing)
+            conn.execute(
+                """
+                INSERT INTO agent_handles (
+                    id, profile, session_id, cwd, status, idempotency_key,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, 'idle', ?, ?, ?)
+                """,
+                (handle_id, profile, session_id, cwd, idempotency_key, now, now),
+            )
+            row = conn.execute(
+                "SELECT * FROM agent_handles WHERE id = ?",
+                (handle_id,),
+            ).fetchone()
+            return dict(row)
+
+    def get_handle(self, handle_id: str) -> dict[str, Any] | None:
+        self.refresh_expired_leases()
+        with self._connect() as conn:
+            return _row_to_dict(
+                conn.execute("SELECT * FROM agent_handles WHERE id = ?", (handle_id,)).fetchone()
+            )
+
+    def get_handle_by_idempotency_key(self, key: str) -> dict[str, Any] | None:
+        if not key:
+            return None
+        with self._connect() as conn:
+            return _row_to_dict(
+                conn.execute(
+                    "SELECT * FROM agent_handles WHERE idempotency_key = ?",
+                    (key,),
+                ).fetchone()
+            )
+
+    def list_handles(self, profile: str | None = None, limit: int = 50) -> list[dict[str, Any]]:
+        self.refresh_expired_leases()
+        limit = max(1, min(int(limit or 50), 200))
+        with self._connect() as conn:
+            if profile:
+                rows = conn.execute(
+                    """
+                    SELECT * FROM agent_handles
+                    WHERE profile = ?
+                    ORDER BY updated_at DESC
+                    LIMIT ?
+                    """,
+                    (profile, limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """
+                    SELECT * FROM agent_handles
+                    ORDER BY updated_at DESC
+                    LIMIT ?
+                    """,
+                    (limit,),
+                ).fetchall()
+        return [dict(row) for row in rows]
+
+    def update_handle(
+        self,
+        handle_id: str,
+        *,
+        status: str | None = None,
+        session_id: str | None = None,
+        cwd: str | None = None,
+        last_run_id: str | None = None,
+        last_response: str | None = None,
+        last_error: str | None = None,
+    ) -> None:
+        fields: list[str] = ["updated_at = ?"]
+        values: list[Any] = [_now()]
+        for name, value in (
+            ("status", status),
+            ("session_id", session_id),
+            ("cwd", cwd),
+            ("last_run_id", last_run_id),
+            ("last_response", last_response),
+            ("last_error", last_error),
+        ):
+            if value is not None:
+                fields.append(f"{name} = ?")
+                values.append(value)
+        values.append(handle_id)
+        with self._connect() as conn:
+            conn.execute(
+                f"UPDATE agent_handles SET {', '.join(fields)} WHERE id = ?",
+                tuple(values),
+            )
+
+    def acquire_handle_lease(
+        self,
+        handle_id: str,
+        *,
+        owner: str,
+        ttl_seconds: float = DEFAULT_LEASE_SECONDS,
+        wait_seconds: float = 0.0,
+    ) -> bool:
+        deadline = _now() + max(0.0, wait_seconds)
+        while True:
+            now = _now()
+            with self._connect() as conn:
+                cur = conn.execute(
+                    """
+                    UPDATE agent_handles
+                    SET lease_owner = ?, lease_until = ?, status = 'running',
+                        updated_at = ?
+                    WHERE id = ?
+                      AND (lease_until IS NULL OR lease_until < ? OR lease_owner = ?)
+                    """,
+                    (owner, now + ttl_seconds, now, handle_id, now, owner),
+                )
+                if cur.rowcount == 1:
+                    return True
+            if _now() >= deadline:
+                return False
+            time.sleep(0.1)
+
+    def release_handle_lease(self, handle_id: str, *, owner: str, status: str = "idle") -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE agent_handles
+                SET lease_owner = NULL, lease_until = NULL, status = ?,
+                    updated_at = ?
+                WHERE id = ? AND lease_owner = ?
+                """,
+                (status, _now(), handle_id, owner),
+            )
+
+    def acquire_session_lease(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        handle_id: str,
+        owner: str,
+        ttl_seconds: float = DEFAULT_LEASE_SECONDS,
+        wait_seconds: float = 0.0,
+    ) -> bool:
+        profile = _normalize_profile(profile)
+        session_id = str(session_id or "").strip()
+        if not session_id:
+            raise ValueError("session_id is required for agent session lease")
+
+        deadline = _now() + max(0.0, wait_seconds)
+        while True:
+            now = _now()
+            with self._connect() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                cur = conn.execute(
+                    """
+                    UPDATE agent_session_leases
+                    SET handle_id = ?, lease_owner = ?, lease_until = ?, updated_at = ?
+                    WHERE profile = ?
+                      AND session_id = ?
+                      AND (lease_until < ? OR lease_owner = ?)
+                    """,
+                    (
+                        handle_id,
+                        owner,
+                        now + ttl_seconds,
+                        now,
+                        profile,
+                        session_id,
+                        now,
+                        owner,
+                    ),
+                )
+                if cur.rowcount == 1:
+                    return True
+                try:
+                    conn.execute(
+                        """
+                        INSERT INTO agent_session_leases (
+                            profile, session_id, handle_id, lease_owner,
+                            lease_until, created_at, updated_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            profile,
+                            session_id,
+                            handle_id,
+                            owner,
+                            now + ttl_seconds,
+                            now,
+                            now,
+                        ),
+                    )
+                    return True
+                except sqlite3.IntegrityError:
+                    pass
+            if _now() >= deadline:
+                return False
+            time.sleep(0.1)
+
+    def release_session_lease(self, *, profile: str, session_id: str, owner: str) -> None:
+        profile = _normalize_profile(profile)
+        session_id = str(session_id or "").strip()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                DELETE FROM agent_session_leases
+                WHERE profile = ? AND session_id = ? AND lease_owner = ?
+                """,
+                (profile, session_id, owner),
+            )
+
+    @contextmanager
+    def leased_handle(
+        self,
+        handle_id: str,
+        *,
+        owner: str,
+        ttl_seconds: float = DEFAULT_LEASE_SECONDS,
+        wait_seconds: float = 0.0,
+    ):
+        acquired = self.acquire_handle_lease(
+            handle_id,
+            owner=owner,
+            ttl_seconds=ttl_seconds,
+            wait_seconds=wait_seconds,
+        )
+        if not acquired:
+            raise TimeoutError(f"agent handle {handle_id} is busy")
+        status = "idle"
+        try:
+            yield
+        except Exception:
+            status = "error"
+            raise
+        finally:
+            self.release_handle_lease(handle_id, owner=owner, status=status)
+
+    @contextmanager
+    def leased_session(
+        self,
+        handle_id: str,
+        *,
+        profile: str,
+        session_id: str,
+        owner: str,
+        ttl_seconds: float = DEFAULT_LEASE_SECONDS,
+        wait_seconds: float = 0.0,
+    ):
+        acquired_session = self.acquire_session_lease(
+            profile=profile,
+            session_id=session_id,
+            handle_id=handle_id,
+            owner=owner,
+            ttl_seconds=ttl_seconds,
+            wait_seconds=wait_seconds,
+        )
+        if not acquired_session:
+            raise TimeoutError(f"agent session {profile}/{session_id} is busy")
+
+        acquired_handle = self.acquire_handle_lease(
+            handle_id,
+            owner=owner,
+            ttl_seconds=ttl_seconds,
+            wait_seconds=0.0,
+        )
+        if not acquired_handle:
+            self.release_session_lease(profile=profile, session_id=session_id, owner=owner)
+            raise TimeoutError(f"agent handle {handle_id} is busy")
+
+        status = "idle"
+        try:
+            yield
+        except Exception:
+            status = "error"
+            raise
+        finally:
+            try:
+                self.release_handle_lease(handle_id, owner=owner, status=status)
+            finally:
+                self.release_session_lease(profile=profile, session_id=session_id, owner=owner)
+
+    def create_run(
+        self,
+        *,
+        handle_id: str,
+        profile: str,
+        session_id: str,
+        prompt: str,
+    ) -> dict[str, Any]:
+        run_id = f"run-{uuid.uuid4().hex[:12]}"
+        now = _now()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO agent_runs (
+                    id, handle_id, profile, session_id, prompt, status,
+                    started_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, 'running', ?, ?)
+                """,
+                (run_id, handle_id, profile, session_id, prompt, now, now),
+            )
+            conn.execute(
+                """
+                UPDATE agent_handles
+                SET last_run_id = ?, status = 'running', updated_at = ?
+                WHERE id = ?
+                """,
+                (run_id, now, handle_id),
+            )
+        return self.get_run(run_id) or {"id": run_id, "status": "running"}
+
+    def finish_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        response: str | None = None,
+        stop_reason: str | None = None,
+        error: str | None = None,
+        usage: dict[str, Any] | None = None,
+    ) -> None:
+        now = _now()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE agent_runs
+                SET status = ?, response = ?, stop_reason = ?, error = ?,
+                    usage_json = ?, finished_at = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    status,
+                    response,
+                    stop_reason,
+                    error,
+                    _json_dumps(usage or {}),
+                    now,
+                    now,
+                    run_id,
+                ),
+            )
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM agent_runs WHERE id = ?", (run_id,)).fetchone()
+        out = _row_to_dict(row)
+        if out and out.get("usage_json"):
+            try:
+                out["usage"] = json.loads(out["usage_json"])
+            except json.JSONDecodeError:
+                out["usage"] = {}
+        return out
+
+    def last_run_for_handle(self, handle_id: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT * FROM agent_runs
+                WHERE handle_id = ?
+                ORDER BY started_at DESC
+                LIMIT 1
+                """,
+                (handle_id,),
+            ).fetchone()
+        out = _row_to_dict(row)
+        if out and out.get("usage_json"):
+            try:
+                out["usage"] = json.loads(out["usage_json"])
+            except json.JSONDecodeError:
+                out["usage"] = {}
+        return out
+
+
+class AgentController:
+    """High-level operations for controlling peer Hermes profiles."""
+
+    def __init__(
+        self,
+        *,
+        store: AgentControlStore | None = None,
+        client_factory: Callable[..., HermesACPClient] = HermesACPClient,
+    ):
+        self.store = store or AgentControlStore()
+        self.client_factory = client_factory
+
+    def _profile_exists(self, profile: str) -> bool:
+        profile = _normalize_profile(profile)
+        if profile == "default":
+            return True
+        return (get_default_hermes_root() / "profiles" / profile).is_dir()
+
+    def _new_client(
+        self,
+        *,
+        profile: str,
+        cwd: str,
+        approval_policy: str = "deny",
+    ) -> HermesACPClient:
+        return self.client_factory(
+            profile=profile,
+            cwd=cwd,
+            approval_policy=approval_policy,
+        )
+
+    def start_agent(
+        self,
+        *,
+        profile: str,
+        cwd: str | None = None,
+        session_id: str | None = None,
+        idempotency_key: str | None = None,
+        approval_policy: str = "deny",
+    ) -> dict[str, Any]:
+        try:
+            profile = _normalize_profile(profile)
+            cwd = _normalize_cwd(cwd)
+        except (FileNotFoundError, ValueError) as exc:
+            return {"ok": False, "error": str(exc)}
+        if not self._profile_exists(profile):
+            return {
+                "ok": False,
+                "error": f"Profile '{profile}' does not exist.",
+            }
+
+        if idempotency_key:
+            existing = self.store.get_handle_by_idempotency_key(idempotency_key)
+            if existing:
+                return {"ok": True, "reused": True, "agent": existing}
+
+        client = self._new_client(profile=profile, cwd=cwd, approval_policy=approval_policy)
+        try:
+            client.connect()
+            actual_session_id = (
+                client.load_session(session_id, cwd)
+                if session_id
+                else client.new_session(cwd)
+            )
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+        finally:
+            client.close()
+
+        handle = self.store.create_handle(
+            profile=profile,
+            session_id=actual_session_id,
+            cwd=cwd,
+            idempotency_key=idempotency_key,
+        )
+        return {"ok": True, "reused": False, "agent": handle}
+
+    def list_agents(self, *, profile: str | None = None, limit: int = 50) -> dict[str, Any]:
+        try:
+            normalized_profile = _normalize_profile(profile) if profile else None
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc)}
+        return {"ok": True, "agents": self.store.list_handles(profile=normalized_profile, limit=limit)}
+
+    def status(self, *, agent_id: str) -> dict[str, Any]:
+        handle = self.store.get_handle(agent_id)
+        if handle is None:
+            return {"ok": False, "error": f"Unknown agent_id: {agent_id}"}
+        last_run = self.store.last_run_for_handle(agent_id)
+        return {"ok": True, "agent": handle, "last_run": last_run}
+
+    def fork_agent(
+        self,
+        *,
+        agent_id: str,
+        cwd: str | None = None,
+        idempotency_key: str | None = None,
+        approval_policy: str = "deny",
+        lease_wait_seconds: float = 5.0,
+    ) -> dict[str, Any]:
+        handle = self.store.get_handle(agent_id)
+        if handle is None:
+            return {"ok": False, "error": f"Unknown agent_id: {agent_id}"}
+        if idempotency_key:
+            existing = self.store.get_handle_by_idempotency_key(idempotency_key)
+            if existing:
+                return {"ok": True, "agent": existing, "forked_from": agent_id, "reused": True}
+        profile = str(handle["profile"])
+        try:
+            target_cwd = _normalize_cwd(cwd or handle["cwd"])
+        except FileNotFoundError as exc:
+            return {"ok": False, "error": str(exc)}
+        client = self._new_client(profile=profile, cwd=target_cwd, approval_policy=approval_policy)
+        owner = f"{os.getpid()}:{threading.get_ident()}:{uuid.uuid4().hex[:8]}"
+        session_id = str(handle["session_id"])
+        try:
+            with self.store.leased_session(
+                agent_id,
+                profile=profile,
+                session_id=session_id,
+                owner=owner,
+                ttl_seconds=DEFAULT_LEASE_SECONDS,
+                wait_seconds=lease_wait_seconds,
+            ):
+                try:
+                    client.connect()
+                    new_session_id = client.fork_session(session_id, target_cwd)
+                except Exception as exc:
+                    return {"ok": False, "error": str(exc)}
+                finally:
+                    client.close()
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
+        new_handle = self.store.create_handle(
+            profile=profile,
+            session_id=new_session_id,
+            cwd=target_cwd,
+            idempotency_key=idempotency_key,
+        )
+        return {"ok": True, "agent": new_handle, "forked_from": agent_id}
+
+    def prompt_agent(
+        self,
+        *,
+        agent_id: str,
+        prompt: str,
+        timeout_seconds: float = 600.0,
+        lease_wait_seconds: float = 5.0,
+        approval_policy: str = "deny",
+    ) -> dict[str, Any]:
+        handle = self.store.get_handle(agent_id)
+        if handle is None:
+            return {"ok": False, "error": f"Unknown agent_id: {agent_id}"}
+        if not prompt or not str(prompt).strip():
+            return {"ok": False, "error": "prompt is required."}
+        try:
+            target_cwd = _normalize_cwd(str(handle["cwd"]))
+        except FileNotFoundError as exc:
+            return {"ok": False, "agent_id": agent_id, "error": str(exc)}
+
+        owner = f"{os.getpid()}:{threading.get_ident()}:{uuid.uuid4().hex[:8]}"
+        run_id: str | None = None
+
+        try:
+            with self.store.leased_session(
+                agent_id,
+                profile=str(handle["profile"]),
+                session_id=str(handle["session_id"]),
+                owner=owner,
+                ttl_seconds=max(DEFAULT_LEASE_SECONDS, float(timeout_seconds) + 60.0),
+                wait_seconds=lease_wait_seconds,
+            ):
+                run = self.store.create_run(
+                    handle_id=agent_id,
+                    profile=str(handle["profile"]),
+                    session_id=str(handle["session_id"]),
+                    prompt=str(prompt),
+                )
+                run_id = str(run["id"])
+                client = self._new_client(
+                    profile=str(handle["profile"]),
+                    cwd=target_cwd,
+                    approval_policy=approval_policy,
+                )
+                try:
+                    client.connect()
+                    session_id = client.load_session(str(handle["session_id"]), target_cwd)
+                    result = client.prompt(session_id, str(prompt), timeout=float(timeout_seconds))
+                finally:
+                    client.close()
+
+                response = str(result.get("text") or "")
+                stop_reason = result.get("stop_reason")
+                usage = result.get("usage") if isinstance(result.get("usage"), dict) else {}
+                self.store.finish_run(
+                    run_id,
+                    status="completed",
+                    response=response,
+                    stop_reason=str(stop_reason or ""),
+                    usage=usage,
+                )
+                self.store.update_handle(
+                    agent_id,
+                    status="idle",
+                    session_id=session_id,
+                    last_run_id=run_id,
+                    last_response=response,
+                    last_error="",
+                )
+                return {
+                    "ok": True,
+                    "run_id": run_id,
+                    "agent_id": agent_id,
+                    "profile": handle["profile"],
+                    "session_id": session_id,
+                    "stop_reason": stop_reason,
+                    "response": response,
+                    "usage": usage,
+                }
+        except Exception as exc:
+            error = str(exc)
+            if run_id:
+                self.store.finish_run(run_id, status="error", error=error)
+                self.store.update_handle(
+                    agent_id,
+                    status="error",
+                    last_run_id=run_id,
+                    last_error=error,
+                )
+            return {"ok": False, "run_id": run_id, "agent_id": agent_id, "error": error}

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -65,6 +65,7 @@ CONFIGURABLE_TOOLSETS = [
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
+    ("agent_control",   "🎼 Agent Control",             "persistent profile-agent orchestration"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("messaging",       "📨 Cross-Platform Messaging",  "send_message"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),

--- a/tests/acp/test_client.py
+++ b/tests/acp/test_client.py
@@ -1,0 +1,140 @@
+"""Tests for the lightweight Hermes ACP client."""
+
+from __future__ import annotations
+
+import io
+import json
+import threading
+from types import SimpleNamespace
+
+from acp_adapter.client import (
+    HermesACPClient,
+    _select_auth_method_id,
+    build_hermes_acp_env,
+    build_hermes_acp_command,
+)
+
+
+def test_select_auth_method_id_uses_preferred_match():
+    init_result = {"authMethods": [{"id": "openrouter"}, {"id": "anthropic"}]}
+
+    assert _select_auth_method_id(init_result, preferred_method="anthropic") == "anthropic"
+
+
+def test_select_auth_method_id_falls_back_to_first_method():
+    init_result = {"authMethods": [{"id": "openrouter"}, {"id": "anthropic"}]}
+
+    assert _select_auth_method_id(init_result) == "openrouter"
+
+
+def test_select_auth_method_id_returns_none_without_methods():
+    assert _select_auth_method_id({}) is None
+    assert _select_auth_method_id({"authMethods": []}) is None
+
+
+def test_build_command_includes_default_profile_for_python_launcher():
+    cmd = build_hermes_acp_command("default", hermes_bin="/usr/bin/python3")
+
+    assert cmd == ["/usr/bin/python3", "-m", "hermes_cli.main", "-p", "default", "acp"]
+
+
+def test_build_command_includes_profile_for_named_profile():
+    cmd = build_hermes_acp_command("researcher", hermes_bin="/usr/local/bin/hermes")
+
+    assert cmd == ["/usr/local/bin/hermes", "-p", "researcher", "acp"]
+
+
+def test_permission_request_auto_denies_by_default():
+    client = HermesACPClient("default")
+    out = io.StringIO()
+    client.proc = SimpleNamespace(stdin=out, poll=lambda: None)
+    client._lock = threading.Lock()
+
+    client._respond_to_server_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "session/requestPermission",
+            "params": {},
+        }
+    )
+
+    payload = json.loads(out.getvalue())
+    assert payload["id"] == 7
+    assert payload["result"]["outcome"]["outcome"] == "cancelled"
+
+
+def test_client_marks_acp_process_to_use_profile_toolsets(monkeypatch):
+    captured = {}
+
+    class FakePopen:
+        stdin = io.StringIO()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs["env"]
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr("acp_adapter.client.subprocess.Popen", FakePopen)
+    monkeypatch.setattr("acp_adapter.client.threading.Thread", lambda *a, **kw: SimpleNamespace(start=lambda: None))
+
+    client = HermesACPClient("default", hermes_bin="/usr/bin/python3")
+    client._start()
+
+    assert captured["env"]["HERMES_ACP_USE_PROFILE_TOOLSETS"] == "1"
+
+
+def test_python_launcher_env_preserves_checkout_on_pythonpath(monkeypatch):
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+
+    env = build_hermes_acp_env(hermes_bin="/usr/bin/python3")
+
+    assert env["HERMES_ACP_USE_PROFILE_TOOLSETS"] == "1"
+    assert "hermes-agent" in env["PYTHONPATH"]
+
+
+def test_start_replaces_exited_process(monkeypatch):
+    starts = []
+
+    class DeadProcess:
+        def poll(self):
+            return 1
+
+    class FakePopen:
+        stdin = io.StringIO()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        def __init__(self, cmd, **kwargs):
+            starts.append(cmd)
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr("acp_adapter.client.subprocess.Popen", FakePopen)
+    monkeypatch.setattr("acp_adapter.client.threading.Thread", lambda *a, **kw: SimpleNamespace(start=lambda: None))
+
+    client = HermesACPClient("default", hermes_bin="/usr/bin/python3")
+    client.proc = DeadProcess()
+    client._start()
+
+    assert len(starts) == 1
+
+
+def test_load_session_fails_when_server_returns_null():
+    class NullLoadClient(HermesACPClient):
+        def _send_rpc_raw(self, method, params=None, timeout=120.0):
+            return None
+
+    client = NullLoadClient("default")
+
+    try:
+        client.load_session("missing-session")
+    except RuntimeError as exc:
+        assert "missing-session" in str(exc)
+    else:
+        raise AssertionError("load_session should fail on null ACP result")

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -9,7 +9,11 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from acp_adapter import session as acp_session
-from acp_adapter.session import SessionManager, SessionState
+from acp_adapter.session import (
+    SessionManager,
+    SessionState,
+    _resolve_acp_base_toolsets,
+)
 from hermes_state import SessionDB
 
 
@@ -76,6 +80,17 @@ class TestCreateSession:
 
     def test_get_nonexistent_session_returns_none(self, manager):
         assert manager.get_session("does-not-exist") is None
+
+    def test_acp_defaults_to_editor_toolset(self, monkeypatch):
+        monkeypatch.delenv("HERMES_ACP_TOOLSETS", raising=False)
+        monkeypatch.delenv("HERMES_ACP_USE_PROFILE_TOOLSETS", raising=False)
+
+        assert _resolve_acp_base_toolsets({}) == ["hermes-acp"]
+
+    def test_acp_can_use_explicit_toolset_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ACP_TOOLSETS", "web, file")
+
+        assert _resolve_acp_base_toolsets({}) == ["web", "file"]
 
 
 

--- a/tests/agent/test_orchestration.py
+++ b/tests/agent/test_orchestration.py
@@ -1,0 +1,349 @@
+"""Tests for the durable profile-agent orchestration control plane."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent.orchestration import AgentControlStore, AgentController
+from tools.agent_control_tool import (
+    AGENT_FORK_SCHEMA,
+    AGENT_PROMPT_SCHEMA,
+    AGENT_START_SCHEMA,
+    _ADMIN_APPROVAL_POLICY_ENV,
+    _approval_policy_from_env,
+)
+
+
+class FakeACPClient:
+    prompts: list[tuple[str, str]] = []
+    loaded_sessions: list[str] = []
+    sessions_created = 0
+
+    def __init__(self, profile: str, cwd: str, approval_policy: str = "deny"):
+        self.profile = profile
+        self.cwd = cwd
+        self.approval_policy = approval_policy
+        self.closed = False
+
+    def connect(self):
+        return "fake-auth"
+
+    def new_session(self, cwd=None):
+        type(self).sessions_created += 1
+        return f"sid-{self.profile}-{type(self).sessions_created}"
+
+    def resume_session(self, session_id, cwd=None):
+        return session_id
+
+    def load_session(self, session_id, cwd=None):
+        self.loaded_sessions.append(session_id)
+        return session_id
+
+    def fork_session(self, session_id, cwd=None):
+        return f"{session_id}-fork"
+
+    def prompt(self, session_id, text, timeout=600.0):
+        self.prompts.append((session_id, text))
+        return {
+            "stop_reason": "end_turn",
+            "text": f"{self.profile}: {text}",
+            "usage": {"totalTokens": 3},
+        }
+
+    def cancel(self, session_id):
+        return None
+
+    def close(self):
+        self.closed = True
+
+
+def _controller(tmp_path: Path) -> AgentController:
+    FakeACPClient.prompts = []
+    FakeACPClient.loaded_sessions = []
+    FakeACPClient.sessions_created = 0
+    store = AgentControlStore(tmp_path / "agent-control.db")
+    return AgentController(store=store, client_factory=FakeACPClient)
+
+
+def test_start_agent_creates_persistent_handle(tmp_path):
+    controller = _controller(tmp_path)
+
+    result = controller.start_agent(profile="default", cwd=str(tmp_path))
+
+    assert result["ok"] is True
+    agent = result["agent"]
+    assert agent["profile"] == "default"
+    assert agent["session_id"].startswith("sid-default")
+    assert agent["status"] == "idle"
+
+
+def test_start_agent_rejects_invalid_profile_name(tmp_path):
+    controller = _controller(tmp_path)
+
+    result = controller.start_agent(profile="../bad", cwd=str(tmp_path))
+
+    assert result["ok"] is False
+    assert "Invalid profile name" in result["error"]
+
+
+def test_start_agent_rejects_missing_cwd(tmp_path):
+    controller = _controller(tmp_path)
+
+    result = controller.start_agent(profile="default", cwd=str(tmp_path / "missing"))
+
+    assert result["ok"] is False
+    assert "Working directory does not exist" in result["error"]
+
+
+def test_start_agent_surfaces_client_start_errors(tmp_path):
+    class BrokenClient(FakeACPClient):
+        def connect(self):
+            raise RuntimeError("acp unavailable")
+
+    store = AgentControlStore(tmp_path / "agent-control.db")
+    controller = AgentController(store=store, client_factory=BrokenClient)
+
+    result = controller.start_agent(profile="default", cwd=str(tmp_path))
+
+    assert result["ok"] is False
+    assert "acp unavailable" in result["error"]
+
+
+def test_start_agent_loads_existing_session_strictly(tmp_path):
+    controller = _controller(tmp_path)
+
+    result = controller.start_agent(
+        profile="default",
+        cwd=str(tmp_path),
+        session_id="existing-session",
+    )
+
+    assert result["ok"] is True
+    assert result["agent"]["session_id"] == "existing-session"
+    assert FakeACPClient.loaded_sessions == ["existing-session"]
+
+
+def test_start_agent_reuses_idempotency_key(tmp_path):
+    controller = _controller(tmp_path)
+
+    first = controller.start_agent(
+        profile="default",
+        cwd=str(tmp_path),
+        idempotency_key="team:researcher",
+    )
+    second = controller.start_agent(
+        profile="default",
+        cwd=str(tmp_path),
+        idempotency_key="team:researcher",
+    )
+
+    assert first["agent"]["id"] == second["agent"]["id"]
+    assert second["reused"] is True
+
+
+def test_prompt_agent_serializes_and_persists_result(tmp_path):
+    controller = _controller(tmp_path)
+    started = controller.start_agent(profile="default", cwd=str(tmp_path))
+    agent_id = started["agent"]["id"]
+
+    result = controller.prompt_agent(agent_id=agent_id, prompt="Summarize repo")
+
+    assert result["ok"] is True
+    assert result["response"] == "default: Summarize repo"
+    assert FakeACPClient.prompts == [(started["agent"]["session_id"], "Summarize repo")]
+
+    status = controller.status(agent_id=agent_id)
+    assert status["agent"]["status"] == "idle"
+    assert status["last_run"]["status"] == "completed"
+    assert status["last_run"]["response"] == "default: Summarize repo"
+    assert status["last_run"]["usage"] == {"totalTokens": 3}
+
+
+def test_expired_lease_is_marked_error_on_status(tmp_path):
+    controller = _controller(tmp_path)
+    started = controller.start_agent(profile="default", cwd=str(tmp_path))
+    agent_id = started["agent"]["id"]
+    acquired = controller.store.acquire_handle_lease(
+        agent_id,
+        owner="stale-worker",
+        ttl_seconds=-1,
+    )
+    assert acquired is True
+
+    status = controller.status(agent_id=agent_id)
+
+    assert status["agent"]["status"] == "error"
+    assert status["agent"]["lease_owner"] is None
+    assert status["agent"]["last_error"] == "agent_control lease expired"
+
+
+def test_expired_lease_marks_running_run_error(tmp_path):
+    controller = _controller(tmp_path)
+    started = controller.start_agent(profile="default", cwd=str(tmp_path))
+    agent = started["agent"]
+    run = controller.store.create_run(
+        handle_id=agent["id"],
+        profile=agent["profile"],
+        session_id=agent["session_id"],
+        prompt="work",
+    )
+    acquired = controller.store.acquire_handle_lease(
+        agent["id"],
+        owner="stale-worker",
+        ttl_seconds=-1,
+    )
+    assert acquired is True
+
+    status = controller.status(agent_id=agent["id"])
+
+    assert status["last_run"]["id"] == run["id"]
+    assert status["last_run"]["status"] == "error"
+    assert status["last_run"]["error"] == "agent_control lease expired"
+
+
+def test_prompt_agent_returns_busy_without_creating_run_when_lease_held(tmp_path):
+    controller = _controller(tmp_path)
+    started = controller.start_agent(profile="default", cwd=str(tmp_path))
+    agent_id = started["agent"]["id"]
+    acquired = controller.store.acquire_handle_lease(
+        agent_id,
+        owner="other-worker",
+        ttl_seconds=60,
+    )
+    assert acquired is True
+
+    result = controller.prompt_agent(
+        agent_id=agent_id,
+        prompt="Do work",
+        lease_wait_seconds=0,
+    )
+
+    assert result["ok"] is False
+    assert result["run_id"] is None
+    assert "busy" in result["error"]
+    assert controller.store.last_run_for_handle(agent_id) is None
+
+
+def test_session_lease_blocks_duplicate_handles_for_same_profile_session(tmp_path):
+    controller = _controller(tmp_path)
+    started = controller.start_agent(profile="default", cwd=str(tmp_path))
+    agent = started["agent"]
+    duplicate = controller.store.create_handle(
+        profile=agent["profile"],
+        session_id=agent["session_id"],
+        cwd=agent["cwd"],
+    )
+
+    with controller.store.leased_session(
+        agent["id"],
+        profile=agent["profile"],
+        session_id=agent["session_id"],
+        owner="worker-a",
+        ttl_seconds=60,
+    ):
+        result = controller.prompt_agent(
+            agent_id=duplicate["id"],
+            prompt="Do work",
+            lease_wait_seconds=0,
+        )
+
+    assert result["ok"] is False
+    assert result["run_id"] is None
+    assert "agent session" in result["error"]
+    assert "busy" in result["error"]
+    assert controller.store.last_run_for_handle(duplicate["id"]) is None
+
+
+def test_prompt_agent_rejects_missing_handle_cwd_before_run(tmp_path):
+    controller = _controller(tmp_path)
+    started = controller.start_agent(profile="default", cwd=str(tmp_path))
+    agent_id = started["agent"]["id"]
+    missing = tmp_path / "missing"
+    controller.store.update_handle(agent_id, cwd=str(missing))
+
+    result = controller.prompt_agent(agent_id=agent_id, prompt="Do work")
+
+    assert result["ok"] is False
+    assert "Working directory does not exist" in result["error"]
+    assert controller.store.last_run_for_handle(agent_id) is None
+
+
+def test_fork_agent_creates_new_handle_with_forked_session(tmp_path):
+    controller = _controller(tmp_path)
+    started = controller.start_agent(profile="default", cwd=str(tmp_path))
+
+    forked = controller.fork_agent(agent_id=started["agent"]["id"])
+
+    assert forked["ok"] is True
+    assert forked["forked_from"] == started["agent"]["id"]
+    assert forked["agent"]["session_id"] == f"{started['agent']['session_id']}-fork"
+
+
+def test_fork_agent_takes_source_session_lease(tmp_path):
+    controller = _controller(tmp_path)
+    started = controller.start_agent(profile="default", cwd=str(tmp_path))
+    agent = started["agent"]
+
+    with controller.store.leased_session(
+        agent["id"],
+        profile=agent["profile"],
+        session_id=agent["session_id"],
+        owner="worker-a",
+        ttl_seconds=60,
+    ):
+        result = controller.fork_agent(agent_id=agent["id"], lease_wait_seconds=0)
+
+    assert result["ok"] is False
+    assert "agent session" in result["error"]
+    assert "busy" in result["error"]
+
+
+def test_session_lease_is_keyed_by_profile_and_session(tmp_path):
+    store = AgentControlStore(tmp_path / "agent-control.db")
+
+    first = store.acquire_session_lease(
+        profile="default",
+        session_id="shared-session",
+        handle_id="agent-a",
+        owner="worker-a",
+        ttl_seconds=60,
+    )
+    second_same_session = store.acquire_session_lease(
+        profile="default",
+        session_id="shared-session",
+        handle_id="agent-b",
+        owner="worker-b",
+        ttl_seconds=60,
+        wait_seconds=0,
+    )
+    second_other_session = store.acquire_session_lease(
+        profile="default",
+        session_id="other-session",
+        handle_id="agent-c",
+        owner="worker-b",
+        ttl_seconds=60,
+        wait_seconds=0,
+    )
+
+    assert first is True
+    assert second_same_session is False
+    assert second_other_session is True
+
+
+def test_agent_control_tool_schema_does_not_expose_approval_policy():
+    for schema in (AGENT_START_SCHEMA, AGENT_PROMPT_SCHEMA, AGENT_FORK_SCHEMA):
+        properties = schema["parameters"]["properties"]
+        assert "approval_policy" not in properties
+        assert "allow_once" not in json.dumps(schema)
+
+
+def test_agent_control_approval_policy_is_admin_env_only(monkeypatch):
+    monkeypatch.delenv(_ADMIN_APPROVAL_POLICY_ENV, raising=False)
+    assert _approval_policy_from_env() == "deny"
+
+    monkeypatch.setenv(_ADMIN_APPROVAL_POLICY_ENV, "allow_once")
+    assert _approval_policy_from_env() == "allow_once"
+
+    monkeypatch.setenv(_ADMIN_APPROVAL_POLICY_ENV, "allow")
+    assert _approval_policy_from_env() == "deny"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -96,7 +96,15 @@ class TestChildSystemPrompt(unittest.TestCase):
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):
-        result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution"])
+        result = _strip_blocked_tools([
+            "terminal",
+            "file",
+            "delegation",
+            "agent_control",
+            "clarify",
+            "memory",
+            "code_execution",
+        ])
         self.assertEqual(sorted(result), ["file", "terminal"])
 
     def test_preserves_allowed_toolsets(self):

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -291,6 +291,7 @@ class TestCheckFnExceptionHandling:
 class TestBuiltinDiscovery:
     def test_matches_previous_manual_builtin_tool_set(self):
         expected = {
+            "tools.agent_control_tool",
             "tools.browser_cdp_tool",
             "tools.browser_dialog_tool",
             "tools.browser_tool",

--- a/tools/agent_control_tool.py
+++ b/tools/agent_control_tool.py
@@ -1,0 +1,271 @@
+"""Agent-control tools for orchestrating peer Hermes profiles."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from typing import Any
+
+from agent.orchestration import AgentController
+from tools.registry import registry, tool_error
+
+
+_controller: AgentController | None = None
+
+
+def _get_controller() -> AgentController:
+    global _controller
+    if _controller is None:
+        _controller = AgentController()
+    return _controller
+
+
+def check_agent_control_requirements() -> bool:
+    return importlib.util.find_spec("acp") is not None
+
+
+def _json_result(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False)
+
+
+_ADMIN_APPROVAL_POLICY_ENV = "HERMES_AGENT_CONTROL_APPROVAL_POLICY"
+
+
+def _approval_policy_from_env() -> str:
+    """Resolve dangerous-permission policy from process/admin configuration only."""
+    value = os.environ.get(_ADMIN_APPROVAL_POLICY_ENV, "deny").strip().lower()
+    if value in {"allow_once", "once"}:
+        return "allow_once"
+    return "deny"
+
+
+def _handle_start(args: dict, **kw) -> str:
+    profile = str(args.get("profile") or "").strip()
+    if not profile:
+        return tool_error("profile is required.")
+    result = _get_controller().start_agent(
+        profile=profile,
+        cwd=args.get("cwd"),
+        session_id=args.get("session_id"),
+        idempotency_key=args.get("idempotency_key"),
+        approval_policy=_approval_policy_from_env(),
+    )
+    return _json_result(result)
+
+
+def _handle_prompt(args: dict, **kw) -> str:
+    agent_id = str(args.get("agent_id") or "").strip()
+    prompt = str(args.get("prompt") or "")
+    if not agent_id:
+        return tool_error("agent_id is required.")
+    if not prompt.strip():
+        return tool_error("prompt is required.")
+    result = _get_controller().prompt_agent(
+        agent_id=agent_id,
+        prompt=prompt,
+        timeout_seconds=float(args.get("timeout_seconds") or 600.0),
+        lease_wait_seconds=float(args.get("lease_wait_seconds") or 5.0),
+        approval_policy=_approval_policy_from_env(),
+    )
+    return _json_result(result)
+
+
+def _handle_status(args: dict, **kw) -> str:
+    agent_id = str(args.get("agent_id") or "").strip()
+    if not agent_id:
+        return tool_error("agent_id is required.")
+    return _json_result(_get_controller().status(agent_id=agent_id))
+
+
+def _handle_list(args: dict, **kw) -> str:
+    return _json_result(
+        _get_controller().list_agents(
+            profile=args.get("profile"),
+            limit=int(args.get("limit") or 50),
+        )
+    )
+
+
+def _handle_fork(args: dict, **kw) -> str:
+    agent_id = str(args.get("agent_id") or "").strip()
+    if not agent_id:
+        return tool_error("agent_id is required.")
+    result = _get_controller().fork_agent(
+        agent_id=agent_id,
+        cwd=args.get("cwd"),
+        idempotency_key=args.get("idempotency_key"),
+        approval_policy=_approval_policy_from_env(),
+    )
+    return _json_result(result)
+
+
+AGENT_START_SCHEMA = {
+    "name": "agent_start",
+    "description": (
+        "Create or attach to a persistent Hermes ACP session for another "
+        "profile. This controls a real profile agent with its own config, "
+        "memory, skills, session history, and tool surface; it is not an "
+        "ephemeral delegate_task subagent. Returns an agent_id handle."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "string",
+                "description": "Hermes profile name to control, e.g. 'researcher' or 'reviewer'.",
+            },
+            "cwd": {
+                "type": "string",
+                "description": "Working directory for the controlled session. Defaults to the current process cwd.",
+            },
+            "session_id": {
+                "type": "string",
+                "description": "Existing ACP session id to load instead of creating a new one.",
+            },
+            "idempotency_key": {
+                "type": "string",
+                "description": "Optional key to safely reuse an existing handle across retries.",
+            },
+        },
+        "required": ["profile"],
+    },
+}
+
+
+AGENT_PROMPT_SCHEMA = {
+    "name": "agent_prompt",
+    "description": (
+        "Send a prompt to a controlled profile agent and wait for its reply. "
+        "Calls are serialized per agent_id with a durable lease so two "
+        "orchestrators do not race the same profile session. Ask for "
+        "structured handoffs with files changed, tests run, artifacts, and "
+        "blockers when reliability matters."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "agent_id": {
+                "type": "string",
+                "description": "Handle returned by agent_start or agent_fork.",
+            },
+            "prompt": {
+                "type": "string",
+                "description": "Instruction to send to the controlled profile agent.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "description": "Maximum seconds to wait for the controlled agent response. Default 600.",
+            },
+            "lease_wait_seconds": {
+                "type": "number",
+                "description": "Seconds to wait if another run currently owns this profile session. Default 5.",
+            },
+        },
+        "required": ["agent_id", "prompt"],
+    },
+}
+
+
+AGENT_STATUS_SCHEMA = {
+    "name": "agent_status",
+    "description": "Return the durable state and latest run for a controlled profile agent.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "agent_id": {"type": "string", "description": "Agent handle id."},
+        },
+        "required": ["agent_id"],
+    },
+}
+
+
+AGENT_LIST_SCHEMA = {
+    "name": "agent_list",
+    "description": "List controlled profile-agent handles known to this Hermes profile.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "string",
+                "description": "Optional profile filter.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum handles to return, capped at 200. Default 50.",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+AGENT_FORK_SCHEMA = {
+    "name": "agent_fork",
+    "description": (
+        "Fork a controlled profile agent's ACP session and return a new "
+        "agent_id. Use this for speculative work where the same profile "
+        "identity should branch without mutating the original session history."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "agent_id": {"type": "string", "description": "Source agent handle id."},
+            "cwd": {
+                "type": "string",
+                "description": "Working directory for the fork. Defaults to the source handle cwd.",
+            },
+            "idempotency_key": {
+                "type": "string",
+                "description": "Optional key to safely reuse an existing fork handle across retries.",
+            },
+        },
+        "required": ["agent_id"],
+    },
+}
+
+
+registry.register(
+    name="agent_start",
+    toolset="agent_control",
+    schema=AGENT_START_SCHEMA,
+    handler=_handle_start,
+    check_fn=check_agent_control_requirements,
+    emoji="",
+)
+
+registry.register(
+    name="agent_prompt",
+    toolset="agent_control",
+    schema=AGENT_PROMPT_SCHEMA,
+    handler=_handle_prompt,
+    check_fn=check_agent_control_requirements,
+    emoji="",
+)
+
+registry.register(
+    name="agent_status",
+    toolset="agent_control",
+    schema=AGENT_STATUS_SCHEMA,
+    handler=_handle_status,
+    check_fn=check_agent_control_requirements,
+    emoji="",
+)
+
+registry.register(
+    name="agent_list",
+    toolset="agent_control",
+    schema=AGENT_LIST_SCHEMA,
+    handler=_handle_list,
+    check_fn=check_agent_control_requirements,
+    emoji="",
+)
+
+registry.register(
+    name="agent_fork",
+    toolset="agent_control",
+    schema=AGENT_FORK_SCHEMA,
+    handler=_handle_fork,
+    check_fn=check_agent_control_requirements,
+    emoji="",
+)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -637,6 +637,7 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     """Remove toolsets that contain only blocked tools."""
     blocked_toolset_names = {
         "delegation",
+        "agent_control",
         "clarify",
         "memory",
         "code_execution",

--- a/toolsets.py
+++ b/toolsets.py
@@ -198,6 +198,19 @@ TOOLSETS = {
         "includes": []
     },
 
+    "agent_control": {
+        "description": (
+            "Control other Hermes profiles as persistent peer agents via ACP. "
+            "Use for orchestrator profiles that need durable teammates with "
+            "their own memory, config, skills, and session history."
+        ),
+        "tools": [
+            "agent_start", "agent_prompt", "agent_status",
+            "agent_list", "agent_fork",
+        ],
+        "includes": [],
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 

--- a/website/docs/developer-guide/agent-orchestration-adr.md
+++ b/website/docs/developer-guide/agent-orchestration-adr.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 8
+title: "ADR: Agent Orchestration Primitives"
+description: "Why Hermes has delegate_task, agent_control, and Kanban as separate orchestration primitives"
+---
+
+# ADR: Agent Orchestration Primitives
+
+Status: Proposed
+
+## Context
+
+Hermes now has three related, but intentionally separate, ways to coordinate agent work:
+
+- `delegate_task`: spawn short-lived subagents inside the current agent process.
+- `agent_control`: command persistent Hermes profiles as peer agents through ACP.
+- Kanban: coordinate durable asynchronous work through a shared task board.
+
+These should not collapse into one abstraction. They solve different lifecycle, identity, and reliability problems.
+
+This ADR also supersedes the direction explored in [PR #14009](https://github.com/NousResearch/hermes-agent/pull/14009), which introduced an ACP session client for external orchestration. The new direction keeps ACP as the control protocol, but moves orchestration into Hermes itself as an opt-in toolset with durable handles, run records, and per-agent leases.
+
+## Decision
+
+Keep three primitives:
+
+| Primitive | Shape | Identity and memory | State | Parent behavior | Best use | Not for |
+|---|---|---|---|---|---|---|
+| `delegate_task` | Synchronous RPC to an isolated child `AIAgent` | Anonymous child, fresh context, no shared memory writes | In process only | Parent waits for final summary | Bounded subtasks, parallel research, code review slices, context isolation | Long-lived roles, resumable work, named teammates |
+| `agent_control` | Direct command channel to another Hermes profile over ACP | Real profile with its own config, skills, tools, memory, and session history | `~/.hermes/agent-control.db` plus ACP session storage | Parent sends prompt and waits for reply | Manager/team patterns, durable specialists, reusable reviewer/researcher/operator profiles | Fire-and-forget queues, multi-day task boards, broad human workflow |
+| Kanban | Shared durable task board and state machine | Named profiles can pick up tasks over time | `~/.hermes/kanban.db` | Parent can create work and continue | Async workflows, retries, human-in-the-loop, multi-agent pipelines | Immediate request/response control of one profile |
+
+## Why `agent_control` Exists
+
+`delegate_task` is deliberately disposable. That is good for isolation, but bad for "team" behavior. A manager agent needs to address a reviewer, researcher, planner, or operator that has:
+
+- a stable profile identity
+- its own configured tool surface
+- memory and skills selected for that role
+- a session history that can be resumed
+- durable run metadata for auditing
+
+Kanban solves a different problem: distributed coordination. It is the right primitive when work should be visible, recoverable, and picked up asynchronously. It is heavier than a direct command channel and does not replace the need to say "ask this named profile to do this now and return the answer."
+
+## Reliability Boundaries
+
+`agent_control` is designed as a production-oriented direct-control primitive:
+
+- Handles and runs are persisted in SQLite.
+- A session lease keyed by `(profile, session_id)` prevents two orchestrators or duplicate handles from racing the same ACP session.
+- Forking takes the same source-session lease before branching history.
+- Expired leases are marked as errors instead of leaving handles stuck forever.
+- Permission requests from controlled profiles fail closed by default.
+- Permissive approval policies are process/admin configuration, not model-selected tool arguments.
+- `delegate_task` children cannot inherit `agent_control`, preventing recursive escalation.
+- Cancellation is intentionally omitted from the model-facing toolset until the control plane has an async or pollable run API with response dispatching.
+
+It does not try to become a scheduler, queue, or workflow engine. Those remain Kanban's job.
+
+## Relationship to ACP
+
+ACP remains the transport boundary between the orchestrator and the controlled profile. This keeps controlled agents close to normal Hermes execution:
+
+- profile selection still flows through `hermes -p <profile> acp`
+- session creation/loading/forking uses existing ACP methods
+- editor ACP behavior remains unchanged by default
+- agent-control subprocesses opt into the controlled profile's CLI toolsets
+
+This avoids introducing a second internal agent runtime while still giving the orchestrator durable control handles.
+
+## Expected User Mental Model
+
+Use `delegate_task` when you want "do this isolated subtask and summarize back."
+
+Use `agent_control` when you want "ask Alice the reviewer, Bob the researcher, or Ops the operator, each as a real Hermes profile."
+
+Use Kanban when you want "put this work on the board so agents and humans can pick it up, retry it, comment on it, and complete it over time."

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -52,6 +52,7 @@ Or in-session:
 
 | Toolset | Tools | Purpose |
 |---------|-------|---------|
+| `agent_control` | `agent_fork`, `agent_list`, `agent_prompt`, `agent_start`, `agent_status` | Control persistent Hermes profiles as peer agents through ACP. Opt-in for orchestrator profiles. |
 | `browser` | `browser_back`, `browser_click`, `browser_console`, `browser_get_images`, `browser_navigate`, `browser_press`, `browser_scroll`, `browser_snapshot`, `browser_type`, `browser_vision`, `web_search` | Core browser automation. Includes `web_search` as a fallback for quick lookups. `browser_cdp` and `browser_dialog` live in a separate `browser-cdp` toolset and are registered only when a CDP endpoint is reachable at session start — via `/browser connect`, `browser.cdp_url` config, Browserbase, or Camofox. `browser_dialog` works together with the `pending_dialogs` and `frame_tree` fields that `browser_snapshot` adds when a CDP supervisor is attached. |
 | `clarify` | `clarify` | Ask the user a question when the agent needs clarification. |
 | `code_execution` | `execute_code` | Run Python scripts that call Hermes tools programmatically. |

--- a/website/docs/user-guide/features/agent-control.md
+++ b/website/docs/user-guide/features/agent-control.md
@@ -1,0 +1,89 @@
+---
+sidebar_position: 8
+title: "Agent Control"
+description: "Control persistent Hermes profiles as peer agents through ACP"
+---
+
+# Agent Control
+
+`agent_control` lets an orchestrator profile command other Hermes profiles as persistent peer agents. These are not anonymous `delegate_task` children: each controlled agent runs through ACP with its own profile config, tools, skills, memory providers, and session history.
+
+This toolset is intentionally opt-in. Enable it only for profiles that are meant to orchestrate other agents.
+
+Agent Control requires the ACP extra:
+
+```bash
+pip install 'hermes-agent[acp]'
+# From a source checkout:
+pip install -e '.[acp]'
+```
+
+## Enable the toolset
+
+For a one-off orchestrator run:
+
+```bash
+hermes -p orchestrator --toolsets agent_control
+```
+
+Or add `agent_control` to the orchestrator profile's configured toolsets.
+
+The controlled profiles must already exist under `~/.hermes/profiles/<profile-name>`. When `agent_control` launches a profile through ACP, the profile uses its configured CLI toolsets instead of the editor-focused `hermes-acp` default.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `agent_start` | Create or attach to a durable handle for a profile session. |
+| `agent_prompt` | Send work to a controlled profile and wait for its response. |
+| `agent_status` | Inspect the handle and latest run. |
+| `agent_list` | List known controlled profile handles. |
+| `agent_fork` | Branch a controlled agent's session for speculative work. |
+
+State is stored in `~/.hermes/agent-control.db`. Handles survive process restarts; active subprocesses do not. A later `agent_prompt` loads the stored ACP session before sending new work.
+
+## Basic pattern
+
+```python
+agent_start(
+    profile="researcher",
+    cwd="/home/user/project",
+    idempotency_key="team:researcher"
+)
+
+agent_prompt(
+    agent_id="agent-abc123",
+    prompt="""Inspect the repository and return:
+    - findings with file paths
+    - tests run
+    - open blockers
+    """,
+    timeout_seconds=900
+)
+
+agent_status(agent_id="agent-abc123")
+```
+
+Use idempotency keys for named team roles. If the orchestrator retries after a transient failure, it can reuse the same handle instead of spawning duplicate sessions.
+
+## Permissions
+
+`agent_prompt`, `agent_start`, and `agent_fork` deny dangerous local permission requests by default. The model cannot choose a permissive approval policy through tool arguments.
+
+For trusted local automation, an administrator can set `HERMES_AGENT_CONTROL_APPROVAL_POLICY=allow_once` in the Hermes process environment. Keep the default `deny` policy for untrusted or shared orchestrator profiles.
+
+## Agent Control vs. Delegation vs. Kanban
+
+Use `delegate_task` for short, context-isolated subtasks where the parent needs an answer before continuing. Delegated children are fresh in-process agents and only their final summary returns.
+
+Use `agent_control` when identity matters: a reviewer, researcher, operator, or planner should keep a real profile, durable session, tool configuration, and memory across prompts.
+
+Use Kanban when the work should be asynchronous, recoverable, and visible as a task board across multiple profiles or humans. `agent_control` is a direct command channel; Kanban is a durable coordination surface.
+
+## Reliability model
+
+Each controlled ACP session has a SQLite lease keyed by profile and session id. Only one orchestrator run can own the same profile session at a time, even if multiple handles point at it, so concurrent prompts do not corrupt session history. Forks take the same lease before branching source history. Runs are persisted with status, response, error, and usage metadata.
+
+`agent_control` intentionally exposes synchronous request/response commands only. Cancellation is not a model-facing tool until Hermes has an async or pollable run API with response dispatching strong enough to cancel in-flight ACP work reliably.
+
+For production orchestration, ask controlled agents for structured handoffs: files touched, commands run, tests passed or failed, artifacts produced, and blockers. The control plane makes execution durable; the prompt contract makes team behavior predictable.

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -243,24 +243,15 @@ Visually the target is the familiar Linear / Fusion layout: dark theme, column h
 
 The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer with no domain logic of its own:
 
-```
-┌────────────────────────┐      WebSocket (tails task_events)
-│   React SPA (plugin)   │ ◀──────────────────────────────────┐
-│   HTML5 drag-and-drop  │                                    │
-└──────────┬─────────────┘                                    │
-           │ REST over fetchJSON                              │
-           ▼                                                  │
-┌────────────────────────┐     writes call kanban_db.*        │
-│  FastAPI router        │     directly — same code path      │
-│  plugins/kanban/       │     the CLI /kanban verbs use      │
-│  dashboard/plugin_api.py                                    │
-└──────────┬─────────────┘                                    │
-           │                                                  │
-           ▼                                                  │
-┌────────────────────────┐                                    │
-│  ~/.hermes/kanban.db   │ ───── append task_events ──────────┘
-│  (WAL, shared)         │
-└────────────────────────┘
+```mermaid
+flowchart TD
+    ui["React SPA (plugin)<br/>HTML5 drag-and-drop"]
+    api["FastAPI router<br/>plugins/kanban/dashboard/plugin_api.py"]
+    db["~/.hermes/kanban.db<br/>(WAL, shared)"]
+
+    ui -->|"REST over fetchJSON"| api
+    api -->|"writes call kanban_db.* directly<br/>same code path the CLI /kanban verbs use"| db
+    db -->|"append task_events over WebSocket"| ui
 ```
 
 ### REST surface

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -63,6 +63,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'user-guide/features/cron',
             'user-guide/features/delegation',
+            'user-guide/features/agent-control',
             'user-guide/features/kanban',
             'user-guide/features/kanban-tutorial',
             'user-guide/features/goals',
@@ -196,6 +197,7 @@ const sidebars: SidebarsConfig = {
             'developer-guide/gateway-internals',
             'developer-guide/session-storage',
             'developer-guide/provider-runtime',
+            'developer-guide/agent-orchestration-adr',
           ],
         },
         {


### PR DESCRIPTION
## Summary

This PR restores the work from #18493 after the original fork branch was deleted and GitHub could not reopen the closed pull request.

This PR adds `agent_control`: a durable orchestration layer that lets Hermes profiles manage other Hermes profiles as persistent peer agents over ACP.

The core idea is simple: `delegate_task` is for disposable subagents, Kanban is for asynchronous task-board workflows, and `agent_control` is for direct manager/team orchestration. A Hermes orchestrator can now command named specialist profiles with their own memory, tools, skills, config, and resumable session history.

This turns Hermes profiles into composable agent teammates without inventing a separate swarm runtime. It reuses the primitives Hermes already trusts: profiles for identity, ACP for process/session control, toolsets for capability boundaries, and SQLite for durable state.

This builds on the external orchestration direction from #14009, but moves the control plane into Hermes as an opt-in toolset designed for production reliability.

## What changed

- Add a lightweight ACP stdio JSON-RPC client for Hermes profile sessions.
- Add a durable SQLite-backed control plane for profile-agent handles, runs, and leases.
- Add the `agent_control` toolset and tools:
  - `agent_start`
  - `agent_prompt`
  - `agent_status`
  - `agent_list`
  - `agent_fork`
- Keep editor ACP behavior unchanged by default.
- Allow agent-control ACP subprocesses to use the controlled profile's CLI toolsets.
- Prevent `delegate_task` children from inheriting `agent_control`.
- Keep dangerous permission approval policy outside the model-facing schema; trusted local automation can opt into one-shot approvals only via process/admin configuration.
- Omit model-facing cancellation until Hermes has an async or pollable run API with ACP response dispatching strong enough to cancel in-flight work reliably.
- Add user docs and an ADR comparing `delegate_task`, `agent_control`, and Kanban.
- Convert the existing Kanban architecture diagram to Mermaid so docs diagram lint stays green when website docs are touched.

## Reliability notes

- SQLite session leases are keyed by `(profile, session_id)`, so duplicate handles or separate orchestrator profiles cannot race the same ACP session history.
- `agent_fork` takes the same source-session lease before branching history.
- Expired leases are marked as errors instead of leaving handles stuck.
- Existing ACP sessions are loaded strictly; missing sessions fail instead of silently creating ghost state.
- Dangerous permission requests fail closed by default.
- The model cannot set `approval_policy="allow_once"` through tool arguments; permissive behavior requires `HERMES_AGENT_CONTROL_APPROVAL_POLICY=allow_once`.
- `agent_control` is gated on the ACP extra.

## Tests

- `.venv/bin/python -m pytest tests/acp/test_client.py tests/agent/test_orchestration.py tests/acp/test_session.py tests/tools/test_delegate.py tests/tools/test_registry.py::TestBuiltinDiscovery::test_matches_previous_manual_builtin_tool_set -q`
  - `190 passed`
- `.venv/bin/python -m compileall acp_adapter/client.py acp_adapter/session.py agent/orchestration.py tools/agent_control_tool.py hermes_cli/tools_config.py tests/acp/test_client.py tests/acp/test_session.py tests/agent/test_orchestration.py tests/tools/test_delegate.py tests/tools/test_registry.py`
- agent_control registry smoke check
- agent_control toolset smoke check
- `.venv/bin/ascii-guard lint website/docs`
- `npm run build`
  - completed successfully with the venv Python on `PATH` so the skill metadata prebuild matches CI's `pyyaml` setup.
- `git diff --check`

The targeted test set covers the new ACP client, the durable orchestration control plane, ACP toolset behavior, and the regression that prevents `delegate_task` children from inheriting `agent_control`. The full repository suite is left to CI.
