### PR TITLE
feat: add cron show command

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -187,6 +187,57 @@ def cron_status():
     print()
 
 
+def cron_show(args):
+    """Show full details for one scheduled job."""
+    result = _cron_api(action="show", job_id=args.job_id)
+    if not result.get("success"):
+        print(color(f"Job not found: {args.job_id}", Colors.RED))
+        return 1
+
+    job = result["job"]
+    print()
+    print(color("┌─────────────────────────────────────────────────────────────────────────┐", Colors.CYAN))
+    print(color("│                         Scheduled Job                                   │", Colors.CYAN))
+    print(color("└─────────────────────────────────────────────────────────────────────────┘", Colors.CYAN))
+    print()
+    print(f"  {color(job['job_id'], Colors.YELLOW)}")
+    print(f"    Name:      {job.get('name', '(unnamed)')}")
+    print(f"    State:     {job.get('state', '?')}")
+    print(f"    Schedule:  {job.get('schedule', '?')}")
+    print(f"    Repeat:    {job.get('repeat', '?')}")
+    print(f"    Next run:  {job.get('next_run_at') or '?'}")
+    print(f"    Deliver:   {job.get('deliver', 'local')}")
+    if job.get("skills"):
+        print(f"    Skills:    {', '.join(job['skills'])}")
+    if job.get("script"):
+        print(f"    Script:    {job['script']}")
+    if job.get("no_agent"):
+        print(f"    Mode:      {color('no-agent', Colors.DIM)} (script stdout delivered directly)")
+    if job.get("workdir"):
+        print(f"    Workdir:   {job['workdir']}")
+    if job.get("profile"):
+        print(f"    Profile:   {job['profile']}")
+    if job.get("model") or job.get("provider") or job.get("base_url"):
+        print(f"    Model:     {job.get('provider') or '?'} / {job.get('model') or '?'}")
+        if job.get("base_url"):
+            print(f"    Base URL:  {job['base_url']}")
+    if job.get("last_status"):
+        last_status = job["last_status"]
+        status_display = color("ok", Colors.GREEN) if last_status == "ok" else color(last_status, Colors.RED)
+        print(f"    Last run:  {job.get('last_run_at') or '?'}  {status_display}")
+    if job.get("last_delivery_error"):
+        print(f"    {color('⚠ Delivery failed:', Colors.YELLOW)} {job['last_delivery_error']}")
+    print("    Prompt:")
+    prompt = job.get("prompt") or ""
+    if prompt:
+        for line in prompt.splitlines():
+            print(f"      {line}")
+    else:
+        print(color("      (empty)", Colors.DIM))
+    print()
+    return 0
+
+
 def cron_create(args):
     # Defense: reject cron jobs that contain gateway lifecycle commands.
     # Prevents agents from scheduling their own restart/stop, which creates
@@ -349,6 +400,9 @@ def cron_command(args):
     if subcmd == "edit":
         return cron_edit(args)
 
+    if subcmd in {"show", "inspect"}:
+        return cron_show(args)
+
     if subcmd == "pause":
         return _job_action("pause", args.job_id, "Paused")
 
@@ -362,5 +416,5 @@ def cron_command(args):
         return _job_action("remove", args.job_id, "Removed")
 
     print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick]")
+    print("Usage: hermes cron [list|show|create|edit|pause|resume|run|remove|status|tick]")
     sys.exit(1)

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -23,6 +23,11 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_list = cron_subparsers.add_parser("list", help="List scheduled jobs")
     cron_list.add_argument("--all", action="store_true", help="Include disabled jobs")
 
+    cron_show = cron_subparsers.add_parser(
+        "show", aliases=["inspect"], help="Show full details for one scheduled job"
+    )
+    cron_show.add_argument("job_id", help="Job ID or unique job name to inspect")
+
     # cron create/add
     cron_create = cron_subparsers.add_parser(
         "create", aliases=["add"], help="Create a scheduled job"

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -17,6 +17,31 @@ def tmp_cron_dir(tmp_path, monkeypatch):
 
 
 class TestCronCommandLifecycle:
+    def test_show_prints_single_job_details(self, tmp_cron_dir, capsys):
+        job = create_job(
+            prompt="Check server status and report anomalies",
+            schedule="every 1h",
+            name="Server Check",
+            skills=["ops", "incident-review"],
+            deliver="local",
+        )
+
+        rc = cron_command(Namespace(cron_command="show", job_id=job["id"]))
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Server Check" in out
+        assert job["id"] in out
+        assert "Check server status and report anomalies" in out
+        assert "ops, incident-review" in out
+        assert "Deliver:" in out
+
+    def test_show_reports_missing_job(self, tmp_cron_dir, capsys):
+        rc = cron_command(Namespace(cron_command="show", job_id="missing"))
+
+        assert rc == 1
+        assert "Job not found: missing" in capsys.readouterr().out
+
     def test_pause_resume_run(self, tmp_cron_dir, capsys):
         job = create_job(prompt="Check server status", schedule="every 1h")
 

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -264,6 +264,33 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_show_returns_one_full_job_without_listing_noise(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status and report anomalies",
+                schedule="every 1h",
+                name="Server Check",
+                skills=["ops", "incident-review"],
+            )
+        )
+
+        shown = json.loads(cronjob(action="show", job_id=created["job_id"]))
+
+        assert shown["success"] is True
+        assert shown["job"]["job_id"] == created["job_id"]
+        assert shown["job"]["name"] == "Server Check"
+        assert shown["job"]["skills"] == ["ops", "incident-review"]
+        assert "jobs" not in shown
+
+    def test_show_accepts_inspect_alias(self):
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+
+        shown = json.loads(cronjob(action="inspect", job_id=created["job_id"]))
+
+        assert shown["success"] is True
+        assert shown["job"]["job_id"] == created["job_id"]
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -417,7 +417,7 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     return None
 
 
-def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
+def _format_job(job: Dict[str, Any], *, include_prompt: bool = False) -> Dict[str, Any]:
     prompt = str(job.get("prompt") or "")
     skills = _canonical_skills(job.get("skill"), job.get("skills"))
     job_id = str(job.get("id") or "unknown")
@@ -443,6 +443,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
     }
+    if include_prompt:
+        result["prompt"] = prompt
     if job.get("script"):
         result["script"] = job["script"]
     if job.get("no_agent"):
@@ -596,6 +598,9 @@ def cronjob(
         # Resolve to canonical ID (supports name-based lookup)
         job_id = job["id"]
 
+        if normalized in {"show", "inspect"}:
+            return json.dumps({"success": True, "job": _format_job(job, include_prompt=True)}, indent=2)
+
         if normalized == "remove":
             removed = remove_job(job_id)
             if not removed:
@@ -726,6 +731,7 @@ CRONJOB_SCHEMA = {
 
 Use action='create' to schedule a new job from a prompt or one or more skills.
 Use action='list' to inspect jobs.
+Use action='show' with job_id to inspect one job's full details, including the complete prompt.
 Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing job.
 
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
@@ -744,11 +750,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
         "properties": {
             "action": {
                 "type": "string",
-                "description": "One of: create, list, update, pause, resume, remove, run. When action=create, the 'schedule' and 'prompt' fields are REQUIRED."
+                "description": "One of: create, list, show, inspect, update, pause, resume, remove, run. When action=create, the 'schedule' and 'prompt' fields are REQUIRED."
             },
             "job_id": {
                 "type": "string",
-                "description": "Required for update/pause/resume/remove/run"
+                "description": "Required for show/inspect/update/pause/resume/remove/run"
             },
             "prompt": {
                 "type": "string",


### PR DESCRIPTION
## Summary
- Add `cronjob(action="show")` with `inspect` alias to inspect one scheduled job with its full prompt.
- Add `hermes cron show <job_id>` / `hermes cron inspect <job_id>` CLI surface.
- Cover tool and CLI behavior with focused tests.

## Why
`hermes cron list` is good for overview, but it truncates prompts. A read-only show command makes morning/ops inspection safer before editing, pausing, or removing jobs.

## Tests
- `scripts/run_tests.sh tests/tools/test_cronjob_tools.py tests/hermes_cli/test_cron.py` — 66 passed.
- Smoke: temp `HERMES_HOME` create + `python -m hermes_cli.main cron show <job_id>` asserted name, prompt, and delivery output.

## Notes
- Read-only only; no scheduler/deployment changes.
