### PR TITLE
fix(email): use BODY.PEEK[] to avoid marking messages as read on IMAP fetch

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -383,7 +383,7 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -868,6 +868,36 @@ class TestFetchNewMessages(unittest.TestCase):
 
         self.assertEqual(results, [])
 
+    def test_fetch_uses_body_peek(self):
+        """_fetch_new_messages must use BODY.PEEK[] to avoid marking messages as read."""
+        adapter = self._make_adapter()
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        mock_imap = MagicMock()
+        fetch_args = []
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                fetch_args.append(args)
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        # Verify BODY.PEEK[] was used, not RFC822
+        self.assertEqual(len(fetch_args), 1)
+        self.assertEqual(fetch_args[0], (b"1", "(BODY.PEEK[])"))
+
     def test_fetch_extracts_sender_name(self):
         """Sender name should be extracted from 'Name <addr>' format."""
         adapter = self._make_adapter()


### PR DESCRIPTION
## Problem

When the Email gateway polls IMAP for unseen messages, `UID FETCH (RFC822)` implicitly sets the \\Seen\ flag on Gmail and other IMAP servers. This causes the gateway to silently mark unread messages as read during polling — even before sender allowlist checks or any message handling occurs.

## Root Cause

`gateway/platforms/email.py:386` — `(RFC822)` is not a peek operation on most IMAP servers.

## Fix

One-line change: replace `(RFC822)` with `(BODY.PEEK[])`:

```python
# Before
status, msg_data = imap.uid("fetch", uid, "(RFC822)")

# After
status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
```

`BODY.PEEK[]` fetches the full message body without altering the \\Seen\ flag. The raw message parsing is identical — only the IMAP command changes.

Closes #42997

## Test

Added `test_fetch_uses_body_peek` — verifies that the fetch command uses `(BODY.PEEK[])` and not `(RFC822)`. All 61 tests in `tests/gateway/test_email.py` pass. Ruff clean.