### PR TITLE
Add planning, code-review, and documentation skills

### DIFF
--- a/skills/planning/code-review/SKILL.md
+++ b/skills/planning/code-review/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: code-review
+description: >
+  Multi-specialist review for plans and code changes. Runs structured review passes
+  with area-specific checklists, tracks findings across rounds, and aggregates into an index.
+  Covers plan review (architecture, boundaries, contracts, data-flow, alignment, tradeoffs, testability)
+  and concise MR/PR description drafting. Use when the user asks to review a plan, review code changes,
+  or write a merge request description.
+version: 1.0.0
+author: community
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [code-review, plan-review, merge-request, description, review, architecture]
+    sources:
+      - eqlion/skills-and-agents/skills/plan-review
+      - eqlion/skills-and-agents/skills/mr-description
+---
+
+# Code Review
+
+This skill provides two review capabilities: **plan review** (reviewing a technical spec before implementation) and **MR/PR description drafting** (writing concise change descriptions).
+
+---
+
+## 1. Plan Review
+
+Multi-specialist review of a task's `plan.md`. Orchestrate domain specialists to review architecture, boundaries, contracts, data-flow, requirements alignment, tradeoffs, and testability.
+
+### When to invoke
+
+- The user wants to review a plan before implementation
+- The user wants to stress-test or challenge an architectural plan
+- The user asks for a review of design decisions
+
+### Inputs (required)
+
+- **task_context_path** — absolute path to the task context directory (the folder with `plan.md`, `requirements.md`, etc.).
+
+### Procedure
+
+#### Step 1 — Validate inputs
+
+1. Confirm `task_context_path` exists and is a directory.
+2. Confirm `(task_context_path)/plan.md` exists and is non-empty. If missing, note "no plan to review" and exit.
+3. Note whether `requirements.md` exists and is non-empty.
+
+#### Step 2 — Prepare output paths
+
+Create `(task_context_path)/plan-review/` if it does not exist.
+
+Each specialist writes findings to its own file:
+
+| Specialist | Area tag | Output file |
+|---|---|---|
+| boundaries | `boundaries` | `plan-review/boundaries.md` |
+| contracts | `contracts` | `plan-review/contracts.md` |
+| data-flow | `data-flow` | `plan-review/data-flow.md` |
+| requirements-alignment | `requirements-alignment` | `plan-review/requirements-alignment.md` |
+| tradeoffs | `tradeoffs` | `plan-review/tradeoffs.md` |
+| testability | `testability` | `plan-review/testability.md` |
+
+#### Step 3 — Review each area
+
+For each specialist area, review the plan from that perspective:
+
+- **Boundaries**: Are module/layer boundaries clean? Are responsibilities in the right place? Any coupling that shouldn't exist?
+- **Contracts**: Are API/interface contracts clear? Are inputs/outputs well-defined? Are error cases covered?
+- **Data-flow**: Does data flow correctly through the architecture? Are there bottlenecks, missing transformations, or race conditions?
+- **Requirements-alignment**: Does the plan actually address what the requirements ask for? Are there gaps?
+- **Tradeoffs**: Are the design decisions well-reasoned? Were viable alternatives considered and dismissed with good reasons?
+- **Testability**: Can the proposed architecture be tested? Are there hard-to-test components?
+
+For each finding, record:
+- **id**: stable identifier (e.g., `boundaries-001`)
+- **status**: `open` | `fixed` | `wontfix` | `disputed` | `resolved` | `withdrawn`
+- **severity**: `blocker` | `major` | `minor` | `nit`
+- **location**: section or area of the plan
+- **title**: short description
+- **description**: full explanation
+
+#### Step 4 — Write the aggregated index
+
+Write `(task_context_path)/plan-review/index.md`:
+
+```markdown
+# Plan Review Index
+
+- **task:** <task-id-or-folder-name>
+- **timestamp:** <YYYY-MM-DD HH:MM>
+- **round:** <N>
+
+## Convergence
+
+- **converged:** <true | false> (true iff every finding is `resolved` or `withdrawn`)
+
+## Status totals
+
+| Status | Count |
+|---|---|
+| open | <N> |
+| fixed | <N> |
+| wontfix | <N> |
+| disputed | <N> |
+| resolved | <N> |
+| withdrawn | <N> |
+
+## Active worklist
+
+Sorted by: status priority (disputed > open > wontfix > fixed), then severity (blocker > major > minor > nit).
+
+Each row: `<status> · <id> · <severity> · <area> · <short title> · <location>`
+```
+
+#### Step 5 — Report to the user
+
+Print a short summary (≤ 12 lines):
+- Round number
+- Converged: yes/no
+- Status totals
+- One-line note per area with non-terminal findings
+- Pointer to the index file
+
+### Multi-round review
+
+After a review round:
+1. The implementer reads the index, picks up each item from the Active worklist
+2. For every `open` or `disputed` finding, the implementer edits the relevant per-area file
+   - Set status to `fixed`, `wontfix`, or `disputed`
+   - Add `planner-response` with a summary or justification
+3. Re-run plan-review — reviewers evaluate planner responses and either resolve findings or hold
+4. Repeat until **converged: yes**
+
+---
+
+## 2. MR/PR Description Drafting
+
+Long MR descriptions don't get read. Reviewers skim. Keep the body on one screen and answer three questions: what changed, why, and how to verify.
+
+### When to invoke
+
+- The user asks to create/draft an MR or PR description
+- The user asks to write up changes for review
+- The user says "create a merge request" or "write a PR description"
+
+### Procedure
+
+**Step 1: Gather context**
+
+1. Run `git log <base>..HEAD --oneline` and `git diff <base>...HEAD --stat` to understand the full set of changes.
+2. Identify any ticket reference from branch name or commit subjects.
+3. If the repo has a PR/MR template, read it.
+
+**Step 2: Draft the title**
+
+Format: `[<ticket>] <type>(<scope>): <description>`
+
+Example: `[PROJ-1234] feat(auth): add biometric unlock flow`
+
+**Step 3: Draft the body**
+
+Target ≤ 15 lines for the body (excluding title and ticket link).
+
+Required structure:
+```markdown
+# Links
+- TICKET-XXX
+
+# What's the goal or problem this MR addresses?
+<1-2 sentences. State the outcome, not the steps.>
+
+# How was it implemented?
+- <main change 1, one line>
+- <main change 2, one line>
+- <main change 3, one line>
+- <Optional: 1 line for any non-obvious trade-off>
+
+/assign me
+```
+
+**Step 4: Verify length**
+
+1. Count lines of the body.
+2. If > 20 lines, warn and offer to regenerate with the strict template.
+
+### Rules
+
+#### Hard limits
+- **Body**: ≤ 15 lines (excluding title and link)
+- **No file-by-file changelog** — group by area or intent
+- **No "background" sections longer than 2 sentences** — link to the ticket
+- **No tables of changes** unless >5 distinct logical areas
+
+#### Anti-patterns to avoid
+- Restating every section of the plan/requirements doc
+- Listing every modified file with a description
+- Multiple subsection levels — flatten to one bullet list
+- Embedding rollback strategy unless non-trivial
+- "Stats" sections with token counts
+
+#### When it can be longer
+
+Exceed the 15-line cap only for:
+- Architectural migrations affecting >20 files across modules
+- Breaking API changes with explicit consumer migration steps
+- Security-sensitive changes needing a threat-model rationale
+
+In all other cases: **15 lines or less**.

--- a/skills/planning/technical-planning/SKILL.md
+++ b/skills/planning/technical-planning/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: technical-planning
+description: >
+  Plans technical work by drafting structured implementation plans or refining existing ones.
+  Covers architecture, module breakdowns, design decisions, tradeoffs, and step-by-step execution.
+  Use when the user asks to plan, design, architect, or think through how to implement a feature or task.
+  Combines architectural planning (eqlion/plan), step-by-step implementation planning (jtsang4/writing-plans),
+  and batch execution with checkpoints (jtsang4/executing-plans).
+version: 1.0.0
+author: community
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [planning, architecture, implementation, design-decisions, tradeoffs]
+    sources:
+      - eqlion/skills-and-agents/skills/plan
+      - jtsang4/efficient-coding/skills/writing-plans
+      - jtsang4/efficient-coding/skills/executing-plans
+---
+
+# Technical Planning
+
+This skill covers three interconnected activities: **architectural planning** (what and why), **writing implementation plans** (step-by-step tasks), and **executing plans** (batch execution with checkpoints).
+
+---
+
+## 1. Architectural Planning (Technical Spec)
+
+`plan.md` is the **technical spec** for a task. It answers HOW we're going to achieve the goal — at the architectural level: which modules and layers are involved, where new responsibility lives, what flows through where, what alternatives were considered, and why this shape was chosen.
+
+A good plan is one a senior engineer could read and then go implement the feature themselves without needing to ask which files to open — because the architecture and boundaries are clear enough to make those decisions locally.
+
+### When to draft a plan
+
+- The user wants to draft the initial technical plan for a task whose requirements are roughly settled
+- The user wants to refine an existing plan after an architecture conversation
+- The user wants to talk through design decisions, tradeoffs, or module boundaries
+- The user wants to stress-test a plan
+
+### What a plan is NOT
+
+- **Not a file-by-file edit list.** Do not enumerate the specific files to touch.
+- **Not a code-snippet appendix.** No code blocks. Restate the intent in prose; the implementer will write the code.
+- **Not a phased implementation checklist.** Implementation order is decided during implementation. If sequencing matters *architecturally*, record it as a dependency under **Risks & open questions**, not as a phase.
+
+### Plan template
+
+```markdown
+# <Ticket>: <Title>
+
+## Context
+One paragraph: pointer to requirements.md and a one-sentence framing of the goal.
+
+## Prior art (optional)
+1-3 bullets summarising lessons from POCs, abandoned attempts, ADRs, or related tickets.
+
+## Architecture overview
+The shape of the change, end-to-end. A diagram or sequence description covering:
+- Which modules / layers are involved
+- How data flows between them for the primary scenario
+- Where the new responsibility lives, and where existing responsibilities are reused vs extended
+
+## Module / layer breakdown
+For each affected boundary: what responsibility this layer holds for this feature, what it depends on, what it exposes. Name modules/protocols by existing names; do NOT name new files — call the new responsibility by its role.
+
+## Design decisions
+For each non-obvious decision:
+- **What**: the decision in one sentence.
+- **Why**: the constraints / requirements that drove it.
+- **Alternatives considered**: 1-3 bullets, each with the reason it was rejected. If there were no real alternatives, say so.
+
+## Risks & open questions
+- **Risks**: things that could go wrong at runtime or during rollout, and how the design bounds them.
+- **Open questions**: things the implementer resolves at implementation time.
+
+## Out of scope
+Bulleted list of things this task explicitly does not address, one line each.
+```
+
+### Drafting rules
+
+- **No file paths in the body** except when referencing existing, unchanged anchors.
+- **No code snippets.** Prose only.
+- **Scale to complexity.** A two-file fix needs Context plus a short Architecture paragraph. A new module needs the full template.
+- **Surface ambiguities.** Put unresolved decisions in **Risks & open questions** rather than papering over them.
+
+---
+
+## 2. Writing Implementation Plans
+
+Write comprehensive implementation plans before touching code. Document everything an implementer needs: which files to touch, exact code, testing instructions, how to verify.
+
+**Announce at start:** "I'm using the technical-planning skill to create the implementation plan."
+
+### Task granularity
+
+Each step is one action (2-5 minutes):
+- "Write the failing test" — step
+- "Run it to make sure it fails" — step
+- "Implement the minimal code" — step
+- "Run the tests" — step
+- "Commit" — step
+
+### Plan document header
+
+```markdown
+# [Feature Name] Implementation Plan
+
+**Goal:** [One sentence describing what this builds]
+**Architecture:** [2-3 sentences about approach]
+**Tech Stack:** [Key technologies/libraries]
+
+---
+```
+
+### Task structure
+
+```markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/file.py`
+- Modify: `exact/path/to/existing.py:123-145`
+- Test: `tests/exact/path/to/test.py`
+
+**Step 1: Write the failing test**
+
+[test code]
+
+**Step 2: Run test to verify it fails**
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+[exact code]
+
+**Step 4: Run test to verify it passes**
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+git add tests/ src/
+git commit -m "feat: add specific feature"
+```
+
+### Key principles
+- Exact file paths always
+- Complete code in plan (not "add validation")
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+
+---
+
+## 3. Executing Plans
+
+Load a written plan, review critically, execute tasks in batches, report for review between batches.
+
+**Announce at start:** "I'm using the technical-planning skill to execute the plan."
+
+### Process
+
+**Step 1: Load and Review Plan**
+1. Read plan file
+2. Review critically — identify any questions or concerns
+3. If concerns: raise them before starting
+4. If no concerns: create task list and proceed
+
+**Step 2: Execute Batch (default: first 3 tasks)**
+For each task:
+1. Mark as in_progress
+2. Follow each step exactly
+3. Run verifications as specified
+4. Mark as completed
+
+**Step 3: Report**
+- Show what was implemented
+- Show verification output
+- Say: "Ready for feedback."
+
+**Step 4: Continue**
+- Apply changes based on feedback
+- Execute next batch
+- Repeat until complete
+
+**Step 5: Complete Development**
+- Verify all tests pass
+- Present options for finalizing (PR, merge, etc.)
+
+### When to Stop and Ask for Help
+- Hit a blocker mid-batch (missing dependency, test fails, instruction unclear)
+- Plan has critical gaps preventing starting
+- Verification fails repeatedly
+- **Ask for clarification rather than guessing.**
+
+---
+
+## Integration notes
+
+- Start with **requirements** before planning (WHAT before HOW).
+- Use the architectural plan to write the implementation plan.
+- Execute the implementation plan in batches with review checkpoints.
+- For code review of the implemented plan, use the `code-review` skill.

--- a/skills/productivity/documentation/SKILL.md
+++ b/skills/productivity/documentation/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: documentation
+description: >
+  Drafts or refines product specifications (requirements docs) — WHAT we're building or changing
+  and WHY it matters, framed from the user's perspective. Also provides structured templates
+  for writing clear, actionable documentation. Use when the user asks to draft requirements,
+  write a product spec, capture acceptance criteria, or create documentation for a feature.
+  Do not use for technical/architectural planning (see the technical-planning skill).
+version: 1.0.0
+author: community
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [documentation, requirements, product-spec, acceptance-criteria, specification]
+    sources:
+      - eqlion/skills-and-agents/skills/requirements
+---
+
+# Documentation (Product Spec)
+
+`requirements.md` is the **product spec** for a task. It answers WHAT we're building or changing and WHY it matters — framed from the user's perspective, not the codebase's. The HOW (architecture, layering, tradeoffs) belongs in `plan.md`; use the `technical-planning` skill for that.
+
+This skill is content-only. It produces documentation; it does not move task folders between stages or manage branches.
+
+## When to invoke
+
+The user wants to:
+- Draft the initial product spec for a new task
+- Refine an existing `requirements.md` after a product conversation
+- Capture acceptance criteria, links, or out-of-scope items for the product side of a task
+- Write documentation for a feature, API, or system
+
+## Where the file lives
+
+Find the most relevant task folder. If working in a project with a standard layout:
+- If there is exactly one active task folder, use it
+- Otherwise, look in draft/staging folders
+- If multiple candidates exist or no folder is obvious, ask the user which task this is for. Do not guess.
+
+Write or edit `requirements.md` (or the appropriate documentation file). If the file does not exist, create it from the scaffold below. If it does exist, edit it in place — preserve any content the user has already written, and ask before deleting sections.
+
+## Scaffold
+
+```markdown
+# <task-id> — <title>
+
+<!--
+PRODUCT spec. WHAT we're building or changing and WHY it matters. The HOW
+(architecture, layering, tradeoffs) lives in plan.md. Do not put
+implementation details here.
+-->
+
+## Goal
+<!-- One or two sentences: what user-observable outcome are we trying to
+     achieve? Frame it from the user's perspective, not the codebase's. -->
+
+## Problem / motivation
+<!-- What's the current state, and what's wrong or missing about it? Who is
+     affected? What business or product driver makes this worth doing now? -->
+
+## Acceptance criteria
+<!-- Bulleted list of user-observable conditions that must hold for the task
+     to be considered done. Each bullet should be checkable without reading
+     the code. -->
+
+## Out of scope (product)
+<!-- Things adjacent stakeholders might assume we're doing but we're
+     explicitly not. One line each. -->
+
+## Links
+<!-- Jira ticket, Figma frames, BE/API specs, related tickets, Confluence
+     docs. -->
+
+## Notes
+<!-- Any product/UX constraints, open product questions, edge cases the
+     spec hasn't fully resolved yet. -->
+```
+
+## Drafting rules
+
+- **User-observable, not implementation-observable.** Acceptance criteria should be things a PM or QA could verify without reading the codebase. "Tapping the deeplink opens the challenge screen and shows a confirmation toast" is good; "the parser registers a new `DeepLinkDestination`" is not.
+- **Why, not how.** If you're describing modules, layers, services, types, or files, you're in plan territory. Move it.
+- **Link, don't copy.** When the source of truth is Jira/Figma/Confluence, link to it. Quote only the parts that are load-bearing for the task.
+- **Surface unknowns, don't hide them.** If the spec has gaps (e.g. error-state copy missing, edge case ambiguous), record them under **Notes** as open questions rather than inventing answers.
+- **Scale to complexity.** A two-line bugfix needs Goal + Acceptance criteria + Links. A new feature needs the full scaffold.
+
+## API documentation template
+
+When documenting APIs specifically:
+
+```markdown
+# <API Name> Documentation
+
+## Overview
+<!-- One paragraph: what this API does and who it's for -->
+
+## Authentication
+<!-- How to authenticate, required headers/tokens -->
+
+## Endpoints
+
+### <Method> <Path>
+
+**Description:** <what it does>
+
+**Request:**
+- Parameters, body, headers
+
+**Response:**
+- Status codes, response body schema
+
+**Example:**
+```
+<request/response example>
+```
+
+## Error handling
+<!-- Error codes, error response format -->
+
+## Rate limits
+<!-- If applicable -->
+```
+
+## General documentation guidelines
+
+1. **Start with the user's perspective** — what problem does this solve for them?
+2. **Be specific and checkable** — acceptance criteria and claims that can be verified
+3. **Distinguish WHAT from HOW** — the product spec describes outcomes; the plan describes implementation
+4. **Surface ambiguities explicitly** — open questions are better than assumed answers
+5. **Link to sources** — don't duplicate information that lives elsewhere
+6. **Keep it concise** — the spec should be scannable, not exhaustive
+
+## Hand-off
+
+When the product spec is solid enough that someone can start thinking about HOW, point the user at the `technical-planning` skill. It is fine — and common — to iterate on requirements after a planning conversation surfaces ambiguities.


### PR DESCRIPTION
## Summary

Adds three new Hermes skills sourced from the eqlion/skills-and-agents and jtsang4/efficient-coding repos:

### 1. `skills/planning/technical-planning/SKILL.md` (category: planning)
**Sources:**
- eqlion/skills-and-agents `skills/plan` — architectural planning (technical spec, design decisions, module breakdown)
- jtsang4/efficient-coding `skills/writing-plans` — step-by-step implementation plan writing (bite-sized tasks, TDD, exact paths/commands)
- jtsang4/efficient-coding `skills/executing-plans` — batch execution with review checkpoints

Combines three complementary planning activities into one skill: architectural spec drafting, implementation plan writing, and plan execution.

### 2. `skills/planning/code-review/SKILL.md` (category: planning)
**Sources:**
- eqlion/skills-and-agents `skills/plan-review` — multi-specialist plan review (boundaries, contracts, data-flow, requirements-alignment, tradeoffs, testability) with round-based finding tracking
- eqlion/skills-and-agents `skills/mr-description` — concise MR/PR description drafting with strict length limits

Provides structured review for plans and change descriptions.

### 3. `skills/productivity/documentation/SKILL.md` (category: productivity)
**Sources:**
- eqlion/skills-and-agents `skills/requirements` — product spec/requirements drafting (WHAT and WHY, acceptance criteria, out-of-scope, links)

Covers product-level documentation with scaffold templates and drafting rules.

### Notes
- All skills use standard Hermes SKILL.md format (YAML frontmatter + markdown body)
- Categories match the task requirement: `planning` and `productivity`
- The existing `skills/software-development/plan/SKILL.md` and `skills/software-development/requesting-code-review/SKILL.md` are not modified — these new skills are complementary additions with different scope