### PR TITLE
fix(cli): run one-shot query cleanup before lease release

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -952,7 +952,7 @@ def _prepare_deferred_agent_startup() -> None:
             exc_info=True,
         )
 
-def _run_cleanup():
+def _run_cleanup(*, notify_session_finalize: bool = True):
     """Run resource cleanup exactly once."""
     global _cleanup_done
     if _cleanup_done:
@@ -988,16 +988,12 @@ def _run_cleanup():
         pass
     # Shut down memory provider (on_session_end + shutdown_all) at actual
     # session boundary — NOT per-turn inside run_conversation().
-    try:
-        from hermes_cli.plugins import invoke_hook as _invoke_hook
-        _invoke_hook(
-            "on_session_finalize",
+    if notify_session_finalize:
+        _notify_session_finalize(
             session_id=_active_agent_ref.session_id if _active_agent_ref else None,
             platform="cli",
             reason="shutdown",
         )
-    except Exception:
-        pass
     try:
         if _active_agent_ref and hasattr(_active_agent_ref, 'shutdown_memory_provider'):
             # Forward the agent's own transcript so memory providers'
@@ -1011,6 +1007,24 @@ def _run_cleanup():
                 _active_agent_ref.shutdown_memory_provider(_session_msgs)
             else:
                 _active_agent_ref.shutdown_memory_provider()
+    except Exception:
+        pass
+
+
+def _notify_session_finalize(
+    *,
+    session_id: str | None,
+    platform: str = "cli",
+    reason: str = "shutdown",
+) -> None:
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _invoke_hook(
+            "on_session_finalize",
+            session_id=session_id,
+            platform=platform,
+            reason=reason,
+        )
     except Exception:
         pass
 
@@ -1049,6 +1063,25 @@ def _emit_interrupted_session_end(cli, *, reason: str = "keyboard_interrupt") ->
         )
     except Exception:
         pass
+
+
+def _notify_single_query_session_finalize(cli, *, reason: str = "shutdown") -> None:
+    agent = getattr(cli, "agent", None)
+    session_id = getattr(agent, "session_id", None) or getattr(cli, "session_id", None)
+    _notify_session_finalize(
+        session_id=session_id,
+        platform=getattr(agent, "platform", None) or "cli",
+        reason=reason,
+    )
+
+
+def _finalize_single_query(cli) -> None:
+    """Close one-shot CLI resources before releasing the active session lease."""
+    try:
+        _notify_single_query_session_finalize(cli)
+        _run_cleanup(notify_session_finalize=False)
+    finally:
+        cli._release_active_session()
 
 
 def _reset_terminal_input_modes_on_exit() -> None:
@@ -13582,7 +13615,7 @@ def main(
                 cli.chat(query, images=single_query_images or None)
                 cli._print_exit_summary()
         finally:
-            cli._release_active_session()
+            _finalize_single_query(cli)
         return
     
     # Run interactive mode

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -144,3 +144,73 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
         "summary",
         ("finalize", "single-query-session"),
     ]
+
+
+def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatch):
+    calls = []
+
+    import cli as cli_mod
+
+    def run_conversation(*, user_message, conversation_history):
+        calls.append(("run", user_message, conversation_history))
+        return {
+            "final_response": "",
+            "error": "provider failed",
+            "failed": True,
+        }
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.provider = "test-provider"
+            self.model = "test-model"
+            self.session_id = "quiet-session"
+            self.conversation_history = []
+            self._active_agent_route_signature = "same-route"
+            self.agent = SimpleNamespace(
+                session_id="quiet-session",
+                platform="cli",
+                quiet_mode=False,
+                suppress_status_output=False,
+                stream_delta_callback=object(),
+                tool_gen_callback=object(),
+                run_conversation=run_conversation,
+            )
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            calls.append(("claim", surface, stderr))
+            return True
+
+        def _ensure_runtime_credentials(self):
+            calls.append("credentials")
+            return True
+
+        def _resolve_turn_agent_config(self, effective_query):
+            calls.append(("resolve", effective_query))
+            return {
+                "signature": "same-route",
+                "model": None,
+                "runtime": None,
+                "request_overrides": None,
+            }
+
+        def _init_agent(self, **kwargs):
+            calls.append(("init", kwargs))
+            return True
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(query="hello", quiet=True, toolsets="terminal")
+
+    assert exc_info.value.code == 1
+    assert ("claim", "cli", True) in calls
+    assert ("run", "hello", []) in calls
+    assert calls[-1] == ("finalize", "quiet-session")

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -1,0 +1,146 @@
+from types import SimpleNamespace
+
+import pytest
+
+import cli
+
+
+def test_finalize_single_query_runs_cleanup_without_reemitting_finalize_before_release(monkeypatch):
+    calls = []
+    fake_cli = SimpleNamespace(_release_active_session=lambda: calls.append(("release", {})))
+
+    def cleanup(**kwargs):
+        calls.append(("cleanup", kwargs))
+
+    monkeypatch.setattr(
+        cli,
+        "_notify_single_query_session_finalize",
+        lambda _cli: calls.append(("finalize", {})),
+    )
+    monkeypatch.setattr(cli, "_run_cleanup", cleanup)
+
+    cli._finalize_single_query(fake_cli)
+
+    assert calls == [
+        ("finalize", {}),
+        ("cleanup", {"notify_session_finalize": False}),
+        ("release", {}),
+    ]
+
+
+def test_finalize_single_query_releases_session_when_cleanup_fails(monkeypatch):
+    calls = []
+    fake_cli = SimpleNamespace(_release_active_session=lambda: calls.append("release"))
+
+    def cleanup(**kwargs):
+        calls.append("cleanup")
+        raise RuntimeError("cleanup failed")
+
+    monkeypatch.setattr(
+        cli,
+        "_notify_single_query_session_finalize",
+        lambda _cli: calls.append("finalize"),
+    )
+    monkeypatch.setattr(cli, "_run_cleanup", cleanup)
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        cli._finalize_single_query(fake_cli)
+
+    assert calls == ["finalize", "cleanup", "release"]
+
+
+def test_finalize_single_query_runs_cleanup_when_finalize_hook_fails(monkeypatch):
+    calls = []
+    fake_agent = SimpleNamespace(session_id="agent-session", platform="cli")
+    fake_cli = SimpleNamespace(
+        agent=fake_agent,
+        session_id="cli-session",
+        _release_active_session=lambda: calls.append("release"),
+    )
+
+    def invoke_hook(name, **kwargs):
+        calls.append("finalize")
+        raise RuntimeError("hook failed")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoke_hook)
+    monkeypatch.setattr(cli, "_run_cleanup", lambda **kwargs: calls.append("cleanup"))
+
+    cli._finalize_single_query(fake_cli)
+
+    assert calls == ["finalize", "cleanup", "release"]
+
+
+def test_notify_single_query_session_finalize_uses_agent_session(monkeypatch):
+    calls = []
+    fake_agent = SimpleNamespace(session_id="agent-session", platform="cli")
+    fake_cli = SimpleNamespace(agent=fake_agent, session_id="cli-session")
+
+    def invoke_hook(name, **kwargs):
+        calls.append((name, kwargs))
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoke_hook)
+
+    cli._notify_single_query_session_finalize(fake_cli)
+
+    assert calls == [
+        (
+            "on_session_finalize",
+            {
+                "session_id": "agent-session",
+                "platform": "cli",
+                "reason": "shutdown",
+            },
+        )
+    ]
+
+
+def test_human_single_query_main_finalizes_after_query(monkeypatch):
+    calls = []
+
+    import cli as cli_mod
+
+    class _Console:
+        def print(self, *_args, **_kwargs):
+            calls.append("query-label")
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = _Console()
+            self.session_id = "single-query-session"
+            self.agent = SimpleNamespace(
+                session_id="single-query-session",
+                platform="cli",
+            )
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            calls.append(("claim", surface, stderr))
+            return True
+
+        def _show_security_advisories(self):
+            calls.append("advisories")
+
+        def chat(self, query, images=None):
+            calls.append(("chat", query, images))
+            return "done"
+
+        def _print_exit_summary(self):
+            calls.append("summary")
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
+    )
+
+    cli_mod.main(query="hello", quiet=False, toolsets="terminal")
+
+    assert calls == [
+        ("claim", "cli", False),
+        "query-label",
+        "advisories",
+        ("chat", "hello", None),
+        "summary",
+        ("finalize", "single-query-session"),
+    ]


### PR DESCRIPTION
## What does this PR do?

Ensures non-interactive one-shot CLI runs finalize plugin session state before releasing the active-session lease.

The one-shot `hermes chat -q ...` path previously released the active-session lease directly in its `finally` block. That could leave plugin/session-finalize cleanup to the later process cleanup path, after the one-shot session boundary had already moved on.

This change keeps the fix local to one-shot CLI shutdown:

- Emit `on_session_finalize` using the active agent session id before cleanup.
- Run process cleanup without re-emitting the same session-finalize hook.
- Always release the active-session lease in a `finally` block.

No new memory-provider logic is added; this reuses the existing process cleanup
path at the one-shot boundary.

## Related Issue

No linked public issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `cli.py`
  - Added a small session-finalize helper for one-shot query shutdown.
  - Updated `_run_cleanup()` so callers that already emitted `on_session_finalize` can skip re-emitting it.
  - Updated the one-shot query `finally` path to finalize plugin session state, run cleanup, and then release the active-session lease.

- `tests/cli/test_single_query_session_finalize.py`
  - Covers cleanup ordering before lease release.
  - Covers release-on-cleanup-failure.
  - Covers cleanup still running when the finalize hook fails.
  - Covers using the active agent session id.
  - Covers the `main()` one-shot call site.
  - Covers the quiet `main()` one-shot path preserving its `SystemExit` code
    while still finalizing.

## How to Test

1. Focused Hermes wrapper validation:

```bash
scripts/run_tests.sh tests/cli/test_single_query_session_finalize.py tests/cli/test_session_boundary_hooks.py tests/cli/test_tui_terminal_reset_on_exit.py tests/cli/test_cli_shutdown_memory_messages.py tests/plugins/test_nemo_relay_plugin.py -- -q
```

Result:

```text
62 tests passed, 0 failed
```

2. Lint touched files:

```bash
uv run ruff check cli.py tests/cli/test_single_query_session_finalize.py
```

Result:

```text
All checks passed
```

3. Whitespace check:

```bash
git diff --check
```

Result: passed.

Full `scripts/run_tests.sh` was also attempted locally, but did not complete within the local timeout and surfaced unrelated baseline failures outside this diff. I am not claiming full-suite green for this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide - N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## For New Skills

N/A. This PR does not add a skill.

## Screenshots / Logs

Not applicable. This is a CLI lifecycle cleanup fix covered by regression tests.
