### PR TITLE
feat(config): add code_execution.auto_approve to skip execute_code approval prompt

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2078,6 +2078,13 @@ DEFAULT_CONFIG = {
         # Env scrubbing (strips *_API_KEY, *_TOKEN, *_SECRET, ...) and the
         # tool whitelist apply identically in both modes.
         "mode": "project",
+        # Skip the execute_code approval prompt in gateway/ask sessions.
+        # When true, scripts run without an interactive approval step —
+        # equivalent to per-session YOLO for execute_code only.  Terminal
+        # commands *inside* the script still go through their own guards.
+        # Useful for trusted autonomous deployments (e.g. always-on gateway
+        # bots) where no human is present to click "Approve".
+        "auto_approve": False,
     },
 
     # Tool Search (progressive disclosure for large tool surfaces).

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -190,6 +190,7 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("display", "show_reasoning"),
         ("privacy", "redact_pii"),
         ("tts", "provider"),
+        ("code_execution", "auto_approve"),
     ]
 
     for section, key in interesting_paths:

--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -394,3 +394,42 @@ def test_env_scrub_no_log_when_nothing_dropped(caplog):
             is_windows=False,
         )
     assert "dropped" not in "\n".join(r.getMessage() for r in caplog.records)
+
+
+
+# ---------------------------------------------------------------------------
+# 6. code_execution.auto_approve config bypass (#42921)
+# ---------------------------------------------------------------------------
+
+def test_auto_approve_config_bypasses_guard(gw_session, monkeypatch):
+    """When code_execution.auto_approve is True, skip the approval prompt."""
+    _register_resolver(gw_session, "deny")  # would deny if prompt fires
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_execution": {"auto_approve": True}},
+    )
+    result = A.check_execute_code_guard("import os", "local")
+    assert result["approved"] is True
+
+
+def test_auto_approve_false_does_not_bypass(gw_session, monkeypatch):
+    """When code_execution.auto_approve is False (default), the guard proceeds normally."""
+    _register_resolver(gw_session, "deny")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_execution": {"auto_approve": False}},
+    )
+    # In gateway context with a denier, the guard should block.
+    result = A.check_execute_code_guard("import os", "local")
+    assert result["approved"] is False
+
+
+def test_auto_approve_missing_config_does_not_bypass(gw_session, monkeypatch):
+    """When code_execution section is absent, the guard proceeds normally."""
+    _register_resolver(gw_session, "deny")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {},
+    )
+    result = A.check_execute_code_guard("import os", "local")
+    assert result["approved"] is False

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1599,6 +1599,16 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
         return {"approved": True, "message": None}
 
+    # code_execution.auto_approve: per-tool opt-out of the approval prompt.
+    # Terminal commands *inside* the script still go through their own guards.
+    try:
+        from hermes_cli.config import load_config
+        _ce_cfg = load_config().get("code_execution", {})
+        if isinstance(_ce_cfg, dict) and _ce_cfg.get("auto_approve"):
+            return {"approved": True, "message": None}
+    except Exception:
+        pass
+
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 


### PR DESCRIPTION
## Problem

The `execute_code` tool triggers an approval prompt in gateway/ask sessions, even when the user has configured other auto-approve settings like `subagent_auto_approve: true`. There is no config option to disable this specific approval prompt without enabling full YOLO mode (`--yolo` or `approvals.mode=off`), which bypasses ALL approval checks.

This blocks trusted autonomous deployments (always-on gateway bots) where no human is present to click "Approve" on each `execute_code` call.

## Solution

Add `code_execution.auto_approve` config option (default: `false`) that skips the `execute_code` approval prompt when set to `true`.

```yaml
code_execution:
  mode: project
  auto_approve: true  # skip execute_code approval prompt
```

**Key properties:**
- Only bypasses the `execute_code` whole-script approval — terminal commands *inside* the script still go through their own per-command guards
- Does not affect `--yolo`, `approvals.mode`, or other approval mechanisms
- Graceful fallback: if config is missing or unreadable, approval proceeds normally

## Changes

- `hermes_cli/config.py` — Add `auto_approve: false` to `code_execution` config section
- `tools/approval.py` — Check `code_execution.auto_approve` in `check_execute_code_guard()` after the yolo/approval-mode checks
- `hermes_cli/dump.py` — Add to `interesting_paths` for `hermes config display`
- `tests/tools/test_execute_code_approval_cluster.py` — 3 tests: bypass when true, no-bypass when false, no-bypass when missing

Closes #42921
