### PR TITLE
fix(cron): fall back to local delivery when deliver=origin is unresolvable

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -734,11 +734,21 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     """
     targets = _resolve_delivery_targets(job)
     if not targets:
-        if job.get("deliver", "local") != "local":
-            msg = f"no delivery target resolved for deliver={job.get('deliver', 'local')}"
-            logger.warning("Job '%s': %s", job["id"], msg)
-            return msg
-        return None  # local-only jobs don't deliver — not a failure
+        deliver = job.get("deliver", "local")
+        if deliver == "local":
+            return None  # local-only jobs don't deliver — not a failure
+        if deliver == "origin":
+            # Origin unresolvable (CLI session, no gateway home channels set).
+            # Treat as local — output is still saved in last_output.
+            logger.debug(
+                "Job '%s': deliver=origin but no origin/home channel found; "
+                "falling back to local (output saved in last_output)",
+                job.get("id", "?"),
+            )
+            return None
+        msg = f"no delivery target resolved for deliver={deliver}"
+        logger.warning("Job '%s': %s", job["id"], msg)
+        return msg
 
     from tools.send_message_tool import _send_to_platform
     from gateway.config import load_gateway_config, Platform

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2736,3 +2736,31 @@ class TestCronDeliveryTargets:
         monkeypatch.setattr(gateway_config, "load_gateway_config", _boom)
 
         assert cron_delivery_targets() == []
+
+
+class TestDeliverOriginFallbackToLocal:
+    """deliver=origin falls back to local when origin is unresolvable."""
+
+    def test_origin_with_no_origin_and_no_home_channels_returns_none(self, monkeypatch):
+        """When deliver=origin but no origin and no home channels, return None (local fallback)."""
+        # Clear all home channel env vars
+        for var in [
+            "TELEGRAM_HOME_CHANNEL", "DISCORD_HOME_CHANNEL", "SLACK_HOME_CHANNEL",
+            "SIGNAL_HOME_CHANNEL", "MATRIX_HOME_ROOM", "EMAIL_HOME_ADDRESS",
+            "WEIXIN_HOME_CHANNEL", "WECOM_HOME_CHANNEL", "FEISHU_HOME_CHANNEL",
+            "QQBOT_HOME_CHANNEL", "DINGTALK_HOME_CHANNEL", "BLUEBUBBLES_HOME_CHANNEL",
+            "WHATSAPP_HOME_CHANNEL", "MATTERMOST_HOME_CHANNEL", "SMS_HOME_CHANNEL",
+        ]:
+            monkeypatch.delenv(var, raising=False)
+
+        job = {"id": "cli-job", "deliver": "origin", "origin": None}
+        result = _deliver_result(job, "Cron output here.")
+        assert result is None  # local fallback, not an error
+
+    def test_explicit_platform_still_returns_error(self, monkeypatch):
+        """deliver=telegram with no home channel should still error (not affected by origin fallback)."""
+        monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+        job = {"id": "no-tg", "deliver": "telegram"}
+        result = _deliver_result(job, "Output.")
+        assert result is not None
+        assert "no delivery target" in result


### PR DESCRIPTION
## What does this PR do?

Fixes `deliver=origin` cron jobs silently failing with "no delivery target resolved" when created from CLI sessions where no gateway home channels are configured. The fix treats unresolvable `deliver=origin` as local delivery instead of an error.

## Related Issue

Fixes #43014

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: In `_deliver_result()`, when `deliver=origin` and no delivery targets can be resolved (no origin stored, no gateway home channels configured), return `None` (local fallback) instead of returning an error string. The job output is still saved in `last_output`. Only explicit platform delivery (e.g. `deliver=telegram`) still errors when unresolvable.
- `tests/cron/test_scheduler.py`: Added `TestDeliverOriginFallbackToLocal` with 2 tests: (1) `deliver=origin` with no origin and no home channels returns `None`, (2) explicit platform delivery still returns error when unresolvable.

## How to Test

1. Start a CLI session: `hermes`
2. Create a cron job with `deliver=origin`:
   ```python
   cronjob(action='create', schedule='every 1m', deliver='origin', prompt='echo hello', script='echo test', no_agent=True)
   ```
3. Wait for the cron to fire
4. Check job status: `cronjob(action='list')` — `last_delivery_error` should be `null` (not "no delivery target resolved")
5. Run `pytest tests/cron/test_scheduler.py::TestDeliverOriginFallbackToLocal -xvs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/test_scheduler.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cron/scheduler.py::_deliver_result` (callers: `run_job` via scheduler tick, 2 call sites)
- Blast radius: LOW — only affects the error-handling path when delivery target resolution returns empty for `deliver=origin`
- Related patterns: `_resolve_single_delivery_target` fallback chain, `_origin_from_env` CLI gap
