### PR TITLE
feat(security): add first-invoke approval for MCP server tools

### DIFF
--- a/tests/tools/test_mcp_tool_approval.py
+++ b/tests/tools/test_mcp_tool_approval.py
@@ -1,0 +1,350 @@
+"""Tests for the MCP first-invoke approval guard (#16462).
+
+Covers:
+
+  1. tools.approval.check_mcp_tool_guard — the decision matrix (config
+     toggle, yolo/off bypass, headless/cron auto-approve, session and
+     wildcard approval short-circuits, gateway approve/deny/timeout/
+     missing-notify, CLI callback prompting, persistence scopes).
+  2. tools.mcp_tool._make_tool_handler — a denied guard blocks the tool
+     call BEFORE anything is dispatched to the MCP server, and the denial
+     does not bump the server circuit breaker.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools import approval as A
+
+
+SERVER = "test-mcp-server"
+TOOL = "run_query"
+KEY = f"mcp:{SERVER}:{TOOL}"
+
+
+def _clean_state(session_key: str):
+    with A._lock:
+        A._session_approved.pop(session_key, None)
+        A._session_yolo.discard(session_key)
+        A._permanent_approved.discard(KEY)
+        A._permanent_approved.discard(f"mcp:{SERVER}:*")
+        A._pending.pop(session_key, None)
+        A._gateway_queues.pop(session_key, None)
+        A._gateway_notify_cbs.pop(session_key, None)
+
+
+@pytest.fixture
+def gw_session(monkeypatch):
+    """A clean gateway session: HERMES_GATEWAY_SESSION set, a bound session
+    key, and isolated gateway queues/callbacks. Yields the session_key."""
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(A, "_get_approval_config", lambda: {})
+    monkeypatch.setattr(A, "save_permanent_allowlist", lambda _p: None)
+
+    session_key = "mcp-guard-test-session"
+    token = A.set_current_session_key(session_key)
+    _clean_state(session_key)
+    try:
+        yield session_key
+    finally:
+        A.reset_current_session_key(token)
+        _clean_state(session_key)
+
+
+@pytest.fixture
+def cli_session(monkeypatch):
+    """A clean interactive-CLI session context. Yields the session_key."""
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(A, "_get_approval_config", lambda: {})
+    monkeypatch.setattr(A, "save_permanent_allowlist", lambda _p: None)
+
+    session_key = "mcp-guard-cli-session"
+    token = A.set_current_session_key(session_key)
+    _clean_state(session_key)
+    try:
+        yield session_key
+    finally:
+        A.reset_current_session_key(token)
+        _clean_state(session_key)
+
+
+def _register_resolver(session_key: str, result):
+    """Register a gateway notify callback that immediately resolves the most
+    recent queued approval entry with *result* (simulating a user response)."""
+    def cb(_approval_data):
+        with A._lock:
+            entries = A._gateway_queues.get(session_key, [])
+            if entries:
+                entry = entries[-1]
+                entry.result = result
+                entry.event.set()
+    with A._lock:
+        A._gateway_notify_cbs[session_key] = cb
+
+
+# ---------------------------------------------------------------------------
+# 1. Decision matrix
+# ---------------------------------------------------------------------------
+
+def test_guard_disabled_via_config(gw_session, monkeypatch):
+    monkeypatch.setattr(A, "_get_approval_config",
+                        lambda: {"mcp_first_invoke": False})
+    # Even with a denier registered, the toggle short-circuits.
+    _register_resolver(gw_session, "deny")
+    res = A.check_mcp_tool_guard(SERVER, TOOL, {"q": "x"})
+    assert res["approved"] is True
+
+
+def test_guard_disabled_via_config_string_value(gw_session, monkeypatch):
+    monkeypatch.setattr(A, "_get_approval_config",
+                        lambda: {"mcp_first_invoke": "false"})
+    _register_resolver(gw_session, "deny")
+    assert A.check_mcp_tool_guard(SERVER, TOOL, {})["approved"] is True
+
+
+def test_guard_mode_off_bypasses(gw_session, monkeypatch):
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "off")
+    _register_resolver(gw_session, "deny")
+    assert A.check_mcp_tool_guard(SERVER, TOOL, {})["approved"] is True
+
+
+def test_guard_session_yolo_bypasses(gw_session):
+    A.enable_session_yolo(gw_session)
+    try:
+        _register_resolver(gw_session, "deny")
+        assert A.check_mcp_tool_guard(SERVER, TOOL, {})["approved"] is True
+    finally:
+        A.disable_session_yolo(gw_session)
+
+
+def test_guard_headless_auto_approves(monkeypatch):
+    # No approval surface → preserve auto-run, matching the terminal guard's
+    # non-interactive contract.
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(A, "_get_approval_config", lambda: {})
+    assert A.check_mcp_tool_guard(SERVER, TOOL, {})["approved"] is True
+
+
+def test_guard_cron_auto_approves(monkeypatch):
+    # Cron has no user present; first-invoke visibility has no value there.
+    # MCP exposure for unattended profiles is governed by tools.include/exclude.
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(A, "_get_approval_config", lambda: {})
+    assert A.check_mcp_tool_guard(SERVER, TOOL, {})["approved"] is True
+
+
+def test_guard_gateway_user_approves_once_is_one_shot(gw_session):
+    _register_resolver(gw_session, "once")
+    res = A.check_mcp_tool_guard(SERVER, TOOL, {"q": "1"})
+    assert res["approved"] is True
+    assert res.get("user_approved") is True
+    # One-shot: approval must NOT persist to future calls.
+    assert A.is_approved(gw_session, KEY) is False
+
+
+def test_guard_gateway_user_approves_session_persists(gw_session):
+    _register_resolver(gw_session, "session")
+    res = A.check_mcp_tool_guard(SERVER, TOOL, {"q": "1"})
+    assert res["approved"] is True
+    assert A.is_approved(gw_session, KEY) is True
+    # Subsequent calls auto-approve without prompting (denier would fire).
+    _register_resolver(gw_session, "deny")
+    res2 = A.check_mcp_tool_guard(SERVER, TOOL, {"q": "2"})
+    assert res2["approved"] is True
+
+
+def test_guard_gateway_user_approves_always_persists(gw_session):
+    _register_resolver(gw_session, "always")
+    res = A.check_mcp_tool_guard(SERVER, TOOL, {"q": "1"})
+    assert res["approved"] is True
+    with A._lock:
+        assert KEY in A._permanent_approved
+
+
+def test_guard_session_approval_is_per_tool(gw_session):
+    # Approving one tool must not approve a different tool on the same server.
+    A.approve_session(gw_session, KEY)
+    _register_resolver(gw_session, "deny")
+    res = A.check_mcp_tool_guard(SERVER, "send_email", {})
+    assert res["approved"] is False
+
+
+def test_guard_server_wildcard_approves_all_tools(gw_session):
+    A.approve_session(gw_session, f"mcp:{SERVER}:*")
+    _register_resolver(gw_session, "deny")
+    assert A.check_mcp_tool_guard(SERVER, TOOL, {})["approved"] is True
+    assert A.check_mcp_tool_guard(SERVER, "send_email", {})["approved"] is True
+
+
+def test_guard_clear_session_resets_approval(gw_session):
+    _register_resolver(gw_session, "session")
+    assert A.check_mcp_tool_guard(SERVER, TOOL, {})["approved"] is True
+    assert A.is_approved(gw_session, KEY) is True
+    A.clear_session(gw_session)
+    assert A.is_approved(gw_session, KEY) is False
+
+
+def test_guard_gateway_user_denies_blocks(gw_session):
+    _register_resolver(gw_session, "deny")
+    res = A.check_mcp_tool_guard(SERVER, TOOL, {"q": "1"})
+    assert res["approved"] is False
+    assert res["outcome"] == "denied"
+    assert res["user_consent"] is False
+    assert "Do NOT retry" in res["message"]
+
+
+def test_guard_gateway_timeout_blocks(gw_session, monkeypatch):
+    # Callback that never resolves; force an immediate timeout.
+    with A._lock:
+        A._gateway_notify_cbs[gw_session] = lambda _d: None
+    monkeypatch.setattr(A, "_get_approval_config",
+                        lambda: {"gateway_timeout": 0})
+    res = A.check_mcp_tool_guard(SERVER, TOOL, {})
+    assert res["approved"] is False
+    assert res["outcome"] == "timeout"
+    assert "Silence is not consent" in res["message"]
+
+
+def test_guard_gateway_missing_notify_is_pending(gw_session):
+    res = A.check_mcp_tool_guard(SERVER, TOOL, {})
+    assert res["approved"] is False
+    assert res["status"] == "pending_approval"
+    assert res["pattern_key"] == KEY
+
+
+def test_guard_prompt_includes_server_tool_and_args(gw_session):
+    seen = {}
+
+    def cb(approval_data):
+        seen.update(approval_data)
+        with A._lock:
+            entries = A._gateway_queues.get(gw_session, [])
+            if entries:
+                entries[-1].result = "once"
+                entries[-1].event.set()
+
+    with A._lock:
+        A._gateway_notify_cbs[gw_session] = cb
+
+    A.check_mcp_tool_guard(SERVER, TOOL, {"query": "DROP TABLE users"})
+    assert SERVER in seen["command"]
+    assert TOOL in seen["command"]
+    assert "DROP TABLE users" in seen["command"]
+    assert seen["pattern_key"] == KEY
+
+
+def test_guard_args_preview_truncated(gw_session):
+    seen = {}
+
+    def cb(approval_data):
+        seen.update(approval_data)
+        with A._lock:
+            entries = A._gateway_queues.get(gw_session, [])
+            if entries:
+                entries[-1].result = "once"
+                entries[-1].event.set()
+
+    with A._lock:
+        A._gateway_notify_cbs[gw_session] = cb
+
+    A.check_mcp_tool_guard(SERVER, TOOL, {"blob": "x" * 5000})
+    assert len(seen["command"]) < 1000
+    assert "truncated" in seen["command"]
+
+
+# ---------------------------------------------------------------------------
+# 2. CLI interactive path
+# ---------------------------------------------------------------------------
+
+def test_guard_cli_callback_deny_blocks(cli_session):
+    calls = {}
+
+    def cb(command, description, allow_permanent=True):
+        calls["command"] = command
+        calls["description"] = description
+        return "deny"
+
+    res = A.check_mcp_tool_guard(SERVER, TOOL, {"q": "x"},
+                                 approval_callback=cb)
+    assert res["approved"] is False
+    assert res["outcome"] == "denied"
+    assert SERVER in calls["command"]
+    assert TOOL in calls["command"]
+
+
+def test_guard_cli_callback_session_persists(cli_session):
+    res = A.check_mcp_tool_guard(
+        SERVER, TOOL, {},
+        approval_callback=lambda c, d, allow_permanent=True: "session")
+    assert res["approved"] is True
+    assert A.is_approved(cli_session, KEY) is True
+    # Second call short-circuits without prompting.
+    def explode(*_a, **_k):
+        raise AssertionError("must not re-prompt after session approval")
+    res2 = A.check_mcp_tool_guard(SERVER, TOOL, {}, approval_callback=explode)
+    assert res2["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Handler integration — deny blocks before MCP dispatch
+# ---------------------------------------------------------------------------
+
+def test_handler_blocks_before_dispatch_when_guard_denies(gw_session, monkeypatch):
+    import tools.mcp_tool as M
+
+    class _FakeServer:
+        session = object()  # truthy: passes the connected check
+
+    monkeypatch.setitem(M._servers, SERVER, _FakeServer())
+    monkeypatch.setitem(M._server_error_counts, SERVER, 0)
+
+    def _no_dispatch(*_a, **_k):
+        raise AssertionError("MCP loop must not be reached on guard deny")
+    monkeypatch.setattr(M, "_run_on_mcp_loop", _no_dispatch)
+
+    _register_resolver(gw_session, "deny")
+    handler = M._make_tool_handler(SERVER, TOOL, tool_timeout=5)
+    result = json.loads(handler({"q": "x"}))
+    assert "error" in result
+    assert "BLOCKED" in result["error"]
+    # User denial is not a server fault — breaker must not be bumped.
+    assert M._server_error_counts.get(SERVER, 0) == 0
+
+
+def test_handler_dispatches_when_guard_approves(gw_session, monkeypatch):
+    import tools.mcp_tool as M
+
+    class _FakeServer:
+        session = object()
+
+    monkeypatch.setitem(M._servers, SERVER, _FakeServer())
+    monkeypatch.setitem(M._server_error_counts, SERVER, 0)
+    monkeypatch.setattr(
+        M, "_run_on_mcp_loop",
+        lambda coro_or_factory, timeout=30: json.dumps({"result": "ok"}))
+
+    _register_resolver(gw_session, "once")
+    handler = M._make_tool_handler(SERVER, TOOL, tool_timeout=5)
+    result = json.loads(handler({"q": "x"}))
+    assert result == {"result": "ok"}

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -12,6 +12,7 @@ import contextvars
 import fnmatch
 import functools
 import hashlib
+import json
 import logging
 import os
 import re
@@ -4341,10 +4342,227 @@ def request_elicitation_consent(
     if choice in ("once", "session", "always"):
         return "accept"
     if choice == "timeout":
-        # Prompt expired without a user response — mirror the gateway's
-        # unresolved outcome ("cancel") rather than an explicit decline.
         return "cancel"
     return "decline"
+
+
+# =========================================================================
+# MCP tool first-invoke guard (#16462)
+# =========================================================================
+
+def mcp_approval_key(server_name: str, tool_name: str) -> str:
+    """Build the approval pattern key for an MCP (server, tool) pair.
+
+    The ``mcp:`` prefix namespaces these keys away from the dangerous-command
+    descriptions in the shared session/permanent approval stores. The wildcard
+    form ``mcp:<server>:*`` can be added to ``command_allowlist`` in
+    config.yaml to permanently trust every tool on a server.
+    """
+    return f"mcp:{server_name}:{tool_name}"
+
+
+def _mcp_first_invoke_enabled() -> bool:
+    """Read ``approvals.mcp_first_invoke`` from config (default: enabled)."""
+    value = _get_approval_config().get("mcp_first_invoke", True)
+    if isinstance(value, str):
+        return is_truthy_value(value)
+    return bool(value)
+
+
+def _format_mcp_call_preview(server_name: str, tool_name: str,
+                             arguments) -> str:
+    """Render an MCP tool call as the 'command' string shown in approval
+    prompts: server, tool, and a truncated JSON dump of the arguments so the
+    user can see exactly what the first invocation would do."""
+    try:
+        args_preview = json.dumps(arguments or {}, ensure_ascii=False,
+                                  default=str)
+    except (TypeError, ValueError):
+        args_preview = repr(arguments)
+    if len(args_preview) > 600:
+        args_preview = args_preview[:600] + "… (truncated)"
+    return (f"MCP tool call: {server_name}/{tool_name}\n"
+            f"Arguments: {args_preview}")
+
+
+def check_mcp_tool_guard(server_name: str, tool_name: str, arguments=None,
+                         approval_callback=None) -> dict:
+    """Approve the first invocation of an MCP tool in this session (#16462).
+
+    MCP server tools are registered dynamically at ``hermes mcp add`` /
+    connect time and were previously callable by the LLM without any human
+    confirmation — unlike terminal commands, which pass through
+    DANGEROUS_PATTERNS and the approval system. SECURITY.md assigns MCP
+    servers lower trust than installed skills; this guard makes that trust
+    distinction real in the dispatch path.
+
+    The first call to each ``(server, tool)`` pair triggers the same approval
+    flow used for dangerous commands. Scope of an approval:
+
+    - ``once``    — this single dispatch only (no persistence)
+    - ``session`` — this (server, tool) pair until the session is cleared
+      (``/new`` resets it via ``clear_session``)
+    - ``always``  — persisted to ``command_allowlist`` in config.yaml
+
+    First-use consent is a visibility decision (the user learning what a
+    newly added server can do), not a risk assessment, so ``smart`` mode does
+    not auto-approve it — only ``off``/yolo bypass the prompt, plus the
+    dedicated ``approvals.mcp_first_invoke: false`` toggle.
+
+    Scope (interactive surfaces only): headless and cron contexts
+    auto-approve with a log line — no user is present to respond, and
+    blocking every MCP tool there would break existing automation. Restrict
+    the tool surface for unattended profiles via
+    ``mcp_servers.<name>.tools.include`` / ``exclude`` instead.
+
+    Returns the same dict contract as ``check_all_command_guards``.
+    """
+    if not _mcp_first_invoke_enabled():
+        return {"approved": True, "message": None}
+
+    if (_YOLO_MODE_FROZEN or is_current_session_yolo_enabled()
+            or _get_approval_mode() == "off"):
+        return {"approved": True, "message": None}
+
+    pattern_key = mcp_approval_key(server_name, tool_name)
+    server_wildcard = mcp_approval_key(server_name, "*")
+    session_key = get_current_session_key()
+
+    if (is_approved(session_key, pattern_key)
+            or is_approved(session_key, server_wildcard)):
+        return {"approved": True, "message": None}
+
+    is_cli = env_var_enabled("HERMES_INTERACTIVE")
+    is_gateway = _is_gateway_approval_context()
+    is_ask = env_var_enabled("HERMES_EXEC_ASK")
+
+    if not is_cli and not is_gateway and not is_ask:
+        logger.info(
+            "MCP first-invoke auto-approved in non-interactive context: %s/%s",
+            server_name, tool_name,
+        )
+        return {"approved": True, "message": None}
+
+    command = _format_mcp_call_preview(server_name, tool_name, arguments)
+    description = (
+        f"first use of MCP tool '{tool_name}' from server '{server_name}' "
+        "in this session"
+    )
+    approval_data = {
+        "command": command,
+        "pattern_key": pattern_key,
+        "pattern_keys": [pattern_key],
+        "description": description,
+    }
+
+    def _persist(choice: str) -> None:
+        if choice == "session":
+            approve_session(session_key, pattern_key)
+        elif choice == "always":
+            approve_session(session_key, pattern_key)
+            approve_permanent(pattern_key)
+            save_permanent_allowlist(_permanent_approved)
+
+    if is_gateway or is_ask:
+        notify_cb = None
+        with _lock:
+            notify_cb = _gateway_notify_cbs.get(session_key)
+
+        if notify_cb is None:
+            submit_pending(session_key, approval_data)
+            return {
+                "approved": False,
+                "pattern_key": pattern_key,
+                "status": "pending_approval",
+                "approval_pending": True,
+                "command": command,
+                "description": description,
+                "message": (
+                    f"⚠️ {description}. Asking the user for approval.\n\n"
+                    f"**Tool call:**\n```\n{command}\n```"
+                ),
+            }
+
+        decision = _await_gateway_decision(
+            session_key, notify_cb, approval_data, surface="gateway"
+        )
+        if decision.get("notify_failed"):
+            return {
+                "approved": False,
+                "message": ("BLOCKED: Failed to send MCP tool approval "
+                            "request to user. Do NOT retry."),
+                "pattern_key": pattern_key,
+                "description": description,
+                "outcome": "notify_failed",
+                "user_consent": False,
+            }
+
+        resolved = decision["resolved"]
+        choice = decision["choice"]
+
+        if not resolved or choice is None or choice == "deny":
+            reason = ("timed out without user response" if not resolved
+                      else "denied by user")
+            addendum = " Silence is not consent." if not resolved else ""
+            return {
+                "approved": False,
+                "message": (
+                    f"BLOCKED: MCP tool call {reason}. The user has NOT "
+                    f"consented to '{tool_name}' from server '{server_name}'. "
+                    f"Do NOT retry this tool, do NOT rephrase the arguments, "
+                    f"and do NOT attempt the same outcome via a different "
+                    f"tool.{addendum}"
+                ),
+                "pattern_key": pattern_key,
+                "description": description,
+                "outcome": "timeout" if not resolved else "denied",
+                "user_consent": False,
+            }
+
+        _persist(choice)
+        return {"approved": True, "message": None,
+                "user_approved": True, "description": description}
+
+    _fire_approval_hook(
+        "pre_approval_request",
+        command=command,
+        description=description,
+        pattern_key=pattern_key,
+        pattern_keys=[pattern_key],
+        session_key=session_key,
+        surface="cli",
+    )
+    choice = prompt_dangerous_approval(command, description,
+                                       approval_callback=approval_callback)
+    _fire_approval_hook(
+        "post_approval_response",
+        command=command,
+        description=description,
+        pattern_key=pattern_key,
+        pattern_keys=[pattern_key],
+        session_key=session_key,
+        surface="cli",
+        choice=choice,
+    )
+
+    if choice == "deny":
+        return {
+            "approved": False,
+            "message": (
+                f"BLOCKED: User denied this MCP tool call. The user has NOT "
+                f"consented to '{tool_name}' from server '{server_name}'. "
+                f"Do NOT retry this tool, do NOT rephrase the arguments, and "
+                f"do NOT attempt the same outcome via a different tool."
+            ),
+            "pattern_key": pattern_key,
+            "description": description,
+            "outcome": "denied",
+            "user_consent": False,
+        }
+
+    _persist(choice)
+    return {"approved": True, "message": None,
+            "user_approved": True, "description": description}
 
 
 # Load permanent allowlist from config on module import

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4942,6 +4942,28 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                 return tool_error(f"MCP server '{server_name}' is not connected")
 
+        # First-invoke approval gate (#16462): MCP tools are registered
+        # dynamically and would otherwise be callable without any human
+        # confirmation, unlike terminal commands which pass through
+        # DANGEROUS_PATTERNS. Gate the first call to each (server, tool)
+        # pair per session. Runs in the tool-executor thread, which holds
+        # the session context and (in CLI) the per-thread approval callback.
+        from tools.approval import check_mcp_tool_guard
+        try:
+            from tools.terminal_tool import _get_approval_callback
+            _approval_cb = _get_approval_callback()
+        except Exception:
+            _approval_cb = None
+        _guard = check_mcp_tool_guard(server_name, tool_name, args,
+                                      approval_callback=_approval_cb)
+        if not _guard.get("approved", False):
+            # An approval denial is user intent, not a server fault — do not
+            # bump the circuit breaker.
+            return json.dumps({
+                "error": (_guard.get("message")
+                          or "MCP tool call blocked by approval guard."),
+            }, ensure_ascii=False)
+
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -35,6 +35,7 @@ approvals:
   timeout: 300                    # seconds to wait for user response (default: 300)
   cron_mode: deny                 # deny | approve — what cron jobs do when they hit a dangerous command
   mcp_reload_confirm: true        # /reload-mcp asks before invalidating the MCP tool cache
+  mcp_first_invoke: true          # first call to each MCP (server, tool) pair asks for approval
   destructive_slash_confirm: true # /clear, /new, /reset, /undo prompt before discarding state
 ```
 
@@ -46,6 +47,7 @@ The full set of keys:
 | `timeout` | `300` | Seconds Hermes waits for an approval reply before timing out. |
 | `cron_mode` | `deny` | How [cron jobs](./features/cron.md) behave headlessly when they trigger a dangerous-command prompt. `deny` blocks the command (the agent must find another path); `approve` auto-approves everything in cron context. |
 | `mcp_reload_confirm` | `true` | When true, `/reload-mcp` asks before rebuilding the MCP tool set. Rebuilding invalidates the provider prompt cache (tool schemas live in the system prompt), so the next message re-sends full input tokens. Users who click **Always Approve** flip this key to `false`. |
+| `mcp_first_invoke` | `true` | When true, the **first** call to each MCP `(server, tool)` pair in a session triggers an approval prompt showing the server, tool, and arguments — making a newly added server's capabilities visible before anything runs. Approve **once** (this call only), for the **session** (this pair until `/new`), or **always** (persisted to `command_allowlist`; add `mcp:<server>:*` there to trust a whole server). Only fires on interactive surfaces (CLI, gateway); headless and cron sessions auto-approve with a log line — restrict their tool surface via `mcp_servers.<name>.tools.include`/`exclude` instead. |
 | `destructive_slash_confirm` | `true` | When true, destructive session slash commands (`/clear`, `/new`, `/reset`, `/undo`) prompt before discarding conversation state. Three-option dialog (Approve Once / Always Approve / Cancel) routed through native yes/no buttons on Telegram, Discord, and Slack; text fallback elsewhere. Users who click **Always Approve** flip this key to `false`. TUI uses its own modal overlay (set `HERMES_TUI_NO_CONFIRM=1` to opt out there). |
 
 | Mode | Behavior |


### PR DESCRIPTION
## What does this PR do?

Implements first-invoke approval for MCP server tools, as proposed in #16462.

Today, when a user adds an MCP server, its tools are registered in the tool registry and become **immediately callable by the LLM with no human confirmation** — unlike the terminal tool, which is gated by `DANGEROUS_PATTERNS` and the approval system. SECURITY.md assigns MCP servers lower trust than installed skills, but the dispatch path didn't reflect that.

With this change, the **first call to each `(server, tool)` pair per session** triggers the same approval flow already used for dangerous commands. The prompt shows the server id, tool name, and a truncated JSON dump of the arguments, so the user sees exactly what a newly added server is about to do before anything runs. Approval scopes map onto the existing once/session/always machinery:

- **once** — this single dispatch only (no persistence; addresses @kayalopez's "approve once is consumed by one dispatch only")
- **session** — this `(server, tool)` pair until the session is cleared (`/new` resets it via `clear_session`, matching the issue's "reset on /new")
- **always** — persisted to `command_allowlist` in config.yaml

Per-tool keys (`mcp:<server>:<tool>`) are deliberately **narrower than per-server**, following the review comments on the issue ("approve for this server should not silently approve newly added tools" — @kayalopez, @Ram9199). Users who want server-wide permanent trust can add `mcp:<server>:*` to `command_allowlist` explicitly.

Design decisions worth flagging for review:

1. **Default-enabled** (`approvals.mcp_first_invoke: true`). Friction is one prompt per `(server, tool)` pair per session, on interactive surfaces only. Happy to flip the default to opt-in if preferred — it's one line.
2. **Headless/cron contexts auto-approve with a log line** rather than blocking. First-use visibility has no value when nobody is watching, and a default-deny would break every existing cron/batch profile that uses MCP tools. Unattended profiles should restrict their tool surface via `mcp_servers.<name>.tools.include/exclude` instead (docs updated to say so).
3. **`smart` mode does not auto-approve first invokes.** First-use consent is a visibility decision, not a risk assessment the aux LLM can make; only `--yolo`/`mode: off`/the dedicated toggle bypass it.
4. **A denial does not bump the MCP circuit breaker** — it's user intent, not a server fault.
5. Scope is `tools/call` dispatch only; the resources/prompts utility tools are unchanged (can follow up if desired).

## Related Issue

Fixes #16462

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix

## Changes Made

- `tools/approval.py` — new `check_mcp_tool_guard()` (modeled on `check_execute_code_guard`), plus `mcp_approval_key()` and the `approvals.mcp_first_invoke` config read. Reuses the existing session/permanent approval stores, gateway approval queue (`_await_gateway_decision`), CLI prompt path, and `pre/post_approval_request` plugin hooks.
- `tools/mcp_tool.py` — `_make_tool_handler()` calls the guard before dispatching `tools/call`; a block returns the standard `{"error": ...}` JSON to the model without reaching the MCP loop.
- `website/docs/user-guide/security.md` — documents the new key in the approvals table and example YAML.
- `tests/tools/test_mcp_tool_approval.py` — 21 new tests covering the decision matrix (toggle, yolo/off, headless/cron auto-approve, once/session/always persistence, per-tool vs wildcard keys, `/new` reset, gateway deny/timeout/missing-notify, CLI callback path, args preview + truncation) and handler integration (deny blocks **before** dispatch; breaker not bumped).

## How to Test

1. `scripts/run_tests.sh tests/tools/test_mcp_tool_approval.py` — 21/21 pass.
2. Regression: `scripts/run_tests.sh tests/tools/test_approval.py tests/tools/test_execute_code_approval_cluster.py tests/tools/test_approval_plugin_hooks.py tests/tools/test_cron_approval_mode.py tests/tools/test_yolo_mode.py tests/tools/test_hardline_blocklist.py tests/gateway/test_approve_deny_commands.py` — 395/395 pass.
3. Regression: all MCP tool test files (`tests/tools/test_mcp_*.py` handler/breaker/discovery/stability suites) — 283/283 pass (hermetic test env is headless, so existing handler tests hit the auto-approve path unchanged).
4. Manual: add any MCP server, ask the agent to call one of its tools in a gateway session → approval request with server/tool/args appears; `/approve` once allows that call only, asking again re-prompts; approve session silences that pair until `/new`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suites above via `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (the `approvals:` block is not present in the example file; documented in `website/docs/user-guide/security.md` alongside the other approvals keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python control flow, no platform-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema changes; blocked calls return the standard error JSON contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)