### PR TITLE
fix(mcp): re-validate PGID ownership before killing orphaned process groups

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -170,6 +170,71 @@ class TestStdioPidTracking:
         mock_kill.assert_any_call(fake_pid, signal.SIGTERM)
         assert mock_sleep.called
 
+    def test_kill_orphaned_skips_recycled_pid(self):
+        """PID-reuse guard: a recycled PID (start-time changed) is NOT signalled.
+
+        Regression test: once an MCP child exits and is reaped, the kernel can
+        recycle its PID/PGID onto an unrelated process group.  The sweep must
+        not signal the stale number, or it kills a stranger (observed: a desktop
+        browser whose session leader reused a dead MCP child's PID).
+        """
+        from tools.mcp_tool import (
+            _kill_orphaned_mcp_children,
+            _orphan_stdio_pids,
+            _stdio_pgids,
+            _stdio_starttimes,
+            _lock,
+        )
+
+        fake_pid = 454545
+        with _lock:
+            _orphan_stdio_pids.clear()
+            _orphan_stdio_pids.add(fake_pid)
+            _stdio_pgids[fake_pid] = fake_pid
+            _stdio_starttimes[fake_pid] = 111111  # recorded at spawn
+
+        # Current start time differs -> PID was recycled -> guard must skip.
+        with patch("gateway.status.get_process_start_time", return_value=222222), \
+             patch("tools.mcp_tool.os.killpg") as mock_killpg, \
+             patch("tools.mcp_tool.os.kill") as mock_kill, \
+             patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.mcp_tool.time.sleep"):
+            _kill_orphaned_mcp_children()
+
+        mock_killpg.assert_not_called()
+        mock_kill.assert_not_called()
+        with _lock:
+            _stdio_pgids.pop(fake_pid, None)
+            _stdio_starttimes.pop(fake_pid, None)
+
+    def test_kill_orphaned_signals_when_start_time_matches(self):
+        """The orphan IS signalled when its leader start-time still matches."""
+        from tools.mcp_tool import (
+            _kill_orphaned_mcp_children,
+            _orphan_stdio_pids,
+            _stdio_pgids,
+            _stdio_starttimes,
+            _lock,
+        )
+
+        fake_pid = 464646
+        with _lock:
+            _orphan_stdio_pids.clear()
+            _orphan_stdio_pids.add(fake_pid)
+            _stdio_pgids[fake_pid] = fake_pid
+            _stdio_starttimes[fake_pid] = 333333
+
+        with patch("gateway.status.get_process_start_time", return_value=333333), \
+             patch("tools.mcp_tool.os.killpg") as mock_killpg, \
+             patch("gateway.status._pid_exists", return_value=False), \
+             patch("tools.mcp_tool.time.sleep"):
+            _kill_orphaned_mcp_children()
+
+        mock_killpg.assert_any_call(fake_pid, signal.SIGTERM)
+        with _lock:
+            _stdio_pgids.pop(fake_pid, None)
+            _stdio_starttimes.pop(fake_pid, None)
+
         with _lock:
             assert fake_pid not in _orphan_stdio_pids
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -557,6 +557,10 @@ class LocalEnvironment(BaseEnvironment):
         if not _IS_WINDOWS:
             try:
                 proc._hermes_pgid = os.getpgid(proc.pid)
+                # Record the group leader's start time so _kill_process can
+                # detect PID/PGID recycling before signalling the group.
+                from gateway.status import get_process_start_time
+                proc._hermes_pgid_start = get_process_start_time(proc.pid)
             except ProcessLookupError:
                 pass
 
@@ -601,12 +605,33 @@ class LocalEnvironment(BaseEnvironment):
             if _IS_WINDOWS:
                 proc.terminate()
             else:
+                expected_start = getattr(proc, "_hermes_pgid_start", None)
+
+                def _leader_is_ours(pgid) -> bool:
+                    # The setsid group leader's PID == its PGID.  Confirm it is
+                    # still the process we spawned before signalling the whole
+                    # group, so a recycled PID/PGID can never take down an
+                    # unrelated process group.  When no start-time baseline was
+                    # captured (e.g. macOS, which has no /proc), fall back to the
+                    # legacy best-effort behaviour rather than refusing to kill.
+                    if pgid is None:
+                        return False
+                    if expected_start is None:
+                        return True
+                    from gateway.status import get_process_start_time
+                    return get_process_start_time(pgid) == expected_start
+
                 try:
                     pgid = os.getpgid(proc.pid)
                 except ProcessLookupError:
                     pgid = getattr(proc, "_hermes_pgid", None)
-                    if pgid is None:
-                        raise
+
+                if not _leader_is_ours(pgid):
+                    # Leader exited and its PID/PGID may have been recycled onto
+                    # an unrelated process group; signalling the stale number is
+                    # unsafe.  Bail out — a rare orphaned grandchild may leak,
+                    # which is strictly preferable to killing a stranger.
+                    return
 
                 try:
                     os.killpg(pgid, signal.SIGTERM)  # windows-footgun: ok — POSIX process-group SIGTERM (guarded by _IS_WINDOWS above)
@@ -617,6 +642,11 @@ class LocalEnvironment(BaseEnvironment):
                 # load the wrapper can exit before grandchildren do; returning
                 # at that point leaves orphaned process-group members behind.
                 if _wait_for_group_exit(pgid, 1.0):
+                    return
+
+                if not _leader_is_ours(pgid):
+                    # Leader exited during the grace window; do not escalate to
+                    # SIGKILL on a possibly-recycled PGID.
                     return
 
                 try:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1415,6 +1415,8 @@ class MCPServerTask:
                     # sweep needs the pgid to reach any reparented descendants
                     # (e.g. ``claude mcp serve`` spawned by a stdio wrapper).
                     new_pgids: Dict[int, int] = {}
+                    new_starts: Dict[int, int] = {}
+                    from gateway.status import get_process_start_time
                     for _pid in new_pids:
                         try:
                             new_pgids[_pid] = os.getpgid(_pid)
@@ -1422,10 +1424,17 @@ class MCPServerTask:
                             # AttributeError: Windows (os.getpgid is POSIX-only)
                             # ProcessLookupError: child raced and already exited
                             pass
+                        # Record the leader's start time so a later sweep can
+                        # detect PID/PGID recycling before signalling (see
+                        # _stdio_starttimes).
+                        _start = get_process_start_time(_pid)
+                        if _start is not None:
+                            new_starts[_pid] = _start
                     with _lock:
                         for _pid in new_pids:
                             _stdio_pids[_pid] = self.name
                         _stdio_pgids.update(new_pgids)
+                        _stdio_starttimes.update(new_starts)
                 async with ClientSession(
                     read_stream, write_stream, **sampling_kwargs
                 ) as session:
@@ -2396,6 +2405,15 @@ _orphan_stdio_pids: set = set()
 # exited and been removed from the active map.  Empty on Windows
 # (``os.getpgid`` is POSIX-only).
 _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
+
+# Spawn-time start ticks (/proc/<pid>/stat field 22) of each stdio child's
+# pgroup leader, captured alongside the PGID.  PIDs/PGIDs are recycled by the
+# kernel once the original process exits and is reaped, so a long-lived
+# tracker holding a bare PGID is unsafe: by the time a sweep runs, that number
+# may name an unrelated process group (observed in the wild: a desktop browser
+# whose session leader happened to reuse a dead MCP child's PID).  We re-check
+# the leader's start time before signalling so a recycled PGID is never killed.
+_stdio_starttimes: Dict[int, int] = {}  # pid -> leader start ticks
 
 
 def _snapshot_child_pids() -> set:
@@ -3839,11 +3857,14 @@ def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
         if include_active:
             pids.update(dict(_stdio_pids))
             _stdio_pids.clear()
-        # Snapshot pgids for the pids we're about to kill, then drop the
-        # entries so a future spawn can't collide with stale state.
+        # Snapshot pgids + spawn-time leader start ticks for the pids we're
+        # about to kill, then drop the entries so a future spawn can't collide
+        # with stale state.
         pgids: Dict[int, int] = {pid: _stdio_pgids[pid] for pid in pids if pid in _stdio_pgids}
-        for pid in pgids:
+        starts: Dict[int, int] = {pid: _stdio_starttimes[pid] for pid in pids if pid in _stdio_starttimes}
+        for pid in pids:
             _stdio_pgids.pop(pid, None)
+            _stdio_starttimes.pop(pid, None)
 
     # Fast path: no tracked stdio PIDs to reap. Skip the SIGTERM/sleep/SIGKILL
     # dance entirely — otherwise every MCP-free shutdown pays a 2s sleep tax.
@@ -3852,6 +3873,23 @@ def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
 
     def _send_signal(pid: int, sig: int, server_name: str) -> None:
         """SIGTERM/SIGKILL via pgroup on POSIX, fall back to pid signal."""
+        # PID-reuse guard: only signal if ``pid`` still names the process we
+        # spawned.  Once an MCP child exits and is reaped the kernel may recycle
+        # its PID/PGID onto an unrelated process group; signalling the stale
+        # number would kill a stranger (e.g. a recycled PGID landing on a
+        # desktop browser's session leader).  Skip when the leader's start time
+        # no longer matches.  With no recorded start time we fall through to the
+        # legacy best-effort path (capture raced the child's exit).
+        expected_start = starts.get(pid)
+        if expected_start is not None:
+            from gateway.status import get_process_start_time
+            if get_process_start_time(pid) != expected_start:
+                logger.debug(
+                    "Skip signalling MCP pid %d (%s): start-time mismatch — "
+                    "PID was recycled; refusing to kill an unrelated process group.",
+                    pid, server_name,
+                )
+                return
         pgid = pgids.get(pid)
         killpg = getattr(os, "killpg", None)
         if pgid is not None and killpg is not None:


### PR DESCRIPTION
Fixes #43044

## Problem

The stdio-MCP orphan reaper (`_kill_orphaned_mcp_children`) and the local environment's `_kill_process` both terminate a process **group** with `os.killpg(pgid, sig)` using a PGID captured at spawn time. Once the original child exits **and is reaped**, the kernel is free to recycle that PID/PGID onto a completely unrelated process group — so a later sweep can `killpg` a stranger.

## Evidence

On a host where a Hermes gateway had been running for days, an unrelated desktop **Firefox** was being SIGTERM-ed at irregular intervals (every few minutes to ~an hour). It was not OOM, not a crash (no minidump, exit 143 = SIGTERM), and `auditd` on `kill/tgkill/pidfd_send_signal` showed nothing. The kernel `signal:signal_generate` tracepoint named the sender unambiguously:

```
hermes-2505465 ... signal_generate: sig=15 ... comm=firefox pid=396240 grp=1
```

`grp=1` = a process-**group** signal (`killpg`). Firefox's session leader had reused a dead MCP child's PID, so the reaper's stored PGID now pointed at Firefox's group.

## Fix

Record each group leader's **start time** (`/proc/<pid>/stat` field 22, via the existing `gateway.status.get_process_start_time`) alongside the PGID, and re-validate it immediately before signalling. A PGID whose leader's start time no longer matches — or whose leader is gone — is never signalled. This mirrors the existing "re-validate stale entry before a destructive action" pattern (cf. the cron-output re-validation fix).

**Cross-platform:** when no start time is available (e.g. macOS has no `/proc`, `get_process_start_time` returns `None`), the guard degrades to the prior best-effort behaviour, so non-Linux platforms are unaffected. `killpg`/`/proc` usage stays Linux-gated as before.

## Tests

`scripts/run_tests.sh tests/tools/test_mcp_stability.py tests/tools/test_local_interrupt_cleanup.py` — 24 passed, including two new regression tests:
- `test_kill_orphaned_skips_recycled_pid` — recycled PID (start-time changed) is **not** signalled.
- `test_kill_orphaned_signals_when_start_time_matches` — live orphan still gets reaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
