### PR TITLE
fix(feishu): custom interactive card button-click round-trip

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -66,7 +66,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Literal, Optional, Sequence
+from typing import Any, Dict, List, Literal, Optional, Sequence, Union
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
@@ -108,9 +108,17 @@ try:
     from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
     from lark_oapi.core.model import BaseRequest
     from lark_oapi.event.callback.model.p2_card_action_trigger import (
+        CallBackAction,
         CallBackCard,
+        CallBackToast,
         P2CardActionTriggerResponse,
     )
+    # Accept both string and dict button values (Feishu API spec allows
+    # both, but the SDK model requires Dict).  Prevents 200671 errors.
+    # Relies on lark-oapi's parse() treating Union types as pass-through
+    # (tested with lark-oapi 1.6.8).
+    if CallBackAction is not None:
+        CallBackAction._types["value"] = Union[str, Dict[str, Any]]
     from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
     from lark_oapi.ws import Client as FeishuWSClient
 
@@ -118,7 +126,9 @@ try:
 except ImportError:
     FEISHU_AVAILABLE = False
     lark = None  # type: ignore[assignment]
+    CallBackAction = None  # type: ignore[assignment]
     CallBackCard = None  # type: ignore[assignment]
+    CallBackToast = None  # type: ignore[assignment]
     P2CardActionTriggerResponse = None  # type: ignore[assignment]
     EventDispatcherHandler = None  # type: ignore[assignment]
     FeishuWSClient = None  # type: ignore[assignment]
@@ -242,7 +252,7 @@ async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> byt
 
 
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
-_FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
+_FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003, 99992354})  # reply target invalid/withdrawn/missing → create fallback
 
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so
@@ -1383,8 +1393,11 @@ def check_feishu_requirements() -> bool:
         from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
         from lark_oapi.core.model import BaseRequest
         from lark_oapi.event.callback.model.p2_card_action_trigger import (
-            CallBackCard, P2CardActionTriggerResponse,
+            CallBackAction, CallBackCard, CallBackToast, P2CardActionTriggerResponse,
         )
+        # Accept both string and dict button values (see static import above).
+        if CallBackAction is not None:
+            CallBackAction._types["value"] = Union[str, Dict[str, Any]]
         from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
         from lark_oapi.ws import Client as FeishuWSClient
         return {
@@ -2670,7 +2683,17 @@ class FeishuAdapter(BasePlatformAdapter):
         self._submit_on_loop(loop, self._handle_card_action_event(data))
         if P2CardActionTriggerResponse is None:
             return None
-        return P2CardActionTriggerResponse()
+        # Return a toast to give the user immediate visual feedback,
+        # while the agent processes the action asynchronously in chat.
+        # The card stays intact so multi-button panels remain usable.
+        action_tag = str(getattr(action, "tag", "") or "button")
+        response = P2CardActionTriggerResponse()
+        if CallBackToast is not None:
+            toast = CallBackToast()
+            toast.type = "info"
+            toast.content = f"✅ Received '{action_tag}' action, processing..."
+            response.toast = toast
+        return response
 
     @staticmethod
     def _loop_accepts_callbacks(loop: Any) -> bool:
@@ -2986,20 +3009,24 @@ class FeishuAdapter(BasePlatformAdapter):
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
 
-        synthetic_text = f"/card {action_tag}"
+        synthetic_text = f"Card button '{action_tag}' clicked"
         if action_value:
             try:
-                synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
+                synthetic_text += f" with data: {json.dumps(action_value, ensure_ascii=False)}"
             except Exception:
                 pass
 
-        sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
+        sender_id = SimpleNamespace(
+            open_id=open_id,
+            user_id=None,
+            union_id=str(getattr(operator, "union_id", "") or ""),
+        )
         sender_profile = await self._resolve_sender_profile(sender_id)
         chat_info = await self.get_chat_info(chat_id)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type="group"),
+            chat_type=chat_info.get("type") or "group",
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
             thread_id=None,
@@ -3010,7 +3037,7 @@ class FeishuAdapter(BasePlatformAdapter):
             message_type=MessageType.COMMAND,
             source=source,
             raw_message=data,
-            message_id=token or str(uuid.uuid4()),
+            message_id=None,
             channel_prompt=self._resolve_channel_prompt(chat_id),
             timestamp=datetime.now(),
         )

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -435,7 +435,120 @@ class TestNonApprovalCardAction:
 
         mock_handle.assert_called_once()
         event = mock_handle.call_args[0][0]
-        assert "/card button" in event.text
+        assert "Card button 'button' clicked" in event.text
+
+    @pytest.mark.asyncio
+    async def test_message_id_is_none(self):
+        """Synthetic card-action events should not carry a message_id,
+        so the gateway sends as a new message instead of trying to reply
+        to an invalid target."""
+        adapter = _make_adapter()
+
+        data = _make_card_action_data(
+            action_value={"custom_action": "something_else"},
+            token="tok_normal",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        event = mock_handle.call_args[0][0]
+        assert event.message_id is None
+
+    @pytest.mark.asyncio
+    async def test_text_includes_action_value_data(self):
+        """When action.value is a dict, the synthetic text should include its JSON data."""
+        adapter = _make_adapter()
+
+        data = _make_card_action_data(
+            action_value={"command": "deploy", "env": "staging"},
+            token="tok_data",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        event = mock_handle.call_args[0][0]
+        assert "deploy" in event.text
+        assert "env" in event.text
+
+    @pytest.mark.asyncio
+    async def test_dm_source_type(self):
+        """DM card actions should carry chat_type='dm' on the source."""
+        adapter = _make_adapter()
+
+        data = _make_card_action_data(
+            action_value={"custom_action": "something_else"},
+            token="tok_dm",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(
+                adapter, "get_chat_info", new_callable=AsyncMock,
+                return_value={"type": "dm", "name": "Dave Chat"},
+            ),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        event = mock_handle.call_args[0][0]
+        assert event.source.chat_type == "dm"
+
+    @pytest.mark.asyncio
+    async def test_union_id_propagation(self):
+        """operator.union_id should flow through to source.user_id_alt."""
+        adapter = _make_adapter()
+
+        # Build data with a union_id on the operator.
+        data = _make_card_action_data(
+            action_value={"custom_action": "something_else"},
+            token="tok_union",
+            open_id="ou_user1",
+        )
+        # Overwrite the operator to include a union_id (the helper creates
+        # a bare operator without one by default).
+        operator = SimpleNamespace(open_id="ou_user1", union_id="on_99999")
+        data.event.operator = operator
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_user1", "user_name": "Dave",
+                              "user_id_alt": "on_99999"},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        event = mock_handle.call_args[0][0]
+        assert event.source.user_id_alt == "on_99999"
+
+    @pytest.mark.asyncio
+    async def test_99992354_in_fallback_codes(self):
+        """99992354 must be in _FEISHU_REPLY_FALLBACK_CODES so invalid
+        reply-target errors gracefully fall back to new messages."""
+        from plugins.platforms.feishu import adapter as feishu_adapter
+
+        assert 99992354 in feishu_adapter._FEISHU_REPLY_FALLBACK_CODES
 
 
 # ===========================================================================
@@ -448,16 +561,24 @@ class _FakeCallBackCard:
         self.data = None
 
 
+class _FakeCallBackToast:
+    def __init__(self):
+        self.type = None
+        self.content = None
+
+
 class _FakeP2Response:
     def __init__(self):
         self.card = None
+        self.toast = None
 
 
 @pytest.fixture(autouse=False)
 def _patch_callback_card_types(monkeypatch):
-    """Provide real-ish P2CardActionTriggerResponse / CallBackCard for tests."""
+    """Provide real-ish P2CardActionTriggerResponse / CallBackCard / CallBackToast for tests."""
     monkeypatch.setattr(feishu_module, "P2CardActionTriggerResponse", _FakeP2Response)
     monkeypatch.setattr(feishu_module, "CallBackCard", _FakeCallBackCard)
+    monkeypatch.setattr(feishu_module, "CallBackToast", _FakeCallBackToast)
 
 
 class TestCardActionCallbackResponse:
@@ -548,6 +669,22 @@ class TestCardActionCallbackResponse:
 
         assert response is not None
         assert response.card is None
+
+    def test_toast_for_non_approval_button(self, _patch_callback_card_types):
+        """Non-approval button clicks should return a toast for immediate
+        user feedback while the agent processes asynchronously."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        data = _make_card_action_data({"some_other": "value"})
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.toast is not None
+        assert response.toast.type == "info"
+        assert "processing" in response.toast.content
 
     def test_falls_back_to_open_id_when_name_not_cached(self, _patch_callback_card_types):
         adapter = _make_adapter()


### PR DESCRIPTION
> **Updated 2026-07-14:** Rebased onto latest main. All four fixes re-applied cleanly. Added 7 regression tests covering the _handle_card_action_event and _on_card_action_trigger paths. lark-oapi version comment corrected (1.5.3 → 1.6.8).

---

### 🔮 The vision

Agents should be able to send **arbitrary interactive Feishu cards**
and have button clicks flow back as natural conversation turns in the
**same session** — and have the agent's reply actually delivered.
Think multi-button confirmations, inline selectors, wizard panels —
all generated by the agent at runtime via `im_send_card`.

Three bugs in the card-action callback path make this impossible today.
This PR fixes all three, completing the full round-trip.

---

### 🐛 Bug 1 — `200671` when button `value` is a plain string

The Feishu API spec says `value` can be a string **or** an object,
but the `lark-oapi` SDK model types it as `Dict[str, Any]` only.
When a card has `"value": "yes"`, the SDK's `UnmarshalException`
fires **before** `_on_card_action_trigger` is reached, Feishu receives
a non-200 response, and the client shows `出错了 code:200671`.

**Fix:** Monkey-patch `CallBackAction._types["value"]` to
`Union[str, Dict[str, Any]]` at import time (both static and lazy
paths). The SDK's `parse()` routine only validates `list`/`dict`/
`set`/`object` — `Union` passes through unvalidated, accepting both
forms without touching SDK internals.

---

### 🐛 Bug 2 — Card actions always create **new isolated sessions**

In `_handle_card_action_event()`, two mistakes in `SessionSource`
construction cause the session key to **never match** the active
conversation:

| Field | Before | Effect |
|-------|--------|--------|
| `chat_type` | `event_chat_type="group"` **hardcoded** | DMs get key `…group:oc_xxx` instead of `…dm:oc_xxx` |
| `union_id` | **discarded** (`union_id=None`) | Group-chat key misses `user_id_alt` → per-user isolation broken |

**Fix:** Use `chat_info["type"]` (already correctly resolved by
`get_chat_info()`) and pass through `operator.union_id`.

---

### 🐛 Bug 3 — Agent responses silently dropped (`99992354`)

The synthetic `MessageEvent` was using the card action token (`c-xxx`)
as `message_id`. The gateway (`_reply_anchor_for_event()`) interprets
a non-empty `message_id` as a reply target — but neither card tokens
nor UUIDs are valid Feishu `open_message_id` values, so Feishu rejects
the send with `99992354`. The agent response is generated, sent, and
silently discarded.

**Fix (two layers):**

1. **Root cause:** Set `message_id=None` on the synthetic event.
   `_reply_anchor_for_event()` returns `None`, so the gateway sends as
   a plain (non-reply) message — no invalid ID ever reaches Feishu.

2. **Defense-in-depth:** Add `99992354` to `_FEISHU_REPLY_FALLBACK_CODES`
   so any invalid reply target gracefully falls back to a new message.

---

### 🍰 Bonus — Toast feedback for custom buttons

Added `CallBackToast` to the callback response so custom buttons get
the same immediate visual feedback that approval cards already have.

---

### ✅ New in this revision (2026-07-14)

- **Rebased** onto current `main` (226e8de).
- **lark-oapi version comment** corrected from 1.5.3 to 1.6.8.
- **7 regression tests** added to `TestNonApprovalCardAction`:
  `test_message_id_is_none`, `test_text_includes_action_value_data`,
  `test_dm_source_type`, `test_union_id_propagation`,
  `test_99992354_in_fallback_codes`, updated `test_routes_as_synthetic_command`,
  plus `test_toast_for_non_approval_button` in `TestCardActionCallbackResponse`.

### 🔒 No breaking changes

- **Approval cards** (`hermes_action`) and **prompt-update cards**
  (`hermes_update_prompt_action`) are handled in dedicated branches of
  `_on_card_action_trigger()` and never reach the changed paths.
- `CallBackAction._types` patch only **relaxes** the type constraint
  (dict → dict | str), never tightens it.
- Both import paths (static + lazy `_import()`) are patched.
- Card deduplication (`_is_card_action_duplicate`) is unaffected by
  the `message_id` change.

---

### ✅ Verified

| Scenario | Before | After |
|----------|--------|-------|
| String-valued button (`"value": "yes"`) | 200671 ❌ | Toast + agent receives click ✅ |
| DM button click | Isolated session ❌ | Same session ✅ |
| Agent response to card click | 99992354 dropped ❌ | Delivered ✅ |
| Dict-valued button | Works ✅ | Still works ✅ |
| Approval card | Works ✅ | Still works ✅ |