### PR TITLE
fix(agent): catch persist errors in finalize_turn to avoid losing tur…

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -139,8 +139,11 @@ def finalize_turn(
     # scaffolding has been removed. Otherwise a later user "continue" turn
     # can replay assistant("(empty)") / recovery nudges and fall into the
     # same empty-response loop again.
-    agent._drop_trailing_empty_response_scaffolding(messages)
-    agent._persist_session(messages, conversation_history)
+    try:
+        agent._drop_trailing_empty_response_scaffolding(messages)
+        agent._persist_session(messages, conversation_history)
+    except Exception as exc:
+        logger.warning("turn finalization persist failed: %s", exc)
 
     # ── Turn-exit diagnostic log ─────────────────────────────────────
     # Always logged at INFO so agent.log captures WHY every turn ended.

--- a/tests/agent/test_turn_finalizer.py
+++ b/tests/agent/test_turn_finalizer.py
@@ -1,0 +1,79 @@
+"""Tests for agent/turn_finalizer.py — graceful degradation on persist failure."""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.turn_finalizer import finalize_turn
+
+
+def _base_agent():
+    agent = MagicMock()
+    agent.max_iterations = 1
+    agent.iteration_budget.remaining = 1
+    agent.quiet_mode = True
+    agent.session_id = "session-1"
+    agent.model = "test-model"
+    agent.provider = "test-provider"
+    agent.base_url = "https://test"
+    agent.session_input_tokens = 0
+    agent.session_output_tokens = 0
+    agent.session_cache_read_tokens = 0
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_estimated_cost_usd = None
+    agent.session_cost_status = None
+    agent.session_cost_source = None
+    agent.context_compressor = MagicMock()
+    agent.context_compressor.last_prompt_tokens = 0
+    agent._response_was_previewed = False
+    agent._interrupt_message = None
+    agent._tool_guardrail_halt_decision = None
+    agent._file_mutation_verifier_enabled.return_value = False
+    agent._turn_completion_explainer_enabled.return_value = False
+    agent._skill_nudge_interval = 0
+    agent._iters_since_skill = 0
+    agent.valid_tool_names = []
+    agent._drain_pending_steer.return_value = None
+    agent.clear_interrupt.return_value = None
+    agent._stream_callback = None
+    agent._turn_failed_file_mutations = None
+    agent._active_children = []
+    agent._sync_external_memory_for_turn.return_value = None
+    agent._spawn_background_review.return_value = None
+    return agent
+
+
+def test_finalize_turn_survives_persist_session_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """finalize_turn must return a result dict even when _persist_session raises."""
+    agent = _base_agent()
+    agent._drop_trailing_empty_response_scaffolding.return_value = None
+    agent._persist_session.side_effect = OSError("disk full")
+
+    with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+        result = finalize_turn(
+            agent,
+            final_response="done",
+            api_call_count=0,
+            interrupted=False,
+            failed=False,
+            messages=[],
+            conversation_history=[],
+            effective_task_id="task-1",
+            turn_id="turn-1",
+            user_message="hi",
+            original_user_message="hi",
+            _should_review_memory=False,
+            _turn_exit_reason="completed",
+        )
+
+    assert isinstance(result, dict)
+    assert result["final_response"] == "done"
+    agent._persist_session.assert_called_once()
+    assert "turn finalization persist failed" in caplog.text
+    assert "disk full" in caplog.text


### PR DESCRIPTION
## Summary

Wraps `_drop_trailing_empty_response_scaffolding` and `_persist_session`
in `finalize_turn()` with a `try/except` block. When session persistence
fails due to a disk or SQLite error, the turn result is still returned to
the caller instead of propagating an unhandled exception.

---

## Root cause

`finalize_turn()` in `agent/turn_finalizer.py` calls
`_drop_trailing_empty_response_scaffolding()` and `_persist_session()`
without any error handling. If `_persist_session()` raises (e.g.
`OSError: disk full`, `sqlite3.OperationalError: database is locked`),
the exception propagates up through `run_conversation()` with no catch
at that level either. The caller receives an exception instead of the
expected `result` dict, the turn response is never delivered to the
user, and the session is not saved.

---

## Behavioral change

Before: any exception in `_persist_session()` caused `finalize_turn()`
to raise, losing the turn result and the user's response entirely.

After: exceptions from both `_drop_trailing_empty_response_scaffolding()`
and `_persist_session()` are caught as a pair. A `logger.warning` is
emitted with the error details, and `finalize_turn()` continues to
return the `result` dict. The user receives the response for this turn
even if the session was not persisted to SQLite.

---

## What changed

**`agent/turn_finalizer.py`**
- Wrapped lines 142-143 (`_drop_trailing_empty_response_scaffolding` and
  `_persist_session`) in `try/except Exception as exc: logger.warning(...)`
- Both calls kept in the same block so that `_persist_session` is never
  called with unclean messages if `_drop_trailing_empty_response_scaffolding`
  raises first

**`tests/agent/test_turn_finalizer.py`** (new file)
- Added `test_finalize_turn_survives_persist_session_failure`: patches
  `_persist_session` to raise `OSError("disk full")`, verifies that
  `finalize_turn` returns a valid `result` dict and emits the expected
  warning

---

## What is NOT changed

- `finalize_turn()` return contract unchanged: always returns `result` dict
- All hook try/except blocks (transform_llm_output, post_llm_call) unchanged
- `_persist_session` internals unchanged
- No behavior change when persistence succeeds
- `except Exception` scope is consistent with the file's existing
  graceful-degradation pattern used in `transform_llm_output` and
  `post_llm_call` hooks