### PR TITLE
feat(backup): scheduled auto-backups with retention + hermes backup --list

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25887,6 +25887,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     PASTE_SWEEP_EVERY = 60   # ticks — once per hour
     CURATOR_EVERY = 60       # ticks — poll hourly (inner gate handles the real cadence)
     AUTO_ARCHIVE_EVERY = 60  # ticks — poll hourly (state_meta gate owns the real cadence)
+    AUTO_BACKUP_EVERY = 60   # ticks — poll hourly (inner gate handles the real cadence)
     MEMORY_TRIM_EVERY = 1    # shared helper cooldown bounds actual allocator work
 
     # Every platform media cache prunes on the same hourly cadence — one loop
@@ -26014,6 +26015,20 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
                     type(exc).__name__,
                     exc,
                 )
+
+        # Scheduled auto-backup (#12238) — piggy-back on the cron ticker so
+        # long-running gateways get periodic snapshots without a user-created
+        # cron job. maybe_create_auto_backup() is internally gated by the
+        # backup config block (off by default; cadence from backup.schedule),
+        # so AUTO_BACKUP_EVERY is just the poll rate.
+        if tick_count % AUTO_BACKUP_EVERY == 0:
+            try:
+                from hermes_cli.backup import maybe_create_auto_backup
+                created = maybe_create_auto_backup()
+                if created:
+                    logger.info("Auto-backup created: %s", created)
+            except Exception as e:
+                logger.debug("Auto-backup tick error: %s", e)
 
         stop_event.wait(timeout=interval)
     logger.info("Gateway housekeeping stopped")

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -19,7 +19,7 @@ import threading
 import time
 import zipfile
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -1825,6 +1825,270 @@ def create_pre_update_backup(
 
     _prune_pre_update_backups(backup_dir, keep=keep)
     return out_path
+
+
+# ---------------------------------------------------------------------------
+# Scheduled auto-backup (#12238)
+# ---------------------------------------------------------------------------
+#
+# Anacron-style periodic full backups, gated by the ``backup`` config block:
+#
+#   backup:
+#     enabled: true        # default false — opt-in
+#     schedule: daily      # hourly | daily | weekly | <hours as integer>
+#     keep_last: 7         # auto-backup archives to retain
+#     dir: ~/backups       # optional override (default: <HERMES_HOME>/backups)
+#
+# ``maybe_create_auto_backup()`` is cheap when nothing is due (one config read
+# + one small JSON stat) and is polled from the gateway cron ticker, mirroring
+# how agent/curator.py::maybe_run_curator gets its weekly cadence. The real
+# cadence lives here, in the ``last_run_at`` gate — the poll rate doesn't
+# matter. Archives are written with the same exclusion rules and SQLite
+# safe-copy as ``hermes backup`` and restore with ``hermes import``.
+
+_AUTO_BACKUP_PREFIX = "auto-"
+_AUTO_STATE_FILE = ".auto_backup_state.json"
+_AUTO_DEFAULT_KEEP = 7
+_AUTO_DEFAULT_SCHEDULE = "daily"
+_SCHEDULE_HOURS = {"hourly": 1.0, "daily": 24.0, "weekly": 168.0}
+
+
+def _get_backup_config() -> dict:
+    """Read the ``backup`` config block. Returns {} when unset/unreadable."""
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        block = config.get("backup", {})
+        return block if isinstance(block, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load backup config: %s", exc)
+        return {}
+
+
+def _auto_backup_enabled(cfg: dict) -> bool:
+    value = cfg.get("enabled", False)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _auto_backup_interval_hours(cfg: dict) -> float:
+    """Resolve ``backup.schedule`` to hours. Unknown values fall back to daily."""
+    schedule = cfg.get("schedule", _AUTO_DEFAULT_SCHEDULE)
+    if isinstance(schedule, (int, float)) and not isinstance(schedule, bool):
+        return max(float(schedule), 1.0)
+    if isinstance(schedule, str):
+        normalized = schedule.strip().lower()
+        if normalized in _SCHEDULE_HOURS:
+            return _SCHEDULE_HOURS[normalized]
+        try:
+            return max(float(normalized), 1.0)
+        except ValueError:
+            pass
+    logger.warning("backup.schedule %r not recognized; using daily", schedule)
+    return _SCHEDULE_HOURS[_AUTO_DEFAULT_SCHEDULE]
+
+
+def _auto_backup_keep(cfg: dict) -> int:
+    try:
+        # Floor 1 for the same reason as _prune_pre_update_backups: pruning
+        # the archive we just paid to write would be worse than no backup.
+        return max(int(cfg.get("keep_last", _AUTO_DEFAULT_KEEP)), 1)
+    except (ValueError, TypeError):
+        return _AUTO_DEFAULT_KEEP
+
+
+def _auto_backup_dir(cfg: dict, hermes_home: Optional[Path] = None) -> Path:
+    home = hermes_home or get_default_hermes_root()
+    raw = cfg.get("dir")
+    if raw:
+        try:
+            return Path(str(raw)).expanduser()
+        except (TypeError, ValueError):
+            logger.warning("backup.dir %r invalid; using default", raw)
+    return home / _PRE_UPDATE_BACKUPS_DIR
+
+
+def _load_auto_backup_state(state_path: Path) -> dict:
+    try:
+        with open(state_path, encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_auto_backup_state(state_path: Path, state: dict) -> None:
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = state_path.parent / f".{state_path.name}.tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2)
+        os.replace(tmp, state_path)
+    except OSError as exc:
+        logger.warning("Could not persist auto-backup state: %s", exc)
+
+
+def _prune_auto_backups(backup_dir: Path, keep: int) -> int:
+    """Remove oldest auto-backups beyond the keep limit.
+
+    Only touches ``auto-*.zip`` so manual/pre-update/pre-migration archives
+    in the same directory are never affected. Returns count deleted.
+    """
+    keep = max(keep, 1)
+    if not backup_dir.exists():
+        return 0
+
+    backups = sorted(
+        (p for p in backup_dir.iterdir()
+         if p.is_file() and p.name.startswith(_AUTO_BACKUP_PREFIX)
+         and p.suffix.lower() == ".zip"),
+        key=lambda p: p.name,
+        reverse=True,
+    )
+
+    deleted = 0
+    for p in backups[keep:]:
+        try:
+            p.unlink()
+            deleted += 1
+        except OSError as exc:
+            logger.warning("Failed to prune auto-backup %s: %s", p.name, exc)
+
+    return deleted
+
+
+def maybe_create_auto_backup(
+    hermes_home: Optional[Path] = None,
+    now: Optional[datetime] = None,
+) -> Optional[Path]:
+    """Create a scheduled full backup if one is due. Never raises.
+
+    Gated by ``backup.enabled`` (default false) and ``backup.schedule``.
+    Cheap when disabled or not yet due, so callers can poll freely — the
+    gateway cron ticker polls hourly. Returns the archive path when a backup
+    was created, ``None`` otherwise (disabled, not due, or failed).
+    """
+    cfg = _get_backup_config()
+    if not _auto_backup_enabled(cfg):
+        return None
+
+    hermes_root = hermes_home or get_default_hermes_root()
+    if not hermes_root.is_dir():
+        return None
+
+    backup_dir = _auto_backup_dir(cfg, hermes_root)
+    state_path = backup_dir / _AUTO_STATE_FILE
+    state = _load_auto_backup_state(state_path)
+
+    now = now or datetime.now(timezone.utc)
+    interval_hours = _auto_backup_interval_hours(cfg)
+
+    last_raw = state.get("last_run_at")
+    if last_raw:
+        try:
+            last = datetime.fromisoformat(last_raw)
+            if last.tzinfo is None:
+                last = last.replace(tzinfo=timezone.utc)
+            due_at = last + timedelta(hours=interval_hours)
+            if now < due_at:
+                return None
+        except ValueError:
+            logger.debug("Unparseable auto-backup last_run_at: %r", last_raw)
+
+    try:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning("Could not create auto-backup dir %s: %s", backup_dir, exc)
+        return None
+
+    stamp = now.astimezone().strftime("%Y-%m-%d-%H%M%S")
+    out_path = backup_dir / f"{_AUTO_BACKUP_PREFIX}{stamp}.zip"
+
+    result = _write_full_zip_backup(out_path, hermes_root)
+
+    # Stamp last_run_at even on failure so a persistently failing backup
+    # (e.g. read-only destination) retries once per interval instead of on
+    # every poll, hammering the disk with full-tree walks.
+    state.update({
+        "last_run_at": now.isoformat(),
+        "last_status": "ok" if result else "failed",
+        "last_path": str(result) if result else None,
+    })
+    _save_auto_backup_state(state_path, state)
+
+    if result is None:
+        logger.warning("Auto-backup failed (see prior warnings); next attempt "
+                       "in %.0fh", interval_hours)
+        return None
+
+    pruned = _prune_auto_backups(backup_dir, keep=_auto_backup_keep(cfg))
+    if pruned:
+        logger.info("Auto-backup pruning: removed %d old archive(s)", pruned)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Backup listing (hermes backup --list)
+# ---------------------------------------------------------------------------
+
+def list_backup_archives(hermes_home: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """List backup archives in the backups directory, newest first.
+
+    Covers auto, pre-update, pre-migration, and any manually placed ``.zip``
+    files. Includes the configured ``backup.dir`` when it differs from the
+    default location.
+    """
+    home = hermes_home or get_default_hermes_root()
+    cfg = _get_backup_config()
+    dirs = {home / _PRE_UPDATE_BACKUPS_DIR, _auto_backup_dir(cfg, home)}
+
+    archives = []
+    for backup_dir in dirs:
+        if not backup_dir.is_dir():
+            continue
+        for p in backup_dir.iterdir():
+            if not (p.is_file() and p.suffix.lower() == ".zip"):
+                continue
+            if p.name.startswith(_AUTO_BACKUP_PREFIX):
+                kind = "auto"
+            elif p.name.startswith(_PRE_UPDATE_PREFIX):
+                kind = "pre-update"
+            elif p.name.startswith(_PRE_MIGRATION_PREFIX):
+                kind = "pre-migration"
+            else:
+                kind = "manual"
+            try:
+                st = p.stat()
+            except OSError:
+                continue
+            archives.append({
+                "path": p,
+                "kind": kind,
+                "size": st.st_size,
+                "mtime": st.st_mtime,
+            })
+
+    archives.sort(key=lambda a: a["mtime"], reverse=True)
+    return archives
+
+
+def run_backup_list(args) -> None:
+    """CLI entry point for ``hermes backup --list``."""
+    archives = list_backup_archives()
+    if not archives:
+        print("No backup archives found.")
+        print("  Create one with: hermes backup")
+        print("  Or enable scheduled backups in config.yaml:")
+        print("    backup:\n      enabled: true\n      schedule: daily")
+        return
+
+    print(f"{len(archives)} backup archive(s):\n")
+    for a in archives:
+        when = datetime.fromtimestamp(a["mtime"]).strftime("%Y-%m-%d %H:%M")
+        print(f"  {when}  {_format_size(a['size']):>10}  "
+              f"[{a['kind']}]  {a['path']}")
+    print("\nRestore with: hermes import <path>")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4898,7 +4898,11 @@ def cmd_skin(args):
 
 def cmd_backup(args):
     """Back up Hermes home directory to a zip file."""
-    if getattr(args, "quick", False):
+    if getattr(args, "list_archives", False):
+        from hermes_cli.backup import run_backup_list
+
+        run_backup_list(args)
+    elif getattr(args, "quick", False):
         from hermes_cli.backup import run_quick_backup
 
         run_quick_backup(args)

--- a/hermes_cli/subcommands/backup.py
+++ b/hermes_cli/subcommands/backup.py
@@ -35,4 +35,10 @@ def build_backup_parser(subparsers, *, cmd_backup: Callable) -> None:
     backup_parser.add_argument(
         "-l", "--label", help="Label for the snapshot (only used with --quick)"
     )
+    backup_parser.add_argument(
+        "--list",
+        action="store_true",
+        dest="list_archives",
+        help="List existing backup archives (auto, pre-update, pre-migration, manual)",
+    )
     backup_parser.set_defaults(func=cmd_backup)

--- a/tests/hermes_cli/test_auto_backup.py
+++ b/tests/hermes_cli/test_auto_backup.py
@@ -1,0 +1,286 @@
+"""Tests for scheduled auto-backup and `hermes backup --list` (#12238).
+
+Covers:
+
+  1. maybe_create_auto_backup — disabled-by-default gate, schedule parsing,
+     interval gating via last_run_at, archive creation, keep_last pruning,
+     failure stamping (no retry-hammering), custom dir override.
+  2. list_backup_archives / run_backup_list — kind classification, ordering,
+     empty-state output.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from argparse import Namespace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import backup as B
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_home(tmp_path: Path) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model:\n  provider: openrouter\n")
+    (home / "skills").mkdir()
+    (home / "skills" / "SKILL.md").write_text("# skill\n")
+    return home
+
+
+def _set_cfg(monkeypatch, cfg: dict) -> None:
+    monkeypatch.setattr(B, "_get_backup_config", lambda: cfg)
+
+
+def _state(home: Path) -> dict:
+    path = home / "backups" / B._AUTO_STATE_FILE
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _write_state(home: Path, state: dict) -> None:
+    backups = home / "backups"
+    backups.mkdir(exist_ok=True)
+    (backups / B._AUTO_STATE_FILE).write_text(json.dumps(state))
+
+
+# ---------------------------------------------------------------------------
+# Config parsing
+# ---------------------------------------------------------------------------
+
+class TestScheduleParsing:
+    def test_named_schedules(self):
+        assert B._auto_backup_interval_hours({"schedule": "hourly"}) == 1.0
+        assert B._auto_backup_interval_hours({"schedule": "daily"}) == 24.0
+        assert B._auto_backup_interval_hours({"schedule": "weekly"}) == 168.0
+
+    def test_default_is_daily(self):
+        assert B._auto_backup_interval_hours({}) == 24.0
+
+    def test_numeric_hours(self):
+        assert B._auto_backup_interval_hours({"schedule": 6}) == 6.0
+        assert B._auto_backup_interval_hours({"schedule": "12"}) == 12.0
+
+    def test_numeric_floor_one_hour(self):
+        assert B._auto_backup_interval_hours({"schedule": 0}) == 1.0
+
+    def test_garbage_falls_back_to_daily(self):
+        assert B._auto_backup_interval_hours({"schedule": "fortnightly"}) == 24.0
+        assert B._auto_backup_interval_hours({"schedule": True}) == 24.0
+
+    def test_enabled_parsing(self):
+        assert B._auto_backup_enabled({}) is False
+        assert B._auto_backup_enabled({"enabled": True}) is True
+        assert B._auto_backup_enabled({"enabled": "true"}) is True
+        assert B._auto_backup_enabled({"enabled": "false"}) is False
+
+    def test_keep_floor_is_one(self):
+        assert B._auto_backup_keep({"keep_last": 0}) == 1
+        assert B._auto_backup_keep({"keep_last": "junk"}) == B._AUTO_DEFAULT_KEEP
+
+
+# ---------------------------------------------------------------------------
+# maybe_create_auto_backup
+# ---------------------------------------------------------------------------
+
+class TestMaybeCreateAutoBackup:
+    def test_disabled_by_default(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {})
+        assert B.maybe_create_auto_backup(hermes_home=home) is None
+        assert not (home / "backups").exists()
+
+    def test_first_run_creates_archive(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {"enabled": True, "schedule": "daily"})
+        result = B.maybe_create_auto_backup(hermes_home=home)
+        assert result is not None
+        assert result.name.startswith("auto-")
+        assert result.suffix == ".zip"
+        assert zipfile.is_zipfile(result)
+        with zipfile.ZipFile(result) as zf:
+            assert "config.yaml" in zf.namelist()
+        state = _state(home)
+        assert state["last_status"] == "ok"
+        assert state["last_run_at"]
+
+    def test_not_due_returns_none(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {"enabled": True, "schedule": "daily"})
+        now = datetime.now(timezone.utc)
+        _write_state(home, {"last_run_at": (now - timedelta(hours=2)).isoformat()})
+        assert B.maybe_create_auto_backup(hermes_home=home, now=now) is None
+
+    def test_due_after_interval(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {"enabled": True, "schedule": "daily"})
+        now = datetime.now(timezone.utc)
+        _write_state(home, {"last_run_at": (now - timedelta(hours=25)).isoformat()})
+        result = B.maybe_create_auto_backup(hermes_home=home, now=now)
+        assert result is not None
+
+    def test_hourly_schedule(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {"enabled": True, "schedule": "hourly"})
+        now = datetime.now(timezone.utc)
+        _write_state(home, {"last_run_at": (now - timedelta(minutes=61)).isoformat()})
+        assert B.maybe_create_auto_backup(hermes_home=home, now=now) is not None
+
+    def test_unparseable_last_run_recovers(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {"enabled": True})
+        _write_state(home, {"last_run_at": "not-a-date"})
+        assert B.maybe_create_auto_backup(hermes_home=home) is not None
+
+    def test_naive_last_run_treated_as_utc(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {"enabled": True, "schedule": "daily"})
+        now = datetime.now(timezone.utc)
+        naive = (now - timedelta(hours=2)).replace(tzinfo=None)
+        _write_state(home, {"last_run_at": naive.isoformat()})
+        assert B.maybe_create_auto_backup(hermes_home=home, now=now) is None
+
+    def test_prunes_beyond_keep_last(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {"enabled": True, "keep_last": 2})
+        backups = home / "backups"
+        backups.mkdir()
+        for i in range(3):
+            (backups / f"auto-2026-01-0{i + 1}-000000.zip").write_bytes(b"old")
+        # Manual + pre-update archives in the same dir must never be touched.
+        (backups / "pre-update-2026-01-01-000000.zip").write_bytes(b"keep")
+        (backups / "my-manual.zip").write_bytes(b"keep")
+
+        result = B.maybe_create_auto_backup(hermes_home=home)
+        assert result is not None
+        autos = sorted(p.name for p in backups.glob("auto-*.zip"))
+        assert len(autos) == 2
+        assert result.name in autos
+        assert (backups / "pre-update-2026-01-01-000000.zip").exists()
+        assert (backups / "my-manual.zip").exists()
+
+    def test_failure_stamps_state_no_hammering(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {"enabled": True, "schedule": "daily"})
+        monkeypatch.setattr(B, "_write_full_zip_backup", lambda out, root: None)
+        now = datetime.now(timezone.utc)
+        assert B.maybe_create_auto_backup(hermes_home=home, now=now) is None
+        state = _state(home)
+        assert state["last_status"] == "failed"
+        # The failure stamped last_run_at, so an immediate re-poll is gated.
+        monkeypatch.undo()
+        _set_cfg(monkeypatch, {"enabled": True, "schedule": "daily"})
+        assert B.maybe_create_auto_backup(hermes_home=home, now=now) is None
+
+    def test_custom_dir(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        dest = tmp_path / "external-drive"
+        _set_cfg(monkeypatch, {"enabled": True, "dir": str(dest)})
+        result = B.maybe_create_auto_backup(hermes_home=home)
+        assert result is not None
+        assert result.parent == dest
+
+    def test_missing_home_returns_none(self, tmp_path, monkeypatch):
+        _set_cfg(monkeypatch, {"enabled": True})
+        assert B.maybe_create_auto_backup(hermes_home=tmp_path / "nope") is None
+
+    def test_never_raises_on_config_error(self, tmp_path, monkeypatch):
+        """A broken config load degrades to 'disabled', not an exception."""
+        import hermes_cli.config as config_mod
+
+        home = _make_home(tmp_path)
+
+        def boom():
+            raise RuntimeError("config exploded")
+
+        monkeypatch.setattr(config_mod, "load_config", boom)
+        assert B._get_backup_config() == {}
+        assert B.maybe_create_auto_backup(hermes_home=home) is None
+
+    def test_archive_restores_with_import_validation(self, tmp_path, monkeypatch):
+        """The auto-backup zip passes the same validation `hermes import` uses."""
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {"enabled": True})
+        result = B.maybe_create_auto_backup(hermes_home=home)
+        with zipfile.ZipFile(result) as zf:
+            ok, reason = B._validate_backup_zip(zf)
+        assert ok, reason
+
+
+# ---------------------------------------------------------------------------
+# list_backup_archives / run_backup_list
+# ---------------------------------------------------------------------------
+
+class TestListArchives:
+    def test_classifies_kinds(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {})
+        backups = home / "backups"
+        backups.mkdir()
+        (backups / "auto-2026-01-01-000000.zip").write_bytes(b"a")
+        (backups / "pre-update-2026-01-02-000000.zip").write_bytes(b"b")
+        (backups / "pre-migration-2026-01-03-000000.zip").write_bytes(b"c")
+        (backups / "hand-rolled.zip").write_bytes(b"d")
+        (backups / "not-a-backup.txt").write_text("ignored")
+
+        archives = B.list_backup_archives(hermes_home=home)
+        kinds = {a["path"].name: a["kind"] for a in archives}
+        assert kinds == {
+            "auto-2026-01-01-000000.zip": "auto",
+            "pre-update-2026-01-02-000000.zip": "pre-update",
+            "pre-migration-2026-01-03-000000.zip": "pre-migration",
+            "hand-rolled.zip": "manual",
+        }
+
+    def test_includes_custom_dir(self, tmp_path, monkeypatch):
+        home = _make_home(tmp_path)
+        dest = tmp_path / "elsewhere"
+        dest.mkdir()
+        (dest / "auto-2026-01-01-000000.zip").write_bytes(b"a")
+        _set_cfg(monkeypatch, {"dir": str(dest)})
+        archives = B.list_backup_archives(hermes_home=home)
+        assert [a["path"].parent for a in archives] == [dest]
+
+    def test_sorted_newest_first(self, tmp_path, monkeypatch):
+        import os
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {})
+        backups = home / "backups"
+        backups.mkdir()
+        older = backups / "auto-2026-01-01-000000.zip"
+        newer = backups / "auto-2026-01-02-000000.zip"
+        older.write_bytes(b"a")
+        newer.write_bytes(b"b")
+        os.utime(older, (1000000000, 1000000000))
+        os.utime(newer, (2000000000, 2000000000))
+        archives = B.list_backup_archives(hermes_home=home)
+        assert [a["path"].name for a in archives] == [newer.name, older.name]
+
+    def test_run_backup_list_empty(self, tmp_path, monkeypatch, capsys):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {})
+        monkeypatch.setattr(B, "get_default_hermes_root", lambda: home)
+        B.run_backup_list(Namespace())
+        out = capsys.readouterr().out
+        assert "No backup archives found" in out
+
+    def test_run_backup_list_output(self, tmp_path, monkeypatch, capsys):
+        home = _make_home(tmp_path)
+        _set_cfg(monkeypatch, {})
+        monkeypatch.setattr(B, "get_default_hermes_root", lambda: home)
+        backups = home / "backups"
+        backups.mkdir()
+        (backups / "auto-2026-01-01-000000.zip").write_bytes(b"x" * 2048)
+        B.run_backup_list(Namespace())
+        out = capsys.readouterr().out
+        assert "auto-2026-01-01-000000.zip" in out
+        assert "[auto]" in out
+        assert "hermes import" in out

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -895,6 +895,7 @@ Create a zip archive of your Hermes configuration, skills, sessions, and data. T
 | `-o`, `--output <path>` | Output path for the zip file (default: `~/hermes-backup-<timestamp>.zip`). |
 | `-q`, `--quick` | Quick snapshot: only critical state files (config.yaml, state.db, .env, auth, cron jobs). Much faster than a full backup. |
 | `-l`, `--label <name>` | Label for the snapshot (only used with `--quick`). |
+| `--list` | List existing backup archives (scheduled auto-backups, pre-update, pre-migration, and manual zips) with date, size, and path. |
 
 The backup uses SQLite's `backup()` API for safe copying, so it works correctly even when Hermes is running (WAL-mode safe).
 
@@ -911,7 +912,31 @@ hermes backup                           # Full backup to ~/hermes-backup-*.zip
 hermes backup -o /tmp/hermes.zip        # Full backup to specific path
 hermes backup --quick                   # Quick state-only snapshot
 hermes backup --quick --label "pre-upgrade"  # Quick snapshot with label
+hermes backup --list                    # List existing backup archives
 ```
+
+### Scheduled auto-backups
+
+Hermes can take periodic full backups automatically — no cron job or OS
+scheduler required. Enable it in `~/.hermes/config.yaml`:
+
+```yaml
+backup:
+  enabled: true       # default: false (opt-in)
+  schedule: daily     # hourly | daily | weekly | <hours as integer>
+  keep_last: 7        # auto-backup archives to retain (oldest pruned first)
+  dir: ~/backups      # optional — default: ~/.hermes/backups/
+```
+
+While the gateway is running, it checks hourly whether a backup is due and
+writes `auto-<timestamp>.zip` to the backup directory, pruning the oldest
+archives beyond `keep_last`. Archives use the same exclusion rules and
+WAL-safe SQLite copies as `hermes backup`, and restore with `hermes import`.
+
+Point `dir` at a mounted external drive or a cloud-synced folder (Dropbox,
+Syncthing, etc.) to get off-machine copies. Note the schedule is driven by
+the gateway process — CLI-only installs without a running gateway should use
+`hermes backup` directly or a system scheduler.
 
 ## `hermes checkpoints`
 


### PR DESCRIPTION
## What does this PR do?

Implements the **automatic** half of #12238 (Built-in Automatic Backup & Version Control).

The backup building blocks already shipped — `hermes backup` (full zip), `hermes import` (restore), `--quick` state snapshots, pre-update archives — but getting *periodic* backups today still means hand-wiring a cron job, which is exactly the barrier the issue calls out for non-developer users. A single disk failure still wipes months of accumulated skills and memory for anyone who never set that up.

This adds an anacron-style scheduled backup, **off by default**, driven by the config block the issue proposed:

```yaml
backup:
  enabled: true       # default: false — opt-in
  schedule: daily     # hourly | daily | weekly | <hours as integer>
  keep_last: 7        # auto archives to retain (oldest pruned first)
  dir: ~/backups      # optional — default: ~/.hermes/backups/
```

`maybe_create_auto_backup()` mirrors the curator's gating pattern exactly: cheap when disabled or not due (one config read + one small JSON stat), with the real cadence enforced by a `last_run_at` stamp in `backups/.auto_backup_state.json`. The gateway cron ticker polls it hourly alongside the curator, so any long-running gateway gets periodic snapshots with **zero user setup** — no OS cron, identical behavior on Linux/macOS/Windows. Archives reuse `_write_full_zip_backup()` (same exclusions, same WAL-safe SQLite copies) and restore with the existing `hermes import`.

Design decisions worth flagging for review:

1. **Opt-in default.** Silent disk consumption felt like the wrong default to ship; flipping to default-on is a one-line change if you prefer.
2. **Failures stamp `last_run_at` too** — a persistently failing destination (e.g. unmounted drive) retries once per interval instead of walking the full tree on every hourly poll.
3. **Pruning only touches `auto-*.zip`** — pre-update/pre-migration/manual archives in the shared `backups/` directory are never deleted, and `keep_last` floors at 1 (same rationale as `_prune_pre_update_backups`).
4. **`backup.dir` instead of cloud destinations.** Pointing it at a mounted drive or a cloud-synced folder (Dropbox/Syncthing) covers the off-machine need without a provider integration; S3/R2 targets from the issue would be a separate, much larger PR.
5. **Scope:** this covers the issue's backup acceptance criteria (scheduled runs, `keep_last` pruning, restore, `--list`). Per-skill `history`/`rollback` and `memory diff` are a version-control subsystem, not a backup mechanism — better served by a dedicated follow-up PR if there's appetite.

---

I had Claude Fable 5 do this work - specifically to test it's capabilities when analyzing a request on Github, an unknown codebase (to me), and to use some of my Claude-time to give back to the open source community.  This may or may not be in the style or format that the maintainers wish - and it's my highest goal NOT to actually get involved in the software but rather push Fable itself to see how effective it can be with limited context - if the maintainers accept this PR, that's an implicit nod of approval to Fable as I gave it very very little to work from

---

## Related Issue

Partially addresses #12238 (backup acceptance criteria — see scope note above)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/backup.py` — new "Scheduled auto-backup" section: `maybe_create_auto_backup()`, `backup:` config parsing (`enabled`/`schedule`/`keep_last`/`dir`), `_prune_auto_backups()`, state persistence, plus `list_backup_archives()`/`run_backup_list()` for `--list`.
- `gateway/run.py` — `_start_cron_ticker()` polls `maybe_create_auto_backup()` hourly (`AUTO_BACKUP_EVERY`), same pattern and error-handling as the curator tick.
- `hermes_cli/subcommands/backup.py` + `hermes_cli/main.py` — `--list` flag and dispatch.
- `website/docs/reference/cli-commands.md` — `--list` option row and a "Scheduled auto-backups" section documenting the config block and the gateway-driven cadence.
- `tests/hermes_cli/test_auto_backup.py` — 25 new tests: schedule parsing (named/numeric/garbage), disabled-by-default, interval gating (incl. naive-timestamp and unparseable-state recovery), archive creation + `hermes import` validation compatibility, `keep_last` pruning that spares non-auto archives, failure stamping (no poll-hammering), custom dir, `--list` classification/ordering/output.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_auto_backup.py` — 25/25 pass.
2. Regression: `scripts/run_tests.sh tests/hermes_cli/test_backup.py tests/hermes_cli/test_subcommands_batch.py` — all pass except `TestProfileRestoration::test_import_creates_profile_wrappers`, which fails identically on unmodified `main` in my environment (the test's alias-collision check consults the real `PATH`, and my machine has an unrelated `~/.local/bin/researcher` binary). Pre-existing, unrelated to this change.
3. Manual smoke (isolated `HERMES_HOME`): set the config block with `schedule: hourly`, call `maybe_create_auto_backup()` → `auto-<timestamp>.zip` created with config/skills/.env inside; immediate second call returns `None` (gated); `hermes backup --list` shows the archive with kind/date/size.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suites via `scripts/run_tests.sh` (see How to Test, incl. one pre-existing environmental failure on main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (the example file doesn't carry optional feature blocks like `approvals:`/`updates:`; documented in `website/docs/reference/cli-commands.md`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python pathlib/zipfile/JSON; the in-gateway scheduler specifically avoids OS cron so Windows gets the same behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (CLI + gateway internals only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)