### PR TITLE
feat(kanban): add request_review transition (running → review)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3741,6 +3741,81 @@ def complete_task(
     return True
 
 
+def request_review(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Transition ``running -> review`` and release the claim lock.
+
+    This is the first-class way for a worker to signal that its
+    implementation is complete and the task needs review before being
+    marked done.  The current run is closed with outcome
+    ``review_requested`` and the task's claim lock is cleared so the
+    dispatcher can pick it up for a review run.
+
+    ``reason`` is recorded in the ``review_requested`` event payload
+    and surfaced to the reviewer.  ``expected_run_id`` gates the
+    transition on the current run matching (same CAS pattern as
+    :func:`complete_task`).
+
+    Returns ``True`` on success, ``False`` if the task is not in
+    ``running`` status or the run id doesn't match.
+    """
+    now = int(time.time())
+
+    with write_txn(conn):
+        # Verify the task is in 'running' status.
+        if expected_run_id is None:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'review',
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL
+                 WHERE id = ?
+                   AND status = 'running'
+                """,
+                (task_id,),
+            )
+        else:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'review',
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL
+                 WHERE id = ?
+                   AND status = 'running'
+                   AND current_run_id = ?
+                """,
+                (task_id, int(expected_run_id)),
+            )
+        if cur.rowcount != 1:
+            return False
+
+        # Close the current run with outcome 'review_requested'.
+        run_id = _end_run(
+            conn, task_id,
+            outcome="review_requested",
+            status="review_requested",
+            summary=reason,
+        )
+
+        # Record the event.
+        _append_event(
+            conn, task_id, "review_requested",
+            {"reason": reason} if reason else {},
+            run_id=run_id,
+        )
+
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Workspace / tmux cleanup
 # ---------------------------------------------------------------------------

--- a/tests/test_kanban_request_review.py
+++ b/tests/test_kanban_request_review.py
@@ -1,0 +1,125 @@
+"""Tests for kanban request_review transition (running → review)."""
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def kanban_conn(tmp_path):
+    """Create an in-memory kanban DB with the schema applied."""
+    db_path = tmp_path / "test_kanban.db"
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect(db_path)
+    yield conn
+    conn.close()
+
+
+def _make_running_task(conn, assignee="worker"):
+    """Create and claim a task so it's in 'running' status."""
+    from hermes_cli import kanban_db as kb
+
+    task_id = kb.create_task(conn, title="Test task", assignee=assignee)
+    # Promote to ready first
+    kb.promote_task(conn, task_id, actor="test", force=True)
+    # Claim it → running
+    task = kb.claim_task(conn, task_id, claimer="test-claim")
+    assert task is not None
+    return task_id
+
+
+class TestRequestReview:
+    """Test the request_review DB function."""
+
+    def test_running_to_review(self, kanban_conn):
+        """A running task should transition to review."""
+        from hermes_cli import kanban_db as kb
+
+        task_id = _make_running_task(kanban_conn)
+        ok = kb.request_review(kanban_conn, task_id, reason="Done, please review")
+        assert ok is True
+        task = kb.get_task(kanban_conn, task_id)
+        assert task.status == "review"
+
+    def test_releases_claim_lock(self, kanban_conn):
+        """request_review should release the claim lock."""
+        from hermes_cli import kanban_db as kb
+
+        task_id = _make_running_task(kanban_conn)
+        kb.request_review(kanban_conn, task_id)
+        task = kb.get_task(kanban_conn, task_id)
+        assert task.claim_lock is None
+        assert task.claim_expires is None
+        assert task.worker_pid is None
+
+    def test_non_running_fails(self, kanban_conn):
+        """A non-running task should fail the transition."""
+        from hermes_cli import kanban_db as kb
+
+        task_id = kb.create_task(conn=kanban_conn, title="Not running")
+        ok = kb.request_review(kanban_conn, task_id)
+        assert ok is False
+
+    def test_expected_run_id_mismatch(self, kanban_conn):
+        """Should fail when expected_run_id doesn't match."""
+        from hermes_cli import kanban_db as kb
+
+        task_id = _make_running_task(kanban_conn)
+        ok = kb.request_review(kanban_conn, task_id, expected_run_id=999)
+        assert ok is False
+        task = kb.get_task(kanban_conn, task_id)
+        assert task.status == "running"
+
+    def test_expected_run_id_match(self, kanban_conn):
+        """Should succeed when expected_run_id matches."""
+        from hermes_cli import kanban_db as kb
+
+        task_id = _make_running_task(kanban_conn)
+        task = kb.get_task(kanban_conn, task_id)
+        ok = kb.request_review(
+            kanban_conn, task_id,
+            expected_run_id=task.current_run_id,
+        )
+        assert ok is True
+        task2 = kb.get_task(kanban_conn, task_id)
+        assert task2.status == "review"
+
+    def test_records_event(self, kanban_conn):
+        """request_review should emit a review_requested event."""
+        from hermes_cli import kanban_db as kb
+
+        task_id = _make_running_task(kanban_conn)
+        kb.request_review(kanban_conn, task_id, reason="All tests pass")
+        events = kb.list_events(kanban_conn, task_id)
+        rr_events = [e for e in events if e.kind == "review_requested"]
+        assert len(rr_events) == 1
+        assert rr_events[0].payload["reason"] == "All tests pass"
+
+    def test_ends_run(self, kanban_conn):
+        """request_review should close the current run."""
+        from hermes_cli import kanban_db as kb
+
+        task_id = _make_running_task(kanban_conn)
+        kb.request_review(kanban_conn, task_id)
+        run = kb.latest_run(kanban_conn, task_id)
+        assert run is not None
+        assert run.outcome == "review_requested"
+
+    def test_nonexistent_task(self, kanban_conn):
+        """Should fail gracefully for a nonexistent task."""
+        from hermes_cli import kanban_db as kb
+
+        ok = kb.request_review(kanban_conn, "t_nonexistent")
+        assert ok is False
+
+    def test_review_task_cannot_request_review(self, kanban_conn):
+        """A task already in review should fail."""
+        from hermes_cli import kanban_db as kb
+
+        task_id = _make_running_task(kanban_conn)
+        kb.request_review(kanban_conn, task_id)
+        # Try again — should fail since it's now in review
+        ok = kb.request_review(kanban_conn, task_id)
+        assert ok is False


### PR DESCRIPTION
## Problem

Kanban already has a `review` task status and dispatcher support for claiming `review → running` tasks, but normal worker/CLI lifecycle paths do not expose a supported way to move a completed implementation task into that review state.

As a result, review workflows are forced into awkward workarounds: workers block with free-form `review-required:` reasons, orchestrators create separate reviewer child cards, or implementer cards are completed as "handoff only" even though the actual work is not accepted yet.

## Solution

Add a first-class `request_review()` function to `kanban_db.py` that provides the natural Kanban lifecycle transition:

```
todo → ready → running/implementation → review → running/reviewer → done
```

### What `request_review()` does:
- Transitions `running → review` status
- Releases the claim lock (`claim_lock`, `claim_expires`, `worker_pid` all set to NULL)
- Closes the current run with outcome `review_requested`
- Emits a `review_requested` event with optional `reason` for the reviewer
- Supports `expected_run_id` CAS for atomicity (same pattern as `complete_task`)

### API:
```python
def request_review(
    conn: sqlite3.Connection,
    task_id: str,
    *,
    reason: Optional[str] = None,
    expected_run_id: Optional[int] = None,
) -> bool:
```

## Testing

- 9 comprehensive tests covering:
  - `running → review` transition
  - Claim lock release
  - Non-running task rejection
  - `expected_run_id` CAS (match and mismatch)
  - Event recording with reason
  - Run closure with outcome
  - Nonexistent task handling
  - Already-in-review task rejection

All tests pass: `pytest tests/test_kanban_request_review.py -v`

## Related

Fixes #42896
