### PR TITLE
fix(tools): add .pdf to BINARY_EXTENSIONS to prevent read_file from dumping raw PDF bytes

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -8,6 +8,7 @@ Covers:
 import pytest
 from unittest.mock import MagicMock, patch
 
+from tools.binary_extensions import has_binary_extension, BINARY_EXTENSIONS
 from tools.file_operations import ShellFileOperations, _parse_search_context_line
 
 
@@ -74,6 +75,35 @@ class TestIsLikelyBinary:
         # Remaining 1000 chars: all NUL → ignored by [:1000] slice
         sample = "\x00" * 200 + "a" * 800 + "\x00" * 1000
         assert ops._is_likely_binary("file.xyz", content_sample=sample) is False
+
+
+class TestPdfBinaryDetection:
+    """PDF files must be detected as binary (issue #43059)."""
+
+    @pytest.fixture()
+    def ops(self):
+        return ShellFileOperations.__new__(ShellFileOperations)
+
+    def test_pdf_in_binary_extensions(self):
+        """PDF must be in the BINARY_EXTENSIONS set."""
+        assert ".pdf" in BINARY_EXTENSIONS
+
+    def test_has_binary_extension_pdf(self):
+        """has_binary_extension must return True for .pdf files."""
+        assert has_binary_extension("document.pdf") is True
+        assert has_binary_extension("report.PDF") is True
+        assert has_binary_extension("path/to/file.pdf") is True
+
+    def test_is_likely_binary_pdf_extension_gate(self, ops):
+        """_is_likely_binary should catch .pdf via extension before content analysis."""
+        # PDF first 1000 bytes are ASCII header — content sniff would NOT detect it.
+        # The extension gate must catch it instead.
+        pdf_header = "%PDF-1.4 1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj"
+        assert ops._is_likely_binary("document.pdf", content_sample=pdf_header) is True
+
+    def test_is_likely_binary_pdf_no_content_sample(self, ops):
+        """Even without content sample, .pdf extension alone should trigger binary."""
+        assert ops._is_likely_binary("report.pdf") is True
 
 
 # =========================================================================

--- a/tools/binary_extensions.py
+++ b/tools/binary_extensions.py
@@ -16,8 +16,8 @@ BINARY_EXTENSIONS = frozenset({
     # Executables/binaries
     ".exe", ".dll", ".so", ".dylib", ".bin", ".o", ".a", ".obj", ".lib",
     ".app", ".msi", ".deb", ".rpm",
-    # Documents (exclude .pdf — text-based, agents may want to inspect)
-    ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+    # Documents
+    ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
     ".odt", ".ods", ".odp",
     # Fonts
     ".ttf", ".otf", ".woff", ".woff2", ".eot",


### PR DESCRIPTION
## What does this PR do?

Adds `.pdf` to `BINARY_EXTENSIONS` so that `read_file` refuses PDF files with the standard binary-file error instead of dumping raw PDF bytes into the model context window.

## Related Issue

Fixes #43059

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/binary_extensions.py`: Added `.pdf` to `BINARY_EXTENSIONS` frozenset and removed the "text-based, agents may want to inspect" exclusion comment
- `tests/tools/test_file_operations_edge_cases.py`: Added `TestPdfBinaryDetection` class with 4 tests verifying PDF detection via extension check, `has_binary_extension()`, and `_is_likely_binary()` content-sniff bypass

## How to Test

1. Run `pytest tests/tools/test_file_operations_edge_cases.py::TestPdfBinaryDetection -v` — all 4 tests should pass
2. Run `pytest tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py -v` — all 116 tests should pass
3. Verify `python -c "from tools.binary_extensions import BINARY_EXTENSIONS; assert '.pdf' in BINARY_EXTENSIONS; print('OK')"` prints `OK`
4. In a running Hermes instance, attach a PDF and ask the agent to `read_file` it — should get the binary-file refusal message instead of raw bytes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `tools/binary_extensions.py` (consumers: `tools/file_operations.py:_is_likely_binary`, `tools/file_tools.py:has_binary_extension`)
- Blast radius: LOW — `.pdf` was deliberately excluded; adding it back restores the expected binary-gate behavior. No downstream logic depends on `.pdf` being readable via `read_file`.
- Related patterns: Content-sniff fallback in `_is_likely_binary` samples first 1000 bytes with >30% non-printable threshold — PDF ASCII headers always pass this check, making the extension gate the only reliable detector.
