### PR TITLE
fix(gateway): add video_generate to auto-append media allowlist

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -692,6 +692,7 @@ _AUTO_APPEND_MEDIA_TOOL_NAMES = {
     "text_to_speech",
     "text_to_speech_tool",
     "image_generate",
+    "video_generate",
 }
 
 # Tools in this set return their deliverable artifact as a JSON payload with a
@@ -700,6 +701,10 @@ _AUTO_APPEND_MEDIA_TOOL_NAMES = {
 # extracts the path from these fields so delivery is deterministic and does not
 # depend on the model restating the path in its final reply.
 _JSON_MEDIA_TOOL_PATH_FIELDS = ("host_image", "image", "agent_visible_image")
+# video_generate returns {"success": true, "video": "/abs/path.mp4"} when the
+# backend saves the video locally (remote CDN URLs are not matched by
+# _TOOL_MEDIA_RE and still require the model to restate them).
+_JSON_VIDEO_TOOL_PATH_FIELD = "video"
 
 
 # Extension-anchored MEDIA: matcher for tool results. Mirrors the dispatch-site
@@ -767,9 +772,9 @@ def _collect_auto_append_media_tags(
             continue
         content = str(msg.get("content") or "")
         tool_name = tool_name_by_call_id.get(call_id)
-        # JSON-payload tools (image_generate) return a local-file path in a
-        # known field rather than a MEDIA: tag. Extract it so delivery is
-        # deterministic even when the model omits the path from its reply.
+        # JSON-payload tools (image_generate, video_generate) return a local-file
+        # path in a known field rather than a MEDIA: tag. Extract it so delivery
+        # is deterministic even when the model omits the path from its reply.
         if tool_name == "image_generate" and "MEDIA:" not in content:
             try:
                 payload = json.loads(content)
@@ -783,6 +788,18 @@ def _collect_auto_append_media_tags(
                             and path not in history_media_paths):
                         media_tags.append(f"MEDIA:{path}")
                         break
+            continue
+        if tool_name == "video_generate" and "MEDIA:" not in content:
+            try:
+                payload = json.loads(content)
+            except Exception:
+                payload = None
+            if isinstance(payload, dict) and payload.get("success"):
+                path = payload.get(_JSON_VIDEO_TOOL_PATH_FIELD)
+                if (isinstance(path, str)
+                        and _TOOL_MEDIA_RE.fullmatch(f"MEDIA:{path}")
+                        and path not in history_media_paths):
+                    media_tags.append(f"MEDIA:{path}")
             continue
         if "MEDIA:" not in content:
             continue


### PR DESCRIPTION
## Problem

`video_generate` was missing from `_AUTO_APPEND_MEDIA_TOOL_NAMES` in
`gateway/run.py`. The gateway's auto-append logic is gated on that set,
so it never ran for video tool results — video files were only delivered
if the model happened to restate the path in its reply text.

`image_generate` received the symmetric fix in #42616, but `video_generate`
was not included in the same change. This PR closes the remaining gap.

## Root cause

`video_generate` returns `{"success": true, "video": "/abs/path.mp4", ...}`
with no `MEDIA:` tag in its result string. Without an entry in
`_AUTO_APPEND_MEDIA_TOOL_NAMES`, `_collect_auto_append_media_tags()` never
inspects the result, so no `MEDIA:` tag is appended to the gateway reply.

## Fix

1. Add `"video_generate"` to `_AUTO_APPEND_MEDIA_TOOL_NAMES`.
2. Add `_JSON_VIDEO_TOOL_PATH_FIELD = "video"` constant (mirrors
   `_JSON_MEDIA_TOOL_PATH_FIELDS` for the image path).
3. Add a handler block in `_collect_auto_append_media_tags()` that
   JSON-parses the tool result, reads the `"video"` field, and appends a
   `MEDIA:` tag when `_TOOL_MEDIA_RE.fullmatch()` passes (local-path guard).

Remote CDN URLs (HTTPS) are not matched by `_TOOL_MEDIA_RE` and still
require model restatement — identical scope to the `image_generate` fix.

Fixes #19105 (video path).

## Test plan

- [ ] Existing `tests/gateway/test_media_extraction.py` — 13/13 pass
- [ ] `video_generate` with a local-file backend: `MEDIA:/abs/path.mp4`
      appended automatically, video delivered without model restatement
- [ ] `video_generate` with a CDN-URL backend (FAL, xAI): no `MEDIA:` tag
      injected (URL not matched by `_TOOL_MEDIA_RE`), behaviour unchanged
- [ ] `image_generate` path unaffected — no regression