### PR TITLE
fix: preserve messages after compaction split, keep busy follow-ups as separate turns

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -549,6 +549,15 @@ def compress_context(
             agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
             # Reset flush cursor — new session starts with no messages written
             agent._last_flushed_db_idx = 0
+            # The next persistence pass still receives the pre-compression
+            # ``conversation_history`` argument from the caller (gateway/CLI
+            # built it before this session rotated).  That history belongs to
+            # the OLD session and is usually much longer than the compressed
+            # child transcript.  If _flush_messages_to_session_db uses it as
+            # an offset, messages[old_history_len:] is empty and the child
+            # session never gets the summary/tail that compression produced.
+            # Mark the next flush to ignore that stale offset once.
+            agent._ignore_conversation_history_on_next_flush = True
         except Exception as e:
             logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3666,12 +3666,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # successful steer — the text already landed inside the run and
         # must NOT also be replayed as a next-turn user message.
         if not steered:
-            merge_pending_message_event(
-                adapter._pending_messages,
-                session_key,
-                event,
-                merge_text=event.message_type == MessageType.TEXT,
-            )
+            self._queue_or_replace_pending_event(session_key, event)
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
@@ -8629,6 +8624,73 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # _flush_messages_to_session_db(), so skip the DB write here
             # to prevent the duplicate-write bug (#860 / #42039).
             agent_persisted = self._session_db is not None
+            session_db_for_agent_persistence = self._session_db
+
+            def _message_content_for_db_compare(content: Any) -> Any:
+                if isinstance(content, list):
+                    parts = []
+                    for part in content:
+                        if not isinstance(part, dict):
+                            continue
+                        if part.get("type") == "text":
+                            parts.append(str(part.get("text", "")))
+                        elif part.get("type") in {"image", "image_url", "input_image"}:
+                            parts.append("[screenshot]")
+                    return "\n".join(parts) if parts else None
+                return content
+
+            def _agent_db_has_current_turn(expected_entries: list[dict]) -> bool:
+                if not agent_persisted or session_db_for_agent_persistence is None or not expected_entries:
+                    return agent_persisted
+                try:
+                    persisted = session_db_for_agent_persistence.get_messages(session_entry.session_id)
+                except Exception as exc:
+                    logger.warning(
+                        "Session DB get_messages failed while verifying agent persistence "
+                        "for %s; gateway will mirror current turn to SQLite: %s",
+                        session_entry.session_id,
+                        exc,
+                    )
+                    return False
+                if not isinstance(persisted, list):
+                    # Unknown/mock DB implementation: preserve the historical
+                    # duplicate-write guard rather than guessing.
+                    return agent_persisted
+
+                expected = [
+                    {
+                        "role": entry.get("role"),
+                        "content": _message_content_for_db_compare(entry.get("content")),
+                    }
+                    for entry in expected_entries
+                    if entry.get("role") not in {"system", "session_meta"}
+                ]
+                if not expected:
+                    return agent_persisted
+                if len(persisted) < len(expected):
+                    logger.warning(
+                        "Agent session DB persistence missing current turn for %s "
+                        "(db_rows=%d expected_tail=%d); gateway will mirror to SQLite.",
+                        session_entry.session_id,
+                        len(persisted),
+                        len(expected),
+                    )
+                    return False
+
+                tail = persisted[-len(expected):]
+                tail_matches = all(
+                    stored.get("role") == want.get("role")
+                    and stored.get("content") == want.get("content")
+                    for stored, want in zip(tail, expected)
+                )
+                if not tail_matches:
+                    logger.warning(
+                        "Agent session DB persistence did not include current turn for %s; "
+                        "gateway will mirror to SQLite to prevent response loss.",
+                        session_entry.session_id,
+                    )
+                    return False
+                return True
 
             # Find only the NEW messages from this turn (skip history we loaded).
             # Use the filtered history length (history_offset) that was actually
@@ -8644,10 +8706,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
                 if event.message_id:
                     _user_entry["message_id"] = str(event.message_id)
+                _skip_db = _agent_db_has_current_turn([_user_entry])
                 self.session_store.append_to_transcript(
                     session_entry.session_id,
                     _user_entry,
-                    skip_db=agent_persisted,
+                    skip_db=_skip_db,
                 )
             else:
                 history_len = agent_result.get("history_offset", len(history))
@@ -8658,16 +8721,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
                     if event.message_id:
                         _user_entry["message_id"] = str(event.message_id)
+                    _entries = [_user_entry]
+                    if response:
+                        _entries.append({"role": "assistant", "content": response, "timestamp": ts})
+                    _skip_db = _agent_db_has_current_turn(_entries)
                     self.session_store.append_to_transcript(
                         session_entry.session_id,
                         _user_entry,
-                        skip_db=agent_persisted,
+                        skip_db=_skip_db,
                     )
-                    if response:
+                    if len(_entries) > 1:
                         self.session_store.append_to_transcript(
                             session_entry.session_id,
-                            {"role": "assistant", "content": response, "timestamp": ts},
-                            skip_db=agent_persisted,
+                            _entries[1],
+                            skip_db=_skip_db,
                         )
                 else:
                     # Attach the inbound platform message_id to the first user
@@ -8675,6 +8742,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # (e.g. Yuanbao QuoteContextMiddleware's transcript fallback)
                     # can find earlier @bot messages by their original message_id.
                     _user_msg_id_attached = False
+                    _entries = []
                     for msg in new_messages:
                         # Skip system messages (they're rebuilt each run)
                         if msg.get("role") == "system":
@@ -8689,9 +8757,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         ):
                             entry["message_id"] = str(event.message_id)
                             _user_msg_id_attached = True
+                        _entries.append(entry)
+
+                    _skip_db = _agent_db_has_current_turn(_entries)
+                    for entry in _entries:
                         self.session_store.append_to_transcript(
                             session_entry.session_id, entry,
-                            skip_db=agent_persisted,
+                            skip_db=_skip_db,
                         )
             
             # Token counts and model are now persisted by the agent directly.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1546,8 +1546,60 @@ class AIAgent:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:
                 self._ensure_db_session()
-            start_idx = len(conversation_history) if conversation_history else 0
-            flush_from = max(start_idx, self._last_flushed_db_idx)
+            ignore_stale_history_offset = bool(
+                getattr(self, "_ignore_conversation_history_on_next_flush", False)
+            )
+            start_idx = 0 if ignore_stale_history_offset else (
+                len(conversation_history) if conversation_history else 0
+            )
+            # ``_last_flushed_db_idx`` is an index into the message list from
+            # the previous persistence pass, so it is only safe while the next
+            # turn's ``conversation_history`` and the DB still have at least
+            # that many rows.  Gateway sessions reuse cached AIAgent instances,
+            # but rebuild ``messages`` from state.db on every turn.  If a
+            # busy/steer race (or operator rewind) means state.db is missing
+            # rows the user already saw, the cached cursor can point past the
+            # rebuilt list's new turn; ``max(start_idx, cursor)`` would then
+            # silently skip the current user+assistant pair.  Clamp only when
+            # the canonical DB row count proves the cursor is stale - repeated
+            # finalizer calls with the same message list must still dedupe.
+            last_flushed = self._last_flushed_db_idx
+            if not ignore_stale_history_offset and start_idx < last_flushed:
+                persisted_messages = None
+                try:
+                    persisted_messages = self._session_db.get_messages(self.session_id)
+                except Exception:
+                    persisted_messages = None
+                persisted_count = (
+                    len(persisted_messages) if isinstance(persisted_messages, list) else None
+                )
+                cursor_span = messages[start_idx:last_flushed]
+                tail_matches_cursor_span = False
+                if isinstance(persisted_messages, list) and cursor_span:
+                    persisted_tail = persisted_messages[-len(cursor_span):]
+                    tail_matches_cursor_span = len(persisted_tail) == len(cursor_span) and all(
+                        (stored.get("role") == expected.get("role")
+                         and stored.get("content") == expected.get("content"))
+                        for stored, expected in zip(persisted_tail, cursor_span)
+                    )
+                if (
+                    persisted_count is not None
+                    and persisted_count < last_flushed
+                    and not tail_matches_cursor_span
+                ):
+                    logger.warning(
+                        "Session DB flush cursor ahead of persisted history for %s "
+                        "(cursor=%d db_rows=%d history=%d messages=%d); clamping "
+                        "to history boundary to avoid dropping current-turn transcript rows.",
+                        self.session_id,
+                        last_flushed,
+                        persisted_count,
+                        start_idx,
+                        len(messages),
+                    )
+                    last_flushed = start_idx
+                    self._last_flushed_db_idx = start_idx
+            flush_from = max(start_idx, last_flushed)
             for msg in messages[flush_from:]:
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
@@ -1588,6 +1640,8 @@ class AIAgent:
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
                 )
             self._last_flushed_db_idx = len(messages)
+            if ignore_stale_history_offset:
+                self._ignore_conversation_history_on_next_flush = False
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)
 

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -217,6 +217,12 @@ async def test_normal_path_skip_db_when_agent_has_session_db(
     monkeypatch, tmp_path
 ):
     runner = _bootstrap(monkeypatch, tmp_path)
+    session_db = MagicMock()
+    session_db.get_messages.return_value = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "Hello!"},
+    ]
+    runner._session_db = session_db
 
     # Agent succeeds with new messages
     runner._run_agent = AsyncMock(
@@ -238,4 +244,78 @@ async def test_normal_path_skip_db_when_agent_has_session_db(
 
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
+    )
+
+
+@pytest.mark.asyncio
+async def test_normal_path_mirrors_to_db_when_agent_persistence_missing_current_turn(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    session_db = MagicMock()
+    session_db.get_messages.return_value = [
+        {"role": "user", "content": "older question"},
+        {"role": "assistant", "content": "older answer"},
+    ]
+    runner._session_db = session_db
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Hello!",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "Hello!"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    _assert_user_call_has_skip_db(
+        runner.session_store.append_to_transcript.call_args_list, False
+    )
+    assistant_calls = [
+        call
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2
+        and isinstance(call.args[1], dict)
+        and call.args[1].get("role") == "assistant"
+    ]
+    assert assistant_calls
+    assert all(call.kwargs.get("skip_db", False) is False for call in assistant_calls)
+
+
+@pytest.mark.asyncio
+async def test_not_new_messages_mirrors_to_db_when_agent_fallback_tail_missing(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    session_db = MagicMock()
+    session_db.get_messages.return_value = [
+        {"role": "user", "content": "older question"},
+        {"role": "assistant", "content": "older answer"},
+    ]
+    runner._session_db = session_db
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Hello!",
+            "messages": [],
+            "tools": [],
+            "history_offset": 1,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    _assert_user_call_has_skip_db(
+        runner.session_store.append_to_transcript.call_args_list, False
     )

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -312,13 +312,12 @@ class TestBusySessionAck:
         agent.steer = MagicMock(return_value=False)  # rejected
         runner._running_agents[sk] = agent
 
-        with patch("gateway.run.merge_pending_message_event") as mock_merge:
-            await runner._handle_active_session_busy_message(event, sk)
+        await runner._handle_active_session_busy_message(event, sk)
 
         agent.steer.assert_called_once()
         agent.interrupt.assert_not_called()
-        # Fell back to queue semantics: event was merged into pending messages
-        mock_merge.assert_called_once()
+        # Fell back to queue semantics: event was queued for the next turn.
+        assert adapter._pending_messages[sk] is event
 
         # Ack uses queue-mode wording (not steer, not interrupt)
         call_kwargs = adapter._send_with_retry.call_args
@@ -340,11 +339,10 @@ class TestBusySessionAck:
         # Agent is still being set up — sentinel in place
         runner._running_agents[sk] = sentinel
 
-        with patch("gateway.run.merge_pending_message_event") as mock_merge:
-            await runner._handle_active_session_busy_message(event, sk)
+        await runner._handle_active_session_busy_message(event, sk)
 
         # Event was queued instead of steered
-        mock_merge.assert_called_once()
+        assert adapter._pending_messages[sk] is event
 
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
@@ -391,6 +389,49 @@ class TestBusySessionAck:
         assert adapter._send_with_retry.call_count == 1  # still 1, no new ack
 
         # But interrupt should still be called for both (since we are in interrupt mode)
+        assert agent.interrupt.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_interrupt_mode_preserves_rapid_text_followups_as_fifo(self):
+        """Busy interrupt text follow-ups must remain distinct turns.
+
+        Telegram users see each follow-up as a separate message. Collapsing
+        them into one newline-joined pending event makes post-compaction
+        history look like the agent received a single block with no individual
+        message boundaries.
+        """
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        first = _make_event(text="first")
+        second = MessageEvent(
+            text="second",
+            message_type=MessageType.TEXT,
+            source=first.source,
+            message_id="msg2",
+        )
+        sk = build_session_key(first.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 5,
+            "max_iterations": 60,
+            "current_tool": None,
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "api_call",
+            "seconds_since_activity": 0.5,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 60
+        runner.adapters[first.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(first, sk)
+        await runner._handle_active_session_busy_message(second, sk)
+
+        assert adapter._pending_messages[sk].text == "first"
+        assert [event.text for event in runner._queued_events[sk]] == ["second"]
+        assert "\nsecond" not in adapter._pending_messages[sk].text
         assert agent.interrupt.call_count == 2
 
     @pytest.mark.asyncio

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -100,8 +100,14 @@ class TestFlushAfterCompression:
                 f"Compression persistence bug: messages not written to SQLite."
             )
 
-    def test_flush_with_stale_history_loses_messages(self):
-        """Demonstrates the bug condition: stale conversation_history causes data loss."""
+    def test_flush_with_stale_history_after_compression_preserves_messages(self):
+        """A compression split invalidates the caller's old conversation_history offset.
+
+        The gateway passes the pre-compression history into run_conversation().
+        After _compress_context() rotates to a child session, that history
+        belongs to the parent.  The next DB flush must ignore it once so the
+        child receives the compressed summary and protected tail.
+        """
         from hermes_state import SessionDB
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -114,23 +120,74 @@ class TestFlushAfterCompression:
             agent.session_id = "new-session"
             db.create_session(session_id="new-session", source="test")
             agent._last_flushed_db_idx = 0
+            agent._ignore_conversation_history_on_next_flush = True
 
             compressed = [
                 {"role": "user", "content": "summary"},
                 {"role": "assistant", "content": "continuing..."},
             ]
 
-            # Bug: passing a conversation_history longer than compressed messages
+            # Stale pre-compression history is longer than the child transcript.
             stale_history = [{"role": "user", "content": f"msg{i}"} for i in range(100)]
             agent._flush_messages_to_session_db(compressed, stale_history)
 
             rows = db.get_messages("new-session")
-            # With the stale history, flush_from = max(100, 0) = 100
-            # But compressed only has 2 entries → messages[100:] = empty
-            assert len(rows) == 0, (
-                "Expected 0 messages with stale conversation_history "
-                "(this test verifies the bug condition exists)"
+            assert len(rows) == 2, (
+                "Expected compressed child messages to be flushed even when "
+                "the caller supplied stale parent conversation_history."
             )
+            assert [row["content"] for row in rows] == ["summary", "continuing..."]
+            assert agent._ignore_conversation_history_on_next_flush is False
+
+    def test_stale_flush_cursor_is_clamped_after_external_transcript_rewrite(self):
+        """Cached agents must not skip turns after another path rewrites history.
+
+        Manual /compress, /retry, /undo, and hygiene compression can replace the
+        transcript outside the cached AIAgent instance.  If the old in-memory
+        _last_flushed_db_idx is larger than the freshly loaded message list,
+        max(start_idx, _last_flushed_db_idx) skips the current user turn and the
+        later assistant reply.  The gateway then sets skip_db=True because a
+        SessionDB exists, so the delivered assistant reply vanishes from the next
+        turn's conversation_history.
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = self._make_agent(db)
+            db.create_session(session_id="rewritten-session", source="test")
+            agent.session_id = "rewritten-session"
+
+            rewritten_history = [
+                {"role": "user", "content": "compacted summary"},
+                {"role": "assistant", "content": "tail reply"},
+            ]
+            db.replace_messages("rewritten-session", rewritten_history)
+
+            # Stale cursor from the pre-rewrite, much longer transcript.
+            agent._last_flushed_db_idx = 100
+
+            # Early turn-start persistence: history + the new user message.
+            early_messages = rewritten_history + [
+                {"role": "user", "content": "follow-up after rewrite"},
+            ]
+            agent._flush_messages_to_session_db(early_messages, rewritten_history)
+
+            # Final turn persistence: same history + user + delivered assistant.
+            final_messages = early_messages + [
+                {"role": "assistant", "content": "assistant reply after rewrite"},
+            ]
+            agent._flush_messages_to_session_db(final_messages, rewritten_history)
+
+            rows = db.get_messages("rewritten-session")
+            assert [row["content"] for row in rows] == [
+                "compacted summary",
+                "tail reply",
+                "follow-up after rewrite",
+                "assistant reply after rewrite",
+            ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_session_db_flush_cursor.py
+++ b/tests/run_agent/test_session_db_flush_cursor.py
@@ -1,0 +1,78 @@
+from run_agent import AIAgent
+
+
+class RecordingSessionDB:
+    def __init__(self, existing_rows=0):
+        self.appended = []
+        self.existing_rows = existing_rows
+
+    def append_message(self, **kwargs):
+        self.appended.append(kwargs)
+
+    def get_messages(self, session_id):
+        return [{} for _ in range(self.existing_rows + len(self.appended))]
+
+
+def _agent_with_db(last_flushed_idx, existing_rows=0):
+    agent = AIAgent.__new__(AIAgent)
+    agent._session_db = RecordingSessionDB(existing_rows=existing_rows)
+    agent._session_db_created = True
+    agent._last_flushed_db_idx = last_flushed_idx
+    agent._ignore_conversation_history_on_next_flush = False
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent.session_id = "session-1"
+    return agent
+
+
+def test_flush_clamps_stale_cursor_when_gateway_history_is_shorter():
+    """A cached gateway agent may carry a DB cursor from a longer in-memory
+    transcript than the conversation_history reloaded from state.db.
+
+    That happens after busy/steer races where the user saw the previous
+    assistant response but the next turn's DB history is missing it.  The stale
+    cursor must not skip the current turn's user+assistant messages; otherwise
+    the gateway also skips its fallback DB write and the assistant response is
+    lost again.
+    """
+    agent = _agent_with_db(last_flushed_idx=10, existing_rows=8)
+    history = [
+        {"role": "user", "content": f"old user {idx}"}
+        if idx % 2 == 0
+        else {"role": "assistant", "content": f"old assistant {idx}"}
+        for idx in range(8)
+    ]
+    messages = [
+        *history,
+        {"role": "user", "content": "current question"},
+        {"role": "assistant", "content": "current answer"},
+    ]
+
+    agent._flush_messages_to_session_db(messages, conversation_history=history)
+
+    assert [row["role"] for row in agent._session_db.appended] == ["user", "assistant"]
+    assert [row["content"] for row in agent._session_db.appended] == [
+        "current question",
+        "current answer",
+    ]
+    assert agent._last_flushed_db_idx == len(messages)
+
+
+def test_flush_keeps_cursor_when_history_matches_cached_prefix():
+    agent = _agent_with_db(last_flushed_idx=2)
+    history = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    messages = [
+        *history,
+        {"role": "user", "content": "current question"},
+        {"role": "assistant", "content": "current answer"},
+    ]
+
+    agent._flush_messages_to_session_db(messages, conversation_history=history)
+
+    assert [row["content"] for row in agent._session_db.appended] == [
+        "current question",
+        "current answer",
+    ]


### PR DESCRIPTION
## Summary

Fixes #43066 — assistant messages lost after context compaction, and user follow-ups merged into single turns.

## Root Cause

Three related persistence failures:

1. **Stale offset after compression split** — compress_context() rotates to a child session but _flush_messages_to_session_db still computes start_idx from the pre-compression history length, making messages[start_idx:] empty.

2. **Stale flush cursor on cached gateway agents** — A long-lived gateway AIAgent retains _last_flushed_db_idx from a longer transcript. After compaction shortens the DB, the cursor exceeds actual row count and subsequent flushes skip all new messages.

3. **No gateway-side verification** — When agent_persisted=True, the gateway skips its own DB writes. If the agent flush silently fails, assistant messages are delivered but never persisted.

## Fix

1. compress_context() sets a one-shot flag; flush consumes it to write from index 0.
2. Flush cursor clamped when exceeding DB row count (duplicate-write protection preserved).
3. Gateway verifies DB tail after each turn; mirrors current turn if absent.
4. Busy-mode text follow-ups route through FIFO queue instead of newline-merge.

## Tests

- test_compression_persistence.py — child session persistence
- test_session_db_flush_cursor.py — stale cursor clamp
- test_42039_duplicate_user_message.py — gateway fallback
- test_busy_session_ack.py — FIFO text follow-ups

All 183 targeted tests pass.