### PR TITLE
fix(tools): increase clarify MAX_CHOICES from 4 to 6

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -189,6 +189,6 @@ class TestClarifySchema:
         choices_spec = CLARIFY_SCHEMA["parameters"]["properties"]["choices"]
         assert choices_spec.get("maxItems") == MAX_CHOICES
 
-    def test_max_choices_is_four(self):
-        """MAX_CHOICES constant should be 4."""
-        assert MAX_CHOICES == 4
+    def test_max_choices_is_six(self):
+        """MAX_CHOICES constant should be 6."""
+        assert MAX_CHOICES == 6

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -17,7 +17,7 @@ from typing import List, Optional, Callable
 
 # Maximum number of predefined choices the agent can offer.
 # A 5th "Other (type your answer)" option is always appended by the UI.
-MAX_CHOICES = 4
+MAX_CHOICES = 6
 
 
 def clarify_tool(


### PR DESCRIPTION
## What does this PR do?

Increases `MAX_CHOICES` in the clarify tool from 4 to 6, allowing skills with 5-6 sub-operations to present all their options without dropping choices.

## Related Issue

Fixes #43056

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/clarify_tool.py`: Increased `MAX_CHOICES` from 4 to 6
- `tests/tools/test_clarify_tool.py`: Updated `test_max_choices_is_six` assertion from 4 to 6

## How to Test

1. Run `pytest tests/tools/test_clarify_tool.py -v` — all 20 tests should pass
2. Verify `python -c "from tools.clarify_tool import MAX_CHOICES; assert MAX_CHOICES == 6; print('OK')"` prints `OK`
3. In a running Hermes instance, invoke a skill with 6 choices — all 6 should be presented to the user

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `tools/clarify_tool.py` (consumers: CLI clarify handler, gateway clarify handler, tool schema)
- Blast radius: LOW — `MAX_CHOICES` is only referenced within `clarify_tool.py` (validation + schema). Increasing it allows more choices through; no downstream logic depends on the old value of 4.
- Related patterns: The schema's `maxItems` field is derived from `MAX_CHOICES`, so the OpenAI function-calling schema automatically reflects the new limit.
