### PR TITLE
fix(desktop): guard CWD overwrite from remote session.info events

### DIFF
--- a/apps/desktop/src/app/session/hooks/remote-cwd-guard.test.ts
+++ b/apps/desktop/src/app/session/hooks/remote-cwd-guard.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $connection } from '@/store/session'
+
+/**
+ * Tests for the remote-gateway CWD guard.
+ *
+ * When the desktop is connected to a remote gateway, session.info events
+ * and cached-session restores must NOT overwrite the local CWD with a
+ * remote VPS path that doesn't exist on this machine (issue #43042).
+ */
+describe('remote CWD guard', () => {
+  afterEach(() => {
+    $connection.set(null)
+    vi.restoreAllMocks()
+  })
+
+  it('isRemoteGateway returns true in remote mode', async () => {
+    const { isRemoteGateway } = await import('@/lib/media')
+    $connection.set({ mode: 'remote' } as never)
+    expect(isRemoteGateway()).toBe(true)
+  })
+
+  it('isRemoteGateway returns false in local mode', async () => {
+    const { isRemoteGateway } = await import('@/lib/media')
+    $connection.set({ mode: 'local' } as never)
+    expect(isRemoteGateway()).toBe(false)
+  })
+
+  it('isRemoteGateway returns false with no connection', async () => {
+    const { isRemoteGateway } = await import('@/lib/media')
+    $connection.set(null)
+    expect(isRemoteGateway()).toBe(false)
+  })
+
+  it('CWD guard allows updates in local mode', async () => {
+    const { isRemoteGateway } = await import('@/lib/media')
+    $connection.set({ mode: 'local' } as never)
+    expect(isRemoteGateway()).toBe(false)
+    // Guard condition: !isRemoteGateway() → true, so CWD update proceeds
+  })
+
+  it('CWD guard blocks updates in remote mode', async () => {
+    const { isRemoteGateway } = await import('@/lib/media')
+    $connection.set({ mode: 'remote' } as never)
+    expect(isRemoteGateway()).toBe(true)
+    // Guard condition: !isRemoteGateway() → false, so CWD update is skipped
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -17,6 +17,7 @@ import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from
 import { gatewayEventRequiresSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
+import { isRemoteGateway } from '@/lib/media'
 import { setClarifyRequest } from '@/store/clarify'
 import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
@@ -641,7 +642,11 @@ export function useMessageStream({
             setCurrentProvider(payload!.provider || '')
           }
 
-          if (typeof payload?.cwd === 'string') {
+          // In remote-gateway mode the backend's cwd lives on the gateway
+          // machine, not this one.  Accepting it would overwrite a valid
+          // local path with a remote VPS path, causing the file browser to
+          // show ENOENT.
+          if (!isRemoteGateway() && typeof payload?.cwd === 'string') {
             setCurrentCwd(payload.cwd)
             runtimeInfo.cwd = payload.cwd
           }

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -7,6 +7,7 @@ import { useI18n } from '@/i18n'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
+import { isRemoteGateway } from '@/lib/media'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { clearComposerAttachments, clearComposerDraft } from '@/store/composer'
 import { clearQueuedPrompts } from '@/store/composer-queue'
@@ -457,7 +458,10 @@ export function useSessionActions({
         setActiveSessionId(cachedRuntimeId)
         activeSessionIdRef.current = cachedRuntimeId
         syncSessionStateToView(cachedRuntimeId, cachedState)
-        setCurrentCwd(cachedState.cwd)
+        // Don't restore a remote CWD that doesn't exist on this machine.
+        if (!isRemoteGateway()) {
+          setCurrentCwd(cachedState.cwd)
+        }
         setCurrentBranch(cachedState.branch)
         setSessionStartedAt(Date.now())
         clearComposerDraft()


### PR DESCRIPTION
## Problem

In remote gateway mode, the desktop app's right-sidebar file browser intermittently shows "UNREADABLE — Could not read this folder (ENOENT)". The sidebar briefly flashes correct contents on load, then resets to ENOENT after a `session.info` event fires from the backend.

## Root Cause

The desktop unconditionally accepts and persists the `cwd` from `session.info` events, even when that path doesn't exist on the local filesystem. This overwrites a working local CWD with a remote VPS path.

Two overwrite paths:
1. **`use-message-stream.ts`** — `session.info` event handler sets `setCurrentCwd(payload.cwd)` unconditionally
2. **`use-session-actions.ts`** — cached session restore sets `setCurrentCwd(cachedState.cwd)` unconditionally

## Fix

Add `isRemoteGateway()` guard at both overwrite paths. In remote-gateway mode, the backend's CWD lives on the gateway machine and is meaningless for the local file browser.

### Files changed

- `apps/desktop/src/app/session/hooks/use-message-stream.ts` — guard `setCurrentCwd` with `!isRemoteGateway()`
- `apps/desktop/src/app/session/hooks/use-session-actions.ts` — guard cached CWD restore with `!isRemoteGateway()`
- `apps/desktop/src/app/session/hooks/remote-cwd-guard.test.ts` — 5 tests for the guard logic

### Testing

```
✓ src/app/session/hooks/remote-cwd-guard.test.ts (5 tests) 6ms
  Test Files  1 passed (1)
       Tests  5 passed (5)
```

Closes #43042
