### PR TITLE
fix(matrix): send gateway status/progress messages as m.notice

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1084,9 +1084,15 @@ class MatrixAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, MAX_MESSAGE_LENGTH)
 
+        # Allow callers to override msgtype via metadata (e.g. m.notice
+        # for gateway status messages so receiving bots don't respond).
+        _notice_msgtype = (metadata or {}).get("matrix_msgtype")
+
         last_event_id = None
         for i, chunk in enumerate(chunks):
-            msg_content = self._build_text_message_content(chunk)
+            msg_content = self._build_text_message_content(
+                chunk, msgtype=_notice_msgtype or "m.text",
+            )
 
             # Reply-to support.
             if reply_to:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3589,6 +3589,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else:
                 message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
 
+            _status_meta = {**(thread_meta or {}), "matrix_msgtype": "m.notice"}
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
                 content=message,
@@ -3599,7 +3600,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and event.source.thread_id
                     else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
                 ),
-                metadata=thread_meta,
+                metadata=_status_meta,
             )
             return True
 
@@ -3789,6 +3790,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         reply_anchor = self._reply_anchor_for_event(event)
         thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+        _status_meta = {**(thread_meta or {}), "matrix_msgtype": "m.notice"}
         try:
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
@@ -3800,7 +3802,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and event.source.thread_id
                     else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
                 ),
-                metadata=thread_meta,
+                metadata=_status_meta,
             )
         except Exception as e:
             logger.debug("Failed to send busy-ack: %s", e)
@@ -13113,7 +13115,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._thread_metadata_for_source(source, event_message_id)
             if _progress_thread_id == source.thread_id
             else {"thread_id": _progress_thread_id}
-        ) if _progress_thread_id else None
+        ) if _progress_thread_id else {}
+        # Mark progress messages as m.notice for Matrix to prevent
+        # bot-to-bot ping-pong loops (#43047).
+        if _progress_metadata is not None:
+            _progress_metadata["matrix_msgtype"] = "m.notice"
+        else:
+            _progress_metadata = {"matrix_msgtype": "m.notice"}
         _progress_reply_to = (
             event_message_id
             if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2859,3 +2859,90 @@ class TestCreateMatrixSession:
                     assert session.connector is fake_connector
                 finally:
                     await session.close()
+
+
+# ---------------------------------------------------------------------------
+# matrix_msgtype metadata: m.notice for status/progress messages (#43047)
+# ---------------------------------------------------------------------------
+
+class TestMatrixNoticeMsgtype:
+    """Verify that matrix_msgtype metadata overrides msgtype in send()."""
+
+    @pytest.mark.asyncio
+    async def test_send_with_notice_metadata_uses_m_notice(self):
+        """When metadata contains matrix_msgtype='m.notice', send() should
+        build the message content with msgtype=m.notice."""
+        adapter = _make_adapter()
+        fake_client = MagicMock()
+        fake_client.send_message_event = AsyncMock(return_value="$event_notice")
+        adapter._client = fake_client
+
+        result = await adapter.send(
+            "!room:example.org",
+            "⚡ Interrupting current task",
+            metadata={"matrix_msgtype": "m.notice"},
+        )
+
+        assert result.success is True
+        # Verify the content dict passed to send_message_event uses m.notice
+        call_args = fake_client.send_message_event.call_args
+        content = call_args[0][2]  # third positional arg is the content dict
+        assert content["msgtype"] == "m.notice"
+        assert content["body"] == "⚡ Interrupting current task"
+
+    @pytest.mark.asyncio
+    async def test_send_without_notice_metadata_uses_m_text(self):
+        """Without matrix_msgtype metadata, send() defaults to m.text."""
+        adapter = _make_adapter()
+        fake_client = MagicMock()
+        fake_client.send_message_event = AsyncMock(return_value="$event_text")
+        adapter._client = fake_client
+
+        result = await adapter.send("!room:example.org", "hello")
+
+        assert result.success is True
+        call_args = fake_client.send_message_event.call_args
+        content = call_args[0][2]
+        assert content["msgtype"] == "m.text"
+
+    @pytest.mark.asyncio
+    async def test_send_with_empty_metadata_uses_m_text(self):
+        """Empty metadata dict should not change the default m.text."""
+        adapter = _make_adapter()
+        fake_client = MagicMock()
+        fake_client.send_message_event = AsyncMock(return_value="$event_text")
+        adapter._client = fake_client
+
+        result = await adapter.send(
+            "!room:example.org", "hello", metadata={},
+        )
+
+        assert result.success is True
+        call_args = fake_client.send_message_event.call_args
+        content = call_args[0][2]
+        assert content["msgtype"] == "m.text"
+
+    @pytest.mark.asyncio
+    async def test_send_notice_preserves_thread_metadata(self):
+        """matrix_msgtype should coexist with thread_id in metadata."""
+        adapter = _make_adapter()
+        fake_client = MagicMock()
+        fake_client.send_message_event = AsyncMock(return_value="$event_t")
+        adapter._client = fake_client
+
+        result = await adapter.send(
+            "!room:example.org",
+            "⏳ Working...",
+            metadata={
+                "thread_id": "$thread_event",
+                "matrix_msgtype": "m.notice",
+            },
+        )
+
+        assert result.success is True
+        call_args = fake_client.send_message_event.call_args
+        content = call_args[0][2]
+        assert content["msgtype"] == "m.notice"
+        relates = content.get("m.relates_to", {})
+        assert relates.get("rel_type") == "m.thread"
+        assert relates.get("event_id") == "$thread_event"

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -285,11 +285,11 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
             "chat_id": "-1001",
             "content": '💻 terminal: "pwd"',
             "reply_to": None,
-            "metadata": {"thread_id": "17585"},
+            "metadata": {"thread_id": "17585", "matrix_msgtype": "m.notice"},
         }
     ]
     assert adapter.edits
-    assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.typing)
+    assert all(call["metadata"] == {"thread_id": "17585", "matrix_msgtype": "m.notice"} for call in adapter.typing)
 
 
 @pytest.mark.asyncio
@@ -327,7 +327,7 @@ async def test_run_agent_progress_edits_keep_originating_topic_metadata(monkeypa
 
     assert result["final_response"] == "done"
     assert adapter.edits
-    assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.edits)
+    assert all(call["metadata"] == {"thread_id": "17585", "matrix_msgtype": "m.notice"} for call in adapter.edits)
 
 
 @pytest.mark.asyncio
@@ -368,8 +368,8 @@ async def test_run_agent_progress_does_not_use_event_message_id_for_telegram_dm(
 
     assert result["final_response"] == "done"
     assert adapter.sent
-    assert adapter.sent[0]["metadata"] is None
-    assert all(call["metadata"] is None for call in adapter.typing)
+    assert adapter.sent[0]["metadata"] == {"matrix_msgtype": "m.notice"}
+    assert all(call["metadata"] == {"matrix_msgtype": "m.notice"} for call in adapter.typing)
 
 
 @pytest.mark.asyncio
@@ -418,8 +418,8 @@ async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch
 
     assert result["final_response"] == "done"
     assert adapter.sent
-    assert adapter.sent[0]["metadata"] == {"thread_id": "1234567890.000001"}
-    assert all(call["metadata"] == {"thread_id": "1234567890.000001"} for call in adapter.typing)
+    assert adapter.sent[0]["metadata"] == {"thread_id": "1234567890.000001", "matrix_msgtype": "m.notice"}
+    assert all(call["metadata"] == {"thread_id": "1234567890.000001", "matrix_msgtype": "m.notice"} for call in adapter.typing)
 
 
 @pytest.mark.asyncio
@@ -461,7 +461,7 @@ async def test_run_agent_feishu_progress_replies_inside_existing_thread(monkeypa
     assert result["final_response"] == "done"
     assert adapter.sent
     assert adapter.sent[0]["reply_to"] == "om_triggering_user_message"
-    assert adapter.sent[0]["metadata"] == {"thread_id": "topic_17585"}
+    assert adapter.sent[0]["metadata"] == {"thread_id": "topic_17585", "matrix_msgtype": "m.notice"}
     assert adapter.edits
     assert adapter.edits[0]["message_id"] == "progress-1"
 

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -566,6 +566,7 @@ async def test_gateway_runner_busy_ack_replies_to_triggering_message_for_telegra
         "telegram_dm_topic_reply_fallback": True,
         "direct_messages_topic_id": "20197",
         "telegram_reply_to_message_id": "463",
+        "matrix_msgtype": "m.notice",
     }
 
 


### PR DESCRIPTION
## What does this PR do?

Sends gateway status and progress messages as `m.notice` instead of `m.text` in Matrix, preventing bot-to-bot ping-pong loops when two Hermes gateways share a Matrix DM room.

## Related Issue

Fixes #43047

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/matrix.py`: Add `matrix_msgtype` metadata support in `send()` — when metadata contains `matrix_msgtype`, it overrides the default `m.text` msgtype. This allows callers to send `m.notice` messages that receiving bots correctly ignore.
- `gateway/run.py`: Mark all gateway status messages (interrupt, queue, drain) and tool progress messages with `matrix_msgtype: m.notice` in metadata. Three call sites updated: gateway drain status, interrupt/queue status, and progress message metadata.
- `tests/gateway/test_matrix.py`: Add 4 tests verifying `matrix_msgtype` metadata behavior — notice override, default m.text, empty metadata, and thread metadata coexistence.

## How to Test

1. Set up two Hermes gateways with Matrix adapters sharing a DM room
2. Send a message from one gateway to the other
3. Verify that status messages (⚡ Interrupting, ⏳ Queued, tool progress) do NOT trigger responses from the receiving gateway
4. Run `pytest tests/gateway/test_matrix.py::TestMatrixNoticeMsgtype -v` — all 4 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/matrix.py::send()`, `gateway/run.py::_handle_active_session_busy_message()`
- Blast radius: LOW — additive metadata field, no existing behavior changed for non-Matrix platforms
- Related patterns: Matrix adapter already filters incoming `m.notice` (line 1760); this completes the outbound side
