### PR TITLE
fix(cron): pass shell scripts to bash with POSIX paths

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -30,7 +30,7 @@ except ImportError:
         import msvcrt
     except ImportError:
         msvcrt = None
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import List, Optional
 
 # Add parent directory to path for imports BEFORE repo-level imports.
@@ -954,6 +954,18 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
+def _bash_script_path_arg(path: PurePath) -> str:
+    """Return the script path format Git Bash expects.
+
+    On Windows, ``str(Path(...))`` uses backslashes. Passing that directly
+    as an argv element to bash still lets bash interpret backslash escape
+    sequences, so paths like ``C:\\Users\\...`` are mangled. ``as_posix()``
+    keeps native POSIX paths unchanged and converts Windows paths to the
+    forward-slash form accepted by Git Bash.
+    """
+    return path.as_posix()
+
+
 def _run_job_script(script_path: str) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -1028,7 +1040,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        argv = [_bash, str(path)]
+        argv = [_bash, _bash_script_path_arg(path)]
     else:
         argv = [sys.executable, str(path)]
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -11,7 +11,7 @@ import json
 import os
 import sys
 import textwrap
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -171,6 +171,13 @@ class TestRunJobScript:
         assert success is True
         parsed = json.loads(output)
         assert parsed["new_prs"][0]["number"] == 42
+
+    def test_bash_script_path_arg_uses_forward_slashes_for_windows_paths(self):
+        from cron.scheduler import _bash_script_path_arg
+
+        path = PureWindowsPath(r"C:\Users\graem\AppData\Local\hermes\scripts\cron-watchdog.sh")
+
+        assert _bash_script_path_arg(path) == "C:/Users/graem/AppData/Local/hermes/scripts/cron-watchdog.sh"
 
 
 class TestBuildJobPromptWithScript:


### PR DESCRIPTION
## Summary
- Fixes `.sh`/`.bash` cron script execution on Windows by passing Git Bash a forward-slash script path.
- Closes #43073.

## Why
- `str(Path(...))` produces backslash-separated Windows paths.
- Bash treats those backslashes as escapes, so paths like `C:\Users\...\cron-watchdog.sh` are mangled before execution.

## Changes
- `cron/scheduler.py`: formats bash script argv paths via `Path.as_posix()` while leaving Python script execution unchanged.
- `tests/cron/test_cron_script.py`: adds a regression check for Windows path conversion.

## Validation
- `python -m pytest tests/cron/test_cron_script.py -o 'addopts=' -q`
- `python -m py_compile cron/scheduler.py`
- `python -m ruff check cron/scheduler.py tests/cron/test_cron_script.py`

## Scope
- In scope: `.sh`/`.bash` cron script argv path formatting for bash.
- Out of scope: changing cron script path validation or Python script execution.