### PR TITLE
ci: add OpenSSF Scorecard workflow for recurring security-health checks

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,68 @@
+name: OpenSSF Scorecard
+
+# Runs the OpenSSF Scorecard check to produce a recurring, standardized
+# security-health signal for repository practices: branch protection,
+# token permissions, pinned dependencies/actions, dangerous workflow
+# patterns, and other supply-chain controls.
+#
+# Results are uploaded to the repo's Security tab (Code Scanning) and
+# published to the OpenSSF API for the public Scorecard dashboard.
+#
+# Complements the existing security workflows:
+#   - osv-scanner.yml        — CVE scanning on pinned lockfiles
+#   - supply-chain-audit.yml — critical supply-chain risk patterns in PR diffs
+#
+# Scorecard covers the orthogonal "repo-level security hygiene" dimension
+# that neither of the above addresses.
+#
+# See: https://github.com/ossf/scorecard
+# See: https://securityscorecards.dev/
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly scan — Sunday 07:17 UTC (offset from top-of-hour to avoid
+    # GitHub Actions thundering herd).
+    - cron: '17 7 * * 0'
+  workflow_dispatch:
+
+# Declare default permissions as read-only; the job overrides where needed.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload SARIF results to the Security tab.
+      security-events: write
+      # Needed to publish results to the OpenSSF API (optional but
+      # recommended — feeds the public dashboard).
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to the OpenSSF API (public dashboard).
+          publish_results: true
+
+      - name: Upload SARIF
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to Code Scanning
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f  # v3.28.18
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Problem

The repo has targeted supply-chain checks (OSV-Scanner, supply-chain-audit, PyPI dep bounds) but does not run OpenSSF Scorecard — a standardized, recurring security-health signal that has become a common OSS baseline for tracking repository security practices.

## Solution

Add a GitHub Actions workflow that runs the [OpenSSF Scorecard](https://github.com/ossf/scorecard) analysis:

- **Triggers**: push to `main`, weekly schedule (Sunday 07:17 UTC), and manual dispatch
- **Results**: uploaded to the repo's Security tab (Code Scanning via SARIF) and published to the [public Scorecard dashboard](https://securityscorecards.dev/)
- **All actions pinned by SHA** (checkout, scorecard, upload-artifact, codeql-action)
- **Minimal permissions**: `read-all` default, job-level overrides for `security-events: write` and `id-token: write`

## What Scorecard checks

Scorecard evaluates repo-level security hygiene across multiple dimensions:

| Check | What it measures |
|-------|-----------------|
| Branch-Protection | Require reviews, status checks, force-push prevention |
| Token-Permissions | Workflow `permissions:` are minimally scoped |
| Pinned-Dependencies | Actions and deps pinned by SHA/version |
| Vulnerabilities | Known CVEs in dependencies (complements OSV-Scanner) |
| Dangerous-Workflow | Patterns like `pull_request_target` + checkout |
| CII-Best-Practices | Badge, documentation, test coverage |

## How it complements existing workflows

| Existing workflow | Covers |
|-------------------|--------|
| `osv-scanner.yml` | CVE scanning on pinned lockfiles |
| `supply-chain-audit.yml` | Critical supply-chain risk patterns in PR diffs |
| **This workflow** | Repo-level security hygiene (branch protection, permissions, pinning) |

## Closes

Closes #43074
