### PR TITLE
Fix Desktop remote gateway cwd from replacing local workspace

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -64,6 +64,8 @@ import {
   setCronSessions,
   setCurrentBranch,
   setCurrentCwd,
+  setCurrentCwdFromRuntime,
+  shouldSyncRuntimeCwdToWorkspace,
   setCurrentModel,
   setCurrentProvider,
   setMessages,
@@ -665,9 +667,16 @@ export function DesktopController() {
       // The next message creates the backend session in $currentCwd, so seed
       // it (and the branch) from the workspace the user clicked the + on.
       setCurrentCwd(target)
+
+      if (!shouldSyncRuntimeCwdToWorkspace()) {
+        setCurrentBranch('')
+
+        return
+      }
+
       void requestGateway<{ branch?: string; cwd?: string }>('config.get', { key: 'project', cwd: target })
         .then(info => {
-          setCurrentCwd(info.cwd || target)
+          setCurrentCwdFromRuntime(info.cwd || target)
           setCurrentBranch(info.branch || '')
         })
         .catch(() => undefined)

--- a/apps/desktop/src/app/session/hooks/use-cwd-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-cwd-actions.ts
@@ -2,7 +2,13 @@ import { type MutableRefObject, useCallback } from 'react'
 
 import { useI18n } from '@/i18n'
 import { notify, notifyError } from '@/store/notifications'
-import { $currentCwd, setCurrentBranch, setCurrentCwd } from '@/store/session'
+import {
+  $currentCwd,
+  setCurrentBranch,
+  setCurrentCwd,
+  setCurrentCwdFromRuntime,
+  shouldSyncRuntimeCwdToWorkspace
+} from '@/store/session'
 import type { SessionRuntimeInfo } from '@/types/hermes'
 
 interface CwdActionsOptions {
@@ -25,6 +31,12 @@ export function useCwdActions({
       const target = cwd.trim()
 
       if (!target || activeSessionIdRef.current) {
+        return
+      }
+
+      if (!shouldSyncRuntimeCwdToWorkspace()) {
+        setCurrentBranch('')
+
         return
       }
 
@@ -52,6 +64,13 @@ export function useCwdActions({
         return
       }
 
+      if (!shouldSyncRuntimeCwdToWorkspace()) {
+        setCurrentCwd(trimmed)
+        setCurrentBranch('')
+
+        return
+      }
+
       if (!activeSessionId) {
         setCurrentCwd(trimmed)
 
@@ -64,7 +83,7 @@ export function useCwdActions({
           // Adopt the backend's normalized cwd so the persisted workspace and
           // branch stay consistent with what the agent will use.
           if (info.cwd) {
-            setCurrentCwd(info.cwd)
+            setCurrentCwdFromRuntime(info.cwd)
           }
 
           setCurrentBranch(info.branch || '')
@@ -81,7 +100,7 @@ export function useCwdActions({
           cwd: trimmed
         })
 
-        setCurrentCwd(info.cwd || trimmed)
+        setCurrentCwdFromRuntime(info.cwd || trimmed)
         setCurrentBranch(info.branch || '')
         onSessionRuntimeInfo?.({ branch: info.branch || '', cwd: info.cwd || trimmed })
       } catch (err) {

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -10,7 +10,8 @@ import {
   setCurrentPersonality,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
-  setIntroPersonality
+  setIntroPersonality,
+  shouldSyncRuntimeCwdToWorkspace
 } from '@/store/session'
 
 const DEFAULT_VOICE_SECONDS = 120
@@ -51,7 +52,7 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
 
       const cwd = (config.terminal?.cwd ?? '').trim()
 
-      if (cwd && cwd !== '.') {
+      if (cwd && cwd !== '.' && shouldSyncRuntimeCwdToWorkspace()) {
         setCurrentCwd(prev => prev || cwd)
         void refreshProjectBranch($currentCwd.get() || cwd)
       }

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -25,7 +25,7 @@ import { requestDesktopOnboarding } from '@/store/onboarding'
 import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import {
   setCurrentBranch,
-  setCurrentCwd,
+  setCurrentCwdFromRuntime,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentPersonality,
@@ -651,7 +651,7 @@ export function useMessageStream({
           }
 
           if (typeof payload?.cwd === 'string') {
-            setCurrentCwd(payload.cwd)
+            setCurrentCwdFromRuntime(payload.cwd)
             runtimeInfo.cwd = payload.cwd
           }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -7,7 +7,7 @@ import { $composerAttachments, type ComposerAttachment } from '@/store/composer'
 import { $connection, $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
-import { uploadComposerAttachment, usePromptActions } from './use-prompt-actions'
+import { readImageForRemoteAttach, uploadComposerAttachment, usePromptActions } from './use-prompt-actions'
 
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
@@ -102,6 +102,37 @@ function Harness({
 
   return null
 }
+
+describe('readImageForRemoteAttach', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  it('extracts upload bytes and filename from a local data URL', async () => {
+    const readFileDataUrl = vi.fn(async () => 'data:image/png;base64,AAA=')
+    ;(window as unknown as { hermesDesktop: { readFileDataUrl: typeof readFileDataUrl } }).hermesDesktop = {
+      readFileDataUrl
+    }
+
+    const result = await readImageForRemoteAttach('/Users/local-user/Desktop/screen.png')
+
+    expect(result).toEqual({
+      contentBase64: 'AAA=',
+      filename: 'screen.png'
+    })
+    expect(readFileDataUrl).toHaveBeenCalledWith('/Users/local-user/Desktop/screen.png')
+  })
+
+  it('returns null when the local file cannot be read', async () => {
+    const readFileDataUrl = vi.fn(async () => '')
+    ;(window as unknown as { hermesDesktop: { readFileDataUrl: typeof readFileDataUrl } }).hermesDesktop = {
+      readFileDataUrl
+    }
+
+    await expect(readImageForRemoteAttach('/Users/local-user/Desktop/missing.png')).resolves.toBeNull()
+  })
+})
 
 describe('usePromptActions /title', () => {
   beforeEach(() => {
@@ -751,4 +782,3 @@ describe('uploadComposerAttachment remote read failures', () => {
     ).rejects.toThrow('ENOENT: no such file')
   })
 })
-

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -97,7 +97,7 @@ function imageFilenameFromPath(filePath: string): string {
 // Remote gateway: the local composer-image file lives on THIS machine's disk,
 // not the gateway's, so read the bytes here and upload them via
 // image.attach_bytes. Returns null when the file can't be read.
-async function readImageForRemoteAttach(
+export async function readImageForRemoteAttach(
   filePath: string
 ): Promise<{ contentBase64: string; filename: string } | null> {
   const dataUrl = await window.hermesDesktop?.readFileDataUrl(filePath)
@@ -543,7 +543,8 @@ export function usePromptActions({
           sid,
           state => ({
             ...state,
-            messages: state.messages.map(message => (message.id === optimisticId ? buildUserMessage() : message))
+            messages: state.messages.map(message => (message.id === optimisticId ? buildUserMessage() : message)),
+            interrupted: false
           }),
           selectedStoredSessionIdRef.current
         )

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -26,6 +26,7 @@ import {
   setBusy,
   setCurrentBranch,
   setCurrentCwd,
+  setCurrentCwdFromRuntime,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentPersonality,
@@ -238,7 +239,7 @@ function applyRuntimeInfo(info: SessionCreateResponse['info'] | undefined): Part
   }
 
   if (info.cwd) {
-    setCurrentCwd(info.cwd)
+    setCurrentCwdFromRuntime(info.cwd)
     sessionState.cwd = info.cwd
   }
 
@@ -472,7 +473,7 @@ export function useSessionActions({
         setActiveSessionId(cachedRuntimeId)
         activeSessionIdRef.current = cachedRuntimeId
         syncSessionStateToView(cachedRuntimeId, cachedState)
-        setCurrentCwd(cachedState.cwd)
+        setCurrentCwdFromRuntime(cachedState.cwd)
         setCurrentBranch(cachedState.branch)
         setSessionStartedAt(Date.now())
         clearComposerDraft()

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
 import {
   $activeSessionId,
+  $connection,
   $attentionSessionIds,
   $currentCwd,
   $workingSessionIds,
@@ -11,6 +12,9 @@ import {
   getRecentlySettledSessionIds,
   mergeSessionPage,
   sessionPinId,
+  setConnection,
+  setCurrentCwd,
+  setCurrentCwdFromRuntime,
   setSessionAttention,
   setSessionWorking,
   workspaceCwdForNewSession
@@ -60,6 +64,53 @@ describe('setSessionAttention', () => {
     setSessionAttention('', true)
     setSessionAttention('missing', false)
     expect($attentionSessionIds.get()).toEqual([])
+  })
+})
+
+describe('setCurrentCwdFromRuntime', () => {
+  const connection = (mode: 'local' | 'remote') => ({
+    authMode: 'token' as const,
+    baseUrl: mode === 'remote' ? 'http://box:9119' : 'http://127.0.0.1:9119',
+    isFullscreen: false,
+    logs: [],
+    mode,
+    nativeOverlayWidth: 0,
+    source: mode === 'remote' ? ('settings' as const) : ('local' as const),
+    token: 't',
+    windowButtonPosition: null,
+    wsUrl: mode === 'remote' ? 'ws://box:9119/api/ws?token=t' : 'ws://127.0.0.1:9119/api/ws?token=t'
+  })
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    setConnection(null)
+    setCurrentCwd('')
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    setConnection(null)
+    setCurrentCwd('')
+  })
+
+  it('does not replace the local workspace cwd with a remote runtime cwd', () => {
+    setConnection(connection('remote'))
+    setCurrentCwd('/Users/local-user')
+
+    setCurrentCwdFromRuntime('/home/stegeler')
+
+    expect($connection.get()?.mode).toBe('remote')
+    expect($currentCwd.get()).toBe('/Users/local-user')
+    expect(window.localStorage.getItem('hermes.desktop.workspace-cwd')).toBe('/Users/local-user')
+  })
+
+  it('still adopts runtime cwd in local mode', () => {
+    setConnection(connection('local'))
+    setCurrentCwd('/Users/local-user')
+
+    setCurrentCwdFromRuntime('/Users/local-user/Documents/Hermes')
+
+    expect($currentCwd.get()).toBe('/Users/local-user/Documents/Hermes')
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -239,6 +239,18 @@ export const setCurrentCwd = (next: Updater<string>) => {
 export const workspaceCwdForNewSession = (): string =>
   getConfiguredDefaultProjectDir() || getRememberedWorkspaceCwd() || $currentCwd.get().trim()
 
+export const shouldSyncRuntimeCwdToWorkspace = (): boolean => $connection.get()?.mode !== 'remote'
+
+export const setCurrentCwdFromRuntime = (cwd: string) => {
+  const trimmed = cwd.trim()
+
+  if (!trimmed || !shouldSyncRuntimeCwdToWorkspace()) {
+    return
+  }
+
+  setCurrentCwd(trimmed)
+}
+
 export const setCurrentBranch = (next: Updater<string>) => updateAtom($currentBranch, next)
 export const setCurrentUsage = (next: Updater<UsageStats>) => updateAtom($currentUsage, next)
 export const setSessionStartedAt = (next: Updater<number | null>) => updateAtom($sessionStartedAt, next)


### PR DESCRIPTION
## Summary
- keep the Desktop Files workspace cwd separate from remote gateway runtime cwd
- avoid asking a remote gateway to inspect local-only workspace paths when starting or switching workspace context
- add regression coverage for remote cwd sync and local image-byte attachment handling

## Validation
- `npm run test:ui -- src/store/session.test.ts src/app/session/hooks/use-prompt-actions.test.tsx`
- `npm run type-check`
- `npm run build`

## Background
In remote gateway mode, runtime events can report a cwd such as `/home/user` from the gateway host. The Desktop Files pane is browsing the local machine, so syncing that runtime cwd into the shared workspace cwd makes the local folder unreadable with ENOENT. This keeps runtime cwd updates from clobbering the local workspace selection while preserving local-mode behavior.