### PR TITLE
fix: handle Anthropic stop_reason=refusal instead of 3× invalid-response retry

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1044,6 +1044,12 @@ def run_conversation(
                 
                 # Validate response shape before proceeding
                 response_invalid = False
+                # Set when an Anthropic response is an HTTP-200 safety refusal
+                # (stop_reason="refusal", empty content). Routed to the
+                # content-policy path instead of the generic invalid-response
+                # retry loop, which would burn paid retries on a deterministic
+                # block and mislabel it "response.content invalid".
+                anthropic_refusal = False
                 error_details = []
                 if agent.api_mode == "codex_responses":
                     _ct_v = agent._get_transport()
@@ -1096,11 +1102,27 @@ def run_conversation(
                 elif agent.api_mode == "anthropic_messages":
                     _tv = agent._get_transport()
                     if not _tv.validate_response(response):
-                        response_invalid = True
-                        if response is None:
-                            error_details.append("response is None")
+                        # An HTTP-200 safety refusal arrives as stop_reason
+                        # "refusal" with an empty content list. It is
+                        # deterministic for the unchanged request, so the
+                        # generic invalid-response path (3× backoff retry,
+                        # "response.content invalid" wording) is both wrong and
+                        # wasteful. Flag it so it routes to the content-policy
+                        # handler below instead.
+                        if (
+                            response is not None
+                            and getattr(response, "stop_reason", None) == "refusal"
+                        ):
+                            anthropic_refusal = True
+                            error_details.append(
+                                "model safety refusal (stop_reason=refusal)"
+                            )
                         else:
-                            error_details.append("response.content invalid (not a non-empty list)")
+                            response_invalid = True
+                            if response is None:
+                                error_details.append("response is None")
+                            else:
+                                error_details.append("response.content invalid (not a non-empty list)")
                 elif agent.api_mode == "bedrock_converse":
                     _btv = agent._get_transport()
                     if not _btv.validate_response(response):
@@ -1121,6 +1143,88 @@ def run_conversation(
                             error_details.append("response.choices is None")
                         else:
                             error_details.append("response.choices is empty")
+
+                if anthropic_refusal:
+                    # HTTP-200 safety refusal: deterministic for the unchanged
+                    # request, so retrying just reproduces the block and burns
+                    # paid attempts. Mirror the exception-driven
+                    # content_policy_blocked path: stop the spinner, try a
+                    # configured fallback, otherwise return an honest
+                    # "provider safety filter blocked this" result rather than
+                    # the misleading "Invalid API response after 3 retries".
+                    agent._invoke_api_request_error_hook(
+                        task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        api_call_count=api_call_count,
+                        api_start_time=api_start_time,
+                        api_kwargs=api_kwargs,
+                        error_type="ContentPolicyBlocked",
+                        error_message=", ".join(error_details) or "model safety refusal",
+                        status_code=None,
+                        retry_count=retry_count,
+                        max_retries=max_retries,
+                        retryable=False,
+                        reason="content_policy_blocked",
+                    )
+                    if thinking_spinner:
+                        thinking_spinner.stop("")
+                        thinking_spinner = None
+                    if agent.thinking_callback:
+                        agent.thinking_callback("")
+
+                    _refusal_model = getattr(agent, "model", "unknown")
+                    if agent._has_pending_fallback():
+                        agent._buffer_status(
+                            "⚠️ Model safety filter refused this request — trying fallback..."
+                        )
+                    if agent._try_activate_fallback():
+                        retry_count = 0
+                        compression_attempts = 0
+                        _retry.primary_recovery_attempted = False
+                        continue
+
+                    agent._flush_status_buffer()
+                    agent._emit_status(
+                        f"❌ The model ({_refusal_model}) refused this request "
+                        f"(safety filter, stop_reason=refusal)."
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}   💡 This is a model-level safety refusal, "
+                        f"not a Hermes or network error. Retrying the same request won't help.",
+                        force=True,
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}      • Try rephrasing, narrowing the context, "
+                        f"or switching to a less restrictive model.",
+                        force=True,
+                    )
+                    agent._vprint(
+                        f"{agent.log_prefix}      • Configure a fallback provider so future "
+                        f"refusals route automatically:  hermes fallback add",
+                        force=True,
+                    )
+                    logger.warning(
+                        "%sModel safety refusal (stop_reason=refusal) on model=%s provider=%s. "
+                        "Not retrying (deterministic).",
+                        agent.log_prefix, _refusal_model, getattr(agent, "provider", "unknown"),
+                    )
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": (
+                            f"⚠️  The model ({_refusal_model}) declined to respond to this "
+                            f"request (provider safety filter, stop_reason=refusal — not a "
+                            f"Hermes or network failure).\n\n"
+                            f"Try rephrasing the request, narrowing the context, switching to "
+                            f"a less restrictive model, or adding a fallback provider with "
+                            f"`hermes fallback add`."
+                        ),
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "error": "content_policy_blocked: model safety refusal (stop_reason=refusal)",
+                    }
 
                 if response_invalid:
                     agent._invoke_api_request_error_hook(

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -147,6 +147,13 @@ class AnthropicTransport(ProviderTransport):
         — the model's canonical way of signalling "nothing more to add" after
         a tool turn that already delivered the user-facing text. Treating it
         as invalid falsely retries a completed response.
+
+        An empty content list with ``stop_reason == "refusal"`` is an HTTP-200
+        safety refusal. This still returns False here (the response carries no
+        usable content), but the conversation loop special-cases the refusal
+        ``stop_reason`` *before* the generic invalid-response retry path and
+        routes it to content-policy handling instead of retrying 3× — see the
+        ``anthropic_refusal`` branch in ``agent/conversation_loop.py``.
         """
         if response is None:
             return False

--- a/tests/run_agent/test_anthropic_refusal_empty_content.py
+++ b/tests/run_agent/test_anthropic_refusal_empty_content.py
@@ -1,0 +1,90 @@
+"""Regression guard: an Anthropic HTTP-200 safety refusal (``stop_reason ==
+"refusal"`` with an empty ``content`` list) must NOT be mislabeled as
+"response.content invalid (not a non-empty list)" and retried 3× before
+giving up.
+
+Real-world symptom: a stricter Claude model (e.g. ``claude-fable-5``) refuses
+offensive-security / fuzzing / crash-corpus material that a broader model
+(e.g. ``claude-opus-4-8``) handles. The provider returns HTTP 200 with::
+
+    {"stop_reason": "refusal", "content": []}
+
+The Anthropic ``validate_response`` correctly returns False (no usable
+content), but the conversation loop used to treat that as a generic invalid
+response: 3× jittered-backoff retries (each deterministically reproducing the
+same refusal), then "Invalid API response after 3 retries" — burning paid
+attempts and giving the user no idea their prompt was refused.
+
+The fix special-cases ``stop_reason == "refusal"`` at the validation site and
+routes it to the existing ``content_policy_blocked`` recovery (try fallback,
+else surface a clear "model refused this request" message). This guards both
+the transport-level signal and the loop's refusal-detection predicate.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+class TestAnthropicTransportValidateRefusal:
+    """The transport's validate_response must reject an empty-content refusal
+    (it carries nothing usable) while still accepting the legitimate
+    empty-content ``end_turn`` case.
+    """
+
+    def _transport(self):
+        from agent.transports.anthropic import AnthropicTransport
+
+        return AnthropicTransport()
+
+    def test_empty_content_refusal_is_invalid(self):
+        resp = SimpleNamespace(content=[], stop_reason="refusal")
+        assert self._transport().validate_response(resp) is False
+
+    def test_empty_content_end_turn_is_valid(self):
+        # The model's canonical "nothing more to add" after a tool turn.
+        resp = SimpleNamespace(content=[], stop_reason="end_turn")
+        assert self._transport().validate_response(resp) is True
+
+    def test_nonempty_content_is_valid_regardless_of_stop_reason(self):
+        resp = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="hi")],
+            stop_reason="refusal",
+        )
+        assert self._transport().validate_response(resp) is True
+
+    def test_refusal_maps_to_content_filter_finish_reason(self):
+        # _STOP_REASON_MAP already encodes the intent; lock it in.
+        assert self._transport().map_finish_reason("refusal") == "content_filter"
+
+
+class TestRefusalDetectionPredicate:
+    """Mirror the ``anthropic_refusal`` decision in
+    ``agent/conversation_loop.py``: when validate_response fails, a response
+    whose ``stop_reason`` is ``"refusal"`` routes to the content-policy path;
+    everything else stays in the generic invalid-response path.
+
+    Kept in lock-step with the source — if you change one, change both.
+    """
+
+    def _is_refusal(self, response) -> bool:
+        return (
+            response is not None
+            and getattr(response, "stop_reason", None) == "refusal"
+        )
+
+    def test_empty_refusal_routes_to_content_policy(self):
+        resp = SimpleNamespace(content=[], stop_reason="refusal")
+        assert self._is_refusal(resp) is True
+
+    def test_none_response_is_not_a_refusal(self):
+        # A None response is a genuine invalid response, not a refusal.
+        assert self._is_refusal(None) is False
+
+    def test_malformed_non_refusal_is_not_a_refusal(self):
+        # e.g. a truncated/garbled body with no usable stop_reason.
+        resp = SimpleNamespace(content=None, stop_reason=None)
+        assert self._is_refusal(resp) is False
+
+    def test_end_turn_is_not_a_refusal(self):
+        resp = SimpleNamespace(content=[], stop_reason="end_turn")
+        assert self._is_refusal(resp) is False


### PR DESCRIPTION
## Problem

An Anthropic model can return **HTTP 200 with `stop_reason: "refusal"` and an empty `content: []`** — a server-side safety-classifier halt. It's deterministic for the unchanged request.

Hermes' Anthropic `validate_response` correctly rejects this (no usable content), but the conversation loop then treats it as a *generic invalid response*:

- 3× jittered-backoff retries, each deterministically reproducing the same refusal (≈35s wasted, paid attempts burned)
- terminal message `Invalid API response after 3 retries: response time 28.8s`

The user gets no signal that the model **refused** their prompt — it looks like a network/provider flake.

### It's model-specific

Different Claude models ship different safety classifiers. Observed in the wild: a stricter named model (`claude-fable-5`) refuses offensive-security / fuzzing / crash-corpus material that a broader model (`claude-opus-4-8`) handles — even for a benign-looking `"list the files"` request, because the *`tool_result` content* (a directory tree full of `fuzz/`, `*.ips` crash logs, exploit script names) is what trips the classifier.

The irony: `_STOP_REASON_MAP` already maps `"refusal" → "content_filter"`, and `agent/error_classifier.py` documents that refusals are deterministic and must not be retried — but the empty-content refusal fails `validate_response` *before* that exception-driven logic ever runs.

## Fix

Special-case `stop_reason == "refusal"` at the validation site in `agent/conversation_loop.py` and route it to the **existing** `content_policy_blocked` recovery, mirroring the exception path from #18028:

1. fire the `api_request_error` hook with `reason="content_policy_blocked"`,
2. stop the spinner,
3. try a configured fallback model if one exists,
4. otherwise return an honest terminal result: *"The model declined to respond to this request (provider safety filter, stop_reason=refusal — not a Hermes or network failure)."*

No retry burn (the block is deterministic), and the wording tells the user it's a model-level refusal with actionable next steps (rephrase, narrow context, switch model, or `hermes fallback add`).

The Anthropic transport's `validate_response` is unchanged in behavior (an empty refusal still carries no usable content → returns `False`); only a docstring note is added pointing at the upstream handling.

## Verification

Reproduced the original failure with `HERMES_DUMP_REQUESTS=true`, replayed the captured request body against the raw `/v1/messages` endpoint, and confirmed `stop_reason: "refusal"` + `content: []`. Controlled experiment isolated the cause to model + content (not key, not thinking config): same body returns `tool_use` on `claude-opus-4-8` and on `claude-fable-5` with benign content.

**Before:** `❌ Max retries (3) exceeded for invalid responses. Giving up.` after ~35s
**After:** immediate, clear refusal message; one log line `Model safety refusal (stop_reason=refusal) ... Not retrying (deterministic).`

## Tests

New `tests/run_agent/test_anthropic_refusal_empty_content.py`:
- transport `validate_response`: empty+refusal → invalid, empty+end_turn → valid, non-empty → valid, `map_finish_reason("refusal") == "content_filter"`
- refusal-detection predicate mirrors the loop branch (refusal vs None vs malformed vs end_turn)

```
191 passed  (new file + test_18028_content_policy_blocked + transports + error_classifier)
633 passed in tests/agent/transports + adapter + error_classifier
```

The 3 failing `TestRunOauthSetupToken` tests are **pre-existing on clean `origin/main`** (OAuth credential-file resolution, unrelated to this change).
