### PR TITLE
feat: add Goose Pincher hook plugin

### DIFF
--- a/.agents/plugins/hermes-pincher-hooks/README.md
+++ b/.agents/plugins/hermes-pincher-hooks/README.md
@@ -1,0 +1,32 @@
+# hermes-pincher-hooks for Goose
+
+Project-scoped Goose Open Plugins hook extension that mirrors the repo's Claude Code hook posture for Pincher-first work.
+
+## What it does
+
+- Registers a Goose `PreToolUse` hook from `.agents/plugins/hermes-pincher-hooks/hooks/hooks.json`.
+- Matches Goose's built-in developer tools: `developer__shell|developer__text_editor`.
+- Runs `${PLUGIN_ROOT}/scripts/pincher-hook-check.sh`, which forwards Goose's hook payload to `pincher hook-check`.
+- Records `last-event.log` beside the plugin for local debugging without making logging a blocker.
+
+## Why this shape
+
+Goose discovers project-scoped Open Plugins under `<project-root>/.agents/plugins/<name>/`. That keeps the extension local to this checkout, similar to how the repo-local `.claude/settings.json` wires Claude Code hooks for this project.
+
+## Init / verification
+
+From the repository root:
+
+```bash
+chmod +x .agents/plugins/hermes-pincher-hooks/scripts/pincher-hook-check.sh
+
+goose session
+```
+
+On startup Goose should discover the plugin automatically. A developer tool call should trigger the `PreToolUse` hook and append the raw payload to:
+
+```text
+.agents/plugins/hermes-pincher-hooks/last-event.log
+```
+
+If Goose is installed outside the normal shell `PATH`, make sure the `pincher` binary is reachable from the environment that launches Goose.

--- a/.agents/plugins/hermes-pincher-hooks/hooks/hooks.json
+++ b/.agents/plugins/hermes-pincher-hooks/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "developer__shell|developer__text_editor",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/scripts/pincher-hook-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.agents/plugins/hermes-pincher-hooks/plugin.json
+++ b/.agents/plugins/hermes-pincher-hooks/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "hermes-pincher-hooks",
+  "version": "0.1.0",
+  "description": "Project-scoped Goose Open Plugins hooks that route Goose developer tool calls through Pincher hook-check guardrails."
+}

--- a/.agents/plugins/hermes-pincher-hooks/scripts/pincher-hook-check.sh
+++ b/.agents/plugins/hermes-pincher-hooks/scripts/pincher-hook-check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Goose Open Plugins hook bridge for Pincher.
+#
+# Goose invokes this command for PreToolUse events and pipes the event payload
+# as JSON on stdin. Keep the bridge tiny and deterministic: preserve the exact
+# Goose payload, annotate where it came from, then delegate the policy decision
+# to Pincher's hook checker. Pincher already emits the JSON decision shape the
+# host agent expects.
+set -euo pipefail
+
+payload="$(cat)"
+plugin_root="${PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# Lightweight audit trail for local dogfood/debugging. Never block if the log
+# cannot be written; hook correctness must depend on pincher hook-check only.
+{
+  printf -- '---- PreToolUse @ %s ----\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  printf '%s\n' "$payload"
+} >> "${plugin_root}/last-event.log" 2>/dev/null || true
+
+# Pass the event through unchanged. This preserves Goose's native fields
+# (event, tool_name, tool_input, etc.) and also works with Claude-style payloads
+# if a user runs the script manually while comparing agent hook systems.
+printf '%s' "$payload" | pincher hook-check

--- a/tests/integrations/test_goose_pincher_plugin.py
+++ b/tests/integrations/test_goose_pincher_plugin.py
@@ -1,0 +1,53 @@
+"""Tests for the repo-local Goose Open Plugins hook extension."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_ROOT = ROOT / ".agents" / "plugins" / "hermes-pincher-hooks"
+
+
+def test_goose_plugin_manifest_is_valid_open_plugin_metadata():
+    manifest = json.loads((PLUGIN_ROOT / "plugin.json").read_text())
+
+    assert manifest["name"] == "hermes-pincher-hooks"
+    assert manifest["version"]
+    assert "Pincher" in manifest["description"]
+
+
+def test_goose_plugin_registers_pincher_pre_tool_hook_for_developer_tools():
+    hooks = json.loads((PLUGIN_ROOT / "hooks" / "hooks.json").read_text())
+
+    pre_tool_hooks = hooks["hooks"]["PreToolUse"]
+    assert len(pre_tool_hooks) == 1
+
+    entry = pre_tool_hooks[0]
+    assert entry["matcher"] == "developer__shell|developer__text_editor"
+    assert entry["hooks"] == [
+        {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/scripts/pincher-hook-check.sh",
+        }
+    ]
+
+
+def test_goose_pincher_hook_script_is_executable_and_uses_pincher_hook_check():
+    script = PLUGIN_ROOT / "scripts" / "pincher-hook-check.sh"
+
+    mode = script.stat().st_mode
+    assert mode & stat.S_IXUSR
+
+    text = script.read_text()
+    assert "pincher hook-check" in text
+    assert "PLUGIN_ROOT" in text
+
+
+def test_goose_plugin_documents_project_scope_installation():
+    readme = (PLUGIN_ROOT / "README.md").read_text()
+
+    assert ".agents/plugins/hermes-pincher-hooks" in readme
+    assert "goose session" in readme
+    assert "PreToolUse" in readme


### PR DESCRIPTION
## Summary
- Adds a project-scoped Goose Open Plugins extension at `.agents/plugins/hermes-pincher-hooks`.
- Registers a Goose `PreToolUse` hook for `developer__shell|developer__text_editor`.
- Bridges Goose hook payloads to `pincher hook-check`, mirroring the existing Claude hook guardrail posture.
- Documents init/verification and adds regression tests for manifest, hook registration, executable bridge, and README guidance.

## Test Plan
- [x] `python -m pytest tests/integrations/test_goose_pincher_plugin.py tests/agent/test_shell_hooks.py::TestParseResponse::test_block_claude_code_style -q -o 'addopts='`
- [x] `mcp_pincher_changes(scope="base:HEAD~1")` reported 5 changed files, 0 impacted symbols, 0 suggested tests.

## Notes
- Upstream `NousResearch/hermes-agent` is read-only for this account, so the branch is pushed from the `kwad77` fork.
