### PR TITLE
feat(whatsapp): support native location pins

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -180,6 +180,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.whatsapp_location import parse_whatsapp_location_directive
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -213,38 +214,6 @@ def check_whatsapp_requirements() -> bool:
         return result.returncode == 0
     except Exception:
         return False
-
-
-def _parse_location_directive(content: str) -> Optional[Dict[str, Any]]:
-    """Parse an exact native-location directive for WhatsApp sends."""
-    stripped = (content or "").strip()
-    if not stripped.startswith("LOCATION:"):
-        return None
-
-    body = stripped[len("LOCATION:"):]
-    parts = body.split("|", 2)
-    coord_text = parts[0].strip()
-    if "," not in coord_text:
-        raise ValueError("LOCATION directive must use '<latitude>,<longitude>'")
-
-    lat_text, lon_text = [piece.strip() for piece in coord_text.split(",", 1)]
-    try:
-        latitude = float(lat_text)
-        longitude = float(lon_text)
-    except ValueError as exc:
-        raise ValueError("LOCATION directive latitude/longitude must be numeric") from exc
-
-    if not (-90 <= latitude <= 90):
-        raise ValueError("LOCATION directive latitude must be between -90 and 90")
-    if not (-180 <= longitude <= 180):
-        raise ValueError("LOCATION directive longitude must be between -180 and 180")
-
-    location: Dict[str, Any] = {"latitude": latitude, "longitude": longitude}
-    if len(parts) > 1 and parts[1].strip():
-        location["name"] = parts[1].strip()
-    if len(parts) > 2 and parts[2].strip():
-        location["address"] = parts[2].strip()
-    return location
 
 
 class WhatsAppAdapter(BasePlatformAdapter):
@@ -964,7 +933,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            location = _parse_location_directive(content)
+            location = parse_whatsapp_location_directive(content)
             if location is not None:
                 payload: Dict[str, Any] = {"chatId": chat_id, **location}
                 if reply_to:

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -215,6 +215,38 @@ def check_whatsapp_requirements() -> bool:
         return False
 
 
+def _parse_location_directive(content: str) -> Optional[Dict[str, Any]]:
+    """Parse an exact native-location directive for WhatsApp sends."""
+    stripped = (content or "").strip()
+    if not stripped.startswith("LOCATION:"):
+        return None
+
+    body = stripped[len("LOCATION:"):]
+    parts = body.split("|", 2)
+    coord_text = parts[0].strip()
+    if "," not in coord_text:
+        raise ValueError("LOCATION directive must use '<latitude>,<longitude>'")
+
+    lat_text, lon_text = [piece.strip() for piece in coord_text.split(",", 1)]
+    try:
+        latitude = float(lat_text)
+        longitude = float(lon_text)
+    except ValueError as exc:
+        raise ValueError("LOCATION directive latitude/longitude must be numeric") from exc
+
+    if not (-90 <= latitude <= 90):
+        raise ValueError("LOCATION directive latitude must be between -90 and 90")
+    if not (-180 <= longitude <= 180):
+        raise ValueError("LOCATION directive longitude must be between -180 and 180")
+
+    location: Dict[str, Any] = {"latitude": latitude, "longitude": longitude}
+    if len(parts) > 1 and parts[1].strip():
+        location["name"] = parts[1].strip()
+    if len(parts) > 2 and parts[2].strip():
+        location["address"] = parts[2].strip()
+    return location
+
+
 class WhatsAppAdapter(BasePlatformAdapter):
     """
     WhatsApp adapter.
@@ -931,6 +963,22 @@ class WhatsAppAdapter(BasePlatformAdapter):
 
         try:
             import aiohttp
+
+            location = _parse_location_directive(content)
+            if location is not None:
+                payload: Dict[str, Any] = {"chatId": chat_id, **location}
+                if reply_to:
+                    payload["replyTo"] = reply_to
+                async with self._http_session.post(
+                    f"http://127.0.0.1:{self._bridge_port}/send-location",
+                    json=payload,
+                    timeout=aiohttp.ClientTimeout(total=30)
+                ) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        return SendResult(success=True, message_id=data.get("messageId"))
+                    error = await resp.text()
+                    return SendResult(success=False, error=error)
 
             # Format and chunk the message
             formatted = self.format_message(content)

--- a/gateway/platforms/whatsapp_location.py
+++ b/gateway/platforms/whatsapp_location.py
@@ -1,0 +1,62 @@
+"""WhatsApp native-location directive parsing.
+
+This module is shared by both the gateway WhatsApp adapter and the standalone
+send_message tool so the LOCATION contract evolves in exactly one place.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+_LOCATION_PREFIX = "LOCATION:"
+
+
+class WhatsAppLocationPayload(TypedDict, total=False):
+    """JSON payload fields accepted by the WhatsApp bridge location endpoint."""
+
+    latitude: float
+    longitude: float
+    name: str
+    address: str
+
+
+def parse_whatsapp_location_directive(content: str | None) -> WhatsAppLocationPayload | None:
+    """Parse a full-message WhatsApp native location directive.
+
+    Supported format:
+        LOCATION:<lat>,<lon>|optional name|optional address
+
+    The directive must begin the whole stripped message. That keeps ordinary
+    prose containing the word ``LOCATION:`` from being treated as a native send.
+    """
+    stripped = (content or "").strip()
+    if not stripped.startswith(_LOCATION_PREFIX):
+        return None
+
+    body = stripped[len(_LOCATION_PREFIX):]
+    parts = body.split("|", 2)
+    coord_text = parts[0].strip()
+    if "," not in coord_text:
+        raise ValueError("LOCATION directive must use '<latitude>,<longitude>'")
+
+    lat_text, lon_text = [piece.strip() for piece in coord_text.split(",", 1)]
+    try:
+        latitude = float(lat_text)
+        longitude = float(lon_text)
+    except ValueError as exc:
+        raise ValueError("LOCATION directive latitude/longitude must be numeric") from exc
+
+    if not (-90 <= latitude <= 90):
+        raise ValueError("LOCATION directive latitude must be between -90 and 90")
+    if not (-180 <= longitude <= 180):
+        raise ValueError("LOCATION directive longitude must be between -180 and 180")
+
+    location: WhatsAppLocationPayload = {
+        "latitude": latitude,
+        "longitude": longitude,
+    }
+    if len(parts) > 1 and parts[1].strip():
+        location["name"] = parts[1].strip()
+    if len(parts) > 2 and parts[2].strip():
+        location["address"] = parts[2].strip()
+    return location

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -522,6 +522,46 @@ app.post('/send', async (req, res) => {
   }
 });
 
+// Send a native WhatsApp location pin
+app.post('/send-location', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const { chatId, latitude, longitude, name, address } = req.body;
+  if (!chatId || latitude === undefined || longitude === undefined) {
+    return res.status(400).json({ error: 'chatId, latitude, and longitude are required' });
+  }
+
+  const lat = Number(latitude);
+  const lon = Number(longitude);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return res.status(400).json({ error: 'latitude and longitude must be numeric' });
+  }
+  if (lat < -90 || lat > 90) {
+    return res.status(400).json({ error: 'latitude must be between -90 and 90' });
+  }
+  if (lon < -180 || lon > 180) {
+    return res.status(400).json({ error: 'longitude must be between -180 and 180' });
+  }
+
+  try {
+    const location = {
+      degreesLatitude: lat,
+      degreesLongitude: lon,
+    };
+    if (name) location.name = String(name);
+    if (address) location.address = String(address);
+
+    const sent = await sendWithTimeout(chatId, { location });
+    trackSentMessageId(sent);
+
+    res.json({ success: true, messageId: sent?.key?.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Edit a previously sent message
 app.post('/edit', async (req, res) => {
   if (!sock || connectionState !== 'connected') {

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -247,6 +247,32 @@ class TestSendChunking:
         assert payload["message"] == "*bold text*"
 
     @pytest.mark.asyncio
+    async def test_location_directive_sends_native_pin_endpoint(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "loc1"})
+        http_session = adapter._http_session
+        assert http_session is not None
+        http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.send(
+            "chat1",
+            "LOCATION:37.7749,-122.4194|San Francisco City Hall|1 Dr Carlton B Goodlett Pl",
+        )
+
+        assert result.success
+        call_args = http_session.post.call_args
+        assert call_args.args[0] == "http://127.0.0.1:3000/send-location"
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        assert payload == {
+            "chatId": "chat1",
+            "latitude": 37.7749,
+            "longitude": -122.4194,
+            "name": "San Francisco City Hall",
+            "address": "1 Dr Carlton B Goodlett Pl",
+        }
+
+    @pytest.mark.asyncio
     async def test_reply_to_only_on_first_chunk(self):
         """reply_to should only be set on the first chunk."""
         adapter = _make_adapter()

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -29,10 +29,12 @@ from gateway.config import Platform
 from tools.send_message_tool import (
     _is_telegram_thread_not_found,
     _parse_target_ref,
+    _parse_whatsapp_location_directive,
     _send_matrix_via_adapter,
     _send_signal,
     _send_telegram,
     _send_to_platform,
+    _send_whatsapp,
     send_message_tool,
 )
 # Discord helpers moved to the plugin in #24325.  Import from the new path
@@ -863,6 +865,66 @@ class TestSendToPlatformWhatsapp:
 
         assert result["success"] is True
         async_mock.assert_awaited_once_with({"bridge_port": 3000}, chat_id, "hello from hermes")
+
+    def test_location_directive_parser_accepts_native_pin_format(self):
+        parsed = _parse_whatsapp_location_directive(
+            "LOCATION:37.7749,-122.4194|San Francisco City Hall|1 Dr Carlton B Goodlett Pl"
+        )
+
+        assert parsed == {
+            "latitude": 37.7749,
+            "longitude": -122.4194,
+            "name": "San Francisco City Hall",
+            "address": "1 Dr Carlton B Goodlett Pl",
+        }
+
+    def test_location_directive_parser_rejects_out_of_range_coordinates(self):
+        with pytest.raises(ValueError, match="latitude"):
+            _parse_whatsapp_location_directive("LOCATION:118.0,-69.0|Bad")
+
+    @staticmethod
+    def _build_whatsapp_mock(response_status=200, response_data=None, response_text="error body"):
+        mock_resp = MagicMock()
+        mock_resp.status = response_status
+        mock_resp.json = AsyncMock(return_value=response_data or {"messageId": "loc123"})
+        mock_resp.text = AsyncMock(return_value=response_text)
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.post = MagicMock(return_value=mock_resp)
+        return mock_session, mock_resp
+
+    def test_send_whatsapp_location_directive_posts_native_location_endpoint(self):
+        mock_session, _ = self._build_whatsapp_mock(response_data={"messageId": "loc123"})
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(
+                _send_whatsapp(
+                    {"bridge_port": 3000},
+                    "test-user@lid",
+                    "LOCATION:37.7749,-122.4194|San Francisco City Hall|1 Dr Carlton B Goodlett Pl",
+                )
+            )
+
+        assert result == {
+            "success": True,
+            "platform": "whatsapp",
+            "chat_id": "test-user@lid",
+            "message_id": "loc123",
+            "native_location": True,
+        }
+        call = mock_session.post.call_args
+        assert call.args[0] == "http://localhost:3000/send-location"
+        assert call.kwargs["json"] == {
+            "chatId": "test-user@lid",
+            "latitude": 37.7749,
+            "longitude": -122.4194,
+            "name": "San Francisco City Hall",
+            "address": "1 Dr Carlton B Goodlett Pl",
+        }
 
 
 class TestSendTelegramHtmlDetection:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -26,10 +26,10 @@ def _reset_signal_scheduler():
     _reset_scheduler()
 
 from gateway.config import Platform
+from gateway.platforms.whatsapp_location import parse_whatsapp_location_directive
 from tools.send_message_tool import (
     _is_telegram_thread_not_found,
     _parse_target_ref,
-    _parse_whatsapp_location_directive,
     _send_matrix_via_adapter,
     _send_signal,
     _send_telegram,
@@ -867,7 +867,7 @@ class TestSendToPlatformWhatsapp:
         async_mock.assert_awaited_once_with({"bridge_port": 3000}, chat_id, "hello from hermes")
 
     def test_location_directive_parser_accepts_native_pin_format(self):
-        parsed = _parse_whatsapp_location_directive(
+        parsed = parse_whatsapp_location_directive(
             "LOCATION:37.7749,-122.4194|San Francisco City Hall|1 Dr Carlton B Goodlett Pl"
         )
 
@@ -880,7 +880,7 @@ class TestSendToPlatformWhatsapp:
 
     def test_location_directive_parser_rejects_out_of_range_coordinates(self):
         with pytest.raises(ValueError, match="latitude"):
-            _parse_whatsapp_location_directive("LOCATION:118.0,-69.0|Bad")
+            parse_whatsapp_location_directive("LOCATION:118.0,-69.0|Bad")
 
     @staticmethod
     def _build_whatsapp_mock(response_status=200, response_data=None, response_text="error body"):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -15,6 +15,7 @@ import time
 from email.utils import formatdate
 
 from agent.redact import redact_sensitive_text
+from gateway.platforms.whatsapp_location import parse_whatsapp_location_directive
 
 logger = logging.getLogger(__name__)
 
@@ -65,45 +66,6 @@ _GENERIC_SECRET_ASSIGN_RE = re.compile(
     r"\b(access_token|api[_-]?key|auth[_-]?token|signature|sig)\s*=\s*([^\s,;]+)",
     re.IGNORECASE,
 )
-
-
-def _parse_whatsapp_location_directive(message: str) -> dict | None:
-    """Parse a full-message WhatsApp native location directive.
-
-    Supported format:
-        LOCATION:<lat>,<lon>|optional name|optional address
-
-    The directive must occupy the whole message.  That keeps ordinary prose
-    containing the word ``LOCATION:`` from being treated as a native send.
-    """
-    stripped = (message or "").strip()
-    if not stripped.startswith("LOCATION:"):
-        return None
-
-    body = stripped[len("LOCATION:"):]
-    parts = body.split("|", 2)
-    coord_text = parts[0].strip()
-    if "," not in coord_text:
-        raise ValueError("LOCATION directive must use '<latitude>,<longitude>'")
-
-    lat_text, lon_text = [piece.strip() for piece in coord_text.split(",", 1)]
-    try:
-        latitude = float(lat_text)
-        longitude = float(lon_text)
-    except ValueError as exc:
-        raise ValueError("LOCATION directive latitude/longitude must be numeric") from exc
-
-    if not (-90 <= latitude <= 90):
-        raise ValueError("LOCATION directive latitude must be between -90 and 90")
-    if not (-180 <= longitude <= 180):
-        raise ValueError("LOCATION directive longitude must be between -180 and 180")
-
-    location: dict[str, object] = {"latitude": latitude, "longitude": longitude}
-    if len(parts) > 1 and parts[1].strip():
-        location["name"] = parts[1].strip()
-    if len(parts) > 2 and parts[2].strip():
-        location["address"] = parts[2].strip()
-    return location
 
 
 def _sanitize_error_text(text) -> str:
@@ -1133,7 +1095,7 @@ async def _send_whatsapp(extra, chat_id, message):
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         bridge_port = extra.get("bridge_port", 3000)
-        location = _parse_whatsapp_location_directive(message)
+        location = parse_whatsapp_location_directive(message)
         async with aiohttp.ClientSession() as session:
             if location is not None:
                 payload = {"chatId": chat_id, **location}

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -67,6 +67,45 @@ _GENERIC_SECRET_ASSIGN_RE = re.compile(
 )
 
 
+def _parse_whatsapp_location_directive(message: str) -> dict | None:
+    """Parse a full-message WhatsApp native location directive.
+
+    Supported format:
+        LOCATION:<lat>,<lon>|optional name|optional address
+
+    The directive must occupy the whole message.  That keeps ordinary prose
+    containing the word ``LOCATION:`` from being treated as a native send.
+    """
+    stripped = (message or "").strip()
+    if not stripped.startswith("LOCATION:"):
+        return None
+
+    body = stripped[len("LOCATION:"):]
+    parts = body.split("|", 2)
+    coord_text = parts[0].strip()
+    if "," not in coord_text:
+        raise ValueError("LOCATION directive must use '<latitude>,<longitude>'")
+
+    lat_text, lon_text = [piece.strip() for piece in coord_text.split(",", 1)]
+    try:
+        latitude = float(lat_text)
+        longitude = float(lon_text)
+    except ValueError as exc:
+        raise ValueError("LOCATION directive latitude/longitude must be numeric") from exc
+
+    if not (-90 <= latitude <= 90):
+        raise ValueError("LOCATION directive latitude must be between -90 and 90")
+    if not (-180 <= longitude <= 180):
+        raise ValueError("LOCATION directive longitude must be between -180 and 180")
+
+    location: dict[str, object] = {"latitude": latitude, "longitude": longitude}
+    if len(parts) > 1 and parts[1].strip():
+        location["name"] = parts[1].strip()
+    if len(parts) > 2 and parts[2].strip():
+        location["address"] = parts[2].strip()
+    return location
+
+
 def _sanitize_error_text(text) -> str:
     """Redact secrets from error text before surfacing it to users/models."""
     redacted = redact_sensitive_text(text)
@@ -1094,7 +1133,27 @@ async def _send_whatsapp(extra, chat_id, message):
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         bridge_port = extra.get("bridge_port", 3000)
+        location = _parse_whatsapp_location_directive(message)
         async with aiohttp.ClientSession() as session:
+            if location is not None:
+                payload = {"chatId": chat_id, **location}
+                async with session.post(
+                    f"http://localhost:{bridge_port}/send-location",
+                    json=payload,
+                    timeout=aiohttp.ClientTimeout(total=30),
+                ) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        return {
+                            "success": True,
+                            "platform": "whatsapp",
+                            "chat_id": chat_id,
+                            "message_id": data.get("messageId"),
+                            "native_location": True,
+                        }
+                    body = await resp.text()
+                    return _error(f"WhatsApp bridge location error ({resp.status}): {body}")
+
             async with session.post(
                 f"http://localhost:{bridge_port}/send",
                 json={"chatId": chat_id, "message": message},
@@ -1110,6 +1169,8 @@ async def _send_whatsapp(extra, chat_id, message):
                     }
                 body = await resp.text()
                 return _error(f"WhatsApp bridge error ({resp.status}): {body}")
+    except ValueError as e:
+        return _error(f"WhatsApp location directive error: {e}")
     except Exception as e:
         return _error(f"WhatsApp send failed: {e}")
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -180,6 +180,22 @@ whatsapp:
 
 WhatsApp supports **streaming (progressive) responses** — the bot edits its message in real-time as the AI generates text, just like Discord and Telegram. Internally, WhatsApp is classified as a TIER_MEDIUM platform for delivery capabilities.
 
+### Native Location Pins
+
+Hermes can send a native WhatsApp location pin from `send_message` by making the entire message a `LOCATION:` directive:
+
+```text
+LOCATION:<latitude>,<longitude>|<name>|<address>
+```
+
+Example:
+
+```text
+LOCATION:37.7749,-122.4194|San Francisco City Hall|1 Dr Carlton B Goodlett Pl, San Francisco, CA
+```
+
+The `name` and `address` fields are optional, but the latitude and longitude are required. Coordinates are validated before delivery (`latitude` must be between `-90` and `90`; `longitude` between `-180` and `180`). This uses the local WhatsApp bridge to send a native location message rather than plain text.
+
 ### Chunking
 
 Long responses are automatically split into multiple messages at **4,096 characters** per chunk (WhatsApp's practical display limit). You don't need to configure anything — the gateway handles splitting and sends chunks sequentially.


### PR DESCRIPTION
## What does this PR do?

Adds native WhatsApp location pin delivery for the messaging tool and WhatsApp gateway path.

Hermes can now send a full-message location directive:

```text
LOCATION:<latitude>,<longitude>|<name>|<address>
```

When the target is WhatsApp, the directive is parsed and delivered through the local WhatsApp bridge as a native location message instead of plain text. Latitude/longitude are validated before delivery; `name` and `address` are optional.

## Related Issue

N/A — small feature/docs improvement; I did not find an existing issue or PR for WhatsApp native location delivery.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/send_message_tool.py`
  - Parse full-message `LOCATION:` directives for WhatsApp sends.
  - Call the WhatsApp bridge `/send-location` endpoint with validated coordinates.
- `gateway/platforms/whatsapp.py`
  - Detect the same directive in gateway adapter sends and route it to the native location endpoint.
- `scripts/whatsapp-bridge/bridge.js`
  - Add `POST /send-location` with coordinate validation and Baileys native location payload.
- `tests/tools/test_send_message_tool.py`
  - Add parser validation and standalone bridge call coverage.
- `tests/gateway/test_whatsapp_formatting.py`
  - Add adapter coverage for native location endpoint payloads.
- `website/docs/user-guide/messaging/whatsapp.md`
  - Document the native location pin directive format.

## How to Test

1. Run syntax checks:
   ```bash
   python -m py_compile tools/send_message_tool.py gateway/platforms/whatsapp.py
   node --check scripts/whatsapp-bridge/bridge.js
   ```
2. Run targeted tests:
   ```bash
   python -m pytest tests/tools/test_send_message_tool.py::TestSendToPlatformWhatsapp tests/gateway/test_whatsapp_formatting.py::TestSendChunking -q
   ```
3. Build docs:
   ```bash
   cd website
   npm ci
   npm run build
   ```

Local results:

- `python -m py_compile ...` passed
- `node --check scripts/whatsapp-bridge/bridge.js` passed
- targeted pytest: `14 passed, 2 warnings`
- `npm run build` completed successfully; it reported existing broken-link/anchor warnings unrelated to this WhatsApp page change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test output:

```text
..............                                                           [100%]
14 passed, 2 warnings in 4.02s
```
