### PR TITLE
fix(sys.path): strip absolute CWD to prevent module shadowing

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -323,6 +323,14 @@ def _require_tty(command_name: str) -> None:
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
 
+# Strip CWD from sys.path — prevents local files from shadowing Hermes
+# packages.  Virtualenv .pth hooks may resolve '' to the absolute CWD.
+# Re-insert PROJECT_ROOT in case CWD happens to equal it.
+_cwd = os.getcwd()
+sys.path = [p for p in sys.path if p not in {"", ".", _cwd}]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 
 # ---------------------------------------------------------------------------
 # Profile override — MUST happen before any hermes module import.

--- a/tests/hermes_cli/test_cwd_shadowing.py
+++ b/tests/hermes_cli/test_cwd_shadowing.py
@@ -1,0 +1,93 @@
+"""Regression tests for CWD package shadowing.
+
+When a user runs ``hermes`` from a directory containing a file named
+``tools.py`` (or ``utils.py``, etc.), Python's PathFinder resolves
+``import tools`` to that file instead of the Hermes ``tools/`` package.
+The CWD entries ('', '.', and the absolute CWD path) must be stripped
+from sys.path at startup to prevent this.
+
+The bug is compounded by virtualenv .pth hooks which resolve '' to the
+absolute CWD path before user code runs, meaning a guard that only strips
+'' and '.' misses the absolute path entry.
+
+See: https://github.com/NousResearch/hermes-agent/issues/XXXX
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def shadow_dir(tmp_path: Path):
+    """Create a temp dir with empty ``tools.py`` and ``utils.py``."""
+    (tmp_path / "tools.py").write_text("# shadow file\n")
+    (tmp_path / "utils.py").write_text("# shadow file\n")
+    return tmp_path
+
+
+def test_cwd_tools_py_does_not_shadow_hermes_package(
+    shadow_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An empty ``tools.py`` in CWD must not shadow the Hermes ``tools/`` package.
+
+    Before the fix, running ``hermes`` from a directory with a ``tools.py``
+    file caused every ``from tools.xxx import …`` to fail with
+    ``'tools' is not a package``.
+    """
+    monkeypatch.chdir(shadow_dir)
+    # Simulate what main.py does: insert PROJECT_ROOT then strip CWD entries.
+    project_root = str(Path(__file__).resolve().parent.parent.parent)
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+    # The fix: strip '', '.', and the absolute CWD.
+    # Virtualenv .pth hooks may resolve '' to the absolute CWD before our
+    # code runs, so we must strip all three forms.
+    cwd = os.getcwd()
+    sys.path = [p for p in sys.path if p not in {"", ".", cwd}]
+
+    # Clear any cached 'tools' module from previous tests.
+    sys.modules.pop("tools", None)
+    sys.modules.pop("tools.registry", None)
+
+    import tools  # noqa: F811
+
+    assert hasattr(tools, "__path__"), (
+        f"'tools' resolved to a file ({tools.__file__}), not a package. "
+        "CWD shadowing is not prevented."
+    )
+    assert "hermes-agent" in str(tools.__file__), (
+        f"'tools' resolved to {tools.__file__}, expected Hermes package."
+    )
+
+
+def test_cwd_utils_py_does_not_shadow_hermes_utils(
+    shadow_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An empty ``utils.py`` in CWD must not shadow the Hermes ``utils`` module."""
+    monkeypatch.chdir(shadow_dir)
+    project_root = str(Path(__file__).resolve().parent.parent.parent)
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+    cwd = os.getcwd()
+    sys.path = [p for p in sys.path if p not in {"", ".", cwd}]
+
+    sys.modules.pop("utils", None)
+
+    import utils  # noqa: F811
+
+    assert "hermes-agent" in str(utils.__file__), (
+        f"'utils' resolved to {utils.__file__}, expected Hermes module."
+    )
+
+
+def test_sys_path_strips_cwd_entries():
+    """Verify the guard logic removes '', '.', and absolute CWD."""
+    cwd = os.getcwd()
+    test_path = ["/some/path", "", "/another", ".", cwd, "/last"]
+    result = [p for p in test_path if p not in {"", ".", cwd}]
+    assert result == ["/some/path", "/another", "/last"]

--- a/tests/tui_gateway/test_entry_sys_path.py
+++ b/tests/tui_gateway/test_entry_sys_path.py
@@ -24,7 +24,10 @@ def _reload_entry_with_env(env_overrides: dict) -> None:
             _src_root = os.environ.get("HERMES_PYTHON_SRC_ROOT", "")
             if _src_root and _src_root not in sys.path:
                 sys.path.insert(0, _src_root)
-            sys.path = [p for p in sys.path if p not in {"", "."}]
+            _cwd = os.getcwd()
+            sys.path = [p for p in sys.path if p not in {"", ".", _cwd}]
+            if _src_root and _src_root not in sys.path:
+                sys.path.insert(0, _src_root)
         return sys.path[:]
     finally:
         sys.path = original_path
@@ -44,7 +47,8 @@ def test_empty_string_and_dot_removed_from_sys_path():
         assert "." in sys.path
 
         # Run the entry.py fixup logic directly
-        sys.path = [p for p in sys.path if p not in {"", "."}]
+        _cwd = os.getcwd()
+        sys.path = [p for p in sys.path if p not in {"", ".", _cwd}]
 
         assert "" not in sys.path
         assert "." not in sys.path
@@ -60,7 +64,10 @@ def test_hermes_src_root_inserted_at_front():
             _src_root = os.environ.get("HERMES_PYTHON_SRC_ROOT", "")
             if _src_root and _src_root not in sys.path:
                 sys.path.insert(0, _src_root)
-            sys.path = [p for p in sys.path if p not in {"", "."}]
+            _cwd = os.getcwd()
+            sys.path = [p for p in sys.path if p not in {"", ".", _cwd}]
+            if _src_root and _src_root not in sys.path:
+                sys.path.insert(0, _src_root)
 
         assert sys.path[0] == fake_root
     finally:
@@ -78,7 +85,10 @@ def test_src_root_not_duplicated_if_already_present():
             _src_root = os.environ.get("HERMES_PYTHON_SRC_ROOT", "")
             if _src_root and _src_root not in sys.path:
                 sys.path.insert(0, _src_root)
-            sys.path = [p for p in sys.path if p not in {"", "."}]
+            _cwd = os.getcwd()
+            sys.path = [p for p in sys.path if p not in {"", ".", _cwd}]
+            if _src_root and _src_root not in sys.path:
+                sys.path.insert(0, _src_root)
 
         assert sys.path.count(fake_root) == count_before
     finally:
@@ -94,7 +104,27 @@ def test_no_src_root_env_does_not_crash():
             _src_root = os.environ.get("HERMES_PYTHON_SRC_ROOT", "")
             if _src_root and _src_root not in sys.path:
                 sys.path.insert(0, _src_root)
-            sys.path = [p for p in sys.path if p not in {"", "."}]
+            _cwd = os.getcwd()
+            sys.path = [p for p in sys.path if p not in {"", ".", _cwd}]
+            if _src_root and _src_root not in sys.path:
+                sys.path.insert(0, _src_root)
         # No exception raised
+    finally:
+        sys.path = original
+
+
+def test_absolute_cwd_removed_from_sys_path():
+    """Virtualenv .pth hooks may resolve '' to the absolute CWD path."""
+    original = sys.path[:]
+    try:
+        cwd = os.getcwd()
+        # Simulate what virtualenv does: replace '' with absolute CWD
+        sys.path = [cwd if p == "" else p for p in sys.path]
+        assert cwd in sys.path
+
+        _cwd = os.getcwd()
+        sys.path = [p for p in sys.path if p not in {"", ".", _cwd}]
+
+        assert cwd not in sys.path
     finally:
         sys.path = original

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -7,9 +7,13 @@ import sys
 _src_root = os.environ.get("HERMES_PYTHON_SRC_ROOT", "")
 if _src_root and _src_root not in sys.path:
     sys.path.insert(0, _src_root)
-# Strip '' and '.' — both resolve to CWD at import time and can let a local
-# directory shadow installed packages.
-sys.path = [p for p in sys.path if p not in {"", "."}]
+# Strip CWD from sys.path — prevents local files from shadowing Hermes
+# packages.  Virtualenv .pth hooks may resolve '' to the absolute CWD.
+# Re-insert _src_root in case CWD happens to equal it.
+_cwd = os.getcwd()
+sys.path = [p for p in sys.path if p not in {"", ".", _cwd}]
+if _src_root and _src_root not in sys.path:
+    sys.path.insert(0, _src_root)
 
 import json
 import logging


### PR DESCRIPTION
## What does this PR do?

Running `hermes` from a directory containing a file named after a Hermes package (e.g. `tools.py`, `utils.py`) causes Python's `PathFinder` to resolve `import tools` to that file instead of the Hermes `tools/` package. This silently poisons every subsequent `from tools.xxx import …` across all plugins, crashing both the TUI and gateway.

**Root cause:** Python seeds `sys.path` with `''` (CWD) at startup. In some environments — particularly editable installs (`pip install -e .`) — virtualenv `.pth` hooks resolve `''` to the **absolute CWD path** before user code runs. `PathFinder` searches `sys.path` in order and finds the CWD file before the Hermes package.

**What breaks:** Any file in CWD matching an internal package name (`tools.py`, `utils.py`, `plugins.py`, `gateway.py`, etc.) shadows the corresponding Hermes module. The user sees `No module named 'tools.registry'; 'tools' is not a package` and the TUI/gateway crashes immediately.

## Relationship to #15989 / #19885

Issue [#15989](https://github.com/NousResearch/hermes-agent/issues/15989) reported the same class of bug — a `utils/` **directory** in CWD shadowing the installed `utils` module. PR [#19885](https://github.com/NousResearch/hermes-agent/pull/19885) fixed it by stripping `''` and `'.'` from `sys.path` in `tui_gateway/entry.py`.

That guard worked for #15989 because `''` was still in `sys.path` when the guard ran — stripping it prevented PathFinder from searching CWD. However, the guard is insufficient when virtualenv `.pth` hooks have already resolved `''` to the absolute CWD path (e.g. `/home/user/myproject`). In that case, the guard strips `''` (already gone) and `'.'`, but the absolute path passes through untouched.

This PR extends the guard to also strip `os.getcwd()`, covering both the standard case (`''`) and the virtualenv/ editable-install edge case (absolute CWD). After stripping, the project root / src root is re-inserted at position 0 so that `CWD == repo root` doesn't collaterally remove the project root from `sys.path`.

**Is the virtualenv behavior environment-specific?** Partially. The `_virtualenv.pth` → `import _virtualenv` hook is standard in every virtualenv. But the timing of when `''` resolves to an absolute path depends on Python version, how the venv was created, and whether it's an editable install. Our environment uses `pip install -e .` which adds an additional `.pth` finder that may trigger the `''` → absolute path resolution earlier than typical. On a different system with a standard `pip install`, `''` might remain as `''` and the #19885 guard alone would work. Stripping `os.getcwd()` costs nothing and eliminates the variable entirely.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: Added CWD guard after `PROJECT_ROOT` insertion — strips `''`, `'.'`, and `os.getcwd()` from `sys.path`, then re-inserts `PROJECT_ROOT` if it was collateral.
- `tui_gateway/entry.py`: Upgraded existing guard (#19885) to also strip the absolute CWD path and re-insert `_src_root`.
- `tests/tui_gateway/test_entry_sys_path.py`: Updated existing tests to match new guard logic; added `test_absolute_cwd_removed_from_sys_path`.
- `tests/hermes_cli/test_cwd_shadowing.py` (new): 3 regression tests covering `tools.py` and `utils.py` shadowing.

## How to Test

```bash
# Reproduce (before fix):
mkdir /tmp/test-shadow
cd /tmp/test-shadow && touch ./tools.py
hermes --tui
# → crash: "No module named 'tools.registry'; 'tools' is not a package"

# Verify fix (after):
cd /tmp/test-shadow && hermes --tui
# → TUI starts normally

# Also test utils.py:
cd /tmp/test-shadow && touch ./utils.py
hermes --tui
# → TUI starts normally

# Regression tests:
pytest tests/hermes_cli/test_cwd_shadowing.py tests/tui_gateway/test_entry_sys_path.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13 (Linux 6.12)

### Documentation & Housekeeping

- [x] N/A — no docs or config changes needed