### PR TITLE
fix(agent): move tool-call argument redaction to persistence boundary (#43083)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1003,18 +1003,14 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
                     "arguments": tool_call.function.arguments
                 },
             }
-            # Defence-in-depth: redact credentials from tool call arguments
-            # before they enter conversation history. Tool execution uses the
-            # raw API response object, not this dict, so redacting the
-            # persisted shape is safe and only affects storage. Catches the
-            # case where a model accidentally inlines a secret into a tool
-            # call (e.g. `terminal(command="curl -H 'Authorization: Bearer
-            # sk-...'")`). (#19798)
-            if isinstance(tc_dict["function"]["arguments"], str):
-                from agent.redact import redact_sensitive_text
-                tc_dict["function"]["arguments"] = redact_sensitive_text(
-                    tc_dict["function"]["arguments"]
-                )
+            # NOTE: tool call arguments are intentionally NOT redacted here.
+            # The in-memory messages list is replayed to the model on every
+            # subsequent turn. Redacting secrets to `***` in the conversation
+            # history causes the model to copy the placeholder on the next
+            # tool call, breaking credential-dependent commands (e.g.
+            # PGPASSWORD='***' psql). Redaction is applied at the
+            # persistence boundary instead — see _persist_session() in
+            # run_agent.py. (#43083)
             # Preserve extra_content (e.g. Gemini thought_signature) so it
             # is sent back on subsequent API calls.  Without this, Gemini 3
             # thinking models reject the request with a 400 error.

--- a/run_agent.py
+++ b/run_agent.py
@@ -2219,6 +2219,22 @@ class AIAgent:
                 if "content" in msg:
                     msg = dict(msg)
                     msg["content"] = self._redact_message_content(msg.get("content"))
+                # Redact tool call arguments at the persistence boundary
+                # so session logs don't store raw credentials. The in-memory
+                # messages list keeps unredacted arguments so the model can
+                # replay them correctly on subsequent turns. (#43083)
+                if msg.get("tool_calls"):
+                    if "content" not in msg:
+                        msg = dict(msg)
+                    redacted_tcs = []
+                    for tc in msg["tool_calls"]:
+                        tc = dict(tc)
+                        fn = tc.get("function")
+                        if isinstance(fn, dict) and isinstance(fn.get("arguments"), str):
+                            tc["function"] = dict(fn)
+                            tc["function"]["arguments"] = redact_sensitive_text(fn["arguments"])
+                        redacted_tcs.append(tc)
+                    msg["tool_calls"] = redacted_tcs
                 cleaned.append(msg)
 
             # Guard: never overwrite a larger session log with fewer messages.

--- a/tests/agent/test_tool_call_redaction.py
+++ b/tests/agent/test_tool_call_redaction.py
@@ -1,0 +1,263 @@
+"""Tests for tool-call argument redaction at the persistence boundary.
+
+Verifies fix for #43083: redacting tool call arguments in build_assistant_message
+caused the model to see ``***`` instead of real credentials on subsequent turns,
+breaking credential-dependent commands.
+
+The fix moves redaction from build_assistant_message (in-memory, replayed to model)
+to _persist_session (storage-only, never replayed).
+"""
+
+import json
+import os
+import tempfile
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _FakeToolCall:
+    """Minimal stand-in for the API response ToolCall object."""
+
+    def __init__(self, tc_id, name, arguments, extra_content=None):
+        self.id = tc_id
+        self.type = "function"
+        self.function = MagicMock()
+        self.function.name = name
+        self.function.arguments = arguments
+        self.extra_content = extra_content
+
+
+class _FakeAssistantMsg:
+    """Minimal stand-in for the API response message object."""
+
+    def __init__(self, content, tool_calls=None):
+        self.content = content
+        self.tool_calls = tool_calls or []
+        self.function_call = None
+        self.reasoning_content = None
+        self.model_extra = None
+
+
+class _FakeAgent:
+    """Minimal agent with the attributes build_assistant_message reads."""
+
+    def __init__(self):
+        self.stream_delta_callback = None
+        self._stream_callback = None
+        self.reasoning_callback = None
+        self.reasoning_effort = None
+
+    @staticmethod
+    def _strip_think_blocks(text):
+        return text
+
+    @staticmethod
+    def _extract_reasoning(assistant_message):
+        return None
+
+    @staticmethod
+    def _needs_thinking_reasoning_pad():
+        return False
+
+    @staticmethod
+    def _deterministic_call_id(name, args, idx):
+        return f"call_{idx}"
+
+    @staticmethod
+    def _split_responses_tool_id(raw_id):
+        return raw_id, None
+
+    @staticmethod
+    def _derive_responses_function_call_id(call_id, response_item_id):
+        return call_id
+
+
+_PASSWORD = "SuperSecret123!"
+_CMD_WITH_SECRET = f"PGPASSWORD='{_PASSWORD}' psql -c 'SELECT 1'"
+
+
+class TestBuildAssistantMessageNoRedaction:
+    """build_assistant_message must NOT redact tool call arguments.
+
+    The in-memory messages list is replayed to the model on every turn.
+    Redacting secrets to ``***`` here causes the model to copy the
+    placeholder, breaking subsequent tool calls that need the real value.
+    """
+
+    def test_tool_call_arguments_preserved(self):
+        """Credential in tool call arguments must survive build_assistant_message."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        args_json = json.dumps({"command": _CMD_WITH_SECRET})
+        tc = _FakeToolCall("call_0", "terminal", args_json)
+        assistant_msg = _FakeAssistantMsg("Running query...", [tc])
+
+        agent = _FakeAgent()
+        result = build_assistant_message(agent, assistant_msg, "tool_calls")
+
+        assert "tool_calls" in result
+        args = result["tool_calls"][0]["function"]["arguments"]
+        assert _PASSWORD in args, (
+            "Tool call arguments must NOT be redacted in the in-memory message. "
+            "The model needs the real value to replay on subsequent turns."
+        )
+
+    def test_multiple_tool_calls_preserved(self):
+        """Multiple tool calls with secrets must all be preserved."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        tc1 = _FakeToolCall(
+            "call_0", "terminal",
+            json.dumps({"command": "curl -H 'Authorization: Bearer *** https://api.example.com"}),
+        )
+        tc2 = _FakeToolCall(
+            "call_1", "execute_code",
+            json.dumps({"code": "import os; os.environ['DB_PASS'] = 'hunter2'"}),
+        )
+        assistant_msg = _FakeAssistantMsg("", [tc1, tc2])
+
+        agent = _FakeAgent()
+        result = build_assistant_message(agent, assistant_msg, "tool_calls")
+
+        args0 = result["tool_calls"][0]["function"]["arguments"]
+        args1 = result["tool_calls"][1]["function"]["arguments"]
+        assert "***" in args0  # original value preserved, not redacted further
+        assert "hunter2" in args1
+
+    def test_no_tool_calls_still_works(self):
+        """Assistant message without tool calls must still build correctly."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        assistant_msg = _FakeAssistantMsg("Here is the result.")
+
+        agent = _FakeAgent()
+        result = build_assistant_message(agent, assistant_msg, "stop")
+
+        assert result["content"] == "Here is the result."
+        assert result.get("tool_calls") is None or result.get("tool_calls") == []
+
+
+class TestPersistSessionRedactsToolCalls:
+    """_persist_session must redact tool call arguments in the session log.
+
+    This is the safety net: even though build_assistant_message no longer
+    redacts, the persisted session file must not store raw credentials.
+    """
+
+    def _make_agent(self, tmpdir):
+        from pathlib import Path
+        agent = object.__new__(__import__("run_agent").AIAgent)
+        agent.session_id = "test-session"
+        agent.model = "test-model"
+        agent.base_url = ""
+        agent.platform = "test"
+        agent.logs_dir = Path(tmpdir)
+        agent.session_start = datetime.now()
+        agent._cached_system_prompt = "test"
+        agent._session_db = None
+        agent._last_flushed_db_idx = 0
+        agent._session_json_enabled = True
+        agent._session_messages = []
+        agent.verbose_logging = False
+        agent.tools = []
+        return agent
+
+    def test_persist_redacts_tool_call_arguments(self):
+        """Session log must have redacted tool call arguments."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            agent = self._make_agent(tmpdir)
+            messages = [
+                {
+                    "role": "assistant",
+                    "content": "Running query...",
+                    "tool_calls": [
+                        {
+                            "id": "call_0",
+                            "call_id": "call_0",
+                            "type": "function",
+                            "function": {
+                                "name": "terminal",
+                                "arguments": json.dumps({"command": _CMD_WITH_SECRET}),
+                            },
+                        }
+                    ],
+                }
+            ]
+
+            with patch("agent.redact._REDACT_ENABLED", True), \
+                 patch.object(agent, "_flush_messages_to_session_db"):
+                agent._persist_session(messages)
+
+            log_path = os.path.join(tmpdir, "session_test-session.json")
+            with open(log_path) as f:
+                log = json.load(f)
+
+            persisted_args = log["messages"][0]["tool_calls"][0]["function"]["arguments"]
+            assert _PASSWORD not in persisted_args, (
+                "Session log must redact credentials in tool call arguments."
+            )
+
+    def test_persist_does_not_mutate_original_messages(self):
+        """The in-memory messages list must not be mutated by _persist_session."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            agent = self._make_agent(tmpdir)
+            original_args = json.dumps({"command": _CMD_WITH_SECRET})
+            messages = [
+                {
+                    "role": "assistant",
+                    "content": "Running...",
+                    "tool_calls": [
+                        {
+                            "id": "call_0",
+                            "call_id": "call_0",
+                            "type": "function",
+                            "function": {
+                                "name": "terminal",
+                                "arguments": original_args,
+                            },
+                        }
+                    ],
+                }
+            ]
+
+            with patch("agent.redact._REDACT_ENABLED", True), \
+                 patch.object(agent, "_flush_messages_to_session_db"):
+                agent._persist_session(messages)
+
+            # Original messages list must be untouched
+            assert messages[0]["tool_calls"][0]["function"]["arguments"] == original_args
+
+    def test_persist_preserves_non_string_arguments(self):
+        """Non-string arguments (dict) must pass through without error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            agent = self._make_agent(tmpdir)
+            messages = [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_0",
+                            "call_id": "call_0",
+                            "type": "function",
+                            "function": {
+                                "name": "some_tool",
+                                "arguments": {"key": "value"},  # dict, not str
+                            },
+                        }
+                    ],
+                }
+            ]
+
+            # Must not raise
+            with patch("agent.redact._REDACT_ENABLED", True), \
+                 patch.object(agent, "_flush_messages_to_session_db"):
+                agent._persist_session(messages)
+
+            log_path = os.path.join(tmpdir, "session_test-session.json")
+            with open(log_path) as f:
+                log = json.load(f)
+            # Dict arguments should pass through unchanged
+            assert log["messages"][0]["tool_calls"][0]["function"]["arguments"] == {"key": "value"}


### PR DESCRIPTION
## What does this PR do?

Moves tool-call argument redaction from `build_assistant_message()` (in-memory, replayed to model on every turn) to `_persist_session()`'s JSON writer (storage-only). This fixes a bug where credential-dependent commands like `PGPASSWORD='real_pass' psql` broke on the second tool call because the model saw `***` in its own conversation history and copied the placeholder.

## Related Issue

Fixes #43083

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: Remove tool-call argument redaction from `build_assistant_message()`. The in-memory messages list is replayed to the model on every subsequent turn — redacting secrets here corrupts the model's context.
- `run_agent.py`: Add tool-call argument redaction to `_persist_session()` at the JSON persistence boundary, so session logs don't store raw credentials. Uses `dict()` copy to avoid mutating the original in-memory messages list.
- `tests/agent/test_tool_call_redaction.py`: 6 tests — 3 verify `build_assistant_message` preserves tool call arguments (single, multiple, no-tool-calls), 3 verify `_persist_session` redacts arguments in the log file, doesn't mutate originals, and handles non-string argument shapes.

## How to Test

1. Run `pytest tests/agent/test_tool_call_redaction.py -v` — all 6 tests should pass
2. Run `pytest tests/agent/test_redact.py tests/agent/transports/test_types.py tests/cli/test_reasoning_command.py tests/run_agent/test_empty_response_recovery_persistence.py -v` — all existing tests should pass (166+ tests)
3. Manual: start a session, run a terminal command with a credential (e.g. `curl -H 'Authorization: Bearer sk-test' https://httpbin.org/get`), then run another command — the model should correctly reference the original credential, not `***`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/chat_completion_helpers.py::build_assistant_message`, `run_agent.py::_persist_session`
- Callers of `build_assistant_message`: `_build_assistant_message` (run_agent.py:4780), `_extract_and_build` (transport), tests
- Callers of `_persist_session`: `run_conversation` exit paths, compression, /branch, error handlers
- Blast radius: LOW — only changes where redaction happens, not whether it happens
- Related patterns: persistence-boundary redaction (#19798, #19845)
