### PR TITLE
fix(dashboard-auth): thread-safe lazy init of PyJWKClient in nous and self-hosted providers

### DIFF
--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -74,6 +74,7 @@ import hashlib
 import logging
 import os
 import secrets
+import threading
 import urllib.parse
 from typing import Any, Dict, Optional
 
@@ -173,6 +174,7 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
         # PyJWKClient is lazily imported so plugin discovery doesn't pay the
         # crypto-import cost when the provider isn't activated.
         self._jwks_client: Any = None
+        self._jwks_client_lock = threading.Lock()
 
     # ---- public API (DashboardAuthProvider) -------------------------------
 
@@ -413,15 +415,16 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
         return body if isinstance(body, dict) else {}
 
     def _get_jwks_client(self) -> Any:
-        if self._jwks_client is None:
-            from jwt import PyJWKClient  # lazy import
+        with self._jwks_client_lock:
+            if self._jwks_client is None:
+                from jwt import PyJWKClient  # lazy import
 
-            self._jwks_client = PyJWKClient(
-                self._jwks_url,
-                cache_keys=True,
-                lifespan=_JWKS_CACHE_SECONDS,
-            )
-        return self._jwks_client
+                self._jwks_client = PyJWKClient(
+                    self._jwks_url,
+                    cache_keys=True,
+                    lifespan=_JWKS_CACHE_SECONDS,
+                )
+            return self._jwks_client
 
     def _verify_jwt(self, access_token: str) -> Dict[str, Any]:
         # Lazy import — keeps startup fast for operators who never trigger

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -194,6 +194,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         self._discovery_fetched_at: float = 0.0
         self._discovery_lock = threading.Lock()
         self._jwks_client: Any = None
+        self._jwks_client_lock = threading.Lock()
 
     # ---- public API (DashboardAuthProvider) -------------------------------
 
@@ -478,16 +479,17 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
     # ---- internals: JWT verification --------------------------------------
 
     def _get_jwks_client(self) -> Any:
-        if self._jwks_client is None:
-            from jwt import PyJWKClient  # lazy import
+        with self._jwks_client_lock:
+            if self._jwks_client is None:
+                from jwt import PyJWKClient  # lazy import
 
-            disco = self._get_discovery()
-            self._jwks_client = PyJWKClient(
-                disco["jwks_uri"],
-                cache_keys=True,
-                lifespan=_JWKS_CACHE_SECONDS,
-            )
-        return self._jwks_client
+                disco = self._get_discovery()
+                self._jwks_client = PyJWKClient(
+                    disco["jwks_uri"],
+                    cache_keys=True,
+                    lifespan=_JWKS_CACHE_SECONDS,
+                )
+            return self._jwks_client
 
     def _verify_id_token(self, id_token: str) -> Dict[str, Any]:
         import jwt  # lazy import — keeps startup fast for the ungated path


### PR DESCRIPTION
## Problem

Both `NousDashboardAuthProvider._get_jwks_client()` and
`SelfHostedOIDCProvider._get_jwks_client()` use a lockless check-then-set
pattern for lazy initialisation:

```python
def _get_jwks_client(self) -> Any:
    if self._jwks_client is None:          # ← no lock
        self._jwks_client = PyJWKClient(...)
    return self._jwks_client
```

The dashboard auth middleware (`_dashboard_auth_gate`) handles concurrent
HTTP requests, so multiple threads can reach `_get_jwks_client()` at the
same time. Both see `None`, both construct a `PyJWKClient` (each issuing
a redundant JWKS endpoint fetch), and the second write overwrites the
first. The surviving object is functionally correct, but the extra
network round-trip is wasted work and can race with key-rotation events.

## Fix

Add `self._jwks_client_lock = threading.Lock()` in each provider's
`__init__` and wrap the lazy-init body in `_get_jwks_client()` with
`with self._jwks_client_lock:`.

`threading` was already imported in `self_hosted/__init__.py` (it already
used `threading.Lock()` for `_discovery_lock`); added to
`nous/__init__.py`.

This is the same fix applied to:
- `plugins/observability/langfuse` — PR #42326
- `plugins/memory/hindsight` — PR #42328

## Testing

- [ ] All 120 existing tests in `tests/plugins/dashboard_auth/test_nous_provider.py` and `tests/plugins/dashboard_auth/test_self_hosted_provider.py` pass.