### PR TITLE
fix(google-workspace): recursively extract body from nested MIME parts in gmail get

### DIFF
--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -136,22 +136,53 @@ def _headers_dict(msg: dict) -> dict[str, str]:
     }
 
 
+def _extract_part_body(part: dict) -> str:
+    """Recursively extract the best text body from a MIME part tree."""
+    # Direct body data on this part
+    data = part.get("body", {}).get("data")
+    if data:
+        return base64.urlsafe_b64decode(data).decode("utf-8", errors="replace")
+
+    # Recurse into sub-parts
+    sub_parts = part.get("parts")
+    if not sub_parts:
+        return ""
+
+    # Prefer text/plain
+    for sp in sub_parts:
+        if sp.get("mimeType") == "text/plain":
+            text = _extract_part_body(sp)
+            if text:
+                return text
+
+    # Handle message/rfc822 (forwarded emails) — recurse into nested payload
+    for sp in sub_parts:
+        if sp.get("mimeType") == "message/rfc822":
+            nested = sp.get("payload", {})
+            text = _extract_part_body(nested)
+            if text:
+                return text
+
+    # Fall back to text/html
+    for sp in sub_parts:
+        if sp.get("mimeType") == "text/html":
+            text = _extract_part_body(sp)
+            if text:
+                return text
+
+    # Last resort: recurse into any multipart children
+    for sp in sub_parts:
+        if sp.get("mimeType", "").startswith("multipart/"):
+            text = _extract_part_body(sp)
+            if text:
+                return text
+
+    return ""
+
+
 def _extract_message_body(msg: dict) -> str:
-    body = ""
     payload = msg.get("payload", {})
-    if payload.get("body", {}).get("data"):
-        body = base64.urlsafe_b64decode(payload["body"]["data"]).decode("utf-8", errors="replace")
-    elif payload.get("parts"):
-        for part in payload["parts"]:
-            if part.get("mimeType") == "text/plain" and part.get("body", {}).get("data"):
-                body = base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8", errors="replace")
-                break
-        if not body:
-            for part in payload["parts"]:
-                if part.get("mimeType") == "text/html" and part.get("body", {}).get("data"):
-                    body = base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8", errors="replace")
-                    break
-    return body
+    return _extract_part_body(payload)
 
 
 def _extract_doc_text(doc: dict) -> str:

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -484,3 +484,130 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+# ── _extract_message_body / _extract_part_body recursive MIME tests ────
+
+
+def _b64(text: str) -> str:
+    """Base64url-encode a string (no padding) for MIME body.data fields."""
+    import base64
+
+    return base64.urlsafe_b64encode(text.encode()).decode()
+
+
+def test_extract_message_body_simple_text(api_module):
+    """Top-level text/plain body is returned directly."""
+    msg = {"payload": {"body": {"data": _b64("Hello world")}}}
+    assert api_module._extract_message_body(msg) == "Hello world"
+
+
+def test_extract_message_body_multipart_plain(api_module):
+    """text/plain part is preferred inside multipart."""
+    msg = {
+        "payload": {
+            "parts": [
+                {"mimeType": "text/plain", "body": {"data": _b64("Plain text")}},
+                {"mimeType": "text/html", "body": {"data": _b64("<p>HTML</p>")}},
+            ]
+        }
+    }
+    assert api_module._extract_message_body(msg) == "Plain text"
+
+
+def test_extract_message_body_falls_back_to_html(api_module):
+    """When no text/plain exists, text/html is returned."""
+    msg = {
+        "payload": {
+            "parts": [
+                {"mimeType": "text/html", "body": {"data": _b64("<p>HTML</p>")}},
+            ]
+        }
+    }
+    assert api_module._extract_message_body(msg) == "<p>HTML</p>"
+
+
+def test_extract_message_body_forwarded_email_rfc822(api_module):
+    """Forwarded email nested inside message/rfc822 is extracted."""
+    forwarded_body = "This is the forwarded email content."
+    msg = {
+        "payload": {
+            "parts": [
+                {
+                    "mimeType": "text/plain",
+                    "body": {"data": _b64("---------- Forwarded message ---------")},
+                },
+                {
+                    "mimeType": "message/rfc822",
+                    "payload": {
+                        "parts": [
+                            {
+                                "mimeType": "text/plain",
+                                "body": {"data": _b64(forwarded_body)},
+                            },
+                        ]
+                    },
+                },
+            ]
+        }
+    }
+    # text/plain at top level is found first (wrapper note)
+    assert "Forwarded message" in api_module._extract_message_body(msg)
+
+
+def test_extract_message_body_nested_multipart_mixed(api_module):
+    """Deeply nested multipart/mixed → multipart/alternative → text/plain."""
+    inner_body = "Inner plain text content"
+    msg = {
+        "payload": {
+            "mimeType": "multipart/mixed",
+            "parts": [
+                {
+                    "mimeType": "multipart/alternative",
+                    "parts": [
+                        {
+                            "mimeType": "text/plain",
+                            "body": {"data": _b64(inner_body)},
+                        },
+                        {
+                            "mimeType": "text/html",
+                            "body": {"data": _b64("<p>HTML</p>")},
+                        },
+                    ],
+                }
+            ],
+        }
+    }
+    assert api_module._extract_message_body(msg) == inner_body
+
+
+def test_extract_message_body_empty_on_no_parts(api_module):
+    """Empty result when no body data and no parts."""
+    msg = {"payload": {}}
+    assert api_module._extract_message_body(msg) == ""
+
+
+def test_extract_part_body_deeply_nested_forward(api_module):
+    """Forwarded-as-attachment inside nested multipart:
+    multipart/mixed → message/rfc822 → multipart/alternative → text/plain."""
+    forward_content = "The actual forwarded email body."
+    msg = {
+        "payload": {
+            "mimeType": "multipart/mixed",
+            "parts": [
+                {
+                    "mimeType": "message/rfc822",
+                    "payload": {
+                        "mimeType": "multipart/alternative",
+                        "parts": [
+                            {
+                                "mimeType": "text/plain",
+                                "body": {"data": _b64(forward_content)},
+                            },
+                        ],
+                    },
+                }
+            ],
+        }
+    }
+    assert api_module._extract_message_body(msg) == forward_content


### PR DESCRIPTION
## What does this PR do?

Fixes `_extract_message_body()` in the google-workspace skill's Gmail integration to recursively traverse nested MIME part trees. Previously, only top-level parts were examined, causing forwarded emails (`message/rfc822`) and bodies nested inside `multipart/mixed` or `multipart/alternative` containers to be silently dropped.

## Related Issue

Fixes #43054

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `skills/productivity/google-workspace/scripts/google_api.py`: Extracted the flat top-level-only iteration into a recursive `_extract_part_body()` function that handles `message/rfc822` nested payloads, deeply nested `multipart/*` containers, and preserves the text/plain > text/html preference order.
- `tests/skills/test_google_workspace_api.py`: Added 7 tests covering simple text, multipart plain/html, forwarded email (rfc822), nested multipart/mixed → multipart/alternative, empty payload, and deeply nested forward-as-attachment scenarios.

## How to Test

1. Run `pytest tests/skills/test_google_workspace_api.py -v` — all 23 tests should pass
2. Verify the new tests cover nested MIME scenarios:
   - `test_extract_message_body_forwarded_email_rfc822`
   - `test_extract_message_body_nested_multipart_mixed`
   - `test_extract_part_body_deeply_nested_forward`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_extract_message_body` → `_extract_part_body` (recursive MIME traversal)
- Blast radius: LOW — changes isolated to google-workspace skill's `google_api.py`, only affects Gmail body extraction
- Related patterns: Gmail MIME structure (multipart/mixed, message/rfc822, multipart/alternative)
