### PR TITLE
fix(desktop): skip per-file codesign timestamping on local --dir packs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5202,7 +5202,18 @@ def cmd_gui(args: argparse.Namespace):
                 stopped = _stop_desktop_processes_locking_build(desktop_dir)
                 if stopped:
                     print(f"  ⚠ Stopped running desktop app to free the build output (pid {', '.join(map(str, stopped))})")
-            build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
+            build_cmd = [npm, "run", build_script]
+            if not source_mode and sys.platform == "darwin":
+                # Local `--dir` packs sign every file with a bare `codesign
+                # --timestamp`, which makes a network round-trip to Apple's
+                # timestamp authority PER FILE (~50+ Electron locales +
+                # frameworks): minutes of added build time, and a hard hang when
+                # offline. Disable secure timestamping for the LOCAL dev pack
+                # only — `--config.mac.timestamp=none` skips it. Notarized
+                # release builds (`dist:mac*`) never run this `pack` path, so
+                # they keep real timestamps.
+                build_cmd += ["--", "--config.mac.timestamp=none"]
+            build_result = subprocess.run(build_cmd, cwd=desktop_dir, env=env, check=False)
             if build_result.returncode != 0 and not source_mode:
                 # A corrupt cached Electron zip makes `pack` fail with an ENOENT
                 # on the final `electron` -> `Hermes` rename: unpack-electron
@@ -5225,7 +5236,7 @@ def cmd_gui(args: argparse.Namespace):
                     # The purge can't remove a win-unpacked tree whose Hermes.exe
                     # is still locked by a running instance; stop it before retry.
                     _stop_desktop_processes_locking_build(desktop_dir)
-                    build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
+                    build_result = subprocess.run(build_cmd, cwd=desktop_dir, env=env, check=False)
             if build_result.returncode != 0 and not source_mode and not env.get("ELECTRON_MIRROR"):
                 # Still failing and the user hasn't pinned a mirror: GitHub's
                 # Electron release host is likely blocked/throttled (the repeating
@@ -5242,7 +5253,7 @@ def cmd_gui(args: argparse.Namespace):
                 mirror_env = dict(env)
                 mirror_env["ELECTRON_MIRROR"] = "https://npmmirror.com/mirrors/electron/"
                 _stop_desktop_processes_locking_build(desktop_dir)
-                build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=mirror_env, check=False)
+                build_result = subprocess.run(build_cmd, cwd=desktop_dir, env=mirror_env, check=False)
             if build_result.returncode != 0:
                 print("✗ Desktop GUI build failed")
                 print(f"  Run manually:  cd apps/desktop && npm run {build_script}")

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -71,7 +71,11 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
 
     assert exc.value.code == 0
     mock_install.assert_called_once_with("/usr/bin/npm", root, capture_output=False, env=None)
-    assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
+    # macOS local --dir packs append --config.mac.timestamp=none (offline-safe);
+    # see test_gui_macos_local_pack_disables_codesign_timestamp.
+    assert mock_run.call_args_list[0].args[0] == [
+        "/usr/bin/npm", "run", "pack", "--", "--config.mac.timestamp=none"
+    ]
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
     assert mock_run.call_args_list[1].args[0] == [str(packaged_exe)]
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
@@ -244,6 +248,66 @@ def test_gui_source_mode_uses_renderer_build_and_electron(tmp_path, monkeypatch)
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
     assert mock_run.call_args_list[1].args[0] == ["/usr/bin/npm", "exec", "--", "electron", "."]
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
+
+
+def test_gui_macos_local_pack_disables_codesign_timestamp(tmp_path, monkeypatch):
+    """Local macOS ``--dir`` packs append ``--config.mac.timestamp=none`` so
+    codesign skips per-file network timestamping (offline-safe, faster).
+    Notarized release builds (``dist:mac*``) never run this ``pack`` path."""
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="darwin")
+
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic",
+               return_value=subprocess.CompletedProcess(["npm", "ci"], 0)), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    assert mock_run.call_args_list[0].args[0] == [
+        "/usr/bin/npm", "run", "pack", "--", "--config.mac.timestamp=none"
+    ]
+
+
+def test_gui_non_darwin_local_pack_keeps_default_timestamp(tmp_path, monkeypatch):
+    """The codesign-timestamp opt-out is macOS-only; non-darwin packs are
+    invoked with no extra args."""
+    import stat as stat_mod
+
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+    # Simulate an already-configured (root-owned 4755) chrome-sandbox so the
+    # launch path runs only [pack, launch] with no sudo fixup calls between.
+    sandbox = packaged_exe.parent / "chrome-sandbox"
+    sandbox.write_text("", encoding="utf-8")
+    fake_stat = type("s", (), {"st_uid": 0, "st_mode": 0o4755 | stat_mod.S_IFREG})()
+    monkeypatch.setattr(type(sandbox), "lstat", lambda self: fake_stat)
+
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic",
+               return_value=subprocess.CompletedProcess(["npm", "ci"], 0)), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Local macOS desktop `--dir` packs (`hermes desktop` / `hermes gui` without a release target) sign every file with a bare `codesign --timestamp`, which makes a network round-trip to Apple's timestamp authority **per file**. With 50+ Electron locale `.lproj`s and frameworks that is minutes of added build time, and a hard hang when offline. This routes the local pack through a single `build_cmd` that appends `--config.mac.timestamp=none` for the **local macOS dev pack only**.

## Related Issue

None filed — small, self-contained build-tooling fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` (`cmd_gui`): build the pack command once as `build_cmd` and append `--config.mac.timestamp=none` when `not source_mode and sys.platform == "darwin"`; route the initial pack **and both retry paths** (cached-Electron purge retry, npmmirror mirror retry) through `build_cmd`.
- `tests/hermes_cli/test_gui_command.py`: add `test_gui_macos_local_pack_disables_codesign_timestamp` (flag added on darwin) and `test_gui_non_darwin_local_pack_keeps_default_timestamp` (flag absent elsewhere); update the existing darwin pack assertion.

## How to Test

1. On macOS, offline (or with the GitHub/Apple hosts throttled), run `hermes desktop --force-build`.
2. **Before:** the `pack` step spins/hangs on per-file `codesign --timestamp` network calls to Apple's TSA.
3. **After:** the pack completes without contacting the TSA. Notarized release builds (`dist:mac*`) never run this `pack` path and keep real timestamps.
4. `pytest tests/hermes_cli/test_gui_command.py -q` → all pass.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs — no duplicate
- [x] PR contains only changes related to this fix
- [x] Added tests for the change
- [x] Tested on macOS
