### PR TITLE
fix(profile): strip reserved runtime vars when cloning env

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -58,6 +58,8 @@ _CLONE_CONFIG_FILES = [
     "SOUL.md",
 ]
 
+_ENV_ASSIGNMENT_RE = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=")
+
 # Subdirectory files copied during --clone (path relative to profile root).
 # Memory files are part of the agent's curated identity — just as important
 # as SOUL.md for continuity when cloning a profile.
@@ -114,6 +116,27 @@ def has_bundled_skills_opt_out(profile_dir: Path) -> bool:
         return (profile_dir / NO_BUNDLED_SKILLS_MARKER).exists()
     except OSError:
         return False
+
+
+def _runtime_location_env_names() -> frozenset[str]:
+    """Return denylisted HERMES_* runtime-location env names."""
+    from hermes_cli.config import _ENV_VAR_NAME_DENYLIST
+
+    return frozenset(
+        name for name in _ENV_VAR_NAME_DENYLIST if name.startswith("HERMES_")
+    )
+
+
+def _copy_clone_env_file(src: Path, dst: Path) -> None:
+    """Copy .env for profile clone, dropping runtime profile-routing vars."""
+    denied_names = _runtime_location_env_names()
+    filtered_lines = []
+    for line in src.read_text(encoding="utf-8").splitlines(keepends=True):
+        match = _ENV_ASSIGNMENT_RE.match(line)
+        if match and match.group(1) in denied_names:
+            continue
+        filtered_lines.append(line)
+    dst.write_text("".join(filtered_lines), encoding="utf-8")
 
 
 def _clone_all_copytree_ignore(source_dir: Path):
@@ -793,7 +816,11 @@ def create_profile(
             profile_dir,
             ignore=_clone_all_copytree_ignore(source_dir),
         )
-        # Strip runtime files
+        # Strip runtime files and profile-routing env vars that should not
+        # carry over to the cloned HERMES_HOME.
+        env_file = profile_dir / ".env"
+        if env_file.exists():
+            _copy_clone_env_file(env_file, env_file)
         for stale in _CLONE_ALL_STRIP:
             (profile_dir / stale).unlink(missing_ok=True)
     else:
@@ -808,11 +835,15 @@ def create_profile(
                 src = source_dir / filename
                 if src.exists():
                     dst = profile_dir / filename
-                    shutil.copy2(src, dst)
+                    if filename == ".env":
+                        _copy_clone_env_file(src, dst)
+                    else:
+                        shutil.copy2(src, dst)
                     # Tighten .env to owner-only after copy. shutil.copy2
-                    # preserves source mode bits, but if the source's .env
-                    # was loose (host umask 0o022 leaving 0o644), tighten
-                    # explicitly so the clone doesn't inherit weak perms.
+                    # preserves source mode bits for regular copies, but if
+                    # the source's .env was loose (host umask 0o022 leaving
+                    # 0o644), tighten explicitly so the clone doesn't inherit
+                    # weak perms.
                     if filename == ".env":
                         try:
                             os.chmod(str(dst), 0o600)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -185,6 +185,31 @@ class TestCreateProfile:
         assert (profile_dir / ".env").read_text() == "KEY=val"
         assert (profile_dir / "SOUL.md").read_text() == "Be helpful."
 
+    def test_clone_config_strips_reserved_runtime_env_vars(self, profile_env):
+        source_profile = create_profile("source", no_alias=True)
+        (source_profile / "config.yaml").write_text("model: test")
+        (source_profile / ".env").write_text(
+            "# keep comments\n"
+            "OPENAI_API_KEY=x\n"
+            f"HERMES_HOME={source_profile}\n"
+            "export HERMES_PROFILE=source\n"
+            "HERMES_CONFIG=/tmp/source-config.yaml\n"
+            "export HERMES_ENV=/tmp/source.env\n"
+            "HERMES_GEMINI_CLIENT_ID=keep\n"
+            "export OPENROUTER_API_KEY=y\n"
+        )
+
+        profile_dir = create_profile(
+            "coder", clone_from="source", clone_config=True, no_alias=True
+        )
+
+        assert (profile_dir / ".env").read_text() == (
+            "# keep comments\n"
+            "OPENAI_API_KEY=x\n"
+            "HERMES_GEMINI_CLIENT_ID=keep\n"
+            "export OPENROUTER_API_KEY=y\n"
+        )
+
     def test_clone_config_copies_source_skills(self, profile_env):
         tmp_path = profile_env
         default_home = tmp_path / ".hermes"
@@ -209,6 +234,11 @@ class TestCreateProfile:
         (default_home / "memories").mkdir(exist_ok=True)
         (default_home / "memories" / "note.md").write_text("remember this")
         (default_home / "config.yaml").write_text("model: gpt-4")
+        (default_home / ".env").write_text(
+            "OPENAI_API_KEY=x\n"
+            f"HERMES_HOME={default_home}\n"
+            "HERMES_GEMINI_CLIENT_ID=keep\n"
+        )
         # Runtime files that should be stripped
         (default_home / "gateway.pid").write_text("12345")
         (default_home / "gateway_state.json").write_text("{}")
@@ -219,6 +249,10 @@ class TestCreateProfile:
         # Content should be copied
         assert (profile_dir / "memories" / "note.md").read_text() == "remember this"
         assert (profile_dir / "config.yaml").read_text() == "model: gpt-4"
+        assert (profile_dir / ".env").read_text() == (
+            "OPENAI_API_KEY=x\n"
+            "HERMES_GEMINI_CLIENT_ID=keep\n"
+        )
         # Runtime files should be stripped
         assert not (profile_dir / "gateway.pid").exists()
         assert not (profile_dir / "gateway_state.json").exists()


### PR DESCRIPTION
## What does this PR do?

When cloning a profile, the source profile's `.env` was copied verbatim — including reserved **runtime-location** variables such as `HERMES_HOME`. A clone that inherits the source's `HERMES_HOME` resolves its runtime/data dir to the *wrong* home, so the cloned profile silently loads another profile's data instead of its own. This strips the reserved `HERMES_*` runtime-routing vars when copying `.env` during a clone.

## Related Issue

None filed — self-contained correctness fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py`: `_copy_clone_env_file()` drops reserved runtime-location vars while copying `.env`; `_runtime_location_env_names()` derives that set from the existing env-writer denylist (`HERMES_HOME`, `HERMES_PROFILE`, `HERMES_CONFIG`, `HERMES_ENV`) so the two stay in sync.
- `tests/hermes_cli/test_profiles.py`: coverage for the strip behavior (reserved vars removed, non-reserved vars preserved).

## How to Test

1. Add `HERMES_HOME=/some/other/path` (and a normal var like `OPENAI_API_KEY=...`) to a profile's `.env`.
2. Clone that profile.
3. **Before:** the clone's `.env` still contains `HERMES_HOME` → the clone loads the wrong home. **After:** `HERMES_HOME` (and the other reserved runtime vars) are stripped; the normal vars are kept.
4. `pytest tests/hermes_cli/test_profiles.py -q` → all pass.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs — no duplicate
- [x] PR contains only changes related to this fix
- [x] Added tests for the change
- [x] Tested on macOS
