### PR TITLE
fix(profile): clone provider-owned memory configs

### DIFF
--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -151,6 +151,15 @@ class MemoryProvider(ABC):
     def shutdown(self) -> None:
         """Clean shutdown — flush queues, close connections."""
 
+    def get_profile_config_paths(self) -> List[str]:
+        """Return HERMES_HOME-relative provider config paths copied by profile clone.
+
+        Providers that persist native config files under the active profile
+        should return those file or directory paths here. Providers that use
+        only config.yaml or env vars can keep the default empty list.
+        """
+        return []
+
     # -- Optional hooks (override to opt in) ---------------------------------
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -163,6 +163,100 @@ def _clone_all_copytree_ignore(source_dir: Path):
     return _ignore
 
 
+def _safe_profile_config_relpath(raw_path: object) -> Optional[Path]:
+    """Return a safe HERMES_HOME-relative config path, or None."""
+    try:
+        raw = os.fspath(raw_path)
+    except TypeError:
+        return None
+
+    if not isinstance(raw, str):
+        return None
+
+    raw = raw.strip()
+    if not raw:
+        return None
+
+    posix_path = PurePosixPath(raw)
+    windows_path = PureWindowsPath(raw)
+    if posix_path.is_absolute() or windows_path.is_absolute() or windows_path.drive:
+        return None
+
+    relpath = Path(raw)
+    if relpath.is_absolute():
+        return None
+
+    parts = relpath.parts
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        return None
+
+    return relpath
+
+
+def _iter_memory_provider_profile_config_paths() -> List[Path]:
+    """Ask discovered memory providers which profile-local config paths they own."""
+    try:
+        from plugins.memory import discover_memory_providers, load_memory_provider
+    except Exception:
+        return []
+
+    try:
+        discovered = discover_memory_providers()
+    except Exception:
+        return []
+
+    config_paths: list[Path] = []
+    seen: set[str] = set()
+    for provider_info in discovered:
+        if not provider_info:
+            continue
+        provider_name = provider_info[0]
+        try:
+            provider = load_memory_provider(provider_name)
+        except Exception:
+            continue
+        if provider is None:
+            continue
+
+        get_paths = getattr(provider, "get_profile_config_paths", None)
+        if not callable(get_paths):
+            continue
+
+        try:
+            raw_paths = get_paths()
+        except Exception:
+            continue
+
+        if isinstance(raw_paths, (str, os.PathLike)):
+            raw_paths = [raw_paths]
+
+        for raw_path in raw_paths or []:
+            relpath = _safe_profile_config_relpath(raw_path)
+            if relpath is None:
+                continue
+            key = relpath.as_posix()
+            if key in seen:
+                continue
+            seen.add(key)
+            config_paths.append(relpath)
+
+    return config_paths
+
+
+def _copy_profile_config_path(source_dir: Path, profile_dir: Path, relpath: Path) -> None:
+    """Copy one profile-relative provider config file or directory if present."""
+    src = source_dir / relpath
+    if not src.exists():
+        return
+
+    dst = profile_dir / relpath
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if src.is_dir():
+        shutil.copytree(src, dst, dirs_exist_ok=True)
+    elif src.is_file() or src.is_symlink():
+        shutil.copy2(src, dst)
+
+
 # Directories/files to exclude when exporting the default (~/.hermes) profile.
 # The default profile contains infrastructure (repo checkout, worktrees, DBs,
 # caches, binaries) that named profiles don't have.  We exclude those so the
@@ -834,6 +928,13 @@ def create_profile(
                     dst = profile_dir / relpath
                     dst.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(src, dst)
+
+            # Clone provider-owned native config files for every provider
+            # that has config present in the source profile, active or not.
+            # Values are copied verbatim: provider-scoped memory banks remain
+            # shared with the source profile until the clone is reconfigured.
+            for relpath in _iter_memory_provider_profile_config_paths():
+                _copy_profile_config_path(source_dir, profile_dir, relpath)
 
     # Seed a default SOUL.md so the user has a file to customize immediately.
     # Skipped when the profile already has one (from --clone / --clone-all).

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -604,6 +604,9 @@ class HindsightMemoryProvider(MemoryProvider):
     def name(self) -> str:
         return "hindsight"
 
+    def get_profile_config_paths(self) -> List[str]:
+        return ["hindsight/config.json"]
+
     def is_available(self) -> bool:
         try:
             cfg = _load_config()

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -239,6 +239,9 @@ class HonchoMemoryProvider(MemoryProvider):
     def name(self) -> str:
         return "honcho"
 
+    def get_profile_config_paths(self) -> List[str]:
+        return ["honcho.json"]
+
     def is_available(self) -> bool:
         """Check if Honcho is configured. No network calls."""
         try:

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -139,6 +139,9 @@ class Mem0MemoryProvider(MemoryProvider):
     def name(self) -> str:
         return "mem0"
 
+    def get_profile_config_paths(self) -> List[str]:
+        return ["mem0.json"]
+
     def is_available(self) -> bool:
         cfg = _load_config()
         return bool(cfg.get("api_key"))

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -472,6 +472,9 @@ class SupermemoryMemoryProvider(MemoryProvider):
     def name(self) -> str:
         return "supermemory"
 
+    def get_profile_config_paths(self) -> List[str]:
+        return ["supermemory.json"]
+
     def is_available(self) -> bool:
         api_key = os.environ.get("SUPERMEMORY_API_KEY", "")
         if not api_key:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -30,6 +30,7 @@ from hermes_cli.profiles import (
     import_profile,
     _get_profiles_root,
     _get_default_hermes_home,
+    _safe_profile_config_relpath,
     seed_profile_skills,
     has_bundled_skills_opt_out,
     NO_BUNDLED_SKILLS_MARKER,
@@ -201,6 +202,63 @@ class TestCreateProfile:
             / "installed-skill"
             / "SKILL.md"
         ).read_text() == "---\nname: installed-skill\n---\n"
+
+    def test_clone_config_copies_memory_provider_config_paths(
+        self, profile_env, monkeypatch
+    ):
+        import plugins.memory as memory_plugins
+
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        (default_home / "config.yaml").write_text(
+            "memory:\n  provider: hindsight\n"
+        )
+        (default_home / "hindsight").mkdir()
+        (default_home / "hindsight" / "config.json").write_text(
+            '{"mode": "local_embedded", "bank_id": "hermes"}'
+        )
+        (default_home / "mem0.json").write_text('{"agent_id": "hermes"}')
+
+        class FakeProvider:
+            def __init__(self, paths):
+                self._paths = paths
+
+            def get_profile_config_paths(self):
+                return self._paths
+
+        providers = {
+            "hindsight": FakeProvider(["hindsight/config.json"]),
+            "mem0": FakeProvider(["mem0.json"]),
+            "honcho": FakeProvider(["honcho.json"]),
+        }
+        monkeypatch.setattr(
+            memory_plugins,
+            "discover_memory_providers",
+            lambda: [(name, "", True) for name in providers],
+        )
+        monkeypatch.setattr(
+            memory_plugins,
+            "load_memory_provider",
+            lambda name: providers[name],
+        )
+
+        profile_dir = create_profile("coder", clone_config=True, no_alias=True)
+
+        assert (
+            profile_dir / "hindsight" / "config.json"
+        ).read_text() == '{"mode": "local_embedded", "bank_id": "hermes"}'
+        assert (profile_dir / "mem0.json").read_text() == '{"agent_id": "hermes"}'
+        assert not (profile_dir / "honcho.json").exists()
+
+    def test_memory_provider_config_paths_must_be_profile_relative(self):
+        assert _safe_profile_config_relpath("hindsight/config.json") == Path(
+            "hindsight/config.json"
+        )
+
+        unsafe_paths = ["", ".", "..", "../outside.json", "/tmp/config.json"]
+        unsafe_paths.append(r"C:\tmp\config.json")
+        for raw_path in unsafe_paths:
+            assert _safe_profile_config_relpath(raw_path) is None
 
     def test_clone_all_copies_entire_tree(self, profile_env):
         tmp_path = profile_env


### PR DESCRIPTION
## What does this PR do?

Cloning a memory-enabled profile did not copy provider-owned **native config files** — several memory plugins (hindsight, honcho, mem0, supermemory) persist their own config under the active profile, outside `config.yaml`/env. As a result the clone came up with a misconfigured (or unconfigured) memory provider. This adds a provider hook that declares those config paths and copies them during a clone, with path-traversal-safe resolution.

## Related Issue

None filed — self-contained correctness fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/memory_provider.py`: new `get_profile_config_paths()` hook (default empty list) so providers can declare HERMES_HOME-relative config files copied on clone.
- `plugins/memory/{hindsight,honcho,mem0,supermemory}/__init__.py`: each declares its provider-owned config path(s).
- `hermes_cli/profiles.py`: copies the declared provider config paths during clone, via `_safe_profile_config_relpath()` which rejects absolute paths and `..`/traversal.
- `tests/hermes_cli/test_profiles.py`: coverage for the copy behavior and the path-safety guard.

## How to Test

1. Configure a memory provider that writes a native config file under the profile (e.g. hindsight), then clone the profile.
2. **Before:** the clone is missing the provider's config file. **After:** the declared config path(s) are copied into the clone.
3. `pytest tests/hermes_cli/test_profiles.py -q` → all pass.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs — no duplicate
- [x] PR contains only changes related to this fix
- [x] Added tests for the change
- [x] Tested on macOS
