### PR TITLE
fix(agent): surface model refusals (stop_reason=refusal / message.refusal) instead of retrying them as errors

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1312,6 +1312,116 @@ def run_conversation(
                         )
                         finish_reason = "length"
 
+                # ── Content-policy refusal (HTTP 200) ──────────────────
+                # The model — or the provider's safety system — returned a
+                # *successful* response whose stop/finish reason is a refusal:
+                # Anthropic ``stop_reason="refusal"`` → ``content_filter``;
+                # OpenAI / portal ``finish_reason="content_filter"`` or a
+                # populated ``message.refusal`` (mapped in the chat_completions
+                # transport); Bedrock ``guardrail_intervened``. The content is
+                # typically empty, so without this branch the response falls
+                # through to the empty-response / invalid-response retry loops
+                # and is mis-surfaced as "rate limited" / "no content after
+                # retries" — burning paid attempts reproducing a deterministic
+                # refusal. Surface it clearly and stop. Mirrors the
+                # exception-based ``content_policy_blocked`` recovery: try a
+                # configured fallback once, otherwise return the refusal.
+                if finish_reason == "content_filter":
+                    _refusal_transport = agent._get_transport()
+                    if agent.api_mode == "anthropic_messages":
+                        _refusal_result = _refusal_transport.normalize_response(
+                            response, strip_tool_prefix=agent._is_anthropic_oauth
+                        )
+                    else:
+                        _refusal_result = _refusal_transport.normalize_response(response)
+                    _refusal_text = (getattr(_refusal_result, "content", None) or "").strip()
+                    # Some refusals carry the explanation only in the reasoning
+                    # channel; fall back to it so the user sees *something*.
+                    if not _refusal_text:
+                        _refusal_text = (agent._extract_reasoning(_refusal_result) or "").strip()
+
+                    agent._invoke_api_request_error_hook(
+                        task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        api_call_count=api_call_count,
+                        api_start_time=api_start_time,
+                        api_kwargs=api_kwargs,
+                        error_type="ContentPolicyBlocked",
+                        error_message=_refusal_text or "model declined to respond (content_filter)",
+                        status_code=None,
+                        retry_count=retry_count,
+                        max_retries=max_retries,
+                        retryable=False,
+                        reason="content_policy_blocked",
+                    )
+
+                    if thinking_spinner:
+                        thinking_spinner.stop("")
+                        thinking_spinner = None
+                    if agent.thinking_callback:
+                        agent.thinking_callback("")
+
+                    # Deterministic for the unchanged prompt — never retry.
+                    # Try a configured fallback once (a different model may not
+                    # refuse); otherwise surface the refusal terminally.
+                    if agent._has_pending_fallback():
+                        agent._buffer_status(
+                            "⚠️ Model declined to respond (safety refusal) — trying fallback..."
+                        )
+                    if agent._try_activate_fallback():
+                        retry_count = 0
+                        compression_attempts = 0
+                        _retry.primary_recovery_attempted = False
+                        continue
+
+                    agent._flush_status_buffer()
+                    _refusal_log = (
+                        _refusal_text[:500] + "..."
+                        if len(_refusal_text) > 500
+                        else _refusal_text
+                    )
+                    logger.warning(
+                        "%sModel declined to respond (finish_reason=content_filter). "
+                        "model=%s provider=%s refusal=%s",
+                        agent.log_prefix, agent.model, agent.provider,
+                        _refusal_log or "(no text)",
+                    )
+                    agent._emit_status(
+                        "⚠️ The model declined to respond to this request (safety refusal)."
+                    )
+
+                    if _refusal_text:
+                        _refusal_response = (
+                            "⚠️  The model declined to respond to this request "
+                            "(safety refusal — not a Hermes/gateway failure).\n\n"
+                            f"Model's explanation: {_refusal_text}\n\n"
+                            "Try rephrasing the request, narrowing the context, or "
+                            "adding a fallback provider with `hermes fallback add`."
+                        )
+                    else:
+                        _refusal_response = (
+                            "⚠️  The model declined to respond to this request "
+                            "(safety refusal — not a Hermes/gateway failure). The "
+                            "model returned no explanation.\n\n"
+                            "Try rephrasing the request, narrowing the context, or "
+                            "adding a fallback provider with `hermes fallback add`."
+                        )
+
+                    agent._cleanup_task_resources(effective_task_id)
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": _refusal_response,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "error": (
+                            "content_policy_blocked: "
+                            + (_refusal_text or "model declined (content_filter)")
+                        ),
+                    }
+
                 if finish_reason == "length":
                     if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
                         agent._vprint(

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -143,10 +143,21 @@ class AnthropicTransport(ProviderTransport):
     def validate_response(self, response: Any) -> bool:
         """Check Anthropic response structure is valid.
 
-        An empty content list is legitimate when ``stop_reason == "end_turn"``
-        — the model's canonical way of signalling "nothing more to add" after
-        a tool turn that already delivered the user-facing text. Treating it
-        as invalid falsely retries a completed response.
+        An empty content list is legitimate for terminal stop reasons that
+        carry no text payload:
+
+        - ``end_turn`` — the model's canonical "nothing more to add" after a
+          tool turn that already delivered the user-facing text.
+        - ``refusal`` — the model declined to respond (Claude 4.5+). The
+          Messages API returns an empty ``content`` list with this stop
+          reason. Treating it as invalid sends a deterministic refusal into
+          the invalid-response retry loop, which reproduces the refusal on
+          every attempt and surfaces a misleading "rate limited / invalid
+          response" error instead of the refusal. ``normalize_response`` maps
+          ``refusal`` → ``content_filter`` so the agent loop's refusal handler
+          can surface it.
+
+        Treating either as invalid falsely retries a completed response.
         """
         if response is None:
             return False
@@ -154,7 +165,7 @@ class AnthropicTransport(ProviderTransport):
         if not isinstance(content_blocks, list):
             return False
         if not content_blocks:
-            return getattr(response, "stop_reason", None) == "end_turn"
+            return getattr(response, "stop_reason", None) in {"end_turn", "refusal"}
         return True
 
     def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -664,8 +664,32 @@ class ChatCompletionsTransport(ProviderTransport):
         if rd:
             provider_data["reasoning_details"] = rd
 
+        # OpenAI structured-refusal field. When a model declines, the SDK
+        # populates ``message.refusal`` with the explanation and leaves
+        # ``content`` empty. OpenAI-compatible proxies that front Anthropic /
+        # Bedrock (e.g. Nous Portal) surface a Claude refusal this way — or via
+        # ``finish_reason="content_filter"`` — instead of the native
+        # ``stop_reason="refusal"``. Without capturing it the refusal looks
+        # like an empty response, so the agent loop retries a deterministic
+        # refusal three times and gives up with "no content after retries".
+        # Promote it to content + a ``content_filter`` finish reason so the
+        # loop's refusal handler surfaces it clearly and stops. ``refusal`` is
+        # ``None`` for normal responses, so this is a no-op in the common case.
+        content = msg.content
+        refusal = getattr(msg, "refusal", None)
+        if refusal is None and hasattr(msg, "model_extra"):
+            _msg_extra = getattr(msg, "model_extra", None) or {}
+            if isinstance(_msg_extra, dict):
+                refusal = _msg_extra.get("refusal")
+        if isinstance(refusal, str) and refusal.strip():
+            if not (isinstance(content, str) and content.strip()):
+                content = refusal
+            if finish_reason in (None, "stop"):
+                finish_reason = "content_filter"
+            provider_data["refusal"] = refusal
+
         return NormalizedResponse(
-            content=msg.content,
+            content=content,
             tool_calls=tool_calls,
             finish_reason=finish_reason,
             reasoning=reasoning,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -843,6 +843,81 @@ class TestChatCompletionsNormalize:
         nr = transport.normalize_response(r)
         assert nr.provider_data == {"reasoning_content": "model-extra scratchpad"}
 
+    def test_refusal_field_promoted_to_content_filter(self, transport):
+        """OpenAI-compatible proxies (e.g. Nous Portal fronting Anthropic) can
+        surface a Claude refusal via ``message.refusal`` with empty content and
+        ``finish_reason="stop"``. Promote it to content + a ``content_filter``
+        finish reason so the agent loop's refusal handler surfaces it instead
+        of retrying an empty response three times and giving up."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None, tool_calls=None, reasoning_content=None,
+                    refusal="I can't help with that.",
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.finish_reason == "content_filter"
+        assert nr.content == "I can't help with that."
+        assert nr.provider_data == {"refusal": "I can't help with that."}
+
+    def test_refusal_none_is_noop(self, transport):
+        """The common case: ``refusal`` is None → behavior unchanged."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content="hello", tool_calls=None, reasoning_content=None,
+                    refusal=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.finish_reason == "stop"
+        assert nr.content == "hello"
+        assert nr.provider_data is None
+
+    def test_refusal_preserves_explicit_content_filter_finish_reason(self, transport):
+        """When the proxy already sets ``finish_reason="content_filter"`` and
+        also provides refusal text, surface the text without disturbing the
+        finish reason."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None, tool_calls=None, reasoning_content=None,
+                    refusal="declined",
+                ),
+                finish_reason="content_filter",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.finish_reason == "content_filter"
+        assert nr.content == "declined"
+        assert nr.provider_data == {"refusal": "declined"}
+
+    def test_refusal_does_not_clobber_existing_content(self, transport):
+        """If the model emitted partial text *and* a refusal, keep the visible
+        text as content but still flag the refusal via content_filter."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content="partial answer", tool_calls=None,
+                    reasoning_content=None, refusal="cannot continue",
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.content == "partial answer"
+        assert nr.finish_reason == "content_filter"
+        assert nr.provider_data == {"refusal": "cannot continue"}
+
 
 class TestChatCompletionsCacheStats:
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -900,6 +900,28 @@ class TestChatCompletionsNormalize:
         assert nr.content == "declined"
         assert nr.provider_data == {"refusal": "declined"}
 
+    def test_explicit_content_filter_finish_reason_passes_through(self, transport):
+        """OpenRouter (and other OpenAI-compatible providers) surface an
+        upstream Claude / moderation refusal as ``finish_reason="content_filter"``
+        — often with empty content and no ``message.refusal`` field. The
+        transport must pass that finish reason straight through so the loop's
+        content_filter refusal handler fires; no ``message.refusal`` required.
+        This is the OpenRouter coverage path (OpenRouter uses the default
+        chat_completions transport)."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None, tool_calls=None, reasoning_content=None,
+                    refusal=None,
+                ),
+                finish_reason="content_filter",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.finish_reason == "content_filter"
+        assert nr.content is None
+
     def test_refusal_does_not_clobber_existing_content(self, transport):
         """If the model emitted partial text *and* a refusal, keep the visible
         text as content but still flag the refusal via content_filter."""

--- a/tests/agent/transports/test_transport.py
+++ b/tests/agent/transports/test_transport.py
@@ -128,6 +128,15 @@ class TestAnthropicTransport:
         r = SimpleNamespace(content=[], stop_reason="tool_use")
         assert transport.validate_response(r) is False
 
+    def test_validate_response_empty_content_with_refusal_is_valid(self, transport):
+        # Claude 4.5+ returns an empty content list with stop_reason="refusal"
+        # when it declines to respond. It must validate so the response flows
+        # through to normalize_response (which maps refusal → content_filter)
+        # and the loop's refusal handler — instead of being rejected as an
+        # "invalid response" and retried as a deterministic refusal.
+        r = SimpleNamespace(content=[], stop_reason="refusal")
+        assert transport.validate_response(r) is True
+
     def test_validate_response_valid(self, transport):
         r = SimpleNamespace(content=[SimpleNamespace(type="text", text="hello")])
         assert transport.validate_response(r) is True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4660,6 +4660,47 @@ class TestRetryExhaustion:
         assert "error" in result
         assert "Invalid API response" in result["error"]
 
+    def test_content_filter_refusal_surfaced_not_retried(self, agent):
+        """A model refusal must be surfaced immediately, NOT laundered into
+        the empty-response retry loop and reported as "rate limited" / "no
+        content after retries".
+
+        Regression: running a Claude refusal through an OpenAI-compatible
+        portal (Nous Portal fronting Anthropic) returns ``message.refusal``
+        with empty content. The transport now promotes that to a
+        ``content_filter`` finish reason and the loop surfaces it as a terminal
+        ``content_policy_blocked`` result instead of retrying a deterministic
+        refusal three times.
+        """
+        self._setup_agent(agent)
+        refusal_resp = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None, tool_calls=None, reasoning=None,
+                    reasoning_content=None, refusal="I won't help with that.",
+                ),
+                finish_reason="stop",
+            )],
+            model="test/model",
+            usage=None,
+            id="resp_1",
+        )
+        agent.client.chat.completions.create.return_value = refusal_resp
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("please do something disallowed")
+        assert result.get("completed") is False
+        assert result.get("failed") is True
+        assert "content_policy_blocked" in result.get("error", "")
+        # The model's refusal text is surfaced to the user, not swallowed.
+        assert "I won't help with that." in (result.get("final_response") or "")
+        # Crucial regression guard: a deterministic refusal is NOT retried —
+        # exactly one API call, no empty-response retry loop.
+        assert agent.client.chat.completions.create.call_count == 1
+
     def test_api_error_returns_gracefully_after_retries(self, agent):
         """Exhausted retries on API errors must return error result, not crash."""
         self._setup_agent(agent)


### PR DESCRIPTION
## Problem

A Claude model can return **HTTP 200 with a refusal** — a deterministic, server-side safety-classifier halt. Hermes mislabels it as a transient infra error and retries it 3×, burning paid attempts and giving the user no signal that their prompt was actually **refused**.

It surfaces on **two distinct paths**, and the existing handling misses both:

### 1. Direct Anthropic (`anthropic_messages`)
The Messages API returns `stop_reason: "refusal"` with `content: []`. `AnthropicTransport.validate_response` rejects the empty content **before** `normalize_response` ever maps `refusal → content_filter`, so it lands in the generic invalid-response retry loop:

```
⚠️  Invalid API response (attempt 1/3): response.content invalid (not a non-empty list)
   ⏱️  fast response (3.4s) — likely rate limited
❌ Max retries (3) exceeded for invalid responses. Giving up.
```

### 2. OpenAI-compatible providers (`chat_completions`) — Nous Portal, OpenRouter, etc.
These front Anthropic and surface the refusal via OpenAI's `message.refusal` field (empty `content`) or a `finish_reason: "content_filter"`. `ChatCompletionsTransport.validate_response` only checks that `choices` exist, so the refusal **passes validation** and dies later in the *empty-response* retry loop:

```
⚠️ Empty response from model — retrying (1/3)
⚠️ Empty response from model — retrying (2/3)
⚠️ Empty response from model — retrying (3/3)
❌ Model returned no content after all retries. No fallback providers configured.
```

This is the path users actually hit running a stricter named model (`claude-fable-5`) through the Nous Portal: the model refuses offensive-security / fuzzing / crash-corpus material (often the *`tool_result` content* — a directory tree full of `fuzz/`, crash logs, exploit script names — not the user's words), and the session looks like a network flake.

The irony: `_STOP_REASON_MAP` already maps `"refusal" → "content_filter"`, and `agent/error_classifier.py` already documents that refusals are deterministic and must route to `content_policy_blocked` — but a **200-OK refusal never raises an exception**, so that recovery never runs.

## Fix

One unified `content_filter` dispatch that works for every backend:

1. **`AnthropicTransport.validate_response`** — accept an empty content list when `stop_reason == "refusal"` (it's a complete response, not a truncated one), so it flows through `normalize_response` → `finish_reason="content_filter"`.
2. **`ChatCompletionsTransport.normalize_response`** — promote OpenAI's `message.refusal` to `content` + a `content_filter` finish reason. No-op when `refusal` is absent (the common case). A bare `finish_reason="content_filter"` already passes straight through.
3. **`agent/conversation_loop.py`** — handle `finish_reason == "content_filter"` once, right after the finish reason is computed: fire the `api_request_error` hook with `reason="content_policy_blocked"`, stop the spinner, try a configured fallback **once**, otherwise return an honest terminal result. No retry burn — the block is deterministic.

**After:**
```
⚠️ The model declined to respond to this request (safety refusal).
```
plus a `final_response` explaining it's a model-level refusal (not a Hermes/network failure) with actionable next steps (rephrase, narrow context, switch model, `hermes fallback add`), and one log line. Exactly one API call.

### Provider coverage

Because the handler keys on the normalized `content_filter` finish reason rather than a path-specific flag, **one fix covers every provider**:

| Provider | api_mode | Refusal signal | Covered by |
|---|---|---|---|
| Anthropic (direct) | `anthropic_messages` | `stop_reason="refusal"`, empty content | fix 1 + 3 |
| Nous Portal | `chat_completions` | `message.refusal` / `content_filter` | fix 2 + 3 |
| **OpenRouter** | `chat_completions` | `content_filter` / `message.refusal` | fix 2 + 3 |
| other OpenAI-compatible (NVIDIA, xAI, DeepSeek, …) | `chat_completions` | `content_filter` / `message.refusal` | fix 2 + 3 |
| Bedrock | `bedrock_converse` | `guardrail_intervened → content_filter` | fix 3 |

No provider-specific code: OpenRouter and the rest all use the default `chat_completions` transport. (Provider *moderation errors* that arrive as exceptions — e.g. an OpenRouter 403 — were already handled by `error_classifier.py`'s `content_policy_blocked` patterns; this PR closes the **200-OK** gap.)

## Supersedes #43084

#43084 fixed only path 1, and by a mechanism (intercept where `validate_response` fails) that **structurally cannot reach path 2** — the `chat_completions` validator doesn't fail on a refusal, so there's nothing to intercept. This PR unifies both paths through the existing `refusal → content_filter` mapping. #43084 is closed in favor of this.

## Tests

- `tests/agent/transports/test_transport.py` — empty-content `refusal` now validates.
- `tests/agent/transports/test_chat_completions.py` — `message.refusal` promotion to `content_filter`; bare `content_filter` passthrough (OpenRouter); no-op when absent; partial-content and explicit-content_filter cases.
- `tests/run_agent/test_run_agent.py::TestRetryExhaustion::test_content_filter_refusal_surfaced_not_retried` — end-to-end: a portal-style `message.refusal` is surfaced as `content_policy_blocked` with the refusal text, and the model is called **exactly once** (no retry loop).

```
scripts/run_tests.sh tests/agent/transports/ tests/run_agent/test_empty_response_recovery_persistence.py \
  tests/run_agent/test_partial_stream_finish_reason.py tests/run_agent/test_provider_fallback.py
  → 368 passed
```
(The 3 failing `TestRunOauthSetupToken` tests are **pre-existing on clean `origin/main`** — OAuth credential-file resolution, unrelated to this change.)
