### PR TITLE
feat(providers): add 'local' provider overlay with LOCAL_BASE_URL env var

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -993,6 +993,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (Pay-per-use API aggregator)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (Local desktop app with built-in model server)"),
+    ProviderEntry("local",          "Local Server",             "Local Server (vLLM, llama.cpp, or any OpenAI-compatible local endpoint)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models via API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)"),
     ProviderEntry("openai-api",     "OpenAI API",               "OpenAI API (api.openai.com, API key)"),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -88,6 +88,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="http://127.0.0.1:1234/v1",
         base_url_env_var="LM_BASE_URL",
     ),
+    "local": HermesOverlay(
+        transport="openai_chat",
+        auth_type="api_key",
+        base_url_env_var="LOCAL_BASE_URL",
+    ),
     "copilot-acp": HermesOverlay(
         transport="codex_responses",
         auth_type="external_process",

--- a/tests/hermes_cli/test_local_provider.py
+++ b/tests/hermes_cli/test_local_provider.py
@@ -1,0 +1,91 @@
+"""Tests for the 'local' provider overlay (vLLM, llama.cpp, etc.)."""
+
+import pytest
+
+
+# =============================================================================
+# HERMES_OVERLAYS registration
+# =============================================================================
+
+
+class TestLocalOverlay:
+    def test_local_in_hermes_overlays(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        assert "local" in HERMES_OVERLAYS
+
+    def test_local_overlay_transport(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        overlay = HERMES_OVERLAYS["local"]
+        assert overlay.transport == "openai_chat"
+
+    def test_local_overlay_auth_type(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        overlay = HERMES_OVERLAYS["local"]
+        assert overlay.auth_type == "api_key"
+
+    def test_local_overlay_base_url_env_var(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        overlay = HERMES_OVERLAYS["local"]
+        assert overlay.base_url_env_var == "LOCAL_BASE_URL"
+
+    def test_local_overlay_no_base_url_override(self):
+        """local should not have a hardcoded base_url_override —
+        the user must provide the URL via config or env var."""
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        overlay = HERMES_OVERLAYS["local"]
+        assert overlay.base_url_override == ""
+
+
+# =============================================================================
+# CANONICAL_PROVIDERS registration
+# =============================================================================
+
+
+class TestLocalCanonicalEntry:
+    def test_local_in_canonical_providers(self):
+        from hermes_cli.models import CANONICAL_PROVIDERS
+
+        slugs = [p.slug for p in CANONICAL_PROVIDERS]
+        assert "local" in slugs
+
+    def test_local_entry_label(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+
+        assert _PROVIDER_LABELS.get("local") == "Local Server"
+
+
+# =============================================================================
+# Alias mapping (vllm, llamacpp → local)
+# =============================================================================
+
+
+class TestLocalAliases:
+    def test_vllm_aliases_to_local(self):
+        from hermes_cli.providers import ALIASES
+
+        assert ALIASES.get("vllm") == "local"
+
+    def test_llamacpp_aliases_to_local(self):
+        from hermes_cli.providers import ALIASES
+
+        assert ALIASES.get("llamacpp") == "local"
+
+
+# =============================================================================
+# ENV VAR resolution
+# =============================================================================
+
+
+class TestLocalBaseUrlEnvVar:
+    def test_local_base_url_from_env(self, monkeypatch):
+        """LOCAL_BASE_URL env var should be picked up for base URL."""
+        monkeypatch.setenv("LOCAL_BASE_URL", "http://192.168.1.100:8000/v1")
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        overlay = HERMES_OVERLAYS["local"]
+        assert overlay.base_url_env_var == "LOCAL_BASE_URL"


### PR DESCRIPTION
## Problem

Currently, `vllm` is aliased to `local` in `providers.py`, but the `local` provider lacks a corresponding entry in `HERMES_OVERLAYS` and `CANONICAL_PROVIDERS`.

This causes two issues:

1. **No `base_url_env_var` for `local`** — users cannot easily configure a local server (vLLM, llama.cpp, etc.) via environment variables. In contrast, `lmstudio` has `LM_BASE_URL` which makes it trivial to point to a custom local endpoint.
2. **`local` is not visible in the interactive model picker** (`hermes model`) — it does not appear in `CANONICAL_PROVIDERS`, so users are forced to either manually type the URL via the "Custom endpoint" option or edit `config.yaml` manually.

## Solution

Add a `local` overlay in `HERMES_OVERLAYS` (similar to `lmstudio`) with `LOCAL_BASE_URL` as the env var, and add `local` to `CANONICAL_PROVIDERS` so it appears in the interactive model picker.

### Changes

- **`hermes_cli/providers.py`** — Add `"local"` entry to `HERMES_OVERLAYS` with `transport="openai_chat"`, `auth_type="api_key"`, `base_url_env_var="LOCAL_BASE_URL"`
- **`hermes_cli/models.py`** — Add `ProviderEntry("local", "Local Server", ...)` to `CANONICAL_PROVIDERS`
- **`tests/hermes_cli/test_local_provider.py`** — 10 tests covering overlay registration, canonical entry, alias mapping, and env var resolution

### Usage

```bash
# Set the local server URL via env var
export LOCAL_BASE_URL=http://192.168.1.100:8000/v1

# Or configure in config.yaml
# model:
#   provider: local
#   base_url: http://192.168.1.100:8000/v1

hermes model  # "Local Server" now appears in the picker
```

Closes #43052
