### PR TITLE
fix(tui): surface descriptive error when skill fails to load (#43053)

### DIFF
--- a/tests/tui_gateway/test_skill_dispatch_error_message.py
+++ b/tests/tui_gateway/test_skill_dispatch_error_message.py
@@ -1,0 +1,121 @@
+"""Tests for skill command dispatch error messages (#43053).
+
+When a skill is registered (shows in autocomplete) but fails to load at
+dispatch time, the user should see a descriptive error — not the misleading
+"not a quick/plugin/skill command" message.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _call_dispatch(name: str, arg: str = ""):
+    """Call the ``command.dispatch`` handler and return the raw result dict.
+
+    The handler is registered via ``@method("command.dispatch")`` so we
+    import the module and invoke ``dispatch`` directly.  Returns the
+    JSON-RPC envelope: ``{"jsonrpc": "2.0", "id": N, "result": ...}``
+    on success or ``{"jsonrpc": "2.0", "id": N, "error": ...}`` on error.
+    """
+    from tui_gateway.server import dispatch
+
+    rid = 1
+    params = {"name": name, "arg": arg, "session_id": "test-sid"}
+    req = {"id": rid, "method": "command.dispatch", "params": params}
+    return dispatch(req)
+
+
+# ── Happy-path: skill found and loaded ─────────────────────────────────
+
+
+def test_skill_command_returns_skill_type():
+    """When a skill is found AND loads, dispatch returns type=skill."""
+    fake_skill_info = {
+        "/nano-pdf": {
+            "name": "nano-pdf",
+            "description": "Edit PDFs",
+            "skill_md_path": "/fake/SKILL.md",
+            "skill_dir": "/fake",
+        }
+    }
+    fake_message = "[Skill loaded: nano-pdf]"
+
+    with patch(
+        "agent.skill_commands.scan_skill_commands",
+        return_value=fake_skill_info,
+    ), patch(
+        "agent.skill_commands.build_skill_invocation_message",
+        return_value=fake_message,
+    ):
+        result = _call_dispatch("nano-pdf")
+
+    assert "result" in result, f"Expected success but got: {result}"
+    assert result["result"]["type"] == "skill"
+    assert result["result"]["message"] == fake_message
+    assert result["result"]["name"] == "nano-pdf"
+
+
+# ── Bug #43053: skill found but failed to load ────────────────────────
+
+
+def test_skill_found_but_load_fails_returns_descriptive_error():
+    """When scan finds the skill but build_skill_invocation_message returns
+    None, the user should see a descriptive error — NOT the generic
+    'not a quick/plugin/skill command' message."""
+    fake_skill_info = {
+        "/nano-pdf": {
+            "name": "nano-pdf",
+            "description": "Edit PDFs",
+            "skill_md_path": "/fake/SKILL.md",
+            "skill_dir": "/fake",
+        }
+    }
+
+    with patch(
+        "agent.skill_commands.scan_skill_commands",
+        return_value=fake_skill_info,
+    ), patch(
+        "agent.skill_commands.build_skill_invocation_message",
+        return_value=None,
+    ):
+        result = _call_dispatch("nano-pdf")
+
+    assert "error" in result, f"Expected error but got: {result}"
+    err_msg = result["error"]["message"]
+    # Must mention the skill name and explain the failure
+    assert "nano-pdf" in err_msg
+    assert "failed to load" in err_msg
+    # Must NOT use the misleading generic message
+    assert "not a quick/plugin/skill command" not in err_msg
+
+
+def test_skill_load_exception_returns_descriptive_error():
+    """When scan_skill_commands or build_skill_invocation_message raises,
+    the error message should include the exception text."""
+    with patch(
+        "agent.skill_commands.scan_skill_commands",
+        side_effect=RuntimeError("permission denied"),
+    ):
+        result = _call_dispatch("nano-pdf")
+
+    assert "error" in result, f"Expected error but got: {result}"
+    err_msg = result["error"]["message"]
+    assert "permission denied" in err_msg
+    assert "not a quick/plugin/skill command" not in err_msg
+
+
+# ── Unregistered command still shows generic message ───────────────────
+
+
+def test_unknown_command_still_shows_generic_message():
+    """Commands that are NOT skills should still get the generic error."""
+    with patch(
+        "agent.skill_commands.scan_skill_commands",
+        return_value={},
+    ):
+        result = _call_dispatch("nonexistent-command-xyz")
+
+    assert "error" in result, f"Expected error but got: {result}"
+    err_msg = result["error"]["message"]
+    assert "not a quick/plugin/skill command" in err_msg

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7182,8 +7182,14 @@ def _(rid, params: dict) -> dict:
                         "name": cmds[key].get("name", name),
                     },
                 )
-    except Exception:
-        pass
+            return _err(
+                rid,
+                4018,
+                f"skill '{cmds[key].get('name', name)}' is registered but "
+                f"failed to load — check the skill files",
+            )
+    except Exception as exc:
+        return _err(rid, 4018, f"skill command '{name}' error: {exc}")
 
     # ── Commands that queue messages onto _pending_input in the CLI ───
     # In the TUI the slash worker subprocess has no reader for that queue,


### PR DESCRIPTION
## What does this PR do?

Fixes a misleading error message when a skill command is registered (shows in autocomplete) but fails to load at dispatch time. Users previously saw "not a quick/plugin/skill command: X" even though the skill existed — now they see "skill 'X' is registered but failed to load — check the skill files".

## Related Issue

Fixes #43053

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: When `scan_skill_commands()` finds a skill but `build_skill_invocation_message()` returns None (failed to load), return a descriptive error instead of falling through to the generic "not a quick/plugin/skill command" catch-all. Also surface exception messages instead of silently swallowing them.
- `tests/tui_gateway/test_skill_dispatch_error_message.py`: 4 tests — 1 happy-path (skill loads), 2 error-path (load returns None, load raises), 1 generic-fallback (unregistered command still gets the old message).

## How to Test

1. Run `pytest tests/tui_gateway/test_skill_dispatch_error_message.py -v` — all 4 tests should pass
2. Run `pytest tests/tui_gateway/ -v` — all 110 tests should pass (no regressions)
3. Manual: register a skill with a broken SKILL.md (invalid YAML), try `/broken-skill` in TUI — should see "skill 'X' is registered but failed to load" instead of "not a quick/plugin/skill command"

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tui_gateway/ -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked files: `tui_gateway/server.py` (command.dispatch handler, lines 7164-7186), `agent/skill_commands.py` (build_skill_invocation_message, _load_skill_payload)
- Blast radius: LOW — only affects the error path when a registered skill fails to load; happy-path behavior unchanged
- Related patterns: `command.dispatch` skill handling, `slash.exec` skill detection, `build_skill_invocation_message` return value
