### PR TITLE
feat(agent): per-model tool allow/deny policy

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -556,6 +556,17 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
 
+    # Per-model tool policy (#42999): restrict which tools the *active*
+    # model may see. Resolved against agent.model/provider, so a fallback
+    # model is scoped to its own allow/deny list without touching the
+    # primary model's tool set. No-op (returns the same list) when the
+    # active model has no policy configured.
+    try:
+        from agent.tool_policy import filter_tool_defs, policy_for_agent
+        tools_for_api = filter_tool_defs(tools_for_api, policy_for_agent(agent))
+    except Exception as _policy_err:  # never let policy resolution break a request
+        logger.debug("tool policy filtering skipped: %s", _policy_err)
+
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
         anthropic_messages = agent._prepare_anthropic_messages_for_api(api_messages)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -313,6 +313,27 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         except Exception:
             pass
 
+        # ── Per-model tool policy gate (#42999) ──────────────────────────
+        # Defense in depth: build_api_kwargs already hides disallowed tools
+        # from the active model, but a model can still hallucinate a tool
+        # name (or call one through a stale definition). Reject it here,
+        # before any hook/checkpoint/dispatch fires, with the same shape as
+        # the tool-search scope block above.
+        _policy_block = None
+        if _ts_scope_block is None:
+            try:
+                from agent.tool_policy import policy_for_agent
+                if not policy_for_agent(agent).is_allowed(function_name):
+                    _policy_block = json.dumps({
+                        "error": (
+                            f"'{function_name}' is not available to the current model "
+                            f"({getattr(agent, 'model', '') or 'unknown'}). It is "
+                            "restricted by the model's tool policy."
+                        ),
+                    }, ensure_ascii=False)
+            except Exception:
+                _policy_block = None
+
         function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
             agent,
             function_name=function_name,
@@ -339,6 +360,21 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 status="blocked",
                 error_type="tool_scope_block",
                 error_message=_ts_scope_block,
+                middleware_trace=list(middleware_trace),
+            )
+        elif _policy_block is not None:
+            # Disallowed by the active model's tool policy (#42999).
+            block_result = _policy_block
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=block_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status="blocked",
+                error_type="tool_policy_block",
+                error_message=_policy_block,
                 middleware_trace=list(middleware_trace),
             )
         else:

--- a/agent/tool_policy.py
+++ b/agent/tool_policy.py
@@ -1,0 +1,232 @@
+"""Per-model tool allow/deny policy (issue #42999).
+
+Lets a user restrict which tools a *specific model* is allowed to see and
+call, configured in ``config.yaml`` next to the other per-model overrides
+(mirrors the ``supports_vision`` lookup in ``agent/image_routing.py``).
+
+The motivating case: an agent that falls back to a weaker or local model
+should be prevented from doing harm (e.g. coding / running a terminal)
+while still being usable for generic chat — without having to disable
+toolsets globally for the whole agent.
+
+Config shape (first hit wins, same precedence as ``supports_vision``):
+
+    # 1. Top-level shortcut — applies to the active top-level model
+    model:
+      denied_tools: [terminal, execute_code]
+
+    # 2. Per-provider, per-model (named custom / local providers)
+    providers:
+      my-local:
+        models:
+          llama-3-8b:
+            allowed_tools: [web_search, web_extract, send_message]
+            # ...or a denylist instead:
+            # denied_tools: [terminal, execute_code, write_file, patch]
+
+Semantics:
+  * ``allowed_tools`` present  → allowlist: ONLY these tools are exposed.
+  * ``denied_tools`` present   → denylist: every tool except these.
+  * Both present               → a tool must be in ``allowed_tools`` AND not
+                                 in ``denied_tools``.
+  * Neither present            → no restriction (the policy is a no-op).
+
+The policy is applied in two places:
+  1. ``build_api_kwargs`` filters the tool definitions sent to the active
+     model, so a restricted model never even sees the tool.
+  2. ``tool_executor`` rejects a disallowed call defensively, in case the
+     model invents a tool name or a stale definition slips through.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Optional
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_KEY = "allowed_tools"
+DENIED_KEY = "denied_tools"
+
+
+@dataclass(frozen=True)
+class ToolPolicy:
+    """Resolved allow/deny decision for a single (provider, model)."""
+
+    allowed: Optional[frozenset] = None  # None ⇒ no allowlist restriction
+    denied: frozenset = frozenset()
+
+    @property
+    def is_noop(self) -> bool:
+        """True when the policy imposes no restriction at all."""
+        return self.allowed is None and not self.denied
+
+    def is_allowed(self, tool_name: str) -> bool:
+        if tool_name in self.denied:
+            return False
+        if self.allowed is not None and tool_name not in self.allowed:
+            return False
+        return True
+
+
+_NOOP_POLICY = ToolPolicy()
+
+
+def _normalize_names(raw: Any) -> Optional[frozenset]:
+    """Coerce a config value into a set of tool names, or None if unset.
+
+    Accepts a list/tuple/set of names or a comma/whitespace-separated
+    string. Returns ``None`` when the value is missing or unusable so the
+    caller can distinguish "no allowlist" from "empty allowlist" (the
+    latter would block every tool).
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        parts = [p.strip() for p in raw.replace(",", " ").split()]
+    elif isinstance(raw, (list, tuple, set, frozenset)):
+        parts = [str(p).strip() for p in raw]
+    else:
+        return None
+    return frozenset(p for p in parts if p)
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _per_model_blocks(
+    cfg: Optional[Dict[str, Any]], provider: str, model: str
+) -> Iterator[Dict[str, Any]]:
+    """Yield candidate config blocks for ``model`` in precedence order.
+
+    Mirrors ``agent/image_routing._supports_vision_override`` so a model's
+    tool policy lives in exactly the same place as its other per-model
+    overrides:
+      1. ``model`` (top-level shortcut for the active model)
+      2. ``providers.<provider>.models.<model>``
+      3. legacy list-style ``custom_providers[].models.<model>``
+    """
+    if not isinstance(cfg, dict) or not model:
+        return
+
+    # 1. Top-level shortcut.
+    yield _as_dict(cfg.get("model"))
+
+    model_cfg = _as_dict(cfg.get("model"))
+    config_provider = str(model_cfg.get("provider") or "").strip()
+
+    # 2. Per-provider, per-model. Named custom providers are rewritten to
+    # provider="custom" at runtime while the config keeps the declared
+    # name under model.provider, so try both candidate provider keys.
+    providers_cfg = _as_dict(cfg.get("providers"))
+    seen_providers = set()
+    for p in (provider, config_provider):
+        p = (p or "").strip()
+        if not p or p in seen_providers:
+            continue
+        seen_providers.add(p)
+        models_cfg = _as_dict(_as_dict(providers_cfg.get(p)).get("models"))
+        yield _as_dict(models_cfg.get(model))
+
+    # 3. Legacy list-style custom_providers.
+    custom_providers = cfg.get("custom_providers")
+    if isinstance(custom_providers, list):
+        candidate_names = set()
+        for p in (provider, config_provider):
+            p = (p or "").strip()
+            if not p:
+                continue
+            candidate_names.add(p)
+            if p.startswith("custom:"):
+                candidate_names.add(p[len("custom:"):])
+            else:
+                candidate_names.add(f"custom:{p}")
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("name") or "").strip() not in candidate_names:
+                continue
+            models_cfg = _as_dict(entry.get("models"))
+            yield _as_dict(models_cfg.get(model))
+
+
+def resolve_tool_policy(
+    cfg: Optional[Dict[str, Any]], provider: str, model: str
+) -> ToolPolicy:
+    """Resolve the tool policy for ``(provider, model)`` from config.
+
+    First config block (in precedence order) that declares ``allowed_tools``
+    or ``denied_tools`` wins. Returns a no-op policy when none do.
+    """
+    for block in _per_model_blocks(cfg, provider, model):
+        if ALLOWED_KEY in block or DENIED_KEY in block:
+            allowed = _normalize_names(block.get(ALLOWED_KEY))
+            denied = _normalize_names(block.get(DENIED_KEY)) or frozenset()
+            return ToolPolicy(allowed=allowed, denied=denied)
+    return _NOOP_POLICY
+
+
+def _tool_name(tool_def: Any) -> str:
+    """Extract the callable name from an OpenAI-style tool definition."""
+    if not isinstance(tool_def, dict):
+        return ""
+    fn = tool_def.get("function")
+    if isinstance(fn, dict) and isinstance(fn.get("name"), str):
+        return fn["name"]
+    name = tool_def.get("name")
+    return name if isinstance(name, str) else ""
+
+
+def filter_tool_defs(tool_defs: Optional[List[Any]], policy: ToolPolicy) -> Optional[List[Any]]:
+    """Return ``tool_defs`` with policy-disallowed tools removed.
+
+    The original list is returned unchanged when the policy is a no-op, so
+    the common (unconfigured) path allocates nothing. Definitions whose
+    name can't be resolved are kept — they're structural, not model tools.
+    """
+    if not tool_defs or policy.is_noop:
+        return tool_defs
+    kept = []
+    dropped: List[str] = []
+    for t in tool_defs:
+        name = _tool_name(t)
+        if not name or policy.is_allowed(name):
+            kept.append(t)
+        else:
+            dropped.append(name)
+    if dropped:
+        logger.debug("tool policy filtered %d tool(s): %s", len(dropped), ", ".join(sorted(dropped)))
+    return kept
+
+
+def _load_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+        return load_config() or {}
+    except Exception:
+        return {}
+
+
+def policy_for_agent(agent: Any) -> ToolPolicy:
+    """Resolve and cache the active model's tool policy on ``agent``.
+
+    The cache is keyed by ``(provider, model)`` so a fallback model switch
+    transparently picks up that model's own policy. Tests may inject a
+    config dict via ``agent._tool_policy_config`` to avoid disk access.
+    """
+    provider = str(getattr(agent, "provider", "") or "")
+    model = str(getattr(agent, "model", "") or "")
+    cache = getattr(agent, "_tool_policy_cache", None)
+    if isinstance(cache, tuple) and cache and cache[0] == (provider, model):
+        return cache[1]
+    cfg = getattr(agent, "_tool_policy_config", None)
+    if not isinstance(cfg, dict):
+        cfg = _load_config()
+    policy = resolve_tool_policy(cfg, provider, model)
+    try:
+        agent._tool_policy_cache = ((provider, model), policy)
+    except Exception:
+        pass
+    return policy

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -576,6 +576,7 @@ AUTHOR_MAP = {
     "137614867+cutepawss@users.noreply.github.com": "cutepawss",
     "96793918+memosr@users.noreply.github.com": "memosr",
     "mehmet.sr35@gmail.com": "memosr",
+    "mehmet.kar@std.yildiz.edu.tr": "mehmetkr-31",
     "milkoor@users.noreply.github.com": "milkoor",
     "xuerui911@gmail.com": "Fatty911",
     "131039422+SHL0MS@users.noreply.github.com": "SHL0MS",

--- a/tests/agent/test_tool_policy.py
+++ b/tests/agent/test_tool_policy.py
@@ -1,0 +1,193 @@
+"""Tests for the per-model tool allow/deny policy (issue #42999).
+
+Covers:
+  * config resolution precedence (top-level model shortcut, per-provider
+    per-model, legacy custom_providers) — mirrors supports_vision lookup
+  * allowlist / denylist / combined semantics
+  * filter_tool_defs dropping the right tool definitions
+  * policy_for_agent caching per (provider, model) so a fallback model
+    picks up its own policy
+  * the tool_executor enforcement gate rejecting a disallowed call
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.tool_policy import (
+    ToolPolicy,
+    filter_tool_defs,
+    policy_for_agent,
+    resolve_tool_policy,
+)
+
+
+def _tool(name: str) -> dict:
+    return {"type": "function", "function": {"name": name, "description": ""}}
+
+
+# ── resolution precedence ────────────────────────────────────────────────
+
+def test_no_config_is_noop():
+    policy = resolve_tool_policy({}, "my-local", "llama-3-8b")
+    assert policy.is_noop
+    assert policy.is_allowed("terminal")
+
+
+def test_top_level_model_shortcut():
+    cfg = {"model": {"denied_tools": ["terminal", "execute_code"]}}
+    policy = resolve_tool_policy(cfg, "anything", "any-model")
+    assert not policy.is_allowed("terminal")
+    assert not policy.is_allowed("execute_code")
+    assert policy.is_allowed("web_search")
+
+
+def test_per_provider_per_model():
+    cfg = {
+        "providers": {
+            "my-local": {
+                "models": {
+                    "llama-3-8b": {"allowed_tools": ["web_search", "web_extract"]},
+                }
+            }
+        }
+    }
+    policy = resolve_tool_policy(cfg, "my-local", "llama-3-8b")
+    assert policy.is_allowed("web_search")
+    assert not policy.is_allowed("terminal")
+    # a different model under the same provider is unrestricted
+    assert resolve_tool_policy(cfg, "my-local", "other-model").is_noop
+
+
+def test_named_custom_provider_resolved_as_custom():
+    # Runtime rewrites a named custom provider to provider="custom" while the
+    # config keeps the declared name under model.provider — both must match.
+    cfg = {
+        "model": {"provider": "my-local"},
+        "providers": {
+            "my-local": {
+                "models": {"llama-3-8b": {"denied_tools": ["terminal"]}}
+            }
+        },
+    }
+    policy = resolve_tool_policy(cfg, "custom", "llama-3-8b")
+    assert not policy.is_allowed("terminal")
+
+
+def test_legacy_custom_providers_list():
+    cfg = {
+        "custom_providers": [
+            {"name": "my-local", "models": {"llama-3-8b": {"denied_tools": ["patch"]}}}
+        ]
+    }
+    policy = resolve_tool_policy(cfg, "my-local", "llama-3-8b")
+    assert not policy.is_allowed("patch")
+
+
+def test_top_level_wins_over_provider_block():
+    cfg = {
+        "model": {"denied_tools": ["terminal"]},
+        "providers": {
+            "my-local": {"models": {"m": {"allowed_tools": ["web_search"]}}}
+        },
+    }
+    policy = resolve_tool_policy(cfg, "my-local", "m")
+    # top-level block declares a key first → it wins
+    assert policy.denied == frozenset({"terminal"})
+    assert policy.allowed is None
+
+
+# ── allow/deny semantics ─────────────────────────────────────────────────
+
+def test_allowlist_only():
+    policy = ToolPolicy(allowed=frozenset({"web_search"}))
+    assert policy.is_allowed("web_search")
+    assert not policy.is_allowed("terminal")
+
+
+def test_denylist_only():
+    policy = ToolPolicy(denied=frozenset({"terminal"}))
+    assert not policy.is_allowed("terminal")
+    assert policy.is_allowed("web_search")
+
+
+def test_allow_and_deny_combined():
+    policy = ToolPolicy(allowed=frozenset({"web_search", "terminal"}),
+                        denied=frozenset({"terminal"}))
+    assert policy.is_allowed("web_search")
+    assert not policy.is_allowed("terminal")  # deny overrides allow
+
+
+def test_string_list_is_parsed():
+    cfg = {"model": {"denied_tools": "terminal, execute_code"}}
+    policy = resolve_tool_policy(cfg, "p", "m")
+    assert not policy.is_allowed("terminal")
+    assert not policy.is_allowed("execute_code")
+
+
+def test_empty_allowlist_blocks_everything():
+    cfg = {"model": {"allowed_tools": []}}
+    policy = resolve_tool_policy(cfg, "p", "m")
+    assert not policy.is_noop
+    assert not policy.is_allowed("web_search")
+
+
+# ── filter_tool_defs ─────────────────────────────────────────────────────
+
+def test_filter_drops_disallowed_defs():
+    defs = [_tool("web_search"), _tool("terminal"), _tool("execute_code")]
+    policy = ToolPolicy(denied=frozenset({"terminal", "execute_code"}))
+    kept = filter_tool_defs(defs, policy)
+    assert [d["function"]["name"] for d in kept] == ["web_search"]
+
+
+def test_filter_noop_returns_same_object():
+    defs = [_tool("web_search")]
+    assert filter_tool_defs(defs, ToolPolicy()) is defs
+
+
+def test_filter_keeps_unnamed_structural_defs():
+    weird = {"type": "custom"}  # no resolvable name
+    defs = [weird, _tool("terminal")]
+    kept = filter_tool_defs(defs, ToolPolicy(allowed=frozenset({"web_search"})))
+    assert weird in kept
+    assert _tool("terminal") not in kept
+
+
+# ── policy_for_agent caching across fallback ─────────────────────────────
+
+def test_policy_for_agent_caches_per_model():
+    cfg = {
+        "providers": {
+            "my-local": {"models": {"weak": {"denied_tools": ["terminal"]}}},
+        }
+    }
+    agent = SimpleNamespace(
+        provider="cloud", model="strong", _tool_policy_config=cfg,
+    )
+    # strong/cloud model: unrestricted
+    assert policy_for_agent(agent).is_allowed("terminal")
+    # simulate a fallback switch to the weak local model
+    agent.provider = "my-local"
+    agent.model = "weak"
+    assert not policy_for_agent(agent).is_allowed("terminal")
+
+
+# ── request-path filtering mirrors execution-path enforcement ────────────
+
+def test_request_and_execution_paths_agree():
+    """A tool hidden from the model (build_api_kwargs) must also be the one
+    rejected at execution (tool_executor) — both consult the same policy."""
+    cfg = {"model": {"allowed_tools": ["web_search"]}}
+    agent = SimpleNamespace(provider="p", model="m", _tool_policy_config=cfg)
+    policy = policy_for_agent(agent)
+
+    defs = [_tool("web_search"), _tool("terminal")]
+    visible = {d["function"]["name"] for d in filter_tool_defs(defs, policy)}
+
+    assert visible == {"web_search"}
+    # Execution gate would reject exactly the tools that were not visible.
+    assert policy.is_allowed("web_search")
+    assert not policy.is_allowed("terminal")

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1286,6 +1286,31 @@ model:
 
 The same key is honored on per-named-provider models (`custom_providers[*].models[*].supports_vision`) and accepts standard YAML booleans (`true/false/yes/no/on/off/1/0`).
 
+**Restricting tools per model.** Some models are great at chat but unreliable
+at coding — and when an agent falls back to a weaker or local model you may
+want to stop it from doing harm without disabling toolsets for the whole
+agent. Set a per-model tool policy with `allowed_tools` (allowlist — only
+these tools are offered) or `denied_tools` (denylist — everything except
+these), in the same places as `supports_vision`:
+
+```yaml
+providers:
+  my-local:
+    models:
+      llama-3-8b:
+        denied_tools: [terminal, execute_code, write_file, patch]
+        # ...or an allowlist instead:
+        # allowed_tools: [web_search, web_extract, send_message]
+```
+
+A `model.allowed_tools` / `model.denied_tools` shortcut at the top level
+applies to the active top-level model. Resolution follows the same
+first-hit-wins precedence as `supports_vision` (top-level `model` →
+`providers.<name>.models.<model>` → legacy `custom_providers`). The policy
+is enforced both ways: restricted tools are hidden from the model's request
+and rejected at execution if the model calls one anyway. A fallback model
+picks up its own policy automatically.
+
 Switch between them mid-session with the triple syntax:
 
 ```


### PR DESCRIPTION
## What & why

Closes #42999.

Some models are good at chat but unreliable at coding. When an agent falls back to a weaker or local model, you may want to stop it from doing harm (running a terminal, editing files) **without** disabling toolsets for the whole agent. This adds an optional **per-model tool policy**: restrict a specific model to a subset of tools, configured next to the other per-model overrides in `config.yaml` (same lookup precedence as `supports_vision`).

## Config

First hit wins: top-level `model` → `providers.<p>.models.<model>` → legacy `custom_providers`.

```yaml
providers:
  my-local:
    models:
      llama-3-8b:
        denied_tools: [terminal, execute_code, write_file, patch]   # denylist
        # ...or an allowlist (only these are offered):
        # allowed_tools: [web_search, web_extract, send_message]
```

- `allowed_tools` → allowlist (only these tools are exposed)
- `denied_tools` → denylist (everything except these)
- both → must be allowed **and** not denied
- neither → no restriction (no-op)

A `model.allowed_tools` / `model.denied_tools` shortcut applies to the active top-level model. Accepts a YAML list or a comma/space-separated string.

## How it works

Enforced in two places, both consulting the same resolved policy:

1. **`build_api_kwargs()`** filters the tool definitions sent to the active model, so a restricted model never even sees the tool. Keyed on the live `agent.model`/`agent.provider`, so a **fallback model automatically gets its own policy** (the request path is the single chokepoint where the active model is known).
2. **`tool_executor`** rejects a disallowed call defensively — in case the model hallucinates a tool name or a stale definition slips through — reusing the existing pre-dispatch block path (same shape as the tool-search scope block).

The resolution mirrors `agent/image_routing.py`'s `supports_vision` lookup, including named-custom-provider rewrite (`provider="custom"` + declared name under `model.provider`) and the legacy list-style `custom_providers`.

No behavior change when no policy is configured: the filter is a no-op and returns the same tool list (allocates nothing).

## How to test

```bash
scripts/run_tests.sh tests/agent/test_tool_policy.py
```

New tests cover resolution precedence, allow/deny/combined semantics, string-list parsing, empty-allowlist-blocks-everything, `filter_tool_defs` dropping the right defs, and `policy_for_agent` caching per `(provider, model)` so a fallback switch picks up the right policy.

- Full new file passes (16 tests).
- Regression-checked the touched paths: `tests/run_agent/test_tool_executor_contextvar_propagation.py`, `test_tool_call_guardrail_runtime.py`, `test_concurrent_interrupt.py`, `test_provider_parity.py`, `tests/tools/test_tool_search.py`, `tests/agent/test_gemini_fast_fallback.py` — 155 passed. `ruff check` clean.

## Platforms

Pure Python, no OS-specific calls — platform-agnostic (developed on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)