### PR TITLE
fix(plugins): discover pip entry-point plugins in enable/disable commands

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -877,12 +877,41 @@ def _scan_level(
         _scan_level(d, source, set(), sub_prefix, depth + 1, seen)
 
 
+def _scan_entry_point_plugins(seen: dict) -> None:
+    """Add pip entry-point plugins (``hermes_agent.plugins`` group) to *seen*."""
+    try:
+        import importlib.metadata
+
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+
+        eps = importlib.metadata.entry_points()
+        if hasattr(eps, "select"):
+            group_eps = eps.select(group=ENTRY_POINTS_GROUP)
+        elif isinstance(eps, dict):
+            group_eps = eps.get(ENTRY_POINTS_GROUP, [])
+        else:
+            group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+
+        for ep in group_eps:
+            if ep.name not in seen:
+                seen[ep.name] = (
+                    ep.name,     # name
+                    "",          # version
+                    "",          # description
+                    "entrypoint",  # source
+                    Path(),      # no dir_path for entry-point plugins
+                    ep.name,     # key
+                )
+    except Exception:
+        pass
+
+
 def _discover_all_plugins() -> list:
     """Return a list of (name, version, description, source, dir_path, key) for
-    every plugin the loader can see — user + bundled + project.
+    every plugin the loader can see — user + bundled + entry-point + project.
 
     Matches the ordering/dedup of ``PluginManager.discover_and_load``:
-    bundled first, then user, then project; user overrides bundled on
+    bundled first, then user, then entry-point; user overrides bundled on
     key collision.
     """
     seen: dict = {}  # key -> (name, version, description, source, path, key)
@@ -895,6 +924,10 @@ def _discover_all_plugins() -> list:
         (_plugins_dir(), "user", set()),
     ):
         _scan_level(base, source, skip, "", 0, seen)
+
+    # Pip entry-point plugins (same group the runtime loader scans).
+    _scan_entry_point_plugins(seen)
+
     return list(seen.values())
 
 

--- a/tests/hermes_cli/test_plugins_cmd_entry_points.py
+++ b/tests/hermes_cli/test_plugins_cmd_entry_points.py
@@ -1,0 +1,162 @@
+"""Tests for entry-point plugin discovery in hermes_cli.plugins_cmd.
+
+Verifies that ``_scan_entry_point_plugins`` and ``_discover_all_plugins``
+correctly surface pip-installed plugins that declare the
+``hermes_agent.plugins`` entry-point group.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli.plugins_cmd import (
+    _discover_all_plugins,
+    _plugin_exists,
+    _resolve_plugin_key,
+    _scan_entry_point_plugins,
+)
+
+
+# ── _scan_entry_point_plugins ──────────────────────────────────────────
+
+
+class TestScanEntryPointPlugins:
+    """Unit tests for the entry-point scanner."""
+
+    def test_adds_entry_point_plugin_to_seen(self):
+        """A single entry-point plugin is added to the seen dict."""
+        fake_ep = MagicMock()
+        fake_ep.name = "my-custom-plugin"
+        fake_eps = MagicMock()
+        fake_eps.select.return_value = [fake_ep]
+
+        seen: dict = {}
+        with patch("importlib.metadata.entry_points", return_value=fake_eps):
+            _scan_entry_point_plugins(seen)
+
+        assert "my-custom-plugin" in seen
+        entry = seen["my-custom-plugin"]
+        assert entry[0] == "my-custom-plugin"  # name
+        assert entry[3] == "entrypoint"         # source
+        assert entry[5] == "my-custom-plugin"   # key
+
+    def test_multiple_entry_points(self):
+        """Multiple entry-point plugins are all discovered."""
+        ep1 = MagicMock()
+        ep1.name = "plugin-a"
+        ep2 = MagicMock()
+        ep2.name = "plugin-b"
+        fake_eps = MagicMock()
+        fake_eps.select.return_value = [ep1, ep2]
+
+        seen: dict = {}
+        with patch("importlib.metadata.entry_points", return_value=fake_eps):
+            _scan_entry_point_plugins(seen)
+
+        assert "plugin-a" in seen
+        assert "plugin-b" in seen
+
+    def test_does_not_overwrite_existing(self):
+        """Entry-point plugins do not overwrite bundled/user plugins."""
+        fake_ep = MagicMock()
+        fake_ep.name = "existing-plugin"
+        fake_eps = MagicMock()
+        fake_eps.select.return_value = [fake_ep]
+
+        # Pre-populate seen with a bundled entry
+        seen: dict = {
+            "existing-plugin": (
+                "existing-plugin", "1.0", "desc", "bundled",
+                Path("/some/path"), "existing-plugin",
+            )
+        }
+        with patch("importlib.metadata.entry_points", return_value=fake_eps):
+            _scan_entry_point_plugins(seen)
+
+        # Should still be the bundled version
+        assert seen["existing-plugin"][3] == "bundled"
+
+    def test_graceful_on_import_error(self):
+        """Scanner returns silently if entry_points() raises."""
+        seen: dict = {}
+        with patch("importlib.metadata.entry_points", side_effect=ImportError):
+            _scan_entry_point_plugins(seen)
+        assert len(seen) == 0
+
+    def test_dict_fallback_for_older_python(self):
+        """Falls back to eps.get() on dict-style entry points()."""
+        fake_ep = MagicMock()
+        fake_ep.name = "legacy-plugin"
+        # Simulate Python <3.12 dict-style return
+        fake_eps = {"hermes_agent.plugins": [fake_ep]}
+
+        seen: dict = {}
+        with patch("importlib.metadata.entry_points", return_value=fake_eps):
+            _scan_entry_point_plugins(seen)
+
+        assert "legacy-plugin" in seen
+
+    def test_no_entry_points_group(self):
+        """Handles empty group gracefully (no matching entry points)."""
+        fake_eps = MagicMock()
+        fake_eps.select.return_value = []
+
+        seen: dict = {}
+        with patch("importlib.metadata.entry_points", return_value=fake_eps):
+            _scan_entry_point_plugins(seen)
+
+        assert len(seen) == 0
+
+
+# ── Integration: _discover_all_plugins + _plugin_exists ─────────────────
+
+
+class TestDiscoverWithEntryPoints:
+    """Integration tests for entry-point discovery in the full plugin pipeline."""
+
+    def test_discover_includes_entry_point_plugins(self):
+        """_discover_all_plugins returns entry-point plugins alongside bundled."""
+        fake_ep = MagicMock()
+        fake_ep.name = "pip-plugin"
+        fake_eps = MagicMock()
+        fake_eps.select.return_value = [fake_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=fake_eps):
+            plugins = _discover_all_plugins()
+
+        # Should have bundled plugins plus our fake entry-point plugin
+        names = [p[0] for p in plugins]
+        assert "pip-plugin" in names
+
+    def test_plugin_exists_finds_entry_point(self):
+        """_plugin_exists returns True for an entry-point-only plugin."""
+        fake_ep = MagicMock()
+        fake_ep.name = "ep-only-plugin"
+        fake_eps = MagicMock()
+        fake_eps.select.return_value = [fake_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=fake_eps):
+            assert _plugin_exists("ep-only-plugin") is True
+
+    def test_plugin_exists_false_for_unknown(self):
+        """_plugin_exists returns False for a plugin that does not exist."""
+        fake_eps = MagicMock()
+        fake_eps.select.return_value = []
+
+        with patch("importlib.metadata.entry_points", return_value=fake_eps):
+            assert _plugin_exists("nonexistent-plugin-xyz") is False
+
+    def test_resolve_plugin_key_returns_entry_point_key(self):
+        """_resolve_plugin_key resolves entry-point plugins to their canonical key."""
+        fake_ep = MagicMock()
+        fake_ep.name = "my-web-search"
+        fake_eps = MagicMock()
+        fake_eps.select.return_value = [fake_ep]
+
+        with patch("importlib.metadata.entry_points", return_value=fake_eps):
+            key = _resolve_plugin_key("my-web-search")
+
+        assert key == "my-web-search"


### PR DESCRIPTION
## What does this PR do?

Extends `_discover_all_plugins()` to scan `importlib.metadata` entry points (the `hermes_agent.plugins` group), so that `hermes plugins enable`/`disable` can find pip-installed plugins that the runtime loader already supports but the CLI validation path rejected.

## Related Issue

Fixes #43117

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins_cmd.py`: Added `_scan_entry_point_plugins()` helper that queries `importlib.metadata` for the `hermes_agent.plugins` entry-point group using the same Python-version-compatible select/get/list fallback pattern as `PluginManager._scan_entry_points()`. Called from `_discover_all_plugins()` after bundled/user directory scanning.
- `tests/hermes_cli/test_plugins_cmd_entry_points.py`: 10 tests covering single/multiple entry-point discovery, no-overwrite semantics, graceful error handling, dict fallback for older Python, and integration with `_plugin_exists`/`_resolve_plugin_key`.

## How to Test

1. `pip install` any package exposing a `hermes_agent.plugins` entry point
2. Run `hermes plugins enable <name>` — previously failed with "not installed or bundled", now succeeds
3. Run `pytest tests/hermes_cli/test_plugins_cmd_entry_points.py -v` — all 10 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_discover_all_plugins`, `_resolve_plugin_key`, `_plugin_exists` in `hermes_cli/plugins_cmd.py`; `_scan_entry_points` in `hermes_cli/plugins.py`
- Blast radius: LOW — changes only the CLI plugin discovery path; runtime loader unaffected
- Related patterns: Mirrors `PluginManager._scan_entry_points()` Python-version-compatible entry-point resolution (select/get/list fallback)
