### PR TITLE
fix(gateway+codex): desktop/dashboard event-stream reliability — detached-session black hole, turn-end persistence, live codex events

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -16,11 +16,12 @@ compatibility.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +174,124 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     }
 
 
+def _codex_tool_descriptor(item: dict) -> Optional[Tuple[str, str, dict]]:
+    """(call_id, tool_name, args) for a tool-shaped codex item.
+
+    Mirrors codex_event_projector's naming and deterministic call ids so
+    live tool.start/tool.complete events correlate with the tool_calls the
+    projector later writes into history. Non-tool items return None.
+    """
+    from agent.transports.codex_event_projector import _deterministic_call_id
+
+    item_type = item.get("type") or ""
+    item_id = item.get("id") or ""
+    if item_type == "commandExecution":
+        return (
+            _deterministic_call_id("exec", item_id),
+            "exec_command",
+            {"command": item.get("command") or "", "cwd": item.get("cwd") or ""},
+        )
+    if item_type == "fileChange":
+        changes = [
+            {
+                "kind": (change.get("kind") or {}).get("type") or "update",
+                "path": change.get("path") or "",
+            }
+            for change in item.get("changes") or []
+        ]
+        return (
+            _deterministic_call_id("apply_patch", item_id),
+            "apply_patch",
+            {"changes": changes},
+        )
+    if item_type == "mcpToolCall":
+        server = item.get("server") or "mcp"
+        tool = item.get("tool") or "unknown"
+        args = item.get("arguments") or {}
+        if not isinstance(args, dict):
+            args = {"arguments": args}
+        return (
+            _deterministic_call_id(f"mcp_{server}_{tool}", item_id),
+            f"mcp.{server}.{tool}",
+            args,
+        )
+    if item_type == "dynamicToolCall":
+        tool = item.get("tool") or "unknown"
+        args = item.get("arguments") or {}
+        if not isinstance(args, dict):
+            args = {"arguments": args}
+        return (_deterministic_call_id(f"dyn_{tool}", item_id), tool, args)
+    return None
+
+
+def _codex_tool_result(item: dict) -> str:
+    """Result string for a completed tool-shaped codex item (projector parity)."""
+    item_type = item.get("type") or ""
+    if item_type == "commandExecution":
+        output = item.get("aggregatedOutput") or ""
+        exit_code = item.get("exitCode")
+        if exit_code is not None and exit_code != 0:
+            output = f"[exit {exit_code}]\n{output}"
+        return output
+    if item_type == "fileChange":
+        status = item.get("status") or "unknown"
+        n = len(item.get("changes") or [])
+        return f"apply_patch status={status}, {n} change(s)"
+    if item_type == "mcpToolCall":
+        error = item.get("error")
+        if error:
+            return f"[error] {json.dumps(error, ensure_ascii=False)[:1000]}"
+        result = item.get("result")
+        return json.dumps(result, ensure_ascii=False)[:4000] if result is not None else ""
+    if item_type == "dynamicToolCall":
+        content_items = item.get("contentItems") or []
+        if isinstance(content_items, list) and content_items:
+            return json.dumps(content_items, ensure_ascii=False)[:4000]
+        return f"success={item.get('success')}"
+    return ""
+
+
+def _codex_live_event(agent, note: dict) -> None:
+    """Bridge codex app-server notifications to the agent's live display
+    callbacks so connected clients see streaming text, reasoning, and tool
+    activity DURING a codex turn instead of only the final answer.
+
+    The gateway wires _stream_callback / reasoning_callback /
+    tool_start_callback / tool_complete_callback onto the agent before
+    every turn; the default chat_completions loop fires them but the codex
+    path historically consumed every notification silently. Display is
+    best-effort: nothing here may break a turn.
+    """
+    try:
+        method = note.get("method", "")
+        params = note.get("params", {}) or {}
+        if method == "item/agentMessage/delta":
+            delta = params.get("delta")
+            if delta:
+                agent._fire_stream_delta(str(delta))
+            return
+        if method in ("item/reasoning/delta", "item/reasoning/summaryDelta"):
+            delta = params.get("delta")
+            if delta:
+                agent._fire_reasoning_delta(str(delta))
+            return
+        if method in ("item/started", "item/completed"):
+            descriptor = _codex_tool_descriptor(params.get("item") or {})
+            if descriptor is None:
+                return
+            call_id, name, args = descriptor
+            if method == "item/started":
+                cb = getattr(agent, "tool_start_callback", None)
+                if cb is not None:
+                    cb(call_id, name, args)
+            else:
+                cb = getattr(agent, "tool_complete_callback", None)
+                if cb is not None:
+                    cb(call_id, name, args, _codex_tool_result(params.get("item") or {}))
+    except Exception:
+        logger.debug("codex live event bridge raised", exc_info=True)
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -207,6 +326,9 @@ def run_codex_app_server_turn(
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            # Live display bridge: stream deltas / reasoning / tool events to
+            # whatever callbacks the host (gateway, TUI) re-binds per turn.
+            on_event=lambda note: _codex_live_event(agent, note),
         )
 
     # NOTE: the user message is ALREADY appended to messages by the
@@ -256,7 +378,20 @@ def run_codex_app_server_turn(
     # standard {role, content, tool_calls, tool_call_id} entries, which
     # is exactly what curator.py / sessions DB expect.
     if turn.projected_messages:
-        messages.extend(turn.projected_messages)
+        projected = list(turn.projected_messages)
+        # Codex echoes the submitted input back as its own userMessage event,
+        # but run_conversation already appended the user message before
+        # handing us the turn — splicing both stores every user message
+        # twice, which shows up as doubled user bubbles in any persisted /
+        # resumed transcript.
+        if (
+            projected
+            and isinstance(projected[0], dict)
+            and projected[0].get("role") == "user"
+            and projected[0].get("content") == user_message
+        ):
+            projected = projected[1:]
+        messages.extend(projected)
 
     # Counter ticks for the agent-improvement loop.
     # _turns_since_memory and _user_turn_count are ALREADY incremented
@@ -311,6 +446,23 @@ def run_codex_app_server_turn(
         except Exception:
             logger.debug("background review spawn raised", exc_info=True)
 
+    # Final reasoning for the turn: the projector stashes it on the spliced
+    # assistant messages, but the codex dispatch early-returns before
+    # run_conversation's last_reasoning back-walk — without this the gateway
+    # never gets payload["reasoning"] on message.complete and the UI shows
+    # no thinking at all. Walk back to the current turn's first user row.
+    last_reasoning = None
+    for msg in reversed(messages):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "user":
+            break
+        if msg.get("role") == "assistant":
+            reasoning = msg.get("reasoning")
+            if isinstance(reasoning, str) and reasoning.strip():
+                last_reasoning = reasoning.strip()
+                break
+
     return {
         "final_response": turn.final_text,
         "messages": messages,
@@ -318,6 +470,7 @@ def run_codex_app_server_turn(
         "completed": not turn.interrupted and turn.error is None,
         "partial": turn.interrupted or turn.error is not None,
         "error": turn.error,
+        "last_reasoning": last_reasoning,
         "codex_thread_id": turn.thread_id,
         "codex_turn_id": turn.turn_id,
         **usage_result,

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -504,6 +504,14 @@ class CodexAppServerSession:
                     pending = self._client.take_notification(timeout=0)
                     if pending is None:
                         break
+                    # Display parity with the main poll loop below: deltas
+                    # consumed during an approval round-trip must still
+                    # reach the live-event hook or the UI stream stalls.
+                    if self._on_event is not None:
+                        try:
+                            self._on_event(pending)
+                        except Exception:  # pragma: no cover - display callback
+                            logger.debug("on_event callback raised", exc_info=True)
                     _apply_token_usage_notification(result, pending)
                     self._track_pending_file_change(pending)
                     proj = projector.project(pending)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,8 +43,14 @@ NC='\033[0m' # No Color
 BOLD='\033[1m'
 
 # Configuration
-REPO_URL_SSH="git@github.com:NousResearch/hermes-agent.git"
-REPO_URL_HTTPS="https://github.com/NousResearch/hermes-agent.git"
+# HERMES_REPO_URL / HERMES_REPO_URL_SSH let embedders and fork maintainers
+# install from a pinned fork without maintaining a divergent copy of this
+# script.
+REPO_URL_HTTPS="${HERMES_REPO_URL:-https://github.com/NousResearch/hermes-agent.git}"
+# When only the HTTPS override is given, use it for the primary attempt too —
+# otherwise the SSH-first clone would still hit the default repo (where a
+# fork-only branch does not exist) before falling back.
+REPO_URL_SSH="${HERMES_REPO_URL_SSH:-${HERMES_REPO_URL:-git@github.com:NousResearch/hermes-agent.git}}"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 # INSTALL_DIR is resolved AFTER arg parsing and OS detection so we can pick an
 # FHS-style layout for root installs.  Track whether the user gave us an

--- a/tests/agent/test_codex_runtime_live_events.py
+++ b/tests/agent/test_codex_runtime_live_events.py
@@ -1,0 +1,102 @@
+"""Live-event bridge for codex app-server turns (agent/codex_runtime.py).
+
+Regression: codex turns were fully silent in connected UIs — the session's
+on_event hook was never wired, so streaming text, reasoning, and tool
+activity all vanished and clients saw only message.start → message.complete.
+"""
+
+from types import SimpleNamespace
+
+from agent.codex_runtime import (
+    _codex_live_event,
+    _codex_tool_descriptor,
+    _codex_tool_result,
+)
+
+
+def _recording_agent():
+    calls = {"stream": [], "reasoning": [], "tool_start": [], "tool_complete": []}
+    agent = SimpleNamespace(
+        _fire_stream_delta=lambda text: calls["stream"].append(text),
+        _fire_reasoning_delta=lambda text: calls["reasoning"].append(text),
+        tool_start_callback=lambda cid, name, args: calls["tool_start"].append((cid, name, args)),
+        tool_complete_callback=lambda cid, name, args, result: calls["tool_complete"].append(
+            (cid, name, args, result)
+        ),
+    )
+    return agent, calls
+
+
+def test_agent_message_delta_streams_text():
+    agent, calls = _recording_agent()
+    _codex_live_event(agent, {"method": "item/agentMessage/delta", "params": {"delta": "hel"}})
+    _codex_live_event(agent, {"method": "item/agentMessage/delta", "params": {"delta": "lo"}})
+    assert calls["stream"] == ["hel", "lo"]
+    assert calls["reasoning"] == []
+
+
+def test_reasoning_delta_fires_reasoning_callback():
+    agent, calls = _recording_agent()
+    _codex_live_event(agent, {"method": "item/reasoning/delta", "params": {"delta": "thinking…"}})
+    assert calls["reasoning"] == ["thinking…"]
+    assert calls["stream"] == []
+
+
+def test_command_execution_start_and_complete_fire_tool_events():
+    agent, calls = _recording_agent()
+    item = {"type": "commandExecution", "id": "abc123", "command": "echo hi", "cwd": "/tmp"}
+    _codex_live_event(agent, {"method": "item/started", "params": {"item": item}})
+    done = dict(item, aggregatedOutput="hi\n", exitCode=0)
+    _codex_live_event(agent, {"method": "item/completed", "params": {"item": done}})
+
+    assert calls["tool_start"] == [
+        ("codex_exec_abc123", "exec_command", {"command": "echo hi", "cwd": "/tmp"})
+    ]
+    (cid, name, args, result) = calls["tool_complete"][0]
+    assert cid == "codex_exec_abc123"
+    assert name == "exec_command"
+    assert result == "hi\n"
+
+
+def test_failed_command_result_carries_exit_code():
+    item = {"type": "commandExecution", "id": "x", "aggregatedOutput": "boom", "exitCode": 2}
+    assert _codex_tool_result(item) == "[exit 2]\nboom"
+
+
+def test_non_tool_items_and_junk_are_ignored():
+    agent, calls = _recording_agent()
+    _codex_live_event(agent, {"method": "item/started", "params": {"item": {"type": "reasoning"}}})
+    _codex_live_event(agent, {"method": "item/completed", "params": {"item": {"type": "agentMessage"}}})
+    _codex_live_event(agent, {"method": "turn/completed", "params": {}})
+    _codex_live_event(agent, {})
+    assert calls == {"stream": [], "reasoning": [], "tool_start": [], "tool_complete": []}
+
+
+def test_bridge_never_raises_even_when_callbacks_blow_up():
+    def _boom(*_a, **_k):
+        raise RuntimeError("display crashed")
+
+    agent = SimpleNamespace(_fire_stream_delta=_boom)
+    _codex_live_event(agent, {"method": "item/agentMessage/delta", "params": {"delta": "x"}})
+
+
+def test_descriptor_call_ids_match_projector_history_ids():
+    """Live tool cards must correlate with the tool_calls persisted by the
+    projector — same deterministic id scheme."""
+    from agent.transports.codex_event_projector import _deterministic_call_id
+
+    mcp = {"type": "mcpToolCall", "id": "i1", "server": "srv", "tool": "t", "arguments": {"a": 1}}
+    cid, name, args = _codex_tool_descriptor(mcp)
+    assert cid == _deterministic_call_id("mcp_srv_t", "i1")
+    assert name == "mcp.srv.t"
+    assert args == {"a": 1}
+
+    patch = {
+        "type": "fileChange",
+        "id": "i2",
+        "changes": [{"kind": {"type": "add"}, "path": "a.py"}],
+    }
+    cid, name, args = _codex_tool_descriptor(patch)
+    assert cid == _deterministic_call_id("apply_patch", "i2")
+    assert name == "apply_patch"
+    assert args == {"changes": [{"kind": "add", "path": "a.py"}]}

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1192,6 +1192,107 @@ def test_ws_orphan_reap_disabled_when_grace_zero(monkeypatch):
     assert fired["timer"] is False
 
 
+def test_turn_end_history_persist_writes_messages(monkeypatch):
+    """A finished turn is durable immediately — not only at the NEXT submit.
+
+    Regression: turn results lived solely in process memory until the next
+    prompt.submit persisted them, so any backend restart between turns
+    (desktop profile switch, sidecar respawn) erased the completed exchange —
+    the session row kept its generated title but message_count stayed 0 and
+    resume painted an empty transcript.
+    """
+    calls = {}
+
+    class _FakeDB:
+        def replace_messages(self, session_id, messages):
+            calls["sid"] = session_id
+            calls["messages"] = messages
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    session = _session(session_key="stored-key")
+    history = [
+        {"role": "user", "content": "hey"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    server._persist_session_history(session, history)
+    assert calls["sid"] == "stored-key"
+    assert calls["messages"] == history
+
+
+def test_turn_end_history_persist_survives_db_failure(monkeypatch):
+    """Persistence is best-effort: a db error must never kill the turn thread."""
+
+    class _ExplodingDB:
+        def replace_messages(self, session_id, messages):
+            raise RuntimeError("disk full")
+
+    monkeypatch.setattr(server, "_get_db", lambda: _ExplodingDB())
+    server._persist_session_history(_session(session_key="k"), [])
+
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    server._persist_session_history(_session(session_key="k"), [])
+
+
+def test_sess_nowait_rebinds_stdio_parked_session_to_live_ws():
+    """A session-scoped RPC over a live WS reclaims a stdio-parked session.
+
+    After a WS drop parks a session on _stdio_transport (a black hole in
+    dashboard mode), any session-scoped RPC arriving over a new live WS must
+    re-bind the event stream so the rest of the turn reaches the client.
+    """
+    from tui_gateway.transport import bind_transport, reset_transport
+
+    class _LiveTransport:
+        def write(self, *a, **k):
+            return True
+
+    live = _LiveTransport()
+    server._sessions["rebind-sid"] = _session(transport=server._stdio_transport)
+    token = bind_transport(live)
+    try:
+        session, err = server._sess_nowait({"session_id": "rebind-sid"}, 1)
+        assert err is None
+        assert session["transport"] is live
+    finally:
+        reset_transport(token)
+        server._sessions.pop("rebind-sid", None)
+
+
+def test_sess_nowait_does_not_steal_from_live_transport():
+    """A second live client must not hijack another websocket's stream."""
+    from tui_gateway.transport import bind_transport, reset_transport
+
+    class _LiveTransport:
+        def write(self, *a, **k):
+            return True
+
+    owner, intruder = _LiveTransport(), _LiveTransport()
+    server._sessions["owned-sid"] = _session(transport=owner)
+    token = bind_transport(intruder)
+    try:
+        session, err = server._sess_nowait({"session_id": "owned-sid"}, 1)
+        assert err is None
+        assert session["transport"] is owner
+    finally:
+        reset_transport(token)
+        server._sessions.pop("owned-sid", None)
+
+
+def test_sess_nowait_leaves_real_stdio_gateway_untouched():
+    """Ink/stdio gateways dispatch with _stdio_transport — never 'upgrade' there."""
+    from tui_gateway.transport import bind_transport, reset_transport
+
+    server._sessions["stdio-sid"] = _session(transport=server._stdio_transport)
+    token = bind_transport(server._stdio_transport)
+    try:
+        session, err = server._sess_nowait({"session_id": "stdio-sid"}, 1)
+        assert err is None
+        assert session["transport"] is server._stdio_transport
+    finally:
+        reset_transport(token)
+        server._sessions.pop("stdio-sid", None)
+
+
 def test_init_session_fires_reset_hook(monkeypatch):
     hooks = []
 
@@ -3744,7 +3845,20 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
             {"role": "assistant", "content": "edited reply"},
         ]
         assert server._sessions["sid"]["history_version"] == 2
-        assert stub_db.replaced == [("session-key", original_history[:2])]
+        # Two persists: the truncation rewrite before the turn, then the
+        # turn-end transcript persist (so a backend restart between turns
+        # can't erase the completed exchange).
+        assert stub_db.replaced == [
+            ("session-key", original_history[:2]),
+            (
+                "session-key",
+                [
+                    *original_history[:2],
+                    {"role": "user", "content": "edited second"},
+                    {"role": "assistant", "content": "edited reply"},
+                ],
+            ),
+        ]
     finally:
         server._sessions.pop("sid", None)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -967,8 +967,32 @@ def _start_agent_build(sid: str, session: dict) -> None:
     threading.Thread(target=_build, daemon=True).start()
 
 
+def _rebind_ws_transport(session: dict | None) -> None:
+    """Upgrade a stdio-parked session to the calling WS transport.
+
+    When a websocket drops mid-turn, ``handle_ws`` points every session it
+    owned at ``_stdio_transport`` — in dashboard mode a black hole with no
+    reader, so the rest of the turn (deltas, message.complete) vanishes.
+    Any session-scoped RPC arriving over a live WS proves the rightful
+    client is back, so re-bind the stream to it. Only sessions parked on
+    the stdio transport are upgraded: a second live client cannot hijack
+    another websocket's stream, and real stdio gateways (Ink TUI, where
+    stdio has a genuine peer) dispatch with ``_stdio_transport`` as the
+    current transport and are left untouched.
+    """
+    if not session:
+        return
+    t = current_transport()
+    if t is None or t is _stdio_transport:
+        return
+    if session.get("transport") is _stdio_transport:
+        session["transport"] = t
+
+
 def _sess_nowait(params, rid):
     s = _sessions.get(params.get("session_id") or "")
+    if s is not None:
+        _rebind_ws_transport(s)
     return (s, None) if s else (None, _err(rid, 4001, "session not found"))
 
 
@@ -1125,6 +1149,51 @@ def _ensure_session_db_row(session: dict) -> None:
         )
     except Exception:
         logger.debug("failed to persist desktop session row", exc_info=True)
+    finally:
+        if close_db:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+
+def _persist_session_history(session: dict, history: list) -> None:
+    """Write the session's transcript to its state.db at turn end.
+
+    Until now a finished turn lived only in this process's memory; the next
+    prompt.submit (or a /retry-style rewrite) was the first thing to persist
+    it. Any backend restart between turns — desktop profile switch, sidecar
+    respawn, crash — therefore lost every completed exchange: the session row
+    existed (and got a generated title) but message_count stayed 0 and a
+    resume painted an empty transcript. Mirrors _ensure_session_db_row's
+    profile-home routing so global-remote-mode sessions persist into their
+    own profile's state.db.
+    """
+    key = session.get("session_key")
+    if not key:
+        return
+    close_db = False
+    profile_home = session.get("profile_home")
+    if profile_home:
+        from hermes_state import SessionDB
+
+        try:
+            db = SessionDB(db_path=Path(profile_home) / "state.db")
+            close_db = True
+        except Exception:
+            logger.debug("failed to open profile db for history persist", exc_info=True)
+            return
+    else:
+        db = _get_db()
+    if db is None:
+        return
+    try:
+        db.replace_messages(key, history)
+    except Exception as exc:
+        print(
+            f"[tui_gateway] turn-end history persist failed: {exc}",
+            file=sys.stderr,
+        )
     finally:
         if close_db:
             try:
@@ -5015,6 +5084,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
 
             last_reasoning = None
             status_note = None
+            turn_history = None
             if isinstance(result, dict):
                 if isinstance(result.get("messages"), list):
                     with session["history_lock"]:
@@ -5022,6 +5092,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         if current_version == history_version:
                             session["history"] = result["messages"]
                             session["history_version"] = history_version + 1
+                            turn_history = list(result["messages"])
                         else:
                             # History mutated externally during the turn
                             # (undo/compress/retry/rollback now guard on
@@ -5051,6 +5122,13 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 _sync_session_key_after_compress(
                     sid, session, clear_pending_title=False, restart_slash_worker=True,
                 )
+
+                # Durable transcript: persist the finished turn NOW (after any
+                # compression key rotation) instead of waiting for the next
+                # prompt.submit — a backend restart between turns must not
+                # erase a completed exchange.
+                if turn_history is not None:
+                    _persist_session_history(session, turn_history)
 
                 raw = result.get("final_response", "")
                 status = (


### PR DESCRIPTION
## Summary

Four reliability fixes for gateway-served UIs (dashboard / desktop SPA) plus a small installer override, found while running the gateway under an embedding desktop app that reloads webviews and respawns the backend frequently. Each fix is independent; together they take websocket chat from "first turn works, everything after a reconnect dies silently" to fully durable.

### 1. Detached-session black hole (`tui_gateway/server.py`)

**Problem.** When a websocket drops (page reload, transient disconnect, host respawn), `handle_ws` parks every session it owned on the module-level `_stdio_transport` — which in dashboard mode has no reader. Nothing ever re-binds the session. The agent finishes the turn (rollouts show `task_complete` with real answers), but every event — deltas, `message.complete` — streams into captured stdout. The client's busy state sticks forever and all later sends are silently swallowed.

**Repro.** Open a dashboard session, send a prompt, reload the page mid-turn, reconnect: the turn never completes client-side and subsequent sends do nothing.

**Fix.** Any session-scoped RPC arriving over a live WS upgrades a stdio-parked session to that transport (`_rebind_ws_transport` in `_sess_nowait`). Only stdio-parked sessions are upgraded: a second live client cannot hijack another websocket's stream, and real stdio gateways (Ink TUI, where stdio has a genuine peer) dispatch with `_stdio_transport` as the current transport and are left untouched.

### 2. Missing turn-end persistence (`tui_gateway/server.py`)

**Problem.** Turn results lived only in process memory until the **next** `prompt.submit` persisted them. Any backend restart between turns (crash, idle reap, host-driven respawn) erased the completed exchange: the session row kept its generated title but `message_count` stayed 0 and `session.resume` painted an empty transcript.

**Repro.** Send one prompt, wait for the reply, kill the gateway process, restart, resume the session: empty transcript despite the titled session row.

**Fix.** `_persist_session_history` writes `replace_messages` into the session's own `state.db` right after the turn's history lands (after any compression key rotation), mirroring `_ensure_session_db_row`'s profile-home routing. Best-effort: a DB failure never kills the turn thread.

### 3. Silent codex app-server turns (`agent/codex_runtime.py`, `agent/transports/codex_app_server_session.py`)

**Problem.** Codex app-server turns were silent in every connected UI: `message.start` then `message.complete` and nothing in between — no deltas, no reasoning, no tool activity — because (1) `CodexAppServerSession`'s `on_event` hook was never wired, (2) the projector drops delta notifications by design (history-only), and (3) the return dict omitted `last_reasoning` even though the projector stashes reasoning on every spliced assistant message.

**Fix.** `_codex_live_event` bridges notifications to the agent's existing display callbacks (the gateway re-binds them every turn): `item/agentMessage/delta` → `_fire_stream_delta`, `item/reasoning/delta` → `_fire_reasoning_delta`, `item/started|completed` for command/fileChange/mcp/dynamic tools → `tool_start`/`tool_complete`, mirroring the projector's names and deterministic call ids so live tool cards correlate with persisted history. `run_codex_app_server_turn` now returns `last_reasoning` so `message.complete` carries `payload.reasoning` like the default chat-completions path. The session pre-drain (approval round-trips) fires `on_event` too, so deltas aren't dropped while an approval is pending. Display is best-effort: nothing in the bridge can break a turn.

### 4. Duplicate user echo (`agent/codex_runtime.py`)

**Problem.** Codex re-emits the submitted input as its own `userMessage` item while `run_conversation` has already appended it — splicing both stored every user message twice, which showed up as doubled user bubbles in any persisted/resumed transcript.

**Fix.** Drop the projector's leading user echo (matched by role + exact content) before splicing.

### 5. Installer repo override (`scripts/install.sh`)

`HERMES_REPO_URL` / `HERMES_REPO_URL_SSH` let embedders and fork maintainers install from a pinned fork branch without carrying a divergent copy of the script. When only the HTTPS override is set it is used for the primary clone attempt too, so a fork-only branch never 404s against the default repo first.

## Test coverage

- `tests/test_tui_gateway_server.py`: WS re-bind upgrade, no-hijack of a live transport, stdio gateways untouched, turn-end persist writes messages, persist survives DB failure, and the truncate test now asserts both the pre-turn rewrite and the turn-end persist.
- `tests/agent/test_codex_runtime_live_events.py` (new): delta → stream callback, reasoning delta → reasoning callback, tool started/completed → tool events with exit-code-tagged results, call ids match the projector's history ids, non-tool/junk items ignored, callback exceptions never escape the bridge.

```
282 passed, 1 deselected
(tests/test_tui_gateway_server.py, tests/agent/test_codex_runtime_live_events.py,
 tests/agent/transports/test_codex_event_projector.py)
```

Also verified live against a running dashboard: tool.start with the real command, tool.complete with result+duration, token-by-token message.delta stream, then message.complete; and send → kill backend → fresh process → `session.resume` returns the full transcript with no duplicated user rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
