### PR TITLE
fix(agent): block deterministic memory quota retries

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -372,7 +372,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     middleware_trace=list(middleware_trace),
                 )
             else:
-                guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
+                guardrail_decision = agent._tool_guardrails.before_call(
+                    function_name,
+                    function_args,
+                    state_token=agent._tool_guardrail_state_token(function_name, function_args),
+                )
                 if not guardrail_decision.allows_execution:
                     block_result = agent._guardrail_block_result(guardrail_decision)
                     blocked_by_guardrail = True
@@ -850,7 +854,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         _guardrail_block_decision: ToolGuardrailDecision | None = None
         if _block_msg is None:
-            guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
+            guardrail_decision = agent._tool_guardrails.before_call(
+                function_name,
+                function_args,
+                state_token=agent._tool_guardrail_state_token(function_name, function_args),
+            )
             if not guardrail_decision.allows_execution:
                 _guardrail_block_decision = guardrail_decision
 

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -232,14 +232,34 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._deterministic_retry_blocks: dict[tuple[ToolCallSignature, str], dict[str, Any]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
 
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
         return self._halt_decision
 
-    def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
+    def before_call(
+        self,
+        tool_name: str,
+        args: Mapping[str, Any] | None,
+        *,
+        state_token: str | None = None,
+    ) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
+        if state_token:
+            blocked = self._deterministic_retry_blocks.get((signature, state_token))
+            if blocked is not None:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="deterministic_retry_blocked",
+                    message=_deterministic_retry_message(tool_name, blocked),
+                    tool_name=tool_name,
+                    count=int(blocked.get("count", 1) or 1),
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
         if not self.config.hard_stop_enabled:
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -289,6 +309,7 @@ class ToolCallGuardrailController:
         result: str | None,
         *,
         failed: bool | None = None,
+        state_token: str | None = None,
     ) -> ToolGuardrailDecision:
         args = _coerce_args(args)
         signature = ToolCallSignature.from_call(tool_name, args)
@@ -296,6 +317,13 @@ class ToolCallGuardrailController:
             failed, _ = classify_tool_failure(tool_name, result)
 
         if failed:
+            quota_failure = _memory_quota_failure_metadata(tool_name, result)
+            if quota_failure is not None:
+                quota_state_token = quota_failure.get("store_state_token") or state_token
+                if isinstance(quota_state_token, str) and quota_state_token:
+                    blocked = dict(quota_failure)
+                    blocked["count"] = int(blocked.get("count", 0) or 0) + 1
+                    self._deterministic_retry_blocks[(signature, quota_state_token)] = blocked
             exact_count = self._exact_failure_counts.get(signature, 0) + 1
             self._exact_failure_counts[signature] = exact_count
             self._no_progress.pop(signature, None)
@@ -420,6 +448,38 @@ def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
         "Try different arguments, a narrower query/path, an absolute path when relevant, "
         "or a different tool that can make progress. If the blocker is external, report "
         "the blocker after one diagnostic attempt instead of repeating the same failing path."
+    )
+
+
+def _memory_quota_failure_metadata(tool_name: str, result: str | None) -> dict[str, Any] | None:
+    if tool_name != "memory" or not isinstance(result, str):
+        return None
+    data = safe_json_loads(result)
+    if not isinstance(data, dict):
+        return None
+    if data.get("error_code") != "memory_quota_exceeded":
+        return None
+    if data.get("success") is not False:
+        return None
+    token = data.get("store_state_token")
+    if not isinstance(token, str) or not token:
+        return None
+    return data
+
+
+def _deterministic_retry_message(tool_name: str, blocked: Mapping[str, Any]) -> str:
+    if tool_name == "memory" and blocked.get("error_code") == "memory_quota_exceeded":
+        operation = blocked.get("operation") or "write"
+        target = blocked.get("target") or "memory"
+        return (
+            f"Blocked {tool_name}: the same {target} {operation} request already failed "
+            "with quota exceeded against the current store state. Shorten the new content, "
+            "replace or remove existing entries to make room, or skip the memory write "
+            "instead of retrying it unchanged."
+        )
+    return (
+        f"Blocked {tool_name}: the same request already failed deterministically against "
+        "the current state. Change strategy instead of retrying it unchanged."
     )
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4955,6 +4955,18 @@ class AIAgent:
         if decision.should_halt and self._tool_guardrail_halt_decision is None:
             self._tool_guardrail_halt_decision = decision
 
+    def _tool_guardrail_state_token(self, tool_name: str, function_args: dict | None) -> str | None:
+        """Return the live state token relevant to a guardrailed tool call."""
+        if tool_name != "memory" or not getattr(self, "_memory_store", None):
+            return None
+        target = (function_args or {}).get("target", "memory")
+        if target not in {"memory", "user"}:
+            return None
+        try:
+            return self._memory_store.state_token(target)
+        except Exception:
+            return None
+
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
         tool = decision.tool_name or "a tool"
         return (
@@ -4977,6 +4989,7 @@ class AIAgent:
             function_args,
             function_result,
             failed=failed,
+            state_token=self._tool_guardrail_state_token(tool_name, function_args),
         )
         if decision.action in {"warn", "halt"}:
             function_result = append_toolguard_guidance(function_result, decision)

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -256,3 +256,33 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+def test_memory_quota_failure_blocks_same_request_only_for_same_store_state():
+    controller = ToolCallGuardrailController()
+    args = {"action": "add", "target": "memory", "content": "new fact"}
+    overflow = json.dumps(
+        {
+            "success": False,
+            "error_code": "memory_quota_exceeded",
+            "error": "would exceed the limit",
+            "operation": "add",
+            "target": "memory",
+            "store_state_token": "state-1",
+        }
+    )
+
+    decision = controller.after_call("memory", args, overflow, failed=True)
+    assert decision.action == "allow"
+
+    blocked = controller.before_call("memory", args, state_token="state-1")
+    assert blocked.action == "block"
+    assert blocked.code == "deterministic_retry_blocked"
+    assert "replace or remove existing entries" in blocked.message
+
+    assert controller.before_call("memory", args, state_token="state-2").action == "allow"
+    assert controller.before_call(
+        "memory",
+        {"action": "add", "target": "memory", "content": "shorter fact"},
+        state_token="state-1",
+    ).action == "allow"

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -1,10 +1,13 @@
 """Runtime tests for tool-call loop guardrails."""
 
 import json
+import tempfile
 import uuid
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import run_agent
 from run_agent import AIAgent
 
 
@@ -37,11 +40,14 @@ def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
 
 
 def _make_agent(*tool_names: str, max_iterations: int = 10, config: dict | None = None) -> AIAgent:
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-test-home-"))
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("hermes_cli.config.load_config", return_value=config or {}),
         patch("run_agent.OpenAI"),
+        patch.object(run_agent, "_hermes_home", hermes_home),
+        patch("agent.agent_init.get_hermes_home", return_value=hermes_home),
     ):
         agent = AIAgent(
             api_key="test-key-1234567890",
@@ -134,6 +140,64 @@ def test_config_enabled_hard_stop_blocks_repeated_exact_failure_before_execution
     assert messages[0]["role"] == "tool"
     assert messages[0]["tool_call_id"] == "c-block"
     assert "repeated_exact_failure_block" in messages[0]["content"]
+
+
+def test_memory_quota_retry_is_blocked_before_reexecution_even_without_global_hard_stop():
+    agent = _make_agent("memory")
+    args = {"action": "add", "target": "memory", "content": "new fact"}
+    agent._memory_store = SimpleNamespace(state_token=lambda target: "state-1")
+    overflow = json.dumps(
+        {
+            "success": False,
+            "error_code": "memory_quota_exceeded",
+            "error": "would exceed the limit",
+            "operation": "add",
+            "target": "memory",
+            "store_state_token": "state-1",
+        }
+    )
+    agent._tool_guardrails.after_call("memory", args, overflow, failed=True)
+    tc = _mock_tool_call("memory", json.dumps(args), "c-memory-block")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as mock_hfc:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    mock_hfc.assert_not_called()
+    assert len(messages) == 1
+    assert messages[0]["tool_call_id"] == "c-memory-block"
+    assert "deterministic_retry_blocked" in messages[0]["content"]
+    assert "skip the memory write" in messages[0]["content"]
+
+
+def test_memory_quota_retry_is_allowed_after_store_state_changes():
+    agent = _make_agent("memory")
+    args = {"action": "add", "target": "memory", "content": "new fact"}
+    state = {"token": "state-1"}
+    agent._memory_store = SimpleNamespace(
+        state_token=lambda target: state["token"],
+        add=lambda target, content: {"success": True},
+    )
+    overflow = json.dumps(
+        {
+            "success": False,
+            "error_code": "memory_quota_exceeded",
+            "error": "would exceed the limit",
+            "operation": "add",
+            "target": "memory",
+            "store_state_token": "state-1",
+        }
+    )
+    agent._tool_guardrails.after_call("memory", args, overflow, failed=True)
+    state["token"] = "state-2"
+    tc = _mock_tool_call("memory", json.dumps(args), "c-memory-allow")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    agent._execute_tool_calls_sequential(msg, messages, "task-1")
+    assert len(messages) == 1
+    assert json.loads(messages[0]["content"]) == {"success": True}
 
 
 def test_sequential_after_call_appends_guidance_to_tool_result_without_extra_messages():

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -292,6 +292,13 @@ class TestMemoryStoreAdd:
         store.add("memory", "x" * 490)
         result = store.add("memory", "this will exceed the limit")
         assert result["success"] is False
+        assert result["error_code"] == "memory_quota_exceeded"
+        assert result["non_retryable"] is True
+        assert result["operation"] == "add"
+        assert result["target"] == "memory"
+        assert result["attempted_total"] > result["limit"]
+        assert result["overage"] == result["attempted_total"] - result["limit"]
+        assert result["store_state_token"] == store.state_token("memory")
         assert "exceed" in result["error"].lower()
         # Overflow response gives the model what it needs to consolidate in-turn
         assert "current_entries" in result
@@ -304,6 +311,13 @@ class TestMemoryStoreAdd:
         store.add("memory", "short")
         result = store.replace("memory", "short", "y" * 600)
         assert result["success"] is False
+        assert result["error_code"] == "memory_quota_exceeded"
+        assert result["non_retryable"] is True
+        assert result["operation"] == "replace"
+        assert result["target"] == "memory"
+        assert result["attempted_total"] > result["limit"]
+        assert result["overage"] == result["attempted_total"] - result["limit"]
+        assert result["store_state_token"] == store.state_token("memory")
         assert "current_entries" in result
         assert "usage" in result
         assert "retry" in result["error"].lower()

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -24,6 +24,7 @@ Design:
 """
 
 import json
+import hashlib
 import logging
 import os
 import tempfile
@@ -57,6 +58,17 @@ def get_memory_dir() -> Path:
     return get_hermes_home() / "memories"
 
 ENTRY_DELIMITER = "\n§\n"
+
+
+def _memory_state_token(entries: List[str], limit: int) -> str:
+    """Return a stable fingerprint for the current store contents and quota."""
+    payload = json.dumps(
+        {"entries": entries, "limit": limit},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 # ---------------------------------------------------------------------------
@@ -329,6 +341,8 @@ class MemoryStore:
                 current = self._char_count(target)
                 return {
                     "success": False,
+                    "error_code": "memory_quota_exceeded",
+                    "non_retryable": True,
                     "error": (
                         f"Memory at {current:,}/{limit:,} chars. "
                         f"Adding this entry ({len(content)} chars) would exceed the limit. "
@@ -336,6 +350,13 @@ class MemoryStore:
                         f"shorter ones or 'remove' stale or less important entries (see "
                         f"current_entries below), then retry this add — all in this turn."
                     ),
+                    "operation": "add",
+                    "target": target,
+                    "store_state_token": self.state_token(target),
+                    "current_total": current,
+                    "attempted_total": new_total,
+                    "limit": limit,
+                    "overage": new_total - limit,
                     "current_entries": entries,
                     "usage": f"{current:,}/{limit:,}",
                 }
@@ -395,12 +416,21 @@ class MemoryStore:
                 current = self._char_count(target)
                 return {
                     "success": False,
+                    "error_code": "memory_quota_exceeded",
+                    "non_retryable": True,
                     "error": (
                         f"Replacement would put memory at {new_total:,}/{limit:,} chars. "
                         f"Shorten the new content, or 'remove' other stale or less important "
                         f"entries to make room (see current_entries below), then retry — all "
                         f"in this turn."
                     ),
+                    "operation": "replace",
+                    "target": target,
+                    "store_state_token": self.state_token(target),
+                    "current_total": current,
+                    "attempted_total": new_total,
+                    "limit": limit,
+                    "overage": new_total - limit,
                     "current_entries": entries,
                     "usage": f"{current:,}/{limit:,}",
                 }
@@ -459,6 +489,12 @@ class MemoryStore:
         """
         block = self._system_prompt_snapshot.get(target, "")
         return block if block else None
+
+    def state_token(self, target: str) -> str:
+        """Return a token that changes whenever the live store state changes."""
+        entries = self._entries_for(target)
+        limit = self._char_limit(target)
+        return _memory_state_token(entries, limit)
 
     # -- Internal helpers --
 
@@ -724,7 +760,6 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
 
 
 


### PR DESCRIPTION
## What does this PR do?

Treat memory quota overflows as deterministic non-retryable failures for the current store state. The memory tool now returns structured overflow metadata, and the tool-call guardrail uses that metadata plus a live store-state token to block an identical same-turn retry before executing the tool again, while still allowing the same write after the model shortens content or changes memory state with another mutation.

## Related Issue

Fixes #35121

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/memory_tool.py`: add structured `memory_quota_exceeded` overflow metadata, including operation, quota numbers, and a live store-state token for add/replace overflows.
- `agent/tool_guardrails.py`: track deterministic retry blocks keyed by tool-call signature plus state token, and emit a specific `deterministic_retry_blocked` result with recovery guidance.
- `run_agent.py` and `agent/tool_executor.py`: pass live memory store-state tokens into the guardrail before and after memory tool execution.
- `tests/tools/test_memory_tool.py`: cover structured overflow payloads for add and replace.
- `tests/agent/test_tool_guardrails.py`: cover same-request blocking only when the memory store state is unchanged.
- `tests/run_agent/test_tool_call_guardrail_runtime.py`: cover runtime blocking before re-execution and allowing the same write after the store state changes.

## How to Test

1. Run the covering subset:
   `pytest tests/tools/test_memory_tool.py tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/agent/test_display_tool_failure.py tests/tools/test_memory_tool_schema.py tests/tools/test_memory_tool_import_fallback.py tests/agent/test_display.py -q`
2. Verify that an overflowing `memory(action=add|replace)` result includes `error_code="memory_quota_exceeded"`, quota details, and `store_state_token`.
3. Verify that repeating the exact same memory write against the same store state returns a synthetic `deterministic_retry_blocked` result without re-executing the tool.
4. Verify that changing the store state first (for example, removing another entry) allows the same memory write to run again.
5. Optionally run the bounded broad suite command:
   `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`
   In this local environment it stops during collection on unrelated missing dependency `fastapi` in `tests/hermes_cli/test_dashboard_auth_401_reauth.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS darwin-arm64 (local)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Scoped lint: `ruff check` on changed Python files passed. The shared repo `ruff` install also reported a pre-existing invalid `# noqa` warning in `run_agent.py:94`, but no lint failures in this diff.
- `python scripts/check-windows-footguns.py <changed files>` passed.
- `git diff --check` passed.
- The bounded broad suite stopped early on unrelated local environment collection error: `tests/hermes_cli/test_dashboard_auth_401_reauth.py` -> `ModuleNotFoundError: No module named 'fastapi'`.

## What platforms tested on

- macOS on darwin-arm64 (local)

<!-- autocontrib:worker-id=issue-new-3af1ff0e kind=pr-open -->