### PR TITLE
fix(gateway): prefer the live launchd domain on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3067,12 +3067,43 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
+def _launchd_service_exists_in_domain(domain: str, label: str) -> bool:
+    """Return True when launchd reports the gateway label in the given domain.
+
+    Some macOS 26 hosts still have older Hermes gateway jobs loaded in
+    ``gui/<uid>`` even though newer installs prefer ``user/<uid>``. Detect the
+    live domain first so start/stop/restart can keep managing the existing job
+    instead of misclassifying it as missing and falling back to detached mode.
+    """
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"{domain}/{label}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0
+
+
 def _launchd_domain() -> str:
-    # The `user/<uid>` domain (vs the older `gui/<uid>`) is reachable from
-    # non-Aqua/background sessions (SSH, headless, login items) and is the only
-    # one that supports service management on macOS 26+. `gui/<uid>` returns
-    # error 125 ("Domain does not support specified action") there. See #23387.
-    return f"user/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    uid = os.getuid()
+    label = get_launchd_label()
+    gui_domain = f"gui/{uid}"
+    user_domain = f"user/{uid}"
+
+    # Prefer whichever domain already owns the live service so management
+    # commands keep targeting the same job across Hermes upgrades.
+    if _launchd_service_exists_in_domain(gui_domain, label):
+        return gui_domain
+    if _launchd_service_exists_in_domain(user_domain, label):
+        return user_domain
+
+    # Default to the newer `user/<uid>` domain for fresh installs because it is
+    # reachable from non-Aqua/background sessions on modern macOS.
+    return user_domain  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
 # On macOS, exit code 125 ("Domain does not support specified action") and

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -451,6 +451,43 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceRecovery:
+    @pytest.fixture(autouse=True)
+    def _stub_launchd_service_probe(self, monkeypatch, request):
+        if request.node.name in {
+            "test_launchd_domain_prefers_gui_when_live_service_exists_there",
+            "test_launchd_domain_defaults_to_user_when_no_live_service_exists",
+        }:
+            return
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_service_exists_in_domain",
+            lambda domain, label: False,
+        )
+
+    def test_launchd_domain_prefers_gui_when_live_service_exists_there(self, monkeypatch):
+        label = gateway_cli.get_launchd_label()
+
+        def fake_run(cmd, capture_output=False, text=False, timeout=None, check=False, **kwargs):
+            target = cmd[-1]
+            if cmd[:2] == ["launchctl", "print"] and target == f"gui/{os.getuid()}/{label}":
+                return SimpleNamespace(returncode=0, stdout="running", stderr="")
+            if cmd[:2] == ["launchctl", "print"] and target == f"user/{os.getuid()}/{label}":
+                return SimpleNamespace(returncode=113, stdout="", stderr="missing")
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._launchd_domain() == f"gui/{os.getuid()}"
+
+    def test_launchd_domain_defaults_to_user_when_no_live_service_exists(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=113, stdout="", stderr="missing"),
+        )
+
+        assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
+
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})


### PR DESCRIPTION
Summary:
- detect whether the live gateway job is already loaded in gui/<uid> or user/<uid>
- keep using that domain for launchd start/stop/restart flows on macOS
- add regression tests for gui-domain preference and user-domain fallback

Problem:
On some macOS 26 hosts, older Hermes gateway jobs remain loaded under gui/<uid> even though newer code prefers user/<uid>. That causes launchctl management to look in the wrong domain, misclassify the service as missing, and fall back to detached background mode even though a valid launchd-managed job already exists.

Repro I hit locally:
- `launchctl print user/501/ai.hermes.gateway` -> service missing
- `launchctl print gui/501/ai.hermes.gateway` -> service running
- `hermes gateway start` printed:
  - Could not find service "ai.hermes.gateway" in domain for uid: 501
  - Bootstrap failed: 5: Input/output error
  - Started gateway as a background process instead

Test plan:
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `python -m pytest tests/hermes_cli/test_gateway_service.py -q -o 'addopts=' -k 'LaunchdServiceRecovery and not systemd'`
