### PR TITLE
feat(tts): support OpenAI instructions field for voice steering

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -998,6 +998,11 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     voice = oai_config.get("voice", DEFAULT_OPENAI_VOICE)
     base_url = oai_config.get("base_url", base_url)
     speed = float(oai_config.get("speed", tts_config.get("speed", 1.0)))
+    # Optional voice-steering instructions (tone, emotion, pacing, character).
+    # Only the gpt-4o-*-tts models support the `instructions` field; older
+    # tts-1 / tts-1-hd models reject it, so we gate on the model name.
+    instructions = oai_config.get("instructions") or ""
+    instructions = str(instructions).strip()
 
     # Determine response format from extension
     if output_path.endswith(".ogg"):
@@ -1017,6 +1022,8 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         }
         if speed != 1.0:
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
+        if instructions and "gpt-4o" in model.lower():
+            create_kwargs["instructions"] = instructions
         response = client.audio.speech.create(**create_kwargs)
 
         response.stream_to_file(output_path)


### PR DESCRIPTION
## Summary

Adds support for the OpenAI TTS `instructions` field, enabling voice-steering (tone, emotion, pacing, character) for the `gpt-4o-*-tts` models.

The OpenAI `gpt-4o-mini-tts` / `gpt-4o-tts` models accept an `instructions` parameter on `audio.speech.create` that steers *how* the chosen voice delivers the text — e.g. "speak as a wise, ancient wizard, measured and mysterious" or "warm late-night radio host". Before this change, `_generate_openai_tts` only passed `model`, `voice`, `input`, `response_format`, and `speed`, so any configured delivery style was silently ignored.

## Changes

- `_generate_openai_tts` now reads `instructions` from the `tts.openai` config block.
- The field is only sent when non-empty **and** the model name contains `gpt-4o` — the older `tts-1` / `tts-1-hd` models reject the parameter with an API error, so this gate keeps them working.

## Config

```yaml
tts:
  provider: openai
  openai:
    model: gpt-4o-mini-tts
    voice: fable
    instructions: "Speak as a wise, ancient wizard. Measured and mysterious, full of gravitas and quiet power, with knowing, deliberate pauses."
```

When `instructions` is absent (the default), behavior is unchanged.

## Test Plan

- [x] `tts_tool.py` parses / imports cleanly.
- [x] Verified end-to-end: `_generate_openai_tts` reads `instructions` from config and produces audio with the steered delivery on `gpt-4o-mini-tts`.
- [x] Backward-compatible: when `instructions` is unset, the API call is identical to before; older `tts-1` models are unaffected by the model-name gate.

## Notes

Fully backward-compatible — no behavior change for existing configs that don't set `tts.openai.instructions`.
