### PR TITLE
feat(delegate_tool): per-task model/provider override

### DIFF
--- a/tests/tools/test_delegate_task_model_override.py
+++ b/tests/tools/test_delegate_task_model_override.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+"""
+Tests for per-task model/provider override in delegate_task.
+
+Issue: https://github.com/NousResearch/hermes-agent/issues/18591
+
+Validates the fallback chain for per-task model routing:
+  1. Per-task `model` field (highest priority)
+  2. `delegation.model` from config
+  3. Inherit parent agent model (current default)
+
+And per-task `provider` credential resolution:
+  - Per-task provider triggers independent credential resolution
+  - Per-task provider + model combo works end-to-end
+  - Invalid provider raises ValueError with helpful message
+
+Uses mock AIAgent instances — no API keys, no network calls.
+
+Run with:  python -m pytest tests/tools/test_delegate_task_model_override.py -v
+"""
+
+import json
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _build_child_agent,
+    _resolve_delegation_credentials,
+    delegate_task,
+)
+
+
+def _make_mock_parent(depth=0):
+    """Create a mock parent agent with the fields delegate_task expects."""
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "sk-or-test-key"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent.openrouter_min_coding_score = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent.max_tokens = None
+    parent.prefill_messages = None
+    parent.reasoning_config = None
+    parent._fallback_chain = None
+    parent._client_kwargs = {}
+    parent.enabled_toolsets = None
+    parent.valid_tool_names = ["terminal", "read_file", "web_search"]
+    return parent
+
+
+def _default_creds():
+    """Standard delegation credentials mock return."""
+    return {
+        "model": None,
+        "provider": None,
+        "base_url": None,
+        "api_key": None,
+        "api_mode": None,
+    }
+
+
+def _openrouter_creds(model="google/gemini-3-flash-preview"):
+    """OpenRouter delegation credentials mock return."""
+    return {
+        "model": model,
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "sk-or-delegation-key",
+        "api_mode": "chat_completions",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+class TestPerTaskModelSchema(unittest.TestCase):
+    """Verify the per-task model/provider fields in the delegate_task schema."""
+
+    def test_tasks_items_has_model_field(self):
+        """Each task item should accept an optional 'model' string."""
+        task_props = (
+            DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+        )
+        self.assertIn("model", task_props)
+        self.assertEqual(task_props["model"]["type"], "string")
+
+    def test_tasks_items_has_provider_field(self):
+        """Each task item should accept an optional 'provider' string."""
+        task_props = (
+            DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+        )
+        self.assertIn("provider", task_props)
+        self.assertEqual(task_props["provider"]["type"], "string")
+
+    def test_model_and_provider_not_required(self):
+        """model and provider must be optional — backward compatible."""
+        task_required = (
+            DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"].get("required", [])
+        )
+        self.assertNotIn("model", task_required)
+        self.assertNotIn("provider", task_required)
+
+    def test_goal_still_required_in_task(self):
+        """'goal' must remain the only required field in each task."""
+        task_required = (
+            DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["required"]
+        )
+        self.assertEqual(task_required, ["goal"])
+
+
+# ---------------------------------------------------------------------------
+# Fallback chain tests — model resolution
+# ---------------------------------------------------------------------------
+class TestPerTaskModelFallback(unittest.TestCase):
+    """Per-task model overrides delegation.model, which overrides parent model."""
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_model_overrides_delegation_model(self, mock_creds, mock_cfg):
+        """When a task specifies model='glm-5-turbo', that model wins over
+        delegation.model='glm-5.1'."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "glm-5.1",
+            "provider": "",
+        }
+        mock_creds.return_value = {
+            "model": "glm-5.1",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": "Search docs", "model": "glm-5-turbo"}],
+                    parent_agent=parent,
+                )
+            )
+
+            self.assertIn("results", result)
+            _, kwargs = MockAgent.call_args
+            # Per-task model should win over delegation.model
+            self.assertEqual(kwargs["model"], "glm-5-turbo")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_model_overrides_parent_model(self, mock_creds, mock_cfg):
+        """When no delegation.model is set but task specifies model, task wins
+        over parent model."""
+        mock_cfg.return_value = {"max_iterations": 45, "model": "", "provider": ""}
+        mock_creds.return_value = _default_creds()
+
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": "Lightweight task", "model": "glm-5-turbo"}],
+                    parent_agent=parent,
+                )
+            )
+
+            self.assertIn("results", result)
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "glm-5-turbo")
+            self.assertNotEqual(kwargs["model"], parent.model)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_no_per_task_model_inherits_delegation_model(self, mock_creds, mock_cfg):
+        """When task has no model field, delegation.model is used."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "glm-5",
+            "provider": "",
+        }
+        mock_creds.return_value = {
+            "model": "glm-5",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": "Default model task"}],
+                    parent_agent=parent,
+                )
+            )
+
+            self.assertIn("results", result)
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "glm-5")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_no_model_anywhere_inherits_parent(self, mock_creds, mock_cfg):
+        """When no model anywhere, child inherits parent model (current behavior)."""
+        mock_cfg.return_value = {"max_iterations": 45, "model": "", "provider": ""}
+        mock_creds.return_value = _default_creds()
+
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": "Inherit from parent"}],
+                    parent_agent=parent,
+                )
+            )
+
+            self.assertIn("results", result)
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], parent.model)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_empty_string_model_treated_as_not_specified(self, mock_creds, mock_cfg):
+        """Empty string model should fall through to delegation.model or parent."""
+        mock_cfg.return_value = {"max_iterations": 45, "model": "glm-5", "provider": ""}
+        mock_creds.return_value = {
+            "model": "glm-5",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": "Empty model", "model": ""}],
+                    parent_agent=parent,
+                )
+            )
+
+            self.assertIn("results", result)
+            _, kwargs = MockAgent.call_args
+            # Empty string should NOT override delegation.model
+            self.assertEqual(kwargs["model"], "glm-5")
+
+
+# ---------------------------------------------------------------------------
+# Per-task provider credential resolution
+# ---------------------------------------------------------------------------
+class TestPerTaskProviderResolution(unittest.TestCase):
+    """Per-task provider triggers independent credential resolution."""
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_provider_triggers_credential_resolution(
+        self, mock_creds, mock_cfg
+    ):
+        """When a task specifies provider='openrouter', credentials are resolved
+        for that provider even though delegation config has no provider."""
+        mock_cfg.return_value = {"max_iterations": 45, "model": "", "provider": ""}
+        # First call: delegation config (no provider)
+        # Second call: per-task provider resolution
+        mock_creds.side_effect = [
+            _default_creds(),
+            _openrouter_creds("google/gemini-3-flash-preview"),
+        ]
+
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    tasks=[{
+                        "goal": "Research topic",
+                        "model": "google/gemini-3-flash-preview",
+                        "provider": "openrouter",
+                    }],
+                    parent_agent=parent,
+                )
+            )
+
+            self.assertIn("results", result)
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "google/gemini-3-flash-preview")
+            self.assertEqual(kwargs["provider"], "openrouter")
+            self.assertEqual(
+                kwargs["base_url"], "https://openrouter.ai/api/v1"
+            )
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_provider_same_as_delegation_no_re_resolve(
+        self, mock_creds, mock_cfg
+    ):
+        """When per-task provider matches delegation.provider, no extra
+        credential resolution needed — reuse delegation creds."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "glm-5",
+            "provider": "openrouter",
+        }
+        mock_creds.return_value = _openrouter_creds("glm-5")
+
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    tasks=[{
+                        "goal": "Same provider",
+                        "model": "glm-5-turbo",
+                        "provider": "openrouter",
+                    }],
+                    parent_agent=parent,
+                )
+            )
+
+            self.assertIn("results", result)
+            # _resolve_delegation_credentials should only be called once
+            # (no re-resolution for same provider)
+            self.assertLessEqual(mock_creds.call_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# Multi-task with different models
+# ---------------------------------------------------------------------------
+class TestMultiTaskDifferentModels(unittest.TestCase):
+    """Multiple tasks with different models should each get their own model."""
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_batch_with_different_models_per_task(self, mock_creds, mock_cfg):
+        """3 tasks: one with glm-5.1, one with glm-5-turbo, one inheriting."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "glm-5",
+            "provider": "",
+        }
+        mock_creds.return_value = {
+            "model": "glm-5",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+
+        parent = _make_mock_parent()
+        captured_models = []
+
+        def make_child(*args, **kwargs):
+            captured_models.append(kwargs.get("model"))
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            return mock_child
+
+        with patch("run_agent.AIAgent", side_effect=make_child):
+            result = json.loads(
+                delegate_task(
+                    tasks=[
+                        {"goal": "Complex analysis", "model": "glm-5.1"},
+                        {"goal": "Quick search", "model": "glm-5-turbo"},
+                        {"goal": "Default task"},
+                    ],
+                    parent_agent=parent,
+                )
+            )
+
+            self.assertIn("results", result)
+            self.assertEqual(len(result["results"]), 3)
+            self.assertEqual(captured_models[0], "glm-5.1")
+            self.assertEqual(captured_models[1], "glm-5-turbo")
+            self.assertEqual(captured_models[2], "glm-5")
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+class TestPerTaskModelErrors(unittest.TestCase):
+    """Error cases for per-task model/provider override."""
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_invalid_provider_returns_error(self, mock_creds, mock_cfg):
+        """Invalid provider in task should produce a clear error, not a crash."""
+        mock_cfg.return_value = {"max_iterations": 45, "model": "", "provider": ""}
+        mock_creds.side_effect = [
+            _default_creds(),
+            ValueError("Cannot resolve delegation provider 'nonexistent': ..."),
+        ]
+
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            result = json.loads(
+                delegate_task(
+                    tasks=[{
+                        "goal": "Bad provider",
+                        "model": "test-model",
+                        "provider": "nonexistent",
+                    }],
+                    parent_agent=parent,
+                )
+            )
+
+            self.assertIn("error", result)
+            self.assertIn("nonexistent", result["error"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_model_without_provider_inherits_delegation_provider(
+        self, mock_creds, mock_cfg
+    ):
+        """Per-task model without provider should use delegation.provider's
+        credentials with the per-task model name."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "glm-5",
+            "provider": "openrouter",
+        }
+        mock_creds.return_value = _openrouter_creds("glm-5")
+
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    tasks=[{
+                        "goal": "Use different model same provider",
+                        "model": "google/gemini-3-flash-preview",
+                    }],
+                    parent_agent=parent,
+                )
+            )
+
+            self.assertIn("results", result)
+            _, kwargs = MockAgent.call_args
+            # Model should be per-task override
+            self.assertEqual(kwargs["model"], "google/gemini-3-flash-preview")
+            # Provider should be from delegation config
+            self.assertEqual(kwargs["provider"], "openrouter")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2111,19 +2111,39 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+
+            # Per-task model/provider override (issue #18591).
+            # Fallback chain: per-task field → delegation config → parent model.
+            task_model = t.get("model") or ""
+            task_provider = t.get("provider") or ""
+
+            # Resolve per-task credentials when provider or model is specified.
+            if task_provider or task_model:
+                task_creds = _resolve_task_credentials(
+                    task_model=task_model,
+                    task_provider=task_provider,
+                    delegation_creds=creds,
+                    parent_agent=parent_agent,
+                )
+                if isinstance(task_creds, str):
+                    # Error string from resolution
+                    return tool_error(task_creds)
+            else:
+                task_creds = creds
+
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
                 or creds.get("command"),
@@ -2569,6 +2589,54 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     }
 
 
+def _resolve_task_credentials(
+    task_model: str,
+    task_provider: str,
+    delegation_creds: dict,
+    parent_agent,
+) -> dict | str:
+    """Resolve credentials for a single task with per-task model/provider.
+
+    Fallback chain for model:
+      1. Per-task ``model`` (highest priority)
+      2. ``delegation_creds["model"]`` (from delegation config)
+      3. ``parent_agent.model`` (inherited — handled by _build_child_agent)
+
+    Fallback chain for provider:
+      1. Per-task ``provider`` (triggers independent credential resolution)
+      2. ``delegation_creds`` provider (reuse already-resolved credentials)
+
+    Returns a credential dict on success, or an error string on failure.
+    """
+    # Resolve effective model: per-task > delegation > parent (parent handled
+    # downstream by _build_child_agent via effective_model = model or parent.model)
+    effective_model = task_model or delegation_creds.get("model") or None
+
+    # Fast path: same provider as delegation or no provider specified — reuse
+    # delegation credentials with the per-task model swapped in.
+    if not task_provider or task_provider == delegation_creds.get("provider"):
+        creds = dict(delegation_creds)
+        if task_model:
+            creds["model"] = task_model
+        return creds
+
+    # Slow path: per-task provider differs from delegation provider — resolve
+    # a fresh credential bundle for this provider.
+    try:
+        task_cfg = {"model": effective_model or "", "provider": task_provider}
+        task_resolved = _resolve_delegation_credentials(task_cfg, parent_agent)
+    except ValueError as exc:
+        return f"Cannot resolve per-task provider '{task_provider}': {exc}"
+    except Exception as exc:
+        return f"Error resolving per-task provider '{task_provider}': {exc}"
+
+    # Ensure per-task model takes priority over whatever the provider resolved
+    if task_model:
+        task_resolved["model"] = task_model
+
+    return task_resolved
+
+
 def _load_config() -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
@@ -2848,6 +2916,22 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override (e.g. 'glm-5-turbo'). "
+                                "Overrides delegation.model and parent model for this task only. "
+                                "Leave empty to use delegation.model or parent model."
+                            ),
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Per-task provider override (e.g. 'openrouter', 'groq'). "
+                                "Triggers independent credential resolution for this provider. "
+                                "Leave empty to use delegation.provider or parent provider."
+                            ),
                         },
                     },
                     "required": ["goal"],


### PR DESCRIPTION
## Summary

Allows each task in a `delegate_task` batch to override the model and/or provider independently. Addresses [issue #18591](https://github.com/NousResearch/hermes-agent/issues/18591).

## Problem

When delegating multiple tasks via `delegate_task`, all children share the same model/provider resolved from the top-level `delegation` config. There is no way to route individual tasks to different providers — for example, sending research tasks to a fast/cheap model while keeping code review on a stronger one.

## Solution

Add two optional fields to each task item:

| Field | Type | Description |
|-------|------|-------------|
| `model` | `string` | Model name override (e.g. `gemini-2.5-flash`). Falls back to delegation config, then parent. |
| `provider` | `string` | Provider name override (e.g. `groq`, `openrouter`). Triggers independent credential resolution. |

### Fallback chain

```
per-task field  >>>  delegation config  >>>  parent agent model
```

If neither field is specified, behavior is identical to before — fully backward compatible.

### Implementation

**`_resolve_task_credentials`** (new helper):
- *Fast path*: same provider or no provider — reuses delegation credentials with model swapped in.
- *Slow path*: different provider — resolves a fresh credential bundle via `_resolve_delegation_credentials`.
- Returns an error string on failure instead of raising.

**Dispatch loop** change: before `_build_child_agent`, checks for per-task fields and resolves credentials when present. Falls through to delegation credentials otherwise.

## Files changed

| File | Change |
|------|--------|
| `tools/delegate_tool.py` | Schema: `model`/`provider` properties on task items. Dispatch: per-task credential resolution. New `_resolve_task_credentials` helper. |
| `tests/tools/test_delegate_task_model_override.py` | 14 new tests. |

## Tests

| Suite | Result |
|-------|--------|
| New tests | 14 passed |
| Existing `test_delegate.py` | 140 passed |
| **Total** | **154 passed, 0 failed** |

## Example

```json
{
  "tasks": [
    {
      "goal": "Research topic X",
      "model": "gemini-2.5-flash",
      "provider": "google"
    },
    {
      "goal": "Write summary",
      "model": "glm-5-turbo"
    },
    {
      "goal": "Review code"
    }
  ]
}
```

Task 1 routes to Google Gemini. Task 2 overrides the model but keeps the current provider. Task 3 inherits everything as usual.

Closes #18591