### PR TITLE
fix(clarify): increase MAX_CHOICES from 4 to 6

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -461,6 +461,7 @@ def load_cli_config() -> Dict[str, Any]:
         },
         "clarify": {
             "timeout": 120,  # Seconds to wait for a clarify answer before auto-proceeding
+            "max_choices": 6,  # Max predefined choices (plus 'Other' option appended by UI)
         },
         "code_execution": {
             "timeout": 300,    # Max seconds a sandbox script can run before being killed (5 min)

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -190,5 +190,5 @@ class TestClarifySchema:
         assert choices_spec.get("maxItems") == MAX_CHOICES
 
     def test_max_choices_is_four(self):
-        """MAX_CHOICES constant should be 4."""
-        assert MAX_CHOICES == 4
+        """MAX_CHOICES constant should be 6."""
+        assert MAX_CHOICES == 6

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -17,7 +17,7 @@ from typing import List, Optional, Callable
 
 # Maximum number of predefined choices the agent can offer.
 # A 5th "Other (type your answer)" option is always appended by the UI.
-MAX_CHOICES = 4
+MAX_CHOICES = 6
 
 
 def clarify_tool(
@@ -30,7 +30,7 @@ def clarify_tool(
 
     Args:
         question: The question text to present.
-        choices:  Up to 4 predefined answer choices. When omitted the
+        choices:  Up to 6 predefined answer choices. When omitted the
                   question is purely open-ended.
         callback: Platform-provided function that handles the actual UI
                   interaction. Signature: callback(question, choices) -> str.
@@ -52,7 +52,7 @@ def clarify_tool(
         if len(choices) > MAX_CHOICES:
             choices = choices[:MAX_CHOICES]
         if not choices:
-            choices = None  # empty list → open-ended
+            choices = None  # empty list -> open-ended
 
     if callback is None:
         return json.dumps(
@@ -79,7 +79,6 @@ def check_clarify_requirements() -> bool:
     """Clarify tool has no external requirements -- always available."""
     return True
 
-
 # =============================================================================
 # OpenAI Function-Calling Schema
 # =============================================================================
@@ -89,8 +88,8 @@ CLARIFY_SCHEMA = {
     "description": (
         "Ask the user a question when you need clarification, feedback, or a "
         "decision before proceeding. Supports two modes:\n\n"
-        "1. **Multiple choice** — provide up to 4 choices. The user picks one "
-        "or types their own answer via a 5th 'Other' option.\n"
+        "1. **Multiple choice** — provide up to 6 choices. The user picks one "
+        "or types their own answer via a 7th 'Other' option.\n"
         "2. **Open-ended** — omit choices entirely. The user types a free-form "
         "response.\n\n"
         "Use this tool when:\n"
@@ -114,7 +113,7 @@ CLARIFY_SCHEMA = {
                 "items": {"type": "string"},
                 "maxItems": MAX_CHOICES,
                 "description": (
-                    "Up to 4 answer choices. Omit this parameter entirely to "
+                    "Up to 6 answer choices. Omit this parameter entirely to "
                     "ask an open-ended question. When provided, the UI "
                     "automatically appends an 'Other (type your answer)' option."
                 ),


### PR DESCRIPTION
## Summary
Increase the maximum number of predefined choices in the clarify tool from 4 to 6, as requested in issue #43056.

## Changes
- **tools/clarify_tool.py**: Increase  constant from 4 to 6
- **tools/clarify_tool.py**: Update schema description and docstrings to reflect new limit (6 choices + 'Other' option = 7 total)
- **cli.py**: Add  config option (default 6) for future configurability
- **tests/tools/test_clarify_tool.py**: Update test to expect 

## Testing
All existing tests pass:
-  - 20 tests pass
-  - 15 tests pass
-  - passes

## Related Issues
Closes #43056