### PR TITLE
fix: suppress gateway tool telemetry in normal chats

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -110,7 +110,10 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
         "tool_progress": "off",
         "busy_ack_detail": False,
     },
-    "discord":     _TIER_HIGH,
+    # Discord is a normal chat surface by default.  Keep raw tool telemetry
+    # (tool names, command/code previews, args) out of user-visible channels;
+    # bounded debug/admin telemetry needs a separate explicit approval path.
+    "discord":     {**_TIER_HIGH, "tool_progress": "off"},
 
     # Tier 2 — edit support, often customer/workspace channels
     # Slack: tool_progress off by default — Bolt posts cannot be edited like CLI;

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -140,6 +140,27 @@ def _gateway_platform_value(platform: Any) -> str:
     return str(getattr(platform, "value", platform) or "").strip().lower()
 
 
+_RAW_TOOL_TELEMETRY_SUPPRESSED_PLATFORMS = {"telegram", "discord"}
+
+
+def _should_suppress_raw_tool_progress(platform: Any) -> bool:
+    """Return True for normal chat platforms that must not show raw tool chrome.
+
+    Telegram/Discord user-visible chats should receive final answers, approval
+    prompts, blockers, and safe progress summaries — not raw tool names,
+    command/code previews, argument dicts, file paths, stack/log-like chatter,
+    or runtime/config/token-shaped material.  A future debug/admin surface can
+    opt into richer telemetry through a separate explicit gate; the normal
+    gateway path stays final-answer-first.
+    """
+    return _gateway_platform_value(platform) in _RAW_TOOL_TELEMETRY_SUPPRESSED_PLATFORMS
+
+
+def _safe_gateway_tool_progress_message(platform: Any = None) -> str:
+    """Safe generic progress line for platforms with raw telemetry suppressed."""
+    return "⏳ Working — internal steps in progress."
+
+
 def _is_transient_network_error(exc: BaseException) -> bool:
     """Return True for transient network errors safe to log + swallow.
 
@@ -12870,9 +12891,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if tool_progress_enabled else None
-        last_tool = [None]  # Mutable container for tracking in closure
-        last_progress_msg = [None]  # Track last message for dedup
-        repeat_count = [0]  # How many times the same message repeated
+        last_tool: List[Optional[str]] = [None]  # Mutable container for tracking in closure
+        last_progress_msg: List[Optional[str]] = [None]  # Track last message for dedup
+        repeat_count: List[int] = [0]  # How many times the same message repeated
 
         # ── Discord voice "verbal ack before tool calls" ────────────────
         # When the bot is in a voice channel with the continuous mixer
@@ -12991,6 +13012,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return
             except Exception:
                 pass
+
+            if _should_suppress_raw_tool_progress(source.platform):
+                msg = _safe_gateway_tool_progress_message(source.platform)
+                if msg == last_progress_msg[0]:
+                    return
+                last_progress_msg[0] = msg
+                repeat_count[0] = 0
+                progress_queue.put(msg)
+                return
 
             # "new" mode: only report when tool changes
             if progress_mode == "new" and tool_name == last_tool[0]:

--- a/tests/gateway/test_tool_telemetry_suppression.py
+++ b/tests/gateway/test_tool_telemetry_suppression.py
@@ -1,0 +1,39 @@
+"""FGD-133: normal Telegram/Discord chats must not expose raw tool telemetry."""
+
+from __future__ import annotations
+
+
+def test_telegram_and_discord_suppress_raw_tool_progress_policy():
+    from gateway.run import (
+        _safe_gateway_tool_progress_message,
+        _should_suppress_raw_tool_progress,
+    )
+
+    for platform in ("telegram", "discord"):
+        assert _should_suppress_raw_tool_progress(platform) is True
+        msg = _safe_gateway_tool_progress_message(platform)
+
+        assert msg
+        assert "terminal" not in msg
+        assert "execute_code" not in msg
+        assert "skill_view" not in msg
+        assert "python" not in msg.lower()
+        assert "command" not in msg.lower()
+        assert "/Users/" not in msg
+
+
+def test_non_chat_platforms_keep_existing_tool_progress_policy_surface():
+    from gateway.run import _should_suppress_raw_tool_progress
+
+    # FGD-133 only hardens normal Telegram/Discord user-visible chat output.
+    # Other platform behavior remains governed by their display settings and
+    # can be handled separately if a bounded issue approves it.
+    assert _should_suppress_raw_tool_progress("api_server") is False
+    assert _should_suppress_raw_tool_progress("local") is False
+
+
+def test_discord_default_tool_progress_is_off_for_normal_chat():
+    from gateway.display_config import resolve_display_setting
+
+    assert resolve_display_setting({}, "discord", "tool_progress") == "off"
+    assert resolve_display_setting({}, "telegram", "tool_progress") == "off"


### PR DESCRIPTION
FGD-133 regression/follow-up patch.

Summary:

* Suppresses raw tool progress for normal Telegram/Discord user-visible output.
* Defaults Discord normal chat tool progress to off.
* Preserves safe generic progress signal.
* Adds targeted tests for telemetry suppression policy.

Validation:

* python -m pytest tests/gateway/test_tool_telemetry_suppression.py tests/gateway/test_per_platform_streaming_defaults.py tests/gateway/test_stream_events.py -q
* 20 passed in 0.40s

Safety:

* No runtime restart/reload performed.
* No live Telegram/Discord QA performed.
* No Linear mutation performed.
* No dependency or lockfile changes.
* Unrelated untracked Telegram no-action suppression files were not included.