### PR TITLE
fix(desktop): stop inheriting busy state when switching sessions

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -493,8 +493,12 @@ export function useSessionActions({
       setFreshDraftReady(false)
       setActiveSessionId(null)
       activeSessionIdRef.current = null
-      busyRef.current = true
-      setBusy(true)
+      // Do not inherit the previous session's busy/streaming UI while the target
+      // session resumes. An idle session would otherwise show Stop/spinner until
+      // resume completes; a running target session will be re-marked busy via
+      // session.info / message.start once the gateway confirms it.
+      busyRef.current = false
+      setBusy(false)
       setAwaitingResponse(false)
       clearNotifications()
       setSelectedStoredSessionId(storedSessionId)
@@ -580,14 +584,16 @@ export function useSessionActions({
 
         patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd)
 
+        const resumedRunning = Boolean(resumed.info?.running)
         updateSessionState(
           resumed.session_id,
           state => ({
             ...state,
             ...(runtimeInfo ?? {}),
             messages: messagesForView,
-            busy: false,
-            awaitingResponse: false
+            busy: resumedRunning,
+            awaitingResponse: resumedRunning,
+            turnStartedAt: resumedRunning ? (state.turnStartedAt ?? Date.now()) : null
           }),
           storedSessionId
         )


### PR DESCRIPTION
## Summary
- When resuming an uncached session, do not set `busy` true at the start of `resumeSession` (that copied the previous chat's streaming UI onto idle sessions).
- After `session.resume`, derive `busy` and `awaitingResponse` from `resumed.info?.running` instead of always clearing them.

## Problem
Switching from a streaming session to another session briefly (or persistently) showed the destination chat as busy/streaming in the desktop app.

## Test plan
- [x] `hermes desktop --build-only` succeeds with this commit (`403d1054f`)
- [ ] Manual: start a long reply in session A, switch to idle session B — B should not show streaming/busy chrome
- [ ] Manual: switch back to A while still streaming — timer and live turn UI should reflect the in-flight turn


Made with [Cursor](https://cursor.com)