### PR TITLE
fix(models): allow spaces in model names for self-hosted providers

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3556,7 +3556,11 @@ def validate_requested_model(
             "message": "Model name cannot be empty.",
         }
 
-    if any(ch.isspace() for ch in requested):
+    # Self-hosted providers (custom, lmstudio) may expose models with spaces
+    # in their names (e.g. VLLM "My Custom Model").  Skip the space check
+    # for those providers; cloud providers never use spaces.
+    _self_hosted = normalized == "custom" or normalized.startswith("custom:") or normalized == "lmstudio"
+    if any(ch.isspace() for ch in requested) and not _self_hosted:
         return {
             "accepted": False,
             "persist": False,

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -465,6 +465,39 @@ class TestValidateFormatChecks:
         result = _validate("anthropic/ claude-opus")
         assert result["accepted"] is False
 
+    def test_custom_provider_allows_spaces_in_model_name(self):
+        """Self-hosted providers (VLLM, Ollama, etc.) may have model names with spaces."""
+        result = _validate(
+            "My Custom Model",
+            provider="custom",
+            api_models=["My Custom Model", "Other Model"],
+        )
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+
+    def test_custom_local_provider_allows_spaces_in_model_name(self):
+        """custom:* sub-providers should also allow spaces."""
+        result = _validate(
+            "My VLLM Model",
+            provider="custom:my-vllm",
+            api_models=["My VLLM Model"],
+        )
+        assert result["accepted"] is True
+
+    def test_lmstudio_provider_allows_spaces_in_model_name(self):
+        """LM Studio is a local provider that may expose models with spaces."""
+        with patch("hermes_cli.models.probe_lmstudio_models", return_value=["My Local Model"]):
+            result = _validate("My Local Model", provider="lmstudio")
+        assert result["accepted"] is True
+        assert result["persist"] is True
+
+    def test_cloud_provider_still_rejects_spaces(self):
+        """Cloud providers should still reject model names with spaces."""
+        result = _validate("anthropic/claude opus", provider="anthropic")
+        assert result["accepted"] is False
+        assert "spaces" in result["message"]
+
     def test_no_slash_model_still_probes_api(self):
         result = _validate("gpt-5.4", api_models=["gpt-5.4", "gpt-5.4-pro"])
         assert result["accepted"] is True


### PR DESCRIPTION
## What does this PR do?

Allows model names with spaces for self-hosted providers (custom, lmstudio) while preserving the space rejection for cloud providers. VLLM and similar backends expose models with names like "My Custom Model" which Hermes previously rejected outright.

## Related Issue

Fixes #43140

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py`: Skip the space check in `validate_requested_model()` for `custom`, `custom:*`, and `lmstudio` providers where users control model naming
- `tests/hermes_cli/test_model_validation.py`: Add 4 tests — custom provider spaces allowed, custom:* sub-provider spaces allowed, lmstudio spaces allowed, cloud provider spaces still rejected

## How to Test

1. Configure a custom VLLM endpoint in `config.yaml` with a model name containing spaces
2. Run `hermes` — the model name should now be accepted instead of showing "Model names cannot contain spaces"
3. Verify cloud providers (openrouter, anthropic) still reject spaces: `/model "claude opus"` → rejected
4. Run `pytest tests/hermes_cli/test_model_validation.py -v` — all 81 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `validate_requested_model` in `hermes_cli/models.py` (callers: model_switch.py, tests)
- Blast radius: LOW — only affects model name format validation for self-hosted providers
- Related patterns: provider normalization via `normalize_provider()`, `_PROVIDER_ALIASES` maps vllm/ollama/llamacpp → custom
