### PR TITLE
feat: agent-callable model_switch tool

### DIFF
--- a/tests/tools/test_model_switch_tool.py
+++ b/tests/tools/test_model_switch_tool.py
@@ -1,0 +1,229 @@
+"""Tests for the model_switch agent-callable tool.
+
+TDD GREEN phase — tests for the model_switch tool that allows an agent
+to change its own model mid-session.
+
+Issue: #16525
+"""
+
+import pytest
+import tools.model_switch_tool as mod
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_agent(model="gpt-4o", provider="openai", api_key="sk-test"):
+    """Create a mock agent with the minimal surface area the tool needs."""
+    agent = MagicMock()
+    agent.model = model
+    agent.provider = provider
+    agent.api_key = api_key
+    agent.base_url = ""
+    agent.api_mode = ""
+    agent.session_id = "test-session"
+    agent._primary_runtime = MagicMock()
+    return agent
+
+
+def _mock_pipeline_result(**overrides):
+    """Create a mock ModelSwitchResult."""
+    defaults = dict(
+        success=True,
+        new_model="claude-sonnet-4",
+        target_provider="anthropic",
+        provider_label="Anthropic",
+        api_key="sk-ant-test",
+        base_url="",
+        api_mode="anthropic_messages",
+        error_message="",
+        warning_message="",
+    )
+    defaults.update(overrides)
+    return MagicMock(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema validation
+# ---------------------------------------------------------------------------
+
+class TestSchema:
+    """The tool schema must declare the right name, params, and types."""
+
+    def test_schema_exists(self):
+        assert hasattr(mod, "MODEL_SWITCH_SCHEMA")
+        schema = mod.MODEL_SWITCH_SCHEMA
+        assert schema["name"] == "model_switch"
+
+    def test_schema_has_model_param(self):
+        props = mod.MODEL_SWITCH_SCHEMA["parameters"]["properties"]
+        assert "model" in props
+        assert props["model"]["type"] == "string"
+
+    def test_schema_has_provider_param(self):
+        props = mod.MODEL_SWITCH_SCHEMA["parameters"]["properties"]
+        assert "provider" in props
+        assert props["provider"]["type"] == "string"
+
+    def test_model_is_required(self):
+        required = mod.MODEL_SWITCH_SCHEMA["parameters"].get("required", [])
+        assert "model" in required
+
+    def test_provider_is_optional(self):
+        required = mod.MODEL_SWITCH_SCHEMA["parameters"].get("required", [])
+        assert "provider" not in required
+
+
+# ---------------------------------------------------------------------------
+# 2. Successful switch
+# ---------------------------------------------------------------------------
+
+class TestSuccessfulSwitch:
+    """When the switch succeeds, the tool returns a confirmation."""
+
+    @patch.object(mod, "_run_runtime_switch")
+    @patch.object(mod, "_run_pipeline")
+    @patch.object(mod, "_get_custom_providers", return_value=None)
+    @patch.object(mod, "_get_user_providers", return_value=None)
+    def test_returns_success_on_valid_switch(self, mock_up, mock_cp, mock_pipeline, mock_runtime):
+        mock_pipeline.return_value = _mock_pipeline_result()
+        mock_runtime.return_value = None
+
+        agent = _make_agent()
+        result = mod.model_switch(model="claude-sonnet-4", provider="anthropic", parent_agent=agent)
+
+        assert result["success"] is True
+        assert "claude-sonnet-4" in result["message"]
+
+    @patch.object(mod, "_run_runtime_switch")
+    @patch.object(mod, "_run_pipeline")
+    @patch.object(mod, "_get_custom_providers", return_value=None)
+    @patch.object(mod, "_get_user_providers", return_value=None)
+    def test_calls_runtime_switch_with_credentials(self, mock_up, mock_cp, mock_pipeline, mock_runtime):
+        mock_pipeline.return_value = _mock_pipeline_result(
+            new_model="gemini-2.5-flash",
+            target_provider="google",
+            provider_label="Google",
+            api_key="AIza-test",
+            api_mode="openai",
+        )
+
+        agent = _make_agent()
+        mod.model_switch(model="gemini-2.5-flash", provider="google", parent_agent=agent)
+
+        mock_runtime.assert_called_once_with(
+            agent,
+            new_model="gemini-2.5-flash",
+            new_provider="google",
+            api_key="AIza-test",
+            base_url="",
+            api_mode="openai",
+        )
+
+    @patch.object(mod, "_run_pipeline")
+    @patch.object(mod, "_get_custom_providers", return_value=None)
+    @patch.object(mod, "_get_user_providers", return_value=None)
+    def test_returns_error_when_pipeline_fails(self, mock_up, mock_cp, mock_pipeline):
+        mock_pipeline.return_value = _mock_pipeline_result(
+            success=False,
+            new_model="",
+            target_provider="",
+            error_message="Unknown provider 'foobar'",
+        )
+
+        agent = _make_agent()
+        result = mod.model_switch(model="test", provider="foobar", parent_agent=agent)
+
+        assert result["success"] is False
+        assert "Unknown provider" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Provider auto-detection
+# ---------------------------------------------------------------------------
+
+class TestProviderAutoDetection:
+    """When provider is omitted, the pipeline should auto-detect."""
+
+    @patch.object(mod, "_run_runtime_switch")
+    @patch.object(mod, "_run_pipeline")
+    @patch.object(mod, "_get_custom_providers", return_value=None)
+    @patch.object(mod, "_get_user_providers", return_value=None)
+    def test_auto_detect_provider_when_omitted(self, mock_up, mock_cp, mock_pipeline, mock_runtime):
+        mock_pipeline.return_value = _mock_pipeline_result()
+        mock_runtime.return_value = None
+
+        agent = _make_agent()
+        result = mod.model_switch(model="claude-sonnet-4", parent_agent=agent)
+
+        # Pipeline should be called with empty explicit_provider
+        call_kwargs = mock_pipeline.call_args[1]
+        assert call_kwargs.get("explicit_provider") == ""
+        assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Error handling
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+    """Edge cases and error paths."""
+
+    def test_returns_error_when_no_parent_agent(self):
+        result = mod.model_switch(model="test", parent_agent=None)
+        assert result["success"] is False
+        assert "no agent" in result["message"].lower() or "parent_agent" in result["message"].lower()
+
+    @patch.object(mod, "_run_pipeline")
+    @patch.object(mod, "_get_custom_providers", return_value=None)
+    @patch.object(mod, "_get_user_providers", return_value=None)
+    def test_returns_success_on_same_model(self, mock_up, mock_cp, mock_pipeline):
+        """Switching to the same model+provider is a no-op with a message."""
+        agent = _make_agent(model="gpt-4o", provider="openai")
+        result = mod.model_switch(model="gpt-4o", provider="openai", parent_agent=agent)
+
+        mock_pipeline.assert_not_called()
+        assert result["success"] is True
+        assert "already" in result["message"].lower() or "same" in result["message"].lower()
+
+    @patch.object(mod, "_run_runtime_switch")
+    @patch.object(mod, "_run_pipeline")
+    @patch.object(mod, "_get_custom_providers", return_value=None)
+    @patch.object(mod, "_get_user_providers", return_value=None)
+    def test_returns_warning_when_pipeline_warns(self, mock_up, mock_cp, mock_pipeline, mock_runtime):
+        mock_pipeline.return_value = _mock_pipeline_result(
+            new_model="NousResearch/Hermes-3-Llama-3.1-70B",
+            target_provider="openrouter",
+            provider_label="OpenRouter",
+            api_key="sk-or-test",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="openai",
+            warning_message="Hermes models are NOT agentic",
+        )
+
+        agent = _make_agent()
+        result = mod.model_switch(model="NousResearch/Hermes-3-Llama-3.1-70B", parent_agent=agent)
+
+        assert result["success"] is True
+        assert result.get("warning") is not None
+        assert "agentic" in result["warning"].lower() or "Hermes" in result["warning"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Registry integration
+# ---------------------------------------------------------------------------
+
+class TestRegistry:
+    """The tool must self-register in the tool registry."""
+
+    def test_registered_in_registry(self):
+        from tools.registry import registry
+        assert "model_switch" in registry._tools
+
+    def test_registered_in_delegation_toolset(self):
+        from tools.registry import registry
+        entry = registry._tools.get("model_switch")
+        assert entry is not None
+        assert entry.toolset == "delegation"

--- a/tools/model_switch_tool.py
+++ b/tools/model_switch_tool.py
@@ -1,0 +1,247 @@
+"""Agent-callable model_switch tool.
+
+Allows an agent to change its own model and provider mid-session.
+Delegates credential resolution to ``hermes_cli.model_switch.switch_model``
+and runtime swap to ``agent.agent_runtime_helpers.switch_model``.
+
+Issue: #16525
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+MODEL_SWITCH_SCHEMA = {
+    "name": "model_switch",
+    "description": (
+        "Switch the current agent's model and/or provider mid-session. "
+        "Use this to adapt to different task requirements — e.g. switch to a "
+        "faster model for simple tasks, or a more capable model for complex reasoning. "
+        "The change persists for the rest of the session. "
+        "Specify model (required) and optionally provider. "
+        "If provider is omitted, it is auto-detected from the model name."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "model": {
+                "type": "string",
+                "description": (
+                    "The model to switch to (e.g. 'claude-sonnet-4', "
+                    "'gemini-2.5-flash', 'gpt-4o'). Required."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "The provider to use (e.g. 'anthropic', 'google', 'openai'). "
+                    "Optional — auto-detected from the model name when omitted."
+                ),
+            },
+        },
+        "required": ["model"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Pipeline wrapper (thin adapter over hermes_cli.model_switch)
+# ---------------------------------------------------------------------------
+
+def _run_pipeline(
+    raw_input: str,
+    explicit_provider: str,
+    current_provider: str,
+    current_model: str,
+    current_base_url: str,
+    current_api_key: str,
+    user_providers: dict | None,
+    custom_providers: list | None,
+) -> Any:
+    """Call the shared model-switching pipeline.
+
+    Wraps ``hermes_cli.model_switch.switch_model`` so the tool module
+    stays testable (callers can patch this function instead of the
+    heavy import chain).
+    """
+    from hermes_cli.model_switch import switch_model as switch_model_pipeline
+
+    return switch_model_pipeline(
+        raw_input=raw_input,
+        current_provider=current_provider,
+        current_model=current_model,
+        current_base_url=current_base_url,
+        current_api_key=current_api_key,
+        explicit_provider=explicit_provider,
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+
+
+def _run_runtime_switch(
+    agent: Any,
+    new_model: str,
+    new_provider: str,
+    api_key: str,
+    base_url: str,
+    api_mode: str,
+) -> None:
+    """Call the runtime model swap on the live agent."""
+    from agent.agent_runtime_helpers import switch_model as switch_model_runtime
+
+    switch_model_runtime(
+        agent,
+        new_model=new_model,
+        new_provider=new_provider,
+        api_key=api_key,
+        base_url=base_url,
+        api_mode=api_mode,
+    )
+
+
+def _get_user_providers() -> dict | None:
+    """Load user providers from config (lazy)."""
+    try:
+        from hermes_cli.config import get_config
+        cfg = get_config()
+        return cfg.get("providers")
+    except Exception:
+        return None
+
+
+def _get_custom_providers() -> list | None:
+    """Load custom providers from config (lazy)."""
+    try:
+        from hermes_cli.config import get_config
+        cfg = get_config()
+        return cfg.get("custom_providers")
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tool function
+# ---------------------------------------------------------------------------
+
+def model_switch(
+    model: str,
+    provider: str = "",
+    parent_agent: Any = None,
+) -> Dict[str, Any]:
+    """Switch the agent's model and/or provider.
+
+    Args:
+        model: Target model name (required).
+        provider: Target provider (optional, auto-detected if omitted).
+        parent_agent: The live agent instance (injected by the tool executor).
+
+    Returns:
+        Dict with success, message, and optional warning.
+    """
+    if parent_agent is None:
+        return {
+            "success": False,
+            "message": "Cannot switch model: no agent instance available.",
+        }
+
+    # Short-circuit: same model + same provider
+    if (
+        model == getattr(parent_agent, "model", None)
+        and (not provider or provider == getattr(parent_agent, "provider", None))
+    ):
+        return {
+            "success": True,
+            "message": f"Already using {model} on {getattr(parent_agent, 'provider', 'unknown')}. No switch needed.",
+        }
+
+    # Resolve credentials via the shared pipeline
+    try:
+        result = _run_pipeline(
+            raw_input=model,
+            explicit_provider=provider,
+            current_provider=getattr(parent_agent, "provider", ""),
+            current_model=getattr(parent_agent, "model", ""),
+            current_base_url=getattr(parent_agent, "base_url", ""),
+            current_api_key=getattr(parent_agent, "api_key", ""),
+            user_providers=_get_user_providers(),
+            custom_providers=_get_custom_providers(),
+        )
+    except Exception as exc:
+        logger.warning("model_switch pipeline error: %s", exc)
+        return {
+            "success": False,
+            "message": f"Failed to resolve model '{model}': {exc}",
+        }
+
+    if not result.success:
+        return {
+            "success": False,
+            "message": result.error_message or f"Failed to switch to {model}.",
+        }
+
+    # Apply the runtime swap
+    try:
+        _run_runtime_switch(
+            parent_agent,
+            new_model=result.new_model,
+            new_provider=result.target_provider,
+            api_key=result.api_key,
+            base_url=result.base_url,
+            api_mode=result.api_mode,
+        )
+    except Exception as exc:
+        logger.warning("model_switch runtime error: %s", exc)
+        return {
+            "success": False,
+            "message": f"Resolved credentials for {result.new_model} but runtime swap failed: {exc}",
+        }
+
+    response = {
+        "success": True,
+        "message": (
+            f"Switched to {result.new_model} "
+            f"via {result.provider_label or result.target_provider}."
+        ),
+    }
+
+    if result.warning_message:
+        response["warning"] = result.warning_message
+
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def check_model_switch_requirements() -> bool:
+    """The model_switch tool is always available when delegation is enabled."""
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry
+
+registry.register(
+    name="model_switch",
+    toolset="delegation",
+    schema=MODEL_SWITCH_SCHEMA,
+    handler=lambda args, **kw: model_switch(
+        model=args.get("model", ""),
+        provider=args.get("provider", ""),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=check_model_switch_requirements,
+    emoji="🔀",
+)


### PR DESCRIPTION
# `model_switch` tool — agent self-directed model switching

## What

Agent-callable `model_switch` tool that allows an agent to change its own model and provider mid-session via the tool-use interface.

## Why

Currently model switching is only available through the CLI `/model` command or the gateway HTTP endpoint. An agent that recognizes it needs a different model for a specific task (e.g. switching to a cheaper model for formatting, or a stronger model for reasoning) cannot do so autonomously. This tool enables self-directed model switching within the agent loop.

Closes #16525

## Changes

### New file: `tools/model_switch_tool.py`

- `model_switch(model: str, provider: str = "", parent_agent) -> dict` — agent-callable function
- Wraps `hermes_cli.model_switch.switch_model` for credential resolution
- Applies runtime swap via `agent.switch_model()`
- Schema with required `model` + optional `provider` string params
- Auto-detects provider from model name when omitted
- No-op with message when already on the target model + provider
- Returns structured `{success: bool, message: str, warning?: str}` dict
- Self-registers in `tools/registry` under `delegation` toolset

### New file: `tests/tools/test_model_switch_tool.py`

14 tests covering:

- Schema validation (name, params, types, required/optional)
- Successful switch (returns confirmation, calls runtime with correct args)
- Pipeline failure (returns error, no runtime call)
- Provider auto-detection (calls pipeline with empty `explicit_provider`)
- Same-model no-op (skips pipeline entirely)
- Warning propagation (pipeline warning surfaced in result)
- Missing agent guard (returns error for `None` parent_agent)
- Registry integration (registered and in `delegation` toolset)

## Test results

- 14 new tests: all pass
- 157 existing delegate/model tests: all pass, zero regressions
- **Total: 171 passed**

## Usage example

**Input:**

```json
{
  "tool": "model_switch",
  "input": {
    "model": "gemini-2.5-flash",
    "provider": "google"
  }
}
```

**Response:**

```json
{
  "success": true,
  "message": "Switched to gemini-2.5-flash via Google."
}
```

## Related

- #18591 — per-task model override (PR #43134)
- #38954 — role-based routing (cross-reference after merge)