### PR TITLE
fix(cli): allow model names with spaces in validate_requested_model (#43140)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3556,14 +3556,6 @@ def validate_requested_model(
             "message": "Model name cannot be empty.",
         }
 
-    if any(ch.isspace() for ch in requested):
-        return {
-            "accepted": False,
-            "persist": False,
-            "recognized": False,
-            "message": "Model names cannot contain spaces.",
-        }
-
     if normalized == "lmstudio":
         from hermes_cli.auth import AuthError
         # Use probe_lmstudio_models so we can distinguish None (unreachable

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -461,9 +461,18 @@ class TestValidateFormatChecks:
         result = _validate("   ")
         assert result["accepted"] is False
 
-    def test_model_with_spaces_rejected(self):
+    def test_model_with_spaces_not_in_api_rejected(self):
+        """Model names with spaces are allowed through validation; rejection is
+        because the model isn't found in the provider's listing, not because of spaces."""
         result = _validate("anthropic/ claude-opus")
         assert result["accepted"] is False
+        assert "not found" in result["message"]
+
+    def test_model_with_spaces_in_api_accepted(self):
+        """A model name containing spaces that exists in the API listing is accepted."""
+        result = _validate("my model with spaces", api_models=["my model with spaces"])
+        assert result["accepted"] is True
+        assert result["recognized"] is True
 
     def test_no_slash_model_still_probes_api(self):
         result = _validate("gpt-5.4", api_models=["gpt-5.4", "gpt-5.4-pro"])


### PR DESCRIPTION
## Problem

`validate_requested_model()` in `hermes_cli/models.py` rejects all model names containing spaces with a blanket error: "Model names cannot contain spaces." However, vLLM and other local inference servers (llama.cpp, text-generation-inference) **allow model names with spaces** when properly quoted, and some popular models are distributed with spaces in their names.

Fixes #43140

## Solution

Remove the blanket space-character check (`any(ch.isspace() for ch in requested)`) from `validate_requested_model()`. Model names are already stripped of leading/trailing whitespace on line 3540 (`requested = (model_name or "").strip()`), so whitespace-only inputs are still caught by the empty-check on line 3551.

After this change, model validation proceeds normally — if the model with spaces exists in the provider's API listing, it's accepted; if not, the standard "not found" rejection applies.

## Changes

- **`hermes_cli/models.py`**: Remove the `isspace()` guard in `validate_requested_model()`
- **`tests/hermes_cli/test_model_validation.py`**:
  - Update `test_model_with_spaces_rejected` → `test_model_with_spaces_not_in_api_rejected` (rejection is now because the model isn't in the API listing, not because of spaces)
  - Add `test_model_with_spaces_in_api_accepted` (verify a model with spaces IS accepted when present in the listing)

## Testing

```
tests/hermes_cli/test_model_validation.py  78 passed
tests/hermes_cli/test_model_switch_custom_providers.py  23 passed
```
