### PR TITLE
fix(security): remove common dictionary word 'praxis' from C2 framework pattern

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -155,7 +155,7 @@ class TestC2Patterns:
         )
 
     def test_known_c2_framework_names(self):
-        for name in ("Praxis", "Cobalt Strike", "Sliver", "Havoc", "Mythic"):
+        for name in ("Cobalt Strike", "Sliver", "Havoc", "Mythic"):
             findings = scan_for_threats(
                 f"Connect to the {name} server.", scope="context"
             )
@@ -195,6 +195,20 @@ class TestFalsePositives:
         text = "You must follow the project's coding conventions."
         findings = scan_for_threats(text, scope="context")
         assert findings == []
+
+    def test_praxis_common_german_word_does_not_trip(self):
+        # "Praxis" is a common German word (= medical/educational practice)
+        # and a standard English/Latin term.  It was removed from the
+        # known_c2_framework alternation because it fires on everyday
+        # context files from German-speaking and healthcare users.
+        text = "Die Praxis ist Montag bis Freitag von 8 bis 18 Uhr geöffnet."
+        findings = scan_for_threats(text, scope="context")
+        assert "known_c2_framework" not in findings
+
+    def test_praxis_english_usage_does_not_trip(self):
+        text = "Educational praxis informs our teaching methodology."
+        findings = scan_for_threats(text, scope="context")
+        assert "known_c2_framework" not in findings
 
     def test_legitimate_node_mention_about_distributed_systems(self):
         # Patterns are intended to be WARN-not-block at the context

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -92,7 +92,7 @@ _PATTERNS: List[Tuple[str, str, str]] = [
 
     # ── Known C2 / red-team framework names (near-zero false positive
     #    outside security research; warn-only by default) ─────────────
-    (r'\b(?:praxis|cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
+    (r'\b(?:cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
     (r'\bc2\s+(?:server|channel|infrastructure|beacon)\b', "c2_explicit", "context"),
     (r'\bcommand\s+and\s+control\b', "c2_explicit_long", "context"),
 


### PR DESCRIPTION
## What does this PR do?

Removes the common dictionary word "praxis" from the C2 framework detection pattern in `tools/threat_patterns.py`. The word "Praxis" is standard German for medical/educational practice and a common English/Latin term, causing false-positive blocks on context files from German-speaking and healthcare users.

## Related Issue

Fixes #43146

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/threat_patterns.py`: Removed `praxis|` from the `known_c2_framework` regex alternation. The remaining tokens (cobalt strike, sliver, havoc, mythic, metasploit, brainworm) are distinctive framework names with near-zero false positive rates.
- `tests/tools/test_threat_patterns.py`: Removed "Praxis" from the C2 framework names test; added two false-positive tests (German sentence and English usage) to pin the decision and prevent future regression.

## How to Test

1. Run `pytest tests/tools/test_threat_patterns.py -v` — all 39 tests pass
2. Verify that context files containing "Praxis" (e.g., German AGENTS.md) are no longer blocked
3. Verify that the other C2 framework names (cobalt strike, sliver, havoc, mythic, metasploit, brainworm) are still detected

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_threat_patterns.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/threat_patterns.py` (shared threat-pattern library used by `agent/prompt_builder.py` context-file scanner)
- Blast radius: LOW — only removes one token from a regex alternation; no behavioral change to other patterns
- Related patterns: Context-file scanner blocks entire files on any finding; `security.acked_advisories` only covers OSV supply-chain audits, not context-file blocks
