### PR TITLE
fix(agent): reset flush cursor after compaction (#43066)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2509,6 +2509,10 @@ def run_conversation(
                         # so _flush_messages_to_session_db writes compressed
                         # messages to the new session, not skipping them.
                         conversation_history = None
+                        # Defensive: ensure _last_flushed_db_idx is reset
+                        # so compressed messages are written to the new
+                        # child session DB, not skipped by stale offset.
+                        agent._last_flushed_db_idx = 0
                         if len(messages) < original_len or old_ctx > _reduced_ctx:
                             agent._buffer_status(
                                 f"🗜️ Context reduced to {_reduced_ctx:,} tokens "
@@ -2682,6 +2686,8 @@ def run_conversation(
                     # so _flush_messages_to_session_db writes compressed
                     # messages to the new session, not skipping them.
                     conversation_history = None
+                    # Defensive: ensure _last_flushed_db_idx is reset
+                    agent._last_flushed_db_idx = 0
 
                     if len(messages) < original_len:
                         agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
@@ -2838,6 +2844,8 @@ def run_conversation(
                     # so _flush_messages_to_session_db writes compressed
                     # messages to the new session, not skipping them.
                     conversation_history = None
+                    # Defensive: ensure _last_flushed_db_idx is reset
+                    agent._last_flushed_db_idx = 0
 
                     if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
                         if len(messages) < original_len:
@@ -3796,6 +3804,8 @@ def run_conversation(
                     # _flush_messages_to_session_db writes compressed messages
                     # to the new session (see preflight compression comment).
                     conversation_history = None
+                    # Defensive: ensure _last_flushed_db_idx is reset
+                    agent._last_flushed_db_idx = 0
                 
                 # Save session log incrementally (so progress is visible even if interrupted)
                 agent._session_messages = messages

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -300,6 +300,8 @@ def build_turn_context(
                 if len(messages) >= _orig_len:
                     break  # Cannot compress further
                 conversation_history = None
+                # Defensive: ensure _last_flushed_db_idx is reset
+                agent._last_flushed_db_idx = 0
                 agent._empty_content_retries = 0
                 agent._thinking_prefill_retries = 0
                 agent._last_content_with_tools = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6786,7 +6786,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             adapter._pending_messages,
                             _quick_key,
                             event,
-                            merge_text=True,
+                            merge_text=False,
                         )
                 return None
 
@@ -6806,7 +6806,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         adapter._pending_messages,
                         _quick_key,
                         event,
-                        merge_text=True,
+                        merge_text=False,
                     )
                 return None
             if self._draining:


### PR DESCRIPTION
Fixes #43066. After context compaction, the session DB flush cursor (_last_flushed_db_idx) could retain a stale offset from the pre-compression history, causing compressed messages to not be written to the new child session. This also fixes merge_text=True in queue-mode busy paths that incorrectly joined separate user messages into a single turn.