### PR TITLE
feat(skills): taskmaster orchestration with automatic model routing

### DIFF
--- a/optional-skills/autonomous-ai-agents/taskmaster/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/taskmaster/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: taskmaster
+description: Orchestrate complex tasks with automatic model routing.
+version: 1.0.0
+author: Rafael Zendron (rafaumeu)
+license: MIT
+metadata:
+  hermes:
+    tags: [orchestration, delegation, model-routing, task-management]
+    related_skills: [kanban-orchestrator, kanban-worker]
+    requires_toolsets: [delegation]
+---
+
+# TaskMaster Skill
+
+Orchestrate complex multi-step tasks by automatically decomposing them into subtasks and routing each subtask to the most appropriate LLM. Uses `delegate_task` with per-task model overrides so a single orchestration call can leverage different models for different work types — fast/cheap models for simple tasks, capable models for complex reasoning.
+
+Does NOT implement a new runtime or framework. It is a structured prompt + procedure that teaches the agent HOW to decompose and route tasks using existing Hermes primitives.
+
+## When to Use
+
+- User asks to "orchestrate", "coordinate", or "break down" a complex task
+- User wants to run multiple subtasks in parallel with different models
+- User wants cost-efficient execution by routing simple work to cheap models
+- User asks for "taskmaster" by name
+
+## Prerequisites
+
+- Hermes config must have at least 2 providers configured (e.g., `openrouter`, `google`)
+- `delegate_task` tool must be available (delegation toolset enabled)
+- Optional: `model_switch` tool for mid-session adaptation
+
+## Quick Reference
+
+| Complexity | Model Family | Cost | Best For |
+|---|---|---|---|
+| LOW | gemini-2.0-flash, gpt-4o-mini | ~$0 | Formatting, extraction, simple lookups |
+| MEDIUM | gemini-2.5-flash, gpt-4o, glm-4 | ~$0 | Summarization, categorization, drafting |
+| HIGH | claude-sonnet-4, gemini-2.5-pro | paid | Reasoning, code generation, analysis |
+| VOTE | 2-3 MEDIUM models | ~$0 | Quality gate via multi-model consensus |
+
+## Procedure
+
+### Step 1: Classify the task
+
+Read the user's request and classify each identified subtask:
+
+- **LOW**: Simple formatting, data extraction, list generation, translation, file I/O
+- **MEDIUM**: Summarization, drafting, categorization, comparison, search synthesis
+- **HIGH**: Complex reasoning, code generation, architectural decisions, multi-step analysis
+- **VOTE**: Any subtask where accuracy is critical and the answer is uncertain
+
+### Step 2: Build the task list
+
+Construct a `delegate_task` call with per-task `model` overrides. Use the routing table above. Example:
+
+```json
+{
+  "tool": "delegate_task",
+  "input": {
+    "tasks": [
+      {
+        "goal": "Extract key metrics from this report",
+        "model": "google/gemini-2.0-flash-001",
+        "toolsets": ["web", "terminal"]
+      },
+      {
+        "goal": "Analyze trends and write executive summary",
+        "model": "anthropic/claude-sonnet-4",
+        "toolsets": ["web"]
+      },
+      {
+        "goal": "Validate analysis with independent review",
+        "model": "openai/gpt-4o",
+        "toolsets": ["web"]
+      }
+    ]
+  }
+}
+```
+
+### Step 3: Fallback chain
+
+If a model fails or is unavailable:
+
+1. Try same-tier alternative (e.g., `gemini-2.0-flash` → `gpt-4o-mini`)
+2. Try next tier up (e.g., `gemini-2.0-flash` → `gemini-2.5-flash`)
+3. Fall back to parent agent model (inherited default)
+
+### Step 4: Quality gate (optional)
+
+For HIGH-complexity or critical tasks, run a VOTE pass:
+
+- Send the same task to 2-3 MEDIUM models
+- Compare results — if all agree, accept
+- If they disagree, flag for user review
+
+### Step 5: Synthesize
+
+Collect all subtask results and present a unified response. If any subtask failed, report which ones and why.
+
+## Model Routing Script
+
+Use `scripts/route_model.py` to resolve the best model for a given complexity tier and available providers:
+
+```
+terminal: python3 optional-skills/autonomous-ai-agents/taskmaster/scripts/route_model.py --tier HIGH --provider openrouter
+```
+
+## Pitfalls
+
+- **Don't over-route**: If a task has 2-3 simple subtasks, just run them all on the same model. Routing overhead isn't worth it for fewer than 3 subtasks.
+- **Free model rate limits**: Some free-tier providers (OpenRouter free, Google) have rate limits. If you get 429 errors, fall back to a different provider.
+- **Provider detection**: The `provider` field is optional in per-task overrides. If you specify just `model`, Hermes auto-detects the provider. Only specify `provider` when the model name is ambiguous across providers.
+- **Context window**: Delegated subtasks start fresh — they don't inherit the parent's conversation. Pass all needed context in the `goal` and `context` fields.
+- **Maximum 3 concurrent subtasks**: `delegate_task` runs up to 3 tasks in parallel. For more subtasks, batch them in groups of 3.
+
+## Verification
+
+1. All subtasks returned results (no failures)
+2. Each subtask used the expected model (check tool output)
+3. Synthesized response addresses the original user request completely
+4. Total token cost stayed within expected range for the task complexity

--- a/optional-skills/autonomous-ai-agents/taskmaster/scripts/route_model.py
+++ b/optional-skills/autonomous-ai-agents/taskmaster/scripts/route_model.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Model routing table for TaskMaster skill.
+
+Resolves the best model for a given complexity tier based on available
+providers. Outputs JSON so the agent can parse it programmatically.
+
+Usage:
+    python3 route_model.py --tier LOW
+    python3 route_model.py --tier HIGH --provider openrouter
+    python3 route_model.py --list-tiers
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Dict, List, Optional
+
+# ---------------------------------------------------------------------------
+# Routing table — models grouped by complexity tier and provider
+# ---------------------------------------------------------------------------
+
+ROUTING_TABLE: Dict[str, Dict[str, List[str]]] = {
+    "LOW": {
+        "openrouter": [
+            "google/gemini-2.0-flash-001",
+            "openai/gpt-4o-mini",
+        ],
+        "google": ["gemini-2.0-flash"],
+        "openai": ["gpt-4o-mini"],
+        "zai": ["glm-4-flash"],
+    },
+    "MEDIUM": {
+        "openrouter": [
+            "google/gemini-2.5-flash-preview-05-20",
+            "openai/gpt-4o",
+        ],
+        "google": ["gemini-2.5-flash"],
+        "openai": ["gpt-4o"],
+        "zai": ["glm-5.1"],
+    },
+    "HIGH": {
+        "openrouter": [
+            "anthropic/claude-sonnet-4",
+            "google/gemini-2.5-pro-preview-06-05",
+        ],
+        "anthropic": ["claude-sonnet-4"],
+        "google": ["gemini-2.5-pro"],
+    },
+    "VOTE": {
+        "openrouter": [
+            "google/gemini-2.5-flash-preview-05-20",
+            "openai/gpt-4o",
+            "meta-llama/llama-4-maverick",
+        ],
+        "google": ["gemini-2.5-flash"],
+    },
+}
+
+TIER_DESCRIPTIONS = {
+    "LOW": "Formatting, extraction, simple lookups, file I/O",
+    "MEDIUM": "Summarization, drafting, categorization, comparison",
+    "HIGH": "Complex reasoning, code generation, architectural decisions",
+    "VOTE": "Multi-model consensus for quality gating",
+}
+
+
+def resolve_model(tier: str, provider: Optional[str] = None) -> dict:
+    """Resolve the best model for a given tier and optional provider.
+
+    Returns a dict with the resolved model, provider, and tier info.
+    """
+    tier = tier.upper()
+    if tier not in ROUTING_TABLE:
+        return {
+            "error": f"Unknown tier '{tier}'. Valid: {list(ROUTING_TABLE.keys())}",
+        }
+
+    tier_models = ROUTING_TABLE[tier]
+
+    if provider:
+        provider_models = tier_models.get(provider)
+        if not provider_models:
+            available_providers = list(tier_models.keys())
+            return {
+                "error": (
+                    f"Provider '{provider}' has no models for tier '{tier}'. "
+                    f"Available providers: {available_providers}"
+                ),
+            }
+        return {
+            "tier": tier,
+            "provider": provider,
+            "model": provider_models[0],
+            "alternatives": provider_models[1:],
+            "description": TIER_DESCRIPTIONS[tier],
+        }
+
+    # No provider specified — return first available across all providers
+    for prov, models in tier_models.items():
+        return {
+            "tier": tier,
+            "provider": prov,
+            "model": models[0],
+            "alternatives": models[1:],
+            "all_providers": {
+                p: ms for p, ms in tier_models.items()
+            },
+            "description": TIER_DESCRIPTIONS[tier],
+        }
+
+    return {"error": f"No models available for tier '{tier}'."}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="TaskMaster model routing table",
+    )
+    parser.add_argument(
+        "--tier",
+        choices=["LOW", "MEDIUM", "HIGH", "VOTE"],
+        help="Complexity tier to resolve",
+    )
+    parser.add_argument(
+        "--provider",
+        default=None,
+        help="Specific provider to use (optional)",
+    )
+    parser.add_argument(
+        "--list-tiers",
+        action="store_true",
+        help="List all tiers and their models",
+    )
+
+    args = parser.parse_args()
+
+    if args.list_tiers:
+        output = {}
+        for tier, desc in TIER_DESCRIPTIONS.items():
+            output[tier] = {
+                "description": desc,
+                "models": ROUTING_TABLE[tier],
+            }
+        print(json.dumps(output, indent=2))
+        return
+
+    if not args.tier:
+        parser.error("--tier is required (or use --list-tiers)")
+
+    result = resolve_model(args.tier, args.provider)
+    print(json.dumps(result, indent=2))
+
+    if "error" in result:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/autonomous-ai-agents/taskmaster/scripts/test_route_model.py
+++ b/optional-skills/autonomous-ai-agents/taskmaster/scripts/test_route_model.py
@@ -1,0 +1,194 @@
+"""Tests for TaskMaster model routing script.
+
+Run with: python -m pytest optional-skills/autonomous-ai-agents/taskmaster/scripts/test_route_model.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Import the module under test
+SCRIPT_DIR = Path(__file__).parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from route_model import ROUTING_TABLE, TIER_DESCRIPTIONS, resolve_model
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingTable:
+    """Validate the routing table structure."""
+
+    def test_all_tiers_exist(self):
+        assert set(ROUTING_TABLE.keys()) == {"LOW", "MEDIUM", "HIGH", "VOTE"}
+
+    def test_all_tiers_have_descriptions(self):
+        for tier in ROUTING_TABLE:
+            assert tier in TIER_DESCRIPTIONS
+            assert len(TIER_DESCRIPTIONS[tier]) > 0
+
+    def test_each_tier_has_at_least_one_provider(self):
+        for tier, providers in ROUTING_TABLE.items():
+            assert len(providers) >= 1, f"Tier {tier} has no providers"
+
+    def test_each_provider_has_at_least_one_model(self):
+        for tier, providers in ROUTING_TABLE.items():
+            for provider, models in providers.items():
+                assert len(models) >= 1, (
+                    f"Tier {tier}, provider {provider} has no models"
+                )
+
+    def test_model_names_are_strings(self):
+        for tier, providers in ROUTING_TABLE.items():
+            for provider, models in providers.items():
+                for model in models:
+                    assert isinstance(model, str)
+                    assert len(model) > 0
+
+
+class TestResolveModel:
+    """Test the resolve_model function."""
+
+    def test_resolve_low_tier(self):
+        result = resolve_model("LOW")
+        assert result["tier"] == "LOW"
+        assert "model" in result
+        assert "provider" in result
+
+    def test_resolve_medium_tier(self):
+        result = resolve_model("MEDIUM")
+        assert result["tier"] == "MEDIUM"
+        assert "model" in result
+
+    def test_resolve_high_tier(self):
+        result = resolve_model("HIGH")
+        assert result["tier"] == "HIGH"
+        assert "model" in result
+
+    def test_resolve_vote_tier(self):
+        result = resolve_model("VOTE")
+        assert result["tier"] == "VOTE"
+        assert "model" in result
+
+    def test_resolve_with_provider(self):
+        result = resolve_model("LOW", "openrouter")
+        assert result["provider"] == "openrouter"
+        assert result["tier"] == "LOW"
+        assert "openrouter" in result["model"] or "/" in result["model"]
+
+    def test_resolve_with_google_provider(self):
+        result = resolve_model("MEDIUM", "google")
+        assert result["provider"] == "google"
+        assert "gemini" in result["model"]
+
+    def test_unknown_tier_returns_error(self):
+        result = resolve_model("INVALID")
+        assert "error" in result
+        assert "INVALID" in result["error"]
+
+    def test_unknown_provider_returns_error(self):
+        result = resolve_model("LOW", "nonexistent_provider")
+        assert "error" in result
+        assert "nonexistent_provider" in result["error"]
+
+    def test_case_insensitive_tier(self):
+        result = resolve_model("low")
+        assert result["tier"] == "LOW"
+        assert "model" in result
+
+    def test_result_has_description(self):
+        result = resolve_model("HIGH")
+        assert "description" in result
+        assert len(result["description"]) > 0
+
+    def test_result_has_alternatives(self):
+        result = resolve_model("LOW", "openrouter")
+        assert "alternatives" in result
+        assert isinstance(result["alternatives"], list)
+
+    def test_no_provider_returns_all_providers(self):
+        result = resolve_model("MEDIUM")
+        assert "all_providers" in result
+        assert len(result["all_providers"]) >= 1
+
+
+class TestFallbackChain:
+    """Test the fallback/recommendation logic."""
+
+    def test_first_model_is_primary(self):
+        result = resolve_model("LOW", "openrouter")
+        primary = result["model"]
+        alternatives = result.get("alternatives", [])
+        # Primary should differ from alternatives
+        assert primary not in alternatives or len(alternatives) == 0
+
+    def test_high_tier_has_premium_models(self):
+        result = resolve_model("HIGH")
+        model = result["model"].lower()
+        # High tier should use premium models
+        premium_keywords = ["claude", "sonnet", "gemini-2.5-pro", "o3", "opus"]
+        assert any(kw in model for kw in premium_keywords), (
+            f"High tier model '{model}' doesn't look premium"
+        )
+
+    def test_low_tier_has_cheap_models(self):
+        result = resolve_model("LOW")
+        model = result["model"].lower()
+        cheap_keywords = ["flash", "mini", "glm-4"]
+        assert any(kw in model for kw in cheap_keywords), (
+            f"Low tier model '{model}' doesn't look cheap"
+        )
+
+
+class TestCLI:
+    """Test the command-line interface."""
+
+    def _run(self, args: list[str]) -> subprocess.CompletedProcess:
+        script = SCRIPT_DIR / "route_model.py"
+        return subprocess.run(
+            [sys.executable, str(script), *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_list_tiers(self):
+        proc = self._run(["--list-tiers"])
+        assert proc.returncode == 0
+        data = json.loads(proc.stdout)
+        assert "LOW" in data
+        assert "HIGH" in data
+
+    def test_tier_flag(self):
+        proc = self._run(["--tier", "HIGH"])
+        assert proc.returncode == 0
+        data = json.loads(proc.stdout)
+        assert data["tier"] == "HIGH"
+
+    def test_tier_with_provider(self):
+        proc = self._run(["--tier", "LOW", "--provider", "google"])
+        assert proc.returncode == 0
+        data = json.loads(proc.stdout)
+        assert data["provider"] == "google"
+
+    def test_invalid_tier_exits_nonzero(self):
+        proc = self._run(["--tier", "INVALID"])
+        assert proc.returncode != 0
+
+    def test_no_args_shows_error(self):
+        proc = self._run([])
+        assert proc.returncode != 0
+
+    def test_output_is_valid_json(self):
+        proc = self._run(["--tier", "MEDIUM"])
+        data = json.loads(proc.stdout)
+        assert isinstance(data, dict)


### PR DESCRIPTION
## Summary

Adds `taskmaster` as an official optional skill that teaches the agent how to automatically decompose complex tasks and route subtasks to appropriate LLMs using existing Hermes primitives.

## What it does

- Classifies subtasks by complexity (LOW / MEDIUM / HIGH / VOTE)
- Routes each subtask to the best model for its tier via `delegate_task` per-task model overrides
- Provides a routing table with free models for LOW/MEDIUM and premium models for HIGH
- Includes quality-gate pattern (VOTE) using multi-model consensus

## Files

| File | Purpose |
|---|---|
| `optional-skills/autonomous-ai-agents/taskmaster/SKILL.md` | Skill instructions: when to use, procedure, pitfalls |
| `optional-skills/autonomous-ai-agents/taskmaster/scripts/route_model.py` | Model routing resolver (stdlib-only, cross-platform) |
| `optional-skills/autonomous-ai-agents/taskmaster/scripts/test_route_model.py` | 26 tests (pytest, no network, all pass) |

## Why a skill, not a tool

Per CONTRIBUTING.md: "The answer is almost always skill." The TaskMaster does not need a new runtime -- it teaches the agent HOW to use existing delegate_task + model_switch primitives for intelligent orchestration.

## Test Results

26 passed in 0.36s

## Dependencies on other PRs

- Uses per-task model override from PR #43154 (refs #18591)
- Uses model_switch tool (commit 5e3c3b6, refs #16525)

Refs #38954