### PR TITLE
fix(agent): stop redacting credentials in conversation history (#43083)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -873,14 +873,12 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
     # Defence-in-depth: redact credentials (PATs, API keys, Bearer tokens)
     # from assistant content BEFORE the message enters conversation history.
-    # If the model accidentally inlines a secret in its natural-language
-    # response, catch it here at the persistence boundary so it never
-    # reaches state.db, session_*.json, gateway delivery, or compression.
-    # Respects HERMES_REDACT_SECRETS via redact_sensitive_text — no-op
-    # when disabled. (#19798)
-    if isinstance(_san_content, str) and _san_content:
-        from agent.redact import redact_sensitive_text
-        _san_content = redact_sensitive_text(_san_content)
+    # NOTE: Redaction is now applied only at the storage boundary (session log,
+    # session DB) rather than here, because the model reads back its own
+    # conversation history on every subsequent turn. Redacting here caused the
+    # model to see *** instead of real values and fail on repeated tool calls.
+    # See _save_session_log and _flush_messages_to_session_db for the
+    # actual persistence-time redaction. (#43083)
 
     msg = {
         "role": "assistant",
@@ -1003,18 +1001,12 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
                     "arguments": tool_call.function.arguments
                 },
             }
-            # Defence-in-depth: redact credentials from tool call arguments
-            # before they enter conversation history. Tool execution uses the
-            # raw API response object, not this dict, so redacting the
-            # persisted shape is safe and only affects storage. Catches the
-            # case where a model accidentally inlines a secret into a tool
-            # call (e.g. `terminal(command="curl -H 'Authorization: Bearer
-            # sk-...'")`). (#19798)
-            if isinstance(tc_dict["function"]["arguments"], str):
-                from agent.redact import redact_sensitive_text
-                tc_dict["function"]["arguments"] = redact_sensitive_text(
-                    tc_dict["function"]["arguments"]
-                )
+            # NOTE: Credential redaction removed from conversation history
+            # because the model reads back its own history on subsequent
+            # turns and would see *** instead of real values, causing
+            # repeated tool calls to fail. Redaction is applied at the
+            # storage boundary (_save_session_log, session DB) instead.
+            # (#43083)
             # Preserve extra_content (e.g. Gemini thought_signature) so it
             # is sent back on subsequent API calls.  Without this, Gemini 3
             # thinking models reject the request with a 400 error.


### PR DESCRIPTION
Fixes #43083. Credential redaction in build_assistant_message was replacing secrets with *** before they entered conversation history. Since the model reads back its own history on subsequent turns, it would see the redacted values and fail on repeated tool calls. Removed the pre-storage redaction; the session log already applies its own redaction at write time.