### PR TITLE
feat(approval): block agents from killing their own gateway/host process

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -7,10 +7,13 @@ gateway /yolo, approvals.mode=off, or cron approve mode.
 Inspired by Mercury Agent's permission-hardened blocklist.
 """
 
+import os
+
 import pytest
 
 from tools.approval import (
     HARDLINE_PATTERNS,
+    _check_self_host_kill,
     check_all_command_guards,
     check_dangerous_command,
     detect_dangerous_command,
@@ -648,3 +651,172 @@ def test_sudo_stdin_guard_container_bypass(clean_session):
         for cmd in _SUDO_STDIN_BLOCK:
             result = check_all_command_guards(cmd, env)
             assert result["approved"] is True, f"container {env} should bypass sudo guard on {cmd!r}"
+
+
+# -------------------------------------------------------------------------
+# Self-host kill guard
+# -------------------------------------------------------------------------
+# Killing the process that hosts the running session (desktop dashboard /
+# gateway, CLI) orphans the session mid-turn. The guard compares numeric kill
+# targets and the $$/$PPID self-tokens against this process + parent, across
+# wrapper spellings (command/builtin/sudo/env/exec/... prefixes), shell -c
+# payloads (bash -c "kill $$"), and deobfuscation variants (subshells).
+
+
+def test_self_host_kill_blocks_own_pid(clean_session):
+    blocked, desc = _check_self_host_kill(f"kill {os.getpid()}")
+    assert blocked is True
+    assert str(os.getpid()) in desc
+
+
+def test_self_host_kill_blocks_parent_pid(clean_session, monkeypatch):
+    # The guard treats this process's *parent* as self-host too — killing it
+    # orphans the session. Pin a deterministic, non-1 parent so the assertion
+    # holds in PID-1-parent environments (containers, some CI runners) where
+    # the real os.getppid() is 1 and _self_host_pids() intentionally excludes
+    # PID 1. The old test used the live os.getppid() as the kill target and so
+    # asserted every runner has a meaningful non-1 parent — false under PID-1
+    # reparenting, which made it fail with `assert False is True`. See
+    # tools/approval._self_host_pids.
+    fake_parent = 424242  # arbitrary, > 1, distinct from this process's PID
+    monkeypatch.setattr(os, "getppid", lambda: fake_parent)
+    blocked, desc = _check_self_host_kill(f"kill -9 {fake_parent}")
+    assert blocked is True
+    assert str(fake_parent) in desc
+
+
+def test_self_host_kill_pid1_parent_is_excluded(clean_session, monkeypatch):
+    # Killing PID 1 (init) is deliberately NOT a self-host kill: a real agent
+    # host is never init, and an orphan reparented to init must not classify
+    # "kill 1" as self-directed. This pins the intentional PID-1 exclusion in
+    # _self_host_pids() so the parent-PID test above can't be "fixed" by
+    # dropping it — the own-PID path must still block.
+    monkeypatch.setattr(os, "getppid", lambda: 1)
+    assert _check_self_host_kill(f"kill {os.getpid()}")[0] is True
+    assert _check_self_host_kill("kill -9 1")[0] is False
+
+
+def test_self_host_kill_blocks_shell_self_tokens(clean_session):
+    assert _check_self_host_kill("kill $$")[0] is True
+    assert _check_self_host_kill("kill -TERM $PPID")[0] is True
+
+
+def test_self_host_kill_blocks_chained_command(clean_session):
+    blocked, _ = _check_self_host_kill(f"echo done && kill -TERM {os.getpid()}")
+    assert blocked is True
+
+
+def test_self_host_kill_allows_foreign_pid(clean_session):
+    assert _check_self_host_kill("kill 999999999")[0] is False
+    assert _check_self_host_kill("kill -9 999999998 999999999")[0] is False
+
+
+def test_self_host_kill_ignores_pkill_and_pgid_forms(clean_session):
+    # pkill matches by name, not our numeric-target scope; negative pgids are
+    # explicitly out of scope (kill -1 is already hardline).
+    assert _check_self_host_kill("pkill -f some-other-daemon")[0] is False
+    assert _check_self_host_kill("kill -- -12345")[0] is False
+
+
+def test_self_host_kill_ignores_unrelated_commands(clean_session):
+    assert _check_self_host_kill("echo kill it with fire")[0] is False
+    assert _check_self_host_kill("ls -la")[0] is False
+
+
+def test_self_host_kill_blocks_command_and_builtin_wrappers(clean_session):
+    # `command kill` / `builtin kill` are plain shell spellings that still
+    # execute kill; they must not slip past the command-position anchor.
+    pid = os.getpid()
+    assert _check_self_host_kill(f"command kill {pid}")[0] is True
+    assert _check_self_host_kill(f"command -- kill {pid}")[0] is True
+    assert _check_self_host_kill(f"builtin kill {pid}")[0] is True
+    assert _check_self_host_kill(f"builtin -- kill {pid}")[0] is True
+    assert _check_self_host_kill("command -p kill $$")[0] is True
+    assert _check_self_host_kill("command -p -- kill $$")[0] is True
+    assert _check_self_host_kill(f"command builtin kill {pid}")[0] is True
+    assert _check_self_host_kill(f"command -- builtin -- kill {pid}")[0] is True
+
+
+def test_self_host_kill_blocks_standard_wrapper_prefixes(clean_session):
+    pid = os.getpid()
+    assert _check_self_host_kill(f"sudo kill {pid}")[0] is True
+    assert _check_self_host_kill(f"sudo -- kill {pid}")[0] is True
+    assert _check_self_host_kill(f"env kill {pid}")[0] is True
+    assert _check_self_host_kill(f"env -- kill {pid}")[0] is True
+    assert _check_self_host_kill("exec kill $PPID")[0] is True
+    assert _check_self_host_kill(f"nohup setsid kill -9 {pid}")[0] is True
+
+
+def test_self_host_kill_allows_foreign_pid_via_wrappers(clean_session):
+    assert _check_self_host_kill("command kill 999999999")[0] is False
+    assert _check_self_host_kill("builtin kill -9 999999998")[0] is False
+
+
+def test_self_host_kill_allows_command_v_lookup(clean_session):
+    # `command -v kill` resolves the name without executing kill, so it is not
+    # a wrapper; only `command [-p]` executes its operand.
+    assert _check_self_host_kill(f"command -v kill {os.getpid()}")[0] is False
+
+
+def test_self_host_kill_blocks_shell_c_forms(clean_session):
+    # `bash -c "kill $$"` runs kill inside a quoted -c payload with no
+    # command-position separator in front of it; the payload is pulled out and
+    # re-scanned as a standalone command. Covers path-qualified interpreters,
+    # bundled flags (-lc), wrapper-nested and interpreter-nested spellings.
+    pid = os.getpid()
+    assert _check_self_host_kill('bash -c "kill $$"')[0] is True
+    assert _check_self_host_kill("sh -c 'kill -9 $PPID'")[0] is True
+    assert _check_self_host_kill(f'bash -c "kill {pid}"')[0] is True
+    assert _check_self_host_kill('sudo bash -c "kill $$"')[0] is True
+    assert _check_self_host_kill('bash -lc "kill $$"')[0] is True
+    assert _check_self_host_kill("/bin/sh -c 'kill $$'")[0] is True
+    assert _check_self_host_kill('bash -c "sh -c \'kill $$\'"')[0] is True
+    assert _check_self_host_kill('bash -c "echo hi; kill $$"')[0] is True
+    assert _check_self_host_kill("zsh -c 'kill $PPID'")[0] is True
+
+
+def test_self_host_kill_allows_shell_c_foreign_and_nonkill(clean_session):
+    # The -c payload is scanned with the same rules: a foreign PID, a
+    # non-command `kill` word, or a non-`-c` invocation stays allowed.
+    assert _check_self_host_kill('bash -c "kill 999999999"')[0] is False
+    assert _check_self_host_kill('bash -c "echo kill it with fire"')[0] is False
+    assert _check_self_host_kill('bash -c "ls -la"')[0] is False
+    assert _check_self_host_kill("bash script.sh")[0] is False
+
+
+def test_check_all_command_guards_blocks_self_host_kill(clean_session):
+    result = check_all_command_guards(f"kill {os.getpid()}", "local")
+    assert result["approved"] is False
+    assert result.get("hardline") is True
+    assert "session-not-found" in result["message"]
+
+
+def test_check_all_command_guards_blocks_wrapped_self_host_kill(clean_session):
+    for cmd in (
+        f"command kill {os.getpid()}",
+        f"command -- kill {os.getpid()}",
+        f"builtin kill {os.getpid()}",
+        f"sudo kill {os.getpid()}",
+        'bash -c "kill $$"',
+        "sh -c 'kill -9 $PPID'",
+    ):
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"leaked wrapped self-host kill: {cmd!r}"
+        assert result.get("hardline") is True
+
+
+def test_yolo_cannot_bypass_self_host_kill(clean_session, monkeypatch):
+    enable_session_yolo("hardline_test")
+    try:
+        for cmd in (f"kill -9 {os.getpid()}", 'bash -c "kill $$"'):
+            result = check_all_command_guards(cmd, "local")
+            assert result["approved"] is False, f"session yolo leaked self-host kill: {cmd!r}"
+    finally:
+        disable_session_yolo("hardline_test")
+
+
+def test_container_bypasses_self_host_kill(clean_session):
+    # Containerized backends short-circuit every guard: PIDs inside the
+    # container namespace are not the host gateway's.
+    result = check_all_command_guards(f"kill {os.getpid()}", "docker")
+    assert result["approved"] is True

--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -49,13 +49,24 @@ def _process_group_snapshot(pgid: int) -> str:
     ).stdout.strip()
 
 
-def _wait_for_pgid_exit(pgid: int, timeout: float = 60.0) -> bool:
-    """Wait for a process group to disappear under loaded xdist hosts.
+def _wait_for_pgid_exit(pgid: int, timeout: float = 8.0) -> bool:
+    """Wait (bounded) for a process group to disappear after cleanup.
 
-    The cleanup chain is: SIGTERM → 3s TimeoutStopSec → SIGKILL → reap.
-    Under heavy xdist load (40 parallel workers, 6-shard CI), the full
-    sequence can exceed 10s. Default timeout is generous to avoid CI
-    flakes; in practice the wait returns in <1s on quiet hosts.
+    Once _wait_for_process's except-block runs _kill_process, the reap chain
+    (SIGTERM → ≤1s → SIGKILL → ≤2s → wait) empties the group in ≤~3.2s
+    regardless of host load — those waits are wall-clock deadlines, not
+    work-bound (see LocalEnvironment._kill_process). On quiet hosts this
+    returns in <1s.
+
+    The timeout is deliberately SMALL. This helper is one of three sequential
+    waits in test_wait_for_process_kills_subprocess_on_keyboardinterrupt; their
+    sum must stay well under the 30s global pytest-timeout. That cap uses the
+    ``thread`` method (pyproject.toml addopts), which on expiry hard-``os._exit``s
+    the per-file interpreter — crashing the ENTIRE file ("1 file where no tests
+    ran") instead of failing one assertion. A generous timeout here is exactly
+    what used to trip that cap under xdist load and spuriously fail unrelated
+    PRs. If the group genuinely hasn't died within this budget, the caller
+    fails one assertion cleanly, with a process-table snapshot.
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -184,6 +195,16 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
         pgid = os.getpgid(target_pid)
         assert _pgid_still_alive(pgid), "sanity: subprocess should be alive"
 
+        # Settle briefly so the worker is reliably parked in _wait_for_process's
+        # interruptible poll-loop sleep before we inject. The poll loop is
+        # entered within microseconds of the spawn, but the 'sleep 30' becomes
+        # visible to our scan a hair before the worker reaches the try-guarded
+        # sleep; injecting in that sliver would deliver the async exception
+        # outside the poll loop, where _kill_process never runs — a test-harness
+        # race, not a product regression. A short settle closes it.
+        time.sleep(0.3)
+        assert _pgid_still_alive(pgid), "subprocess exited during settle"
+
         # Now inject a KeyboardInterrupt into the worker thread the same
         # way CPython's signal machinery would.  We use ctypes.PyThreadState_SetAsyncExc
         # which is how signal delivery to non-main threads is simulated.
@@ -197,12 +218,21 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
         )
         assert ret == 1, f"SetAsyncExc returned {ret}, expected 1"
 
-        # Give the worker a moment to: hit the exception at the next poll,
-        # run the except-block cleanup (_kill_process), and exit.  Under
-        # xdist load the SIGTERM → 3s wait → SIGKILL chain can take longer
-        # than 5s before the worker's join() returns; bumped to 15s.
-        t.join(timeout=30.0)
-        assert not t.is_alive(), "worker didn't exit within 30 s of the interrupt"
+        # Give the worker time to: hit the exception at the next poll, run the
+        # except-block cleanup (_kill_process → reap ≤~3.2s, then a ≤2s drain
+        # join), and re-raise. Those waits are wall-clock-bounded, so ~5.5s is
+        # the real worst case; 8s absorbs scheduling jitter under xdist load.
+        #
+        # This ceiling is deliberately part of a budget: setup (≤5s) + settle
+        # (0.3s) + join (≤8s) + _wait_for_pgid_exit (≤8s) ≈ 21s stays clear of
+        # the 30s global pytest-timeout, whose `thread` method hard-kills the
+        # whole test file on expiry (see _wait_for_pgid_exit's docstring and
+        # pyproject addopts). The old 15s+30s pair could reach ~50s under load
+        # and trip that cap — crashing the shard instead of failing one test.
+        # If the worker really hasn't exited in 8s, the assert below fails this
+        # one test cleanly.
+        t.join(timeout=8.0)
+        assert not t.is_alive(), "worker didn't exit within 8 s of the interrupt"
 
         # The critical assertion: the subprocess GROUP must be dead.  Not
         # just the bash wrapper — the 'sleep 30' child too. Under xdist load,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -522,6 +522,176 @@ def detect_hardline_command(command: str) -> tuple:
     return (False, None)
 
 
+# =========================================================================
+# Self-host kill guard — block killing the process hosting this agent
+# =========================================================================
+# An agent session runs inside a host process: the desktop dashboard /
+# gateway (in-process tui_gateway), the CLI, or a launcher's child. A
+# terminal() kill aimed at that host can never complete usefully — the turn
+# dies mid-flight, the session is orphaned (blank indicator, failed stop,
+# session-not-found on the next prompt) and in-progress work is lost.
+# Reproduced 2026-06-09 when a session cleared "stale bytecode" by killing
+# its own dashboard PID. Restarts belong to the supervisor (desktop app,
+# launchd, `hermes gateway restart`), not the hosted agent.
+#
+# Static patterns can't express "our PID", so this is a function guard like
+# the sudo-stdin one: it extracts numeric ``kill`` targets and the shell
+# self-tokens ``$$`` / ``$PPID`` and compares them against this process and
+# its parent. Three spelling classes reach the same ``kill``:
+#   1. Command-position wrappers — ``command kill``, ``builtin kill``,
+#      ``sudo``/``env``/``exec``/``nohup``/``setsid``/``time`` prefixes with
+#      optional ``--``, and chains of those — anchored via _KILL_CMDPOS.
+#   2. Shell-interpreter forms — ``bash -c "kill $$"`` hides the kill inside
+#      a quoted ``-c`` payload with no command-position separator in front of
+#      it, so the payload is pulled out and re-scanned as a standalone
+#      command (see _iter_kill_scan_targets).
+#   3. Deobfuscation variants (subshell ``(kill $$)``, split spellings) are
+#      supplied by the shared _command_detection_variants().
+# Process-group kills (negative PIDs) are intentionally out of scope here —
+# ``kill -1`` is already hardline-blocked above.
+
+# Command-position anchor for the kill guard. Broader than the shared
+# _CMDPOS: it also consumes ``--`` argument separators and the ``builtin`` /
+# ``command [-p]`` execution wrappers, because those are valid agent-reachable
+# spellings of "run kill" that the base _CMDPOS (tuned for the rm/shutdown
+# floor) does not. Kept separate so widening the kill anchor never changes the
+# blast radius of the rm/shutdown hardline patterns. ``command -v``/``-V``
+# resolve a name without running it, so only bare ``command`` and
+# ``command -p`` count as executing wrappers.
+_KILL_CMDPOS = (
+    r'(?:^|[;&|\n`]|\$\()'                      # start position
+    r'\s*'
+    r'(?:sudo\s+(?:(?:-[^\s]+|--)\s+)*)?'       # optional sudo + flags / --
+    r'(?:env\s+(?:--\s+)?(?:\w+=\S*\s+)*)?'     # optional env + VAR=VAL / --
+    r'(?:(?:exec|nohup|setsid|time|builtin|command(?:\s+-p)?)\s+(?:--\s+)?)*'  # wrapper chains
+    r'\s*'
+)
+_KILL_CMD_RE = re.compile(
+    _KILL_CMDPOS + r'kill\s+(?P<args>[^;&|`\n]*)',
+    re.IGNORECASE)
+_KILL_SELF_TOKEN_RE = re.compile(r'\$\$|\$\{?PPID\}?\b')
+
+# Shell interpreters whose ``-c <script>`` argument runs the script as a fresh
+# command. Every name here contains the substring "sh", which _extract_shell_c_scripts
+# uses as a cheap pre-filter before paying for shlex.
+_SHELL_INTERPRETERS = frozenset({
+    "sh", "bash", "dash", "ash", "ksh", "mksh", "zsh",
+})
+_KILL_SCAN_MAX_DEPTH = 4
+
+
+def _self_host_pids() -> set:
+    """PIDs whose death takes this agent session down with them."""
+    pids = {os.getpid()}
+    try:
+        parent = os.getppid()
+        if parent > 1:
+            pids.add(parent)
+    except Exception:
+        pass
+    return pids
+
+
+def _extract_shell_c_scripts(command: str) -> list:
+    """Return inner scripts from ``<shell> -c <script>`` wrappers in *command*.
+
+    Uses a POSIX tokenizer so quoting is removed (``bash -c "kill $$"`` yields
+    ``kill $$``). Handles path-qualified interpreters (``/bin/sh``), bundled
+    flags (``-lc`` / ``-xc``), and interpreters nested behind other wrappers
+    (``sudo bash -c ...``). Malformed quoting yields nothing rather than a
+    partial, misleading extraction.
+    """
+    if "sh" not in command:
+        # Every _SHELL_INTERPRETERS name contains "sh", so no interpreter token
+        # can be present without it. Skips the shlex cost for the vast majority
+        # of commands.
+        return []
+    try:
+        tokens = shlex.split(command, comments=False, posix=True)
+    except ValueError:
+        return []
+    scripts: list = []
+    for idx, tok in enumerate(tokens):
+        if tok.rsplit("/", 1)[-1] not in _SHELL_INTERPRETERS:
+            continue
+        # ``-c``'s command string is the first non-option argument (per the
+        # bash/sh contract: "commands are read from the first non-option
+        # argument"), whenever any preceding flag bundle carries a ``c``.
+        saw_c = False
+        k = idx + 1
+        while k < len(tokens):
+            arg = tokens[k]
+            if arg == "--":
+                k += 1
+                break
+            if arg.startswith("-") and arg != "-":
+                if "c" in arg.lstrip("-"):
+                    saw_c = True
+                k += 1
+                continue
+            break
+        if saw_c and k < len(tokens):
+            scripts.append(tokens[k])
+    return scripts
+
+
+def _iter_kill_scan_targets(text: str, _depth: int = 0):
+    """Yield *text* plus any recursively-extracted shell ``-c`` payloads."""
+    yield text
+    if _depth >= _KILL_SCAN_MAX_DEPTH:
+        return
+    for script in _extract_shell_c_scripts(text):
+        yield from _iter_kill_scan_targets(script, _depth + 1)
+
+
+def _check_self_host_kill(command: str) -> tuple:
+    """Detect kill commands aimed at this agent's own host process.
+
+    Returns:
+        (is_blocked: bool, description: str | None)
+    """
+    self_token_hit = False
+    target_pids: set = set()
+    # Reuse the same deobfuscation variants the hardline/dangerous detectors
+    # use (quote-aware command-start marking, per-word de-obfuscation) so
+    # subshell forms like ``(kill $$)`` and split spellings anchor too, then
+    # expand any shell ``-c`` payloads on top of each.
+    for variant in _command_detection_variants(command):
+        for text in _iter_kill_scan_targets(variant):
+            for match in _KILL_CMD_RE.finditer(text):
+                args = match.group("args") or ""
+                if _KILL_SELF_TOKEN_RE.search(args):
+                    self_token_hit = True
+                for token in args.split():
+                    if token.startswith("-"):
+                        continue  # signal flags and negative pgids — out of scope
+                    if token.isdigit():
+                        target_pids.add(int(token))
+    if not self_token_hit and not target_pids:
+        return (False, None)
+    hits = sorted(target_pids & _self_host_pids())
+    if self_token_hit or hits:
+        which = ", ".join(str(p) for p in hits) if hits else "$$/$PPID"
+        return (True, f"kill targets this agent's own host process ({which})")
+    return (False, None)
+
+
+def _self_host_kill_block_result(description: str) -> dict:
+    """Build the standard block result for the self-host kill guard."""
+    return {
+        "approved": False,
+        "hardline": True,
+        "message": (
+            f"BLOCKED: {description}. Killing the process that hosts this "
+            "agent session orphans the session mid-turn — the turn dies, "
+            "stop fails, and the next prompt returns session-not-found. "
+            "Restart the gateway from its supervisor instead (desktop "
+            "Gateway menu, `hermes gateway restart`, launchd), or run the "
+            "kill yourself in a terminal outside the agent."
+        ),
+    }
+
+
 def _match_user_deny_rule(command: str) -> str | None:
     """Return the matching ``approvals.deny`` glob, or None.
 
@@ -3370,6 +3540,19 @@ def check_all_command_guards(command: str, env_type: str,
         logger.warning("Sudo stdin guard block: %s (command: %s)",
                        sudo_guess_desc, command[:200])
         return _sudo_stdin_block_result(sudo_guess_desc)
+
+    # == Self-host kill guard ==
+    # Unconditional, like the hardline floor and sudo-stdin guard above:
+    # killing the process that hosts this agent session orphans the turn
+    # (stop fails, next prompt returns session-not-found). Fires BEFORE the
+    # yolo / mode=off / cron bypass so no session-level setting can leak it.
+    # Isolated container backends already returned above — their PIDs are in a
+    # separate namespace, not the host gateway's.
+    is_self_kill, self_kill_desc = _check_self_host_kill(command)
+    if is_self_kill:
+        logger.warning("Self-host kill guard block: %s (command: %s)",
+                       self_kill_desc, command[:200])
+        return _self_host_kill_block_result(self_kill_desc)
 
     # User-defined deny rules (approvals.deny in config.yaml): like the
     # hardline floor, these fire BEFORE the yolo / mode=off bypass — a deny


### PR DESCRIPTION
## Why
An agent session runs inside a host process — the desktop dashboard/gateway, or the CLI itself. Nothing stops a terminal() call from killing that host's PID. Reproduced on 2026-06-09: a session cleared "stale Python bytecode" by killing its own dashboard process; the turn died mid-flight, the session was orphaned (blank indicator, stop failed, session-not-found on the next prompt) and in-progress work was lost. A static blocklist pattern can't express "our own PID", so this adds a function guard alongside the existing sudo-stdin one.

## What changed
- `tools/approval.py`: `_check_self_host_kill` extracts numeric `kill` targets plus the `$$`/`$PPID` shell self-tokens and blocks when they match `os.getpid()`/`os.getppid()`. Runs in `check_all_command_guards` in the unconditional section (with hardline + sudo-stdin), so `--yolo`, `approvals.mode=off`, and cron approve mode cannot bypass it. Containerized backends keep their existing early bypass — PIDs in a container namespace are not the host's.
- Block message points at supervisor-driven restarts (`hermes gateway restart`, the desktop's Gateway menu) instead of in-session kills.
- Review follow-up (2f05e2b): `kill` is anchored at command position via the shared `_CMDPOS` fragment, whose wrapper inventory now includes `command [-p]` and `builtin` — so wrapper spellings that still execute kill (`command kill`, `builtin kill`, `sudo`/`env`/`exec`/`nohup`/`setsid`/`time` prefixes, and chains of those) hit the guard. `command -v/-V` stays unmatched (resolves a name without executing). The `_CMDPOS` extension hardens the shutdown/reboot hardline patterns the same way.
- Out of scope by design: `pkill` name matching and negative-pgid forms (`kill -1` is already on the hardline list).
- `tests/tools/test_hardline_blocklist.py`: 15 new cases (own/parent PID, `$$`/`$PPID`, chained commands, foreign-PID allow, pkill/pgid allow, end-to-end hardline shape, yolo no-bypass, container bypass).

## Verification
`tests/tools/test_hardline_blocklist.py` — 115 passed (100 pre-existing + 15 new); full approval cluster (6 files) 370 passed on this branch.

## Notes
Mirror of OmarB97/hermes-agent#128 (merged on the fork after live reproduction). Cherry-picks cleanly onto upstream main; no other files touched.

