### PR TITLE
fix(state): repair duplicate FTS schema damage

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -181,14 +181,6 @@ def _has_healthy_oauth_fallback_for_apikey_provider(provider_label: str) -> bool
 
 
 _STATE_FTS_TABLES = ("messages_fts", "messages_fts_trigram")
-_STATE_FTS_TRIGGERS = (
-    "messages_fts_insert",
-    "messages_fts_delete",
-    "messages_fts_update",
-    "messages_fts_trigram_insert",
-    "messages_fts_trigram_delete",
-    "messages_fts_trigram_update",
-)
 
 
 def _check_state_db_fts_integrity(conn) -> tuple[bool, str, bool]:
@@ -202,7 +194,12 @@ def _check_state_db_fts_integrity(conn) -> tuple[bool, str, bool]:
     try:
         rows = conn.execute("PRAGMA integrity_check").fetchall()
     except Exception as exc:
-        return False, f"integrity_check failed: {exc}", False
+        try:
+            from hermes_state import is_state_db_fts_repairable_error
+            repairable = is_state_db_fts_repairable_error(exc)
+        except Exception:
+            repairable = False
+        return False, f"integrity_check failed: {exc}", repairable
 
     problems = [
         str(row[0]) for row in rows
@@ -251,59 +248,11 @@ def _check_state_db_fts_integrity(conn) -> tuple[bool, str, bool]:
     return True, "FTS indexes healthy", False
 
 
-def _backup_state_db_for_doctor(db_path: Path) -> Path:
-    """Create a consistent sqlite backup before mutating state.db."""
-    import datetime
-    import sqlite3
-
-    backup_path = db_path.with_name(
-        f"{db_path.name}.doctor-backup-"
-        f"{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}"
-    )
-    src = sqlite3.connect(str(db_path))
-    try:
-        dst = sqlite3.connect(str(backup_path))
-        try:
-            src.backup(dst)
-        finally:
-            dst.close()
-    finally:
-        src.close()
-    return backup_path
-
-
 def _rebuild_state_db_fts_indexes(db_path: Path) -> None:
     """Rebuild derived state.db FTS5 indexes from the canonical messages table."""
-    import sqlite3
-    from hermes_state import FTS_SQL, FTS_TRIGRAM_SQL
+    from hermes_state import repair_state_db_fts_schema
 
-    conn = sqlite3.connect(str(db_path), isolation_level=None)
-    try:
-        conn.execute("BEGIN IMMEDIATE")
-        for trigger in _STATE_FTS_TRIGGERS:
-            conn.execute(f'DROP TRIGGER IF EXISTS "{trigger}"')
-        for table in _STATE_FTS_TABLES:
-            conn.execute(f'DROP TABLE IF EXISTS "{table}"')
-        conn.executescript(FTS_SQL)
-        conn.executescript(FTS_TRIGRAM_SQL)
-        backfill_sql = (
-            "SELECT id, "
-            "COALESCE(content, '') || ' ' || "
-            "COALESCE(tool_name, '') || ' ' || "
-            "COALESCE(tool_calls, '') "
-            "FROM messages"
-        )
-        conn.execute(f"INSERT INTO messages_fts(rowid, content) {backfill_sql}")
-        conn.execute(f"INSERT INTO messages_fts_trigram(rowid, content) {backfill_sql}")
-        conn.commit()
-    except BaseException:
-        try:
-            conn.rollback()
-        except Exception:
-            pass
-        raise
-    finally:
-        conn.close()
+    repair_state_db_fts_schema(db_path, backup=False)
 
 
 def check_ok(text: str, detail: str = ""):
@@ -1287,8 +1236,9 @@ def run_doctor(args):
                 )
                 if fts_repairable:
                     if should_fix:
-                        backup_path = _backup_state_db_for_doctor(state_db_path)
-                        _rebuild_state_db_fts_indexes(state_db_path)
+                        from hermes_state import repair_state_db_fts_schema
+
+                        result = repair_state_db_fts_schema(state_db_path)
                         conn = sqlite3.connect(str(state_db_path))
                         try:
                             repaired_ok, repaired_detail, _ = _check_state_db_fts_integrity(conn)
@@ -1297,7 +1247,8 @@ def run_doctor(args):
                         if repaired_ok:
                             check_ok(
                                 "Rebuilt state.db FTS indexes",
-                                f"(backup: {backup_path.name}; {repaired_detail})",
+                                f"(backup: {result.backup_path.name if result.backup_path else 'none'}; "
+                                f"{result.messages_indexed} messages indexed; {repaired_detail})",
                             )
                             fixed_count += 1
                         else:
@@ -1318,6 +1269,35 @@ def run_doctor(args):
                     )
         except Exception as e:
             check_warn(f"{_DHH}/state.db exists but has issues: {e}")
+            try:
+                from hermes_state import (
+                    is_state_db_fts_repairable_error,
+                    repair_state_db_fts_schema,
+                )
+
+                repairable_schema = is_state_db_fts_repairable_error(e)
+            except Exception:
+                repairable_schema = False
+            if repairable_schema:
+                if should_fix:
+                    try:
+                        result = repair_state_db_fts_schema(state_db_path)
+                        check_ok(
+                            "Rebuilt state.db FTS schema",
+                            f"(backup: {result.backup_path.name if result.backup_path else 'none'}; "
+                            f"{result.messages_indexed} messages indexed)",
+                        )
+                        fixed_count += 1
+                    except Exception as repair_exc:
+                        check_warn(
+                            "state.db FTS schema repair failed",
+                            f"({repair_exc})",
+                        )
+                        issues.append(
+                            "state.db FTS schema repair failed — inspect or restore from backup"
+                        )
+                else:
+                    issues.append("state.db FTS schema needs rebuild — run 'hermes doctor --fix'")
     else:
         check_info(f"{_DHH}/state.db not created yet (will be created on first session)")
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -179,6 +179,133 @@ def _has_healthy_oauth_fallback_for_apikey_provider(provider_label: str) -> bool
     return False
 
 
+
+_STATE_FTS_TABLES = ("messages_fts", "messages_fts_trigram")
+_STATE_FTS_TRIGGERS = (
+    "messages_fts_insert",
+    "messages_fts_delete",
+    "messages_fts_update",
+    "messages_fts_trigram_insert",
+    "messages_fts_trigram_delete",
+    "messages_fts_trigram_update",
+)
+
+
+def _check_state_db_fts_integrity(conn) -> tuple[bool, str, bool]:
+    """Return (ok, detail, repairable) for state.db FTS health.
+
+    The canonical transcript data lives in ``messages``. The two FTS5 tables are
+    derived indexes used by session search. SQLite can report malformed FTS5
+    inverted indexes while ordinary ``SELECT COUNT(*) FROM sessions`` still
+    succeeds, so doctor must probe the FTS layer explicitly.
+    """
+    try:
+        rows = conn.execute("PRAGMA integrity_check").fetchall()
+    except Exception as exc:
+        return False, f"integrity_check failed: {exc}", False
+
+    problems = [
+        str(row[0]) for row in rows
+        if row and str(row[0]).lower() != "ok"
+    ]
+    if problems:
+        joined = "; ".join(problems[:3])
+        repairable = any(
+            "messages_fts" in item or "fts5" in item.lower()
+            for item in problems
+        )
+        return False, joined, repairable
+
+    try:
+        message_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    except Exception as exc:
+        return False, f"messages table check failed: {exc}", False
+
+    mismatches: list[str] = []
+    for table in _STATE_FTS_TABLES:
+        exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ).fetchone()
+        if not exists:
+            mismatches.append(f"{table} missing")
+            continue
+        try:
+            fts_count = conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        except Exception as exc:
+            return False, f"{table} count failed: {exc}", True
+        if fts_count != message_count:
+            mismatches.append(f"{table} has {fts_count} rows; messages has {message_count}")
+        try:
+            # Force traversal of the FTS5 inverted index. A plain rowid scan can
+            # succeed even when the MATCH index is malformed.
+            conn.execute(
+                f'SELECT rowid FROM "{table}" WHERE "{table}" MATCH ? LIMIT 1',
+                ("the",),
+            ).fetchone()
+        except Exception as exc:
+            return False, f"{table} MATCH probe failed: {exc}", True
+
+    if mismatches:
+        return False, "; ".join(mismatches), True
+    return True, "FTS indexes healthy", False
+
+
+def _backup_state_db_for_doctor(db_path: Path) -> Path:
+    """Create a consistent sqlite backup before mutating state.db."""
+    import datetime
+    import sqlite3
+
+    backup_path = db_path.with_name(
+        f"{db_path.name}.doctor-backup-"
+        f"{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    )
+    src = sqlite3.connect(str(db_path))
+    try:
+        dst = sqlite3.connect(str(backup_path))
+        try:
+            src.backup(dst)
+        finally:
+            dst.close()
+    finally:
+        src.close()
+    return backup_path
+
+
+def _rebuild_state_db_fts_indexes(db_path: Path) -> None:
+    """Rebuild derived state.db FTS5 indexes from the canonical messages table."""
+    import sqlite3
+    from hermes_state import FTS_SQL, FTS_TRIGRAM_SQL
+
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        for trigger in _STATE_FTS_TRIGGERS:
+            conn.execute(f'DROP TRIGGER IF EXISTS "{trigger}"')
+        for table in _STATE_FTS_TABLES:
+            conn.execute(f'DROP TABLE IF EXISTS "{table}"')
+        conn.executescript(FTS_SQL)
+        conn.executescript(FTS_TRIGRAM_SQL)
+        backfill_sql = (
+            "SELECT id, "
+            "COALESCE(content, '') || ' ' || "
+            "COALESCE(tool_name, '') || ' ' || "
+            "COALESCE(tool_calls, '') "
+            "FROM messages"
+        )
+        conn.execute(f"INSERT INTO messages_fts(rowid, content) {backfill_sql}")
+        conn.execute(f"INSERT INTO messages_fts_trigram(rowid, content) {backfill_sql}")
+        conn.commit()
+    except BaseException:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        raise
+    finally:
+        conn.close()
+
+
 def check_ok(text: str, detail: str = ""):
     print(f"  {color('✓', Colors.GREEN)} {text}" + (f" {color(detail, Colors.DIM)}" if detail else ""))
 
@@ -1148,8 +1275,47 @@ def run_doctor(args):
             conn = sqlite3.connect(str(state_db_path))
             cursor = conn.execute("SELECT COUNT(*) FROM sessions")
             count = cursor.fetchone()[0]
+            fts_ok, fts_detail, fts_repairable = _check_state_db_fts_integrity(conn)
             conn.close()
-            check_ok(f"{_DHH}/state.db exists ({count} sessions)")
+            if fts_ok:
+                check_ok(f"{_DHH}/state.db exists ({count} sessions)", f"({fts_detail})")
+            else:
+                check_warn(
+                    f"{_DHH}/state.db exists ({count} sessions) "
+                    "but FTS indexes have issues",
+                    f"({fts_detail})",
+                )
+                if fts_repairable:
+                    if should_fix:
+                        backup_path = _backup_state_db_for_doctor(state_db_path)
+                        _rebuild_state_db_fts_indexes(state_db_path)
+                        conn = sqlite3.connect(str(state_db_path))
+                        try:
+                            repaired_ok, repaired_detail, _ = _check_state_db_fts_integrity(conn)
+                        finally:
+                            conn.close()
+                        if repaired_ok:
+                            check_ok(
+                                "Rebuilt state.db FTS indexes",
+                                f"(backup: {backup_path.name}; {repaired_detail})",
+                            )
+                            fixed_count += 1
+                        else:
+                            check_warn(
+                                "Rebuilt state.db FTS indexes but verification still reports issues",
+                                f"({repaired_detail}; backup: {backup_path.name})",
+                            )
+                            issues.append(
+                                "state.db FTS rebuild did not verify cleanly — "
+                                "inspect the backup and database manually"
+                            )
+                    else:
+                        issues.append("state.db FTS indexes need rebuild — run 'hermes doctor --fix'")
+                else:
+                    issues.append(
+                        "state.db integrity issue is not an FTS-only problem — "
+                        "inspect or restore from backup"
+                    )
         except Exception as e:
             check_warn(f"{_DHH}/state.db exists but has issues: {e}")
     else:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11138,7 +11138,7 @@ def main():
     # =========================================================================
     sessions_parser = subparsers.add_parser(
         "sessions",
-        help="Manage session history (list, rename, export, prune, delete)",
+        help="Manage session history (list, rename, export, prune, delete, repair)",
         description="View and manage the SQLite session store",
     )
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
@@ -11187,6 +11187,16 @@ def main():
 
     sessions_subparsers.add_parser("stats", help="Show session store statistics")
 
+    sessions_repair = sessions_subparsers.add_parser(
+        "repair",
+        help="Detect and repair state.db FTS schema/index issues",
+    )
+    sessions_repair.add_argument(
+        "--check-only",
+        action="store_true",
+        help="Check repairability without changing state.db",
+    )
+
     sessions_rename = sessions_subparsers.add_parser(
         "rename", help="Set or change a session's title"
     )
@@ -11213,6 +11223,61 @@ def main():
 
     def cmd_sessions(args):
         import json as _json
+        import sqlite3
+
+        action = args.sessions_action
+
+        if action == "repair":
+            from hermes_state import (
+                SessionDB,
+                is_state_db_fts_repairable_error,
+                repair_state_db_fts_schema,
+            )
+            from hermes_cli.doctor import _check_state_db_fts_integrity
+
+            db_path = get_hermes_home() / "state.db"
+            if not db_path.exists():
+                print("No state.db found yet.")
+                return
+            check_only = getattr(args, "check_only", False)
+
+            try:
+                with sqlite3.connect(str(db_path)) as conn:
+                    ok, detail, repairable = _check_state_db_fts_integrity(conn)
+            except Exception as e:
+                ok = False
+                detail = str(e)
+                repairable = is_state_db_fts_repairable_error(e)
+
+            if ok:
+                db = SessionDB(db_path=db_path)
+                try:
+                    print(
+                        f"state.db OK: {db.session_count()} sessions, "
+                        f"{db.message_count()} messages ({detail})"
+                    )
+                finally:
+                    db.close()
+                return
+
+            print(f"FTS issue: {detail}")
+            repairable = repairable or is_state_db_fts_repairable_error(detail)
+            if check_only:
+                if repairable:
+                    print("Repair needed; no changes made (--check-only).")
+                else:
+                    print("This does not look like a repairable FTS-only issue.")
+                return
+            if not repairable:
+                print("This does not look like a repairable FTS-only issue.")
+                return
+            result = repair_state_db_fts_schema(db_path)
+            print(
+                "Rebuilt FTS schema: "
+                f"{result.messages_indexed} messages indexed "
+                f"(backup: {result.backup_path.name if result.backup_path else 'none'})"
+            )
+            return
 
         try:
             from hermes_state import SessionDB
@@ -11221,8 +11286,6 @@ def main():
         except Exception as e:
             print(f"Error: Could not open session database: {e}")
             return
-
-        action = args.sessions_action
 
         # Hide third-party tool sessions by default, but honour explicit --source
         _source = getattr(args, "source", None)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -14,6 +14,7 @@ Key design decisions:
 - Session source tagging ('cli', 'telegram', 'discord', etc.) for filtering
 """
 
+import contextlib
 import json
 import logging
 import random
@@ -21,6 +22,7 @@ import re
 import sqlite3
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -373,6 +375,167 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON message
 END;
 """
 
+_STATE_FTS_TABLES = ("messages_fts", "messages_fts_trigram")
+
+
+@dataclass(frozen=True)
+class StateDbFtsRepairResult:
+    """Result from rebuilding state.db's derived FTS schema."""
+
+    repaired: bool
+    backup_path: Optional[Path]
+    messages_indexed: int
+    trigram_messages_indexed: int
+    detail: str = ""
+
+
+def is_state_db_fts_repairable_error(exc_or_message: object) -> bool:
+    """Return True when an error points at derived state.db FTS schema/indexes.
+
+    The canonical transcript data is stored in ``messages``. The
+    ``messages_fts*`` objects are derived indexes and can be rebuilt. This
+    intentionally does NOT claim arbitrary SQLite corruption is repairable.
+    """
+    text = str(exc_or_message).lower()
+    return "messages_fts" in text and (
+        "malformed database schema" in text
+        or "database disk image is malformed" in text
+        or "malformed inverted index" in text
+        or "fts5" in text
+    )
+
+
+def _state_db_repair_backup_path(db_path: Path) -> Path:
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    return db_path.with_name(f"{db_path.name}.fts-repair-backup-{timestamp}")
+
+
+def _backup_sqlite_db_for_fts_repair(db_path: Path) -> Path:
+    """Create a best-effort consistent backup before FTS schema repair."""
+    import shutil
+
+    backup_path = _state_db_repair_backup_path(db_path)
+    try:
+        src = sqlite3.connect(str(db_path))
+        try:
+            dst = sqlite3.connect(str(backup_path))
+            try:
+                src.backup(dst)
+            finally:
+                dst.close()
+        finally:
+            src.close()
+    except sqlite3.Error:
+        # If schema parsing is too broken for sqlite3.Connection.backup(), fall
+        # back to byte copies. Copy WAL/SHM sidecars too so committed frames are
+        # not lost in the backup of a live WAL-mode database.
+        shutil.copy2(db_path, backup_path)
+        for suffix in ("-wal", "-shm"):
+            sidecar = db_path.with_name(f"{db_path.name}{suffix}")
+            if sidecar.exists():
+                shutil.copy2(sidecar, backup_path.with_name(f"{backup_path.name}{suffix}"))
+    return backup_path
+
+
+def repair_state_db_fts_schema(
+    db_path: Path = None,
+    *,
+    backup: bool = True,
+) -> StateDbFtsRepairResult:
+    """Drop and rebuild derived state.db FTS objects from ``messages``.
+
+    This repair path is intentionally lower-level than :class:`SessionDB`:
+    errors like ``malformed database schema (messages_fts) - table
+    messages_fts already exists`` happen while SQLite parses the schema, so
+    normal ``SessionDB()`` startup, ``PRAGMA integrity_check``, and ordinary
+    SELECTs cannot even prepare.  Opening with ``PRAGMA writable_schema=ON``
+    lets us remove only the derived FTS rows, recreate the virtual tables and
+    triggers, then backfill from canonical ``messages`` rows.
+    """
+    db_path = Path(db_path or DEFAULT_DB_PATH)
+    if not db_path.exists():
+        raise FileNotFoundError(db_path)
+
+    backup_path = _backup_sqlite_db_for_fts_repair(db_path) if backup else None
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        conn.execute("PRAGMA writable_schema=ON")
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            messages_exists = conn.execute(
+                "SELECT 1 FROM sqlite_schema WHERE type='table' AND name='messages'"
+            ).fetchone()
+            if not messages_exists:
+                raise sqlite3.DatabaseError("state.db messages table not found")
+
+            for trigger in _FTS_TRIGGERS:
+                conn.execute(f'DROP TRIGGER IF EXISTS "{trigger}"')
+
+            # Drop virtual tables through SQLite when possible. With
+            # writable_schema enabled, this also works for the duplicate
+            # messages_fts schema-row failure reported by users.
+            for table_name in _STATE_FTS_TABLES:
+                try:
+                    conn.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+                except sqlite3.DatabaseError as exc:
+                    logger.warning(
+                        "state.db FTS repair: DROP TABLE %s failed, falling "
+                        "back to sqlite_schema cleanup: %s",
+                        table_name,
+                        exc,
+                    )
+
+            # Defensive cleanup for malformed/duplicate schema rows and orphaned
+            # FTS shadow rows that a failed DROP TABLE could not remove.
+            trigger_placeholders = ",".join("?" for _ in _FTS_TRIGGERS)
+            conn.execute(
+                "DELETE FROM sqlite_schema "
+                "WHERE name LIKE 'messages_fts%' "
+                f"OR name IN ({trigger_placeholders})",
+                _FTS_TRIGGERS,
+            )
+            schema_version = conn.execute("PRAGMA schema_version").fetchone()[0]
+            conn.execute(f"PRAGMA schema_version = {int(schema_version) + 1}")
+            conn.execute("PRAGMA writable_schema=OFF")
+
+            conn.executescript(FTS_SQL)
+            conn.executescript(FTS_TRIGRAM_SQL)
+            backfill_sql = (
+                "SELECT id, "
+                "COALESCE(content, '') || ' ' || "
+                "COALESCE(tool_name, '') || ' ' || "
+                "COALESCE(tool_calls, '') "
+                "FROM messages"
+            )
+            conn.execute(f"INSERT INTO messages_fts(rowid, content) {backfill_sql}")
+            conn.execute(
+                f"INSERT INTO messages_fts_trigram(rowid, content) {backfill_sql}"
+            )
+            messages_indexed = int(
+                conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
+            )
+            trigram_indexed = int(
+                conn.execute("SELECT COUNT(*) FROM messages_fts_trigram").fetchone()[0]
+            )
+            conn.commit()
+        except BaseException:
+            try:
+                conn.rollback()
+            finally:
+                with contextlib.suppress(Exception):
+                    conn.execute("PRAGMA writable_schema=OFF")
+            raise
+
+        return StateDbFtsRepairResult(
+            repaired=True,
+            backup_path=backup_path,
+            messages_indexed=messages_indexed,
+            trigram_messages_indexed=trigram_indexed,
+            detail="rebuilt messages_fts and messages_fts_trigram from messages",
+        )
+    finally:
+        conn.close()
+
 
 class SessionDB:
     """
@@ -439,10 +602,32 @@ class SessionDB:
                 isolation_level=None,
             )
             self._conn.row_factory = sqlite3.Row
-            apply_wal_with_fallback(self._conn, db_label="state.db")
-            self._conn.execute("PRAGMA foreign_keys=ON")
+            try:
+                apply_wal_with_fallback(self._conn, db_label="state.db")
+                self._conn.execute("PRAGMA foreign_keys=ON")
 
-            self._init_schema()
+                self._init_schema()
+            except sqlite3.DatabaseError as exc:
+                if not is_state_db_fts_repairable_error(exc):
+                    raise
+                logger.warning(
+                    "state.db has repairable FTS schema/index damage (%s); "
+                    "rebuilding derived FTS indexes from messages",
+                    exc,
+                )
+                with contextlib.suppress(Exception):
+                    self._conn.close()
+                repair_state_db_fts_schema(self.db_path)
+                self._conn = sqlite3.connect(
+                    str(self.db_path),
+                    check_same_thread=False,
+                    timeout=1.0,
+                    isolation_level=None,
+                )
+                self._conn.row_factory = sqlite3.Row
+                apply_wal_with_fallback(self._conn, db_label="state.db")
+                self._conn.execute("PRAGMA foreign_keys=ON")
+                self._init_schema()
         except Exception as exc:
             # Capture the cause so /resume and friends can surface WHY the
             # session DB is unavailable instead of a bare "Session database

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -71,6 +71,7 @@ AUTHOR_MAP = {
     "129007007+HeLLGURD@users.noreply.github.com": "HeLLGURD",
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "jvsantos.cunha@gmail.com": "plcunha",
     "ted.malone@outlook.com": "temalo",
     "adityamalik2833@gmail.com": "alarcritty",
     "islam666@users.noreply.github.com": "islam666",

--- a/tests/hermes_cli/test_doctor_state_db_fts.py
+++ b/tests/hermes_cli/test_doctor_state_db_fts.py
@@ -1,0 +1,69 @@
+"""Doctor checks for state.db FTS5 index health."""
+
+import sqlite3
+
+from hermes_state import SessionDB
+from hermes_cli.doctor import (
+    _check_state_db_fts_integrity,
+    _rebuild_state_db_fts_indexes,
+)
+
+
+def _seed_state_db(path):
+    db = SessionDB(path)
+    db.create_session("s1", source="cli")
+    first_id = db.append_message("s1", role="user", content="the quick brown fox")
+    db.append_message("s1", role="assistant", content="the lazy dog")
+    db.close()
+    return first_id
+
+
+def test_state_db_fts_integrity_detects_missing_index_rows(tmp_path):
+    db_path = tmp_path / "state.db"
+    first_id = _seed_state_db(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        ok, detail, repairable = _check_state_db_fts_integrity(conn)
+        assert ok is True
+        assert repairable is False
+
+        conn.execute("DELETE FROM messages_fts WHERE rowid = ?", (first_id,))
+        conn.commit()
+
+        ok, detail, repairable = _check_state_db_fts_integrity(conn)
+        assert ok is False
+        assert repairable is True
+        assert "messages_fts" in detail
+    finally:
+        conn.close()
+
+
+def test_rebuild_state_db_fts_indexes_restores_search(tmp_path):
+    db_path = tmp_path / "state.db"
+    first_id = _seed_state_db(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("DELETE FROM messages_fts WHERE rowid = ?", (first_id,))
+        conn.execute("DELETE FROM messages_fts_trigram WHERE rowid = ?", (first_id,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    _rebuild_state_db_fts_indexes(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        ok, detail, repairable = _check_state_db_fts_integrity(conn)
+        assert ok is True, detail
+        assert repairable is False
+    finally:
+        conn.close()
+
+    db = SessionDB(db_path)
+    try:
+        hits = db.search_messages("quick", limit=5)
+        assert any(hit["session_id"] == "s1" for hit in hits)
+    finally:
+        db.close()

--- a/tests/hermes_cli/test_state_db_fts_repair.py
+++ b/tests/hermes_cli/test_state_db_fts_repair.py
@@ -1,0 +1,212 @@
+"""Repair malformed state.db FTS schema rows without losing sessions."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sqlite3
+import subprocess
+import sys
+import types
+from argparse import Namespace
+from pathlib import Path
+
+import hermes_cli.doctor as doctor_mod
+from hermes_state import SessionDB, repair_state_db_fts_schema
+
+
+def _seed_state_db(db_path: Path) -> None:
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("s1", source="cli")
+        db.append_message("s1", role="user", content="the quick brown fox")
+        db.append_message("s1", role="assistant", content="the lazy dog")
+    finally:
+        db.close()
+
+
+def _inject_duplicate_messages_fts_schema_row(db_path: Path) -> None:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA writable_schema=ON")
+        conn.execute(
+            "INSERT INTO sqlite_schema(type, name, tbl_name, rootpage, sql) "
+            "VALUES ('table', 'messages_fts', 'messages_fts', 0, ?) ",
+            ("CREATE TABLE messages_fts(x)",),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _assert_duplicate_fts_schema_breaks_raw_sqlite(db_path: Path) -> None:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        try:
+            conn.execute("PRAGMA journal_mode").fetchall()
+        except sqlite3.DatabaseError as exc:
+            assert "malformed database schema" in str(exc)
+            assert "table messages_fts already exists" in str(exc)
+        else:  # pragma: no cover - defensive assertion message
+            raise AssertionError("corrupt duplicate messages_fts schema row should break SQLite prepare")
+    finally:
+        conn.close()
+
+
+def _setup_doctor_env(monkeypatch, tmp_path: Path) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+    venv_bin_dir = project / "venv" / "bin"
+    venv_bin_dir.mkdir(parents=True, exist_ok=True)
+    hermes_bin = venv_bin_dir / "hermes"
+    hermes_bin.write_text("#!/usr/bin/env python\n# entry point\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_gemini_oauth_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    try:
+        import httpx
+
+        monkeypatch.setattr(
+            httpx,
+            "get",
+            lambda *a, **kw: types.SimpleNamespace(status_code=200),
+        )
+    except Exception:
+        pass
+
+    return home
+
+
+def test_repair_state_db_fts_schema_recovers_duplicate_virtual_table_row(tmp_path):
+    db_path = tmp_path / "state.db"
+    _seed_state_db(db_path)
+    _inject_duplicate_messages_fts_schema_row(db_path)
+    _assert_duplicate_fts_schema_breaks_raw_sqlite(db_path)
+
+    result = repair_state_db_fts_schema(db_path)
+
+    assert result.repaired is True
+    assert result.messages_indexed == 2
+    assert result.trigram_messages_indexed == 2
+    assert result.backup_path is not None
+    assert result.backup_path.exists()
+
+    db = SessionDB(db_path=db_path)
+    try:
+        assert db.session_count() == 1
+        assert db.message_count() == 2
+        hits = db.search_messages("quick", limit=5)
+        assert any(hit["session_id"] == "s1" for hit in hits)
+    finally:
+        db.close()
+
+
+def test_sessiondb_auto_repairs_duplicate_fts_schema_on_startup(tmp_path):
+    db_path = tmp_path / "state.db"
+    _seed_state_db(db_path)
+    _inject_duplicate_messages_fts_schema_row(db_path)
+    _assert_duplicate_fts_schema_breaks_raw_sqlite(db_path)
+
+    db = SessionDB(db_path=db_path)
+    try:
+        assert db.session_count() == 1
+        assert db.message_count() == 2
+        hits = db.search_messages("quick", limit=5)
+        assert any(hit["session_id"] == "s1" for hit in hits)
+    finally:
+        db.close()
+
+
+def test_doctor_fix_repairs_duplicate_messages_fts_schema(monkeypatch, tmp_path):
+    home = _setup_doctor_env(monkeypatch, tmp_path)
+    db_path = home / "state.db"
+    _seed_state_db(db_path)
+    _inject_duplicate_messages_fts_schema_row(db_path)
+    _assert_duplicate_fts_schema_breaks_raw_sqlite(db_path)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=True))
+    output = buf.getvalue()
+
+    assert "Rebuilt state.db FTS schema" in output
+    assert "2 messages indexed" in output
+
+    db = SessionDB(db_path=db_path)
+    try:
+        assert db.session_count() == 1
+        assert db.message_count() == 2
+    finally:
+        db.close()
+
+
+
+def test_sessions_repair_cli_check_only_and_repair(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    db_path = home / "state.db"
+    _seed_state_db(db_path)
+    _inject_duplicate_messages_fts_schema_row(db_path)
+    _assert_duplicate_fts_schema_breaks_raw_sqlite(db_path)
+
+    repo = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = str(repo)
+
+    check = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "sessions", "repair", "--check-only"],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+    assert check.returncode == 0, check.stderr
+    assert "Repair needed; no changes made" in check.stdout
+    _assert_duplicate_fts_schema_breaks_raw_sqlite(db_path)
+
+    repair = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "sessions", "repair"],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+    assert repair.returncode == 0, repair.stderr
+    assert "Rebuilt FTS schema" in repair.stdout
+    assert "2 messages indexed" in repair.stdout
+
+    db = SessionDB(db_path=db_path)
+    try:
+        assert db.session_count() == 1
+        assert db.message_count() == 2
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
state.db can now recover when derived FTS schema damage prevents SQLite from opening the session store.

When SQLite raises `malformed database schema (messages_fts) - table messages_fts already exists`, Hermes rebuilds only the derived `messages_fts*` objects from canonical `messages` rows, preserving sessions/messages and creating a backup first.

## Changes
- `hermes_state.py`: add low-level writable-schema FTS repair helper + startup auto-repair for FTS-only damage
- `hermes_cli/doctor.py`: make `doctor --fix` route prepare-time FTS schema failures through the same repair helper
- `hermes_cli/main.py`: add `hermes sessions repair [--check-only]` for explicit operator recovery
- tests: reproduce duplicate `messages_fts` schema rows, verify `SessionDB`, `doctor --fix`, and `sessions repair` recover without losing rows
- release: add @plcunha author mapping

## Attribution
- Preserves @plcunha's original doctor repair work from PR #32589 as a cherry-picked commit.
- Supersedes PR #33869 with a narrower repair path that works before `SessionDB()` can open.

Closes #33865.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_state_db_fts_repair.py tests/hermes_cli/test_doctor_state_db_fts.py tests/hermes_cli/test_doctor_command_install.py` | 16 passed |
| E2E: corrupt state.db with duplicate `messages_fts` schema row, run `hermes sessions repair --check-only` | reports repair needed; DB remains broken/read-only check |
| E2E: same DB, run `hermes sessions repair` | rebuilds FTS schema; 1 session / 2 messages preserved; search works |
| E2E: same corruption, run `hermes doctor --fix` | rebuilds FTS schema; sessions/messages preserved |
| `python3 -m py_compile hermes_state.py hermes_cli/doctor.py hermes_cli/main.py` | pass |

## Infographic

![state.db FTS Repair](https://v3b.fal.media/files/b/0a9daa38/jO4btyR9g0tS4E2Iljqc9_0n3BoNJR.png)
