### PR TITLE
feat(delegation): add per-delegation timeout parameter to delegate_task

### DIFF
--- a/tests/tools/test_delegate_task_timeout.py
+++ b/tests/tools/test_delegate_task_timeout.py
@@ -1,0 +1,244 @@
+"""Tests for delegate_task timeout parameter (issue #42861)."""
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _resolve_task_timeout unit tests
+# ---------------------------------------------------------------------------
+
+def test_resolve_task_timeout_per_task_wins():
+    """Per-task timeout beats top-level and config default."""
+    from tools.delegate_tool import _resolve_task_timeout
+
+    task = {"goal": "test", "timeout": 120}
+    result = _resolve_task_timeout(task, top_level_timeout=300)
+    assert result == 120.0
+
+
+def test_resolve_task_timeout_top_level_fallback():
+    """Top-level timeout is used when per-task is absent."""
+    from tools.delegate_tool import _resolve_task_timeout
+
+    task = {"goal": "test"}
+    result = _resolve_task_timeout(task, top_level_timeout=300)
+    assert result == 300.0
+
+
+def test_resolve_task_timeout_none_when_unset():
+    """Returns None when neither per-task nor top-level is set."""
+    from tools.delegate_tool import _resolve_task_timeout
+
+    task = {"goal": "test"}
+    result = _resolve_task_timeout(task, top_level_timeout=None)
+    assert result is None
+
+
+def test_resolve_task_timeout_floor_30():
+    """Timeouts below 30 seconds are clamped to 30."""
+    from tools.delegate_tool import _resolve_task_timeout
+
+    task = {"goal": "test", "timeout": 5}
+    result = _resolve_task_timeout(task, top_level_timeout=None)
+    assert result == 30.0
+
+
+def test_resolve_task_timeout_top_level_floor_30():
+    """Top-level timeouts below 30 seconds are clamped to 30."""
+    from tools.delegate_tool import _resolve_task_timeout
+
+    task = {"goal": "test"}
+    result = _resolve_task_timeout(task, top_level_timeout=10)
+    assert result == 30.0
+
+
+def test_resolve_task_timeout_invalid_per_task_falls_back():
+    """Invalid per-task timeout falls back to top-level."""
+    from tools.delegate_tool import _resolve_task_timeout
+
+    task = {"goal": "test", "timeout": "not_a_number"}
+    result = _resolve_task_timeout(task, top_level_timeout=300)
+    assert result == 300.0
+
+
+def test_resolve_task_timeout_invalid_per_task_no_top_level():
+    """Invalid per-task timeout with no top-level returns None."""
+    from tools.delegate_tool import _resolve_task_timeout
+
+    task = {"goal": "test", "timeout": "bad"}
+    result = _resolve_task_timeout(task, top_level_timeout=None)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: timeout parameter flows through delegate_task
+# ---------------------------------------------------------------------------
+
+def _make_parent_agent():
+    """Create a minimal mock parent agent for delegate_task."""
+    agent = MagicMock()
+    agent._delegate_depth = 0
+    agent._current_task_id = None
+    agent._delegate_saved_tool_names = []
+    agent._delegate_spinner = None
+    agent._interrupt_requested = False
+    agent._credential_pool = None
+    return agent
+
+
+def _make_child_agent():
+    """Create a mock child agent that completes quickly."""
+    child = MagicMock()
+    child.run_conversation.return_value = {
+        "final_response": "done",
+        "messages": [],
+    }
+    child.get_activity_summary.return_value = {"api_call_count": 1}
+    child._delegate_saved_tool_names = []
+    child._delegate_role = "leaf"
+    return child
+
+
+@patch("tools.delegate_tool._get_max_spawn_depth", return_value=1)
+@patch("tools.delegate_tool._get_max_concurrent_children", return_value=3)
+@patch("tools.delegate_tool._get_child_timeout", return_value=600.0)
+@patch("tools.delegate_tool._resolve_delegation_credentials")
+@patch("tools.delegate_tool._build_child_agent")
+def test_delegate_task_single_with_timeout(
+    mock_build, mock_creds, mock_cfg_timeout, mock_max_children,
+    mock_max_depth,
+):
+    """Single-task delegation respects the timeout parameter."""
+    from tools.delegate_tool import delegate_task
+
+    child = _make_child_agent()
+    mock_build.return_value = child
+    mock_creds.return_value = {
+        "model": None, "provider": None, "base_url": None,
+        "api_key": None, "api_mode": None,
+    }
+    parent = _make_parent_agent()
+
+    with patch("tools.delegate_tool._run_single_child") as mock_run:
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "_child_role": "leaf",
+        }
+        result = delegate_task(
+            goal="test task",
+            timeout=120,
+            parent_agent=parent,
+        )
+
+    # Verify _run_single_child was called with child_timeout=120
+    mock_run.assert_called_once()
+    call_kwargs = mock_run.call_args
+    assert call_kwargs[1]["child_timeout"] == 120.0 or call_kwargs.kwargs.get("child_timeout") == 120.0
+
+
+@patch("tools.delegate_tool._get_max_spawn_depth", return_value=1)
+@patch("tools.delegate_tool._get_max_concurrent_children", return_value=3)
+@patch("tools.delegate_tool._get_child_timeout", return_value=600.0)
+@patch("tools.delegate_tool._resolve_delegation_credentials")
+@patch("tools.delegate_tool._build_child_agent")
+def test_delegate_task_single_no_timeout_uses_none(
+    mock_build, mock_creds, mock_cfg_timeout, mock_max_children,
+    mock_max_depth,
+):
+    """Single-task delegation without timeout passes None (uses config default)."""
+    from tools.delegate_tool import delegate_task
+
+    child = _make_child_agent()
+    mock_build.return_value = child
+    mock_creds.return_value = {
+        "model": None, "provider": None, "base_url": None,
+        "api_key": None, "api_mode": None,
+    }
+    parent = _make_parent_agent()
+
+    with patch("tools.delegate_tool._run_single_child") as mock_run:
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "_child_role": "leaf",
+        }
+        result = delegate_task(
+            goal="test task",
+            parent_agent=parent,
+        )
+
+    # Verify _run_single_child was called with child_timeout=None
+    mock_run.assert_called_once()
+    call_kwargs = mock_run.call_args
+    assert call_kwargs[1].get("child_timeout") is None or call_kwargs.kwargs.get("child_timeout") is None
+
+
+@patch("tools.delegate_tool._get_max_spawn_depth", return_value=1)
+@patch("tools.delegate_tool._get_max_concurrent_children", return_value=3)
+@patch("tools.delegate_tool._get_child_timeout", return_value=600.0)
+@patch("tools.delegate_tool._resolve_delegation_credentials")
+@patch("tools.delegate_tool._build_child_agent")
+def test_delegate_task_batch_per_task_timeout(
+    mock_build, mock_creds, mock_cfg_timeout, mock_max_children,
+    mock_max_depth,
+):
+    """Batch delegation respects per-task timeout overrides."""
+    from tools.delegate_tool import delegate_task
+
+    child1 = _make_child_agent()
+    child2 = _make_child_agent()
+    mock_build.side_effect = [child1, child2]
+    mock_creds.return_value = {
+        "model": None, "provider": None, "base_url": None,
+        "api_key": None, "api_mode": None,
+    }
+    parent = _make_parent_agent()
+
+    def _fake_run(task_index, goal, child, parent_agent, child_timeout=None, **kw):
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": "ok",
+            "_child_role": "leaf",
+        }
+
+    with patch("tools.delegate_tool._run_single_child", side_effect=_fake_run) as mock_run:
+        result = delegate_task(
+            tasks=[
+                {"goal": "task 1", "timeout": 180},
+                {"goal": "task 2"},
+            ],
+            timeout=300,
+            parent_agent=parent,
+        )
+
+    # Task 1 should use per-task timeout (180), task 2 should use top-level (300)
+    calls = mock_run.call_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs.get("child_timeout") == 180.0
+    assert calls[1].kwargs.get("child_timeout") == 300.0
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+def test_schema_has_timeout_property():
+    """DELEGATE_TASK_SCHEMA includes timeout at top level."""
+    from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+
+    props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+    assert "timeout" in props
+    assert props["timeout"]["type"] == "number"
+    assert "seconds" in props["timeout"]["description"].lower()
+
+
+def test_schema_task_items_have_timeout():
+    """Per-task items in schema include timeout."""
+    from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+
+    task_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+    assert "timeout" in task_props
+    assert task_props["timeout"]["type"] == "number"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1375,6 +1375,7 @@ def _run_single_child(
     goal: str,
     child=None,
     parent_agent=None,
+    child_timeout: Optional[float] = None,
     **_kwargs,
 ) -> Dict[str, Any]:
     """
@@ -1540,7 +1541,8 @@ def _run_single_child(
 
         # Run child with a hard timeout to prevent indefinite blocking
         # when the child's API call or tool-level HTTP request hangs.
-        child_timeout = _get_child_timeout()
+        # Per-delegation timeout (from delegate_task arg) beats config default.
+        child_timeout = child_timeout if child_timeout is not None else _get_child_timeout()
         _timeout_executor = ThreadPoolExecutor(
             max_workers=1,
             # Install a non-interactive approval callback in the worker thread
@@ -1967,6 +1969,28 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+def _resolve_task_timeout(task: Dict[str, Any], top_level_timeout: Optional[float]) -> Optional[float]:
+    """Resolve per-task timeout: per-task > top-level > None (use config default).
+
+    Returns the timeout in seconds, or None to let _run_single_child fall
+    through to ``_get_child_timeout()`` (which reads
+    ``delegation.child_timeout_seconds`` from config).
+    """
+    per_task = task.get("timeout")
+    if per_task is not None:
+        try:
+            return max(30.0, float(per_task))
+        except (TypeError, ValueError):
+            logger.warning(
+                "Per-task timeout=%r is not a valid number; "
+                "falling back to top-level / config default",
+                per_task,
+            )
+    if top_level_timeout is not None:
+        return max(30.0, float(top_level_timeout))
+    return None
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -1976,6 +2000,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    timeout: Optional[float] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -1989,6 +2014,10 @@ def delegate_task(
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The 'timeout' parameter overrides delegation.child_timeout_seconds
+    (default 600s / 10 minutes) for this delegation. Per-task timeout
+    beats the top-level one. Floor: 30 seconds.
 
     Returns JSON with results array, one entry per task.
     """
@@ -2144,7 +2173,8 @@ def delegate_task(
     if n_tasks == 1:
         # Single task -- run directly (no thread pool overhead)
         _i, _t, child = children[0]
-        result = _run_single_child(0, _t["goal"], child, parent_agent)
+        _task_timeout = _resolve_task_timeout(_t, timeout)
+        result = _run_single_child(0, _t["goal"], child, parent_agent, child_timeout=_task_timeout)
         results.append(result)
     else:
         # Batch -- run in parallel with per-task progress lines
@@ -2154,12 +2184,14 @@ def delegate_task(
         with ThreadPoolExecutor(max_workers=max_children) as executor:
             futures = {}
             for i, t, child in children:
+                _task_timeout = _resolve_task_timeout(t, timeout)
                 future = executor.submit(
                     _run_single_child,
                     task_index=i,
                     goal=t["goal"],
                     child=child,
                     parent_agent=parent_agent,
+                    child_timeout=_task_timeout,
                 )
                 futures[future] = i
 
@@ -2849,6 +2881,14 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "timeout": {
+                            "type": "number",
+                            "description": (
+                                "Per-task timeout override in seconds. "
+                                "Beats the top-level timeout and config default. "
+                                "Floor: 30 seconds."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -2884,6 +2924,16 @@ DELEGATE_TASK_SCHEMA = {
                     "Leave empty unless acp_command is explicitly provided."
                 ),
             },
+            "timeout": {
+                "type": "number",
+                "description": (
+                    "Override the subagent timeout in seconds for this delegation. "
+                    "Default: delegation.child_timeout_seconds from config (600s). "
+                    "Per-task timeout beats this value. Floor: 30 seconds. "
+                    "Use longer timeouts for research, multi-step analysis, or "
+                    "large file downloads."
+                ),
+            },
         },
         "required": [],
     },
@@ -2906,6 +2956,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        timeout=args.get("timeout"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## Problem

The `delegate_task` tool has a hardcoded 10-minute timeout (configurable only via `delegation.child_timeout_seconds` in config.yaml or `DELEGATION_CHILD_TIMEOUT_SECONDS` env var). Users cannot adjust the timeout per-delegation, forcing them to choose between:
- Using the global config (affects all delegations)
- Moving logic into standalone scripts (defeats the purpose of delegation)

This is particularly problematic for long-running tasks like research pipelines, large downloads, or multi-step analysis that naturally exceed 10 minutes.

Closes #42861

## Solution

Add a `timeout` parameter to `delegate_task` that supports both top-level and per-task overrides with a clear precedence chain:

**per-task timeout > top-level timeout > config default (600s)**

### Changes

- **`tools/delegate_tool.py`** (+55 lines):
  - Add `child_timeout` parameter to `_run_single_child()` 
  - Add `_resolve_task_timeout()` helper for precedence resolution
  - Add `timeout` parameter to `delegate_task()` function and schema
  - Floor of 30 seconds enforced for safety
  - Invalid per-task values fall back gracefully with a warning

- **`tests/tools/test_delegate_task_timeout.py`** (new, 12 tests):
  - Unit tests for `_resolve_task_timeout` (7 tests: precedence, floor, invalid values)
  - Integration tests for single-task and batch delegation (3 tests)
  - Schema validation tests (2 tests)

### Usage

```json
// Top-level timeout override
{"goal": "Research task", "timeout": 1800}  // 30 minutes

// Per-task timeout in batch mode
{"tasks": [
  {"goal": "Quick check", "timeout": 120},
  {"goal": "Deep analysis", "timeout": 3600}
]}
```

### Backward Compatibility

Fully backward compatible — `timeout` is optional. When not provided, behavior is identical to before (reads from `delegation.child_timeout_seconds` config).

## Test Plan

- [x] 12 new tests all passing
- [x] 156 existing delegate tests passing (1 pre-existing flaky test unrelated to changes)
- [x] Import and syntax validation
