### PR TITLE
fix(agent): use max_completion_tokens for gpt-5.x and o-series models regardless of provider path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -317,6 +317,11 @@ class _StreamErrorEvent(Exception):
         }
 
 
+# OpenAI reasoning model ids: o1, o1-mini, o3-mini, o4-mini, o5, ...
+# Trailing boundary is required so ``olmo-7b`` / ``ollama-3`` do NOT match.
+_OPENAI_REASONING_MODEL_RE = re.compile(r"^o[1-9](?:[-_.]|$)")
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -1256,7 +1261,20 @@ class AIAgent:
         'max_completion_tokens' for gpt-5.x models served via the
         OpenAI-compatible endpoint. OpenRouter, local models, and older
         OpenAI models use 'max_tokens'.
+
+        Model-name detection runs alongside the URL checks because a
+        ``custom:openai`` provider configured with
+        ``base_url: https://api.openai.com/v1`` may route through the
+        custom-provider path with ``_base_url_hostname`` unset, so the
+        URL check misses and plain ``max_tokens`` would otherwise be
+        sent to a gpt-5.x or o-series model that only accepts
+        ``max_completion_tokens`` — the server then drops the request
+        and the client sees ``[Errno 32] Broken pipe`` after retries
+        (#37151).
         """
+        model = (getattr(self, "model", "") or "").lower()
+        if model.startswith("gpt-5") or _OPENAI_REASONING_MODEL_RE.match(model):
+            return {"max_completion_tokens": value}
         if self._is_direct_openai_url() or self._is_azure_openai_url() or self._is_github_copilot_url():
             return {"max_completion_tokens": value}
         return {"max_tokens": value}

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5063,6 +5063,69 @@ class TestMaxTokensParam:
         result = agent._max_tokens_param(4096)
         assert result == {"max_completion_tokens": 4096}
 
+    def test_returns_max_completion_tokens_for_gpt_5_on_non_openai_url(self, agent):
+        """gpt-5.x needs max_completion_tokens regardless of base URL (#37151).
+
+        A ``custom:openai`` provider configured with
+        ``base_url: https://api.openai.com/v1`` may route through a path
+        where ``_base_url_hostname`` isn't set as expected, so the URL
+        check misses. Model-name detection must catch this case.
+        """
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "gpt-5.5"
+        assert agent._max_tokens_param(4096) == {"max_completion_tokens": 4096}
+
+    def test_returns_max_completion_tokens_for_gpt_5_1(self, agent):
+        """gpt-5.1 variants also need max_completion_tokens."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "gpt-5.1"
+        assert agent._max_tokens_param(4096) == {"max_completion_tokens": 4096}
+
+    def test_returns_max_completion_tokens_for_o4_mini(self, agent):
+        """OpenAI o-series reasoning models also need max_completion_tokens."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "o4-mini"
+        assert agent._max_tokens_param(4096) == {"max_completion_tokens": 4096}
+
+    def test_returns_max_completion_tokens_for_o1_and_o3(self, agent):
+        """o1 and o3 reasoning models trigger max_completion_tokens too."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        for model_name in ("o1", "o1-mini", "o3", "o3-mini"):
+            agent.model = model_name
+            assert agent._max_tokens_param(4096) == {
+                "max_completion_tokens": 4096
+            }, f"failed for {model_name}"
+
+    def test_returns_max_tokens_for_gpt_4o_on_non_openai_url(self, agent):
+        """gpt-4o on a non-OpenAI URL uses max_tokens — only gpt-5+ and
+        o-series trip the model-name override."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "gpt-4o"
+        assert agent._max_tokens_param(4096) == {"max_tokens": 4096}
+
+    def test_returns_max_tokens_for_claude(self, agent):
+        """Anthropic Claude models use max_tokens (Anthropic wire requires it)."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "claude-3-5-sonnet"
+        assert agent._max_tokens_param(4096) == {"max_tokens": 4096}
+
+    def test_o_prefix_without_digit_uses_max_tokens(self, agent):
+        """Names that happen to start with 'o' but aren't o-series must not match."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        for model_name in ("olmo-7b", "ollama-llama3", "openchat-3.5"):
+            agent.model = model_name
+            assert agent._max_tokens_param(4096) == {
+                "max_tokens": 4096
+            }, f"falsely matched o-series for {model_name}"
+
+    def test_model_name_detection_is_case_insensitive(self, agent):
+        """Mixed-case model names still trigger the gpt-5 / o-series override."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "GPT-5.5"
+        assert agent._max_tokens_param(4096) == {"max_completion_tokens": 4096}
+        agent.model = "O4-Mini"
+        assert agent._max_tokens_param(4096) == {"max_completion_tokens": 4096}
+
 
 class TestGpt5ApiModeRouting:
     """Verify provider-specific GPT-5 API-mode routing."""


### PR DESCRIPTION
## What does this PR do?

Fixes a silent failure where cron jobs and long-running sessions using a `custom:openai` provider with model `gpt-5.5` (or any other gpt-5.x / o-series model) would crash with `[Errno 32] Broken pipe` after 3 retries.

Root cause: `_max_tokens_param()` only returns `max_completion_tokens` when `_is_direct_openai_url()` passes. For `custom:openai` providers, `_base_url_hostname` is not set through the same path, so the check misses and the deprecated `max_tokens` is sent instead — which gpt-5.x and o-series models reject, causing the server to drop the connection.

Fix: add model-name detection before the URL checks so `gpt-5*` and `o[1-9]` models always use `max_completion_tokens` regardless of provider path.

## Related Issue

Closes #37151

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `run_agent.py`: Added `_OPENAI_REASONING_MODEL_RE` module-level regex constant and model-name detection at the top of `_max_tokens_param()`. Extended docstring with failure-mode explanation referencing #37151.
- `tests/run_agent/test_run_agent.py`: Added 8 new test cases to `TestMaxTokensParam` covering gpt-5.x, o-series, false-positive guards, and case-insensitive matching.

## How to Test

Configure a `custom:openai` provider pointing at `https://api.openai.com/v1` with model `gpt-5.5`, then run a cron job — previously resulted in `[Errno 32] Broken pipe` after 3 retries; after this fix the call succeeds.

Or run the unit tests directly:
```bash
scripts/run_tests.sh tests/run_agent/test_run_agent.py -- -k TestMaxTokensParam
```
Expected: **15 tests passed, 0 failed** (7 original + 8 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — extended `_max_tokens_param` docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — model-name check is platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Production failure log showing the root cause (two consecutive runs, same pattern):

```
API call failed (attempt 1/3) error_type=ReadError provider=custom model=gpt-5.5 summary=[Errno 32] Broken pipe
API call failed (attempt 2/3) error_type=ReadError provider=custom model=gpt-5.5 summary=[Errno 32] Broken pipe
API call failed (attempt 3/3) error_type=ReadError provider=custom model=gpt-5.5 summary=[Errno 32] Broken pipe
API call failed after 3 retries. [Errno 32] Broken pipe | provider=custom model=gpt-5.5 msgs=11 tokens=~22,913
```

Direct curl to the same endpoint with `max_completion_tokens` succeeded immediately, confirming the issue was the parameter name, not connectivity.