### PR TITLE
fix(desktop): force-include pinned sessions in session list via include_ids

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -382,7 +382,7 @@ export function DesktopController() {
 
       const result = await listAllProfileSessions(limit, 1, 'exclude', 'recent', sessionProfile, {
         excludeSources: SIDEBAR_EXCLUDED_SOURCES
-      })
+      }, [...$pinnedSessionIds.get()])
 
       if (refreshSessionsRequestRef.current === requestId) {
         setSessions(prev => mergeSessionPage(prev, result.sessions, sessionsToKeep()))
@@ -414,7 +414,7 @@ export function DesktopController() {
 
     const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', key, {
       excludeSources: SIDEBAR_EXCLUDED_SOURCES
-    })
+    }, [...$pinnedSessionIds.get()])
 
     const keep = sessionsToKeep(key)
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -169,7 +169,8 @@ export async function listAllProfileSessions(
   archived: 'exclude' | 'include' | 'only' = 'exclude',
   order: 'created' | 'recent' = 'recent',
   profile: 'all' | (string & {}) = 'all',
-  filter: SessionSourceFilter = {}
+  filter: SessionSourceFilter = {},
+  includeIds?: string[]
 ): Promise<PaginatedSessions> {
   const sourceParam = filter.source ? `&source=${encodeURIComponent(filter.source)}` : ''
 
@@ -177,10 +178,14 @@ export async function listAllProfileSessions(
     ? `&exclude_sources=${encodeURIComponent(filter.excludeSources.join(','))}`
     : ''
 
+  const includeParam = includeIds?.length
+    ? `&include_ids=${encodeURIComponent(includeIds.join(','))}`
+    : ''
+
   const result = await window.hermesDesktop.api<PaginatedSessions>({
     path:
       `/api/profiles/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}` +
-      `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}${sourceParam}${excludeParam}`,
+      `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}${sourceParam}${excludeParam}${includeParam}`,
     timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
   })
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1775,6 +1775,7 @@ async def get_sessions(
     order: str = "created",
     source: str = None,
     exclude_sources: str = None,
+    include_ids: str = None,
 ):
     """List sessions.
 
@@ -1810,6 +1811,7 @@ async def get_sessions(
             # uses these to split recents (exclude=cron) from the cron-jobs
             # section (source=cron) into two independent lists.
             exclude_list = [s for s in (exclude_sources or "").split(",") if s.strip()]
+            include_list = [s for s in (include_ids or "").split(",") if s.strip()] or None
             sessions = db.list_sessions_rich(
                 source=source or None,
                 exclude_sources=exclude_list or None,
@@ -1819,6 +1821,7 @@ async def get_sessions(
                 include_archived=include_archived,
                 archived_only=archived_only,
                 order_by_last_active=order == "recent",
+                include_ids=include_list,
             )
             total = db.session_count(
                 source=source or None,
@@ -1854,6 +1857,7 @@ async def get_profiles_sessions(
     profile: str = "all",
     source: str = None,
     exclude_sources: str = None,
+    include_ids: str = None,
 ):
     """Unified, read-only session list aggregated across ALL profiles.
 
@@ -1894,6 +1898,9 @@ async def get_profiles_sessions(
     # newest cron sessions can't starve the recents page.
     source_filter = source or None
     exclude_list = [s for s in (exclude_sources or "").split(",") if s.strip()]
+    # Parse include_ids: comma-separated session / lineage-root IDs that must
+    # appear in the result regardless of recency (Desktop pinned sessions).
+    include_list = [s for s in (include_ids or "").split(",") if s.strip()] or None
     # Over-fetch per profile so the merged+sorted window is correct for the
     # requested page. Capped so a huge profile can't blow up the response.
     per_profile = min(max(limit + offset, limit), 500)
@@ -1925,6 +1932,7 @@ async def get_profiles_sessions(
                 include_archived=include_archived,
                 archived_only=archived_only,
                 order_by_last_active=order == "recent",
+                include_ids=include_list,
             )
             profile_total = db.session_count(
                 source=source_filter,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from agent.memory_manager import sanitize_context
 from hermes_constants import get_hermes_home
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -1849,6 +1849,7 @@ class SessionDB:
         include_archived: bool = False,
         archived_only: bool = False,
         id_query: str = None,
+        include_ids: List[str] = None,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -1876,6 +1877,13 @@ class SessionDB:
         surfaces in the correct slot. Ordering is computed at SQL level via
         a recursive CTE that walks compression-continuation edges, so LIMIT
         and OFFSET still apply efficiently.
+
+        Pass ``include_ids`` with a list of session IDs (or lineage root IDs)
+        to force-include those conversations in the result, even if they fall
+        outside the pagination window.  Each ID is resolved to its live
+        compression tip when ``project_compression_tips`` is True.  Pinned
+        sessions in the Desktop sidebar rely on this so a pin never silently
+        vanishes when its conversation ages off the recency page.
         """
         where_clauses = []
         params = []
@@ -2077,6 +2085,54 @@ class SessionDB:
                 merged["_lineage_root_id"] = s["id"]
                 projected.append(merged)
             sessions = projected
+
+        # ── include_ids: force-include pinned / bookmarked conversations ──
+        # After the main query + compression-tip projection, resolve each
+        # requested id to its live session row and prepend it to the list if
+        # it is not already present (matched by either live id or lineage root).
+        if include_ids:
+            existing_ids: Set[str] = set()
+            for s in sessions:
+                existing_ids.add(s["id"])
+                root = s.get("_lineage_root_id")
+                if root:
+                    existing_ids.add(root)
+            extra: List[Dict[str, Any]] = []
+            for raw_id in include_ids:
+                sid = str(raw_id).strip()
+                if not sid or sid in existing_ids:
+                    continue
+                # Try as a compression tip first (most common for pinned ids
+                # stored as lineage roots).
+                tip_id = self.get_compression_tip(sid)
+                row = self._get_session_rich_row(tip_id) if tip_id else None
+                if not row:
+                    # Fall back to direct lookup.
+                    row = self._get_session_rich_row(sid)
+                if not row:
+                    continue
+                # Project the tip fields onto the root identity, matching
+                # the projection logic above.
+                if project_compression_tips and tip_id and tip_id != sid:
+                    root_row = self._get_session_rich_row(sid)
+                    if root_row:
+                        merged = dict(root_row)
+                        for key in (
+                            "id", "ended_at", "end_reason", "message_count",
+                            "tool_call_count", "title", "last_active", "preview",
+                            "model", "system_prompt", "cwd",
+                        ):
+                            if key in row:
+                                merged[key] = row[key]
+                        merged["_lineage_root_id"] = sid
+                        row = merged
+                extra.append(row)
+                existing_ids.add(row["id"])
+                root = row.get("_lineage_root_id")
+                if root:
+                    existing_ids.add(root)
+            if extra:
+                sessions = extra + sessions
 
         return sessions
 


### PR DESCRIPTION
## Problem

Pinned sessions that aged off the 50-session recency page silently vanished from the Desktop sidebar. The root cause is twofold:

1. **Initial fetch**: `refreshSessions` only loads the 50 most recent sessions from `/api/profiles/sessions`. Pinned sessions outside that window are never fetched.

2. **Merge limitation**: `mergeSessionPage()` can only preserve sessions already in the in-memory `previous` list — it cannot resurrect sessions that were never loaded. The pinned-IDs-as-keepIds mechanism inherited this limitation.

## Fix

**Backend** (`hermes_state.py`):
- Added `include_ids` parameter to `list_sessions_rich` that resolves each ID to its live compression tip (via `get_compression_tip` + `_get_session_rich_row`) and prepends it to the result, deduped by both live ID and `_lineage_root_id`.

**API** (`web_server.py`):
- Threaded `include_ids` query param through both `/api/sessions` and `/api/profiles/sessions` endpoints.

**Frontend** (`hermes.ts`, `desktop-controller.tsx`):
- `listAllProfileSessions` now accepts optional `includeIds: string[]` and appends `&include_ids=...` to the request URL.
- `refreshSessions` and `loadMoreSessionsForProfile` pass `$pinnedSessionIds` so pinned conversations are always included regardless of how long ago they were last active.

## Testing

- Verified all 8 locally pinned sessions (some as old as May 11) are now force-included in the session list response.
- Desktop app rebuilt successfully; pinned sessions appear immediately on restart.