### PR TITLE
fix(cli): warn when provider config entries shadow a built-in provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5838,6 +5838,81 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
 # Fields that look like they should be inside custom_providers, not at root
 _CUSTOM_PROVIDER_LIKE_FIELDS = {"base_url", "api_key", "rate_limit_delay", "api_mode"}
 
+# Fields that make a ``providers.<id>`` entry a *routing* definition (endpoint /
+# credentials) rather than the documented per-provider timeout tuning schema
+# (request_timeout_seconds / stale_timeout_seconds / models), which is a valid
+# use of a built-in provider's id.
+_PROVIDER_ROUTING_FIELDS = {
+    "base_url", "api", "url", "api_key", "key_env", "api_key_env",
+    "api_mode", "transport", "model", "default_model",
+}
+
+
+def find_shadowed_builtin_provider_entries(
+    config: Optional[Dict[str, Any]] = None,
+) -> List[str]:
+    """Return canonical built-in provider ids that user config tries to redefine.
+
+    ``providers.<id>`` / ``custom_providers`` entries whose name equals a
+    canonical built-in provider id are deliberately ignored by the runtime
+    (``_get_named_custom_provider`` defers to the built-in so user config
+    cannot hijack it), which means their ``base_url`` / ``api_key`` silently
+    do nothing — the built-in's default endpoint and env-var credentials are
+    used instead (GitHub #43026). This helper surfaces those entries so both
+    ``validate_config_structure`` (hermes doctor) and the runtime resolver can
+    make the ignore loud.
+
+    Alias names (``kimi`` → ``kimi-coding``) are NOT shadowing — the runtime
+    honors those as custom-provider names. Only a raw name that is itself the
+    canonical id counts.
+
+    Cost note: this scans every providers./custom_providers entry and calls
+    ``resolve_provider`` per candidate name, which is fine for the validation
+    / doctor path it serves; the runtime hot path only consults it through
+    the once-per-provider memoized warning in ``runtime_provider``.
+    """
+    if config is None:
+        try:
+            config = load_config_readonly()
+        except Exception:
+            return []
+    try:
+        from hermes_cli.auth import AuthError, resolve_provider
+    except Exception:
+        return []
+
+    def _canonical_shadow(name: str) -> Optional[str]:
+        norm = (name or "").strip().lower().replace(" ", "-")
+        if not norm or norm in {"custom", "auto"}:
+            return None
+        try:
+            canonical = resolve_provider(norm)
+        except AuthError:
+            return None
+        except Exception:
+            logger.debug("shadow check: resolve_provider(%r) failed", norm, exc_info=True)
+            return None
+        return norm if (canonical or "").strip().lower() == norm else None
+
+    shadowed: List[str] = []
+    providers = config.get("providers")
+    if isinstance(providers, dict):
+        for key, entry in providers.items():
+            if not isinstance(entry, dict) or not (_PROVIDER_ROUTING_FIELDS & set(entry.keys())):
+                continue
+            hit = _canonical_shadow(str(key))
+            if hit and hit not in shadowed:
+                shadowed.append(hit)
+    custom_providers = config.get("custom_providers")
+    if isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            hit = _canonical_shadow(str(entry.get("name", "")))
+            if hit and hit not in shadowed:
+                shadowed.append(hit)
+    return shadowed
+
 
 @dataclass
 class ConfigIssue:
@@ -5908,6 +5983,41 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                         f"custom_providers[{i}] is missing 'base_url' field",
                         "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
                     ))
+
+    # ── provider entries that shadow a built-in provider (#43026) ─────────
+    # The runtime deliberately ignores providers./custom_providers entries
+    # named after a canonical built-in provider when referenced by raw name,
+    # so their base_url/api_key silently do nothing and requests go to the
+    # built-in's default endpoint with env-var credentials — e.g.
+    # providers.gemini pointing at the OpenAI-compatible endpoint still hits
+    # the native Gemini API. Entries selected via an explicit ``custom:<name>``
+    # menu key are still honored, so only flag names the config actually
+    # routes to by raw name (model.provider / fallback_model providers).
+    referenced_providers = set()
+    _model_cfg = config.get("model")
+    if isinstance(_model_cfg, dict):
+        _p = str(_model_cfg.get("provider") or "").strip().lower().replace(" ", "-")
+        if _p:
+            referenced_providers.add(_p)
+    _fb_cfg = config.get("fallback_model")
+    _fb_entries = _fb_cfg if isinstance(_fb_cfg, list) else ([_fb_cfg] if isinstance(_fb_cfg, dict) else [])
+    for _fb_entry in _fb_entries:
+        if isinstance(_fb_entry, dict):
+            _p = str(_fb_entry.get("provider") or "").strip().lower().replace(" ", "-")
+            if _p:
+                referenced_providers.add(_p)
+    for name in find_shadowed_builtin_provider_entries(config):
+        if name not in referenced_providers:
+            continue
+        issues.append(ConfigIssue(
+            "warning",
+            f"providers/custom_providers entry '{name}' shadows the built-in '{name}' "
+            f"provider — its base_url/api_key are ignored and the built-in's default "
+            f"endpoint + environment credentials are used instead",
+            f"Rename the entry to a non-built-in name (e.g. '{name}-custom') and set "
+            f"model.provider to that name, or configure the built-in provider through "
+            f"its environment variables / 'hermes auth add {name}' and remove the entry",
+        ))
 
     # ── fallback_model: single dict OR list of dicts (chain) ─────────────
     fb = config.get("fallback_model")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1102,6 +1102,95 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
 # Fields that look like they should be inside custom_providers, not at root
 _CUSTOM_PROVIDER_LIKE_FIELDS = {"base_url", "api_key", "rate_limit_delay", "api_mode"}
 
+# Fields that make a ``providers.<id>`` entry a *routing* definition (endpoint /
+# credentials) rather than the documented per-provider timeout tuning schema
+# (request_timeout_seconds / stale_timeout_seconds / models), which is a valid
+# use of a built-in provider's id.
+_PROVIDER_ROUTING_FIELDS = {
+    "base_url", "api", "url", "api_key", "key_env", "api_key_env",
+    "api_mode", "transport", "model", "default_model",
+}
+
+
+#: Canonical built-in provider ids that are deliberately NOT keys of
+#: ``auth.PROVIDER_REGISTRY``. ``auth.py`` keeps ``openrouter`` out on purpose
+#: ("adding them here breaks runtime_provider resolution that relies on
+#: ``openrouter not in PROVIDER_REGISTRY``"), so registry membership alone
+#: would stop flagging a ``providers.openrouter`` entry that the runtime
+#: still ignores. ``custom`` is excluded by the caller instead — it is the
+#: explicit user-supplied escape hatch, not something that can be shadowed.
+_BUILTIN_PROVIDERS_OUTSIDE_REGISTRY = frozenset({"openrouter"})
+
+
+def find_shadowed_builtin_provider_entries(
+    config: Optional[Dict[str, Any]] = None,
+) -> List[str]:
+    """Return canonical built-in provider ids that user config tries to redefine.
+
+    ``providers.<id>`` / ``custom_providers`` entries whose name equals a
+    canonical built-in provider id are deliberately ignored by the runtime
+    (``runtime_provider_custom._shadowed_by_builtin`` defers to the built-in so
+    user config cannot hijack it), which means their ``base_url`` / ``api_key``
+    silently do nothing — the built-in's default endpoint and env-var
+    credentials are used instead (GitHub #43026). This helper surfaces those
+    entries so both ``validate_config_structure`` (hermes doctor) and the
+    runtime resolver can make the ignore loud.
+
+    Alias names (``kimi`` → ``kimi-coding``) are NOT shadowing — the runtime
+    honors those as custom-provider names. Only a raw name that is itself the
+    canonical id counts.
+
+    The built-in check is a static lookup against ``auth.PROVIDER_REGISTRY``
+    and must stay that way: ``resolve_provider()`` calls
+    ``validate_config_structure()`` back to build its unknown-provider hint
+    (``auth._get_config_hint_for_unknown_provider``), so asking it here closes
+    an unbounded mutual recursion (see
+    ``TestShadowCheckDoesNotReenterProviderResolution``).
+    """
+    if config is None:
+        try:
+            config = load_config_readonly()
+        except Exception:
+            return []
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+    except Exception:
+        return []
+
+    def _canonical_shadow(name: str) -> Optional[str]:
+        norm = (name or "").strip().lower().replace(" ", "-")
+        if not norm or norm in {"custom", "auto"}:
+            return None
+        if norm in _BUILTIN_PROVIDERS_OUTSIDE_REGISTRY:
+            return norm
+        entry = PROVIDER_REGISTRY.get(norm)
+        if entry is None:
+            return None
+        # Aliases are registered as extra keys pointing at the canonical
+        # entry (auth.py: "Also register aliases so resolve_provider()
+        # resolves them"), so compare against the entry's own id: only a name
+        # that IS the canonical id counts as shadowing.
+        return norm if (getattr(entry, "id", "") or "").strip().lower() == norm else None
+
+    shadowed: List[str] = []
+    providers = config.get("providers")
+    if isinstance(providers, dict):
+        for key, entry in providers.items():
+            if not isinstance(entry, dict) or not (_PROVIDER_ROUTING_FIELDS & set(entry.keys())):
+                continue
+            hit = _canonical_shadow(str(key))
+            if hit and hit not in shadowed:
+                shadowed.append(hit)
+    custom_providers = config.get("custom_providers")
+    if isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            hit = _canonical_shadow(str(entry.get("name", "")))
+            if hit and hit not in shadowed:
+                shadowed.append(hit)
+    return shadowed
+
 
 @dataclass
 class ConfigIssue:
@@ -1191,6 +1280,41 @@ def _validate_fallback_model(fb: Any, issues: List[ConfigIssue]) -> None:
                         suffix=" — fallback will be disabled")
 
 
+def _validate_shadowed_builtin_providers(config: Dict[str, Any], issues: List[ConfigIssue]) -> None:
+    """Provider entries that shadow a built-in provider (#43026).
+
+    The runtime deliberately ignores ``providers:`` / ``custom_providers:`` entries named after a
+    canonical built-in provider when they are referenced by raw name, so their base_url/api_key
+    silently do nothing and requests go to the built-in's default endpoint with env-var
+    credentials — e.g. ``providers.gemini`` pointing at the OpenAI-compatible endpoint still hits
+    the native Gemini API. Entries selected via an explicit ``custom:<name>`` menu key are still
+    honored, so only flag names the config actually routes to by raw name (``model.provider`` /
+    ``fallback_model`` providers)."""
+    referenced: Set[str] = set()
+    model_cfg = config.get("model")
+    if isinstance(model_cfg, dict):
+        name = str(model_cfg.get("provider") or "").strip().lower().replace(" ", "-")
+        if name:
+            referenced.add(name)
+    fb_cfg = config.get("fallback_model")
+    fb_entries = fb_cfg if isinstance(fb_cfg, list) else ([fb_cfg] if isinstance(fb_cfg, dict) else [])
+    for fb_entry in fb_entries:
+        if isinstance(fb_entry, dict):
+            name = str(fb_entry.get("provider") or "").strip().lower().replace(" ", "-")
+            if name:
+                referenced.add(name)
+    for name in find_shadowed_builtin_provider_entries(config):
+        if name not in referenced:
+            continue
+        _issue(issues, "warning",
+               f"providers/custom_providers entry '{name}' shadows the built-in '{name}' "
+               f"provider — its base_url/api_key are ignored and the built-in's default "
+               f"endpoint + environment credentials are used instead",
+               f"Rename the entry to a non-built-in name (e.g. '{name}-custom') and set "
+               f"model.provider to that name, or configure the built-in provider through "
+               f"its environment variables / 'hermes auth add {name}' and remove the entry")
+
+
 def _validate_web_backends(config: Dict[str, Any], issues: List[ConfigIssue]) -> None:
     """A stale web backend selection otherwise fails only at the first web_search/web_extract
     call with a generic "no registered provider" error; warn at startup instead."""
@@ -1253,6 +1377,7 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                    f"Move '{key}' under the appropriate section")
 
     _validate_web_backends(config, issues)
+    _validate_shadowed_builtin_providers(config, issues)
     return issues
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -629,6 +629,42 @@ def _lift_extra_headers(entry: Dict[str, Any], result: Dict[str, Any]) -> None:
     if extra_headers:
         result["extra_headers"] = extra_headers
 
+# Provider names already checked for built-in shadowing this process — the
+# warning below fires at most once per provider so per-turn resolution doesn't
+# spam the log.
+_shadow_warned_providers: set = set()
+
+
+def _warn_once_if_user_entry_shadowed(provider_norm: str) -> None:
+    """Warn when config defines a provider entry that a built-in shadows (#43026).
+
+    ``providers.gemini: {base_url: …/openai, api_key: …}`` is silently ignored
+    because ``gemini`` is a canonical built-in — requests then go to the
+    built-in's default endpoint with env-var credentials, which looks like an
+    auth bug on the user's endpoint. Make the ignore loud.
+    """
+    if provider_norm in _shadow_warned_providers:
+        return
+    _shadow_warned_providers.add(provider_norm)
+    try:
+        from hermes_cli.config import find_shadowed_builtin_provider_entries
+
+        shadowed = find_shadowed_builtin_provider_entries()
+    except Exception:
+        return
+    if provider_norm not in shadowed:
+        return
+    logger.warning(
+        "config.yaml defines a providers/custom_providers entry named '%s', but "
+        "'%s' is a built-in provider — the entry's base_url/api_key are ignored "
+        "and the built-in's default endpoint + environment credentials are used "
+        "instead. Rename the entry to a non-built-in name (and set model.provider "
+        "to it), or configure the built-in via its env vars. "
+        "Run 'hermes doctor' for details.",
+        provider_norm,
+        provider_norm,
+    )
+
 
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
@@ -667,6 +703,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # the built-in. See tests/hermes_cli/test_runtime_provider_resolution.py
             # ``test_named_custom_provider_does_not_shadow_builtin_provider``.
             if (canonical or "").strip().lower() == requested_norm:
+                _warn_once_if_user_entry_shadowed(requested_norm)
                 return None
 
     config = load_config()

--- a/hermes_cli/runtime_provider_custom.py
+++ b/hermes_cli/runtime_provider_custom.py
@@ -117,6 +117,46 @@ def _shadowed_by_builtin(requested_norm: str) -> bool:
     return (canonical or "").strip().lower() == requested_norm
 
 
+# Provider names already checked for built-in shadowing this process — the warning below fires at
+# most once per provider so per-turn resolution doesn't spam the log.
+_shadow_warned_providers: set = set()
+
+
+def _warn_once_if_user_entry_shadowed(provider_norm: str) -> None:
+    """Warn when config defines a provider entry that a built-in shadows (#43026).
+
+    ``providers.gemini: {base_url: …/openai, api_key: …}`` is silently ignored because ``gemini``
+    is a canonical built-in — requests then go to the built-in's default endpoint with env-var
+    credentials, which looks like an auth bug on the user's endpoint. Make the ignore loud.
+
+    The config lookup is deliberately the STATIC ``PROVIDER_REGISTRY`` scan in
+    ``config.find_shadowed_builtin_provider_entries`` and not ``auth.resolve_provider``: an unknown
+    provider sends ``resolve_provider`` into ``validate_config_structure``, so a dynamic check here
+    would close a mutual-recursion loop.
+    """
+    if provider_norm in _shadow_warned_providers:
+        return
+    _shadow_warned_providers.add(provider_norm)
+    try:
+        from hermes_cli.config import find_shadowed_builtin_provider_entries
+
+        shadowed = find_shadowed_builtin_provider_entries()
+    except Exception:
+        return
+    if provider_norm not in shadowed:
+        return
+    logger.warning(
+        "config.yaml defines a providers/custom_providers entry named '%s', but "
+        "'%s' is a built-in provider — the entry's base_url/api_key are ignored "
+        "and the built-in's default endpoint + environment credentials are used "
+        "instead. Rename the entry to a non-built-in name (and set model.provider "
+        "to it), or configure the built-in via its env vars. "
+        "Run 'hermes doctor' for details.",
+        provider_norm,
+        provider_norm,
+    )
+
+
 def _match_new_style_provider(requested_norm: str, providers: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Scan ``providers:`` (new-style, keyed) for ``requested_norm``."""
     from hermes_cli.config import is_provider_enabled
@@ -171,7 +211,10 @@ def _match_legacy_custom_provider(requested_norm: str, custom_providers) -> Opti
 
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
-    if not requested_norm or requested_norm == "auto" or _shadowed_by_builtin(requested_norm):
+    if not requested_norm or requested_norm == "auto":
+        return None
+    if _shadowed_by_builtin(requested_norm):
+        _warn_once_if_user_entry_shadowed(requested_norm)
         return None
     rp = _rp()
     config = rp.load_config()

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -262,3 +262,84 @@ class TestUnknownTopLevelKeys:
             "model": {"provider": "openrouter"},
         })
         assert issues == []
+
+
+class TestShadowedBuiltinProviderEntries:
+    """providers./custom_providers entries named after canonical built-in
+    providers are ignored by the runtime (their base_url/api_key silently do
+    nothing) — validate_config_structure must flag them (GitHub #43026)."""
+
+    def test_providers_routing_entry_shadowing_builtin_warns(self):
+        """The exact #43026 scenario — providers.gemini pointing at the
+        OpenAI-compatible endpoint still hits the native Gemini API."""
+        issues = validate_config_structure({
+            "providers": {
+                "gemini": {
+                    "api_key": "AIzaSy-test",
+                    "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+                }
+            },
+            "model": {"provider": "gemini", "default": "gemini-2.5-flash"},
+        })
+        warnings = [i for i in issues if i.severity == "warning" and "shadows" in i.message]
+        assert len(warnings) == 1
+        assert "gemini" in warnings[0].message
+        assert "Rename" in warnings[0].hint
+
+    def test_providers_timeout_only_entry_is_not_flagged(self):
+        """Per-provider timeout tuning under a built-in id is the documented
+        providers: schema (cli-config.yaml.example), not endpoint shadowing."""
+        issues = validate_config_structure({
+            "providers": {
+                "anthropic": {
+                    "request_timeout_seconds": 30,
+                    "models": {"claude-opus-4.6": {"timeout_seconds": 600}},
+                }
+            },
+            "model": {"provider": "anthropic", "default": "claude-opus-4.6"},
+        })
+        assert not [i for i in issues if "shadows" in i.message]
+
+    def test_non_builtin_provider_name_is_not_flagged(self):
+        issues = validate_config_structure({
+            "providers": {
+                "gemini-oai": {
+                    "key_env": "GEMINI_API_KEY",
+                    "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+                }
+            },
+            "model": {"provider": "gemini-oai", "default": "gemini-2.5-flash"},
+        })
+        assert not [i for i in issues if "shadows" in i.message]
+
+    def test_custom_providers_entry_shadowing_builtin_warns(self):
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "nous", "base_url": "http://localhost:1234/v1", "api_key": "k"}
+            ],
+            "model": {"provider": "nous", "default": "test"},
+        })
+        assert [i for i in issues if "shadows" in i.message and "nous" in i.message]
+
+    def test_unreferenced_shadow_named_entry_is_not_flagged(self):
+        """An entry named after a built-in but selected via the explicit
+        ``custom:<name>`` menu key (model.provider stays ``custom``) is still
+        honored by the runtime — don't warn about it."""
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "gemini", "base_url": "https://example.com/v1"},
+            ],
+            "model": {"provider": "custom", "default": "test"},
+        })
+        assert not [i for i in issues if "shadows" in i.message]
+
+    def test_alias_name_is_not_flagged(self):
+        """Alias names (kimi -> kimi-coding) are honored as custom-provider
+        names by the runtime (#15743) — they are not shadowing."""
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "kimi", "base_url": "https://my-kimi.example.com/v1", "api_key": "k"}
+            ],
+            "model": {"provider": "kimi", "default": "test"},
+        })
+        assert not [i for i in issues if "shadows" in i.message]

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -141,3 +141,164 @@ class TestUnknownTopLevelKeys:
         assert any("base_url" in i.message for i in misplaced)
         assert any("api_key" in i.message for i in misplaced)
 
+
+
+
+class TestShadowedBuiltinProviderEntries:
+    """providers./custom_providers entries named after canonical built-in
+    providers are ignored by the runtime (their base_url/api_key silently do
+    nothing) — validate_config_structure must flag them (GitHub #43026)."""
+
+    def test_providers_routing_entry_shadowing_builtin_warns(self):
+        """The exact #43026 scenario — providers.gemini pointing at the
+        OpenAI-compatible endpoint still hits the native Gemini API."""
+        issues = validate_config_structure({
+            "providers": {
+                "gemini": {
+                    "api_key": "AIzaSy-test",
+                    "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+                }
+            },
+            "model": {"provider": "gemini", "default": "gemini-2.5-flash"},
+        })
+        warnings = [i for i in issues if i.severity == "warning" and "shadows" in i.message]
+        assert len(warnings) == 1
+        assert "gemini" in warnings[0].message
+        assert "Rename" in warnings[0].hint
+
+    def test_providers_timeout_only_entry_is_not_flagged(self):
+        """Per-provider timeout tuning under a built-in id is the documented
+        providers: schema (cli-config.yaml.example), not endpoint shadowing."""
+        issues = validate_config_structure({
+            "providers": {
+                "anthropic": {
+                    "request_timeout_seconds": 30,
+                    "models": {"claude-opus-4.6": {"timeout_seconds": 600}},
+                }
+            },
+            "model": {"provider": "anthropic", "default": "claude-opus-4.6"},
+        })
+        assert not [i for i in issues if "shadows" in i.message]
+
+    def test_non_builtin_provider_name_is_not_flagged(self):
+        issues = validate_config_structure({
+            "providers": {
+                "gemini-oai": {
+                    "key_env": "GEMINI_API_KEY",
+                    "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+                }
+            },
+            "model": {"provider": "gemini-oai", "default": "gemini-2.5-flash"},
+        })
+        assert not [i for i in issues if "shadows" in i.message]
+
+    def test_custom_providers_entry_shadowing_builtin_warns(self):
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "nous", "base_url": "http://localhost:1234/v1", "api_key": "k"}
+            ],
+            "model": {"provider": "nous", "default": "test"},
+        })
+        assert [i for i in issues if "shadows" in i.message and "nous" in i.message]
+
+    def test_unreferenced_shadow_named_entry_is_not_flagged(self):
+        """An entry named after a built-in but selected via the explicit
+        ``custom:<name>`` menu key (model.provider stays ``custom``) is still
+        honored by the runtime — don't warn about it."""
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "gemini", "base_url": "https://example.com/v1"},
+            ],
+            "model": {"provider": "custom", "default": "test"},
+        })
+        assert not [i for i in issues if "shadows" in i.message]
+
+    def test_alias_name_is_not_flagged(self):
+        """Alias names (kimi -> kimi-coding) are honored as custom-provider
+        names by the runtime (#15743) — they are not shadowing."""
+        issues = validate_config_structure({
+            "custom_providers": [
+                {"name": "kimi", "base_url": "https://my-kimi.example.com/v1", "api_key": "k"}
+            ],
+            "model": {"provider": "kimi", "default": "test"},
+        })
+        assert not [i for i in issues if "shadows" in i.message]
+
+
+class TestShadowCheckDoesNotReenterProviderResolution:
+    """The shadow check must decide "is this a built-in id?" statically.
+
+    ``auth.resolve_provider()`` already calls back into
+    ``validate_config_structure()`` to build its unknown-provider hint
+    (``_get_config_hint_for_unknown_provider``, upstream since dce5f51c7c,
+    2026-04-05). So a shadow check that asks ``resolve_provider`` closes an
+    unbounded mutual recursion:
+
+        resolve_provider -> _get_config_hint_for_unknown_provider
+          -> validate_config_structure -> find_shadowed_builtin_provider_entries
+            -> resolve_provider -> ...
+
+    Each lap re-reads and deep-copies the config, so it does not fail fast —
+    it burns CPU until the CI per-file timeout SIGKILLs the process
+    (tests/hermes_cli/test_aux_picker_inventory.py, 300s exceeded). These
+    tests pin the seam rather than the symptom: they fail immediately instead
+    of hanging the suite.
+    """
+
+    def test_shadow_scan_never_calls_resolve_provider(self, monkeypatch):
+        """The edge that closes the cycle must not exist."""
+        import hermes_cli.auth as auth
+        from hermes_cli.config import find_shadowed_builtin_provider_entries
+
+        class _Tripwire(BaseException):
+            """Not an ``Exception`` on purpose.
+
+            ``_canonical_shadow`` wraps its provider lookup in a broad
+            ``except Exception``, which would swallow a plain assertion and
+            make this test pass against the very code it is meant to catch.
+            """
+
+        def _boom(*args, **kwargs):
+            raise _Tripwire
+
+        monkeypatch.setattr(auth, "resolve_provider", _boom)
+
+        try:
+            find_shadowed_builtin_provider_entries({
+                "providers": {
+                    "gemini": {"base_url": "https://example.com/v1", "api_key": "k"},
+                    "my-llm": {"base_url": "https://myllm.example.com/v1"},
+                },
+                "custom_providers": [{"name": "Legacy Box", "base_url": "https://x/v1"}],
+                "model": {"provider": "gemini", "default": "m"},
+            })
+        except _Tripwire:
+            raise AssertionError(
+                "find_shadowed_builtin_provider_entries() called "
+                "auth.resolve_provider(); resolve_provider() calls "
+                "validate_config_structure() back, so this edge closes an "
+                "unbounded recursion"
+            )
+
+    def test_static_scan_keeps_the_original_verdicts(self):
+        """Same answers as the resolve_provider-based scan it replaces."""
+        from hermes_cli.config import find_shadowed_builtin_provider_entries
+
+        found = find_shadowed_builtin_provider_entries({
+            "providers": {
+                "gemini": {"base_url": "https://example.com/v1"},
+                "openrouter": {"base_url": "https://example.com/v1"},
+                "my-llm": {"base_url": "https://myllm.example.com/v1"},
+                "kimi": {"base_url": "https://my-kimi.example.com/v1"},
+            },
+            "model": {"provider": "gemini", "default": "m"},
+        })
+
+        assert "gemini" in found, "canonical built-in id is shadowing"
+        assert "openrouter" in found, (
+            "openrouter is a real built-in that is deliberately kept OUT of "
+            "PROVIDER_REGISTRY (auth.py: 'openrouter not in PROVIDER_REGISTRY'), "
+            "so a registry-membership test alone would silently stop flagging it"
+        )
+        assert "my-llm" not in found, "a user's own provider id is not shadowing"
+        assert "kimi" not in found, "an alias (kimi -> kimi-coding) is not shadowing"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3439,3 +3439,46 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     assert resolved["source"] == "pool:lmstudio-pool"
     assert resolved["provider"] == "custom"
     assert resolved["requested_provider"] == "custom:lmstudio"
+
+
+def test_shadowed_builtin_provider_entry_warns_once(monkeypatch, caplog):
+    """GitHub #43026: a ``providers.gemini`` routing entry is ignored because
+    ``gemini`` is a canonical built-in — the ignore must be loud, not silent,
+    and must fire at most once per provider per process."""
+    import logging
+
+    import hermes_cli.config as cfg
+
+    shadow_config = {
+        "providers": {
+            "gemini": {
+                "api_key": "AIzaSy-test",
+                "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+            }
+        }
+    }
+    monkeypatch.setattr(cfg, "load_config_readonly", lambda: shadow_config)
+    monkeypatch.setattr(rp, "_shadow_warned_providers", set())
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.runtime_provider"):
+        assert rp._get_named_custom_provider("gemini") is None
+        assert rp._get_named_custom_provider("gemini") is None
+
+    warnings = [r for r in caplog.records if "built-in provider" in r.getMessage()]
+    assert len(warnings) == 1, [r.getMessage() for r in caplog.records]
+    assert "gemini" in warnings[0].getMessage()
+
+
+def test_builtin_provider_without_user_entry_does_not_warn(monkeypatch, caplog):
+    """No providers./custom_providers entry for the built-in -> no warning."""
+    import logging
+
+    import hermes_cli.config as cfg
+
+    monkeypatch.setattr(cfg, "load_config_readonly", lambda: {})
+    monkeypatch.setattr(rp, "_shadow_warned_providers", set())
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.runtime_provider"):
+        assert rp._get_named_custom_provider("gemini") is None
+
+    assert not [r for r in caplog.records if "built-in provider" in r.getMessage()]

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1,5 +1,7 @@
 import base64
+import contextlib
 import json
+import logging
 import time
 from types import SimpleNamespace
 
@@ -1783,3 +1785,83 @@ def test_custom_provider_pool_target_model_wins(monkeypatch):
 
     assert resolved is not None
     assert resolved["model"] == "myproxy/gemini-flash"
+
+
+class _WarningCapture(logging.Handler):
+    """Capture ``hermes_cli.runtime_provider`` warnings via a handler on the logger itself.
+
+    ``caplog`` attaches to the ROOT logger and relies on propagation plus the process-wide
+    ``logging.disable`` level, both of which an earlier test in the same session can leave
+    changed (``hermes_cli/oneshot.py`` calls ``logging.disable(logging.CRITICAL)`` and never
+    restores it). Recording at the source keeps this test about the warning, not about suite
+    ordering."""
+
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.messages: list = []
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
+
+
+@contextlib.contextmanager
+def _captured_provider_warnings():
+    log = logging.getLogger("hermes_cli.runtime_provider")
+    handler = _WarningCapture()
+    prior_level, prior_disabled = log.level, log.disabled
+    prior_global_disable = logging.root.manager.disable
+    log.addHandler(handler)
+    log.setLevel(logging.WARNING)
+    log.disabled = False
+    logging.disable(logging.NOTSET)
+    try:
+        yield handler.messages
+    finally:
+        logging.disable(prior_global_disable)
+        log.removeHandler(handler)
+        log.setLevel(prior_level)
+        log.disabled = prior_disabled
+
+
+def test_shadowed_builtin_provider_entry_warns_once(monkeypatch):
+    """GitHub #43026: a ``providers.gemini`` routing entry is ignored because
+    ``gemini`` is a canonical built-in — the ignore must be loud, not silent,
+    and must fire at most once per provider per process."""
+    import hermes_cli.config as cfg
+    import hermes_cli.runtime_provider_custom as rpc
+
+    shadow_config = {
+        "providers": {
+            "gemini": {
+                "api_key": "AIzaSy-test",
+                "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+            }
+        }
+    }
+    monkeypatch.setattr(cfg, "load_config_readonly", lambda: shadow_config)
+    monkeypatch.setattr(rpc, "_shadow_warned_providers", set())
+
+    # Call through the owning module, not the ``runtime_provider`` re-export: other tests in the
+    # suite re-import ``runtime_provider_custom``, which leaves the re-exported function bound to
+    # a previous module incarnation whose (already-primed) warn-once cache this test cannot reset.
+    with _captured_provider_warnings() as messages:
+        assert rpc._get_named_custom_provider("gemini") is None
+        assert rpc._get_named_custom_provider("gemini") is None
+
+    warnings = [m for m in messages if "built-in provider" in m]
+    assert len(warnings) == 1, messages
+    assert "gemini" in warnings[0]
+
+
+def test_builtin_provider_without_user_entry_does_not_warn(monkeypatch):
+    """No providers./custom_providers entry for the built-in -> no warning."""
+    import hermes_cli.config as cfg
+    import hermes_cli.runtime_provider_custom as rpc
+
+    monkeypatch.setattr(cfg, "load_config_readonly", lambda: {})
+    monkeypatch.setattr(rpc, "_shadow_warned_providers", set())
+
+    with _captured_provider_warnings() as messages:
+        assert rpc._get_named_custom_provider("gemini") is None
+
+    assert not [m for m in messages if "built-in provider" in m]


### PR DESCRIPTION
## What does this PR do?

Makes a silent config trap loud. `providers.<id>` / `custom_providers` entries named after a canonical built-in provider are deliberately ignored when referenced by raw name (`_get_named_custom_provider` defers to the built-in so user config can't hijack it). That behaviour is today neither announced nor tested: the pin that used to cover it, `test_named_custom_provider_does_not_shadow_builtin_provider`, was removed in the upstream test-prune wave. The ignore is also completely silent: in #43026 a `providers.gemini` entry pointing at the OpenAI-compatible endpoint was dropped, requests went to the **native** Gemini API with env-var credentials instead, and the user saw a baffling `Gemini HTTP 400 (INVALID_ARGUMENT): API key not valid` even though the same key + endpoint worked via curl.

This PR keeps the shadowing semantics exactly as designed and adds diagnostics in the two places that can catch it:

1. **Resolve time** — `_get_named_custom_provider` logs a warning (once per provider per process) when the built-in guard drops a user-defined entry, with rename / env-var guidance.
2. **Config validation** — `validate_config_structure` flags shadowed entries, so `hermes doctor`, the model-switch flow, and auth flows all surface it. Only entries the config actually routes to by raw name (`model.provider` / `fallback_model` providers) are flagged — entries selected via an explicit `custom:<name>` menu key are still honored by the runtime and stay unflagged. Per-provider timeout tuning under a built-in id (the documented `providers:` schema in `cli-config.yaml.example`) is not routing config and is never flagged.

**Known scope limit:** the validation check harvests raw-name references from `model.provider` and `fallback_model` only; other routing surfaces (e.g. `model_aliases`, auxiliary model chains) aren't scanned there. Those cases are still covered by the resolve-time warning — they degrade from "silent" to "loud at first request" rather than "flagged by doctor", which is the intended split for a focused diagnostics fix.

## Related Issue

Fixes #43026

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — new `find_shadowed_builtin_provider_entries()` helper (shared by both call sites; skips timeout-only entries via a routing-fields check) + a referenced-only shadow check in `validate_config_structure`
- `hermes_cli/runtime_provider_custom.py` — `_warn_once_if_user_entry_shadowed()` called from the `True` path of the built-in guard `_shadowed_by_builtin` (~`runtime_provider_custom.py:103`), the single choke point used by `_get_named_custom_provider`
- `tests/hermes_cli/test_config_validation.py` — new `TestShadowedBuiltinProviderEntries` (6 cases: the exact #43026 scenario, timeout-only entry, non-built-in name, custom_providers shadow, picker-selected `custom:<name>` entry not flagged, alias name like `kimi` not flagged per #15743)
- `tests/hermes_cli/test_runtime_provider_resolution.py` — warn-once test + no-entry-no-warning test

## How to Test

1. Put the #43026 config in `~/.hermes/config.yaml`: `providers.gemini` with `base_url: https://generativelanguage.googleapis.com/v1beta/openai` + an `api_key`, and `model.provider: gemini`.
2. Run `hermes doctor` → the config section now shows the shadow warning with rename/`hermes auth add gemini` guidance (previously: nothing).
3. Run any chat command → the log shows one `runtime_provider` warning explaining the entry is ignored (previously: silent, then `Gemini HTTP 400` from the native API).
4. `python -m pytest tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_runtime_provider_resolution.py -q` → 86 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: `tests/hermes_cli/test_config_validation.py`, `test_runtime_provider_resolution.py` — 86 passed; plus `pytest tests/hermes_cli/ -k "config or provider or auth"`, which shows the same failure set as clean `main` and +10 passing new tests)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the new helper; no user-facing docs describe the shadowing behavior to update
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python logic, no platform APIs; `scripts/check-windows-footguns.py` clean on the 4 changed files
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

With the exact config from #43026:

```
--- hermes doctor (validate_config_structure) ---
[warning] providers/custom_providers entry 'gemini' shadows the built-in 'gemini' provider — its base_url/api_key are ignored and the built-in's default endpoint + environment credentials are used instead
  hint: Rename the entry to a non-built-in name (e.g. 'gemini-custom') and set model.provider to that name, or configure the built-in provider through its environment variables / 'hermes auth add gemini' and remove the entry

--- runtime resolution (once per provider per process) ---
WARNING hermes_cli.runtime_provider: config.yaml defines a providers/custom_providers entry named 'gemini', but 'gemini' is a built-in provider — the entry's base_url/api_key are ignored and the built-in's default endpoint + environment credentials are used instead. Rename the entry to a non-built-in name (and set model.provider to it), or configure the built-in via its env vars. Run 'hermes doctor' for details.
```

