### PR TITLE
fix(gateway): recover unloaded launchd job during update

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15738,7 +15738,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 )
             except Exception as _e:
                 logger.debug("spawn_async_diagnostic failed: %s", _e)
-        asyncio.create_task(runner.stop())
+        # A planned --replace takeover is operationally a restart from the
+        # user's perspective: another gateway process is already waiting to
+        # come online. Drive the restart stop path so shutdown/startup
+        # lifecycle notifications keep their historical "restarting" / "back
+        # online" semantics and the successor sees .restart_pending.json.
+        asyncio.create_task(runner.stop(restart=planned_takeover))
 
     def restart_signal_handler():
         runner.request_restart(detached=False, via_service=True)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9086,25 +9086,36 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 try:
                     from hermes_cli.gateway import (
                         launchd_restart,
+                        launchd_start,
                         get_launchd_label,
                         get_launchd_plist_path,
                     )
 
                     plist_path = get_launchd_plist_path()
                     if plist_path.exists():
+                        label = get_launchd_label()
                         check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
+                            ["launchctl", "list", label],
                             capture_output=True,
                             text=True,
                             timeout=5,
                         )
-                        if check.returncode == 0:
-                            try:
+                        try:
+                            if check.returncode == 0:
                                 launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
+                            else:
+                                # macOS edge case: a previous stop/update can leave
+                                # the LaunchAgent plist installed but the job
+                                # unloaded. `RunAtLoad` only helps at login; during
+                                # `hermes update --gateway` we must bootstrap it
+                                # explicitly or Telegram/cron stay offline until a
+                                # manual `hermes gateway start`.
+                                print("  ↻ Gateway launchd job is unloaded — starting it")
+                                launchd_start()
+                            restarted_services.append(label)
+                        except subprocess.CalledProcessError as e:
+                            stderr = (getattr(e, "stderr", "") or "").strip()
+                            print(f"  ⚠ Gateway restart failed: {stderr}")
                 except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
                     pass
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -330,6 +330,40 @@ class TestCmdUpdateBranchFallback:
             assert "applying safe config migrations" in captured.out
             assert "API keys require manual entry" in captured.out
 
+    def test_gateway_update_starts_installed_but_unloaded_launchd_job(
+        self, mock_args, tmp_path, capsys
+    ):
+        """macOS gateway updates must recover when the LaunchAgent is installed but unloaded."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        started = []
+
+        def fake_run(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if joined == "launchctl list ai.hermes.gateway":
+                return subprocess.CompletedProcess(cmd, 3, stdout="", stderr="not loaded")
+            return _make_run_side_effect(
+                branch="main", verify_ok=True, commit_count="1"
+            )(cmd, **kwargs)
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("subprocess.run", side_effect=fake_run),
+            patch("hermes_cli.gateway.supports_systemd_services", return_value=False),
+            patch("hermes_cli.gateway.is_macos", return_value=True),
+            patch("hermes_cli.gateway.get_launchd_label", return_value="ai.hermes.gateway"),
+            patch("hermes_cli.gateway.get_launchd_plist_path", return_value=plist_path),
+            patch("hermes_cli.gateway.launchd_start", side_effect=lambda: started.append(True)),
+            patch("hermes_cli.gateway.launchd_restart") as restart_mock,
+        ):
+            cmd_update(mock_args)
+
+        assert started == [True]
+        restart_mock.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Gateway launchd job is unloaded" in out
+        assert "Restarted ai.hermes.gateway" in out
+
 
 class TestCmdUpdateMigrationPrompt:
     """The config-migration prompt names what changed and skips the prompt


### PR DESCRIPTION
## Summary

- treat planned gateway `--replace` takeovers as restart stops so restart lifecycle markers/notifications are preserved
- recover `hermes update` on macOS when the LaunchAgent plist exists but the launchd job is currently unloaded
- add regression coverage for the installed-but-unloaded launchd update path

## Why

A macOS gateway update can leave the LaunchAgent plist installed while `launchctl list <label>` reports the job as unloaded. Before this change, `hermes update` skipped the gateway restart path in that state, leaving Telegram/cron/gateway delivery offline until the user manually ran `hermes gateway start`.

Planned `--replace` gateway takeovers are operational restarts from the user's perspective, so they should use the restart stop path to preserve the expected lifecycle marker and notification semantics.


Fixes #42006.
Related to #37388 and #42524.

## Test plan

```bash
source venv/bin/activate && python -m pytest \
  tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_gateway_update_starts_installed_but_unloaded_launchd_job \
  tests/gateway/test_clean_shutdown_marker.py::TestCleanShutdownMarker::test_marker_written_on_restart_stop \
  tests/gateway/test_restart_resume_pending.py::test_drain_timeout_uses_restart_reason_when_restarting \
  -q -o 'addopts='
```

Result: `3 passed in 9.13s`

