### PR TITLE
fix(tests): use platform-safe timeout method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,12 +300,13 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
 ]
-# pytest-timeout: per-test 30s hard cap with signal method.
+# pytest-timeout: per-test 30s hard cap.
 # This is the fallback inside each per-file pytest subprocess (see
 # scripts/run_tests_parallel.py). Per-file isolation gives every test
 # file a fresh Python interpreter; pytest-timeout catches Python-level
-# hangs within a file.
-addopts = "-m 'not integration' --timeout=30 --timeout-method=signal"
+# hangs within a file. Leave the timeout method unset so pytest-timeout can
+# choose a platform-safe default (signal on POSIX, thread on Windows).
+addopts = "-m 'not integration' --timeout=30"
 
 [tool.ty.environment]
 python-version = "3.13"


### PR DESCRIPTION
## Problem

Running the pytest suite on native Windows can fail before tests execute because `pyproject.toml` forces `pytest-timeout` to use `--timeout-method=signal`. Windows does not expose `signal.SIGALRM`, so pytest exits with an internal error.

## Before / after

Before, commands such as:

```powershell
python -m pytest tests\hermes_cli\test_inventory.py -q
```

failed on Windows with:

```text
AttributeError: module 'signal' has no attribute 'SIGALRM'
```

After, the timeout method is left unset so `pytest-timeout` can choose the platform-safe default. POSIX can still use signal behavior, while Windows can fall back to its supported method.

## Verification

```powershell
.\venv\Scripts\python.exe -m pytest tests\hermes_cli\test_inventory.py -q
.\venv\Scripts\python.exe -m py_compile hermes_cli\inventory.py
```

Result: `23 passed`.