### PR TITLE
fix(website): remove stale JSX.Element return type annotation

### DIFF
--- a/website/src/components/UserStoriesCollage/index.tsx
+++ b/website/src/components/UserStoriesCollage/index.tsx
@@ -145,7 +145,7 @@ function sourceColor(source: string): string {
   }
 }
 
-export default function UserStoriesCollage(): JSX.Element {
+export default function UserStoriesCollage() {
   const [activeCategory, setActiveCategory] = useState<string>('all');
   const [activeSource, setActiveSource] = useState<string>('all');
 


### PR DESCRIPTION
## Summary
- `website/src/components/UserStoriesCollage/index.tsx` declared its component return type as `JSX.Element`, but `@types/react@19` no longer exposes a global `JSX` namespace, so `tsc` fails with `TS2503: Cannot find namespace 'JSX'`.
- Removed the explicit return type annotation, matching the style of every other component in the file/project, which relies on inference.

## Test plan
- [x] `npm run typecheck` in `website/` passes with no errors