### PR TITLE
feat(tui): include session name in the terminal titlebar

### DIFF
--- a/ui-tui/src/__tests__/paths.test.ts
+++ b/ui-tui/src/__tests__/paths.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { fmtCwdBranch, shortCwd } from '../domain/paths.js'
+import { composeTabTitle, fmtCwdBranch, shortCwd } from '../domain/paths.js'
 
 describe('shortCwd', () => {
   const origHome = process.env.HOME
@@ -66,5 +66,45 @@ describe('fmtCwdBranch', () => {
     const out = fmtCwdBranch('/Users/bb/p', 'a-very-long-feature-branch-name')
     expect(out).toMatch(/^~\/p \(…/)
     expect(out).toContain(')')
+  })
+})
+
+describe('composeTabTitle', () => {
+  it('joins marker, name, model, and cwd in order', () => {
+    expect(composeTabTitle('✓', 'auth refactor', 'opus-4', '~/proj')).toBe('✓ auth refactor · opus-4 · ~/proj')
+  })
+
+  it('glues the marker to the first segment with a space, not a separator', () => {
+    expect(composeTabTitle('⏳', 'my session', 'opus-4', '~/proj').startsWith('⏳ my session')).toBe(true)
+  })
+
+  it('omits the session name when empty (matches the pre-name format)', () => {
+    expect(composeTabTitle('✓', '', 'opus-4', '~/proj')).toBe('✓ opus-4 · ~/proj')
+  })
+
+  it('treats a whitespace-only name as absent', () => {
+    expect(composeTabTitle('✓', '   ', 'opus-4', '~/proj')).toBe('✓ opus-4 · ~/proj')
+  })
+
+  it('omits the cwd when empty', () => {
+    expect(composeTabTitle('✓', 'my session', 'opus-4', '')).toBe('✓ my session · opus-4')
+  })
+
+  it('falls back to just the marker when only the marker is present', () => {
+    expect(composeTabTitle('✓', '', '', '')).toBe('✓')
+  })
+
+  it('truncates an over-long session name with an ellipsis', () => {
+    const long = 'a'.repeat(40)
+    const out = composeTabTitle('✓', long, 'opus-4', '', 28)
+    const namePart = out.slice('✓ '.length).split(' · ')[0]
+    expect(namePart.endsWith('…')).toBe(true)
+    expect(namePart.length).toBe(28)
+  })
+
+  it('keeps a name at the boundary length intact', () => {
+    const name = 'b'.repeat(28)
+    const out = composeTabTitle('✓', name, 'opus-4', '', 28)
+    expect(out).toBe(`✓ ${name} · opus-4`)
   })
 })

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -128,6 +128,7 @@ export interface UiState {
   pasteCollapseChars: number
 
   sections: SectionVisibility
+  sessionTitle: string
   showCost: boolean
   showReasoning: boolean
   indicatorStyle: IndicatorStyle

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -22,6 +22,7 @@ const buildUiState = (): UiState => ({
   pasteCollapseLines: 5,
   pasteCollapseChars: 2000,
   sections: {},
+  sessionTitle: '',
   showCost: false,
   showReasoning: false,
   sid: null,

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -7,7 +7,7 @@ import { MAX_HISTORY, WHEEL_SCROLL_STEP } from '../config/limits.js'
 import { hasLeadGap, prevRenderedMsg } from '../domain/blockLayout.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import { attachedImageNotice, imageTokenMeta } from '../domain/messages.js'
-import { fmtCwdBranch, shortCwd } from '../domain/paths.js'
+import { composeTabTitle, fmtCwdBranch, shortCwd } from '../domain/paths.js'
 import { type GatewayClient } from '../gatewayClient.js'
 import type {
   ClarifyRespondResponse,
@@ -524,12 +524,22 @@ export function useMainApp(gw: GatewayClient) {
           if (!stopped && result?.sessions) {
             const liveSessionCount = result.sessions.length
 
-            // Only patch when the count actually changed. patchUiState always
+            // Surface the current session's (auto-)title for the terminal
+            // titlebar. The active_list poll already carries it, so no extra
+            // round-trip is needed.
+            const currentSid = getUiState().sid
+
+            const sessionTitle =
+              result.sessions.find(s => s.current || s.id === currentSid)?.title?.trim() ?? ''
+
+            // Only patch when something actually changed. patchUiState always
             // produces a new state object, which notifies every $uiState
             // subscriber; patching unconditionally on each 1.5s poll re-renders
             // the whole TUI and causes idle flicker.
-            if (getUiState().liveSessionCount !== liveSessionCount) {
-              patchUiState({ liveSessionCount })
+            const prev = getUiState()
+
+            if (prev.liveSessionCount !== liveSessionCount || prev.sessionTitle !== sessionTitle) {
+              patchUiState({ liveSessionCount, sessionTitle })
             }
           }
         })
@@ -546,13 +556,16 @@ export function useMainApp(gw: GatewayClient) {
   }, [gw, ui.sid])
 
   // Tab title: `⚠` waiting on approval/sudo/secret/clarify, `⏳` busy, `✓` idle.
+  // Format: `<marker> <session name> · <model> · <cwd>` — name/cwd omitted when absent.
   const model = ui.info?.model?.replace(/^.*\//, '') ?? ''
 
   const marker = overlay.approval || overlay.sudo || overlay.secret || overlay.clarify ? '⚠' : ui.busy ? '⏳' : '✓'
 
   const tabCwd = ui.info?.cwd
 
-  useTerminalTitle(model ? `${marker} ${model}${tabCwd ? ` · ${shortCwd(tabCwd, 24)}` : ''}` : 'Hermes')
+  useTerminalTitle(
+    model ? composeTabTitle(marker, ui.sessionTitle, model, tabCwd ? shortCwd(tabCwd, 24) : '') : 'Hermes'
+  )
 
   useEffect(() => {
     if (!ui.sid || !stdout) {

--- a/ui-tui/src/domain/paths.ts
+++ b/ui-tui/src/domain/paths.ts
@@ -14,3 +14,27 @@ export const fmtCwdBranch = (cwd: string, branch: null | string, max = 40) => {
 
   return `${shortCwd(cwd, Math.max(8, max - tag.length))}${tag}`
 }
+
+/**
+ * Compose the terminal titlebar string:
+ *   `<marker> <session name> · <model> · <cwd>`
+ *
+ * The session name and cwd are each omitted when empty, and a long session
+ * name is truncated. The marker is always glued to the first present segment
+ * with a plain space (not a ` · ` separator). When no model is known yet the
+ * caller should fall back to a plain brand string instead of calling this.
+ */
+export const composeTabTitle = (
+  marker: string,
+  sessionName: string,
+  model: string,
+  cwd: string,
+  maxName = 28
+): string => {
+  const name = sessionName.trim()
+  const shortName = name.length > maxName ? `${name.slice(0, maxName - 1)}…` : name
+
+  const segments = [shortName, model, cwd].filter(Boolean)
+
+  return segments.length ? `${marker} ${segments.join(' · ')}` : marker
+}


### PR DESCRIPTION
## Summary

The TUI sets the terminal/console titlebar via OSC 0 (`useTerminalTitle`), but until now it was composed from **status marker + model + cwd** only — the session's name never appeared, even though the TUI already knows it (you set it with `/title`, or auto-title generation produces one after the first response).

This changes the format to:

```
<marker> <session name> · <model> · <cwd>
```

- **marker** — `⚠` (waiting on approval/sudo/secret/clarify), `⏳` (busy), `✓` (idle)
- **session name** — the current session's live (auto-)title; omitted when empty
- **model** — short model name
- **cwd** — truncated working dir; omitted when absent

When there's no session name yet (e.g. a brand-new session before auto-title lands), the titlebar is exactly the old `<marker> <model> · <cwd>`, so behavior is unchanged in that case.

## How it works

The current session's title is read from the **existing `session.active_list` poll** that `useMainApp` already runs every 1.5s — each item already carries a `current` flag and its live `title` (server-side `_session_live_item` → `_session_live_title` → DB lookup, so auto-titles are included). No new RPC / round-trip. `UiState` gains a `sessionTitle` field, patched only when it actually changes, preserving the existing idle-flicker guard.

The string-composition logic is extracted into a pure `composeTabTitle()` helper in `domain/paths.ts` (alongside `shortCwd`/`fmtCwdBranch`) so it's unit-testable.

## Impact

Small UX nicety: when you run several Hermes sessions in different terminal tabs/windows, the OS tab/window title now disambiguates them by their session name instead of showing the same `model · cwd` for every tab. No effect on functionality.

## Test plan

- [x] `npm run type-check` — clean
- [x] `eslint` on touched files — 0 errors (remaining warnings are pre-existing, in unrelated hooks)
- [x] `composeTabTitle` covered in `paths.test.ts`: ordering, name-omitted (== old format), whitespace-only name, cwd-omitted, marker-only fallback, truncation, boundary length — 8 new cases, all green
- [x] Full `vitest run` — green except one **pre-existing** failure in `virtualHeights.test.ts` ("compound user prompt width"), confirmed to fail identically on clean `origin/main` (verified by stash) and unrelated to this change