### PR TITLE
fix(dashboard): start background MCP discovery for dashboard-hosted chat sessions

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -131,6 +131,25 @@ async def _lifespan(app: "FastAPI"):
     app.state.event_channels = {}  # dict[str, set]
     app.state.event_lock = asyncio.Lock()
 
+    # Dashboard-hosted chat sessions run on this process's in-memory
+    # tui_gateway (the chat PTY attaches via HERMES_TUI_GATEWAY_URL instead
+    # of spawning its own gateway), so tui_gateway.entry's startup MCP
+    # discovery never runs here.  Without this, configured ``mcp_servers``
+    # contribute zero tools to dashboard/desktop sessions until a manual
+    # ``/reload-mcp`` — the enabled-toolset list includes the server names,
+    # but the registry has nothing to hand out, so they're silently dropped.
+    # Backgrounded + config-gated by the shared helper, so dashboards with
+    # no MCP servers configured pay neither the import nor a thread.
+    try:
+        from hermes_cli.mcp_startup import start_background_mcp_discovery
+
+        start_background_mcp_discovery(
+            logger=_log,
+            thread_name="dashboard-mcp-discovery",
+        )
+    except Exception:
+        _log.debug("MCP tool discovery failed at dashboard startup", exc_info=True)
+
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes
     # dashboard` is unaffected — it relies on its own gateway.

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -140,6 +140,59 @@ def test_cli_get_tool_definitions_briefly_waits_for_fast_mcp_thread(monkeypatch)
     assert not thread.is_alive()
 
 
+def test_web_server_lifespan_starts_background_mcp_discovery(monkeypatch):
+    """Dashboard startup must kick off MCP discovery for in-memory gateway
+    sessions — without it, configured MCP servers contribute zero tools to
+    dashboard/desktop chats until a manual /reload-mcp."""
+    discovered = threading.Event()
+
+    monkeypatch.setattr(
+        mcp_startup,
+        "_has_configured_mcp_servers",
+        lambda: True,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=discovered.set),
+    )
+
+    from fastapi.testclient import TestClient
+
+    from hermes_cli import web_server
+
+    with TestClient(web_server.app):
+        assert discovered.wait(timeout=2.0)
+        assert mcp_startup._mcp_discovery_started is True
+
+
+def test_web_server_lifespan_skips_mcp_discovery_without_servers(monkeypatch):
+    calls = {"mcp": 0}
+
+    monkeypatch.setattr(
+        mcp_startup,
+        "_has_configured_mcp_servers",
+        lambda: False,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(
+            discover_mcp_tools=lambda: calls.__setitem__("mcp", calls["mcp"] + 1)
+        ),
+    )
+
+    from fastapi.testclient import TestClient
+
+    from hermes_cli import web_server
+
+    with TestClient(web_server.app):
+        pass
+
+    assert calls["mcp"] == 0
+    assert mcp_startup._mcp_discovery_thread is None
+
+
 def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):
     waited = {"done": False}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2825,10 +2825,23 @@ def _make_agent(
     # for in-flight discovery to land before building — bounded, so a slow/dead
     # server still can't block.  No-op once discovery has finished (every build
     # after the first during a slow startup).
+    #
+    # Two possible owners for that thread: the standalone PTY gateway starts
+    # it in tui_gateway.entry; a dashboard-hosted in-memory gateway starts it
+    # via hermes_cli.mcp_startup in the web server's lifespan.  Join whichever
+    # exists — each wait is a no-op when its thread was never started.
     try:
         from tui_gateway.entry import wait_for_mcp_discovery
 
         wait_for_mcp_discovery()
+    except Exception:
+        pass
+    try:
+        from hermes_cli.mcp_startup import (
+            wait_for_mcp_discovery as _wait_shared_mcp_discovery,
+        )
+
+        _wait_shared_mcp_discovery()
     except Exception:
         pass
 


### PR DESCRIPTION
## Problem

Chat sessions hosted by `hermes dashboard` (the web UI / desktop-app remote backend) never see configured MCP servers' tools.

The dashboard's chat PTY attaches to the web server process's **in-memory** tui_gateway via `HERMES_TUI_GATEWAY_URL` instead of spawning its own gateway, so `tui_gateway/entry.py`'s startup MCP discovery never runs in that process. The other two entrypoints both run discovery at startup:

- messaging gateway: `gateway/run.py` → `discover_mcp_tools()`
- standalone CLI TUI: `tui_gateway/entry.py:main()` → backgrounded `discover_mcp_tools()`

The dashboard path never did. The failure is silent and confusing: `_get_platform_tools(cfg, "cli", include_default_mcp_servers=True)` correctly resolves the MCP server names into the enabled-toolset list, but the tool registry has no MCP tools to hand out, so the agent is built without them — no warning anywhere. A manual `/reload-mcp` fixes the live session (and is how we confirmed the cause), but it's needed again after every restart.

## Repro

1. `hermes mcp add <any stdio server> ...`
2. `hermes dashboard`, open a chat (web or desktop app)
3. Ask the agent to list tools → zero `mcp_*` tools; `/reload-mcp` makes them appear

Confirmed on a Fly.io deployment running the gateway and dashboard side by side: the gateway process had all 7 configured MCP stdio servers as children; the dashboard process had none.

## Fix

- `hermes_cli/web_server.py`: the lifespan now starts the existing shared background-discovery helper (`hermes_cli.mcp_startup.start_background_mcp_discovery`). It's config-gated (no MCP servers configured → no MCP-SDK import, no thread) and backgrounded (a slow/dead server can't block dashboard startup), same as the CLI path.
- `tui_gateway/server.py:_make_agent`: in addition to the existing `tui_gateway.entry` wait, briefly join the shared `mcp_startup` thread (bounded) so the first agent build in a dashboard process picks up fast-connecting servers. Each wait is a no-op when its thread was never started.

## Tests

Two regression tests in `tests/hermes_cli/test_mcp_startup.py`: lifespan starts discovery when servers are configured; skips entirely when none are. Ran `tests/hermes_cli/test_mcp_startup.py` (6 passed), `tests/hermes_cli/test_web_server.py` (211 passed), `tests/tui_gateway/test_wait_for_mcp_discovery.py` + `test_make_agent_provider.py` (11 passed).
