### PR TITLE
fix(gateway): strip orphan think-tag close tags in progressive stream

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -387,8 +387,47 @@ class GatewayStreamConsumer:
                         self._accumulated += buf[:-held_back]
                         self._think_buffer = buf[-held_back:]
                     else:
-                        self._accumulated += buf
+                        # No (partial) open tag — but the model may have
+                        # emitted an orphan close tag like </think> on its
+                        # own (e.g. when a thinking-mode toggle drops the
+                        # matched open, or when upstream stripping is
+                        # incomplete). Strip those before accumulating so
+                        # they never reach the user.
+                        self._accumulated += self._strip_orphan_close_tags(buf)
                     return
+
+    @classmethod
+    def _strip_orphan_close_tags(cls, text: str) -> str:
+        """Remove any close tags from *text* that have no matching open.
+
+        Mirrors ``agent/think_scrubber.py::StreamingThinkScrubber.
+        _strip_orphan_close_tags`` so the progressive-display filter
+        behaves the same as the post-stream final-response scrubber.
+        An orphan close tag is always noise — stripped along with any
+        trailing whitespace so surrounding prose flows naturally.
+        """
+        if "</" not in text:
+            return text
+        text_lower = text.lower()
+        out: list[str] = []
+        i = 0
+        while i < len(text):
+            matched = False
+            if text_lower[i:i + 2] == "</":
+                for tag in cls._CLOSE_THINK_TAGS:
+                    tag_lower = tag.lower()
+                    tag_len = len(tag_lower)
+                    if text_lower[i:i + tag_len] == tag_lower:
+                        j = i + tag_len
+                        while j < len(text) and text[j] in " \t\n\r":
+                            j += 1
+                        i = j
+                        matched = True
+                        break
+            if not matched:
+                out.append(text[i])
+                i += 1
+        return "".join(out)
 
     def _flush_think_buffer(self) -> None:
         """Flush any held-back partial-tag buffer into accumulated text.
@@ -397,7 +436,9 @@ class GatewayStreamConsumer:
         was held back waiting for a possible opening tag is not lost.
         """
         if self._think_buffer and not self._in_think_block:
-            self._accumulated += self._think_buffer
+            # Strip any orphan close tags that may have been held back —
+            # see _filter_and_accumulate for context.
+            self._accumulated += self._strip_orphan_close_tags(self._think_buffer)
             self._think_buffer = ""
 
     async def run(self) -> None:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1908,3 +1908,110 @@ class TestUtf16OverflowDetection:
         # this file passing — they all use MagicMock adapters.
         assert consumer is not None
 
+
+# ── _strip_orphan_close_tags regression tests ──────────────────────────
+# Regression guard for the /think tag leak: when the stream consumer is
+# NOT inside a think block, stray close tags like </think> must be
+# stripped before text is accumulated — otherwise they leak to Telegram.
+# (Reported by Tony on 2026-06-09.)
+
+
+class TestStripOrphanCloseTags:
+    """Verify orphan close tags are stripped from text the stream consumer
+    would accumulate while NOT inside a think block."""
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "</think>",
+            "</thinking>",
+            "</thought>",
+            "</reasoning>",
+            "</REASONING_SCRATCHPAD>",
+            "</THINKING>",
+        ],
+    )
+    def test_all_close_tag_variants_stripped(self, tag):
+        text = f"before{tag}after"
+        result = GatewayStreamConsumer._strip_orphan_close_tags(text)
+        assert tag not in result
+        assert "before" in result and "after" in result
+
+    def test_no_close_tag_passthrough(self):
+        text = "Just normal text with no tags."
+        assert GatewayStreamConsumer._strip_orphan_close_tags(text) == text
+
+    def test_empty_string(self):
+        assert GatewayStreamConsumer._strip_orphan_close_tags("") == ""
+
+    def test_close_tag_with_trailing_whitespace(self):
+        """The trailing whitespace after the tag should also be eaten so
+        surrounding prose flows naturally (matches StreamingThinkScrubber)."""
+        text = "Looking at this now.\n\n</think>\n\nThe answer is 42."
+        result = GatewayStreamConsumer._strip_orphan_close_tags(text)
+        assert "</think>" not in result
+        assert "Looking at this now" in result
+        assert "The answer is 42" in result
+
+    def test_multiple_orphan_close_tags(self):
+        text = "foo </think> bar </thinking> baz"
+        result = GatewayStreamConsumer._strip_orphan_close_tags(text)
+        assert "</think>" not in result
+        assert "</thinking>" not in result
+        assert "foo" in result and "bar" in result and "baz" in result
+
+    def test_orphan_close_does_not_eat_following_prose(self):
+        text = "answer </think> then this should remain"
+        result = GatewayStreamConsumer._strip_orphan_close_tags(text)
+        assert result == "answer then this should remain"
+
+    def test_partial_close_tag_not_stripped(self):
+        """A partial tag like '</thi' should not be eaten — it's not yet
+        a recognized close tag, and eating it would corrupt following text."""
+        text = "before </thin after"
+        result = GatewayStreamConsumer._strip_orphan_close_tags(text)
+        assert result == text  # unchanged — partial tag, no stripping
+
+    def test_filter_and_accumulate_strips_orphan_close(self):
+        """End-to-end: feed an orphan close tag through _filter_and_accumulate
+        and verify the accumulated text does not contain the raw tag."""
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        config = StreamConsumerConfig(cursor=" ▉")
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        # Simulate a stream delta that contains an orphan close tag with
+        # surrounding prose (the actual leak pattern reported 2026-06-09).
+        consumer._filter_and_accumulate(
+            "Here is the result you asked for.\n\n</think>\n\n"
+            "The answer is 42 and the cat is black."
+        )
+        # No raw close tag should remain in the accumulated text.
+        for tag in GatewayStreamConsumer._CLOSE_THINK_TAGS:
+            assert tag not in consumer._accumulated, (
+                f"Orphan close tag {tag!r} leaked into accumulated text: "
+                f"{consumer._accumulated!r}"
+            )
+        # Surrounding prose must survive intact.
+        assert "Here is the result" in consumer._accumulated
+        assert "The answer is 42" in consumer._accumulated
+
+    def test_flush_think_buffer_strips_orphan_close(self):
+        """The end-of-stream flush should also strip orphan close tags from
+        any held-back buffer text."""
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        config = StreamConsumerConfig(cursor=" ▉")
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        # Plant a held-back buffer with an orphan close tag (simulates the
+        # buffer being held while waiting for a possible opening tag, then
+        # flushed when the stream ends).
+        consumer._think_buffer = "trailing prose </think> more"
+        consumer._in_think_block = False
+        consumer._flush_think_buffer()
+        for tag in GatewayStreamConsumer._CLOSE_THINK_TAGS:
+            assert tag not in consumer._accumulated
+        assert "trailing prose" in consumer._accumulated
+        assert "more" in consumer._accumulated
+


### PR DESCRIPTION
## Summary

When a model emits an inline `<think>...</think>` reasoning block but the
opening tag gets stripped upstream (truncated stream, thinking-mode toggle,
or partial filtering), the bare `</think>` close tag leaks through to the
user in the live Telegram edit.

The agent-side final-response scrubber (`agent/think_scrubber.py::
StreamingThinkScrubber._strip_orphan_close_tags`) already handles this
post-stream, but the progressive display in `gateway/stream_consumer.py`
was missing the same protection.

## Repro

A model that emits thinking-mode output (e.g. `MiniMax-M3`,
`deepseek-reasoner-thinking`) can produce a response where the opening
`<think>` is consumed by upstream filtering but the closing `</think>`
remains. Without this fix, the user sees the raw tag in their chat.

## Fix

Port the same `_strip_orphan_close_tags` classmethod from
`StreamingThinkScrubber` into `GatewayStreamConsumer`. Wire it into
both the "no opening tag found" accumulation branch in
`_filter_and_accumulate` and the held-back partial buffer flush in
`_flush_think_buffer`. The stripper is intentionally aggressive —
strips ANY orphan close tag it finds, since progressive display only
ever sees model output, never user-quoted text.

## Tests

14 new regression tests in `TestStripOrphanCloseTags`:
- All 6 close-tag variants (`</think>`, `</thinking>`, `</thought>`,
  `</reasoning>`, `</REASONING_SCRATCHPAD>`, `</THINKING>`)
- No-tag passthrough, empty string, trailing whitespace
- Multiple orphan tags in one string
- Partial tag (e.g. `</thi`) NOT stripped
- End-to-end through `_filter_and_accumulate` and `_flush_think_buffer`

## Verification

```
pytest tests/gateway/test_stream_consumer.py::TestStripOrphanCloseTags
# 14 passed in 0.24s

pytest tests/gateway/test_stream_consumer.py
# 106 passed in 7.54s
```

Co-Authored-By: Claude <noreply@anthropic.com>