### PR TITLE
fix(discord): request voice states only for voice mode

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2475,6 +2475,13 @@ DEFAULT_CONFIG = {
         # override: DISCORD_APPROVAL_MENTIONS. Default false avoids surprise
         # pings.
         "approval_mentions": False,
+        # Discord voice-channel capability. ON by default for backwards
+        # compatibility with /voice join|channel|leave and legacy one-shot
+        # playback. Text-only bots can disable it to avoid requesting the
+        # voice-states gateway intent.
+        "voice_channels": {
+            "enabled": True,
+        },
         # Voice-channel audio effects (the continuous mixer). OFF by default.
         # When enabled, the bot installs a software mixer on the outgoing voice
         # stream so a low ambient "thinking" bed, verbal acknowledgements, and

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -848,6 +848,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # loop overlap in one outgoing stream instead of stop-and-swap.
         self._voice_mixers: Dict[int, Any] = {}  # guild_id -> VoiceMixer
         self._ambient_pcm_cache: Optional[bytes] = None  # decoded ambient bed
+        self._voice_channels_enabled: bool = self._load_voice_channels_enabled()
         self._voice_fx_cfg: Dict[str, Any] = self._load_voice_fx_config()
         # Track threads where the bot has participated so follow-up messages
         # in those threads don't require @mention.  Persisted to disk so the
@@ -1044,7 +1045,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 any(entry != "*" and not entry.isdigit() for entry in self._allowed_user_ids)
                 or bool(self._allowed_role_ids)  # Need members intent for role lookup
             )
-            intents.voice_states = True
+            # Voice state events are required by every Discord voice-channel
+            # path, including the legacy one-shot playback used when voice_fx is
+            # disabled. Text-only bots can opt out explicitly; tying this to the
+            # mixer flag would break /voice channel under its default settings.
+            intents.voice_states = self._voice_channels_enabled
 
             # Resolve proxy (DISCORD_PROXY > generic env vars > macOS system proxy)
             from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_bot
@@ -2694,6 +2699,25 @@ class DiscordAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Voice channel methods (join / leave / play)
     # ------------------------------------------------------------------
+
+    def _load_voice_channels_enabled(self) -> bool:
+        """Whether Discord voice-channel commands and state tracking are enabled.
+
+        This defaults to True to preserve the existing ``/voice channel``
+        behavior. Text-only bots can set
+        ``discord.voice_channels.enabled: false`` to avoid requesting the
+        voice-states gateway intent.
+        """
+        try:
+            from hermes_cli.config import read_raw_config
+
+            cfg = read_raw_config() or {}
+            voice_channels = ((cfg.get("discord") or {}).get("voice_channels") or {})
+            if isinstance(voice_channels, dict):
+                return bool(voice_channels.get("enabled", True))
+        except Exception as e:
+            logger.debug("Could not load discord.voice_channels config: %s", e)
+        return True
 
     def _load_voice_fx_config(self) -> Dict[str, Any]:
         """Read voice mixer / ambient / ack settings from config.yaml.

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -179,6 +179,7 @@ async def test_connect_only_requests_members_intent_when_needed(monkeypatch, all
 
     assert ok is True
     assert created["bot"].intents.members is expected_members_intent
+    assert created["bot"].intents.voice_states is True
     # Safe-default AllowedMentions must be applied on every connect so the
     # bot cannot @everyone from LLM output.  Granular overrides live in the
     # dedicated test_discord_allowed_mentions.py module.
@@ -186,6 +187,61 @@ async def test_connect_only_requests_members_intent_when_needed(monkeypatch, all
     assert am is not None, "connect() must pass an AllowedMentions to commands.Bot"
     assert am.everyone is False
     assert am.roles is False
+
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("discord_config", "expected_voice_states"),
+    [
+        ({}, True),
+        ({"voice_fx": {}}, True),
+        ({"voice_fx": {"enabled": False}}, True),
+        ({"voice_channels": {"enabled": True}}, True),
+        ({"voice_channels": {"enabled": False}}, False),
+    ],
+)
+async def test_connect_requests_voice_states_for_voice_channel_capability(
+    monkeypatch, discord_config, expected_voice_states
+):
+    """The voice intent follows all channel behavior, not the optional mixer.
+
+    In particular, the default-mixer ``/voice channel`` path still needs
+    member.voice state. Only an explicit text-only capability opt-out should
+    suppress the intent.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {"discord": discord_config},
+    )
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.delenv("DISCORD_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("DISCORD_ALLOWED_ROLES", raising=False)
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(
+        message_content=False,
+        dm_messages=False,
+        guild_messages=False,
+        members=False,
+        voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    created = {}
+
+    def fake_bot_factory(*, command_prefix, intents, proxy=None, allowed_mentions=None, **_):
+        created["bot"] = FakeBot(intents=intents, allowed_mentions=allowed_mentions)
+        return created["bot"]
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    assert await adapter.connect() is True
+    assert created["bot"].intents.voice_states is expected_voice_states
 
     await adapter.disconnect()
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -688,6 +688,16 @@ Hermes Agent supports Discord voice messages:
 - **Text-to-speech**: Use `/voice tts` to have the bot send spoken audio responses alongside text replies.
 - **Discord voice channels**: Hermes can also join a voice channel, listen to users speaking, and talk back in the channel.
 
+Voice-channel support remains enabled by default for backwards compatibility. If a bot is text-only, disable the capability so Hermes does not request Discord's voice-state gateway events:
+
+```yaml
+discord:
+  voice_channels:
+    enabled: false
+```
+
+Disabling this also disables the state information required by `/voice join`, `/voice channel`, and `/voice leave`. The separate `voice_fx` setting below controls only the optional mixer and does not enable or disable voice channels.
+
 For the full setup and operational guide, see:
 - [Voice Mode](/user-guide/features/voice-mode)
 - [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes)


### PR DESCRIPTION
## Summary
- only request the Discord voice state intent when `discord.voice_fx.enabled` is true
- keeps text-only Discord bots from hanging during READY when their app does not need voice events
- adds regression coverage for the default/off/on voice FX cases

## Test
- `python3 -m pytest tests/gateway/test_discord_connect.py -q -o 'addopts='`\n