### PR TITLE
fix(launchd): write restart-notification marker in fallback kill path

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5,6 +5,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
 
 import asyncio
+import json
 import logging
 import os
 import shutil
@@ -12,6 +13,7 @@ import signal
 import subprocess
 import sys
 import textwrap
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -3515,6 +3517,25 @@ def _wait_for_gateway_exit(
     return True
 
 
+def _write_planned_restart_marker() -> None:
+    """Write the .restart_pending.json marker so the next gateway startup
+    sends the \"♻️ Gateway online\" notification to home channels.
+
+    Mirrors the marker written by the graceful SIGUSR1 path inside the
+    gateway process (gateway/run.py ~line 5925).
+    """
+    try:
+        marker = get_hermes_home() / ".restart_pending.json"
+        data = {
+            "requested_at": time.time(),
+            "via_service": True,
+            "detached": False,
+        }
+        marker.write_text(json.dumps(data, indent=None), encoding="utf-8")
+    except Exception as e:
+        print(f"⚠ Failed to write restart notification marker: {e}")
+
+
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
@@ -3526,6 +3547,11 @@ def launchd_restart():
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
             return
+        # SIGUSR1 path failed (terminal is not a gateway child) or no PID found.
+        # Write the planned-restart marker so the next gateway startup sends
+        # "♻️ Gateway online" — mirroring what the graceful SIGUSR1 path does
+        # inside the gateway process (gateway/run.py ~line 5925).
+        _write_planned_restart_marker()
         if pid is not None:
             try:
                 terminate_pid(pid, force=False)


### PR DESCRIPTION
On macOS, `hermes gateway restart` from a terminal silently skipped the "Gateway online" home-channel notification.

**Root Cause**

The restart flow on macOS goes through `launchd_restart()` in `hermes_cli/gateway.py`. It tries two paths:

1. **SIGUSR1 (preferred):** `_request_gateway_self_restart(pid)` sends SIGUSR1 to the running gateway, which then writes `.restart_pending.json`, exits gracefully, and launchd auto-restarts. The notification fires.
2. **Fallback (SIGTERM):** If SIGUSR1 fails, it kills the gateway with SIGTERM and calls `launchctl kickstart -k`. `_restart_requested` is `False` -> no marker -> no notification.

The SIGUSR1 path fails because of `_is_pid_ancestor_of_current_process(pid)` -- it only sends SIGUSR1 if the calling process is a descendant of the gateway. When you run `hermes gateway restart` from a terminal shell, the shell is not a child of the gateway -> the check fails -> fallback to SIGTERM -> no notification.

Linux/systemd does not have this problem because `systemd_restart()` uses `_graceful_restart_via_sigusr1()` which sends SIGUSR1 without the ancestor check.

**The Fix**

A new `_write_planned_restart_marker()` helper is added and called in `launchd_restart()` before the fallback kill path. This ensures the marker exists when the new gateway starts, regardless of whether SIGUSR1 or SIGTERM shut down the old process.

**Verification on macOS**

Before the fix: `hermes gateway restart` restarts the gateway but no "Gateway online" message appears in home channels.
After the fix: the "Gateway online" notification is correctly delivered.

The log confirms:
```
Sent home-channel startup notification to telegram:<chat_id>
```

**Related:** The `--all` restart path (`hermes gateway restart --all`) also bypasses the marker. That is a separate follow-up fix.
