### PR TITLE
fix(gateway): transcribe observed audio context on demand

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1270,6 +1270,10 @@ _LEGACY_OBSERVED_AUDIO_NOTE_RE = re.compile(
     r"\[Observed Telegram (?:voice message|audio)[^:\]]*:\s*'[^']*'\s+saved at:\s*(?P<path>[^\]\r\n]+)\]",
     re.IGNORECASE,
 )
+_REPLIED_TO_AUDIO_NOTE_RE = re.compile(
+    r"\[Replied-to\s+(?:audio|voice(?:\s+message)?)\s+'[^']*'\s+saved at:\s*(?P<path>[^\]\r\n]+)\]",
+    re.IGNORECASE,
+)
 _OBSERVED_AUDIO_TRANSCRIPT_PATH_RE = re.compile(
     rf"\[{re.escape(_OBSERVED_AUDIO_TRANSCRIPT_MARKER)}[^\]]*?\(path:\s*(?P<path>[^)\]\r\n]+)\)\]",
     re.IGNORECASE,
@@ -1277,6 +1281,11 @@ _OBSERVED_AUDIO_TRANSCRIPT_PATH_RE = re.compile(
 _OBSERVED_AUDIO_TRANSCRIPT_RE = re.compile(
     rf"\[{re.escape(_OBSERVED_AUDIO_TRANSCRIPT_MARKER)}:\s*\"(?P<transcript>.*?)\"\s*\(path:\s*(?P<path>[^)\]\r\n]+)\)\]",
     re.IGNORECASE | re.DOTALL,
+)
+_OBSERVED_AUDIO_REQUEST_RE = re.compile(
+    r"\b(?:audio|áudio|voice|voz|ouvir|ouve|escutar|escuta|transcrev\w*|transcri\w*|"
+    r"listen|hear|heard|transcript(?:ion)?)\b",
+    re.IGNORECASE,
 )
 
 
@@ -1341,6 +1350,22 @@ def _is_slack_ignored_channel(config: Any, chat_id: Any) -> bool:
     return bool(channel_id and ("*" in ignored or channel_id in ignored))
 
 
+def _observed_context_start_index(history: List[Dict[str, Any]]) -> int:
+    """Return the first row in the still-relevant observed-context window.
+
+    Observed group chatter is ephemeral context for the next addressed turn,
+    not durable conversation history. Once a normal user turn is recorded,
+    earlier observed rows must no longer be rendered or transcribed merely
+    because they remain in the session transcript.
+    """
+
+    start = 0
+    for index, msg in enumerate(history or []):
+        if msg.get("role") == "user" and not msg.get("observed"):
+            start = index + 1
+    return start
+
+
 def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
     """True when gateway.message_timestamps.enabled is opted in.
 
@@ -1384,11 +1409,48 @@ def _extract_observed_audio_paths(content: Any) -> List[str]:
     return paths
 
 
+def _message_text(message: Any) -> Optional[str]:
+    """Extract text content from a plain or multimodal inbound message."""
+
+    if isinstance(message, str):
+        return message
+    if isinstance(message, list):
+        parts = [
+            str(part.get("text") or "")
+            for part in message
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        return "\n".join(parts)
+    return None
+
+
+def _extract_explicit_audio_reference_paths(message: Any) -> List[str]:
+    """Return cache paths explicitly quoted by the current addressed turn."""
+
+    text = _message_text(message)
+    if not text:
+        return []
+
+    paths = _extract_observed_audio_paths(text)
+    seen = set(paths)
+    for match in _REPLIED_TO_AUDIO_NOTE_RE.finditer(text):
+        raw_path = match.group("path").strip().strip("\"'")
+        if (
+            raw_path
+            and Path(raw_path).suffix.lower() in _OBSERVED_AUDIO_EXTENSIONS
+            and raw_path not in seen
+        ):
+            seen.add(raw_path)
+            paths.append(raw_path)
+    return paths
+
+
 def _observed_audio_transcript_paths(history: List[Dict[str, Any]]) -> set[str]:
     """Return audio paths already represented by an observed transcript note."""
 
     paths: set[str] = set()
-    for msg in history or []:
+    context_start = _observed_context_start_index(history)
+    for msg in (history or [])[context_start:]:
         content = msg.get("content")
         if not isinstance(content, str):
             continue
@@ -1439,17 +1501,22 @@ def _strip_observed_audio_notes(content: Optional[str]) -> Optional[str]:
 
 
 def _observed_audio_transcripts_from_history(history: List[Dict[str, Any]]) -> List[str]:
-    """Return observed-audio transcripts carried by enriched history rows."""
+    """Return transcripts selected for the current addressed turn only.
+
+    An observed row can retain transcript annotations from an earlier turn.
+    Those annotations are context, not an instruction to expose every prior
+    voice message again.  ``_enrich_observed_audio_context`` marks the one
+    transcript selected for this turn with a runtime-only field.
+    """
 
     transcripts: List[str] = []
     seen: set[str] = set()
     for msg in history or []:
-        raw_items = msg.get("_observed_audio_transcripts")
+        raw_items = msg.get("_observed_audio_transcripts_for_current_turn")
         if isinstance(raw_items, list):
             items = [item for item in raw_items if isinstance(item, str)]
         else:
             items = []
-        items.extend(_extract_observed_audio_transcripts(msg.get("content")))
         for transcript in items:
             transcript = transcript.strip()
             if not transcript or transcript in seen:
@@ -1459,43 +1526,89 @@ def _observed_audio_transcripts_from_history(history: List[Dict[str, Any]]) -> L
     return transcripts
 
 
-def _message_requests_observed_audio(message: Any) -> bool:
-    """Return True when the current turn plausibly asks about observed audio."""
+def _clear_observed_audio_current_turn_markers(
+    history: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Drop runtime-only selected-audio markers without mutating transcript rows."""
 
-    if isinstance(message, str):
-        text = message
-    elif isinstance(message, list):
-        parts = []
-        for part in message:
-            if isinstance(part, dict) and part.get("type") == "text":
-                parts.append(str(part.get("text") or ""))
-        text = "\n".join(parts)
-    else:
+    cleaned_history: Optional[List[Dict[str, Any]]] = None
+    for index, msg in enumerate(history or []):
+        if "_observed_audio_transcripts_for_current_turn" not in msg:
+            continue
+        if cleaned_history is None:
+            cleaned_history = list(history)
+        cleaned_msg = dict(msg)
+        cleaned_msg.pop("_observed_audio_transcripts_for_current_turn", None)
+        cleaned_history[index] = cleaned_msg
+    return cleaned_history if cleaned_history is not None else history
+
+
+def _message_requests_observed_audio(message: Any) -> bool:
+    """Return True only for an unambiguous request about audio content."""
+
+    text = _message_text(message)
+    if not text:
         return False
 
-    text = text.lower()
-    return any(
-        marker in text
-        for marker in (
-            "audio",
-            "áudio",
-            "voice",
-            "voz",
-            "ouvir",
-            "ouve",
-            "escutar",
-            "escuta",
-            "transcrev",
-            "transcri",
-            "respondendo",
-            "respondi",
-            "reply",
-            "replied",
-            "said",
-            "disse",
-            "falou",
-        )
-    )
+    # Adapter-added media notes and prior transcript annotations are context,
+    # not user intent. In particular, replying directly to a voice message is
+    # already handled by the normal inbound STT path and must not also select
+    # an unrelated observed audio item.
+    for pattern in (
+        _OBSERVED_AUDIO_NOTE_RE,
+        _LEGACY_OBSERVED_AUDIO_NOTE_RE,
+        _REPLIED_TO_AUDIO_NOTE_RE,
+        _OBSERVED_AUDIO_TRANSCRIPT_RE,
+    ):
+        text = pattern.sub("", text)
+    return bool(_OBSERVED_AUDIO_REQUEST_RE.search(text))
+
+
+def _select_observed_audio_path(
+    history: List[Dict[str, Any]],
+    current_message: Any,
+    *,
+    already_transcribed: set[str],
+    explicit_audio_reference: Any = None,
+) -> Optional[str]:
+    """Choose at most one observed audio item for on-demand transcription.
+
+    A path explicitly quoted by the current turn wins.  Without that anchor,
+    only a clear audio request may use the most recent observed audio.  This
+    intentionally does not treat vague speech references such as "what did
+    they say?" as audio requests: those phrases otherwise fan out across
+    unrelated group voice notes and leak both latency and private context.
+    """
+
+    candidates: List[str] = []
+    seen: set[str] = set()
+    context_start = _observed_context_start_index(history)
+    for msg in (history or [])[context_start:]:
+        content = msg.get("content")
+        if not (
+            msg.get("observed")
+            and msg.get("role") == "user"
+            and isinstance(content, str)
+        ):
+            continue
+        for raw_path in _extract_observed_audio_paths(content):
+            if raw_path in already_transcribed or raw_path in seen:
+                continue
+            seen.add(raw_path)
+            candidates.append(raw_path)
+
+    if not candidates:
+        return None
+
+    candidate_paths = set(candidates)
+    for reference in (current_message, explicit_audio_reference):
+        for raw_path in _extract_explicit_audio_reference_paths(reference):
+            if raw_path in candidate_paths:
+                return raw_path
+
+    if _message_requests_observed_audio(current_message):
+        return candidates[-1]
+    return None
 
 
 def _resolve_observed_audio_cache_path(path: str) -> Optional[str]:
@@ -1593,7 +1706,8 @@ def _build_gateway_agent_history(
     observed_group_context: List[str] = []
     separate_observed_context = _uses_telegram_observed_group_context(channel_prompt)
 
-    for msg in history or []:
+    observed_context_start = _observed_context_start_index(history) if separate_observed_context else 0
+    for index, msg in enumerate(history or []):
         role = msg.get("role")
         if not role:
             continue
@@ -1610,8 +1724,9 @@ def _build_gateway_agent_history(
         content = msg.get("content")
         if inject_timestamps and role == "user" and isinstance(content, str):
             content = _render_msg_ts(content, msg.get("timestamp"), tz=_msg_tz)
-        if separate_observed_context and msg.get("observed") and role == "user" and content:
-            observed_group_context.append(str(content).strip())
+        if separate_observed_context and msg.get("observed") and role == "user":
+            if index >= observed_context_start and content:
+                observed_group_context.append(str(content).strip())
             continue
 
         # Rich agent messages (tool_calls, tool results) must be passed through
@@ -18337,6 +18452,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
+                # Select observed audio from the user's original text, not
+                # from STT output or adapter-added media notes in
+                # ``message_text``. The reply quote remains an explicit
+                # reference anchor when it contains a cached observed path.
+                observed_audio_request_message=event.text,
+                observed_audio_reference=event.reply_to_text,
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
@@ -22583,97 +22704,109 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         *,
         channel_prompt: Optional[str] = None,
         current_message: Any = None,
+        explicit_audio_reference: Any = None,
     ) -> List[Dict[str, Any]]:
-        """Transcribe cached observed audio on the addressed follow-up turn."""
+        """Transcribe cached observed audio on the addressed follow-up turn.
+
+        Telegram observe mode stores unaddressed media as transcript notes so
+        passive group traffic stays cheap.  When a later @mention explicitly
+        asks about that observed context, convert cached audio notes into text
+        using the same configured STT stack as fresh voice messages.
+        """
+
+        # The selected-transcript marker only controls the wrapper for one
+        # addressed turn. A queued follow-up can reuse ``result['messages']``,
+        # so clear its transient marker before deciding whether this turn
+        # selects a new audio item.
+        history = _clear_observed_audio_current_turn_markers(history)
         if not history or not _uses_telegram_observed_group_context(channel_prompt):
             return history
         if not getattr(self.config, "stt_enabled", True):
             return history
-        if not _message_requests_observed_audio(current_message):
-            return history
 
         already_transcribed = _observed_audio_transcript_paths(history)
+        selected_path = _select_observed_audio_path(
+            history,
+            current_message,
+            already_transcribed=already_transcribed,
+            explicit_audio_reference=explicit_audio_reference,
+        )
+        if not selected_path:
+            return history
+
         transcript_cache = getattr(self, "_observed_audio_transcript_cache", None)
         if transcript_cache is None:
             transcript_cache = {}
             self._observed_audio_transcript_cache = transcript_cache
 
-        changed = False
-        enriched_history: List[Dict[str, Any]] = []
-        for msg in history:
+        context_start = _observed_context_start_index(history)
+        for index in range(context_start, len(history)):
+            msg = history[index]
             content = msg.get("content")
             if not (
                 msg.get("observed")
                 and msg.get("role") == "user"
                 and isinstance(content, str)
             ):
-                enriched_history.append(msg)
+                continue
+            if selected_path not in _extract_observed_audio_paths(content):
                 continue
 
-            notes: List[str] = []
-            note_transcripts: List[str] = []
-            for raw_path in _extract_observed_audio_paths(content):
-                if raw_path in already_transcribed:
-                    continue
-                resolved = _resolve_observed_audio_cache_path(raw_path)
-                if not resolved:
-                    logger.debug(
-                        "Skipping observed audio path outside Hermes audio cache: %s",
-                        raw_path,
-                    )
-                    continue
+            resolved = _resolve_observed_audio_cache_path(selected_path)
+            if not resolved:
+                logger.debug("Skipping observed audio path outside Hermes audio cache: %s", selected_path)
+                return history
+
+            try:
+                stat = os.stat(resolved)
+                cache_key = (resolved, stat.st_mtime_ns, stat.st_size)
+            except OSError:
+                return history
+
+            transcript = transcript_cache.get(cache_key)
+            if transcript is None:
                 try:
-                    stat = os.stat(resolved)
-                    cache_key = (resolved, stat.st_mtime_ns, stat.st_size)
-                except OSError:
-                    continue
+                    from tools.transcription_tools import transcribe_audio
 
-                transcript = transcript_cache.get(cache_key)
-                if transcript is None:
-                    try:
-                        from tools.transcription_tools import transcribe_audio
+                    logger.info("Transcribing selected observed audio context: %s", resolved)
+                    result = await asyncio.to_thread(transcribe_audio, resolved)
+                except Exception as exc:
+                    logger.warning("Observed audio transcription failed for %s: %s", resolved, exc)
+                    return history
 
-                        logger.info("Transcribing observed audio context: %s", resolved)
-                        result = await asyncio.to_thread(transcribe_audio, resolved)
-                    except Exception as exc:
-                        logger.warning(
-                            "Observed audio transcription failed for %s: %s",
-                            resolved,
-                            exc,
-                        )
-                        continue
-                    if not result.get("success"):
-                        logger.info(
-                            "Observed audio transcription unavailable for %s: %s",
-                            resolved,
-                            result.get("error", "unknown error"),
-                        )
-                        continue
-                    transcript = str(result.get("transcript") or "").strip()
-                    if not transcript:
-                        continue
-                    transcript_cache[cache_key] = transcript
+                if not result.get("success"):
+                    logger.info(
+                        "Observed audio transcription unavailable for %s: %s",
+                        resolved,
+                        result.get("error", "unknown error"),
+                    )
+                    return history
 
-                notes.append(
-                    _append_observed_audio_transcript_note("", raw_path, transcript)
-                )
-                note_transcripts.append(transcript)
-                already_transcribed.add(raw_path)
-
-            if not notes:
-                enriched_history.append(msg)
-                continue
+                transcript = str(result.get("transcript") or "").strip()
+                if not transcript:
+                    return history
+                transcript_cache[cache_key] = transcript
 
             updated = dict(msg)
-            updated["content"] = f"{content.rstrip()}\n\n" + "\n\n".join(notes)
+            updated["content"] = _append_observed_audio_transcript_note(
+                content,
+                selected_path,
+                transcript,
+            )
             updated["_observed_audio_transcripts"] = [
                 *updated.get("_observed_audio_transcripts", []),
-                *note_transcripts,
+                transcript,
             ]
-            enriched_history.append(updated)
-            changed = True
+            # This marker is deliberately runtime-only. It keeps the current
+            # prompt scoped to the one audio item the user selected instead of
+            # re-injecting transcripts from older observed turns.
+            updated["_observed_audio_transcripts_for_current_turn"] = [transcript]
 
-        return enriched_history if changed else history
+            enriched_history = list(history)
+            enriched_history[index] = updated
+            return enriched_history
+
+        return history
 
     def _pending_event_audio_paths(self, event) -> List[str]:
         """Return STT-eligible paths from a pending voice message."""
@@ -25282,6 +25415,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        observed_audio_request_message: Any = None,
+        observed_audio_reference: Any = None,
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
@@ -25301,7 +25436,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message, context_prompt, history, source, session_id,
                 session_key=session_key, run_generation=run_generation,
                 _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
-                channel_prompt=channel_prompt, moa_config=moa_config,
+                channel_prompt=channel_prompt,
+                observed_audio_request_message=observed_audio_request_message,
+                observed_audio_reference=observed_audio_reference,
+                moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=message_type,
@@ -25313,7 +25451,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message, context_prompt, history, source, session_id,
                 session_key=session_key, run_generation=run_generation,
                 _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
-                channel_prompt=channel_prompt, moa_config=moa_config,
+                channel_prompt=channel_prompt,
+                observed_audio_request_message=observed_audio_request_message,
+                observed_audio_reference=observed_audio_reference,
+                moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=message_type,
@@ -25435,6 +25576,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        observed_audio_request_message: Any = None,
+        observed_audio_reference: Any = None,
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
@@ -25882,7 +26025,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         history = await self._enrich_observed_audio_context(
             history,
             channel_prompt=channel_prompt,
-            current_message=message,
+            current_message=(
+                observed_audio_request_message
+                if observed_audio_request_message is not None
+                else message
+            ),
+            explicit_audio_reference=observed_audio_reference,
         )
         turn_ctx.history = history
         turn_ctx.observed_audio_transcripts = _observed_audio_transcripts_from_history(
@@ -26950,6 +27098,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
                     message_type=next_message_type,
+                    observed_audio_request_message=(
+                        getattr(pending_event, "text", None)
+                        if pending_event is not None
+                        else None
+                    ),
+                    observed_audio_reference=(
+                        getattr(pending_event, "reply_to_text", None)
+                        if pending_event is not None
+                        else None
+                    ),
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18074,26 +18074,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     if _hyg_rotated:
                                         # Reset stored token count — transcript rewritten
                                         session_entry.last_prompt_tokens = 0
+                                        # Measure the compression result itself. The
+                                        # reload may include inherited observed rows that
+                                        # are needed for this turn but are not evidence
+                                        # that compaction failed to make progress.
+                                        _new_count = len(_compressed)
+                                        _new_tokens = estimate_messages_tokens_rough(
+                                            _compressed
+                                        )
                                         # Reload so observed context inherited from
                                         # compression ancestors is visible on this turn.
                                         history = await self.async_session_store.load_transcript(
                                             session_entry.session_id
-                                        )
-                                        _new_count = len(history)
-                                        _new_tokens = estimate_messages_tokens_rough(
-                                            history
                                         )
                                     elif _hyg_in_place:
                                         # archive_and_compact() already persisted the
                                         # compacted transcript inside _compress_context.
                                         # Reset counts to match the new active set.
                                         session_entry.last_prompt_tokens = 0
+                                        _new_count = len(_compressed)
+                                        _new_tokens = estimate_messages_tokens_rough(
+                                            _compressed
+                                        )
                                         history = await self.async_session_store.load_transcript(
                                             session_entry.session_id
-                                        )
-                                        _new_count = len(history)
-                                        _new_tokens = estimate_messages_tokens_rough(
-                                            history
                                         )
                                     else:
                                         # No rewrite happened — transcript preserved

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -79,6 +79,7 @@ from hermes_cli.fallback_config import get_fallback_chain
 # (see gateway/agent_cache_pressure.py).
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
+_OBSERVED_AUDIO_TRANSCRIPT_CACHE_MAX_SIZE = 128
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 # Telegram cold polling now proves one real getUpdates round trip before connect
 # returns. Leave enough outer budget for initialize/deleteWebhook/start_polling
@@ -22736,7 +22737,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         transcript_cache = getattr(self, "_observed_audio_transcript_cache", None)
         if transcript_cache is None:
-            transcript_cache = {}
+            transcript_cache = OrderedDict()
             self._observed_audio_transcript_cache = transcript_cache
 
         context_start = _observed_context_start_index(history)
@@ -22763,6 +22764,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except OSError:
                 return history
 
+            # A path can be reused after the underlying cache file changes.
+            # Drop obsolete stat-key versions so stale private transcripts do
+            # not remain process-long, even though they can no longer be hit.
+            for old_key in list(transcript_cache):
+                if old_key[0] == resolved and old_key != cache_key:
+                    transcript_cache.pop(old_key, None)
+
             transcript = transcript_cache.get(cache_key)
             if transcript is None:
                 try:
@@ -22786,6 +22794,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if not transcript:
                     return history
                 transcript_cache[cache_key] = transcript
+                transcript_cache.move_to_end(cache_key)
+                while len(transcript_cache) > _OBSERVED_AUDIO_TRANSCRIPT_CACHE_MAX_SIZE:
+                    transcript_cache.popitem(last=False)
+            else:
+                transcript_cache.move_to_end(cache_key)
 
             updated = dict(msg)
             updated["content"] = _append_observed_audio_transcript_note(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1260,6 +1260,24 @@ def _build_replay_entry(
 _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER = "observed Telegram group context"
 _OBSERVED_GROUP_CONTEXT_HEADER = "[Observed Telegram group context - context only, not requests]"
 _CURRENT_ADDRESSED_MESSAGE_HEADER = "[Current addressed message - answer only this unless it explicitly asks you to use the observed context]"
+_OBSERVED_AUDIO_TRANSCRIPT_MARKER = "Observed audio transcript"
+_OBSERVED_AUDIO_EXTENSIONS = frozenset({".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac", ".aac", ".webm"})
+_OBSERVED_AUDIO_NOTE_RE = re.compile(
+    r"\[audio\s+'[^']*'\s+saved at:\s*(?P<path>[^\]\r\n]+)\]",
+    re.IGNORECASE,
+)
+_LEGACY_OBSERVED_AUDIO_NOTE_RE = re.compile(
+    r"\[Observed Telegram (?:voice message|audio)[^:\]]*:\s*'[^']*'\s+saved at:\s*(?P<path>[^\]\r\n]+)\]",
+    re.IGNORECASE,
+)
+_OBSERVED_AUDIO_TRANSCRIPT_PATH_RE = re.compile(
+    rf"\[{re.escape(_OBSERVED_AUDIO_TRANSCRIPT_MARKER)}[^\]]*?\(path:\s*(?P<path>[^)\]\r\n]+)\)\]",
+    re.IGNORECASE,
+)
+_OBSERVED_AUDIO_TRANSCRIPT_RE = re.compile(
+    rf"\[{re.escape(_OBSERVED_AUDIO_TRANSCRIPT_MARKER)}:\s*\"(?P<transcript>.*?)\"\s*\(path:\s*(?P<path>[^)\]\r\n]+)\)\]",
+    re.IGNORECASE | re.DOTALL,
+)
 
 
 def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool:
@@ -1341,6 +1359,209 @@ def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
         return bool(mt.get("enabled", False))
     # Allow a bare ``message_timestamps: true`` shorthand.
     return bool(mt)
+
+
+def _extract_observed_audio_paths(content: Any) -> List[str]:
+    """Return cached audio paths from observed-media transcript notes."""
+
+    if not isinstance(content, str):
+        return []
+
+    paths: List[str] = []
+    seen: set[str] = set()
+    for pattern in (_OBSERVED_AUDIO_NOTE_RE, _LEGACY_OBSERVED_AUDIO_NOTE_RE):
+        for match in pattern.finditer(content):
+            raw_path = match.group("path").strip().strip("\"'")
+            if not raw_path:
+                continue
+            suffix = Path(raw_path).suffix.lower()
+            if suffix not in _OBSERVED_AUDIO_EXTENSIONS:
+                continue
+            if raw_path in seen:
+                continue
+            seen.add(raw_path)
+            paths.append(raw_path)
+    return paths
+
+
+def _observed_audio_transcript_paths(history: List[Dict[str, Any]]) -> set[str]:
+    """Return audio paths already represented by an observed transcript note."""
+
+    paths: set[str] = set()
+    for msg in history or []:
+        content = msg.get("content")
+        if not isinstance(content, str):
+            continue
+        for match in _OBSERVED_AUDIO_TRANSCRIPT_PATH_RE.finditer(content):
+            path = match.group("path").strip().strip("\"'")
+            if path:
+                paths.add(path)
+    return paths
+
+
+def _extract_observed_audio_transcripts(content: Any) -> List[str]:
+    """Return transcript strings from observed-audio transcript notes."""
+
+    if not isinstance(content, str):
+        return []
+
+    transcripts: List[str] = []
+    seen: set[str] = set()
+    for match in _OBSERVED_AUDIO_TRANSCRIPT_RE.finditer(content):
+        transcript = match.group("transcript").strip()
+        if not transcript or transcript in seen:
+            continue
+        seen.add(transcript)
+        transcripts.append(transcript)
+    return transcripts
+
+
+def _strip_observed_audio_notes(content: Optional[str]) -> Optional[str]:
+    """Remove cached-audio implementation notes once transcripts are attached."""
+
+    if not isinstance(content, str) or not content.strip():
+        return content
+    cleaned = _OBSERVED_AUDIO_NOTE_RE.sub("", content)
+    cleaned = _LEGACY_OBSERVED_AUDIO_NOTE_RE.sub("", cleaned)
+    cleaned = _OBSERVED_AUDIO_TRANSCRIPT_RE.sub("", cleaned)
+    lines = [line.rstrip() for line in cleaned.splitlines()]
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    meaningful = [
+        line for line in lines
+        if line.strip() and not re.fullmatch(r"\[[^\]]+\]", line.strip())
+    ]
+    if not meaningful:
+        return None
+    return "\n".join(lines).strip() or None
+
+
+def _observed_audio_transcripts_from_history(history: List[Dict[str, Any]]) -> List[str]:
+    """Return observed-audio transcripts carried by enriched history rows."""
+
+    transcripts: List[str] = []
+    seen: set[str] = set()
+    for msg in history or []:
+        raw_items = msg.get("_observed_audio_transcripts")
+        if isinstance(raw_items, list):
+            items = [item for item in raw_items if isinstance(item, str)]
+        else:
+            items = []
+        items.extend(_extract_observed_audio_transcripts(msg.get("content")))
+        for transcript in items:
+            transcript = transcript.strip()
+            if not transcript or transcript in seen:
+                continue
+            seen.add(transcript)
+            transcripts.append(transcript)
+    return transcripts
+
+
+def _message_requests_observed_audio(message: Any) -> bool:
+    """Return True when the current turn plausibly asks about observed audio."""
+
+    if isinstance(message, str):
+        text = message
+    elif isinstance(message, list):
+        parts = []
+        for part in message:
+            if isinstance(part, dict) and part.get("type") == "text":
+                parts.append(str(part.get("text") or ""))
+        text = "\n".join(parts)
+    else:
+        return False
+
+    text = text.lower()
+    return any(
+        marker in text
+        for marker in (
+            "audio",
+            "áudio",
+            "voice",
+            "voz",
+            "ouvir",
+            "ouve",
+            "escutar",
+            "escuta",
+            "transcrev",
+            "transcri",
+            "respondendo",
+            "respondi",
+            "reply",
+            "replied",
+            "said",
+            "disse",
+            "falou",
+        )
+    )
+
+
+def _resolve_observed_audio_cache_path(path: str) -> Optional[str]:
+    """Return the host path for an observed audio cache note, if trusted."""
+
+    try:
+        candidate = Path(path).expanduser()
+    except (OSError, RuntimeError):
+        return None
+
+    if candidate.suffix.lower() not in _OBSERVED_AUDIO_EXTENSIONS:
+        return None
+
+    try:
+        from gateway.platforms.base import get_audio_cache_dir
+        from hermes_constants import get_hermes_home
+        from tools.credential_files import get_cache_directory_mounts
+
+        hermes_home = get_hermes_home()
+        root_pairs: list[tuple[Path, str]] = []
+        for root in (get_audio_cache_dir(), hermes_home / "audio_cache", hermes_home / "cache" / "audio"):
+            root_pairs.append((Path(root), str(Path(root))))
+        for mount in get_cache_directory_mounts():
+            container_path = str(mount.get("container_path") or "")
+            host_path = str(mount.get("host_path") or "")
+            if container_path.endswith("/cache/audio") and host_path:
+                root_pairs.append((Path(host_path), container_path))
+    except Exception:
+        return None
+
+    raw_path = str(path)
+    for host_root, visible_root in root_pairs:
+        try:
+            resolved_host_root = host_root.expanduser().resolve()
+        except (OSError, RuntimeError):
+            continue
+
+        try:
+            direct = candidate.resolve()
+            direct.relative_to(resolved_host_root)
+            if direct.is_file():
+                return str(direct)
+        except (OSError, RuntimeError, ValueError):
+            pass
+
+        visible_prefix = visible_root.rstrip("/") + "/"
+        if raw_path.startswith(visible_prefix):
+            rel = raw_path[len(visible_prefix):]
+            mapped = resolved_host_root / rel
+            try:
+                mapped = mapped.resolve()
+                mapped.relative_to(resolved_host_root)
+            except (OSError, RuntimeError, ValueError):
+                continue
+            if mapped.is_file() and mapped.suffix.lower() in _OBSERVED_AUDIO_EXTENSIONS:
+                return str(mapped)
+
+    return None
+
+
+def _append_observed_audio_transcript_note(content: str, path: str, transcript: str) -> str:
+    note = (
+        f"[{_OBSERVED_AUDIO_TRANSCRIPT_MARKER}: \"{transcript.strip()}\" "
+        f"(path: {path})]"
+    )
+    return f"{content.rstrip()}\n\n{note}" if content else note
 
 
 def _build_gateway_agent_history(
@@ -1482,10 +1703,51 @@ def _select_cached_agent_history(
     return persisted_history
 
 
-def _wrap_current_message_with_observed_context(message: Any, observed_context: Optional[str]) -> Any:
-    """Prepend observed Telegram context to the API-only current user turn."""
+def _wrap_current_message_with_observed_context(
+    message: Any,
+    observed_context: Optional[str],
+    *,
+    observed_audio_transcripts: Optional[List[str]] = None,
+) -> Any:
+    """Attach observed Telegram context to the API-only current user turn."""
 
-    if not observed_context:
+    if not observed_context and not observed_audio_transcripts:
+        return message
+
+    observed_audio_transcripts = (
+        observed_audio_transcripts
+        if observed_audio_transcripts is not None
+        else _extract_observed_audio_transcripts(observed_context)
+    )
+    if observed_audio_transcripts:
+        transcript_lines = "\n\n".join(
+            f"[The user sent a voice message~ Here's what they said: \"{transcript}\"]\n"
+            "[The current text message asks about that voice message. Use the "
+            "transcription above as the audio content; do not ask the user to "
+            "resend it.]"
+            for transcript in observed_audio_transcripts
+        )
+
+    if observed_audio_transcripts:
+        prefix = f"{transcript_lines}\n\n"
+        stripped_observed_context = _strip_observed_audio_notes(observed_context)
+        suffix = ""
+        if stripped_observed_context:
+            suffix = (
+                f"\n\n{_OBSERVED_GROUP_CONTEXT_HEADER}\n"
+                f"{stripped_observed_context}"
+            )
+        if isinstance(message, str):
+            return f"{prefix}{message}{suffix}"
+
+        if isinstance(message, list):
+            wrapped = [dict(part) if isinstance(part, dict) else part for part in message]
+            for part in wrapped:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    part["text"] = f"{prefix}{part.get('text', '')}{suffix}"
+                    return wrapped
+            return [{"type": "text", "text": f"{prefix.rstrip()}{suffix}"}] + wrapped
+
         return message
 
     prefix = (
@@ -1506,6 +1768,15 @@ def _wrap_current_message_with_observed_context(message: Any, observed_context: 
         return [{"type": "text", "text": prefix.rstrip()}] + wrapped
 
     return message
+
+
+def _should_persist_clean_observed_message(
+    observed_context: Optional[str],
+    observed_audio_transcripts: Optional[List[str]],
+) -> bool:
+    """Return True when observed context should stay API-only for persistence."""
+
+    return bool(observed_context and not observed_audio_transcripts)
 
 
 def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
@@ -5581,6 +5852,7 @@ class TurnRunner:
             _api_run_message = _wrap_current_message_with_observed_context(
                 _run_message,
                 observed_group_context,
+                observed_audio_transcripts=ctx.observed_audio_transcripts,
             )
             _conversation_kwargs = {
                 "conversation_history": agent_history,
@@ -5588,7 +5860,10 @@ class TurnRunner:
             }
             if _persist_user_message_override is not None:
                 _conversation_kwargs["persist_user_message"] = _persist_user_message_override
-            elif observed_group_context:
+            elif _should_persist_clean_observed_message(
+                observed_group_context,
+                ctx.observed_audio_transcripts,
+            ):
                 _conversation_kwargs["persist_user_message"] = ctx.message
             if ctx.moa_config is not None:
                 _conversation_kwargs["moa_config"] = ctx.moa_config
@@ -17683,20 +17958,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     if _hyg_rotated:
                                         # Reset stored token count — transcript rewritten
                                         session_entry.last_prompt_tokens = 0
-                                        history = _compressed
-                                        _new_count = len(_compressed)
+                                        # Reload so observed context inherited from
+                                        # compression ancestors is visible on this turn.
+                                        history = await self.async_session_store.load_transcript(
+                                            session_entry.session_id
+                                        )
+                                        _new_count = len(history)
                                         _new_tokens = estimate_messages_tokens_rough(
-                                            _compressed
+                                            history
                                         )
                                     elif _hyg_in_place:
                                         # archive_and_compact() already persisted the
                                         # compacted transcript inside _compress_context.
                                         # Reset counts to match the new active set.
                                         session_entry.last_prompt_tokens = 0
-                                        history = _compressed
-                                        _new_count = len(_compressed)
+                                        history = await self.async_session_store.load_transcript(
+                                            session_entry.session_id
+                                        )
+                                        _new_count = len(history)
                                         _new_tokens = estimate_messages_tokens_rough(
-                                            _compressed
+                                            history
                                         )
                                     else:
                                         # No rewrite happened — transcript preserved
@@ -22296,6 +22577,104 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return prefix, successful_transcripts
         return user_text, successful_transcripts
 
+    async def _enrich_observed_audio_context(
+        self,
+        history: List[Dict[str, Any]],
+        *,
+        channel_prompt: Optional[str] = None,
+        current_message: Any = None,
+    ) -> List[Dict[str, Any]]:
+        """Transcribe cached observed audio on the addressed follow-up turn."""
+        if not history or not _uses_telegram_observed_group_context(channel_prompt):
+            return history
+        if not getattr(self.config, "stt_enabled", True):
+            return history
+        if not _message_requests_observed_audio(current_message):
+            return history
+
+        already_transcribed = _observed_audio_transcript_paths(history)
+        transcript_cache = getattr(self, "_observed_audio_transcript_cache", None)
+        if transcript_cache is None:
+            transcript_cache = {}
+            self._observed_audio_transcript_cache = transcript_cache
+
+        changed = False
+        enriched_history: List[Dict[str, Any]] = []
+        for msg in history:
+            content = msg.get("content")
+            if not (
+                msg.get("observed")
+                and msg.get("role") == "user"
+                and isinstance(content, str)
+            ):
+                enriched_history.append(msg)
+                continue
+
+            notes: List[str] = []
+            note_transcripts: List[str] = []
+            for raw_path in _extract_observed_audio_paths(content):
+                if raw_path in already_transcribed:
+                    continue
+                resolved = _resolve_observed_audio_cache_path(raw_path)
+                if not resolved:
+                    logger.debug(
+                        "Skipping observed audio path outside Hermes audio cache: %s",
+                        raw_path,
+                    )
+                    continue
+                try:
+                    stat = os.stat(resolved)
+                    cache_key = (resolved, stat.st_mtime_ns, stat.st_size)
+                except OSError:
+                    continue
+
+                transcript = transcript_cache.get(cache_key)
+                if transcript is None:
+                    try:
+                        from tools.transcription_tools import transcribe_audio
+
+                        logger.info("Transcribing observed audio context: %s", resolved)
+                        result = await asyncio.to_thread(transcribe_audio, resolved)
+                    except Exception as exc:
+                        logger.warning(
+                            "Observed audio transcription failed for %s: %s",
+                            resolved,
+                            exc,
+                        )
+                        continue
+                    if not result.get("success"):
+                        logger.info(
+                            "Observed audio transcription unavailable for %s: %s",
+                            resolved,
+                            result.get("error", "unknown error"),
+                        )
+                        continue
+                    transcript = str(result.get("transcript") or "").strip()
+                    if not transcript:
+                        continue
+                    transcript_cache[cache_key] = transcript
+
+                notes.append(
+                    _append_observed_audio_transcript_note("", raw_path, transcript)
+                )
+                note_transcripts.append(transcript)
+                already_transcribed.add(raw_path)
+
+            if not notes:
+                enriched_history.append(msg)
+                continue
+
+            updated = dict(msg)
+            updated["content"] = f"{content.rstrip()}\n\n" + "\n\n".join(notes)
+            updated["_observed_audio_transcripts"] = [
+                *updated.get("_observed_audio_transcripts", []),
+                *note_transcripts,
+            ]
+            enriched_history.append(updated)
+            changed = True
+
+        return enriched_history if changed else history
+
     def _pending_event_audio_paths(self, event) -> List[str]:
         """Return STT-eligible paths from a pending voice message."""
         audio_paths: List[str] = []
@@ -25499,6 +25878,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         turn_ctx._progress_metadata = _progress_metadata
         turn_ctx._progress_reply_to = _progress_reply_to
         send_progress_messages = turn_runner.send_progress_messages
+
+        history = await self._enrich_observed_audio_context(
+            history,
+            channel_prompt=channel_prompt,
+            current_message=message,
+        )
+        turn_ctx.history = history
+        turn_ctx.observed_audio_transcripts = _observed_audio_transcripts_from_history(
+            history
+        )
         
         # We need to share the agent instance for interrupt support
         agent_holder = [None]  # Mutable container for the agent instance

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3801,6 +3801,10 @@ class SessionStore:
         chain while reads queried the stale id directly — the transcript
         "vanished" (disk=0) even though every message sat healthy under the
         child session.
+
+        Observed messages from compression-ancestor sessions are prepended so
+        that observed context (e.g. unaddressed media in a Telegram group) is
+        not silently dropped when a compression split creates a new session.
         """
         if not self._db:
             return []
@@ -3820,13 +3824,38 @@ class SessionStore:
         except Exception:
             pass
         try:
-            # repair_alternation: this load feeds LIVE REPLAY. A durable
-            # user;user wedge (e.g. a turn that persisted no assistant row)
-            # would otherwise re-trigger the pre-request repair on every
-            # request forever — heal it once at the restore boundary.
-            return self._db.get_messages_as_conversation(
-                session_id, repair_alternation=True
-            )
+            # Heal alternation at the live replay boundary while retaining
+            # observed messages as hard boundaries: merging adjacent observed
+            # users would discard platform message ids used by audio-reference
+            # selection.
+            messages = self._db.get_messages_as_conversation(session_id)
+            if messages:
+                from agent.agent_runtime_helpers import repair_message_sequence
+
+                repaired_messages: List[Dict[str, Any]] = []
+                unobserved_segment: List[Dict[str, Any]] = []
+
+                def _flush_unobserved_segment() -> None:
+                    if not unobserved_segment:
+                        return
+                    repair_message_sequence(None, unobserved_segment)
+                    repaired_messages.extend(unobserved_segment)
+                    unobserved_segment.clear()
+
+                for message in messages:
+                    if message.get("observed"):
+                        _flush_unobserved_segment()
+                        repaired_messages.append(message)
+                    else:
+                        unobserved_segment.append(message)
+                _flush_unobserved_segment()
+                messages = repaired_messages
+            get_ancestor_observed = getattr(self._db, "get_ancestor_observed_messages", None)
+            if get_ancestor_observed:
+                ancestor_observed = get_ancestor_observed(session_id)
+                if ancestor_observed:
+                    messages = ancestor_observed + messages
+            return messages
         except Exception as e:
             # A failed read must be distinguishable from an empty transcript:
             # downstream guards treat [] as "nothing persisted" and may make

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3824,10 +3824,10 @@ class SessionStore:
         except Exception:
             pass
         try:
-            # Heal alternation at the live replay boundary while retaining
-            # observed messages as hard boundaries: merging adjacent observed
-            # users would discard platform message ids used by audio-reference
-            # selection.
+            # This load feeds LIVE REPLAY. Heal durable alternation violations
+            # at the restore boundary, but keep observed rows as boundaries:
+            # merging consecutive observed users discards all but the first
+            # platform message id and breaks later audio-reference selection.
             messages = self._db.get_messages_as_conversation(session_id)
             if messages:
                 from agent.agent_runtime_helpers import repair_message_sequence

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -79,6 +79,7 @@ class TurnContext:
 
     # --- turn parameters / config snapshots (read-only in run_sync) -------
     history: Any = None
+    observed_audio_transcripts: List[str] = field(default_factory=list)
     context_prompt: Optional[str] = None
     channel_prompt: Optional[str] = None
     session_id: Optional[str] = None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8821,6 +8821,45 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 current = row["parent_session_id"] if hasattr(row, "keys") else row[0]
         return list(reversed(chain)) or [session_id]
 
+    def get_ancestor_observed_messages(self, session_id: str) -> List[Dict[str, Any]]:
+        """Return observed=True messages from compression-split ancestor sessions.
+
+        When context compression creates a new session, observed messages stored
+        in the parent session (e.g. unaddressed media/audio in a Telegram group)
+        are no longer accessible via the new session's transcript. This method
+        fetches those messages so callers can surface them as context.
+
+        Only includes messages from sessions that ended via compression
+        (``end_reason = 'compression'``), avoiding leakage from delegate-subagent
+        parent sessions that happen to share a ``parent_session_id`` link.
+        """
+        lineage = self._session_lineage_root_to_tip(session_id)
+        ancestor_ids = lineage[:-1]
+        if not ancestor_ids:
+            return []
+
+        placeholders = ",".join("?" for _ in ancestor_ids)
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT m.role, m.content, m.platform_message_id "
+                f"FROM messages m "
+                f"JOIN sessions s ON s.id = m.session_id "
+                f"WHERE m.session_id IN ({placeholders}) "
+                f"  AND m.observed = 1 AND m.active = 1 "
+                f"  AND s.end_reason = 'compression' "
+                f"ORDER BY m.id",
+                tuple(ancestor_ids),
+            ).fetchall()
+
+        result = []
+        for row in rows:
+            content = self._decode_content(row["content"])
+            msg: Dict[str, Any] = {"role": row["role"], "content": content, "observed": True}
+            if row["platform_message_id"]:
+                msg["message_id"] = row["platform_message_id"]
+            result.append(msg)
+        return result
+
     @staticmethod
     def _is_duplicate_replayed_user_message(messages: List[Dict[str, Any]], msg: Dict[str, Any]) -> bool:
         if msg.get("role") != "user":

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -483,6 +483,11 @@ def _ensure_test_isolation(db_path: Path) -> None:
                 "@pytest.mark.live_system_guard_bypass."
             )
 
+# Observed gateway messages bypass model-generated compression summaries, so
+# retaining them without a bound can rebuild an oversized live context after
+# compaction. Apply one global cap to both in-place and split-session flows.
+MAX_OBSERVED_CONTEXT_MESSAGES = 50
+
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
 # ---------------------------------------------------------------------------
@@ -8085,6 +8090,56 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     conn, session_id, model_config_patch, on_missing="raise"
                 )
 
+            observed_rows = conn.execute(
+                "SELECT role, content, timestamp, platform_message_id FROM ("
+                "  SELECT id AS message_row_id, role, content, timestamp, "
+                "         platform_message_id "
+                "  FROM messages WHERE session_id = ? AND active = 1 "
+                "    AND observed = 1 "
+                "  ORDER BY id DESC LIMIT ?"
+                ") ORDER BY message_row_id",
+                (session_id, MAX_OBSERVED_CONTEXT_MESSAGES),
+            ).fetchall()
+
+            def _same_observed_message(
+                left: Dict[str, Any], right: Dict[str, Any]
+            ) -> bool:
+                if not right.get("observed"):
+                    return False
+                left_id = left.get("message_id") or left.get("platform_message_id")
+                right_id = right.get("message_id") or right.get("platform_message_id")
+                if left_id and right_id:
+                    return left_id == right_id
+                return (
+                    left.get("role") == right.get("role")
+                    and left.get("content") == right.get("content")
+                )
+
+            retained_observed: List[Dict[str, Any]] = []
+            for row in observed_rows:
+                candidate: Dict[str, Any] = {
+                    "role": row["role"],
+                    "content": self._decode_content(row["content"]),
+                    "timestamp": row["timestamp"],
+                    "observed": True,
+                }
+                if row["platform_message_id"]:
+                    candidate["message_id"] = row["platform_message_id"]
+
+                compacted_copy = next(
+                    (
+                        message
+                        for message in compacted_messages
+                        if _same_observed_message(candidate, message)
+                    ),
+                    None,
+                )
+                retained_observed.append(compacted_copy or candidate)
+
+            compacted_without_observed = [
+                message for message in compacted_messages if not message.get("observed")
+            ]
+
             # Soft-archive the live turns: active=0 hides them from the live
             # context load, compacted=1 marks them as "summarized away" (vs
             # rewind/undo's active=0+compacted=0, which means "user took it
@@ -8097,7 +8152,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (session_id,),
             )
             inserted, tool_calls_total = self._insert_message_rows(
-                conn, session_id, compacted_messages
+                conn,
+                session_id,
+                [*retained_observed, *compacted_without_observed],
             )
             # message_count / tool_call_count reflect the LIVE (active) set —
             # the archived rows are still on disk but not part of the live count.
@@ -8831,7 +8888,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         Only includes messages from sessions that ended via compression
         (``end_reason = 'compression'``), avoiding leakage from delegate-subagent
-        parent sessions that happen to share a ``parent_session_id`` link.
+        parent sessions that happen to share a ``parent_session_id`` link. The
+        newest :data:`MAX_OBSERVED_CONTEXT_MESSAGES` rows are selected globally
+        across those ancestors, then returned in stable chronological order.
         """
         lineage = self._session_lineage_root_to_tip(session_id)
         ancestor_ids = lineage[:-1]
@@ -8841,14 +8900,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         placeholders = ",".join("?" for _ in ancestor_ids)
         with self._lock:
             rows = self._conn.execute(
-                f"SELECT m.role, m.content, m.platform_message_id "
-                f"FROM messages m "
-                f"JOIN sessions s ON s.id = m.session_id "
-                f"WHERE m.session_id IN ({placeholders}) "
-                f"  AND m.observed = 1 AND m.active = 1 "
-                f"  AND s.end_reason = 'compression' "
-                f"ORDER BY m.id",
-                tuple(ancestor_ids),
+                f"SELECT role, content, platform_message_id FROM ("
+                f"  SELECT m.id AS message_row_id, m.role, m.content, "
+                f"         m.platform_message_id "
+                f"  FROM messages m "
+                f"  JOIN sessions s ON s.id = m.session_id "
+                f"  WHERE m.session_id IN ({placeholders}) "
+                f"    AND m.observed = 1 AND m.active = 1 "
+                f"    AND s.end_reason = 'compression' "
+                f"  ORDER BY m.id DESC LIMIT ?"
+                f") ORDER BY message_row_id",
+                (*ancestor_ids, MAX_OBSERVED_CONTEXT_MESSAGES),
             ).fetchall()
 
         result = []

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -452,6 +452,86 @@ class TestLoadTranscriptDBOnly:
         assert result[0]["content"] == "db-q"
         assert result[1]["content"] == "db-a"
 
+    def test_load_transcript_keeps_messages_when_db_lacks_ancestor_helper(self, tmp_path):
+        config = GatewayConfig()
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = MagicMock(spec=["get_messages_as_conversation"])
+        store._db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "db-q"},
+        ]
+
+        result = store.load_transcript("session_without_helper")
+
+        assert result == [{"role": "user", "content": "db-q"}]
+
+    def test_load_transcript_prepends_observed_compression_ancestors(self, tmp_path, monkeypatch):
+        import hermes_state
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        config = GatewayConfig()
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+
+        parent = "parent_session"
+        child = "child_session"
+        store._db.create_session(session_id=parent, source="gateway", model="m")
+        store._db.append_message(
+            session_id=parent,
+            role="user",
+            content="[Alice|111]\n[audio 'voice.ogg' saved at: /tmp/audio.ogg]",
+            observed=True,
+            platform_message_id="tg-1",
+        )
+        store._db.append_message(
+            session_id=parent,
+            role="user",
+            content="ordinary parent turn",
+            observed=False,
+        )
+        store._db.end_session(parent, "compression")
+        store._db.create_session(
+            session_id=child,
+            source="gateway",
+            model="m",
+            parent_session_id=parent,
+        )
+        store._db.append_message(session_id=child, role="user", content="current child turn")
+
+        result = store.load_transcript(child)
+
+        assert [msg["content"] for msg in result] == [
+            "[Alice|111]\n[audio 'voice.ogg' saved at: /tmp/audio.ogg]",
+            "current child turn",
+        ]
+        assert result[0]["observed"] is True
+        assert result[0]["message_id"] == "tg-1"
+
+    def test_load_transcript_ignores_non_compression_parent_observed_messages(self, tmp_path, monkeypatch):
+        import hermes_state
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        config = GatewayConfig()
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+
+        parent = "parent_session"
+        child = "child_session"
+        store._db.create_session(session_id=parent, source="gateway", model="m")
+        store._db.append_message(
+            session_id=parent,
+            role="user",
+            content="delegated parent context",
+            observed=True,
+        )
+        store._db.end_session(parent, "user_exit")
+        store._db.create_session(
+            session_id=child,
+            source="gateway",
+            model="m",
+            parent_session_id=parent,
+        )
+        store._db.append_message(session_id=child, role="user", content="current child turn")
+
+        result = store.load_transcript(child)
+
+        assert [msg["content"] for msg in result] == ["current child turn"]
+
 
 class TestSessionStoreSwitchSession:
     """Regression coverage for gateway /resume session switching semantics."""

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -532,6 +532,116 @@ class TestLoadTranscriptDBOnly:
 
         assert [msg["content"] for msg in result] == ["current child turn"]
 
+    def test_load_transcript_bounds_observed_context_across_compression_ancestors(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        limit = hermes_state.MAX_OBSERVED_CONTEXT_MESSAGES
+        root = "bounded_root"
+        middle = "bounded_middle"
+        child = "bounded_child"
+        root_count = limit // 2 + 2
+
+        store._db.create_session(session_id=root, source="gateway", model="m")
+        for index in range(root_count):
+            store._db.append_message(
+                session_id=root,
+                role="user",
+                content=f"observed-{index:03d}",
+                observed=True,
+            )
+        store._db.end_session(root, "compression")
+
+        store._db.create_session(
+            session_id=middle,
+            source="gateway",
+            model="m",
+            parent_session_id=root,
+        )
+        for index in range(root_count, limit + 5):
+            store._db.append_message(
+                session_id=middle,
+                role="user",
+                content=f"observed-{index:03d}",
+                observed=True,
+            )
+        store._db.end_session(middle, "compression")
+        store._db.create_session(
+            session_id=child,
+            source="gateway",
+            model="m",
+            parent_session_id=middle,
+        )
+        store._db.append_message(
+            session_id=child,
+            role="user",
+            content="current child turn",
+        )
+
+        result = store.load_transcript(child)
+
+        assert [message["content"] for message in result[:-1]] == [
+            f"observed-{index:03d}" for index in range(5, limit + 5)
+        ]
+        assert len(result[:-1]) == limit
+        assert result[-1]["content"] == "current child turn"
+
+    def test_load_transcript_keeps_observed_context_across_in_place_compaction(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        session_id = "in_place_session"
+        limit = hermes_state.MAX_OBSERVED_CONTEXT_MESSAGES
+        store._db.create_session(session_id=session_id, source="gateway", model="m")
+        for index in range(limit + 5):
+            store._db.append_message(
+                session_id=session_id,
+                role="user",
+                content=f"observed-{index:03d}",
+                observed=True,
+                platform_message_id=f"tg-{index:03d}",
+            )
+        store._db.append_message(
+            session_id=session_id,
+            role="user",
+            content="ordinary turn",
+        )
+
+        store._db.archive_and_compact(
+            session_id,
+            [{"role": "assistant", "content": "first compacted summary"}],
+        )
+        first_result = store.load_transcript(session_id)
+        retained_for_second_compaction = [
+            dict(message) for message in first_result if message.get("observed")
+        ]
+        store._db.archive_and_compact(
+            session_id,
+            [
+                *retained_for_second_compaction,
+                {"role": "assistant", "content": "second compacted summary"},
+            ],
+        )
+
+        result = store.load_transcript(session_id)
+
+        assert [message["content"] for message in first_result[:-1]] == [
+            f"observed-{index:03d}" for index in range(5, limit + 5)
+        ]
+        assert [message["content"] for message in result[:-1]] == [
+            f"observed-{index:03d}" for index in range(5, limit + 5)
+        ]
+        assert len(result[:-1]) == limit
+        assert result[-1]["content"] == "second compacted summary"
+        assert result[0]["observed"] is True
+        assert result[0]["message_id"] == "tg-005"
+
 
 class TestSessionStoreSwitchSession:
     """Regression coverage for gateway /resume session switching semantics."""

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -181,6 +181,76 @@ async def test_observed_audio_context_transcribes_on_addressed_followup(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_observed_audio_transcript_cache_is_bounded_lru_and_stat_sensitive(
+    tmp_path, monkeypatch
+):
+    import gateway.run as gateway_run
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr(gateway_run, "_OBSERVED_AUDIO_TRANSCRIPT_CACHE_MAX_SIZE", 3)
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    audio_paths = [tmp_path / f"audio-{index}.ogg" for index in range(4)]
+    for index, audio_path in enumerate(audio_paths):
+        audio_path.write_bytes(f"audio-{index}".encode())
+
+    async def enrich(audio_path):
+        history = [
+            {
+                "role": "user",
+                "observed": True,
+                "content": f"[audio '{audio_path.name}' saved at: {audio_path}]",
+            }
+        ]
+        return await runner._enrich_observed_audio_context(
+            history,
+            channel_prompt="observed Telegram group context",
+            current_message="transcreva o áudio",
+        )
+
+    calls = []
+
+    def transcribe(path):
+        calls.append(path)
+        return {
+            "success": True,
+            "transcript": f"transcript-{len(calls)}",
+            "provider": "test",
+        }
+
+    with patch(
+        "gateway.run._resolve_observed_audio_cache_path",
+        side_effect=lambda path: str(Path(path).resolve()),
+    ), patch("tools.transcription_tools.transcribe_audio", side_effect=transcribe):
+        for audio_path in audio_paths[:3]:
+            await enrich(audio_path)
+        await enrich(audio_paths[0])  # Hit promotes entry 0 to MRU.
+        await enrich(audio_paths[3])  # Capacity eviction must remove entry 1.
+
+        assert len(calls) == 4
+        assert len(runner._observed_audio_transcript_cache) == 3
+        assert [key[0] for key in runner._observed_audio_transcript_cache] == [
+            str(audio_paths[2].resolve()),
+            str(audio_paths[0].resolve()),
+            str(audio_paths[3].resolve()),
+        ]
+
+        await enrich(audio_paths[1])
+        assert len(calls) == 5  # True LRU entry was evicted and retranscribed.
+        assert len(runner._observed_audio_transcript_cache) == 3
+
+        audio_paths[0].write_bytes(b"changed-audio-size")
+        enriched = await enrich(audio_paths[0])
+        assert len(calls) == 6
+        assert "transcript-6" in enriched[0]["content"]
+        assert len(runner._observed_audio_transcript_cache) == 3
+        assert sum(
+            key[0] == str(audio_paths[0].resolve())
+            for key in runner._observed_audio_transcript_cache
+        ) == 1
+
+
+@pytest.mark.asyncio
 async def test_observed_audio_context_transcribes_only_latest_audio_for_clear_request(tmp_path):
     """A broad audio request must never fan out across observed voice notes."""
     from gateway.run import GatewayRunner

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -181,6 +181,233 @@ async def test_observed_audio_context_transcribes_on_addressed_followup(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_observed_audio_context_transcribes_only_latest_audio_for_clear_request(tmp_path):
+    """A broad audio request must never fan out across observed voice notes."""
+    from gateway.run import GatewayRunner
+
+    older_audio = tmp_path / "older.ogg"
+    newer_audio = tmp_path / "newer.ogg"
+    older_audio.write_bytes(b"older ogg bytes")
+    newer_audio.write_bytes(b"newer ogg bytes")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    history = [
+        {
+            "role": "user",
+            "observed": True,
+            "content": f"[Alice|111]\n[audio 'older.ogg' saved at: {older_audio}]",
+        },
+        {
+            "role": "user",
+            "observed": True,
+            "content": f"[Carol|333]\n[audio 'newer.ogg' saved at: {newer_audio}]",
+        },
+    ]
+
+    resolved_paths = {
+        str(older_audio): str(older_audio.resolve()),
+        str(newer_audio): str(newer_audio.resolve()),
+    }
+    with patch(
+        "gateway.run._resolve_observed_audio_cache_path",
+        side_effect=resolved_paths.get,
+    ), patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "latest voice", "provider": "openai"},
+    ) as transcribe:
+        enriched = await runner._enrich_observed_audio_context(
+            history,
+            channel_prompt="observed Telegram group context",
+            current_message="[Bob|222]\ntranscreva o último áudio, por favor",
+        )
+
+    transcribe.assert_called_once_with(str(newer_audio.resolve()))
+    assert enriched[0] is history[0]
+    assert "Observed audio transcript" not in enriched[0]["content"]
+    assert "latest voice" in enriched[1]["content"]
+    assert enriched[1]["_observed_audio_transcripts_for_current_turn"] == ["latest voice"]
+
+
+@pytest.mark.asyncio
+async def test_observed_audio_context_uses_explicit_reference_before_latest_audio(tmp_path):
+    """A reply quote anchors transcription even when its wording is otherwise vague."""
+    from gateway.run import GatewayRunner
+
+    older_audio = tmp_path / "older.ogg"
+    newer_audio = tmp_path / "newer.ogg"
+    older_audio.write_bytes(b"older ogg bytes")
+    newer_audio.write_bytes(b"newer ogg bytes")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    history = [
+        {
+            "role": "user",
+            "observed": True,
+            "content": f"[Alice|111]\n[audio 'older.ogg' saved at: {older_audio}]",
+        },
+        {
+            "role": "user",
+            "observed": True,
+            "content": f"[Carol|333]\n[audio 'newer.ogg' saved at: {newer_audio}]",
+        },
+    ]
+
+    with patch(
+        "gateway.run._resolve_observed_audio_cache_path",
+        side_effect=lambda path: str(Path(path).resolve()),
+    ), patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "older voice", "provider": "openai"},
+    ) as transcribe:
+        enriched = await runner._enrich_observed_audio_context(
+            history,
+            channel_prompt="observed Telegram group context",
+            current_message="o que ele disse?",
+            explicit_audio_reference=f"[audio 'older.ogg' saved at: {older_audio}]",
+        )
+
+    transcribe.assert_called_once_with(str(older_audio.resolve()))
+    assert "older voice" in enriched[0]["content"]
+    assert enriched[1] is history[1]
+
+
+@pytest.mark.asyncio
+async def test_observed_audio_context_ignores_vague_speech_reference(tmp_path):
+    """Words such as 'disse' must not trigger a privacy-costly STT fan-out."""
+    from gateway.run import GatewayRunner
+
+    first_audio = tmp_path / "first.ogg"
+    second_audio = tmp_path / "second.ogg"
+    first_audio.write_bytes(b"first ogg bytes")
+    second_audio.write_bytes(b"second ogg bytes")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    history = [
+        {
+            "role": "user",
+            "observed": True,
+            "content": f"[Alice|111]\n[audio 'first.ogg' saved at: {first_audio}]",
+        },
+        {
+            "role": "user",
+            "observed": True,
+            "content": f"[Carol|333]\n[audio 'second.ogg' saved at: {second_audio}]",
+        },
+    ]
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=AssertionError("vague speech references must not trigger STT"),
+    ) as transcribe:
+        enriched = await runner._enrich_observed_audio_context(
+            history,
+            channel_prompt="observed Telegram group context",
+            current_message=(
+                f"[Bob|222]\no que ele disse?\n"
+                f"[Replied-to audio 'direct.ogg' saved at: {tmp_path / 'direct.ogg'}]"
+            ),
+        )
+
+    transcribe.assert_not_called()
+    assert enriched is history
+
+
+@pytest.mark.asyncio
+async def test_observed_audio_context_ignores_audio_before_last_addressed_turn(tmp_path):
+    """Old observed rows are not candidates after a normal user turn begins a new window."""
+    from gateway.run import GatewayRunner, _build_gateway_agent_history
+
+    old_audio = tmp_path / "old.ogg"
+    old_audio.write_bytes(b"old ogg bytes")
+    history = [
+        {
+            "role": "user",
+            "observed": True,
+            "content": f"[Alice|111]\n[audio 'old.ogg' saved at: {old_audio}]",
+        },
+        {"role": "user", "content": "A previous addressed request"},
+        {"role": "assistant", "content": "A previous answer"},
+    ]
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=AssertionError("stale observed audio must not be transcribed"),
+    ) as transcribe:
+        enriched = await runner._enrich_observed_audio_context(
+            history,
+            channel_prompt="observed Telegram group context",
+            current_message="transcreva o áudio",
+        )
+
+    transcribe.assert_not_called()
+    assert enriched is history
+    _agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt="observed Telegram group context",
+    )
+    assert observed_context is None
+
+
+def test_observed_audio_transcripts_from_history_only_returns_current_selection():
+    from gateway.run import _observed_audio_transcripts_from_history
+
+    transcripts = _observed_audio_transcripts_from_history(
+        [
+            {"_observed_audio_transcripts": ["stale observed audio"]},
+            {"_observed_audio_transcripts_for_current_turn": ["selected audio"]},
+        ]
+    )
+
+    assert transcripts == ["selected audio"]
+
+
+@pytest.mark.asyncio
+async def test_observed_audio_context_clears_prior_turn_marker_without_audio_request(tmp_path):
+    """Queued follow-ups must not re-inject a transcript selected by the prior turn."""
+    from gateway.run import GatewayRunner, _observed_audio_transcripts_from_history
+
+    audio_path = tmp_path / "prior.ogg"
+    audio_path.write_bytes(b"prior ogg bytes")
+    history = [
+        {
+            "role": "user",
+            "observed": True,
+            "content": (
+                f"[Alice|111]\n[audio 'prior.ogg' saved at: {audio_path}]\n\n"
+                f'[Observed audio transcript: "prior transcript" (path: {audio_path})]'
+            ),
+            "_observed_audio_transcripts": ["prior transcript"],
+            "_observed_audio_transcripts_for_current_turn": ["prior transcript"],
+        }
+    ]
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=AssertionError("a non-audio follow-up must not invoke STT"),
+    ) as transcribe:
+        enriched = await runner._enrich_observed_audio_context(
+            history,
+            channel_prompt="observed Telegram group context",
+            current_message="bom dia",
+        )
+
+    transcribe.assert_not_called()
+    assert enriched is not history
+    assert enriched[0] is not history[0]
+    assert "_observed_audio_transcripts_for_current_turn" in history[0]
+    assert "_observed_audio_transcripts_for_current_turn" not in enriched[0]
+    assert enriched[0]["_observed_audio_transcripts"] == ["prior transcript"]
+    assert _observed_audio_transcripts_from_history(enriched) == []
+
+
+@pytest.mark.asyncio
 async def test_observed_audio_context_only_runs_for_telegram_observe_prompt(tmp_path):
     from gateway.run import GatewayRunner
 

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -407,8 +407,16 @@ async def test_observed_audio_context_clears_prior_turn_marker_without_audio_req
     assert _observed_audio_transcripts_from_history(enriched) == []
 
 
+@pytest.mark.parametrize(
+    "channel_prompt",
+    [None, "observed Matrix room context"],
+    ids=["no-observed-prompt", "matrix-observed-context"],
+)
 @pytest.mark.asyncio
-async def test_observed_audio_context_only_runs_for_telegram_observe_prompt(tmp_path):
+async def test_observed_audio_context_only_runs_for_telegram_observe_prompt(
+    tmp_path,
+    channel_prompt,
+):
     from gateway.run import GatewayRunner
 
     audio_path = tmp_path / "audio_123.ogg"
@@ -430,7 +438,7 @@ async def test_observed_audio_context_only_runs_for_telegram_observe_prompt(tmp_
     ):
         enriched = await runner._enrich_observed_audio_context(
             history,
-            channel_prompt=None,
+            channel_prompt=channel_prompt,
             current_message="[Bob|222]\nconsegue acessar esse audio?",
         )
 

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -95,3 +95,176 @@ async def test_enrich_message_with_transcription_guards_empty_transcript():
     assert transcripts == []
 
 
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/queued-voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "queued voice transcript",
+            "provider": "local_command",
+        },
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    # Success path: the transcript passes through as a plain quoted line, with
+    # no "voice message" meta-commentary that the LLM would echo back.
+    assert "queued voice transcript" in result
+
+
+@pytest.mark.asyncio
+async def test_observed_audio_context_transcribes_on_addressed_followup(tmp_path):
+    from gateway.run import GatewayRunner
+
+    audio_path = tmp_path / "audio_123.ogg"
+    audio_path.write_bytes(b"fake ogg bytes")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+
+    history = [
+        {
+            "role": "user",
+            "observed": True,
+            "content": f"[Alice|111]\n[audio 'voice.ogg' saved at: {audio_path}]",
+        },
+        {"role": "assistant", "content": "previous reply"},
+    ]
+
+    with patch("gateway.run._resolve_observed_audio_cache_path", return_value=str(audio_path.resolve())), patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "observed voice transcript",
+            "provider": "openai",
+        },
+    ) as transcribe:
+        enriched = await runner._enrich_observed_audio_context(
+            history,
+            channel_prompt="observed Telegram group context",
+            current_message="[Bob|222]\nconsegue acessar esse audio?",
+        )
+
+    transcribe.assert_called_once_with(str(audio_path.resolve()))
+    assert enriched[0] is not history[0]
+    assert "Observed audio transcript" in enriched[0]["content"]
+    assert "observed voice transcript" in enriched[0]["content"]
+    assert enriched[0]["_observed_audio_transcripts"] == ["observed voice transcript"]
+    assert enriched[1] is history[1]
+
+
+@pytest.mark.asyncio
+async def test_observed_audio_context_only_runs_for_telegram_observe_prompt(tmp_path):
+    from gateway.run import GatewayRunner
+
+    audio_path = tmp_path / "audio_123.ogg"
+    audio_path.write_bytes(b"fake ogg bytes")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    history = [
+        {
+            "role": "user",
+            "observed": True,
+            "content": f"[Alice|111]\n[audio 'voice.ogg' saved at: {audio_path}]",
+        },
+    ]
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=AssertionError("observed audio should not be transcribed"),
+    ):
+        enriched = await runner._enrich_observed_audio_context(
+            history,
+            channel_prompt=None,
+            current_message="[Bob|222]\nconsegue acessar esse audio?",
+        )
+
+    assert enriched is history
+
+
+@pytest.mark.asyncio
+async def test_observed_audio_context_waits_for_audio_request(tmp_path):
+    from gateway.run import GatewayRunner
+
+    audio_path = tmp_path / "audio_123.ogg"
+    audio_path.write_bytes(b"fake ogg bytes")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    history = [
+        {
+            "role": "user",
+            "observed": True,
+            "content": f"[Alice|111]\n[audio 'voice.ogg' saved at: {audio_path}]",
+        },
+    ]
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=AssertionError("observed audio should wait for an audio request"),
+    ):
+        enriched = await runner._enrich_observed_audio_context(
+            history,
+            channel_prompt="observed Telegram group context",
+            current_message="[Bob|222]\nbom dia",
+        )
+
+    assert enriched is history
+
+
+def test_observed_audio_cache_path_resolves_agent_visible_docker_path(tmp_path):
+    from gateway.run import _resolve_observed_audio_cache_path
+
+    host_audio_dir = tmp_path / "cache" / "audio"
+    host_audio_dir.mkdir(parents=True)
+    host_audio = host_audio_dir / "audio_123.ogg"
+    host_audio.write_bytes(b"fake ogg bytes")
+
+    with patch(
+        "gateway.platforms.base.get_audio_cache_dir",
+        return_value=host_audio_dir,
+    ), patch(
+        "hermes_constants.get_hermes_home",
+        return_value=tmp_path,
+    ), patch(
+        "tools.credential_files.get_cache_directory_mounts",
+        return_value=[
+            {
+                "host_path": str(host_audio_dir),
+                "container_path": "/root/.hermes/cache/audio",
+            }
+        ],
+    ):
+        resolved = _resolve_observed_audio_cache_path(
+            "/root/.hermes/cache/audio/audio_123.ogg"
+        )
+
+    assert resolved == str(host_audio.resolve())

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -222,6 +222,123 @@ def test_observed_group_context_uses_shared_source_and_prompt_for_later_mentions
     asyncio.run(_run())
 
 
+def test_observed_group_context_replays_as_current_message_context_not_user_turns():
+    from gateway.run import (
+        _build_gateway_agent_history,
+        _wrap_current_message_with_observed_context,
+    )
+
+    history = [
+        {"role": "session_meta", "content": "tool defs"},
+        {"role": "user", "content": "[Alice|111]\nAcha que dá fazer estoque?", "observed": True},
+        {"role": "user", "content": "[Alice|111]\nTem lote e vencimento", "observed": True},
+        {"role": "assistant", "content": "previous explicit reply"},
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt="You are handling Telegram; observed Telegram group context is present.",
+    )
+    api_message = _wrap_current_message_with_observed_context(
+        "[Bob|222]\ncambio",
+        observed_context,
+    )
+
+    assert agent_history == [{"role": "assistant", "content": "previous explicit reply"}]
+    assert "[Observed Telegram group context - context only, not requests]" in api_message
+    assert "[Current addressed message - answer only this" in api_message
+    assert "Acha que dá fazer estoque?" in api_message
+    assert "Tem lote e vencimento" in api_message
+    assert api_message.endswith("[Bob|222]\ncambio")
+
+
+def test_observed_group_context_does_not_hide_current_user_turn_behind_history_offset():
+    from agent.agent_runtime_helpers import repair_message_sequence
+    from gateway.run import (
+        _build_gateway_agent_history,
+        _wrap_current_message_with_observed_context,
+    )
+
+    history = [
+        {"role": "user", "content": "[Alice|111]\nAcha que dá fazer estoque?", "observed": True},
+    ]
+    agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt="observed Telegram group context",
+    )
+    api_message = _wrap_current_message_with_observed_context("[Bob|222]\ncambio", observed_context)
+    messages = list(agent_history) + [{"role": "user", "content": api_message}]
+
+    repair_message_sequence(object(), messages)
+
+    history_offset = len(agent_history)
+    new_messages = messages[history_offset:]
+    assert len(agent_history) == 0
+    assert new_messages[0]["role"] == "user"
+    assert new_messages[0]["content"].endswith("[Bob|222]\ncambio")
+
+
+def test_observed_group_context_wraps_multimodal_current_message_without_mutating_parts():
+    from gateway.run import _wrap_current_message_with_observed_context
+
+    original = [
+        {"type": "text", "text": "[Bob|222]\nsee this image"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+
+    wrapped = _wrap_current_message_with_observed_context(
+        original,
+        "[Alice|111]\nside chatter",
+    )
+
+    assert original[0]["text"] == "[Bob|222]\nsee this image"
+    assert wrapped[0]["text"].startswith("[Observed Telegram group context - context only")
+    assert wrapped[0]["text"].endswith("[Bob|222]\nsee this image")
+    assert wrapped[1] == original[1]
+
+
+def test_observed_group_context_marks_observed_audio_transcript_as_available():
+    from gateway.run import _wrap_current_message_with_observed_context
+
+    wrapped = _wrap_current_message_with_observed_context(
+        "[Bob|222]\nconsegue acessar esse audio que estou respondendo?",
+        (
+            "[Alice|111]\n"
+            "[audio 'voice.ogg' saved at: /tmp/audio.ogg]\n\n"
+            '[Observed audio transcript: "conteudo do audio" (path: /tmp/audio.ogg)]'
+        ),
+    )
+
+    assert "conteudo do audio" in wrapped
+    assert "The user sent a voice message" in wrapped
+    assert "Here's what they said: \"conteudo do audio\"" in wrapped
+    assert "Use the transcription above as the audio content" in wrapped
+    assert "[audio 'voice.ogg' saved at:" not in wrapped
+    assert "Observed audio transcript:" not in wrapped
+    assert not wrapped.startswith("[Observed Telegram group context")
+    assert wrapped.find("conteudo do audio") < wrapped.find("consegue acessar esse audio")
+
+
+def test_observed_audio_transcript_turn_persists_like_voice_message():
+    from gateway.run import _should_persist_clean_observed_message
+
+    assert _should_persist_clean_observed_message("[Alice]\nside chatter", None) is True
+    assert _should_persist_clean_observed_message("[Alice]\nside chatter", []) is True
+    assert _should_persist_clean_observed_message("[Alice]\n[audio saved]", ["transcrito"]) is False
+
+
+def test_observed_group_context_replays_normally_without_telegram_prompt():
+    from gateway.run import _build_gateway_agent_history
+
+    history = [
+        {"role": "user", "content": "[Alice|111]\nside chatter", "observed": True},
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(history, channel_prompt=None)
+
+    assert observed_context is None
+    assert agent_history == [{"role": "user", "content": "[Alice|111]\nside chatter"}]
+
 def test_observed_group_context_preserves_slash_command_text_for_dispatch():
     from gateway.platforms.base import MessageEvent, MessageType, Platform, SessionSource
 

--- a/tests/gateway/test_telegram_reply_quote.py
+++ b/tests/gateway/test_telegram_reply_quote.py
@@ -9,8 +9,9 @@ actionable-looking text the user did not quote (#22619).
 """
 
 import sys
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from gateway.config import PlatformConfig
 
@@ -44,6 +45,7 @@ def _make_message(
     text="follow-up",
     reply_to_text=None,
     reply_to_caption=None,
+    reply_to_voice=None,
     reply_to_id=42,
     quote_text=None,
 ):
@@ -51,11 +53,16 @@ def _make_message(
     user = SimpleNamespace(id=42, full_name="Alice")
 
     reply_to_message = None
-    if reply_to_text is not None or reply_to_caption is not None:
+    if reply_to_text is not None or reply_to_caption is not None or reply_to_voice is not None:
         reply_to_message = SimpleNamespace(
             message_id=reply_to_id,
             text=reply_to_text,
             caption=reply_to_caption,
+            voice=reply_to_voice,
+            audio=None,
+            photo=None,
+            video=None,
+            document=None,
         )
 
     quote = None
@@ -94,3 +101,88 @@ def test_native_partial_quote_used_as_reply_to_text():
     assert event.reply_to_message_id == "42"
 
 
+def test_full_reply_text_used_when_no_native_quote():
+    """No ``message.quote`` → fall back to the whole replied-to message text."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_message(
+        text="thanks",
+        reply_to_text="Whole prior message body",
+        quote_text=None,
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "Whole prior message body"
+    assert event.reply_to_message_id == "42"
+
+
+def test_caption_fallback_when_no_quote_and_no_text():
+    """Replied-to media message: caption is used when text is absent."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_message(
+        text="see this",
+        reply_to_text=None,
+        reply_to_caption="Photo caption from earlier",
+        quote_text=None,
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "Photo caption from earlier"
+
+
+def test_empty_quote_text_falls_back_to_full_reply():
+    """Defensive: a present-but-empty quote.text shouldn't blank the prefix."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_message(
+        text="follow-up",
+        reply_to_text="Prior message body",
+        quote_text="",
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "Prior message body"
+
+
+def test_replied_to_voice_is_cached_as_audio_context():
+    """Replying to a Telegram voice note should feed the normal STT path."""
+    from gateway.platforms.base import CachedMedia, MessageType
+
+    async def _run():
+        adapter = _make_adapter()
+        voice = SimpleNamespace(file_size=128, get_file=AsyncMock())
+        voice.get_file.return_value = SimpleNamespace(
+            file_path="voice.ogg",
+            download_as_bytearray=AsyncMock(return_value=bytearray(b"fake ogg")),
+        )
+        msg = _make_message(
+            text="@hermes_bot o que tem nesse audio?",
+            reply_to_voice=voice,
+            quote_text=None,
+        )
+        event = adapter._build_message_event(msg, MessageType.TEXT)
+
+        with patch(
+            "gateway.platforms.base.cache_media_bytes",
+            return_value=CachedMedia(
+                path="/home/dev/.hermes/audio_cache/audio_reply.ogg",
+                media_type="audio/ogg",
+                kind="audio",
+                display_name="voice.ogg",
+            ),
+        ) as cache_media:
+            await adapter._cache_replied_media(msg, event)
+
+        cache_media.assert_called_once()
+        assert "[Replied-to audio 'voice.ogg' saved at: /home/dev/.hermes/audio_cache/audio_reply.ogg]" in event.text
+        assert event.media_urls == ["/home/dev/.hermes/audio_cache/audio_reply.ogg"]
+        assert event.media_types == ["audio/ogg"]
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Priority

P2 - broken Telegram observe workflow: a later addressed turn cannot reliably use the intended observed audio without asking the user to resend it.

## Summary

- preserve observed Telegram context across compression-created session splits
- transcribe at most one selected cached observed audio item on a later addressed Telegram turn
- prefer an explicit reply or path reference; otherwise use only the newest eligible item for a clear audio request
- ignore vague wording such as "what did they say?", retain only the valid post-addressed context window, and clear runtime-only selection markers before queued follow-ups
- reuse the configured `transcribe_audio` stack and restrict reads to existing Hermes audio-cache files
- keep observed-audio STT Telegram-only; Matrix observed context never invokes it

## Validation

- rebased onto `4281151ae859241351ba14d8c7682dc67ff4c126` on 2026-07-11; current head: `7ffc3974c25a7a3374e9b1f6ad832c0fa4671ef4`
- `.venv/bin/python -m pytest -q tests/gateway/test_session.py tests/gateway/test_stt_config.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_reply_quote.py` - 189 passed
- includes a regression proving that an `observed Matrix room context` prompt with cached audio does not call STT
- `.venv/bin/ruff check` on changed Python files and `git diff --check upstream/main...HEAD` passed