### PR TITLE
feat(desktop): surface sidebar attention and move profile rail

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.test.tsx
@@ -1,0 +1,132 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarProvider } from '@/components/ui/sidebar'
+import { $pinnedSessionIds, $sidebarSessionOrderIds, $sidebarWorkspaceOrderIds } from '@/store/layout'
+import { $activeGatewayProfile, $profileColors, $profileOrder, $profiles, $showAllProfiles } from '@/store/profile'
+import {
+  $cronSessions,
+  $attentionSessionIds,
+  $selectedStoredSessionId,
+  $sessionProfileTotals,
+  $sessions,
+  $sessionsLoading,
+  $sessionsTotal,
+  $workingSessionIds
+} from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import { ChatSidebar } from './index'
+
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  searchSessions: vi.fn(async () => ({ results: [] })),
+  setApiRequestProfile: vi.fn()
+}))
+
+const session: SessionInfo = {
+  archived: false,
+  cwd: null,
+  ended_at: null,
+  id: 'session-1',
+  _lineage_root_id: null,
+  input_tokens: 0,
+  is_active: false,
+  last_active: 1,
+  message_count: 1,
+  model: null,
+  output_tokens: 0,
+  preview: 'Recent session',
+  profile: 'default',
+  source: 'desktop',
+  started_at: 1,
+  title: 'Recent session',
+  tool_call_count: 0
+}
+
+describe('ChatSidebar', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    $activeGatewayProfile.set('default')
+    $attentionSessionIds.set([])
+    $cronSessions.set([])
+    $pinnedSessionIds.set([])
+    $profileColors.set({})
+    $profileOrder.set([])
+    $profiles.set([
+      {
+        has_env: false,
+        is_default: true,
+        model: null,
+        name: 'default',
+        path: '/Users/test/.hermes',
+        provider: null,
+        skill_count: 0
+      },
+      {
+        has_env: false,
+        is_default: false,
+        model: null,
+        name: 'work',
+        path: '/Users/test/.hermes/profiles/work',
+        provider: null,
+        skill_count: 0
+      }
+    ])
+    $selectedStoredSessionId.set(null)
+    $sessionProfileTotals.set({ default: 1 })
+    $sessions.set([session])
+    $sessionsLoading.set(false)
+    $sessionsTotal.set(1)
+    $showAllProfiles.set(false)
+    $sidebarSessionOrderIds.set([])
+    $sidebarWorkspaceOrderIds.set([])
+    $workingSessionIds.set([])
+  })
+
+  it('places the profile rail below artifacts and above session search', () => {
+    renderSidebar()
+
+    const artifacts = screen.getByText('Artifacts')
+    const profiles = screen.getByLabelText('Profiles')
+    const search = screen.getByRole('textbox', { name: 'Search sessions' })
+
+    expect(Boolean(artifacts.compareDocumentPosition(profiles) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true)
+    expect(Boolean(profiles.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true)
+  })
+
+  it('shows an icon-only needs-input badge on a session row that is waiting for approval', () => {
+    $attentionSessionIds.set(['session-1'])
+    $workingSessionIds.set(['session-1'])
+
+    const { container } = renderSidebar()
+
+    expect(container.querySelector('[data-slot="session-needs-input-badge"]')).toBeTruthy()
+    expect(screen.getByRole('status', { name: 'Needs your input' })).toBeTruthy()
+    expect(screen.queryByText('Needs your input')).toBeNull()
+  })
+})
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter>
+      <SidebarProvider>
+        <ChatSidebar
+          currentView="chat"
+          onArchiveSession={vi.fn()}
+          onDeleteSession={vi.fn()}
+          onLoadMoreSessions={vi.fn()}
+          onManageCronJob={vi.fn()}
+          onNavigate={vi.fn()}
+          onNewSessionInWorkspace={vi.fn()}
+          onResumeSession={vi.fn()}
+          onTriggerCronJob={vi.fn()}
+        />
+      </SidebarProvider>
+    </MemoryRouter>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -837,6 +837,12 @@ export function ChatSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
 
+        {contentVisible && (
+          <div className="shrink-0 px-0.5 pb-1 pt-0">
+            <ProfileRail />
+          </div>
+        )}
+
         {contentVisible && showSessionSections && (
           <div className="shrink-0 px-2 pb-1 pt-1">
             <SearchField
@@ -1037,12 +1043,6 @@ export function ChatSidebar({
         )}
 
         {contentVisible && !showSessionSections && <div className="min-h-0 flex-1" />}
-
-        {contentVisible && (
-          <div className="shrink-0 px-0.5 pb-1 pt-0.5">
-            <ProfileRail />
-          </div>
-        )}
       </SidebarContent>
     </Sidebar>
   )

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -80,8 +80,8 @@ const stepThroughCells: Modifier = ({ containerNodeRect, draggingNodeRect, trans
   return { ...transform, x: Math.min(maxX, Math.max(minX, snapped)), y: 0 }
 }
 
-// Arc-Spaces-style profile rail at the sidebar foot: a default↔all toggle pinned
-// left, the colored named profiles scrolling between, and Manage pinned right.
+// Arc-Spaces-style profile rail in the sidebar header stack: a default↔all toggle
+// pinned left, the colored named profiles scrolling between, and Manage pinned right.
 // The active profile pops in its own color — the "where am I" cue. Single-
 // profile users see the "+" (create their first profile) and the Manage
 // overflow (edit the default profile's SOUL.md); the colored named squares
@@ -461,12 +461,12 @@ function ProfileSquare({ active, color, label, onDelete, onRecolor, onRename, on
           </Tooltip>
         </TooltipProvider>
 
-        {/* The rail sits at the very bottom, so pad off the chrome (esp. the
-            statusbar) — Radix then flips the menu up instead of squishing it. */}
+        {/* Keep menus away from the titlebar/statusbar chrome when the sidebar
+            rail is near either edge. */}
         <ContextMenuContent
           aria-label={p.actionsFor(label)}
           className="w-40"
-          collisionPadding={{ bottom: 44, left: 8, right: 8, top: 8 }}
+          collisionPadding={{ bottom: 44, left: 8, right: 8, top: 44 }}
         >
           <ContextMenuItem onSelect={() => setPickerOpen(true)}>
             <Codicon name="symbol-color" size="0.875rem" />
@@ -486,8 +486,8 @@ function ProfileSquare({ active, color, label, onDelete, onRecolor, onRename, on
       <PopoverContent
         aria-label={p.colorFor(label)}
         className="w-auto p-2"
-        collisionPadding={{ bottom: 44, left: 8, right: 8, top: 8 }}
-        side="top"
+        collisionPadding={{ bottom: 44, left: 8, right: 8, top: 44 }}
+        side="bottom"
       >
         <div className="grid grid-cols-6 gap-1.5">
           {PROFILE_SWATCHES.map(swatch => (

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -10,6 +10,7 @@ import type { SessionInfo } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
+import { AlertCircle } from '@/lib/icons'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
 import { $attentionSessionIds } from '@/store/session'
@@ -76,7 +77,7 @@ export function SidebarSessionRow({
   const handoffSource = handoffOriginSource(session.handoff_state, session.handoff_platform)
   const handoffLabel = handoffSource ? sessionSourceLabel(handoffSource) ?? handoffSource : null
   // Subscribe per-row (the leaf) instead of drilling a set through the list —
-  // the atom is tiny and rarely non-empty. True when a clarify prompt in this
+  // the atom is tiny and rarely non-empty. True when a blocking prompt in this
   // session is waiting on the user.
   const needsInput = useStore($attentionSessionIds).includes(session.id)
 
@@ -121,7 +122,10 @@ export function SidebarSessionRow({
       >
         {isWorking && !needsInput && <span aria-hidden="true" className="arc-border" />}
         <button
-          className="z-0 flex min-w-0 items-center gap-1.5 bg-transparent py-0.5 pl-2 pr-1 text-left group-hover:pr-12"
+          className={cn(
+            'z-0 flex min-w-0 items-center gap-1.5 bg-transparent py-0.5 pl-2 text-left',
+            needsInput ? 'pr-12' : 'pr-1 group-hover:pr-12'
+          )}
           onClick={event => {
             if (event.shiftKey) {
               event.preventDefault()
@@ -201,11 +205,13 @@ export function SidebarSessionRow({
           </span>
         </button>
         <div className="relative z-2 grid w-[1.375rem] place-items-center">
-          {!isWorking && (
+          {needsInput ? (
+            <NeedsInputBadge label={r.needsInput} title={r.waitingForAnswer} />
+          ) : !isWorking ? (
             <span className="pointer-events-none absolute right-6 top-1/2 min-w-6 -translate-y-1/2 text-right text-[0.625rem] leading-none text-(--ui-text-tertiary) opacity-0 transition-opacity group-hover:opacity-100">
               {age}
             </span>
-          )}
+          ) : null}
           <SessionActionsMenu
             onArchive={onArchive}
             onDelete={onDelete}
@@ -231,6 +237,20 @@ export function SidebarSessionRow({
   )
 }
 
+function NeedsInputBadge({ label, title }: { label: string; title: string }) {
+  return (
+    <span
+      aria-label={label}
+      className="pointer-events-none absolute right-6 top-1/2 inline-grid size-5 -translate-y-1/2 place-items-center rounded-[4px] border border-amber-400/35 bg-amber-500/15 text-amber-200 shadow-sm"
+      data-slot="session-needs-input-badge"
+      role="status"
+      title={title}
+    >
+      <AlertCircle aria-hidden="true" className="size-3.5" />
+    </span>
+  )
+}
+
 function SidebarRowDot({
   isWorking,
   needsInput = false,
@@ -243,16 +263,15 @@ function SidebarRowDot({
   const { t } = useI18n()
   const r = t.sidebar.row
 
-  // "Needs input" wins over "working": a clarify-blocked session is technically
+  // "Needs input" wins over "working": a prompt-blocked session is technically
   // still running, but the actionable state is that it's waiting on the user.
   // Amber + steady (no ping) reads as "your turn", distinct from the accent
   // pulse of an active turn.
   if (needsInput) {
     return (
       <span
-        aria-label={r.needsInput}
+        aria-hidden="true"
         className={cn('quest-glow relative size-1.5 rounded-full bg-amber-500', className)}
-        role="status"
         title={r.waitingForAnswer}
       />
     )


### PR DESCRIPTION
## Summary
- Surface an icon-only amber needs-input status on sidebar sessions requiring user attention.
- Preserve accessible status text through the status role/label instead of visible label text.
- Move the profile rail below Artifacts and above Search sessions.
- Add sidebar regression coverage for placement and accessible icon-only status.

## Why
Approval/input prompts can be easy to miss when they are only visible inside the active chat. The sidebar should indicate which session needs attention without stealing title space.

## Verification
- npm run test:ui -- src/app/chat/sidebar/index.test.tsx
- npm run type-check
- npm run pack
