### PR TITLE
fix: remove unused imports across agent, gateway modules

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -18,19 +18,15 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import random
 import re
 import ssl
-import threading
 import time
-import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
-from agent.iteration_budget import IterationBudget
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -37,7 +37,6 @@ import signal
 import tempfile
 import threading
 import time
-import sqlite3
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
@@ -899,7 +898,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
-from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
+from utils import atomic_json_write, is_truthy_value
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -1175,8 +1174,6 @@ from gateway.config import (
     Platform,
     _BUILTIN_PLATFORM_VALUES,
     GatewayConfig,
-    HomeChannel,
-    PlatformConfig,
     load_gateway_config,
 )
 from gateway.session import (
@@ -1207,10 +1204,8 @@ from gateway.restart import (
 )
 
 
-from gateway.whatsapp_identity import (
-    canonical_whatsapp_identifier as _canonical_whatsapp_identifier,  # noqa: F401
-    expand_whatsapp_aliases as _expand_whatsapp_auth_aliases,
-    normalize_whatsapp_identifier as _normalize_whatsapp_identifier,
+from gateway.whatsapp_identity import (  # noqa: F401
+    canonical_whatsapp_identifier as _canonical_whatsapp_identifier,
 )
 
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -26,7 +26,7 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t


### PR DESCRIPTION
## Summary

Remove unused imports flagged by `ruff check --select F401` across 3 files:

- `agent/conversation_loop.py`: `os`, `threading`, `uuid`, `IterationBudget`
- `gateway/run.py`: `sqlite3`, `atomic_yaml_write`, `base_url_host_matches`, `HomeChannel`, `PlatformConfig`, `expand_whatsapp_aliases`, `normalize_whatsapp_identifier`
- `gateway/slash_commands.py`: `typing.Any`

## Notes

- Retained `fetch_account_usage` / `render_account_usage_lines` in `gateway/run.py` — imported for test-patch surface (documented in comment)
- Retained re-exports in `agent/transports/__init__.py` (already has `noqa: F401`)

## Testing

Verified with `ruff check --select F401`.