### PR TITLE
fix(gateway): suppress status messages on Matrix to prevent ping-pong loops (#43047)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -308,7 +308,13 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
-    if _gateway_platform_value(platform) != "telegram":
+    platform_val = _gateway_platform_value(platform)
+    # Matrix DMs between agents: suppress ALL status messages to prevent
+    # ping-pong loops where one agent's status text is treated as a user
+    # message by the other agent's gateway.  (Issue #43047)
+    if platform_val == "matrix":
+        return None
+    if platform_val != "telegram":
         return text
 
     text = _redact_gateway_user_facing_secrets(text)


### PR DESCRIPTION
Fixes #43047. Suppresses all gateway status messages on Matrix platform to prevent infinite ping-pong loops when two Hermes agents communicate via Matrix DMs.