### PR TITLE
fix(memory): forward model kwarg through on_turn_start to memory providers

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -360,7 +360,9 @@ def build_turn_context(
     if agent._memory_manager:
         try:
             _turn_msg = original_user_message if isinstance(original_user_message, str) else ""
-            agent._memory_manager.on_turn_start(agent._user_turn_count, _turn_msg)
+            agent._memory_manager.on_turn_start(
+                agent._user_turn_count, _turn_msg,
+                model=getattr(agent, "model", "") or "")
         except Exception:
             pass
 

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -64,8 +64,8 @@ class FakeMemoryProvider(MemoryProvider):
     def shutdown(self):
         self.shutdown_called = True
 
-    def on_turn_start(self, turn_number, message):
-        self.turn_starts.append((turn_number, message))
+    def on_turn_start(self, turn_number, message, **kwargs):
+        self.turn_starts.append((turn_number, message, kwargs))
 
     def on_session_end(self, messages):
         self.session_end_called = True
@@ -342,7 +342,21 @@ class TestMemoryManager:
         p = FakeMemoryProvider("p")
         mgr.add_provider(p)
         mgr.on_turn_start(3, "hello")
-        assert p.turn_starts == [(3, "hello")]
+        assert p.turn_starts == [(3, "hello", {})]
+
+    def test_on_turn_start_forwards_model_kwarg(self):
+        """model= kwarg must reach providers so they can record the conversing model.
+
+        Regression guard: turn_context.py calls
+        manager.on_turn_start(..., model=agent.model). Without this the model
+        name is silently dropped, and providers such as the Ragger plugin send
+        an empty model string to their backend.
+        """
+        mgr = MemoryManager()
+        p = FakeMemoryProvider("p")
+        mgr.add_provider(p)
+        mgr.on_turn_start(1, "hi", model="claude-opus-4-8")
+        assert p.turn_starts == [(1, "hi", {"model": "claude-opus-4-8"})]
 
     def test_on_session_end(self):
         mgr = MemoryManager()


### PR DESCRIPTION
## Problem

`turn_context.py` notifies memory providers via `on_turn_start()` but never passes the live model name, even though:

- The `MemoryProvider` base class documents a `model=` kwarg on `on_turn_start`
- `MemoryManager.on_turn_start` already fans `**kwargs` through to every provider

Without this, memory providers that need to track which model produced each turn (e.g. external backends that store summaries with model attribution) always receive an empty string. The model name is available on `agent.model` at the call site — it just wasn't being passed.

## Fix

Pass `model=agent.model` at the `on_turn_start` call site in `turn_context.py`. Uses `getattr` with a fallback so the call is safe if `agent.model` is absent or `None` (e.g. subagent scaffolding, tests).

## Tests

- Updated `FakeMemoryProvider.on_turn_start` to accept `**kwargs` so forwarded kwargs are captured rather than raising `TypeError`
- Updated the existing `test_on_turn_start` assertion to match the new tuple shape
- Added `test_on_turn_start_forwards_model_kwarg` as an explicit regression guard

```
2 passed in 0.14s
```

## Impact

- No behaviour change for providers that don't use the `model` kwarg (the base class `on_turn_start` is a no-op)
- Providers that do implement `on_turn_start` without `**kwargs` already get a logged debug warning from the manager's try/except; this fix gives them the data they need if they opt in