### PR TITLE
fix: resolve unused variables (F841) and pass params_schema to MCP

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -828,7 +828,6 @@ def _reconcile_classification(
     Every removed skill is placed in exactly one bucket.
     """
     heur_cons = {e["name"]: e for e in heuristic.get("consolidated", [])}
-    heur_pruned = {e["name"] for e in heuristic.get("pruned", [])}
 
     model_cons = {e["from"]: e for e in model_block.get("consolidations", [])}
     model_pruned = {e["name"]: e for e in model_block.get("prunings", [])}

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -321,7 +321,7 @@ class ChatCompletionsTransport(ProviderTransport):
         ephemeral = params.get("ephemeral_max_output_tokens")
         max_tokens = params.get("max_tokens")
         anthropic_max_out = params.get("anthropic_max_output")
-        is_nvidia_nim = params.get("is_nvidia_nim", False)
+        _is_nvidia_nim = params.get("is_nvidia_nim", False)
         is_kimi = params.get("is_kimi", False)
         is_tokenhub = params.get("is_tokenhub", False)
         reasoning_config = params.get("reasoning_config")
@@ -379,7 +379,7 @@ class ChatCompletionsTransport(ProviderTransport):
         extra_body: dict[str, Any] = {}
 
         is_openrouter = params.get("is_openrouter", False)
-        is_nous = params.get("is_nous", False)
+        _is_nous = params.get("is_nous", False)
         is_github_models = params.get("is_github_models", False)
         provider_name = str(params.get("provider_name") or "").strip().lower()
         base_url = params.get("base_url")

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -175,6 +175,7 @@ def _build_server() -> Any:
                 _make_handler(name),
                 name=name,
                 description=description,
+                input_schema=params_schema,
                 # FastMCP accepts JSON schema directly via the
                 # input_schema parameter on newer versions; older
                 # versions use parameters_schema. Try both for compat.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -208,10 +208,11 @@ def _gateway_loop_exception_handler(
             except Exception:
                 task_name = repr(task)
         logger.warning(
-            "Gateway swallowed transient network error from %s: %s: %s",
+            "Gateway swallowed transient network error from %s: %s: %s — %s",
             task_name or "<unknown task>",
             type(exc).__name__,
             exc,
+            message,
             exc_info=(type(exc), exc, exc.__traceback__),
         )
         return

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -708,7 +708,7 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
 
     try:
         skill_dir.rename(dest)
-    except OSError as e:
+    except OSError as _e:
         # Cross-device — fall back to shutil.move
         import shutil
         try:


### PR DESCRIPTION
## Summary

Fix unused variables flagged by ruff F841 across 5 files.

### Key fix: MCP tool schema passthrough

`agent/transports/hermes_tools_mcp_server.py` - the tool parameter schema was extracted from the registry but never passed to `mcp.add_tool()`. Tools exposed via the Hermes MCP server were missing their input schemas.

### Other changes

- `agent/curator.py`: remove unused `heur_pruned` set (leftover from refactor)
- `agent/transports/chat_completions.py`: prefix unused `is_nvidia_nim`, `is_nous` with `_` (TypedDict interface, reserved)
- `gateway/run.py`: include `message` in transient error log for better diagnostics
- `tools/skill_usage.py`: prefix unused exception variable with `_`