### PR TITLE
Restore LiveKit + Fish voice spine

### DIFF
--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -56,6 +56,7 @@ _BUILTIN_NAMES = frozenset({
     "neutts",
     "kittentts",
     "piper",
+    "fish-audio",
 })
 
 

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -21,6 +21,7 @@ const fs = require('node:fs')
 const http = require('node:http')
 const https = require('node:https')
 const net = require('node:net')
+const os = require('node:os')
 const path = require('node:path')
 const { fileURLToPath, pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
@@ -691,6 +692,176 @@ function rememberLog(chunk) {
   }
 
   scheduleDesktopLogFlush()
+}
+
+const NATIVE_VOICE_PLAYBACK_MAX_BYTES = 4 * 1024 * 1024
+const NATIVE_VOICE_MIME_EXT = {
+  'audio/mpeg': '.mp3',
+  'audio/mp3': '.mp3',
+  'audio/mp4': '.m4a',
+  'audio/ogg': '.ogg',
+  'audio/wav': '.wav',
+  'audio/x-wav': '.wav',
+  'audio/flac': '.flac'
+}
+let nativeVoicePlayback = null
+
+function decodeNativeVoiceDataUrl(dataUrl) {
+  const raw = String(dataUrl || '')
+  const match = /^data:([^;,]+);base64,(.+)$/s.exec(raw)
+
+  if (!match) {
+    throw new Error('Native voice playback requires a base64 data URL')
+  }
+
+  const mimeType = String(match[1] || '').toLowerCase()
+
+  if (!mimeType.startsWith('audio/')) {
+    throw new Error(`Native voice playback only accepts audio data URLs, got ${mimeType || 'unknown'}`)
+  }
+
+  const buffer = Buffer.from(match[2], 'base64')
+
+  if (!buffer.length) {
+    throw new Error('Native voice playback received an empty audio payload')
+  }
+
+  if (buffer.length > NATIVE_VOICE_PLAYBACK_MAX_BYTES) {
+    throw new Error(`Native voice playback payload too large: ${buffer.length} bytes`)
+  }
+
+  return {
+    buffer,
+    extension: NATIVE_VOICE_MIME_EXT[mimeType] || '.audio',
+    mimeType
+  }
+}
+
+function cleanupNativeVoicePlayback(playback) {
+  if (!playback) return
+  try {
+    if (playback.filePath) fs.rmSync(playback.filePath, { force: true })
+  } catch {
+    // Best effort cleanup only.
+  }
+  try {
+    if (playback.dirPath) fs.rmdirSync(playback.dirPath)
+  } catch {
+    // Best effort cleanup only.
+  }
+}
+
+function stopNativeVoicePlayback() {
+  const playback = nativeVoicePlayback
+  nativeVoicePlayback = null
+
+  if (playback?.process && !playback.process.killed) {
+    try {
+      playback.process.kill('SIGTERM')
+    } catch {
+      // Process may already have exited.
+    }
+  }
+
+  return Boolean(playback)
+}
+
+function nativeVoicePlayerCommand(filePath) {
+  if (process.env.HERMES_DESKTOP_NATIVE_AUDIO_PLAYER) {
+    return { command: process.env.HERMES_DESKTOP_NATIVE_AUDIO_PLAYER, args: [filePath] }
+  }
+
+  if (IS_MAC) return { command: 'afplay', args: [filePath] }
+  if (IS_WINDOWS) return null
+
+  return { command: 'mpv', args: ['--no-video', '--really-quiet', '--volume=95', filePath] }
+}
+
+function normalizeNativeVoicePayload(payload) {
+  if (typeof payload === 'string') {
+    return { dataUrl: payload }
+  }
+
+  if (payload && typeof payload === 'object') {
+    return {
+      audioBytes: payload.audioBytes ?? null,
+      dataUrl: String(payload.dataUrl || ''),
+      mimeType: payload.mimeType ? String(payload.mimeType) : null,
+      provider: payload.provider ? String(payload.provider) : null,
+      requestId: payload.requestId ? String(payload.requestId) : null,
+      source: payload.source ? String(payload.source) : null,
+      transport: payload.transport ? String(payload.transport) : null
+    }
+  }
+
+  return { dataUrl: '' }
+}
+
+function logNativeVoicePlaybackEvent(event, requestId, fields = {}) {
+  try {
+    rememberLog(`[voice] native playback event ${JSON.stringify({ event, request_id: requestId, ...fields })}`)
+  } catch {
+    rememberLog(`[voice] native playback event=${event} request_id=${requestId}`)
+  }
+}
+
+function playNativeVoiceDataUrl(payload) {
+  return new Promise((resolve, reject) => {
+    const nativePayload = normalizeNativeVoicePayload(payload)
+    const requestId = nativePayload.requestId || `native-${Date.now().toString(36)}`
+    const startedAt = Date.now()
+    const decoded = decodeNativeVoiceDataUrl(nativePayload.dataUrl)
+    const player = nativeVoicePlayerCommand('')
+
+    if (!player) {
+      reject(new Error('Native voice playback is not configured for this platform'))
+      return
+    }
+
+    stopNativeVoicePlayback()
+
+    const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-voice-'))
+    const filePath = path.join(dirPath, `speech${decoded.extension}`)
+    fs.writeFileSync(filePath, decoded.buffer)
+
+    const commandSpec = nativeVoicePlayerCommand(filePath)
+    const child = spawn(commandSpec.command, commandSpec.args, {
+      detached: false,
+      stdio: 'ignore'
+    })
+    const playback = { dirPath, filePath, process: child }
+    nativeVoicePlayback = playback
+
+    logNativeVoicePlaybackEvent('started', requestId, {
+      audio_bytes: decoded.buffer.length,
+      claimed_audio_bytes: nativePayload.audioBytes,
+      command: commandSpec.command,
+      mime_type: nativePayload.mimeType || decoded.mimeType,
+      provider: nativePayload.provider,
+      source: nativePayload.source,
+      transport: nativePayload.transport
+    })
+
+    child.on('error', error => {
+      if (nativeVoicePlayback === playback) nativeVoicePlayback = null
+      cleanupNativeVoicePlayback(playback)
+      logNativeVoicePlaybackEvent('failed', requestId, {
+        duration_ms: Date.now() - startedAt,
+        error: error.message,
+        error_type: error.name || 'Error'
+      })
+      reject(error)
+    })
+
+    child.on('close', (code, signal) => {
+      if (nativeVoicePlayback === playback) nativeVoicePlayback = null
+      cleanupNativeVoicePlayback(playback)
+      const durationMs = Date.now() - startedAt
+      const ok = code === 0 || signal === 'SIGTERM'
+      logNativeVoicePlaybackEvent('closed', requestId, { code: code ?? null, duration_ms: durationMs, ok, signal: signal ?? null })
+      resolve({ ok, code, signal, durationMs })
+    })
+  })
 }
 
 function openExternalUrl(rawUrl) {
@@ -5234,6 +5405,10 @@ ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
   const data = await fs.promises.readFile(resolvedPath)
   return `data:${mimeTypeForPath(resolvedPath)};base64,${data.toString('base64')}`
 })
+
+ipcMain.handle('hermes:voice:native-play', async (_event, dataUrl) => playNativeVoiceDataUrl(dataUrl))
+
+ipcMain.handle('hermes:voice:native-stop', async () => ({ ok: true, stopped: stopNativeVoicePlayback() }))
 
 ipcMain.handle('hermes:readFileText', async (_event, filePath) => {
   const { resolvedPath, stat } = await resolveReadableFileForIpc(filePath, {

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -21,6 +21,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),
   readFileDataUrl: filePath => ipcRenderer.invoke('hermes:readFileDataUrl', filePath),
+  playAudioDataUrl: (dataUrl, options) => ipcRenderer.invoke('hermes:voice:native-play', { dataUrl, ...(options || {}) }),
+  stopNativeAudioPlayback: () => ipcRenderer.invoke('hermes:voice:native-stop'),
   readFileText: filePath => ipcRenderer.invoke('hermes:readFileText', filePath),
   selectPaths: options => ipcRenderer.invoke('hermes:selectPaths', options),
   writeClipboard: text => ipcRenderer.invoke('hermes:writeClipboard', text),

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -9,6 +9,7 @@ export interface MicRecorderOptions {
   silenceLevel?: number
   silenceMs?: number
   idleSilenceMs?: number
+  minSpeechMs?: number
 }
 
 export interface MicRecording {
@@ -72,6 +73,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): { handle: MicRecorde
   const heardSpeechRef = useRef(false)
   const silenceTriggeredRef = useRef(false)
   const silenceStartedAtRef = useRef<number | null>(null)
+  const speechStartedAtRef = useRef<number | null>(null)
   const stopResolverRef = useRef<((recording: MicRecording | null) => void) | null>(null)
 
   const cleanup = () => {
@@ -131,25 +133,34 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): { handle: MicRecorde
         const speechThreshold = options.silenceLevel ?? 0
         const silenceMs = options.silenceMs ?? 0
         const idleSilenceMs = options.idleSilenceMs ?? 0
+        const minSpeechMs = options.minSpeechMs ?? 0
 
         if (speechThreshold > 0 && options.onSilence && !silenceTriggeredRef.current) {
           if (normalized >= speechThreshold) {
-            heardSpeechRef.current = true
+            speechStartedAtRef.current ??= now
             silenceStartedAtRef.current = null
-          } else if (heardSpeechRef.current && silenceMs > 0) {
-            silenceStartedAtRef.current ??= now
 
-            if (now - silenceStartedAtRef.current >= silenceMs) {
+            if (now - speechStartedAtRef.current >= minSpeechMs) {
+              heardSpeechRef.current = true
+            }
+          } else {
+            speechStartedAtRef.current = null
+
+            if (heardSpeechRef.current && silenceMs > 0) {
+              silenceStartedAtRef.current ??= now
+
+              if (now - silenceStartedAtRef.current >= silenceMs) {
+                silenceTriggeredRef.current = true
+                options.onSilence()
+
+                return
+              }
+            } else if (!heardSpeechRef.current && idleSilenceMs > 0 && now - startedAtRef.current >= idleSilenceMs) {
               silenceTriggeredRef.current = true
               options.onSilence()
 
               return
             }
-          } else if (!heardSpeechRef.current && idleSilenceMs > 0 && now - startedAtRef.current >= idleSilenceMs) {
-            silenceTriggeredRef.current = true
-            options.onSilence()
-
-            return
           }
         }
 
@@ -207,6 +218,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): { handle: MicRecorde
     heardSpeechRef.current = false
     silenceTriggeredRef.current = false
     silenceStartedAtRef.current = null
+    speechStartedAtRef.current = null
     startedAtRef.current = Date.now()
 
     recorder.ondataavailable = event => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
+import { buildSpokenDigest } from '@/lib/speech-text'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { notify, notifyError } from '@/store/notifications'
 
@@ -43,8 +44,6 @@ export function useVoiceConversation({
   const turnClosingRef = useRef(false)
   const awaitingSpokenResponseRef = useRef(false)
   const responseIdRef = useRef<string | null>(null)
-  const spokenSourceLengthRef = useRef(0)
-  const speechBufferRef = useRef('')
   const enabledRef = useRef(enabled)
   const mutedRef = useRef(muted)
   const busyRef = useRef(busy)
@@ -76,58 +75,6 @@ export function useVoiceConversation({
 
   const resetSpeechBuffer = () => {
     responseIdRef.current = null
-    spokenSourceLengthRef.current = 0
-    speechBufferRef.current = ''
-  }
-
-  const appendSpeechText = (text: string) => {
-    if (!text) {
-      return
-    }
-
-    speechBufferRef.current = `${speechBufferRef.current}${text}`
-  }
-
-  const takeSpeechChunk = (force = false): string | null => {
-    const buffer = speechBufferRef.current.replace(/\s+/g, ' ').trim()
-
-    if (!buffer) {
-      speechBufferRef.current = ''
-
-      return null
-    }
-
-    const sentence = buffer.match(/^(.+?[.!?。！？])(?:\s+|$)/)
-
-    if (sentence?.[1] && (sentence[1].length >= 8 || force)) {
-      const chunk = sentence[1].trim()
-      speechBufferRef.current = buffer.slice(sentence[1].length).trim()
-
-      return chunk
-    }
-
-    if (!force && buffer.length > 220) {
-      const softBoundary = Math.max(
-        buffer.lastIndexOf(', ', 180),
-        buffer.lastIndexOf('; ', 180),
-        buffer.lastIndexOf(': ', 180)
-      )
-
-      if (softBoundary > 80) {
-        const chunk = buffer.slice(0, softBoundary + 1).trim()
-        speechBufferRef.current = buffer.slice(softBoundary + 1).trim()
-
-        return chunk
-      }
-    }
-
-    if (!force) {
-      return null
-    }
-
-    speechBufferRef.current = ''
-
-    return buffer
   }
 
   const handleTurn = useCallback(
@@ -198,11 +145,13 @@ export function useVoiceConversation({
     }
 
     try {
-      // VAD tuning mirrors `tools.voice_mode` defaults so the browser loop matches the CLI.
+      // Tight Migi voice loop with a small speech-hold gate so fans, clicks,
+      // and room ghosts don't become fake turns.
       await handle.start({
-        silenceLevel: 0.075,
-        silenceMs: 1_250,
-        idleSilenceMs: 12_000,
+        silenceLevel: 0.105,
+        minSpeechMs: 280,
+        silenceMs: 750,
+        idleSilenceMs: 4_000,
         onError: error => {
           notifyError(error, voiceCopy.microphoneFailed)
           pendingStartRef.current = false
@@ -315,8 +264,9 @@ export function useVoiceConversation({
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
   }, [enabled, stopTurn])
 
-  // Drive the loop: after a voice-submitted turn, speak stable chunks as the
-  // assistant stream grows. Otherwise start listening when idle between turns.
+  // Drive the loop: after a voice-submitted turn, wait for the assistant text
+  // to stabilize, then speak one compact digest. Joe prefers the ears to get a
+  // short Migi pulse, not the entire written response read aloud.
   useEffect(() => {
     if (!enabled || muted) {
       return
@@ -331,23 +281,19 @@ export function useVoiceConversation({
           responseIdRef.current = response.id
         }
 
-        if (response.text.length > spokenSourceLengthRef.current) {
-          appendSpeechText(response.text.slice(spokenSourceLengthRef.current))
-          spokenSourceLengthRef.current = response.text.length
-        }
-
-        const chunk = takeSpeechChunk(!response.pending && !busy)
-
-        if (chunk) {
-          void speak(chunk)
-
-          return
-        }
-
         if (!response.pending && !busy) {
+          const spokenDigest = buildSpokenDigest(response.text)
+
           awaitingSpokenResponseRef.current = false
           consumePendingResponse()
           resetSpeechBuffer()
+
+          if (spokenDigest) {
+            void speak(spokenDigest)
+
+            return
+          }
+
           pendingStartRef.current = true
           setStatus('idle')
 

--- a/apps/desktop/src/app/chat/composer/voice-activity.tsx
+++ b/apps/desktop/src/app/chat/composer/voice-activity.tsx
@@ -1,5 +1,4 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useRef } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { useI18n } from '@/i18n'
@@ -9,32 +8,6 @@ import { stopVoicePlayback } from '@/lib/voice-playback'
 import { $voicePlayback } from '@/store/voice-playback'
 
 import type { VoiceActivityState } from './types'
-
-type BrowserAudioContext = typeof AudioContext
-
-interface ElementAnalyser {
-  analyser: AnalyserNode
-}
-
-const elementAnalysers = new WeakMap<HTMLAudioElement, ElementAnalyser>()
-let playbackAudioContext: AudioContext | null = null
-
-function getPlaybackAudioContext(): AudioContext | null {
-  if (playbackAudioContext && playbackAudioContext.state !== 'closed') {
-    return playbackAudioContext
-  }
-
-  const audioWindow = window as Window & { webkitAudioContext?: BrowserAudioContext }
-  const AudioContextCtor = window.AudioContext || audioWindow.webkitAudioContext
-
-  if (!AudioContextCtor) {
-    return null
-  }
-
-  playbackAudioContext = new AudioContextCtor()
-
-  return playbackAudioContext
-}
 
 function formatElapsed(seconds: number) {
   const safeSeconds = Math.max(0, Math.floor(seconds))
@@ -68,99 +41,8 @@ function VoiceLevelBars({ level, active }: { active: boolean; level: number }) {
   )
 }
 
-function getElementAnalyser(audioElement: HTMLAudioElement): ElementAnalyser | null {
-  let entry = elementAnalysers.get(audioElement)
-
-  if (!entry) {
-    const context = getPlaybackAudioContext()
-
-    if (!context) {
-      return null
-    }
-
-    const source = context.createMediaElementSource(audioElement)
-    const analyser = context.createAnalyser()
-
-    analyser.fftSize = 512
-    analyser.smoothingTimeConstant = 0.65
-    source.connect(analyser)
-    analyser.connect(context.destination)
-    entry = { analyser }
-    elementAnalysers.set(audioElement, entry)
-  }
-
-  void playbackAudioContext?.resume()
-
-  return entry
-}
-
-const WAVE_W = 88
-const WAVE_H = 16
-const BAR_W = 2
-const BAR_GAP = 5
-const STEP = BAR_W + BAR_GAP
-const BARS = Math.floor((WAVE_W + BAR_GAP) / STEP)
-const X0 = Math.round((WAVE_W - (BARS * STEP - BAR_GAP)) / 2)
-
-function PlaybackWaveform({ audioElement }: { audioElement: HTMLAudioElement | null }) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null)
-
-  useEffect(() => {
-    const canvas = canvasRef.current
-
-    if (!canvas || !audioElement) {
-      return
-    }
-
-    const entry = getElementAnalyser(audioElement)
-    const ctx = canvas.getContext('2d')
-
-    if (!entry || !ctx) {
-      return
-    }
-
-    const dpr = Math.max(1, window.devicePixelRatio || 1)
-    const { analyser } = entry
-    const buf = new Uint8Array(analyser.frequencyBinCount)
-    const hi = Math.floor(buf.length * 0.9)
-
-    canvas.width = Math.round(WAVE_W * dpr)
-    canvas.height = Math.round(WAVE_H * dpr)
-    canvas.style.width = `${WAVE_W}px`
-    canvas.style.height = `${WAVE_H}px`
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-    ctx.imageSmoothingEnabled = false
-    ctx.fillStyle = getComputedStyle(canvas).color
-
-    let raf = 0
-
-    const tick = () => {
-      analyser.getByteFrequencyData(buf)
-      ctx.clearRect(0, 0, WAVE_W, WAVE_H)
-
-      for (let i = 0; i < BARS; i++) {
-        const a = Math.floor((i / BARS) * hi)
-        const b = Math.floor(((i + 1) / BARS) * hi)
-        let peak = 0
-
-        for (let j = a; j < b; j++) {
-          peak = Math.max(peak, buf[j] ?? 0)
-        }
-
-        const amp = Math.sqrt(peak / 255)
-        const bh = Math.max(3, Math.round((0.18 + amp * 0.82) * WAVE_H))
-        ctx.fillRect(X0 + i * STEP, Math.round((WAVE_H - bh) / 2), BAR_W, bh)
-      }
-
-      raf = requestAnimationFrame(tick)
-    }
-
-    tick()
-
-    return () => cancelAnimationFrame(raf)
-  }, [audioElement])
-
-  return <canvas aria-hidden="true" className="block h-4 w-[88px]" ref={canvasRef} />
+function PlaybackActivityBars() {
+  return <VoiceLevelBars active level={0.55} />
 }
 
 export function VoiceActivity({ state }: { state: VoiceActivityState }) {
@@ -234,7 +116,7 @@ export function VoicePlaybackActivity() {
 
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <span className="truncate font-medium text-foreground/85">{title}</span>
-        {!preparing && <PlaybackWaveform audioElement={playback.audioElement} />}
+        {!preparing && <PlaybackActivityBars />}
       </div>
 
       <Button

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -37,6 +37,11 @@ declare global {
       notify: (payload: HermesNotification) => Promise<boolean>
       requestMicrophoneAccess: () => Promise<boolean>
       readFileDataUrl: (filePath: string) => Promise<string>
+      playAudioDataUrl?: (
+        dataUrl: string,
+        options?: { audioBytes?: null | number; mimeType?: string; provider?: string; requestId?: string; source?: string; transport?: string }
+      ) => Promise<{ code?: null | number; durationMs?: number; ok: boolean; signal?: null | string }>
+      stopNativeAudioPlayback?: () => Promise<{ ok: boolean; stopped: boolean }>
       readFileText: (filePath: string) => Promise<HermesReadFileTextResult>
       selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
       writeClipboard: (text: string) => Promise<boolean>

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -33,6 +33,7 @@ import type {
   ProfileSetupCommand,
   ProfileSoul,
   ProfilesResponse,
+  RealtimeClientSecretResponse,
   SessionInfo,
   SessionMessagesResponse,
   SessionSearchResponse,
@@ -88,6 +89,7 @@ export type {
   ProfileSetupCommand,
   ProfileSoul,
   ProfilesResponse,
+  RealtimeClientSecretResponse,
   RpcEvent,
   SessionCreateResponse,
   SessionInfo,
@@ -714,11 +716,31 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
   })
 }
 
-export function speakText(text: string): Promise<AudioSpeakResponse> {
+export function speakText(
+  text: string,
+  options: { requestId?: string; source?: string; transport?: string } = {}
+): Promise<AudioSpeakResponse> {
   return window.hermesDesktop.api<AudioSpeakResponse>({
     path: '/api/audio/speak',
     method: 'POST',
-    body: { text }
+    body: {
+      text,
+      ...(options.source ? { source: options.source } : {}),
+      ...(options.transport ? { transport: options.transport } : {}),
+      ...(options.requestId ? { request_id: options.requestId } : {})
+    }
+  })
+}
+
+export function createRealtimeClientSecret(body: {
+  instructions?: string
+  model?: string
+  voice?: string
+} = {}): Promise<RealtimeClientSecretResponse> {
+  return window.hermesDesktop.api<RealtimeClientSecretResponse>({
+    path: '/api/audio/realtime/client-secret',
+    method: 'POST',
+    body
   })
 }
 

--- a/apps/desktop/src/lib/realtime-voice.ts
+++ b/apps/desktop/src/lib/realtime-voice.ts
@@ -1,0 +1,187 @@
+import { createRealtimeClientSecret } from '@/hermes'
+
+const OPENAI_REALTIME_CALLS_URL = 'https://api.openai.com/v1/realtime/calls'
+const OPENAI_REALTIME_LEGACY_URL = 'https://api.openai.com/v1/realtime'
+
+export type RealtimeVoiceStatus = 'closed' | 'connecting' | 'listening' | 'speaking'
+
+export interface RealtimeVoiceSessionOptions {
+  instructions?: string
+  model?: string
+  onError?: (error: unknown) => void
+  onLevel?: (level: number) => void
+  onStatus?: (status: RealtimeVoiceStatus) => void
+  voice?: string
+}
+
+export interface RealtimeVoiceSession {
+  mute: (muted: boolean) => void
+  stop: () => void
+}
+
+function emitStatus(options: RealtimeVoiceSessionOptions, status: RealtimeVoiceStatus) {
+  options.onStatus?.(status)
+}
+
+async function postOfferToCallsApi(clientSecret: string, offer: RTCSessionDescriptionInit, model: string) {
+  const form = new FormData()
+  form.append('sdp', offer.sdp || '')
+  form.append('session', JSON.stringify({ type: 'realtime', model }))
+
+  const response = await fetch(OPENAI_REALTIME_CALLS_URL, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${clientSecret}` },
+    body: form
+  })
+
+  if (!response.ok) {
+    throw new Error(`Realtime calls SDP failed: HTTP ${response.status} ${await response.text()}`)
+  }
+
+  return response.text()
+}
+
+async function postOfferToLegacyApi(clientSecret: string, offer: RTCSessionDescriptionInit, model: string) {
+  const response = await fetch(`${OPENAI_REALTIME_LEGACY_URL}?model=${encodeURIComponent(model)}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${clientSecret}`,
+      'Content-Type': 'application/sdp'
+    },
+    body: offer.sdp || ''
+  })
+
+  if (!response.ok) {
+    throw new Error(`Realtime legacy SDP failed: HTTP ${response.status} ${await response.text()}`)
+  }
+
+  return response.text()
+}
+
+export async function startRealtimeVoiceSession(options: RealtimeVoiceSessionOptions = {}): Promise<RealtimeVoiceSession> {
+  if (typeof RTCPeerConnection === 'undefined') {
+    throw new Error('Realtime voice requires WebRTC support')
+  }
+  if (!navigator.mediaDevices?.getUserMedia) {
+    throw new Error('Realtime voice requires microphone capture support')
+  }
+
+  emitStatus(options, 'connecting')
+  const secret = await createRealtimeClientSecret({
+    instructions: options.instructions,
+    model: options.model,
+    voice: options.voice
+  })
+
+  const pc = new RTCPeerConnection()
+  let stream: MediaStream | null = null
+  let context: AudioContext | null = null
+  let levelTimer: number | null = null
+  const audio = new Audio()
+
+  const cleanup = () => {
+    if (levelTimer !== null) {
+      window.clearInterval(levelTimer)
+      levelTimer = null
+    }
+    options.onLevel?.(0)
+    pc.getSenders().forEach(sender => sender.track?.stop())
+    stream?.getTracks().forEach(track => track.stop())
+    audio.pause()
+    audio.srcObject = null
+    void context?.close().catch(() => undefined)
+  }
+
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    const [track] = stream.getAudioTracks()
+    if (!track) {
+      throw new Error('No microphone audio track available')
+    }
+
+    pc.addTrack(track, stream)
+
+    audio.autoplay = true
+
+    pc.ontrack = event => {
+      const [remoteStream] = event.streams
+      if (remoteStream) {
+        audio.srcObject = remoteStream
+        void audio.play().catch(error => options.onError?.(error))
+      }
+    }
+
+    const dc = pc.createDataChannel('oai-events')
+    dc.onopen = () => emitStatus(options, 'listening')
+    dc.onerror = event => options.onError?.(event)
+    dc.onmessage = event => {
+      try {
+        const data = JSON.parse(String(event.data)) as { type?: string }
+        switch (data.type) {
+          case 'response.audio.started':
+          case 'response.output_audio.started':
+          case 'response.created':
+            emitStatus(options, 'speaking')
+            break
+          case 'response.audio.done':
+          case 'response.output_audio.done':
+          case 'response.done':
+          case 'input_audio_buffer.speech_started':
+            emitStatus(options, 'listening')
+            break
+          default:
+            break
+        }
+      } catch {
+        // Ignore non-JSON diagnostic frames.
+      }
+    }
+
+    context = new AudioContext()
+    const source = context.createMediaStreamSource(stream)
+    const analyser = context.createAnalyser()
+    analyser.fftSize = 256
+    source.connect(analyser)
+    const samples = new Uint8Array(analyser.frequencyBinCount)
+    levelTimer = window.setInterval(() => {
+      analyser.getByteFrequencyData(samples)
+      const average = samples.reduce((sum, value) => sum + value, 0) / Math.max(1, samples.length)
+      options.onLevel?.(Math.min(1, average / 128))
+    }, 100)
+
+    const offer = await pc.createOffer()
+    await pc.setLocalDescription(offer)
+
+    let answerSdp: string
+    try {
+      answerSdp = await postOfferToCallsApi(secret.client_secret, offer, secret.model)
+    } catch (callsError) {
+      console.warn('[hermes] Realtime calls SDP failed; trying legacy SDP endpoint', callsError)
+      answerSdp = await postOfferToLegacyApi(secret.client_secret, offer, secret.model)
+    }
+
+    await pc.setRemoteDescription({ type: 'answer', sdp: answerSdp })
+    emitStatus(options, 'listening')
+
+    return {
+      mute(muted: boolean) {
+        track.enabled = !muted
+      },
+      stop() {
+        try {
+          dc.close()
+        } catch {
+          // already closed
+        }
+        cleanup()
+        pc.close()
+        emitStatus(options, 'closed')
+      }
+    }
+  } catch (error) {
+    cleanup()
+    pc.close()
+    emitStatus(options, 'closed')
+    throw error
+  }
+}

--- a/apps/desktop/src/lib/speech-text.ts
+++ b/apps/desktop/src/lib/speech-text.ts
@@ -28,8 +28,84 @@ export function sanitizeTextForSpeech(text: string): string {
     .replace(URL_RE, ' link ')
     .replace(EMOJI_RE, ' ')
     .replace(/^#{1,6}\s+/gm, '')
+    .replace(/(?:^|[.!?]\s+)[-+*]\s+/g, match => match.replace(/[-+*]\s+$/, ''))
+    .replace(/\s[-+*]\s+/g, ' ')
     .replace(/[*_~>#]/g, '')
     .replace(/^\s*[-+*]\s+/gm, '')
+    .replace(/([.!?])\s*\.\s+/g, '$1 ')
     .replace(/\s+/g, ' ')
     .trim()
+}
+
+const SPOKEN_DIGEST_SHORT_CHARS = 220
+const SPOKEN_DIGEST_TARGET_CHARS = 300
+const SPOKEN_DIGEST_MAX_CHARS = 380
+const SPOKEN_DIGEST_VERDICT_MAX_CHARS = 140
+
+function truncateAtSpeechBoundary(text: string, maxChars = SPOKEN_DIGEST_MAX_CHARS): string {
+  if (text.length <= maxChars) {
+    return text
+  }
+
+  const slice = text.slice(0, maxChars)
+  const boundary = Math.max(
+    slice.lastIndexOf('. '),
+    slice.lastIndexOf('! '),
+    slice.lastIndexOf('? '),
+    slice.lastIndexOf('; '),
+    slice.lastIndexOf(', '),
+    slice.lastIndexOf(' ')
+  )
+
+  return `${slice.slice(0, boundary > 120 ? boundary : maxChars).trim()}…`
+}
+
+function splitSpeechSentences(text: string): string[] {
+  return (text.match(/[^.!?。！？]+[.!?。！？]+(?:\s+|$)|[^.!?。！？]+$/g) ?? [text])
+    .map(sentence => sentence.trim())
+    .filter(Boolean)
+}
+
+function isVerdictSentence(sentence: string): boolean {
+  return sentence.length <= SPOKEN_DIGEST_VERDICT_MAX_CHARS && /^(?:yes|no|partially|good|done|fixed|working|healthy|blocked|not yet|mostly)\b/i.test(sentence)
+}
+
+export function buildSpokenDigest(text: string): string {
+  const speakableText = sanitizeTextForSpeech(text)
+
+  if (!speakableText) {
+    return ''
+  }
+
+  const sentences = splitSpeechSentences(speakableText)
+
+  if (speakableText.length <= SPOKEN_DIGEST_SHORT_CHARS || sentences.length <= 2) {
+    return truncateAtSpeechBoundary(speakableText)
+  }
+
+  const verdict = isVerdictSentence(sentences[0]) ? sentences[0] : null
+  const tail: string[] = []
+  let total = verdict ? verdict.length + 1 : 0
+
+  for (let index = sentences.length - 1; index >= 0; index -= 1) {
+    const sentence = sentences[index]
+
+    if (!sentence || sentence === verdict) {
+      continue
+    }
+
+    if (tail.length > 0 && total + sentence.length > SPOKEN_DIGEST_TARGET_CHARS) {
+      break
+    }
+
+    tail.unshift(sentence)
+    total += sentence.length + 1
+
+    if (tail.length >= 2 || total >= SPOKEN_DIGEST_TARGET_CHARS) {
+      break
+    }
+  }
+
+  const digest = [verdict, ...tail].filter(Boolean).join(' ')
+  return truncateAtSpeechBoundary(digest || speakableText)
 }

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -31,10 +31,35 @@ export interface VoicePlaybackOptions {
   source: VoicePlaybackSource
 }
 
+interface SpeechAudioResponse {
+  audio_bytes?: null | number
+  data_url: string
+  mime_type?: string
+  ok?: boolean
+  playback?: string
+  provider?: string
+  request_id?: string
+  timings_ms?: Record<string, unknown>
+  transport?: string
+}
+
+function voiceRequestId(options: VoicePlaybackOptions): string {
+  const suffix = options.messageId ? `-${options.messageId}` : ''
+  return `desktop-${Date.now().toString(36)}-${sequence}-${options.source}${suffix}`.replace(/[^A-Za-z0-9_.:-]/g, '').slice(0, 80)
+}
+
+async function getSpeechAudio(text: string, options: VoicePlaybackOptions, requestId: string): Promise<SpeechAudioResponse> {
+  return speakText(text, { requestId, source: options.source })
+}
+
 export function stopVoicePlayback() {
   sequence += 1
   currentStop?.()
   currentStop = null
+
+  if (window.hermesDesktop.stopNativeAudioPlayback) {
+    void window.hermesDesktop.stopNativeAudioPlayback().catch(() => undefined)
+  }
 
   if (currentAudio) {
     currentAudio.pause()
@@ -52,6 +77,114 @@ export function stopVoicePlayback() {
   })
 }
 
+function shouldUseNativeAudio(_options: VoicePlaybackOptions) {
+  // Prefer the native player for every Desktop speech path. Chromium/WebAudio
+  // can enter a bad device state on Joe's CachyOS/PipeWire stack while native
+  // players (`mpv`/`afplay`) continue routing cleanly through the OS default
+  // sink. Browser audio remains available as the fallback below.
+  return typeof window.hermesDesktop.playAudioDataUrl === 'function'
+}
+
+async function playNativeSpeechAudio(
+  response: SpeechAudioResponse,
+  options: VoicePlaybackOptions,
+  isCurrent: () => boolean
+): Promise<boolean> {
+  const playAudioDataUrl = window.hermesDesktop.playAudioDataUrl
+  const requestId = response.request_id
+
+  if (!playAudioDataUrl) {
+    return false
+  }
+
+  setVoicePlaybackState(currentState('speaking', options))
+
+  const playbackResult = await new Promise<{ code?: null | number; durationMs?: number; ok: boolean; signal?: null | string }>((resolve, reject) => {
+    currentStop = () => {
+      currentStop = null
+      void window.hermesDesktop.stopNativeAudioPlayback?.().catch(() => undefined)
+      resolve({ ok: true, signal: 'SIGTERM' })
+    }
+
+    playAudioDataUrl(response.data_url, {
+      audioBytes: response.audio_bytes ?? null,
+      mimeType: response.mime_type,
+      provider: response.provider,
+      requestId,
+      source: options.source,
+      transport: response.transport
+    })
+      .then(resolve)
+      .catch(reject)
+  })
+
+  console.info('[voice] native playback result', {
+    request_id: requestId,
+    result: playbackResult,
+    timings_ms: response.timings_ms,
+    transport: response.transport
+  })
+
+  currentStop = null
+
+  if (!isCurrent()) {
+    return false
+  }
+
+  if (!playbackResult.ok) {
+    throw new Error(`Native playback failed (code ${playbackResult.code ?? 'unknown'}, signal ${playbackResult.signal ?? 'none'})`)
+  }
+
+  setVoicePlaybackState(currentState('idle'))
+  return true
+}
+
+async function playBrowserSpeechAudio(
+  response: SpeechAudioResponse,
+  options: VoicePlaybackOptions,
+  isCurrent: () => boolean
+): Promise<boolean> {
+  const audio = new Audio(response.data_url)
+  currentAudio = audio
+  setVoicePlaybackState(currentState('speaking', options, audio))
+
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      audio.removeEventListener('ended', onEnded)
+      audio.removeEventListener('error', onError)
+      currentStop = null
+    }
+
+    const onEnded = () => {
+      cleanup()
+      resolve()
+    }
+
+    const onError = () => {
+      cleanup()
+      reject(new Error('Playback failed'))
+    }
+
+    currentStop = () => {
+      cleanup()
+      resolve()
+    }
+
+    audio.addEventListener('ended', onEnded, { once: true })
+    audio.addEventListener('error', onError, { once: true })
+    void audio.play().catch(reject)
+  })
+
+  if (!isCurrent()) {
+    return false
+  }
+
+  currentAudio = null
+  setVoicePlaybackState(currentState('idle'))
+
+  return true
+}
+
 export async function playSpeechText(text: string, options: VoicePlaybackOptions): Promise<boolean> {
   stopVoicePlayback()
 
@@ -64,54 +197,38 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
   const ownSequence = sequence
   const isCurrent = () => ownSequence === sequence
 
+  const requestId = voiceRequestId(options)
+
   setVoicePlaybackState(currentState('preparing', options))
 
   try {
-    const response = await speakText(speakableText)
+    const response = await getSpeechAudio(speakableText, options, requestId)
+    response.request_id = response.request_id || requestId
 
     if (!isCurrent()) {
       return false
     }
 
-    const audio = new Audio(response.data_url)
-    currentAudio = audio
-    setVoicePlaybackState(currentState('speaking', options, audio))
-
-    await new Promise<void>((resolve, reject) => {
-      const cleanup = () => {
-        audio.removeEventListener('ended', onEnded)
-        audio.removeEventListener('error', onError)
-        currentStop = null
-      }
-
-      const onEnded = () => {
-        cleanup()
-        resolve()
-      }
-
-      const onError = () => {
-        cleanup()
-        reject(new Error('Playback failed'))
-      }
-
-      currentStop = () => {
-        cleanup()
-        resolve()
-      }
-
-      audio.addEventListener('ended', onEnded, { once: true })
-      audio.addEventListener('error', onError, { once: true })
-      void audio.play().catch(reject)
-    })
-
-    if (!isCurrent()) {
-      return false
+    if (response.playback === 'livekit') {
+      // The sidecar already published this audio into the LiveKit room;
+      // playing the data_url locally too would double-speak for anyone at the desk.
+      setVoicePlaybackState(currentState('idle'))
+      return true
     }
 
-    currentAudio = null
-    setVoicePlaybackState(currentState('idle'))
+    if (shouldUseNativeAudio(options)) {
+      try {
+        return await playNativeSpeechAudio(response, options, isCurrent)
+      } catch (nativeError) {
+        console.warn('Native voice playback failed; falling back to browser audio.', nativeError)
 
-    return true
+        if (!isCurrent()) {
+          return false
+        }
+      }
+    }
+
+    return await playBrowserSpeechAudio(response, options, isCurrent)
   } catch (error) {
     if (isCurrent()) {
       currentStop = null

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -21,6 +21,20 @@ export interface AudioSpeakResponse {
   data_url: string
   mime_type: string
   provider?: string
+  transport?: string
+  playback?: string
+  request_id?: string
+  audio_bytes?: number | null
+  timings_ms?: Record<string, number | string | boolean | null>
+}
+
+export interface RealtimeClientSecretResponse {
+  ok: boolean
+  client_secret: string
+  expires_at?: number | null
+  model: string
+  session?: unknown
+  voice: string
 }
 
 export interface ElevenLabsVoice {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -633,6 +633,12 @@ class AudioTranscriptionRequest(BaseModel):
     mime_type: Optional[str] = None
 
 
+class RealtimeClientSecretRequest(BaseModel):
+    model: Optional[str] = None
+    instructions: Optional[str] = None
+    voice: Optional[str] = None
+
+
 class ModelAssignment(BaseModel):
     """Payload for POST /api/model/set — assign a provider/model to a slot.
 
@@ -664,11 +670,54 @@ _AUDIO_MIME_EXTENSIONS: Dict[str, str] = {
     "video/webm": ".webm",
 }
 _MAX_TRANSCRIPTION_UPLOAD_BYTES = 25 * 1024 * 1024
+_REALTIME_CLIENT_SECRET_URL = "https://api.openai.com/v1/realtime/client_secrets"
+_DEFAULT_REALTIME_MODEL = "gpt-realtime-2"
+_DEFAULT_REALTIME_VOICE = "alloy"
+_DEFAULT_REALTIME_INSTRUCTIONS = (
+    "You are Hermes/Migi in a live voice session. Be concise, useful, and direct. "
+    "Keep replies short unless the user asks for depth. Do not claim tool access from "
+    "this realtime voice path; route tool-heavy work back to the main Hermes chat."
+)
 
 
 def _audio_extension_for_mime(mime_type: str) -> str:
     normalized = (mime_type or "").split(";", 1)[0].strip().lower()
     return _AUDIO_MIME_EXTENSIONS.get(normalized, ".webm")
+
+
+def _openai_api_key_from_current_env() -> str:
+    """Return the current OpenAI key, preferring ~/.hermes/.env over stale process env.
+
+    Desktop can keep a backend process alive across key rotations. Mirroring the
+    Realtime2 TTS fix here prevents live voice from inheriting a rejected key
+    until the user restarts the whole app. Voice installs may intentionally keep
+    a separate OpenAI key under VOICE_TOOLS_OPENAI_KEY, so use that as the
+    Realtime fallback before stale inherited process env.
+    """
+    env = load_env()
+    return (
+        env.get("OPENAI_API_KEY")
+        or env.get("VOICE_TOOLS_OPENAI_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+        or os.environ.get("VOICE_TOOLS_OPENAI_KEY")
+        or ""
+    ).strip()
+
+
+def _extract_realtime_client_secret(payload: Dict[str, Any]) -> str:
+    value = payload.get("value")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+
+    nested = payload.get("client_secret")
+    if isinstance(nested, dict):
+        value = nested.get("value")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    if isinstance(nested, str) and nested.strip():
+        return nested.strip()
+
+    return ""
 
 
 class ModelAssignment(BaseModel):
@@ -1529,6 +1578,111 @@ async def check_hermes_update(force: bool = False):
     return payload
 
 
+@app.post("/api/audio/realtime/client-secret")
+async def create_realtime_client_secret(payload: RealtimeClientSecretRequest):
+    """Mint an ephemeral OpenAI Realtime client secret for Desktop WebRTC.
+
+    The long-lived OPENAI_API_KEY stays server-side. The renderer receives only
+    a short-lived client secret that can bootstrap a direct browser WebRTC
+    session with OpenAI's Realtime API.
+    """
+    api_key = _openai_api_key_from_current_env()
+    if not api_key:
+        raise HTTPException(status_code=400, detail="OPENAI_API_KEY or VOICE_TOOLS_OPENAI_KEY is not configured")
+
+    cfg = load_config() or {}
+    voice_cfg = cfg.get("voice", {}) if isinstance(cfg.get("voice"), dict) else {}
+    realtime_cfg = voice_cfg.get("realtime", {}) if isinstance(voice_cfg.get("realtime"), dict) else {}
+
+    model = (
+        (payload.model or "").strip()
+        or str(realtime_cfg.get("model") or "").strip()
+        or _DEFAULT_REALTIME_MODEL
+    )
+    voice = (
+        (payload.voice or "").strip()
+        or str(realtime_cfg.get("voice") or "").strip()
+        or _DEFAULT_REALTIME_VOICE
+    )
+    instructions = (
+        (payload.instructions or "").strip()
+        or str(realtime_cfg.get("instructions") or "").strip()
+        or _DEFAULT_REALTIME_INSTRUCTIONS
+    )
+
+    # VAD tuning (configurable via voice.realtime.turn_detection.*)
+    td = realtime_cfg.get("turn_detection", {}) if isinstance(realtime_cfg.get("turn_detection"), dict) else {}
+    vad = {
+        "type": "server_vad",
+        "create_response": True,
+        "interrupt_response": True,
+        "threshold": float(td.get("threshold", 0.45)),
+        "prefix_padding_ms": int(td.get("prefix_padding_ms", 250)),
+        "silence_duration_ms": int(td.get("silence_duration_ms", 450)),
+    }
+
+    session_payload: Dict[str, Any] = {
+        "session": {
+            "type": "realtime",
+            "model": model,
+            "instructions": instructions,
+            "audio": {
+                "input": {
+                    "turn_detection": vad
+                },
+                "output": {
+                    "voice": voice
+                },
+            },
+        }
+    }
+
+    request = urllib.request.Request(
+        _REALTIME_CLIENT_SECRET_URL,
+        data=json.dumps(session_payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        loop = asyncio.get_running_loop()
+
+        def _fetch() -> Dict[str, Any]:
+            with urllib.request.urlopen(request, timeout=15) as response:
+                return json.loads(response.read().decode("utf-8"))
+
+        result = await loop.run_in_executor(None, _fetch)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        _log.warning("OpenAI Realtime client-secret request failed: %s", detail)
+        raise HTTPException(status_code=502, detail="Could not create Realtime client secret")
+    except Exception as exc:
+        _log.warning("OpenAI Realtime client-secret request failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Could not create Realtime client secret")
+
+    client_secret = _extract_realtime_client_secret(result)
+    if not client_secret:
+        raise HTTPException(status_code=502, detail="Realtime client secret missing from OpenAI response")
+
+    expires_at = result.get("expires_at")
+    nested_secret = result.get("client_secret")
+    if expires_at is None and isinstance(nested_secret, dict):
+        expires_at = nested_secret.get("expires_at")
+
+    return {
+        "ok": True,
+        "client_secret": client_secret,
+        "expires_at": expires_at,
+        "model": model,
+        "voice": voice,
+        "session": result.get("session"),
+    }
+
+
 @app.post("/api/audio/transcribe")
 async def transcribe_audio_upload(payload: AudioTranscriptionRequest):
     data_url = (payload.data_url or "").strip()
@@ -1605,6 +1759,213 @@ async def transcribe_audio_upload(payload: AudioTranscriptionRequest):
 
 class TTSSpeakRequest(BaseModel):
     text: str
+    source: Optional[str] = None
+    transport: Optional[str] = None
+    request_id: Optional[str] = None
+
+
+def _voice_output_config() -> Dict[str, Any]:
+    cfg = load_config() or {}
+    voice_cfg = cfg.get("voice", {}) if isinstance(cfg.get("voice"), dict) else {}
+    livekit_cfg = voice_cfg.get("livekit", {}) if isinstance(voice_cfg.get("livekit"), dict) else {}
+    transport = str(voice_cfg.get("output_transport") or livekit_cfg.get("output_transport") or "").strip().lower()
+    if not transport and livekit_cfg.get("enabled") is True:
+        transport = "livekit"
+    return {
+        "transport": transport,
+        "livekit": livekit_cfg,
+    }
+
+
+def _boolish(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _voice_request_id(raw: Optional[str] = None) -> str:
+    candidate = re.sub(r"[^A-Za-z0-9_.:-]", "", str(raw or "").strip())[:80]
+    return candidate or f"voice-{int(time.time() * 1000):x}-{secrets.token_hex(3)}"
+
+
+def _ms_since(start: float) -> int:
+    return int(round((time.perf_counter() - start) * 1000))
+
+
+def _data_url_payload_bytes(data_url: Any) -> Optional[int]:
+    if not isinstance(data_url, str):
+        return None
+    try:
+        marker = ";base64,"
+        if marker not in data_url:
+            return len(data_url.encode("utf-8"))
+        return len(base64.b64decode(data_url.split(marker, 1)[1], validate=False))
+    except (binascii.Error, ValueError):
+        return None
+
+
+def _voice_log(event: str, request_id: str, **fields: Any) -> None:
+    safe_fields: Dict[str, Any] = {}
+    for key, value in fields.items():
+        if value is None:
+            continue
+        if isinstance(value, (str, int, float, bool)):
+            safe_fields[key] = value
+        elif isinstance(value, (list, tuple)):
+            safe_fields[key] = [item for item in value if isinstance(item, (str, int, float, bool, type(None)))]
+        elif isinstance(value, dict):
+            safe_fields[key] = {
+                str(k): v for k, v in value.items()
+                if isinstance(v, (str, int, float, bool, type(None)))
+            }
+        else:
+            safe_fields[key] = str(value)
+    _log.info("voice_audio_event %s", json.dumps({"event": event, "request_id": request_id, **safe_fields}, sort_keys=True))
+
+
+async def _try_livekit_voice_output(text: str, payload: TTSSpeakRequest, request_id: str) -> Optional[Dict[str, Any]]:
+    requested_transport = (payload.transport or "").strip().lower()
+    cfg = _voice_output_config()
+    livekit_cfg = cfg.get("livekit", {}) if isinstance(cfg.get("livekit"), dict) else {}
+    configured_transport = str(cfg.get("transport") or "").strip().lower()
+    text_chars = len(text)
+
+    if payload.source != "voice-conversation" and requested_transport != "livekit":
+        _voice_log(
+            "livekit_route_skipped",
+            request_id,
+            reason="source_not_voice",
+            source=payload.source or "",
+            requested_transport=requested_transport,
+            configured_transport=configured_transport,
+        )
+        return None
+    if requested_transport != "livekit" and configured_transport != "livekit":
+        _voice_log(
+            "livekit_route_skipped",
+            request_id,
+            reason="transport_not_livekit",
+            requested_transport=requested_transport,
+            configured_transport=configured_transport,
+        )
+        return None
+
+    sidecar_url = str(livekit_cfg.get("sidecar_url") or "http://127.0.0.1:9191/speak").strip()
+    if not sidecar_url:
+        _voice_log("livekit_route_skipped", request_id, reason="missing_sidecar_url")
+        return None
+
+    sidecar_payload = {
+        "text": text,
+        "room": str(livekit_cfg.get("room") or "migi-pilot"),
+        "identity": str(livekit_cfg.get("identity") or "migi-desktop"),
+        "request_id": request_id,
+    }
+    try:
+        timeout = float(livekit_cfg.get("timeout_seconds") or 35)
+    except (TypeError, ValueError):
+        timeout = 35.0
+    sidecar_start = time.perf_counter()
+    parsed_sidecar = urllib.parse.urlparse(sidecar_url)
+
+    _voice_log(
+        "livekit_sidecar_request",
+        request_id,
+        sidecar_host=parsed_sidecar.netloc or parsed_sidecar.path,
+        room=sidecar_payload["room"],
+        identity=sidecar_payload["identity"],
+        timeout_seconds=timeout,
+        text_chars=text_chars,
+        playback=str(livekit_cfg.get("playback") or "both"),
+        required=_boolish(livekit_cfg.get("required"), False),
+    )
+
+    request = urllib.request.Request(
+        sidecar_url,
+        data=json.dumps(sidecar_payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+
+    try:
+        loop = asyncio.get_running_loop()
+
+        def _fetch() -> Dict[str, Any]:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                body = response.read().decode("utf-8")
+                return json.loads(body)
+
+        result = await loop.run_in_executor(None, _fetch)
+        if not isinstance(result, dict):
+            raise ValueError(f"sidecar returned non-object JSON ({type(result).__name__})")
+    except Exception as exc:
+        elapsed_ms = _ms_since(sidecar_start)
+        _voice_log(
+            "livekit_sidecar_failed",
+            request_id,
+            duration_ms=elapsed_ms,
+            error_type=type(exc).__name__,
+            error=str(exc),
+            required=_boolish(livekit_cfg.get("required"), False),
+        )
+        if _boolish(livekit_cfg.get("required"), False):
+            raise HTTPException(status_code=502, detail=f"LiveKit voice sidecar failed: {exc}")
+        _log.warning("LiveKit voice sidecar unavailable; falling back to normal TTS: %s", exc)
+        return None
+
+    sidecar_ms = _ms_since(sidecar_start)
+    data_url = result.get("data_url")
+    audio_bytes = _data_url_payload_bytes(data_url)
+    raw_timings = result.get("timings_ms")
+    sidecar_timings: Dict[str, Any] = raw_timings if isinstance(raw_timings, dict) else {}
+    raw_fish = result.get("fish")
+    fish: Dict[str, Any] = raw_fish if isinstance(raw_fish, dict) else {}
+    raw_livekit = result.get("livekit")
+    livekit: Dict[str, Any] = raw_livekit if isinstance(raw_livekit, dict) else {}
+
+    _voice_log(
+        "livekit_sidecar_response",
+        request_id,
+        duration_ms=sidecar_ms,
+        provider=result.get("provider") or "livekit-fish-sidecar",
+        mime_type=result.get("mime_type") or "audio/mpeg",
+        data_url_chars=len(data_url) if isinstance(data_url, str) else 0,
+        audio_bytes=audio_bytes,
+        fish_bytes=fish.get("bytes"),
+        fish_chunks=fish.get("chunks"),
+        fish_format=fish.get("format"),
+        livekit_frames=livekit.get("frames"),
+        livekit_audio_ms=livekit.get("audio_duration_ms"),
+        livekit_remote_participants=livekit.get("remote_participants"),
+        sidecar_timings_ms=sidecar_timings,
+    )
+
+    if not data_url:
+        if _boolish(livekit_cfg.get("required"), False):
+            raise HTTPException(status_code=502, detail="LiveKit voice sidecar did not return audio")
+        _log.warning("LiveKit voice sidecar returned no audio; falling back to normal TTS")
+        return None
+
+    return {
+        "ok": True,
+        "data_url": data_url,
+        "mime_type": result.get("mime_type") or "audio/mpeg",
+        "provider": result.get("provider") or "livekit-fish-sidecar",
+        "transport": "livekit",
+        "playback": str(livekit_cfg.get("playback") or "both"),
+        "request_id": result.get("request_id") or request_id,
+        "audio_bytes": audio_bytes,
+        "timings_ms": {
+            # The sidecar reports its own internal "sidecar_total"; keep the
+            # HTTP round-trip as measured from this process under a distinct key.
+            "sidecar_roundtrip": sidecar_ms,
+            **sidecar_timings,
+        },
+        "livekit": livekit,
+        "fish": fish,
+    }
 
 
 def _elevenlabs_voice_label(voice: Dict[str, Any]) -> str:
@@ -1673,24 +2034,80 @@ async def speak_text(payload: TTSSpeakRequest):
     existing TTS provider chain (Edge / OpenAI / ElevenLabs / etc.)
     configured in ``~/.hermes/config.yaml`` under ``tts.``.
     """
+    request_id = _voice_request_id(payload.request_id)
+    total_start = time.perf_counter()
     text = (payload.text or "").strip()
     if not text:
+        _voice_log("audio_speak_rejected", request_id, reason="empty_text")
         raise HTTPException(status_code=400, detail="Text is required")
 
+    _voice_log(
+        "audio_speak_start",
+        request_id,
+        source=payload.source or "",
+        requested_transport=(payload.transport or "").strip().lower(),
+        text_chars=len(text),
+    )
+
+    try:
+        livekit_audio = await _try_livekit_voice_output(text, payload, request_id)
+        if livekit_audio:
+            livekit_audio.setdefault("request_id", request_id)
+            raw_timings = livekit_audio.get("timings_ms")
+            timings: Dict[str, Any] = raw_timings if isinstance(raw_timings, dict) else {}
+            livekit_audio["timings_ms"] = {**timings, "api_total": _ms_since(total_start)}
+            _voice_log(
+                "audio_speak_done",
+                request_id,
+                transport="livekit",
+                playback=livekit_audio.get("playback"),
+                provider=livekit_audio.get("provider"),
+                mime_type=livekit_audio.get("mime_type"),
+                audio_bytes=livekit_audio.get("audio_bytes"),
+                total_ms=livekit_audio["timings_ms"].get("api_total"),
+            )
+            return livekit_audio
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _voice_log(
+            "livekit_route_error",
+            request_id,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+        _log.exception("LiveKit voice route errored; falling back to local TTS")
+
+    local_start = time.perf_counter()
+    _voice_log("local_tts_start", request_id, text_chars=len(text))
     try:
         from tools.tts_tool import text_to_speech_tool
         loop = asyncio.get_running_loop()
         result_json = await loop.run_in_executor(None, text_to_speech_tool, text)
     except Exception as exc:
+        _voice_log(
+            "local_tts_failed",
+            request_id,
+            duration_ms=_ms_since(local_start),
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
         _log.exception("Desktop voice TTS failed")
         raise HTTPException(status_code=500, detail=f"Speech synthesis failed: {exc}")
 
     try:
         result = json.loads(result_json) if isinstance(result_json, str) else result_json
     except Exception:
+        _voice_log("local_tts_failed", request_id, duration_ms=_ms_since(local_start), error="Invalid TTS response")
         raise HTTPException(status_code=500, detail="Invalid TTS response")
 
     if not result.get("success"):
+        _voice_log(
+            "local_tts_failed",
+            request_id,
+            duration_ms=_ms_since(local_start),
+            error=str(result.get("error") or "Speech synthesis failed"),
+        )
         raise HTTPException(
             status_code=400,
             detail=result.get("error") or "Speech synthesis failed",
@@ -1698,6 +2115,7 @@ async def speak_text(payload: TTSSpeakRequest):
 
     file_path = result.get("file_path")
     if not file_path or not os.path.isfile(file_path):
+        _voice_log("local_tts_failed", request_id, duration_ms=_ms_since(local_start), error="Audio file missing")
         raise HTTPException(status_code=500, detail="Audio file missing")
 
     ext = os.path.splitext(file_path)[1].lower()
@@ -1713,6 +2131,7 @@ async def speak_text(payload: TTSSpeakRequest):
         with open(file_path, "rb") as fh:
             audio_bytes = fh.read()
     except OSError as exc:
+        _voice_log("local_tts_failed", request_id, duration_ms=_ms_since(local_start), error=str(exc))
         raise HTTPException(status_code=500, detail=f"Could not read audio: {exc}")
     finally:
         try:
@@ -1721,11 +2140,30 @@ async def speak_text(payload: TTSSpeakRequest):
             pass
 
     encoded = base64.b64encode(audio_bytes).decode("ascii")
+    timings_ms = {
+        "local_tts_total": _ms_since(local_start),
+        "api_total": _ms_since(total_start),
+    }
+    _voice_log(
+        "audio_speak_done",
+        request_id,
+        transport="local",
+        playback="local",
+        provider=result.get("provider"),
+        mime_type=mime_type,
+        audio_bytes=len(audio_bytes),
+        total_ms=timings_ms["api_total"],
+    )
     return {
         "ok": True,
         "data_url": f"data:{mime_type};base64,{encoded}",
         "mime_type": mime_type,
         "provider": result.get("provider"),
+        "transport": "local",
+        "playback": "local",
+        "request_id": request_id,
+        "audio_bytes": len(audio_bytes),
+        "timings_ms": timings_ms,
     }
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -754,6 +754,67 @@ class TestWebServerEndpoints:
         assert "/api/audio/transcribe" in paths
         assert "/api/audio/speak" in paths
         assert "/api/audio/elevenlabs/voices" in paths
+        assert "/api/audio/realtime/client-secret" in paths
+
+    def test_realtime_client_secret_prefers_dotenv_key_and_redacts_key(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        captured = {}
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return json.dumps({
+                    "client_secret": {"value": "ek_test_secret", "expires_at": 1893456000},
+                    "session": {"id": "sess_test"},
+                }).encode("utf-8")
+
+        def fake_urlopen(request, timeout=0):
+            captured["url"] = request.full_url
+            captured["timeout"] = timeout
+            captured["headers"] = dict(request.header_items())
+            captured["body"] = json.loads(request.data.decode("utf-8"))
+            return FakeResponse()
+
+        monkeypatch.setattr(web_server, "load_env", lambda: {"OPENAI_API_KEY": "sk-current-dotenv"})
+        monkeypatch.setattr(web_server, "load_config", lambda: {})
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-stale-process")
+        monkeypatch.setattr(web_server.urllib.request, "urlopen", fake_urlopen)
+
+        resp = self.client.post("/api/audio/realtime/client-secret", json={})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["client_secret"] == "ek_test_secret"
+        assert body["expires_at"] == 1893456000
+        assert body["model"] == "gpt-realtime-2"
+        assert captured["url"].endswith("/v1/realtime/client_secrets")
+        assert captured["headers"]["Authorization"] == "Bearer sk-current-dotenv"
+        assert "sk-current-dotenv" not in json.dumps(body)
+        assert "sk-stale-process" not in json.dumps(body)
+        turn_detection = captured["body"]["session"]["audio"]["input"]["turn_detection"]
+        assert turn_detection["type"] == "server_vad"
+        assert turn_detection["create_response"] is True
+        assert turn_detection["interrupt_response"] is True
+
+    def test_realtime_client_secret_requires_openai_key(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server, "load_env", lambda: {})
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+
+        resp = self.client.post("/api/audio/realtime/client-secret", json={})
+
+        assert resp.status_code == 400
+        assert "OPENAI_API_KEY" in resp.json()["detail"]
+        assert "VOICE_TOOLS_OPENAI_KEY" in resp.json()["detail"]
 
     def test_elevenlabs_voices_unavailable_without_key(self, monkeypatch):
         import hermes_cli.web_server as web_server
@@ -787,8 +848,156 @@ class TestWebServerEndpoints:
         assert body["mime_type"] == "audio/mpeg"
         assert body["data_url"].startswith("data:audio/mpeg;base64,")
         assert body["provider"] == "test"
+        assert body["transport"] == "local"
+        assert body["playback"] == "local"
         # The handler streams the bytes back and removes the temp file.
         assert not audio_file.exists()
+
+    def test_speak_text_voice_conversation_stays_local_without_livekit_config(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+        import tools.tts_tool as tts_tool
+
+        audio_file = tmp_path / "speech.mp3"
+        audio_file.write_bytes(b"ID3voice-conversation")
+        monkeypatch.setattr(web_server, "load_config", lambda: {"voice": {}})
+        monkeypatch.setattr(tts_tool, "text_to_speech_tool", lambda _text: json.dumps({
+            "success": True,
+            "file_path": str(audio_file),
+            "provider": "test-local",
+        }))
+
+        resp = self.client.post(
+            "/api/audio/speak",
+            json={"text": "hello there", "source": "voice-conversation"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["provider"] == "test-local"
+        assert body["transport"] == "local"
+        assert body["playback"] == "local"
+        assert body["data_url"].startswith("data:audio/mpeg;base64,")
+
+    def test_speak_text_livekit_transport_posts_to_sidecar(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        captured = {}
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def read(self):
+                return json.dumps({
+                    "ok": True,
+                    "data_url": "data:audio/wav;base64,ZmFrZQ==",
+                    "mime_type": "audio/wav",
+                    "provider": "migi_fish_livekit",
+                }).encode("utf-8")
+
+        def fake_urlopen(request, timeout):
+            captured["url"] = request.full_url
+            captured["timeout"] = timeout
+            captured["body"] = json.loads(request.data.decode("utf-8"))
+            return FakeResponse()
+
+        monkeypatch.setattr(web_server, "load_config", lambda: {
+            "voice": {
+                "livekit": {
+                    "sidecar_url": "http://127.0.0.1:9191/speak",
+                    "room": "test-room",
+                    "identity": "test-identity",
+                    "timeout_seconds": 12,
+                    "required": False,
+                }
+            }
+        })
+        monkeypatch.setattr(web_server.urllib.request, "urlopen", fake_urlopen)
+
+        resp = self.client.post(
+            "/api/audio/speak",
+            json={"text": "hello livekit", "transport": "livekit"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["provider"] == "migi_fish_livekit"
+        assert body["transport"] == "livekit"
+        assert body["playback"] == "both"
+        assert body["mime_type"] == "audio/wav"
+        assert body["data_url"] == "data:audio/wav;base64,ZmFrZQ=="
+        forwarded_request_id = captured["body"].pop("request_id")
+        assert forwarded_request_id == body["request_id"]
+        assert captured == {
+            "url": "http://127.0.0.1:9191/speak",
+            "timeout": 12.0,
+            "body": {
+                "text": "hello livekit",
+                "room": "test-room",
+                "identity": "test-identity",
+            },
+        }
+
+    def test_speak_text_livekit_failure_falls_back_when_not_required(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+        import tools.tts_tool as tts_tool
+
+        audio_file = tmp_path / "fallback.mp3"
+        audio_file.write_bytes(b"ID3fallback")
+
+        monkeypatch.setattr(web_server, "load_config", lambda: {
+            "voice": {
+                "output_transport": "livekit",
+                "livekit": {
+                    "sidecar_url": "http://127.0.0.1:9/speak",
+                    "required": False,
+                },
+            }
+        })
+        monkeypatch.setattr(web_server.urllib.request, "urlopen", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("down")))
+        monkeypatch.setattr(tts_tool, "text_to_speech_tool", lambda _text: json.dumps({
+            "success": True,
+            "file_path": str(audio_file),
+            "provider": "fallback-tts",
+        }))
+
+        resp = self.client.post(
+            "/api/audio/speak",
+            json={"text": "fallback please", "source": "voice-conversation"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["provider"] == "fallback-tts"
+        assert body["transport"] == "local"
+        assert body["playback"] == "local"
+        assert body["data_url"].startswith("data:audio/mpeg;base64,")
+
+    def test_speak_text_livekit_failure_502_when_required(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server, "load_config", lambda: {
+            "voice": {
+                "output_transport": "livekit",
+                "livekit": {
+                    "sidecar_url": "http://127.0.0.1:9/speak",
+                    "required": True,
+                },
+            }
+        })
+        monkeypatch.setattr(web_server.urllib.request, "urlopen", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("down")))
+
+        resp = self.client.post(
+            "/api/audio/speak",
+            json={"text": "must use livekit", "source": "voice-conversation"},
+        )
+
+        assert resp.status_code == 502
+        assert "LiveKit voice sidecar failed" in resp.json()["detail"]
 
     def test_speak_text_requires_nonempty_text(self):
         resp = self.client.post("/api/audio/speak", json={"text": "   "})

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1085,6 +1085,50 @@ def _looks_like_cuda_lib_error(exc: BaseException) -> bool:
     return any(marker in msg for marker in _CUDA_LIB_ERROR_MARKERS)
 
 
+def _preload_nvidia_wheel_libs() -> None:
+    """Expose CUDA runtime libs shipped by NVIDIA PyPI wheels to ctranslate2.
+
+    On Arch/CachyOS-style hosts the NVIDIA driver can be healthy and
+    ctranslate2 can see the GPU, while faster-whisper still fails at first
+    transcribe() because libcublas/libcudnn are installed inside the Python
+    venv rather than the system dynamic-loader path. Loading these exact
+    venv-local shared libraries with RTLD_GLOBAL avoids process-wide
+    LD_LIBRARY_PATH hacks and keeps the fix scoped to local STT.
+    """
+    try:
+        import ctypes
+        import os as _os
+        from pathlib import Path as _Path
+        import site
+    except Exception:
+        return
+
+    mode = getattr(_os, "RTLD_GLOBAL", 0)
+    candidates: list[_Path] = []
+    for raw_site in site.getsitepackages():
+        site_path = _Path(raw_site)
+        candidates.extend(
+            [
+                site_path / "nvidia" / "cuda_nvrtc" / "lib" / "libnvrtc.so.12",
+                site_path / "nvidia" / "cublas" / "lib" / "libcublasLt.so.12",
+                site_path / "nvidia" / "cublas" / "lib" / "libcublas.so.12",
+            ]
+        )
+        cudnn_dir = site_path / "nvidia" / "cudnn" / "lib"
+        if cudnn_dir.is_dir():
+            candidates.extend(sorted(cudnn_dir.glob("libcudnn*.so*")))
+
+    for lib in candidates:
+        if not lib.exists():
+            continue
+        try:
+            ctypes.CDLL(str(lib), mode=mode)
+        except Exception:
+            # Best-effort: if a specific optional CUDA/CUDNN component is not
+            # loadable, let faster-whisper/ctranslate2 surface the real error.
+            continue
+
+
 def _load_local_whisper_model(model_name: str):
     """Load faster-whisper with graceful CUDA → CPU fallback.
 
@@ -1098,6 +1142,7 @@ def _load_local_whisper_model(model_name: str):
     We try ``auto`` first (fast CUDA path when it works), and on any CUDA
     library load failure fall back to CPU + int8.
     """
+    _preload_nvidia_wheel_libs()
     from faster_whisper import WhisperModel
     try:
         return WhisperModel(model_name, device="auto", compute_type="auto")

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -219,6 +219,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "fish-audio": 1200,   # matches the migi_fish_* command providers' cap
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -365,6 +366,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "neutts",
     "kittentts",
     "piper",
+    "fish-audio",
 })
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
@@ -1529,6 +1531,50 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
 # NeuTTS (local, on-device TTS via neutts_cli)
 # ===========================================================================
 
+
+def _generate_fish_audio(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using Fish Audio with the configured reference voice."""
+    import json
+    import urllib.request
+    import urllib.error
+    from pathlib import Path as _Path
+
+    api_key = get_env_value("FISH_AUDIO_API_KEY")
+    ref_id = get_env_value("FISH_AUDIO_REFERENCE_ID")
+    model = get_env_value("FISH_AUDIO_MODEL", "s2-pro")
+
+    if not api_key or not ref_id:
+        raise RuntimeError("FISH_AUDIO_API_KEY and FISH_AUDIO_REFERENCE_ID must be set")
+
+    payload = {
+        "text": text,
+        "reference_id": ref_id,
+        "format": "mp3"
+    }
+
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.fish.audio/v1/tts",
+        data=data,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            # Fish Audio selects the TTS model via this header, not the body.
+            "model": model
+        },
+        method="POST"
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            audio_bytes = resp.read()
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")[:400]
+        raise RuntimeError(f"Fish Audio HTTP {e.code}: {body}")
+
+    _Path(output_path).write_bytes(audio_bytes)
+    return output_path
+
 def _check_neutts_available() -> bool:
     """Check if the neutts engine is importable (installed locally)."""
     try:
@@ -2005,6 +2051,10 @@ def text_to_speech_tool(
         elif provider == "gemini":
             logger.info("Generating speech with Google Gemini TTS...")
             _generate_gemini_tts(text, file_str, tts_config)
+
+        elif provider == "fish-audio":
+            logger.info("Generating speech with Fish Audio (custom Migi voice)...")
+            _generate_fish_audio(text, file_str, tts_config)
 
         elif provider == "neutts":
             if not _check_neutts_available():


### PR DESCRIPTION
## Summary

The June 8 Hermes update orphaned the entire repo-side voice integration on a safety branch — nothing in `main` consumed `voice.livekit` config, leaving the healthy LiveKit/Fish sidecar unreachable. This PR restores and hardens the full voice spine, verified live on 2026-06-09 (full evidence trail in the local knowledge dir: `~/.hermes/knowledge/livekit-fish-voice/ACTIVATION_REPORT.md`).

## Changes

**Backend (`hermes_cli/web_server.py`)**
- `/api/audio/speak`: sidecar-first routing when `voice.livekit` is configured; `required:false` falls back to the local TTS chain on sidecar failure; non-HTTPException errors in the LiveKit route fall through to local TTS instead of surfacing 500s; `required:true` correctly returns 502.
- Structured `voice_audio_event` timing logs with `request_id` propagated end-to-end (api → sidecar → fish → livekit), `sidecar_roundtrip` kept distinct from the sidecar's own `sidecar_total`.
- `/api/audio/realtime/client-secret`: mints ephemeral OpenAI Realtime client secrets server-side; the long-lived key never reaches the renderer, current `.env` key preferred over stale process env.

**Desktop**
- Native audio playback (`mpv`/`afplay`) via new IPC (`hermes:voice:native-play`/`native-stop`) with browser-`Audio` fallback on native failure; 4 MB payload cap; temp files cleaned up.
- `playback: livekit` honored — audio already published to the room is not double-played locally.
- Verdict-first spoken digest capped at 380 chars (`buildSpokenDigest`), replacing full-response readout.
- `minSpeechMs` speech-hold gate in the mic recorder plus retuned VAD so fans/clicks don't become fake turns.
- New `realtime-voice.ts` WebRTC session helper (calls API with legacy SDP fallback).

**TTS / STT**
- New `fish-audio` builtin TTS provider (model selected via HTTP header per Fish API, 1200-char cap, registered in both `tools/tts_tool.py` and `agent/tts_registry.py`) — replaces the broken `openai: gpt-realtime-2` fallback that 404s on `/v1/audio/speech`.
- CUDA wheel-libs preload (`_preload_nvidia_wheel_libs`) so GPU faster-whisper works when libcublas/libcudnn live inside the venv rather than the system loader path.

**Tests**
- 6 voice-route tests restored: sidecar routing, fallback-when-not-required, 502-when-required, local-path response shape, client-secret key redaction and missing-key 400.

## Verification

- 521 Python tests pass (`tests/hermes_cli/test_web_server.py`, `test_tools_config.py`, `tests/gateway/test_api_server.py`); `tsc -b` clean; re-verified after rebasing onto current `main` (no file overlap with the 19 intervening commits).
- Live probes against the rebuilt Desktop + restarted dashboard:
  - LiveKit route: `transport: livekit`, fish_synthesize 1497 ms, sidecar_total 1854 ms, 92 KB audio; publish correctly skipped with `no_remote_participants`; full `voice_audio_event` chain logged.
  - Local fallback route: `provider: fish-audio`, 827 ms, 41 KB.
  - Audible playback confirmed by a human listener through the OS default sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
