### PR TITLE
fix(tui): return specific error when skill payload fails to load (#43053)

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7220,6 +7220,14 @@ def _(rid, params: dict) -> dict:
                         "name": cmds[key].get("name", name),
                     },
                 )
+            # Skill is registered but payload failed to load — tell the
+            # user instead of falling through to the generic error. (#43053)
+            return _err(
+                rid,
+                4018,
+                f"skill '{cmds[key].get('name', name)}' found but could not load — "
+                "try /reload-skills or check ~/.hermes/skills/",
+            )
     except Exception:
         pass
 


### PR DESCRIPTION
Fixes #43053. When a skill is registered but its payload fails to load in command.dispatch (e.g. skill_view returns null), the code now returns a specific error message instead of the generic 'not a quick/plugin/skill command'. This gives users actionable feedback about what went wrong.