### PR TITLE
fix(feishu): use open_id as primary identity instead of user_id to prevent auth mismatch

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3862,8 +3862,12 @@ class FeishuAdapter(BasePlatformAdapter):
         open_id = getattr(sender_id, "open_id", None) or None
         user_id = getattr(sender_id, "user_id", None) or None
         union_id = getattr(sender_id, "union_id", None) or None
-        # Prefer tenant-scoped user_id; fall back to app-scoped open_id.
-        primary_id = user_id or open_id
+        # Always prefer open_id as the primary identifier for auth —
+        # it's always available and won't suddenly change when the bot
+        # gains or loses the contact:user.employee_id:readonly scope.
+        # Putting the tenant-scoped user_id in user_id_alt preserves
+        # session-key stability without breaking pairing auth.
+        primary_id = open_id or user_id
         # bot/v3/bots/basic_batch only accepts open_id.
         name_lookup_id = open_id if is_bot else (primary_id or union_id)
         display_name = await self._resolve_sender_name_from_api(
@@ -3872,7 +3876,7 @@ class FeishuAdapter(BasePlatformAdapter):
         return {
             "user_id": primary_id,
             "user_name": display_name,
-            "user_id_alt": union_id,
+            "user_id_alt": union_id or user_id,
         }
 
     def _get_cached_sender_name(self, sender_id: Optional[str]) -> Optional[str]:


### PR DESCRIPTION
## Problem

When a Feishu app has the `contact:user.employee_id:readonly` permission scope, event payloads include both `open_id` (app-scoped, always present) and `user_id` (tenant-scoped). `_resolve_sender_profile()` was preferring `user_id` over `open_id` as the primary identifier, which causes authorization checks to fail when the pairing list or allowlist was created with the `open_id`.

**Logs:**
```
INFO  [Feishu] Inbound dm message received: sender=user:ou_xxx text=...
WARNING  Unauthorized user: a8ff845e (张正明) on feishu
```

The adapter receives the message with the correct `open_id` (ou_xxx), but resolves the primary identity to the tenant-scoped `user_id`. The auth check then compares `user_id` against a pairing list that was created with `open_id` — no match → rejected as unauthorized.

## Fix

1. **Flip priority:** `primary_id = open_id or user_id` — always use `open_id` (always available, app-stable) as the primary identity for authorization.
2. **Preserve fallback:** `user_id_alt = union_id or user_id` — the tenant-scoped `user_id` still goes into `user_id_alt` so session-key generation keeps its stability.

Fixes #26183, relates to #37252