### PR TITLE
feat(kanban): add inline 'Reply & unblock' banner for blocked tasks

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2841,6 +2841,32 @@
       }).catch(function (e) { setErr(String(e.message || e)); });
     };
 
+    // "Reply & unblock" for the BlockedBanner: post comment (if any),
+    // unblock (PATCH status=ready), then nudge the dispatcher.
+    const handleReplyAndUnblock = function (commentBody, andUnblock) {
+      var chain = Promise.resolve();
+      if (commentBody && commentBody.trim()) {
+        chain = chain.then(function () {
+          return SDK.fetchJSON(
+            withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/comments`, boardSlug),
+            { method: "POST", headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ body: commentBody.trim() }) }
+          );
+        });
+      }
+      if (andUnblock !== false) {
+        chain = chain.then(function () {
+          return doPatch({ status: "ready" });
+        });
+        chain = chain.then(function () {
+          return SDK.fetchJSON(withBoard(`${API}/dispatch?max=8`, boardSlug), { method: "POST" });
+        });
+      }
+      chain.then(function () { load(); props.onRefresh(); })
+        .catch(function (e) { setErr(String(e.message || e)); });
+      return chain;
+    };
+
     // File upload uses raw fetch (not SDK.fetchJSON, which JSON-encodes)
     // so the browser sets the multipart boundary. Auth rides the session
     // cookie + bearer token, matching the rest of the dashboard.
@@ -3047,6 +3073,7 @@
           onDeleteAttachment: handleDeleteAttachment,
           uploadBusy: uploadBusy,
           uploadErr: uploadErr,
+          onReplyAndUnblock: handleReplyAndUnblock,
         }) : null,
         data ? h("div", { className: "hermes-kanban-drawer-comment-row" },
           h(Input, {
@@ -3222,6 +3249,11 @@
         }) : null,
         t.created_by ? h(MetaRow, { label: tx(i18n, "createdBy", "Created by"), value: t.created_by }) : null,
       ),
+      (t.status === "blocked" && t.block_reason) ? h(BlockedBanner, {
+        task: t,
+        i18n: i18n,
+        onReplyAndUnblock: props.onReplyAndUnblock,
+      }) : null,
       h(StatusActions, {
         task: t,
         onPatch: props.onPatch,
@@ -3823,6 +3855,72 @@
           ? "hermes-kanban-msg-ok"
           : "hermes-kanban-msg-err",
       }, decomposeMsg.text) : null,
+    );
+  }
+
+
+  // Inline banner for blocked tasks — shows the block reason and lets
+  // the operator reply and unblock in one action instead of 8+ steps.
+  function BlockedBanner(props) {
+    var task = props.task;
+    var i18n = props.i18n;
+    var reason = task.block_reason;
+    if (!reason) return null;
+
+    var _useState = useState("");
+    var replyText = _useState[0];
+    var setReplyText = _useState[1];
+    var _busyState = useState(false);
+    var busy = _busyState[0];
+    var setBusy = _busyState[1];
+
+    function doReply(andUnblock) {
+      if (busy) return;
+      setBusy(true);
+      Promise.resolve()
+        .then(function () {
+          return props.onReplyAndUnblock(replyText, andUnblock);
+        })
+        .then(function () {
+          setReplyText("");
+        })
+        .catch(function () {})
+        .then(function () { setBusy(false); });
+    }
+
+    return h("div", { className: "hermes-kanban-blocked-banner" },
+      h("div", { className: "hermes-kanban-blocked-banner-header" },
+        "\u26d4 ",
+        tx(i18n, "blockedNeedsInput", "Blocked \u2014 needs your input")
+      ),
+      h("div", { className: "hermes-kanban-blocked-banner-reason" }, reason),
+      h(Input, {
+        value: replyText,
+        onChange: function (e) { setReplyText(e.target.value); },
+        onKeyDown: function (e) {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            doReply(true);
+          }
+        },
+        placeholder: tx(i18n, "replyPlaceholder", "Type your reply\u2026"),
+        className: "hermes-kanban-blocked-banner-input",
+        disabled: busy,
+      }),
+      h("div", { className: "hermes-kanban-blocked-banner-actions" },
+        h(Button, {
+          onClick: function () { doReply(true); },
+          disabled: busy,
+          size: "sm",
+          className: "hermes-kanban-blocked-banner-primary",
+        }, busy ? "Working\u2026" : tx(i18n, "replyAndUnblock", "Reply & unblock")),
+        h(Button, {
+          onClick: function () { doReply(false); },
+          disabled: busy,
+          size: "sm",
+          variant: "ghost",
+        }, tx(i18n, "replyOnly", "Reply only")),
+      ),
     );
   }
 

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -1581,3 +1581,43 @@
 .hermes-kanban-trash-label {
   font-weight: 500;
 }
+
+/* ---- Blocked-task inline banner ---- */
+
+.hermes-kanban-blocked-banner {
+  margin: 0.5rem 0;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(217, 160, 40, 0.45);
+  background: rgba(217, 160, 40, 0.08);
+}
+.hermes-kanban-blocked-banner-header {
+  font-weight: 600;
+  font-size: 0.88rem;
+  margin-bottom: 0.3rem;
+  color: #b8860b;
+}
+.hermes-kanban-blocked-banner-reason {
+  font-size: 0.84rem;
+  line-height: 1.4;
+  margin-bottom: 0.5rem;
+  white-space: pre-wrap;
+  color: var(--color-foreground);
+  opacity: 0.9;
+}
+.hermes-kanban-blocked-banner-input {
+  width: 100%;
+  margin-bottom: 0.4rem;
+}
+.hermes-kanban-blocked-banner-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+.hermes-kanban-blocked-banner-primary {
+  background: rgba(217, 160, 40, 0.85) !important;
+  color: #1a1a1a !important;
+  border-color: rgba(217, 160, 40, 0.9) !important;
+}
+.hermes-kanban-blocked-banner-primary:hover {
+  background: rgba(217, 160, 40, 1) !important;
+}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -234,6 +234,50 @@ def _run_dict(r: kanban_db.Run) -> dict[str, Any]:
     }
 
 
+def _latest_block_reason(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
+    """Return the reason from the most recent ``blocked`` event, or *None*."""
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'blocked' "
+        "ORDER BY created_at DESC, id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if not row or not row["payload"]:
+        return None
+    try:
+        return json.loads(row["payload"]).get("reason")
+    except Exception:
+        return None
+
+
+def _batch_block_reasons(
+    conn: sqlite3.Connection, task_ids: list[str]
+) -> dict[str, str]:
+    """Return ``{task_id: reason}`` for the latest blocked event per task."""
+    if not task_ids:
+        return {}
+    placeholders = ",".join("?" for _ in task_ids)
+    rows = conn.execute(
+        f"SELECT task_id, payload FROM task_events "
+        f"WHERE task_id IN ({placeholders}) AND kind = 'blocked' "
+        f"ORDER BY created_at DESC, id DESC",
+        task_ids,
+    ).fetchall()
+    out: dict[str, str] = {}
+    for r in rows:
+        tid = r["task_id"]
+        if tid in out:
+            continue
+        if r["payload"]:
+            try:
+                reason = json.loads(r["payload"]).get("reason")
+                if reason:
+                    out[tid] = reason
+            except Exception:
+                pass
+    return out
+
+
 # Hallucination-warning event kinds — see complete_task() in kanban_db.py.
 # completion_blocked_hallucination: kernel rejected created_cards with
 #   phantom ids; task stays in prior state.
@@ -459,6 +503,10 @@ def get_board(
         # preview here — the full text is available via /tasks/:id.
         summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
 
+        # Batch-fetch block reasons for blocked tasks.
+        blocked_ids = [t.id for t in tasks if t.status == "blocked"]
+        block_reason_map = _batch_block_reasons(conn, blocked_ids)
+
         for t in tasks:
             full = summary_map.get(t.id)
             preview = (
@@ -475,6 +523,9 @@ def get_board(
                 # needs the summary.
                 d["diagnostics"] = diags
                 d["warnings"] = _warnings_summary_from_diagnostics(diags)
+            reason = block_reason_map.get(t.id)
+            if reason:
+                d["block_reason"] = reason
             col = t.status if t.status in columns else "todo"
             columns[col].append(d)
 
@@ -553,6 +604,12 @@ def get_task(
         if diag_list:
             task_d["diagnostics"] = diag_list
             task_d["warnings"] = _warnings_summary_from_diagnostics(diag_list)
+        # Surface the block reason so the drawer can render a
+        # "Reply & unblock" banner without scanning the events array.
+        if task.status == "blocked":
+            reason = _latest_block_reason(conn, task_id)
+            if reason:
+                task_d["block_reason"] = reason
         return {
             "task": task_d,
             "comments": [_comment_dict(c) for c in kanban_db.list_comments(conn, task_id)],

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2252,3 +2252,88 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+# ---------------------------------------------------------------------------
+# block_reason in get_task and board responses (#43216)
+# ---------------------------------------------------------------------------
+
+
+def test_get_task_includes_block_reason_when_blocked(client):
+    """GET /tasks/:id must return block_reason for blocked tasks."""
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "blocked task"}).json()["task"]
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "blocked", "block_reason": "need API key from admin"},
+    )
+    assert r.status_code == 200
+    assert r.json()["task"]["status"] == "blocked"
+
+    r = client.get(f"/api/plugins/kanban/tasks/{t['id']}")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["task"]["block_reason"] == "need API key from admin"
+
+
+def test_get_task_no_block_reason_when_not_blocked(client):
+    """GET /tasks/:id must NOT include block_reason for non-blocked tasks."""
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "ready task"}).json()["task"]
+    r = client.get(f"/api/plugins/kanban/tasks/{t['id']}")
+    assert r.status_code == 200
+    assert "block_reason" not in r.json()["task"]
+
+
+def test_board_includes_block_reason_for_blocked_tasks(client):
+    """GET /board must include block_reason on blocked task cards."""
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "blocked card"}).json()["task"]
+    client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "blocked", "block_reason": "waiting for deploy"},
+    )
+
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200
+    blocked_col = next(c for c in r.json()["columns"] if c["name"] == "blocked")
+    assert len(blocked_col["tasks"]) == 1
+    assert blocked_col["tasks"][0]["block_reason"] == "waiting for deploy"
+
+
+def test_board_no_block_reason_for_unblocked_tasks(client):
+    """GET /board must NOT include block_reason on non-blocked task cards."""
+    client.post("/api/plugins/kanban/tasks", json={"title": "ready card"})
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200
+    ready_col = next(c for c in r.json()["columns"] if c["name"] == "ready")
+    for task in ready_col["tasks"]:
+        assert "block_reason" not in task
+
+
+def test_block_reason_latest_wins(client):
+    """When a task is blocked multiple times, the latest reason is returned."""
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "multi-block"}).json()["task"]
+    client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "blocked", "block_reason": "first reason"},
+    )
+    client.patch(f"/api/plugins/kanban/tasks/{t['id']}", json={"status": "ready"})
+    client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "blocked", "block_reason": "second reason"},
+    )
+
+    r = client.get(f"/api/plugins/kanban/tasks/{t['id']}")
+    assert r.json()["task"]["block_reason"] == "second reason"
+
+
+def test_blocked_banner_component_and_css_exist():
+    """BlockedBanner component and its CSS classes must be present."""
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert "function BlockedBanner" in js
+    assert "hermes-kanban-blocked-banner" in js
+    assert "hermes-kanban-blocked-banner" in css
+    assert "Reply & unblock" in js or "replyAndUnblock" in js
+    assert "Reply only" in js or "replyOnly" in js
+    assert "onReplyAndUnblock" in js


### PR DESCRIPTION
## Problem

When a kanban worker blocks and asks a question, the current dashboard flow requires 8+ steps:

1. See blocked card on board → click → drawer opens
2. Hunt for the block reason in the events list
3. Scroll to the bottom comment input → type your answer → click Comment
4. Scroll back up → find Unblock button → click Unblock
5. Wait 60s for the next dispatch tick

This is the **only recurring human-in-the-loop moment** in a well-running kanban, and it should be one action.

## Solution

Add a prominent amber banner at the top of the task drawer for blocked tasks that surfaces the block reason and provides two inline actions:

- **"Reply & unblock"** — posts the typed text as a comment, unblocks the task (PATCH status=ready), and triggers immediate dispatch (POST /dispatch) so the worker respawns now instead of waiting 60s.
- **"Reply only"** — posts the comment but leaves the task blocked (for batch/overnight workflows where you want to stage multiple replies and then unblock/dispatch together).

Both buttons work even when the text input is empty — "Reply & unblock" with no text just unblocks + dispatches; "Reply only" with no text is a no-op.

The existing Comment input at the bottom of the drawer and the existing Block/Unblock/Complete action row stay. This is additive — nothing is removed.

## Implementation

### Backend (`plugin_api.py`)
- Added `_latest_block_reason()` helper — queries the most recent `blocked` event's payload
- Added `_batch_block_reasons()` helper — batch version for the board endpoint (avoids N+1 queries)
- `GET /tasks/:id` includes `block_reason` in the task dict when status is `blocked`
- `GET /board` includes `block_reason` on blocked task cards

### Frontend (`index.js` + `style.css`)
- New `BlockedBanner` component rendered in `TaskDetail` above `StatusActions`
- Banner shows: ⛔ header, block reason text, reply input, "Reply & unblock" primary button, "Reply only" ghost button
- Enter key shortcut on the input triggers "Reply & unblock"
- Amber color scheme to match the blocked-state visual language

### Tests (6 new tests)
- `test_get_task_includes_block_reason_when_blocked` — verifies `block_reason` in detail response
- `test_get_task_no_block_reason_when_not_blocked` — verifies absence for non-blocked tasks
- `test_board_includes_block_reason_for_blocked_tasks` — verifies board cards include reason
- `test_board_no_block_reason_for_unblocked_tasks` — verifies board cards don't leak reason
- `test_block_reason_latest_wins` — verifies latest block reason after multiple block/unblock cycles
- `test_blocked_banner_component_and_css_exist` — verifies frontend component and CSS classes

Closes #43216
