### PR TITLE
fix(agent): escalate repeated stale-stream kills across one turn

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1698,6 +1698,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
     last_chunk_time = {"t": time.time()}
+    stale_forced_close = {"pending": False}
+    stale_fallback_pending = {"pending": False}
 
     def _fire_first_delta():
         if not first_delta_fired["done"] and on_first_delta:
@@ -1706,6 +1708,70 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 on_first_delta()
             except Exception:
                 pass
+
+    def _current_stream_runtime_key() -> tuple[str, str, str]:
+        """Identify the active backend for turn-scoped stale tracking."""
+        return (
+            (getattr(agent, "provider", "") or "").strip().lower(),
+            (getattr(agent, "model", "") or "").strip(),
+            str(getattr(agent, "base_url", "") or "").rstrip("/").lower(),
+        )
+
+    def _get_turn_stale_stream_state() -> dict:
+        """Return the current turn's stale-stream state for this runtime."""
+        state = getattr(agent, "_turn_stale_stream_state", None)
+        if not isinstance(state, dict):
+            state = {}
+            agent._turn_stale_stream_state = state
+        runtime_key = _current_stream_runtime_key()
+        if state.get("runtime_key") != runtime_key:
+            state["runtime_key"] = runtime_key
+            state["count"] = 0
+        elif not isinstance(state.get("count"), int):
+            state["count"] = 0
+        return state
+
+    def _reset_stream_retry_state() -> None:
+        """Clear per-attempt delivery state before retrying a stream."""
+        try:
+            agent._reset_stream_delivery_tracking()
+        except Exception:
+            pass
+        result["partial_tool_names"] = []
+        deltas_were_sent["yes"] = False
+        first_delta_fired["done"] = False
+
+    def _try_stream_fallback_after_repeated_stale(
+        error: Exception, *, mid_tool_call: bool,
+    ) -> bool:
+        """Switch to the configured fallback provider after repeated stale kills."""
+        if not stale_fallback_pending["pending"] or not agent._has_pending_fallback():
+            return False
+
+        stale_fallback_pending["pending"] = False
+        stale_forced_close["pending"] = False
+
+        if mid_tool_call:
+            try:
+                agent._fire_stream_delta(
+                    "\n\n⚠ Repeated stale stream errors; switching to fallback provider…\n\n"
+                )
+            except Exception:
+                pass
+
+        agent._buffer_status(
+            "⚠️ Repeated stale stream errors — switching to fallback provider..."
+        )
+        _reset_stream_retry_state()
+
+        from agent.error_classifier import FailoverReason
+
+        if agent._try_activate_fallback(reason=FailoverReason.timeout):
+            _get_turn_stale_stream_state()["count"] = 0
+            return True
+
+        result["error"] = error
+        return False
 
     def _call_chat_completions():
         """Stream a chat completions response."""
@@ -2189,9 +2255,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             type(e).__name__,
                         )
                         return
+                    _forced_stale_error = stale_forced_close["pending"]
+                    if _forced_stale_error:
+                        stale_forced_close["pending"] = False
                     _is_timeout = isinstance(
                         e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout)
-                    )
+                    ) or _forced_stale_error
                     _is_conn_err = isinstance(
                         e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError)
                     )
@@ -2240,6 +2309,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             or _is_sse_conn_err_preview
                             or _is_stream_parse_err
                         )
+                        if (
+                            _forced_stale_error
+                            and stale_fallback_pending["pending"]
+                            and _partial_tool_in_flight
+                        ):
+                            if _try_stream_fallback_after_repeated_stale(
+                                e, mid_tool_call=True,
+                            ):
+                                continue
+                            if result["error"] is not None:
+                                return
                         _can_silent_retry = (
                             _partial_tool_in_flight
                             and _is_transient
@@ -2275,16 +2355,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # fresh preamble doesn't get double-recorded in
                         # _current_streamed_assistant_text (which would
                         # pollute the interim-visible-text comparison).
-                        try:
-                            agent._reset_stream_delivery_tracking()
-                        except Exception:
-                            pass
-                        # Reset in-memory accumulators so the next
-                        # attempt's chunks don't concat onto the dead
-                        # stream's partial JSON.
-                        result["partial_tool_names"] = []
-                        deltas_were_sent["yes"] = False
-                        first_delta_fired["done"] = False
+                        _reset_stream_retry_state()
                         agent._emit_stream_drop(
                             error=e,
                             attempt=_stream_attempt + 2,
@@ -2332,6 +2403,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             )
 
                     if _is_timeout or _is_conn_err or _is_sse_conn_err or _is_stream_parse_err:
+                        if _forced_stale_error and stale_fallback_pending["pending"]:
+                            if _try_stream_fallback_after_repeated_stale(
+                                e, mid_tool_call=False,
+                            ):
+                                continue
+                            if result["error"] is not None:
+                                return
                         # Transient network / timeout error. Retry the
                         # streaming request with a fresh connection first.
                         if _stream_attempt < _max_stream_retries:
@@ -2419,6 +2497,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _stream_stale_timeout_base = _cfg_stale
     else:
         _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
+    _stale_fallback_threshold = max(
+        0, env_int("HERMES_STREAM_STALE_FALLBACK_THRESHOLD", 2)
+    )
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
     # for prefill on large contexts.  Disable the stale detector unless
     # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
@@ -2480,16 +2561,26 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 f"context: ~{_est_ctx:,} tokens). "
                 f"Reconnecting..."
             )
+            _turn_stale_state = _get_turn_stale_stream_state()
+            _turn_stale_state["count"] += 1
+            stale_forced_close["pending"] = True
+            if (
+                _stale_fallback_threshold > 0
+                and _turn_stale_state["count"] >= _stale_fallback_threshold
+                and agent._has_pending_fallback()
+            ):
+                stale_fallback_pending["pending"] = True
             try:
                 _close_request_client_once("stale_stream_kill")
             except Exception:
                 pass
             # Rebuild the primary client too — its connection pool
             # may hold dead sockets from the same provider outage.
-            try:
-                agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
-            except Exception:
-                pass
+            if not stale_fallback_pending["pending"]:
+                try:
+                    agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+                except Exception:
+                    pass
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -139,6 +139,7 @@ def build_turn_context(
     agent._last_content_with_tools = None
     agent._last_content_tools_all_housekeeping = False
     agent._mute_post_response = False
+    agent._turn_stale_stream_state = {"runtime_key": None, "count": 0}
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -3,6 +3,7 @@
 Tests the unified streaming API call, delta callbacks, tool-call
 suppression, provider fallback, and CLI streaming display.
 """
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -1422,6 +1423,124 @@ class TestSilentRetryMidToolCall:
         )
         assert "Stream stalled" not in content, (
             f"Text-only stall should not emit tool-call warning: {content!r}"
+        )
+
+
+class TestRepeatedStaleStreamFallback:
+    """Repeated stale kills within one turn should escalate to runtime fallback."""
+
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_second_stale_in_same_turn_switches_to_fallback_provider(
+        self, mock_close, mock_create, mock_replace, mock_abort, monkeypatch,
+    ):
+        from run_agent import AIAgent
+
+        try:
+            import httpx as _httpx
+        except Exception:  # pragma: no cover - dependency is present in test env
+            pytest.skip("httpx unavailable")
+
+        current_close_event = {"event": None}
+        switched_to_fallback = {"yes": False}
+        stream_attempts = {"n": 0}
+        status_lines = []
+        stream_plan = iter([
+            "stale",
+            "primary_recovered",
+            "stale",
+            "fallback_recovered",
+        ])
+
+        def _stalled_stream(close_event):
+            if False:
+                yield None
+            while not close_event.wait(0.01):
+                pass
+            raise _httpx.ReadError("[Errno 9] Bad file descriptor")
+
+        def _healthy_stream(text):
+            yield _make_stream_chunk(content=text)
+            yield _make_stream_chunk(finish_reason="stop")
+
+        def _make_client():
+            client = MagicMock()
+
+            def _create_stream(*_args, **_kwargs):
+                stream_attempts["n"] += 1
+                behavior = next(stream_plan)
+                if behavior == "primary_recovered":
+                    return _healthy_stream("Primary recovered once")
+                if behavior == "fallback_recovered":
+                    assert switched_to_fallback["yes"] is True
+                    return _healthy_stream("Fallback recovered")
+                close_event = threading.Event()
+                current_close_event["event"] = close_event
+                return _stalled_stream(close_event)
+
+            client.chat.completions.create.side_effect = _create_stream
+            return client
+
+        mock_create.side_effect = lambda *_args, **_kwargs: _make_client()
+
+        def _close_client(_client, *_args, **_kwargs):
+            close_event = current_close_event.get("event")
+            if close_event is not None:
+                close_event.set()
+
+        mock_close.side_effect = _close_client
+        mock_abort.side_effect = _close_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="deepseek",
+            model="deepseek-v4-flash",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        agent._fallback_chain = [{"provider": "openrouter", "model": "kimi-k2"}]
+        agent._fallback_index = 0
+        agent._buffer_status = lambda text: status_lines.append(text)
+
+        def _activate_fallback(reason=None):
+            switched_to_fallback["yes"] = True
+            agent.provider = "openrouter"
+            agent.model = "kimi-k2"
+            agent._fallback_index = 1
+            return True
+
+        agent._try_activate_fallback = MagicMock(side_effect=_activate_fallback)
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "3")
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.05")
+        monkeypatch.setenv("HERMES_STREAM_STALE_FALLBACK_THRESHOLD", "2")
+
+        first_response = agent._interruptible_streaming_api_call(
+            {"model": "deepseek-v4-flash", "messages": []}
+        )
+        assert first_response.choices[0].message.content == "Primary recovered once"
+        assert agent._try_activate_fallback.call_count == 0
+
+        second_response = agent._interruptible_streaming_api_call(
+            {"model": "deepseek-v4-flash", "messages": []}
+        )
+
+        assert second_response.choices[0].message.content == "Fallback recovered"
+        assert stream_attempts["n"] == 4, (
+            "Expected 1 stale + recovery on primary, then 1 stale + fallback recovery; "
+            f"got {stream_attempts['n']} attempts"
+        )
+        assert agent._try_activate_fallback.call_count == 1
+        assert switched_to_fallback["yes"] is True
+        assert agent._turn_stale_stream_state["count"] == 0
+        assert any("fallback" in line.lower() for line in status_lines), (
+            f"Expected a fallback status message, got {status_lines!r}"
         )
 
 


### PR DESCRIPTION
## What does this PR do?

Escalates repeated stale-stream kills to the configured fallback chain when they happen across the same conversation turn, instead of silently rebuilding and retrying the same provider forever.

This is an alternative to #43222 with a narrower semantic difference: it tracks stale kills at the turn/runtime level rather than only inside a single streaming API call. That matches the issue report for providers that briefly recover and then go stale again later in the same turn.

## Related Issue

Fixes #43211

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/chat_completion_helpers.py`: add turn-scoped stale-stream state keyed by the active runtime, arm fallback after the stale threshold is reached, and route the next stale forced-close through the existing timeout fallback path.
- `agent/turn_context.py`: reset turn-scoped stale-stream state at the start of each conversation turn.
- `tests/run_agent/test_streaming.py`: add a regression test covering one stale primary recovery followed by a second stale event in the same turn that switches to the fallback provider.

## How to Test

1. Run `pytest tests/run_agent/test_streaming.py -k second_stale_in_same_turn_switches_to_fallback_provider -q`
2. Run `pytest tests/run_agent/test_streaming.py -q`
3. Run `pytest tests/run_agent/test_provider_fallback.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validated locally on clean baseline `d33965396e5c8b80bc845b33fa4d8446f630f155` with:

- `pytest tests/run_agent/test_streaming.py -k 'second_stale_in_same_turn_switches_to_fallback_provider or silent_retry' -q` → `4 passed`
- `pytest tests/run_agent/test_streaming.py -q` → `37 passed`
- `pytest tests/run_agent/test_provider_fallback.py -q` → `22 passed`
