### PR TITLE
fix(desktop): honor default project directory for new sessions

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -39,6 +39,7 @@ const {
   shouldRemoveAppBundle,
   uninstallArgsForMode
 } = require('./desktop-uninstall.cjs')
+const { isPackagedInstallPath: isPackagedInstallPathUnderRoots } = require('./workspace-cwd.cjs')
 const {
   authModeFromStatus,
   buildGatewayWsUrl,
@@ -1954,41 +1955,14 @@ function resolveRendererIndex() {
 // leaked into a release build) often resolve here — e.g. win-unpacked on
 // Windows — which is exactly where PR #37536 item 16 said we must NOT run.
 function isPackagedInstallPath(dir) {
-  if (!IS_PACKAGED || !dir) {
-    return false
-  }
-
-  let resolved
-
-  try {
-    resolved = path.resolve(String(dir))
-  } catch {
-    return false
-  }
-
-  const installRoots = new Set(
-    [
+  return isPackagedInstallPathUnderRoots(dir, {
+    isPackaged: IS_PACKAGED,
+    installRoots: [
       APP_ROOT,
       path.dirname(process.execPath),
       resolveRemovableAppPath(process.execPath, process.platform, process.env)
     ]
-      .filter(Boolean)
-      .map(candidate => path.resolve(String(candidate)))
-  )
-
-  for (const root of installRoots) {
-    if (resolved === root) {
-      return true
-    }
-
-    const rel = path.relative(root, resolved)
-
-    if (rel && !rel.startsWith('..') && !path.isAbsolute(rel)) {
-      return true
-    }
-  }
-
-  return false
+  })
 }
 
 function resolveHermesCwd() {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1949,6 +1949,48 @@ function resolveRendererIndex() {
   return candidates[0]
 }
 
+// True when `dir` lives inside the packaged app bundle / install tree.
+// Packaged Electron's process.cwd() (and npm's INIT_CWD when dev tooling
+// leaked into a release build) often resolve here — e.g. win-unpacked on
+// Windows — which is exactly where PR #37536 item 16 said we must NOT run.
+function isPackagedInstallPath(dir) {
+  if (!IS_PACKAGED || !dir) {
+    return false
+  }
+
+  let resolved
+
+  try {
+    resolved = path.resolve(String(dir))
+  } catch {
+    return false
+  }
+
+  const installRoots = new Set(
+    [
+      APP_ROOT,
+      path.dirname(process.execPath),
+      resolveRemovableAppPath(process.execPath, process.platform, process.env)
+    ]
+      .filter(Boolean)
+      .map(candidate => path.resolve(String(candidate)))
+  )
+
+  for (const root of installRoots) {
+    if (resolved === root) {
+      return true
+    }
+
+    const rel = path.relative(root, resolved)
+
+    if (rel && !rel.startsWith('..') && !path.isAbsolute(rel)) {
+      return true
+    }
+  }
+
+  return false
+}
+
 function resolveHermesCwd() {
   // In a packaged build, `process.cwd()` resolves to the install root (e.g.
   // `…/win-unpacked` on Windows or `/Applications/Hermes.app/Contents/...`
@@ -1960,7 +2002,7 @@ function resolveHermesCwd() {
   const candidates = [
     readDefaultProjectDir(),
     process.env.HERMES_DESKTOP_CWD,
-    process.env.INIT_CWD,
+    IS_PACKAGED ? null : process.env.INIT_CWD,
     IS_PACKAGED ? null : process.cwd(),
     !IS_PACKAGED ? SOURCE_REPO_ROOT : null,
     app.getPath('home')
@@ -1969,10 +2011,35 @@ function resolveHermesCwd() {
   for (const candidate of candidates) {
     if (!candidate) continue
     const resolved = path.resolve(String(candidate))
+
+    if (isPackagedInstallPath(resolved)) {
+      continue
+    }
+
     if (directoryExists(resolved)) return resolved
   }
 
   return app.getPath('home')
+}
+
+function sanitizeWorkspaceCwd(cwd) {
+  const trimmed = typeof cwd === 'string' ? cwd.trim() : ''
+
+  if (!trimmed || isPackagedInstallPath(trimmed)) {
+    return { cwd: resolveHermesCwd(), sanitized: Boolean(trimmed) }
+  }
+
+  try {
+    const resolved = path.resolve(trimmed)
+
+    if (directoryExists(resolved)) {
+      return { cwd: resolved, sanitized: false }
+    }
+  } catch {
+    // Fall through to the resolved default.
+  }
+
+  return { cwd: resolveHermesCwd(), sanitized: Boolean(trimmed) }
 }
 
 // Persisted "Default project directory" — surfaced as a setting in the
@@ -4448,6 +4515,10 @@ async function spawnPoolBackend(profile, entry) {
       ...process.env,
       HERMES_HOME,
       ...backend.env,
+      // Pin the gateway's tool/terminal cwd to the same directory we chose for
+      // the child process. Inherited TERMINAL_CWD (or a stale config bridge)
+      // can still point at the install dir even when spawn cwd is home.
+      TERMINAL_CWD: hermesCwd,
       HERMES_DASHBOARD_SESSION_TOKEN: token,
       // Marks this dashboard backend as desktop-spawned so it runs the cron
       // scheduler tick loop (the gateway isn't running under the app).
@@ -4650,6 +4721,7 @@ async function startHermes() {
         // can't reliably do that, so we set it inline for every spawn.
         HERMES_HOME,
         ...backend.env,
+        TERMINAL_CWD: hermesCwd,
         HERMES_DASHBOARD_SESSION_TOKEN: token,
         // Marks this dashboard backend as desktop-spawned so it runs the cron
         // scheduler tick loop (the gateway isn't running under the app).
@@ -5424,8 +5496,11 @@ ipcMain.handle('hermes:openExternal', (_event, url) => {
 // session spawn (no app restart needed).
 ipcMain.handle('hermes:setting:defaultProjectDir:get', async () => ({
   dir: readDefaultProjectDir(),
-  defaultLabel: path.join(app.getPath('home'), 'hermes-projects')
+  defaultLabel: app.getPath('home'),
+  resolvedCwd: resolveHermesCwd()
 }))
+
+ipcMain.handle('hermes:workspace:sanitize', async (_event, cwd) => sanitizeWorkspaceCwd(cwd))
 
 ipcMain.handle('hermes:setting:defaultProjectDir:set', async (_event, dir) => {
   const next = typeof dir === 'string' && dir.trim() ? dir.trim() : null

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -42,6 +42,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
+  sanitizeWorkspaceCwd: cwd => ipcRenderer.invoke('hermes:workspace:sanitize', cwd),
   settings: {
     getDefaultProjectDir: () => ipcRenderer.invoke('hermes:setting:defaultProjectDir:get'),
     setDefaultProjectDir: dir => ipcRenderer.invoke('hermes:setting:defaultProjectDir:set', dir),

--- a/apps/desktop/electron/workspace-cwd.cjs
+++ b/apps/desktop/electron/workspace-cwd.cjs
@@ -1,0 +1,38 @@
+const path = require('node:path')
+
+/** True when `dir` lives inside a packaged app bundle / install tree. */
+function isPackagedInstallPath(dir, { installRoots, isPackaged }) {
+  if (!isPackaged || !dir) {
+    return false
+  }
+
+  let resolved
+
+  try {
+    resolved = path.resolve(String(dir))
+  } catch {
+    return false
+  }
+
+  const roots = new Set(
+    (installRoots ?? [])
+      .filter(Boolean)
+      .map(candidate => path.resolve(String(candidate)))
+  )
+
+  for (const root of roots) {
+    if (resolved === root) {
+      return true
+    }
+
+    const rel = path.relative(root, resolved)
+
+    if (rel && !rel.startsWith('..') && !path.isAbsolute(rel)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+module.exports = { isPackagedInstallPath }

--- a/apps/desktop/electron/workspace-cwd.test.cjs
+++ b/apps/desktop/electron/workspace-cwd.test.cjs
@@ -1,0 +1,45 @@
+/**
+ * Tests for electron/workspace-cwd.cjs.
+ *
+ * Run with: node --test electron/workspace-cwd.test.cjs
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const { isPackagedInstallPath } = require('./workspace-cwd.cjs')
+
+const installRoot = path.resolve('/opt/Hermes')
+
+test('isPackagedInstallPath returns false when not packaged', () => {
+  assert.equal(
+    isPackagedInstallPath(installRoot, { isPackaged: false, installRoots: [installRoot] }),
+    false
+  )
+})
+
+test('isPackagedInstallPath flags the install root itself', () => {
+  assert.equal(
+    isPackagedInstallPath(installRoot, { isPackaged: true, installRoots: [installRoot] }),
+    true
+  )
+})
+
+test('isPackagedInstallPath flags paths nested under the install root', () => {
+  const nested = path.join(installRoot, 'resources', 'app.asar')
+
+  assert.equal(
+    isPackagedInstallPath(nested, { isPackaged: true, installRoots: [installRoot] }),
+    true
+  )
+})
+
+test('isPackagedInstallPath ignores paths outside the install root', () => {
+  const homeProject = path.resolve('/home/user/projects/demo')
+
+  assert.equal(
+    isPackagedInstallPath(homeProject, { isPackaged: true, installRoots: [installRoot] }),
+    false
+  )
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -29,6 +29,7 @@ import {
   $connection,
   $sessions,
   $workingSessionIds,
+  ensureDefaultWorkspaceCwd,
   setConnection,
   setSessionsLoading
 } from '@/store/session'
@@ -351,6 +352,7 @@ export function useGatewayBoot({
           message: translateNow('boot.steps.loadingSettings'),
           progress: 97
         })
+        await ensureDefaultWorkspaceCwd()
         await callbacksRef.current.refreshHermesConfig()
 
         if (cancelled) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -20,6 +20,7 @@ import {
   $sessions,
   $yoloActive,
   getRememberedWorkspaceCwd,
+  workspaceCwdForNewSession,
   sessionPinId,
   setActiveSessionId,
   setAwaitingResponse,
@@ -311,8 +312,9 @@ export function useSessionActions({
       })
       setSessionStartedAt(null)
       setTurnStartedAt(null)
-      // New chats inherit the current workspace.
-      setCurrentCwd(getRememberedWorkspaceCwd())
+      // New chats start in the configured default project dir when set,
+      // otherwise the sticky last-used workspace (PR #37586).
+      setCurrentCwd(workspaceCwdForNewSession())
       setCurrentBranch('')
       clearComposerDraft()
       clearComposerAttachments()
@@ -333,7 +335,7 @@ export function useSessionActions({
         // Route the new chat to the chosen profile's backend (null = primary,
         // so single-profile users are unaffected).
         await ensureGatewayProfile($newChatProfile.get())
-        const cwd = $currentCwd.get().trim() || getRememberedWorkspaceCwd()
+        const cwd = $currentCwd.get().trim() || workspaceCwdForNewSession()
         // Pass the owning profile so a new chat under a non-launch profile (global
         // remote mode) builds its agent + persists against THAT profile's home/db.
         const newChatProfile = $newChatProfile.get()

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -8,7 +8,7 @@ import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { Archive, ArchiveOff, FolderOpen, Loader2, Trash2 } from '@/lib/icons'
 import { notify, notifyError } from '@/store/notifications'
-import { setSessions } from '@/store/session'
+import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import { EmptyState, ListRow, LoadingState, SectionHeading, SettingsContent } from './primitives'
@@ -196,6 +196,7 @@ function DefaultProjectDirSetting() {
 
       setDir(result.dir)
       setFallback(result.defaultLabel)
+      applyConfiguredDefaultProjectDir(result.dir)
     })
 
     return () => {
@@ -221,7 +222,8 @@ function DefaultProjectDirSetting() {
 
       const result = await settings.setDefaultProjectDir(picked.dir)
       setDir(result.dir)
-      notify({ durationMs: 2_000, kind: 'success', message: s.defaultDirUpdated })
+      applyConfiguredDefaultProjectDir(result.dir)
+      notify({ durationMs: 4_000, kind: 'success', message: s.defaultDirUpdated })
     } catch (err) {
       notifyError(err, s.updateDirFailed)
     } finally {
@@ -241,6 +243,8 @@ function DefaultProjectDirSetting() {
     try {
       await settings.setDefaultProjectDir(null)
       setDir(null)
+      applyConfiguredDefaultProjectDir(null)
+      await ensureDefaultWorkspaceCwd()
     } catch (err) {
       notifyError(err, s.clearDirFailed)
     } finally {
@@ -268,7 +272,7 @@ function DefaultProjectDirSetting() {
             )}
           </div>
         }
-        description={dir || s.defaultsTo(fallback || '~/hermes-projects')}
+        description={dir || s.defaultsTo(fallback || '~')}
         title={dir ? dir : s.notSet}
       />
     </div>

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -55,8 +55,9 @@ declare global {
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>
       fetchLinkTitle: (url: string) => Promise<string>
+      sanitizeWorkspaceCwd: (cwd?: null | string) => Promise<{ cwd: string; sanitized: boolean }>
       settings: {
-        getDefaultProjectDir: () => Promise<{ defaultLabel: string; dir: null | string }>
+        getDefaultProjectDir: () => Promise<{ defaultLabel: string; dir: null | string; resolvedCwd: string }>
         pickDefaultProjectDir: () => Promise<{ canceled: boolean; dir: null | string }>
         setDefaultProjectDir: (dir: null | string) => Promise<{ dir: null | string }>
       }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -519,7 +519,7 @@ export const en: Translations = {
       defaultDirTitle: 'Default project directory',
       defaultDirDesc:
         'New sessions start in this folder unless you pick another. Leave it unset to use your home directory.',
-      defaultDirUpdated: 'Default project directory updated',
+      defaultDirUpdated: 'Default project directory updated — start a new chat (Ctrl/⌘+N) for it to take effect',
       defaultsTo: label => `Defaults to ${label}.`,
       change: 'Change',
       choose: 'Choose',

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -3,13 +3,17 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { SessionInfo } from '@/types/hermes'
 
 import {
+  $activeSessionId,
   $attentionSessionIds,
+  $currentCwd,
   $workingSessionIds,
+  applyConfiguredDefaultProjectDir,
   getRecentlySettledSessionIds,
   mergeSessionPage,
   sessionPinId,
   setSessionAttention,
-  setSessionWorking
+  setSessionWorking,
+  workspaceCwdForNewSession
 } from './session'
 
 const session = (over: Partial<SessionInfo>): SessionInfo => ({
@@ -135,6 +139,43 @@ describe('mergeSessionPage', () => {
     const merged = mergeSessionPage(previous, incoming, ['root'])
 
     expect(merged.map(s => s.id)).toEqual(['tip', 'other'])
+  })
+})
+
+describe('workspaceCwdForNewSession', () => {
+  afterEach(() => {
+    applyConfiguredDefaultProjectDir(null)
+    $currentCwd.set('')
+    $activeSessionId.set(null)
+    window.localStorage.removeItem('hermes.desktop.workspace-cwd')
+  })
+
+  it('prefers the configured default over the sticky remembered workspace', () => {
+    window.localStorage.setItem('hermes.desktop.workspace-cwd', '/home/user/sticky')
+    applyConfiguredDefaultProjectDir('/home/user/configured')
+
+    expect(workspaceCwdForNewSession()).toBe('/home/user/configured')
+  })
+
+  it('falls back to the remembered workspace when no configured default is set', () => {
+    window.localStorage.setItem('hermes.desktop.workspace-cwd', '/home/user/sticky')
+
+    expect(workspaceCwdForNewSession()).toBe('/home/user/sticky')
+  })
+
+  it('falls back to the live cwd when neither configured nor remembered values exist', () => {
+    $currentCwd.set('/home/user/live')
+
+    expect(workspaceCwdForNewSession()).toBe('/home/user/live')
+  })
+
+  it('does not rewrite the live cwd while a session is active', () => {
+    $activeSessionId.set('sess-1')
+    $currentCwd.set('/live/session/path')
+    applyConfiguredDefaultProjectDir('/home/user/configured')
+
+    expect($currentCwd.get()).toBe('/live/session/path')
+    expect(workspaceCwdForNewSession()).toBe('/home/user/configured')
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -10,7 +10,65 @@ type Updater<T> = T | ((current: T) => T)
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
 
+// Cached copy of Settings → Sessions → Default project directory. The main
+// process persists this in project-dir.json, but the renderer must also honor it
+// when seeding $currentCwd — otherwise PR #37586's sticky localStorage home dir
+// wins and new sessions ignore the user's explicit picker choice.
+let configuredDefaultProjectDir = ''
+
 export const getRememberedWorkspaceCwd = (): string => storedString(WORKSPACE_CWD_KEY)?.trim() || ''
+
+export const getConfiguredDefaultProjectDir = (): string => configuredDefaultProjectDir
+
+export async function syncConfiguredDefaultProjectDir(): Promise<string> {
+  const settings = window.hermesDesktop?.settings?.getDefaultProjectDir
+
+  if (!settings) {
+    configuredDefaultProjectDir = ''
+
+    return ''
+  }
+
+  const { dir } = await settings()
+  configuredDefaultProjectDir = dir?.trim() || ''
+
+  return configuredDefaultProjectDir
+}
+
+/** Align the renderer workspace with the main-process default (home dir when
+ *  packaged, optional Settings override). Clears stale install-dir paths that
+ *  PR #37586's localStorage stickiness can preserve across the #37536 fix. */
+export async function ensureDefaultWorkspaceCwd(): Promise<void> {
+  const sanitize = window.hermesDesktop?.sanitizeWorkspaceCwd
+
+  if (!sanitize) {
+    return
+  }
+
+  await syncConfiguredDefaultProjectDir()
+  const configured = getConfiguredDefaultProjectDir()
+
+  if (configured) {
+    const { cwd } = await sanitize(configured)
+    setCurrentCwd(cwd)
+
+    return
+  }
+
+  const { cwd } = await sanitize(getRememberedWorkspaceCwd())
+
+  if (cwd) {
+    setCurrentCwd(cwd)
+  }
+}
+
+export function applyConfiguredDefaultProjectDir(dir: null | string | undefined): void {
+  configuredDefaultProjectDir = dir?.trim() || ''
+
+  if (configuredDefaultProjectDir) {
+    setCurrentCwd(configuredDefaultProjectDir)
+  }
+}
 
 interface AppAtom<T> {
   get: () => T
@@ -170,6 +228,11 @@ export const setCurrentCwd = (next: Updater<string>) => {
   // empty cwd clears the key (|| null → removeItem).
   persistString(WORKSPACE_CWD_KEY, $currentCwd.get().trim() || null)
 }
+
+/** Workspace for a brand-new chat. Explicit Settings override wins; otherwise
+ *  fall back to the sticky last-used folder, then whatever is already live. */
+export const workspaceCwdForNewSession = (): string =>
+  getConfiguredDefaultProjectDir() || getRememberedWorkspaceCwd() || $currentCwd.get().trim()
 
 export const setCurrentBranch = (next: Updater<string>) => updateAtom($currentBranch, next)
 export const setCurrentUsage = (next: Updater<UsageStats>) => updateAtom($currentUsage, next)

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -48,24 +48,29 @@ export async function ensureDefaultWorkspaceCwd(): Promise<void> {
   await syncConfiguredDefaultProjectDir()
   const configured = getConfiguredDefaultProjectDir()
 
+  const seedLiveCwd = (cwd: string) => {
+    if (cwd && !$activeSessionId.get()) {
+      setCurrentCwd(cwd)
+    }
+  }
+
   if (configured) {
     const { cwd } = await sanitize(configured)
-    setCurrentCwd(cwd)
+    seedLiveCwd(cwd)
 
     return
   }
 
   const { cwd } = await sanitize(getRememberedWorkspaceCwd())
-
-  if (cwd) {
-    setCurrentCwd(cwd)
-  }
+  seedLiveCwd(cwd)
 }
 
 export function applyConfiguredDefaultProjectDir(dir: null | string | undefined): void {
   configuredDefaultProjectDir = dir?.trim() || ''
 
-  if (configuredDefaultProjectDir) {
+  // Cache only — new chats read this via workspaceCwdForNewSession(). Do not
+  // rewrite the live workspace (or localStorage) while a session is active.
+  if (configuredDefaultProjectDir && !$activeSessionId.get()) {
     setCurrentCwd(configuredDefaultProjectDir)
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where **Settings → Archived Chats → Default project directory** saved correctly in the main process (`project-dir.json`) but new desktop sessions still started in the user's home directory.

The renderer was seeding `$currentCwd` from sticky `localStorage` (`hermes.desktop.workspace-cwd`, PR #37586) and never preferred the configured default when calling `session.create`. Restarting the gateway could not help because the cwd was never passed from the picker choice.

This PR wires the configured default through boot, new-chat draft, and `session.create`; pins `TERMINAL_CWD` on backend spawn to match `resolveHermesCwd()`; and rejects packaged install-dir paths (e.g. `win-unpacked`) that could slip back in via `INIT_CWD` or remembered workspace paths (PR #37536 item 16 follow-up).

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/main.cjs` — `isPackagedInstallPath`, `sanitizeWorkspaceCwd`, skip `INIT_CWD` when packaged, set `TERMINAL_CWD` on backend spawn, `hermes:workspace:sanitize` IPC
- `apps/desktop/electron/preload.cjs` — expose `sanitizeWorkspaceCwd`
- `apps/desktop/src/store/session.ts` — cache configured default, `ensureDefaultWorkspaceCwd`, `workspaceCwdForNewSession`
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts` — seed workspace on boot
- `apps/desktop/src/app/session/hooks/use-session-actions.ts` — new chats use configured default
- `apps/desktop/src/app/settings/sessions-settings.tsx` — apply picker choice to live workspace immediately
- `apps/desktop/src/global.d.ts`, `apps/desktop/src/i18n/en.ts` — bridge/types + clearer success toast

## How to Test

1. Open Settings → **Archived Chats** → **Default project directory** → choose a folder that is not your home directory.
2. Start a **new chat** (`Ctrl/⌘+N`) and send: "What directory are you working in?"
3. Confirm the agent reports the chosen folder (not home).
4. Clear the setting → new chat should fall back to home.
5. (Packaged build) Confirm new sessions do not land in the app install dir (`win-unpacked` / `.app` bundle).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: WSL2 / Linux (manual desktop dev verification pending reviewer)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — delete section.

## Screenshots / Logs

N/A — renderer + Electron IPC change; verify via steps above.