### PR TITLE
fix(dashboard): support configured remote hosts

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1464,6 +1464,17 @@ DEFAULT_CONFIG = {
     # Web dashboard settings
     "dashboard": {
         "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
+        "host": "127.0.0.1",  # Dashboard bind host; env override: HERMES_DASHBOARD_HOST
+        "port": 9119,  # Dashboard bind port; env override: HERMES_DASHBOARD_PORT
+        # Extra browser origins allowed by the dashboard CORS layer. Keep this
+        # empty unless you intentionally serve the dashboard through a
+        # different hostname or reverse proxy origin.
+        "cors_origins": [],
+        # Additional Host header values to accept for explicit non-loopback
+        # binds. Use this when the dashboard is intentionally reached through
+        # a stable hostname (for example a Tailscale DNS name) that differs
+        # from the literal bind address.
+        "allowed_hosts": [],
         # Hide the token/cost analytics surfaces (Analytics page, token bars and
         # cost figures on the Models page) by default.  The numbers shown there
         # are a local debug estimate: they only count successful main-agent

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10115,14 +10115,39 @@ def cmd_dashboard(args):
         # the missing-provider state if it matters.
         print(f"⚠ Plugin discovery failed: {exc}", file=sys.stderr)
 
+    from hermes_cli.config import load_config
     from hermes_cli.web_server import start_server
+
+    cfg = load_config() or {}
+    dashboard_cfg = cfg.get("dashboard") if isinstance(cfg.get("dashboard"), dict) else {}
+
+    host_explicit = bool(getattr(args, "host_explicit", False))
+    port_explicit = bool(getattr(args, "port_explicit", False))
+
+    configured_host = os.environ.get("HERMES_DASHBOARD_HOST", "").strip()
+    if not configured_host:
+        configured_host = str((dashboard_cfg or {}).get("host") or "").strip()
+    host = args.host if host_explicit else (configured_host or args.host)
+
+    configured_port = os.environ.get("HERMES_DASHBOARD_PORT", "").strip()
+    if not configured_port:
+        configured_port = str((dashboard_cfg or {}).get("port") or "").strip()
+    port = args.port
+    if not port_explicit and configured_port:
+        try:
+            port = int(configured_port)
+        except ValueError:
+            print(
+                f"⚠ Ignoring invalid dashboard port override: {configured_port!r}",
+                file=sys.stderr,
+            )
 
     # The in-browser Chat tab (the embedded TUI over PTY/WebSocket) is always
     # available — the desktop app and the dashboard's own Chat tab both rely on
     # the `/api/ws` + `/api/pty` sockets, so there is no reason to gate them.
     start_server(
-        host=args.host,
-        port=args.port,
+        host=host,
+        port=port,
         open_browser=not args.no_open,
         allow_public=getattr(args, "insecure", False),
     )

--- a/hermes_cli/subcommands/dashboard.py
+++ b/hermes_cli/subcommands/dashboard.py
@@ -10,6 +10,14 @@ import argparse
 from typing import Callable
 
 
+class _StoreValueAndSeen(argparse.Action):
+    """Record that a dashboard launch flag was explicitly provided."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+        setattr(namespace, f"{self.dest}_explicit", True)
+
+
 def build_dashboard_parser(
     subparsers, *, cmd_dashboard: Callable, cmd_dashboard_register: Callable
 ) -> None:
@@ -23,10 +31,17 @@ def build_dashboard_parser(
         description="Launch the Hermes Agent web dashboard for managing config, API keys, and sessions",
     )
     dashboard_parser.add_argument(
-        "--port", type=int, default=9119, help="Port (default 9119)"
+        "--port",
+        type=int,
+        default=9119,
+        action=_StoreValueAndSeen,
+        help="Port (default 9119; config: dashboard.port)",
     )
     dashboard_parser.add_argument(
-        "--host", default="127.0.0.1", help="Host (default 127.0.0.1)"
+        "--host",
+        default="127.0.0.1",
+        action=_StoreValueAndSeen,
+        help="Host (default 127.0.0.1; config: dashboard.host)",
     )
     dashboard_parser.add_argument(
         "--no-open", action="store_true", help="Don't open browser automatically"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -196,13 +196,82 @@ _reveal_timestamps: List[float] = []
 _REVEAL_MAX_PER_WINDOW = 5
 _REVEAL_WINDOW_SECONDS = 30
 
-# CORS: restrict to localhost origins only.  The web UI is intended to run
-# locally; binding to 0.0.0.0 with allow_origins=["*"] would let any website
-# read/modify config and secrets.
+_LOCALHOST_CORS_ORIGIN_REGEX = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"
+
+
+def _split_dashboard_csv(value: str) -> list[str]:
+    """Split comma/newline-separated dashboard env values into tokens."""
+    if not value:
+        return []
+    parts: list[str] = []
+    for chunk in value.replace("\n", ",").split(","):
+        item = chunk.strip()
+        if item:
+            parts.append(item)
+    return parts
+
+
+def _normalize_dashboard_list(raw: Any) -> tuple[str, ...]:
+    """Normalize dashboard config list-ish values into a stable tuple."""
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        items = _split_dashboard_csv(raw)
+    elif isinstance(raw, (list, tuple, set)):
+        items = [str(item).strip() for item in raw if str(item).strip()]
+    else:
+        return ()
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            normalized.append(item)
+    return tuple(normalized)
+
+
+def _canonical_host(value: str) -> str:
+    """Return a lower-cased host token without scheme, brackets, or port."""
+    raw = (value or "").strip()
+    if not raw:
+        return ""
+    if "://" in raw:
+        raw = urllib.parse.urlparse(raw).netloc or ""
+    if raw.startswith("["):
+        close = raw.find("]")
+        raw = raw[1:close] if close != -1 else raw.strip("[]")
+    elif raw.count(":") == 1:
+        raw = raw.rsplit(":", 1)[0]
+    return raw.strip().lower()
+
+
+def _load_dashboard_network_config() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return (cors_origins, allowed_hosts) from env/config with env winning."""
+    cfg = load_config() or {}
+    dashboard_cfg = cfg.get("dashboard") if isinstance(cfg.get("dashboard"), dict) else {}
+
+    cors_env = os.environ.get("HERMES_DASHBOARD_CORS_ORIGINS", "").strip()
+    host_env = os.environ.get("HERMES_DASHBOARD_ALLOWED_HOSTS", "").strip()
+
+    cors_origins = _normalize_dashboard_list(
+        cors_env if cors_env else (dashboard_cfg or {}).get("cors_origins", ())
+    )
+    allowed_hosts = _normalize_dashboard_list(
+        host_env if host_env else (dashboard_cfg or {}).get("allowed_hosts", ())
+    )
+    return cors_origins, allowed_hosts
+
+
+_DASHBOARD_CORS_ORIGINS, _DASHBOARD_ALLOWED_HOSTS = _load_dashboard_network_config()
+
+# CORS: localhost stays allowed by default. Operators can add exact extra
+# origins for reverse proxies or stable remote hostnames without widening the
+# policy to "*".
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_origins=list(_DASHBOARD_CORS_ORIGINS),
+    allow_origin_regex=_LOCALHOST_CORS_ORIGIN_REGEX,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -278,12 +347,17 @@ def should_require_auth(host: str, allow_public: bool) -> bool:
     return (host not in _LOOPBACK_HOST_VALUES) and (not allow_public)
 
 
-def _is_accepted_host(host_header: str, bound_host: str) -> bool:
+def _is_accepted_host(
+    host_header: str,
+    bound_host: str,
+    allowed_hosts: Optional[tuple[str, ...]] = None,
+) -> bool:
     """True if the Host header targets the interface we bound to.
 
     Accepts:
     - Exact bound host (with or without port suffix)
     - Loopback aliases when bound to loopback
+    - Explicitly configured alternate hostnames
     - Any host when bound to 0.0.0.0 (explicit opt-in to non-loopback,
       no protection possible at this layer)
     """
@@ -295,17 +369,12 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     # Plain hosts/v4:
     #   localhost:9119
     #   127.0.0.1:9119
-    h = host_header.strip()
-    if h.startswith("["):
-        # IPv6 bracketed — port (if any) follows "]:"
-        close = h.find("]")
-        if close != -1:
-            host_only = h[1:close]  # strip brackets
-        else:
-            host_only = h.strip("[]")
-    else:
-        host_only = h.rsplit(":", 1)[0] if ":" in h else h
-    host_only = host_only.lower()
+    host_only = _canonical_host(host_header)
+    allowed_host_values = {
+        _canonical_host(candidate)
+        for candidate in (allowed_hosts or ())
+        if _canonical_host(candidate)
+    }
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer
@@ -314,12 +383,12 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
         return True
 
     # Loopback bind: accept the loopback names
-    bound_lc = bound_host.lower()
+    bound_lc = _canonical_host(bound_host)
     if bound_lc in _LOOPBACK_HOST_VALUES:
-        return host_only in _LOOPBACK_HOST_VALUES
+        return host_only in _LOOPBACK_HOST_VALUES or host_only in allowed_host_values
 
     # Explicit non-loopback bind: require exact host match
-    return host_only == bound_lc
+    return host_only == bound_lc or host_only in allowed_host_values
 
 
 @app.middleware("http")
@@ -339,7 +408,11 @@ async def host_header_middleware(request: Request, call_next):
     bound_host = getattr(app.state, "bound_host", None)
     if bound_host:
         host_header = request.headers.get("host", "")
-        if not _is_accepted_host(host_header, bound_host):
+        if not _is_accepted_host(
+            host_header,
+            bound_host,
+            getattr(app.state, "allowed_hosts", ()),
+        ):
             return JSONResponse(
                 status_code=400,
                 content={
@@ -8397,7 +8470,8 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
         return None
 
     host_header = ws.headers.get("host", "")
-    if not _is_accepted_host(host_header, bound_host):
+    allowed_hosts = getattr(app.state, "allowed_hosts", ())
+    if not _is_accepted_host(host_header, bound_host, allowed_hosts):
         return f"host_mismatch host={host_header or '?'} bound={bound_host}"
 
     origin = ws.headers.get("origin", "")
@@ -8414,7 +8488,7 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
     if not parsed.netloc:
         return f"origin_mismatch origin={origin} bound={bound_host}"
 
-    if not _is_accepted_host(parsed.netloc, bound_host):
+    if not _is_accepted_host(parsed.netloc, bound_host, allowed_hosts):
         return f"origin_mismatch origin={origin} bound={bound_host}"
     return None
 
@@ -10117,6 +10191,7 @@ def start_server(
     # PTY child uses to publish events to the dashboard sidebar.
     app.state.bound_host = host
     app.state.bound_port = port
+    app.state.allowed_hosts = _DASHBOARD_ALLOWED_HOSTS
 
     if open_browser:
         import webbrowser

--- a/tests/hermes_cli/test_dashboard_launch_config.py
+++ b/tests/hermes_cli/test_dashboard_launch_config.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def _ns(**kw):
+    defaults = dict(
+        port=9119,
+        host="127.0.0.1",
+        no_open=False,
+        insecure=False,
+        stop=False,
+        status=False,
+        skip_build=True,
+    )
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+def test_dashboard_launch_uses_env_overrides_when_flags_not_explicit(
+    monkeypatch, tmp_path
+):
+    from hermes_cli import main as mod
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setenv("HERMES_DASHBOARD_HOST", "0.0.0.0")
+    monkeypatch.setenv("HERMES_DASHBOARD_PORT", "9120")
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("ok", encoding="utf-8")
+    monkeypatch.setenv("HERMES_WEB_DIST", str(dist))
+    monkeypatch.setattr(mod, "_sync_bundled_skills_quietly", lambda: None)
+
+    start_calls: dict = {}
+
+    def fake_start_server(**kwargs):
+        start_calls.update(kwargs)
+
+    fake_ws = type("FakeWS", (), {"start_server": staticmethod(fake_start_server)})
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"dashboard": {"host": "127.0.0.9", "port": 9999}},
+    )
+    fake_plugins = type("FakePlugins", (), {"discover_plugins": staticmethod(lambda: None)})
+    monkeypatch.setitem(sys.modules, "hermes_cli.web_server", fake_ws)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", fake_plugins)
+
+    mod.cmd_dashboard(_ns())
+
+    assert start_calls["host"] == "0.0.0.0"
+    assert start_calls["port"] == 9120
+
+
+def test_dashboard_launch_explicit_flags_override_config_and_env(monkeypatch, tmp_path):
+    from hermes_cli import main as mod
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setenv("HERMES_DASHBOARD_HOST", "0.0.0.0")
+    monkeypatch.setenv("HERMES_DASHBOARD_PORT", "9120")
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("ok", encoding="utf-8")
+    monkeypatch.setenv("HERMES_WEB_DIST", str(dist))
+    monkeypatch.setattr(mod, "_sync_bundled_skills_quietly", lambda: None)
+
+    start_calls: dict = {}
+
+    def fake_start_server(**kwargs):
+        start_calls.update(kwargs)
+
+    fake_ws = type("FakeWS", (), {"start_server": staticmethod(fake_start_server)})
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"dashboard": {"host": "10.0.0.5", "port": 9555}},
+    )
+    fake_plugins = type("FakePlugins", (), {"discover_plugins": staticmethod(lambda: None)})
+    monkeypatch.setitem(sys.modules, "hermes_cli.web_server", fake_ws)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", fake_plugins)
+
+    mod.cmd_dashboard(
+        _ns(
+            host="127.0.0.1",
+            port=9119,
+            host_explicit=True,
+            port_explicit=True,
+        )
+    )
+
+    assert start_calls["host"] == "127.0.0.1"
+    assert start_calls["port"] == 9119
+
+
+def test_load_dashboard_network_config_reads_config_and_env(monkeypatch):
+    import hermes_cli.web_server as ws
+
+    monkeypatch.setattr(
+        ws,
+        "load_config",
+        lambda: {
+            "dashboard": {
+                "cors_origins": ["https://dash.example", "https://dash.example"],
+                "allowed_hosts": ["tailscale-node.ts.net"],
+            }
+        },
+    )
+    monkeypatch.delenv("HERMES_DASHBOARD_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("HERMES_DASHBOARD_ALLOWED_HOSTS", raising=False)
+
+    cors_origins, allowed_hosts = ws._load_dashboard_network_config()
+    assert cors_origins == ("https://dash.example",)
+    assert allowed_hosts == ("tailscale-node.ts.net",)
+
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_CORS_ORIGINS",
+        "https://env.example, https://dash.example",
+    )
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_ALLOWED_HOSTS",
+        "env-node.ts.net, tailscale-node.ts.net",
+    )
+
+    cors_origins, allowed_hosts = ws._load_dashboard_network_config()
+    assert cors_origins == ("https://env.example", "https://dash.example")
+    assert allowed_hosts == ("env-node.ts.net", "tailscale-node.ts.net")

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -76,6 +76,22 @@ class TestHostHeaderValidator:
         # Loopback — reject (we bound to a specific non-loopback name)
         assert not _is_accepted_host("localhost", "my-server.corp.net")
 
+    def test_explicit_non_loopback_bind_accepts_configured_alias(self):
+        """Operators can explicitly allow a stable alternate hostname such
+        as a Tailscale DNS name when it differs from the literal bind host."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        assert _is_accepted_host(
+            "my-node.tailnet.ts.net:9119",
+            "100.64.0.10",
+            allowed_hosts=("my-node.tailnet.ts.net",),
+        )
+        assert not _is_accepted_host(
+            "evil.example",
+            "100.64.0.10",
+            allowed_hosts=("my-node.tailnet.ts.net",),
+        )
+
     def test_case_insensitive_comparison(self):
         """Host headers are case-insensitive per RFC — accept variations."""
         from hermes_cli.web_server import _is_accepted_host
@@ -212,6 +228,31 @@ class TestWebSocketHostOriginGuard:
             headers={
                 "Host": "localhost:9119",
                 "Origin": "http://localhost:9119",
+            },
+        ):
+            pass
+
+    def test_explicit_alias_websocket_host_and_origin_are_accepted(self, monkeypatch):
+        from fastapi.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "100.64.0.10", raising=False)
+        monkeypatch.setattr(
+            ws.app.state,
+            "allowed_hosts",
+            ("my-node.tailnet.ts.net",),
+            raising=False,
+        )
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with client.websocket_connect(
+            url,
+            headers={
+                "Host": "my-node.tailnet.ts.net:9119",
+                "Origin": "https://my-node.tailnet.ts.net",
             },
         ):
             pass


### PR DESCRIPTION
## What changed and why
Per the reporter's clarification on June 9, 2026, this issue is not just about bind-host persistence: the dashboard also rejects intentional remote hostnames with `Invalid Host header` even when operators are accessing it over a trusted network path such as Tailscale. This change adds `dashboard.host`, `dashboard.port`, `dashboard.cors_origins`, and `dashboard.allowed_hosts` config support, bridges `HERMES_DASHBOARD_HOST` / `HERMES_DASHBOARD_PORT` / `HERMES_DASHBOARD_CORS_ORIGINS` / `HERMES_DASHBOARD_ALLOWED_HOSTS`, and updates the HTTP and WebSocket host/origin checks to accept explicitly configured alternate hostnames without dropping the localhost-default rebinding defense.

## Addressing maintainer feedback
- #15731: that thread covers the WebSocket chat-tab portion of non-localhost dashboard access. This PR keeps that scope aligned by extending the same configured-host allowance through the dashboard WebSocket host/origin guard.
- #15736: that related thread was also called out as part of the non-localhost dashboard access cluster. This PR stays on the broader dashboard configuration side of the problem by adding persistent host/port/CORS/allowed-host settings rather than narrowing to one chat-only path.

## How to test
1. Set `dashboard.host`, `dashboard.port`, `dashboard.cors_origins`, and `dashboard.allowed_hosts` in `config.yaml`, or export the matching `HERMES_DASHBOARD_*` env vars.
2. Launch `hermes dashboard --skip-build` without explicit `--host/--port` flags and confirm it picks up the configured host/port values.
3. Bind the dashboard to a non-loopback address and access it through an allowed hostname (for example a Tailscale DNS name); verify normal HTTP requests and `/api/events` WebSocket connections are accepted.
4. Confirm unrelated hostnames still fail the Host/Origin guard.
5. Run `source "$HOME/.hermes/hermes-agent/venv/bin/activate" && pytest tests/hermes_cli/test_dashboard_launch_config.py tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_auth_ws_auth.py tests/hermes_cli/test_dashboard_auth_gate.py -q`.

## What platforms tested on
- macOS (local shared Hermes venv)

Fixes #10567

<!-- autocontrib:worker-id=issue-followup-ab7d1c36 kind=pr-open -->