### PR TITLE
fix(tui): show reasoning status for active session

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1955,6 +1955,43 @@ def test_complete_slash_details_args():
     assert any(item["text"] == "expanded" for item in resp_mode["result"]["items"])
 
 
+def test_config_get_reasoning_reports_config_status(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: medium\ndisplay:\n  show_reasoning: false\n",
+        encoding="utf-8",
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "config.get", "params": {"key": "reasoning"}}
+    )
+
+    assert resp["result"] == {"value": "medium", "display": "hide"}
+
+
+def test_config_get_reasoning_prefers_live_session_status(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: low\ndisplay:\n  show_reasoning: false\n",
+        encoding="utf-8",
+    )
+    agent = types.SimpleNamespace(reasoning_config={"enabled": True, "effort": "high"})
+    server._sessions["sid"] = _session(agent=agent, show_reasoning=True)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.get",
+                "params": {"session_id": "sid", "key": "reasoning"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert resp["result"] == {"value": "high", "display": "show"}
+
+
 def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     agent = types.SimpleNamespace(reasoning_config=None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5624,11 +5624,20 @@ def _(rid, params: dict) -> dict:
         effort = str(
             (cfg.get("agent") or {}).get("reasoning_effort", "medium") or "medium"
         )
-        display = (
-            "show"
-            if bool((cfg.get("display") or {}).get("show_reasoning", False))
-            else "hide"
-        )
+        show_reasoning = bool((cfg.get("display") or {}).get("show_reasoning", False))
+        session = _sessions.get(params.get("session_id", ""))
+        if session:
+            agent = session.get("agent")
+            reasoning_config = getattr(agent, "reasoning_config", None)
+            if isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    effort = "none"
+                else:
+                    live_effort = str(reasoning_config.get("effort") or "").strip()
+                    if live_effort:
+                        effort = live_effort
+            show_reasoning = bool(session.get("show_reasoning", show_reasoning))
+        display = "show" if show_reasoning else "hide"
         return _ok(rid, {"value": effort, "display": display})
     if key == "fast":
         return _ok(

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -146,6 +146,16 @@ describe('createSlashHandler', () => {
     })
   })
 
+  it('routes bare /reasoning to the session status lookup', () => {
+    patchUiState({ sid: 'sid-abc' })
+    const rpc = vi.fn(() => Promise.resolve({ display: 'hide', value: 'medium' }))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/reasoning')).toBe(true)
+    expect(rpc).toHaveBeenCalledWith('config.get', { key: 'reasoning', session_id: 'sid-abc' })
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
   it('applies /reasoning hide to the thinking section immediately', async () => {
     patchUiState({ sections: { thinking: 'expanded' }, showReasoning: true, sid: 'sid-abc' })
     const ctx = buildCtx({

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -390,9 +390,11 @@ export const sessionCommands: SlashCommand[] = [
     help: 'inspect or set reasoning effort (updates live agent)',
     name: 'reasoning',
     run: (arg, ctx) => {
-      if (!arg) {
+      const value = arg.trim()
+
+      if (!value) {
         return ctx.gateway
-          .rpc<ConfigGetValueResponse>('config.get', { key: 'reasoning' })
+          .rpc<ConfigGetValueResponse>('config.get', { key: 'reasoning', session_id: ctx.sid })
           .then(
             ctx.guarded<ConfigGetValueResponse>(
               r => r.value && ctx.transcript.sys(`reasoning: ${r.value} · display ${r.display || 'hide'}`)
@@ -401,7 +403,7 @@ export const sessionCommands: SlashCommand[] = [
       }
 
       ctx.gateway
-        .rpc<ConfigSetResponse>('config.set', { key: 'reasoning', session_id: ctx.sid, value: arg })
+        .rpc<ConfigSetResponse>('config.set', { key: 'reasoning', session_id: ctx.sid, value })
         .then(
           ctx.guarded<ConfigSetResponse>(r => {
             if (!r.value) {


### PR DESCRIPTION
## Summary
- Route bare `/reasoning` through the session-scoped status lookup.
- Report live session reasoning effort and display state when available.
- Add TUI and gateway regression coverage for the status path.

Fixes #42643

## Tests
- `.\.venv\Scripts\python.exe -m pytest tests/test_tui_gateway_server.py -k "config_get_reasoning or config_set_reasoning"`
- `npm --workspace ui-tui test -- createSlashHandler.test.ts`
- `npm --workspace ui-tui run type-check`
