### PR TITLE
feat: add transform_api_request plugin hook for full-payload request transformation

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -952,6 +952,37 @@ def run_conversation(
                 except Exception:
                     pass
 
+                # Plugin hook: transform_api_request
+                # Fires once per API call, receiving the MUTABLE api_kwargs
+                # dict by reference.  Plugins can modify messages, model,
+                # and other parameters before the request is sent.
+                # Mutations are ephemeral — they affect only the current
+                # API call, never the persisted messages list or session DB.
+                #
+                # Unlike pre_api_request (observational, shallow-copied
+                # messages), this hook is MUTATIVE: callbacks receive the
+                # actual api_kwargs dict that will be passed to the provider
+                # client on the very next line.  Use cases include context
+                # compression, security scanning, format translation, and
+                # cost-aware model routing.
+                try:
+                    if has_hook("transform_api_request"):
+                        _invoke_hook(
+                            "transform_api_request",
+                            api_kwargs=api_kwargs,
+                            session_id=agent.session_id or "",
+                            task_id=effective_task_id,
+                            turn_id=turn_id,
+                            model=agent.model,
+                            provider=agent.provider,
+                            base_url=agent.base_url,
+                            api_mode=agent.api_mode,
+                            api_call_count=api_call_count,
+                            api_request_id=api_request_id,
+                        )
+                except Exception:
+                    pass
+
                 if env_var_enabled("HERMES_DUMP_REQUESTS"):
                     agent._dump_api_request_debug(api_kwargs, reason="preflight")
 

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -175,6 +175,17 @@ _DEFAULT_PAYLOADS = {
         "assistant_content_chars": 1200,
         "assistant_tool_call_count": 0,
     },
+    "transform_api_request": {
+        "session_id": "test-session",
+        "task_id": "test-task",
+        "model": "claude-sonnet-4-6",
+        "provider": "anthropic",
+        "base_url": "https://api.anthropic.com",
+        "api_mode": "anthropic_messages",
+        "api_call_count": 1,
+        "turn_id": "test-turn",
+        "request": {"body": {"messages": [{"role": "user", "content": "hello"}]}},
+    },
     "subagent_stop": {
         "parent_session_id": "parent-sess",
         "child_role": None,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -138,6 +138,7 @@ VALID_HOOKS: Set[str] = {
     "post_llm_call",
     "pre_api_request",
     "post_api_request",
+    "transform_api_request",
     "api_request_error",
     "on_session_start",
     "on_session_end",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4553,6 +4553,49 @@ class TestRunConversation:
             "_record_task_failure should not be called outside kanban mode"
         )
 
+    def test_transform_api_request_hook_mutates_api_kwargs(self, agent):
+        """The transform_api_request hook receives mutable api_kwargs and
+        plugins can modify messages before they reach the provider."""
+        self._setup_agent(agent)
+        resp = _mock_response(content="Compressed response", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+
+        hook_received_kwargs = {}
+        transform_called = False
+
+        def _transform_hook(name, **kwargs):
+            nonlocal transform_called, hook_received_kwargs
+            if name == "transform_api_request":
+                hook_received_kwargs = dict(kwargs)
+                # Simulate a compression plugin: strip tool outputs
+                api_kw = kwargs.get("api_kwargs", {})
+                msgs = api_kw.get("messages", [])
+                for m in msgs:
+                    if m.get("role") == "tool" and m.get("content"):
+                        m["content"] = "[compressed]"
+                transform_called = True
+            return []
+
+        with (
+            patch("hermes_cli.plugins.has_hook", side_effect=lambda name: name == "transform_api_request"),
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_transform_hook),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("test message")
+
+        assert result["final_response"] == "Compressed response"
+        assert transform_called is True
+        # Verify the hook received api_kwargs by reference
+        assert "api_kwargs" in hook_received_kwargs
+        api_kw = hook_received_kwargs["api_kwargs"]
+        assert isinstance(api_kw, dict)
+        assert "messages" in api_kw
+        # Verify key metadata fields are present
+        assert hook_received_kwargs.get("session_id") == agent.session_id
+        assert hook_received_kwargs.get("model") == agent.model
+
 
 class TestHookPayloadSanitizesSimpleNamespace:
     """Regression: ``_hook_jsonable`` referenced ``SimpleNamespace`` without


### PR DESCRIPTION
## Summary

Adds a `transform_api_request` plugin hook that fires once per API call, receiving the **mutable `api_kwargs` dict by reference** — the same dict passed to the provider client on the next line.

Unlike `pre_api_request` (observational, shallow-copied messages), this hook is **mutative**: plugins can modify messages, model, and other parameters before they reach the provider. Mutations are ephemeral — they affect only the current API call, never the persisted session DB.

## Motivation

Closes #43237. See that issue for detailed rationale, use cases, and comparison to the related `transform_api_message` hook (#20307).

Use cases enabled:
- **Context compression** (Headroom, etc.) — compress full conversation context before the API call
- **Security scanning** — cross-message secret detection
- **Provider format translation** — rewrite requests between provider formats
- **Cost-aware routing** — inspect payload to choose cheap vs. expensive models

## Changes

| File | Change |
|---|---|
| `hermes_cli/plugins.py` | Add `transform_api_request` to `VALID_HOOKS` |
| `agent/conversation_loop.py` | Invoke hook between `pre_api_request` and the actual client API call, passing `api_kwargs` by mutable reference |
| `hermes_cli/hooks.py` | Add test-fixture kwargs |
| `tests/run_agent/test_run_agent.py` | Test that the hook receives mutable `api_kwargs` and can modify messages |

## Test Plan

- [x] New test: `test_transform_api_request_hook_mutates_api_kwargs` — verifies hook receives `api_kwargs`, can mutate messages, metadata fields present
- [x] Existing `TestRunConversation` suite — all 122 tests pass
- [x] Existing `TestPluginHooks` suite — all tests pass
- [x] No regressions in existing `pre_api_request` / `post_api_request` hook tests

## Scope

~86 lines across 4 files. The integration point already exists — this adds a hook invocation in the gap between `pre_api_request` and the streaming/non-streaming API call.