### PR TITLE
fix(cron): Windows detach with constructor-only compatibility fallback and file-backed output capture

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -19,6 +19,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 
@@ -40,7 +41,10 @@ from typing import Any, List, Optional
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from hermes_constants import get_hermes_home
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import (
+    windows_detach_flags,
+    windows_detach_flags_without_breakaway,
+)
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_time import now as _hermes_now
@@ -2110,6 +2114,144 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
     return str(interpreter), env_overlay
 
 
+# ERROR_ACCESS_DENIED. Some Windows/job-object configurations surface a
+# refused CREATE_BREAKAWAY_FROM_JOB request as WinError 5. Modern nested-job
+# configurations may instead create the child successfully while silently
+# retaining it in every job that forbids breakaway; in that case no fallback
+# is possible or needed, and the documented weaker survival guarantee applies.
+_WINERROR_ACCESS_DENIED = 5
+
+
+def _parent_in_job() -> bool:
+    """Best-effort check: is this process inside a Win32 job object?
+
+    Used only to tighten the legacy/configuration-specific WinError-5
+    fallback below. If the parent is in no job, ERROR_ACCESS_DENIED cannot be
+    a job breakaway refusal, so retrying without the flag would be pointless.
+    Returns True on query failure so a genuine WinError-5 breakaway refusal is
+    not suppressed merely because job membership could not be inspected.
+    """
+    if sys.platform != "win32":  # pragma: no cover - Windows-only branch
+        return True
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32
+        in_job = wintypes.BOOL(False)
+        ok = kernel32.IsProcessInJob(
+            kernel32.GetCurrentProcess(), None, ctypes.byref(in_job)
+        )
+        if not ok:
+            return True
+        return bool(in_job.value)
+    except Exception:
+        return True
+
+
+def _is_breakaway_denied(exc: OSError) -> bool:
+    """True iff *exc* plausibly is a breakaway-refusal constructor error.
+
+    Some Windows/job-object configurations report a refused
+    ``CREATE_BREAKAWAY_FROM_JOB`` request as ERROR_ACCESS_DENIED (WinError 5).
+    Modern nested-job configurations may instead succeed while retaining the
+    child in a forbidding job, so this predicate is a narrow compatibility
+    fallback rather than a universal detector.
+
+    Any other ``OSError`` (missing interpreter, bad cwd, handle exhaustion,
+    ...) propagates rather than triggering a second creation attempt. The
+    job-membership check rules out unrelated access-denied failures whenever
+    the parent is known not to be in a job.
+    """
+    if getattr(exc, "winerror", None) != _WINERROR_ACCESS_DENIED:
+        return False
+    return _parent_in_job()
+
+
+def _run_script_windows_detached(
+    argv: list, *, timeout: float, cwd: str, env: dict
+) -> tuple:
+    """Launch a cron script detached from the parent Windows job object,
+    with file-backed (not pipe-backed) output capture.
+
+    Returns ``(returncode, stdout_text, stderr_text)``.
+
+    Design invariants (PR #43252 rework; see the review thread):
+
+    * **At-most-once execution.** Only the ``subprocess.Popen`` constructor
+      can be retried, and only when a parent-in-job launch surfaces the
+      legacy/configuration-specific breakaway refusal as WinError 5. Modern
+      nested jobs may instead accept creation while silently retaining the
+      child in a forbidding job; that is one successful construction, not a
+      retry condition. Once a ``Popen`` object exists, no later path can spawn
+      another child: wait, timeout, decode and redaction failures propagate.
+    * **Durable output sink.** stdout/stderr are unnamed ``TemporaryFile``
+      handles the child inherits. Unlike anonymous pipes -- whose read end
+      dies with the parent, killing an output-producing "detached" child
+      the next time it writes -- the inherited file handles keep the file
+      alive until the child (and any grandchildren holding the handle)
+      exit. A script that outlives Hermes can therefore keep writing and
+      complete its side effects. Windows deletes the ``O_TEMPORARY`` file
+      when the last handle closes, so no unredacted output is left on
+      disk on any path, including parent death.
+    * **No console dependency.** stdin is ``DEVNULL``: a detached child
+      has no console, and inheriting the parent's console stdin would
+      leave a dangling handle after parent exit. Cron scripts are
+      non-interactive by contract.
+    * **Timeout parity.** Timeout kills the direct child
+      (``TerminateProcess``), mirroring ``subprocess.run`` semantics, and
+      never retries.
+
+    Contract level: L2. If Hermes dies mid-run the child survives and
+    completes its side effects, but its output is not recovered after
+    restart -- the occurrence was already claimed (``claim_dispatch``) or
+    advanced (``advance_next_run``) before dispatch, so it is not re-run.
+    """
+    with tempfile.TemporaryFile() as stdout_f, tempfile.TemporaryFile() as stderr_f:
+        common = {
+            "stdin": subprocess.DEVNULL,
+            "stdout": stdout_f,
+            "stderr": stderr_f,
+            "cwd": cwd,
+            "env": env,
+        }
+        try:
+            proc = subprocess.Popen(
+                argv, creationflags=windows_detach_flags(), **common
+            )
+        except OSError as exc:
+            if not _is_breakaway_denied(exc):
+                raise
+            logger.info(
+                "Windows reported CREATE_BREAKAWAY_FROM_JOB access denied for "
+                "cron script interpreter %r while the parent is in a job; "
+                "retrying once without breakaway. The child stays free of "
+                "the console but may still be reaped if a retaining job is "
+                "torn down.",
+                argv[0] if argv else "<empty>",
+            )
+            proc = subprocess.Popen(
+                argv,
+                creationflags=windows_detach_flags_without_breakaway(),
+                **common,
+            )
+        # A child process now exists: nothing below may create another.
+        try:
+            returncode = proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+            raise
+        stdout_f.seek(0)
+        stdout = stdout_f.read().decode("utf-8", errors="replace")
+        stderr_f.seek(0)
+        stderr = stderr_f.read().decode("utf-8", errors="replace")
+    # Match the universal-newline behaviour of text-mode capture.
+    stdout = stdout.replace("\r\n", "\n").replace("\r", "\n")
+    stderr = stderr.replace("\r\n", "\n").replace("\r", "\n")
+    return returncode, stdout, stderr
+
+
 def _run_job_script(script_path: str) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -2197,26 +2339,33 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     try:
         from tools.environments.local import _sanitize_subprocess_env
 
-        popen_kwargs = {}
-        if sys.platform == "win32":
-            popen_kwargs = {
-                "creationflags": windows_hide_flags(),
-                "encoding": "utf-8",
-                "errors": "replace",
-            }
         env = _sanitize_subprocess_env(os.environ.copy())
         env.update(env_overlay)
-        result = subprocess.run(
-            argv,
-            capture_output=True,
-            text=True,
-            timeout=script_timeout,
-            cwd=str(path.parent),
-            env=env,
-            **popen_kwargs,
-        )
-        stdout = (result.stdout or "").strip()
-        stderr = (result.stderr or "").strip()
+        if sys.platform == "win32":
+            # Detached launch with file-backed capture so the script can
+            # survive parent/job-object teardown without losing its output
+            # sink (PR #43252). Constructor-only breakaway fallback keeps
+            # execution at-most-once. POSIX behaviour is unchanged below.
+            returncode, stdout, stderr = _run_script_windows_detached(
+                argv,
+                timeout=script_timeout,
+                cwd=str(path.parent),
+                env=env,
+            )
+        else:
+            result = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=script_timeout,
+                cwd=str(path.parent),
+                env=env,
+            )
+            returncode = result.returncode
+            stdout = result.stdout
+            stderr = result.stderr
+        stdout = (stdout or "").strip()
+        stderr = (stderr or "").strip()
 
         # Redact secrets from both stdout and stderr before any return path.
         try:
@@ -2228,8 +2377,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             stdout = "[REDACTED - redaction failed]"
             stderr = "[REDACTED - redaction failed]"
 
-        if result.returncode != 0:
-            parts = [f"Script exited with code {result.returncode}"]
+        if returncode != 0:
+            parts = [f"Script exited with code {returncode}"]
             if stderr:
                 parts.append(f"stderr:\n{stderr}")
             if stdout:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -194,22 +194,27 @@ class TestRunJobScript:
 
         captured = {}
 
-        def fake_run(argv, **kwargs):
+        def fake_popen(argv, **kwargs):
             captured["argv"] = argv
             captured["kwargs"] = kwargs
-            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+            kwargs["stdout"].write(b"ok\n")
+            return SimpleNamespace(
+                wait=lambda timeout=None: 0,
+                kill=lambda: None,
+            )
 
         monkeypatch.setattr(sched_mod.sys, "platform", "win32")
         monkeypatch.setattr(sched_mod.sys, "executable", str(venv_python))
-        monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
-        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(sched_mod, "windows_detach_flags", lambda: 0x09000208)
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", fake_popen)
 
         success, output = _run_job_script("probe.py")
 
         assert success is True
         assert output == "ok"
         assert captured["argv"] == [str(base_python), str(script.resolve())]
-        assert captured["kwargs"]["creationflags"] == 0x08000000
+        assert captured["kwargs"]["creationflags"] == 0x09000208
+        assert captured["kwargs"]["stdin"] == sched_mod.subprocess.DEVNULL
         env = captured["kwargs"]["env"]
         assert env["VIRTUAL_ENV"] == str(venv)
         assert str(site_packages) in env["PYTHONPATH"]
@@ -231,23 +236,26 @@ class TestRunJobScript:
 
         captured = {}
 
-        def fake_run(argv, **kwargs):
+        def fake_popen(argv, **kwargs):
             captured["argv"] = argv
             captured["kwargs"] = kwargs
-            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+            # Undecodable byte: the runner must decode utf-8 with
+            # errors="replace" (parity with the old encoding/errors kwargs).
+            kwargs["stdout"].write("ok \u00e9\n".encode("utf-8") + b"\xff")
+            return SimpleNamespace(
+                wait=lambda timeout=None: 0,
+                kill=lambda: None,
+            )
 
         monkeypatch.setattr(sched_mod.sys, "platform", "win32")
         monkeypatch.setattr(sched_mod.sys, "executable", str(pythonw))
-        monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
-        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", fake_popen)
 
         success, output = _run_job_script("probe.py")
 
         assert success is True
-        assert output == "ok"
+        assert output == "ok \u00e9\n\ufffd".strip()
         assert captured["argv"] == [str(python), str(script.resolve())]
-        assert captured["kwargs"]["encoding"] == "utf-8"
-        assert captured["kwargs"]["errors"] == "replace"
 
     def test_non_windows_script_preserves_default_text_decoding(self, cron_env, monkeypatch):
         from cron import scheduler as sched_mod
@@ -684,3 +692,315 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+
+
+class TestWindowsDetachedRunner:
+    """Behavioral tests for ``_run_script_windows_detached`` (PR #43252).
+
+    These launch REAL subprocesses. On POSIX the detach-flag helpers return
+    0 by design ("no-ops on non-Windows"), so the launch mechanics --
+    file-backed capture, constructor-only retry, timeout, at-most-once --
+    are exercised identically on every platform; on native Windows the real
+    creationflags are applied. Native job-object lifecycle behaviour is
+    covered separately by tests/cron/test_windows_detach_native.py.
+    """
+
+    @staticmethod
+    def _runner():
+        from cron.scheduler import _run_script_windows_detached
+        return _run_script_windows_detached
+
+    def test_captures_stdout_stderr_and_returncode(self, tmp_path):
+        script = tmp_path / "s.py"
+        script.write_text(
+            "import sys\n"
+            "print('to stdout')\n"
+            "print('to stderr', file=sys.stderr)\n"
+            "sys.exit(3)\n"
+        )
+        rc, out, err = self._runner()(
+            [sys.executable, str(script)],
+            timeout=30, cwd=str(tmp_path), env=os.environ.copy(),
+        )
+        assert rc == 3
+        assert out.strip() == "to stdout"
+        assert err.strip() == "to stderr"
+
+    def test_unicode_output_utf8(self, tmp_path):
+        script = tmp_path / "s.py"
+        script.write_text(
+            "import sys\n"
+            "sys.stdout.buffer.write('héllo 世界\\n'.encode('utf-8'))\n",
+            encoding="utf-8",
+        )
+        rc, out, _ = self._runner()(
+            [sys.executable, str(script)],
+            timeout=30, cwd=str(tmp_path), env=os.environ.copy(),
+        )
+        assert rc == 0
+        assert out.strip() == "héllo 世界"
+
+    def test_output_larger_than_pipe_buffer(self, tmp_path):
+        # 2 MiB >> any anonymous-pipe buffer. A pipe-backed capture without
+        # a live reader would deadlock or truncate; the file sink must not.
+        script = tmp_path / "s.py"
+        script.write_text(
+            "import sys\n"
+            "sys.stdout.write('x' * (2 * 1024 * 1024))\n"
+        )
+        rc, out, _ = self._runner()(
+            [sys.executable, str(script)],
+            timeout=60, cwd=str(tmp_path), env=os.environ.copy(),
+        )
+        assert rc == 0
+        assert len(out) == 2 * 1024 * 1024
+
+    def test_empty_output(self, tmp_path):
+        script = tmp_path / "s.py"
+        script.write_text("pass\n")
+        rc, out, err = self._runner()(
+            [sys.executable, str(script)],
+            timeout=30, cwd=str(tmp_path), env=os.environ.copy(),
+        )
+        assert (rc, out, err) == (0, "", "")
+
+    def test_timeout_kills_child_and_never_retries(self, tmp_path, monkeypatch):
+        import subprocess as sp
+        from cron import scheduler as sched_mod
+
+        spawn_count = {"n": 0}
+        real_popen = sp.Popen
+
+        def counting_popen(*args, **kwargs):
+            spawn_count["n"] += 1
+            return real_popen(*args, **kwargs)
+
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", counting_popen)
+
+        script = tmp_path / "slow.py"
+        script.write_text("import time; time.sleep(60)\n")
+        with pytest.raises(sp.TimeoutExpired):
+            self._runner()(
+                [sys.executable, str(script)],
+                timeout=1, cwd=str(tmp_path), env=os.environ.copy(),
+            )
+        assert spawn_count["n"] == 1
+
+    def test_breakaway_denied_retries_constructor_exactly_once(
+        self, tmp_path, monkeypatch
+    ):
+        """WinError 5 from the constructor -> one retry without breakaway,
+        with every non-flag argument identical."""
+        from cron import scheduler as sched_mod
+
+        calls = []
+
+        class _BreakawayDenied(OSError):
+            winerror = 5  # ERROR_ACCESS_DENIED, as raised by CreateProcessW
+
+        monkeypatch.setattr(sched_mod, "windows_detach_flags", lambda: 0x09000208)
+        monkeypatch.setattr(
+            sched_mod, "windows_detach_flags_without_breakaway", lambda: 0x08000208
+        )
+        monkeypatch.setattr(sched_mod, "_parent_in_job", lambda: True)
+
+        def fake_popen(argv, **kwargs):
+            calls.append((argv, kwargs))
+            if len(calls) == 1:
+                raise _BreakawayDenied(5, "Access is denied")
+            kwargs["stdout"].write(b"second attempt ran\n")
+            from types import SimpleNamespace
+            return SimpleNamespace(wait=lambda timeout=None: 0, kill=lambda: None)
+
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", fake_popen)
+
+        rc, out, _ = self._runner()(
+            ["exe", "arg"], timeout=5, cwd=str(tmp_path), env={"A": "1"},
+        )
+        assert rc == 0
+        assert out.strip() == "second attempt ran"
+        assert len(calls) == 2
+        assert calls[0][1]["creationflags"] == 0x09000208
+        assert calls[1][1]["creationflags"] == 0x08000208
+        # Everything except creationflags must be identical across attempts.
+        for key in ("stdin", "stdout", "stderr", "cwd", "env"):
+            assert calls[0][1][key] is calls[1][1][key] or (
+                calls[0][1][key] == calls[1][1][key]
+            )
+        assert calls[0][0] == calls[1][0] == ["exe", "arg"]
+
+    def test_non_breakaway_oserror_never_retries(self, tmp_path, monkeypatch):
+        from cron import scheduler as sched_mod
+
+        calls = []
+
+        def fake_popen(argv, **kwargs):
+            calls.append(argv)
+            raise FileNotFoundError(2, "No such file")
+
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", fake_popen)
+        with pytest.raises(FileNotFoundError):
+            self._runner()(
+                ["missing-exe"], timeout=5, cwd=str(tmp_path), env={},
+            )
+        assert len(calls) == 1
+
+    def test_post_spawn_oserror_never_spawns_second_child(
+        self, tmp_path, monkeypatch
+    ):
+        """The Codex D1 scenario: the child performs a real side effect,
+        then the post-spawn wait phase raises OSError. The rejected package
+        launched a second child here; the reworked runner must not."""
+        import subprocess as sp
+        from cron import scheduler as sched_mod
+
+        side_effect = tmp_path / "side_effect_count.txt"
+        script = tmp_path / "s.py"
+        script.write_text(
+            "from pathlib import Path\n"
+            f"p = Path({str(side_effect)!r})\n"
+            "n = int(p.read_text()) if p.exists() else 0\n"
+            "p.write_text(str(n + 1))\n"
+            "print('completed run', n + 1)\n"
+        )
+
+        spawn_count = {"n": 0}
+        real_popen = sp.Popen
+
+        class _FaultyWaitPopen:
+            def __init__(self, *args, **kwargs):
+                spawn_count["n"] += 1
+                self._proc = real_popen(*args, **kwargs)
+
+            def wait(self, timeout=None):
+                self._proc.wait(timeout=timeout)  # let the child finish...
+                raise OSError(22, "Invalid argument")  # ...then inject fault
+
+            def kill(self):
+                self._proc.kill()
+
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", _FaultyWaitPopen)
+
+        with pytest.raises(OSError):
+            self._runner()(
+                [sys.executable, str(script)],
+                timeout=30, cwd=str(tmp_path), env=os.environ.copy(),
+            )
+        assert spawn_count["n"] == 1
+        assert side_effect.read_text() == "1"
+
+
+    def test_access_denied_outside_job_never_retries(self, tmp_path, monkeypatch):
+        """WinError 5 when the parent is in no job object cannot be
+        breakaway denial (e.g. AV block, unexecutable file) — the runner
+        must propagate rather than retry with weaker flags."""
+        from cron import scheduler as sched_mod
+
+        calls = []
+
+        class _AccessDenied(OSError):
+            winerror = 5
+
+        monkeypatch.setattr(sched_mod, "_parent_in_job", lambda: False)
+
+        def fake_popen(argv, **kwargs):
+            calls.append(argv)
+            raise _AccessDenied(5, "Access is denied")
+
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", fake_popen)
+        with pytest.raises(OSError):
+            self._runner()(
+                ["blocked-exe"], timeout=5, cwd=str(tmp_path), env={},
+            )
+        assert len(calls) == 1
+
+    def test_dual_large_streams_no_deadlock(self, tmp_path):
+        """1 MiB on BOTH streams simultaneously; a single-threaded pipe
+        reader would deadlock, the file sinks must not."""
+        script = tmp_path / "s.py"
+        script.write_text(
+            "import sys\n"
+            "for _ in range(64):\n"
+            "    sys.stdout.write('o' * 16384)\n"
+            "    sys.stderr.write('e' * 16384)\n"
+        )
+        rc, out, err = self._runner()(
+            [sys.executable, str(script)],
+            timeout=60, cwd=str(tmp_path), env=os.environ.copy(),
+        )
+        assert rc == 0
+        assert len(out) == 64 * 16384 and set(out) == {"o"}
+        assert len(err) == 64 * 16384 and set(err) == {"e"}
+
+    def test_grandchild_holding_stdout_does_not_block_return(self, tmp_path):
+        """A script that daemonizes a worker (which inherits the output
+        handle) must return when the DIRECT child exits. Current main's
+        pipe capture blocks until pipe EOF here — a latent false-timeout
+        (and, on Windows, a post-kill communicate() hang)."""
+        import time as _time
+
+        script = tmp_path / "s.py"
+        script.write_text(
+            "import subprocess, sys\n"
+            "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])\n"
+            "print('done')\n"
+        )
+        t0 = _time.monotonic()
+        rc, out, _ = self._runner()(
+            [sys.executable, str(script)],
+            timeout=30, cwd=str(tmp_path), env=os.environ.copy(),
+        )
+        assert rc == 0
+        assert out.strip() == "done"
+        assert _time.monotonic() - t0 < 10, "returned only after grandchild exit"
+
+    def test_nul_bytes_and_invalid_utf8_do_not_crash(self, tmp_path):
+        script = tmp_path / "s.py"
+        script.write_text(
+            "import sys\n"
+            "sys.stdout.buffer.write(b'a\\x00b\\xff\\xfec\\n')\n"
+        )
+        rc, out, _ = self._runner()(
+            [sys.executable, str(script)],
+            timeout=30, cwd=str(tmp_path), env=os.environ.copy(),
+        )
+        assert rc == 0
+        assert "a\x00b" in out and "c" in out  # replaced, not raised
+
+    def test_run_job_script_routes_win32_to_detached_runner(
+        self, cron_env, monkeypatch
+    ):
+        """On win32, _run_job_script must use the detached runner and pass
+        it the sanitized environment."""
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+        from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+
+        blocked_var = sorted(_HERMES_PROVIDER_ENV_BLOCKLIST)[0]
+        monkeypatch.setenv(blocked_var, "must_not_leak")
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        captured = {}
+
+        def fake_detached(argv, *, timeout, cwd, env):
+            captured["argv"] = argv
+            captured["env"] = env
+            return 0, "ok\n", ""
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "win32")
+        monkeypatch.setattr(
+            sched_mod, "_run_script_windows_detached", fake_detached
+        )
+        # Keep interpreter resolution out of scope for this routing test.
+        monkeypatch.setattr(
+            sched_mod,
+            "_windows_cron_python_invocation",
+            lambda exe: (exe, {}),
+        )
+
+        success, output = _run_job_script("probe.py")
+        assert success is True
+        assert output == "ok"
+        assert blocked_var not in captured["env"]

--- a/tests/cron/test_windows_detach_native.py
+++ b/tests/cron/test_windows_detach_native.py
@@ -1,0 +1,251 @@
+"""Native-Windows lifecycle tests for the detached cron script runner.
+
+These tests exercise REAL Win32 job-object and handle semantics; they are
+skipped everywhere except native Windows (win32).
+
+Isolation note: ``test_breakaway_denied_inside_restrictive_job`` assigns a
+throwaway *child* python process (not the pytest process) to a restrictive
+job object, so it is safe to run in-process. No test here assigns the
+pytest process itself to a job.
+
+Covers PR #43252:
+
+* a detached, file-backed child survives the death of its launcher and
+  completes both its side effect and its output writes (the Codex D2
+  scenario that kills a pipe-backed child);
+* a restrictive job produces exactly one script execution under either
+  observed Windows behavior: constructor denial with a one-time fallback, or
+  successful creation with silent retention in the forbidding job.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="native Windows lifecycle semantics"
+)
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _wait_for(predicate, timeout=30.0, interval=0.2):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+class TestDetachedChildSurvivesParentDeath:
+    def test_output_producing_child_survives_launcher_kill(self, tmp_path):
+        """Launcher process uses _run_script_windows_detached on a child
+        that writes repeatedly (more than a pipe buffer in total) and then
+        records a durable side effect. We hard-kill the launcher mid-run.
+
+        With anonymous pipes (rejected package) the child dies on its next
+        write. With file-backed capture it must finish.
+        """
+        marker = tmp_path / "done.txt"
+        child_script = tmp_path / "child.py"
+        child_script.write_text(textwrap.dedent(f"""\
+            import sys, time
+            from pathlib import Path
+            # ~1.5 MiB in chunks, over ~6s, far beyond any pipe buffer.
+            for i in range(60):
+                sys.stdout.write("x" * 25600)
+                sys.stdout.flush()
+                time.sleep(0.1)
+            Path({str(marker)!r}).write_text("side effect completed")
+            print("child done")
+        """))
+
+        launcher = tmp_path / "launcher.py"
+        launcher.write_text(textwrap.dedent(f"""\
+            import sys
+            sys.path.insert(0, {str(Path(__file__).parent.parent.parent)!r})
+            from cron.scheduler import _run_script_windows_detached
+            import os
+            _run_script_windows_detached(
+                [sys.executable, {str(child_script)!r}],
+                timeout=120,
+                cwd={str(tmp_path)!r},
+                env=os.environ.copy(),
+            )
+        """))
+
+        proc = subprocess.Popen(
+            [sys.executable, str(launcher)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(2.0)  # child is mid-write-loop now
+        proc.kill()      # hard parent death: no cleanup, no drain
+        proc.wait()
+
+        assert _wait_for(marker.exists, timeout=30), (
+            "Detached child did not complete after launcher death — "
+            "output sink or job membership is not durable"
+        )
+        assert marker.read_text() == "side effect completed"
+
+    def test_no_temp_output_files_leak_after_parent_death(self, tmp_path):
+        """O_TEMPORARY files must self-delete once the surviving child
+        exits; parent death must not strand unredacted output on disk."""
+        temp_dir = Path(os.environ.get("TMP", os.environ.get("TEMP")))
+        before = {p.name for p in temp_dir.glob("tmp*")}
+
+        run2 = tmp_path / "run2"
+        run2.mkdir()
+        self.test_output_producing_child_survives_launcher_kill(run2)
+
+        # Give the OS a moment to finalize delete-on-close.
+        time.sleep(2.0)
+        after = {p.name for p in temp_dir.glob("tmp*")}
+        leaked = after - before
+        # Filter to files still present and non-openable-exclusively is
+        # noisy; assert no *persistent* growth instead.
+        assert len(leaked) == 0, f"Leaked temp output files: {leaked}"
+
+
+class TestBreakawayPolicy:
+    def test_restrictive_job_executes_script_once(self, tmp_path):
+        """Run a throwaway Python child inside a restrictive job.
+
+        Windows has exhibited two valid behaviors for a breakaway request
+        when some job in a nested chain forbids it:
+
+        * CreateProcessW reports WinError 5, so the runner performs its single
+          constructor fallback without CREATE_BREAKAWAY_FROM_JOB; or
+        * creation succeeds but Windows silently retains the child in the
+          forbidding job, so no fallback occurs.
+
+        Both outcomes must execute the script exactly once. This test pins the
+        public invariant rather than one OS-build-specific error mechanism.
+        """
+        probe = tmp_path / "probe_in_job.py"
+        probe.write_text(textwrap.dedent(f"""\
+            import json, subprocess, sys
+            sys.path.insert(0, {str(Path(__file__).parent.parent.parent)!r})
+            from cron import scheduler as sched_mod
+
+            calls = []
+            real_popen = subprocess.Popen
+
+            def counting_popen(*args, **kwargs):
+                calls.append(kwargs.get("creationflags", 0))
+                return real_popen(*args, **kwargs)
+
+            sched_mod.subprocess.Popen = counting_popen
+
+            import os
+            rc, out, err = sched_mod._run_script_windows_detached(
+                [sys.executable, "-c", "print('ran once')"],
+                timeout=60,
+                cwd=".",
+                env=os.environ.copy(),
+            )
+            print(json.dumps({{
+                "rc": rc,
+                "out": out.strip(),
+                "attempts": len(calls),
+                "flags": calls,
+            }}))
+        """))
+
+        harness = tmp_path / "job_harness.py"
+        harness.write_text(textwrap.dedent(f"""\
+            import ctypes, subprocess, sys
+            from ctypes import wintypes
+
+            kernel32 = ctypes.windll.kernel32
+
+            class JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+                _fields_ = [
+                    ("PerProcessUserTimeLimit", ctypes.c_int64),
+                    ("PerJobUserTimeLimit", ctypes.c_int64),
+                    ("LimitFlags", wintypes.DWORD),
+                    ("MinimumWorkingSetSize", ctypes.c_size_t),
+                    ("MaximumWorkingSetSize", ctypes.c_size_t),
+                    ("ActiveProcessLimit", wintypes.DWORD),
+                    ("Affinity", ctypes.POINTER(wintypes.ULONG)),
+                    ("PriorityClass", wintypes.DWORD),
+                    ("SchedulingClass", wintypes.DWORD),
+                ]
+
+            class IO_COUNTERS(ctypes.Structure):
+                _fields_ = [(n, ctypes.c_uint64) for n in (
+                    "ReadOperationCount", "WriteOperationCount",
+                    "OtherOperationCount", "ReadTransferCount",
+                    "WriteTransferCount", "OtherTransferCount")]
+
+            class JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+                _fields_ = [
+                    ("BasicLimitInformation", JOBOBJECT_BASIC_LIMIT_INFORMATION),
+                    ("IoInfo", IO_COUNTERS),
+                    ("ProcessMemoryLimit", ctypes.c_size_t),
+                    ("JobMemoryLimit", ctypes.c_size_t),
+                    ("PeakProcessMemoryUsed", ctypes.c_size_t),
+                    ("PeakJobMemoryUsed", ctypes.c_size_t),
+                ]
+
+            JobObjectExtendedLimitInformation = 9
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+            # Deliberately omit JOB_OBJECT_LIMIT_BREAKAWAY_OK (0x0800).
+            # Depending on Windows build and job nesting, the request may be
+            # rejected with WinError 5 or accepted with silent retention.
+
+            job = kernel32.CreateJobObjectW(None, None)
+            info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            assert kernel32.SetInformationJobObject(
+                job, JobObjectExtendedLimitInformation,
+                ctypes.byref(info), ctypes.sizeof(info))
+
+            CREATE_SUSPENDED = 0x00000004
+            proc = subprocess.Popen(
+                [sys.executable, {str(probe)!r}],
+                creationflags=CREATE_SUSPENDED,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            PROCESS_ALL_ACCESS = 0x1FFFFF
+            h = kernel32.OpenProcess(PROCESS_ALL_ACCESS, False, proc.pid)
+            assert kernel32.AssignProcessToJobObject(job, h)
+            # Resume the suspended main thread.
+            import ctypes.wintypes as wt
+            THREAD_SUSPEND_RESUME = 0x0002
+            # Use NtResumeProcess for simplicity:
+            ctypes.windll.ntdll.NtResumeProcess(h)
+            out, err = proc.communicate(timeout=120)
+            sys.stdout.write(out)
+            sys.stderr.write(err)
+            sys.exit(proc.returncode)
+        """))
+
+        result = subprocess.run(
+            [sys.executable, str(harness)],
+            capture_output=True, text=True, timeout=180,
+        )
+        assert result.returncode == 0, (
+            f"harness failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        import json
+        data = json.loads(result.stdout.strip().splitlines()[-1])
+        assert data["rc"] == 0
+        assert data["out"] == "ran once"
+        assert data["attempts"] in (1, 2), (
+            "expected one successful full-flags construction or one "
+            f"breakaway-denied fallback, got {data}"
+        )
+        assert len(data["flags"]) == data["attempts"]
+        # Every path starts with CREATE_BREAKAWAY_FROM_JOB.
+        assert data["flags"][0] & 0x01000000
+        if data["attempts"] == 2:
+            # A constructor denial may retry once, without breakaway.
+            assert not (data["flags"][1] & 0x01000000)


### PR DESCRIPTION
## Problem

On Windows, cron pre-run / `no_agent` scripts are launched with `CREATE_NO_WINDOW` only, so they remain tied to the parent's job-object lifetime. Controlled shutdown is drained elsewhere, but terminal/Desktop teardown or process death can still kill a mid-run script.

## Why the previous revision was wrong

The previous revision had three structural defects:

1. it applied a detach helper unconditionally and changed POSIX session semantics;
2. it retried the entire `subprocess.run()` lifecycle after `OSError`, so an error after child creation could execute a side-effectful script twice;
3. it kept `capture_output=True`, leaving the detached child writing to anonymous pipes whose reader died with the parent.

## Change

The Windows path now uses an explicit `Popen` helper:

- full detach flags on the primary constructor attempt;
- at most one constructor fallback, only when a parent-in-job launch reports WinError 5;
- no fallback after a `Popen` object exists;
- inherited unnamed `TemporaryFile` handles for stdout/stderr;
- `stdin=DEVNULL`;
- UTF-8 replacement decoding and newline normalization;
- unchanged sanitizer, environment overlay, timeout, redaction, and return contract;
- unchanged POSIX `subprocess.run` path with no new session behavior.

## Windows job-object behavior

Breakaway refusal is not represented identically on every Windows/job configuration.

- Some configurations report access denied during child construction. When that occurs as WinError 5 while the parent is in a job, the constructor is retried once without `CREATE_BREAKAWAY_FROM_JOB`.
- On the native Windows 11 nested-job configuration tested here, construction succeeded but Windows silently retained the child in each job that forbade breakaway. No fallback or INFO log occurs in that case.
- A child launched from a permitting nested job escaped that job and survived its teardown.

Therefore, survival is guaranteed only for teardown of jobs that permit breakaway. A child retained by a forbidding job may still be reaped when that job closes.

## Why file-backed output is necessary

Native testing reproduced the anonymous-pipe failure: quiet children survived parent death, while output-producing modes failed on their next write. The file-backed runner completed all eight tested modes with all side effects and zero leaked temp files.

The change also avoids two pipe-lifetime bugs while the parent is alive:

- a daemonized worker holding the inherited pipe can make `subprocess.run()` falsely wait until timeout;
- on Windows, timeout cleanup can wedge while `communicate()` waits on a descendant-held pipe.

Waiting on the direct process with file-backed output removes those pipe-EOF dependencies. Output written by a grandchild after the direct child exits is not collected.

## Guarantees and limitations

Guaranteed:

- at-most-once child execution per invocation;
- durable output sink across parent death;
- survival from teardown of a job that permits breakaway;
- no persistent output file after the last handle closes;
- scheduler claims prevent redispatching the occurrence solely to recover output.

Not guaranteed:

- restart recovery of orphaned output/status;
- survival from a job that forbids breakaway;
- descendant-tree termination on timeout.

## Evidence

- focused behavioral suite: 53 passed and one privilege-dependent symlink skip on native Windows; the skip reproduced on unpatched main;
- native parent-death and temp-leak tests passed;
- corrected restrictive-job test accepts both documented Windows constructor outcomes while requiring one script execution;
- native anonymous-pipe baseline reproduced the output failure;
- native file-backed matrix completed 8/8 with zero leaks;
- post-spawn fault probe reported one spawn and one side effect;
- adjacent shutdown/claim suites passed.
