### PR TITLE
fix(auxiliary): bridge runtime credentials into vision auto-detect (sibling gap of #35259)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4226,9 +4226,17 @@ def resolve_vision_provider_client(
                     main_provider,
                 )
             else:
+                # Bridge the runtime credentials recorded by set_runtime_main()
+                # into the resolver, mirroring _resolve_auto() (#35259). A
+                # custom:<name> main provider is flattened to bare "custom" with
+                # its base_url/api_key carried on the live runtime; without this
+                # bridge resolve_provider_client("custom", ...) finds no endpoint
+                # credentials and the whole vision chain returns None.
                 rpc_client, rpc_model = resolve_provider_client(
                     main_provider, vision_model,
-                    api_mode=resolved_api_mode,
+                    explicit_base_url=_RUNTIME_MAIN_BASE_URL or None,
+                    explicit_api_key=_RUNTIME_MAIN_API_KEY or None,
+                    api_mode=resolved_api_mode or (_RUNTIME_MAIN_API_MODE or None),
                     is_vision=True)
                 if rpc_client is not None:
                     logger.info(

--- a/tests/agent/test_set_runtime_main_custom_provider.py
+++ b/tests/agent/test_set_runtime_main_custom_provider.py
@@ -224,3 +224,44 @@ class TestResolveAutoCustomEndToEnd:
             assert base and base.rstrip("/") == "https://withcfg.example/v1"
         finally:
             mod.clear_runtime_main()
+
+
+class TestResolveVisionUsesRuntimeGlobals:
+    """Vision auto-detect must bridge the same runtime globals as _resolve_auto.
+
+    Regression for the sibling gap of #35259: set_runtime_main() records a
+    custom:<name> main provider as bare "custom" plus base_url/api_key, but
+    resolve_vision_provider_client()'s auto branch did not forward those
+    credentials, so vision_analyze failed with
+    "No LLM provider configured for task=vision provider=auto".
+    """
+
+    def test_vision_auto_forwards_runtime_credentials(self):
+        """The vision auto branch passes explicit_base_url/api_key/api_mode
+        from the runtime globals to resolve_provider_client."""
+        import agent.auxiliary_client as mod
+
+        mod.clear_runtime_main()
+        try:
+            mod.set_runtime_main(
+                "custom",
+                "claude-opus-4-7",
+                base_url="https://gateway.example.com/v1",
+                api_key="sk-vision-123",
+                api_mode="anthropic_messages",
+            )
+
+            with patch.object(mod, "resolve_provider_client") as mock_resolve, \
+                    patch.object(mod, "_main_model_supports_vision", return_value=True):
+                mock_resolve.return_value = (MagicMock(), "claude-opus-4-7")
+                provider, client, _model = mod.resolve_vision_provider_client(provider="auto")
+
+                assert client is not None
+                mock_resolve.assert_called_once()
+                kwargs = mock_resolve.call_args[1]
+                assert kwargs["explicit_base_url"] == "https://gateway.example.com/v1"
+                assert kwargs["explicit_api_key"] == "sk-vision-123"
+                assert kwargs["api_mode"] == "anthropic_messages"
+                assert kwargs["is_vision"] is True
+        finally:
+            mod.clear_runtime_main()


### PR DESCRIPTION
## What does this PR do?

Fixes `vision_analyze` failing with `No LLM provider configured for task=vision provider=auto` for users whose main provider is a named custom provider (`custom:<name>`), even though normal chat and every other auxiliary task work.

This is the **sibling gap of #35259**. That PR taught `set_runtime_main()` to record `base_url`/`api_key`/`api_mode` and bridged them in `_resolve_auto()` — but the parallel vision path in `resolve_vision_provider_client()` was never updated, so vision alone still loses the credentials.

## Related Issue

Fixes #43251

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — in the `resolve_vision_provider_client()` `auto` branch, forward `_RUNTIME_MAIN_BASE_URL` / `_RUNTIME_MAIN_API_KEY` / `_RUNTIME_MAIN_API_MODE` into the `resolve_provider_client()` call as `explicit_base_url` / `explicit_api_key` / `api_mode`, mirroring the existing `_resolve_auto()` bridge.
- `tests/agent/test_set_runtime_main_custom_provider.py` — add `TestResolveVisionUsesRuntimeGlobals::test_vision_auto_forwards_runtime_credentials` asserting the vision auto path forwards the runtime credentials.

## Root Cause

For a `custom:<name>` provider, the agent resolver flattens `agent.provider` to bare `"custom"` and carries the endpoint credentials separately. Each turn `turn_context.py` calls `set_runtime_main("custom", model, base_url=..., api_key=..., api_mode=...)`, so `_RUNTIME_MAIN_PROVIDER == "custom"` with the credentials in `_RUNTIME_MAIN_BASE_URL` / `_RUNTIME_MAIN_API_KEY`.

- Non-vision aux → `_resolve_auto()` bridges those globals (added by #35259) → works.
- Vision → `resolve_vision_provider_client(provider="auto")` reads `main_provider = "custom"` and called `resolve_provider_client("custom", ...)` **without** `explicit_base_url`/`explicit_api_key`. The anonymous-custom branch then finds no credentials, logs `custom/main requested but no endpoint credentials found`, and the chain returns `None`.

## How to Test

Reproduced on v0.16.0 with a `custom:garena-gateway-anthropic` main provider (`api_mode: anthropic_messages`, key via `key_env`):

```python
from agent.auxiliary_client import resolve_vision_provider_client, set_runtime_main
set_runtime_main("custom", "claude-opus-4-7",
                 base_url="https://<gateway>/...",
                 api_key="<key>", api_mode="anthropic_messages")
prov, client, model = resolve_vision_provider_client(provider="auto")
# before: client is None  →  "No LLM provider configured for task=vision"
# after:  client is AnthropicAuxiliaryClient
```

Tests:

```
pytest tests/agent/test_set_runtime_main_custom_provider.py -q -o 'addopts='   # 8 passed
pytest tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_main_first.py \
       tests/agent/test_auxiliary_named_custom_providers.py tests/tools/test_vision_tools.py -q -o 'addopts='   # 335 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(auxiliary): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Python 3.11), v0.16.0

### Documentation & Housekeeping

- [x] Documentation update — N/A (internal routing fix)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact — N/A (pure Python, no platform primitives)
- [x] Tool descriptions/schemas — N/A (no tool behavior change)
