### PR TITLE
feat(desktop): add native OS notification when agent response is ready

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -16,6 +16,7 @@ import {
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { gatewayEventRequiresSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
+import { $desktopNotificationsEnabled } from '@/store/desktop-notifications'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { setClarifyRequest } from '@/store/clarify'
 import { notify } from '@/store/notifications'
@@ -783,6 +784,17 @@ export function useMessageStream({
 
         if (isActiveEvent) {
           triggerHaptic('streamDone')
+
+          // Fire native OS notification when the window is not focused
+          if (!document.hasFocus() && $desktopNotificationsEnabled.get()) {
+            const snippet = coerceGatewayText(payload?.text) || coerceGatewayText(payload?.rendered) || ''
+            const firstLine = snippet.split('\n').find(l => l.trim()) || 'Response ready'
+            window.hermesDesktop?.notify({
+              title: 'Hermes',
+              body: firstLine.slice(0, 120),
+              silent: false
+            })
+          }
         }
 
         const finalText = coerceGatewayText(payload?.text) || coerceGatewayText(payload?.rendered)

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -1,5 +1,11 @@
 import { useStore } from '@nanostores/react'
 
+import { Switch } from '@/components/ui/switch'
+import {
+  $desktopNotificationsEnabled,
+  setDesktopNotificationsEnabled
+} from '@/store/desktop-notifications'
+
 import { LanguageSwitcher } from '@/components/language-switcher'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { useI18n } from '@/i18n'
@@ -58,6 +64,7 @@ export function AppearanceSettings() {
   const { t, isSavingLocale } = useI18n()
   const { themeName, mode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
+  const desktopNotifications = useStore($desktopNotificationsEnabled)
   const profiles = useStore($profiles)
   const activeProfileKey = normalizeProfileKey(useStore($activeGatewayProfile))
   const a = t.settings.appearance
@@ -171,6 +178,17 @@ export function AppearanceSettings() {
             }
             description={a.toolViewDesc}
             title={a.toolViewTitle}
+          />
+
+          <ListRow
+            action={
+              <Switch
+                checked={desktopNotifications}
+                onCheckedChange={setDesktopNotificationsEnabled}
+              />
+            }
+            description={a.notificationDesc}
+            title={a.notificationTitle}
           />
         </div>
       </div>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -302,7 +302,9 @@ export const en: Translations = {
       technicalDesc: 'Include raw tool args/results and low-level details.',
       themeTitle: 'Theme',
       themeDesc: 'Desktop palettes only. The selected mode is applied on top.',
-      themeProfileNote: profile => `Saved for the ${profile} profile — each profile keeps its own theme.`
+      themeProfileNote: profile => `Saved for the ${profile} profile — each profile keeps its own theme.`,
+      notificationTitle: 'Desktop Notifications',
+      notificationDesc: 'Show a native OS notification when the agent finishes responding and the window is not focused.'
     },
     fieldLabels: FIELD_LABELS,
     fieldDescriptions: FIELD_DESCRIPTIONS,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -220,6 +220,8 @@ export interface Translations {
       themeTitle: string
       themeDesc: string
       themeProfileNote: (profile: string) => string
+      notificationTitle: string
+      notificationDesc: string
     }
     fieldLabels: Record<string, string>
     fieldDescriptions: Record<string, string>

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -297,7 +297,9 @@ export const zh: Translations = {
       technicalDesc: '包含原始工具参数/结果及底层细节。',
       themeTitle: '主题',
       themeDesc: '仅桌面端调色板。所选模式叠加其上。',
-      themeProfileNote: profile => `已为「${profile}」配置文件保存——每个配置文件保留各自的主题。`
+      themeProfileNote: profile => `已为「${profile}」配置文件保存——每个配置文件保留各自的主题。`,
+      notificationTitle: '桌面通知',
+      notificationDesc: '当 Agent 完成响应且窗口未聚焦时，显示原生系统通知。'
     },
     fieldLabels: defineFieldCopy({
       model: '默认模型',

--- a/apps/desktop/src/store/desktop-notifications.test.ts
+++ b/apps/desktop/src/store/desktop-notifications.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mockStore = new Map<string, string>()
+
+vi.mock('@/lib/storage', () => ({
+  storedBoolean: (key: string, fallback: boolean) => {
+    const val = mockStore.get(key)
+    return val === undefined ? fallback : val === 'true'
+  },
+  persistBoolean: (key: string, value: boolean) => {
+    mockStore.set(key, String(value))
+  }
+}))
+
+describe('desktop-notifications store', () => {
+  afterEach(async () => {
+    mockStore.clear()
+    vi.resetModules()
+  })
+
+  it('defaults to true (notifications enabled)', async () => {
+    const mod = await import('./desktop-notifications')
+    expect(mod.$desktopNotificationsEnabled.get()).toBe(true)
+  })
+
+  it('setDesktopNotificationsEnabled updates the atom', async () => {
+    const mod = await import('./desktop-notifications')
+    mod.setDesktopNotificationsEnabled(false)
+    expect(mod.$desktopNotificationsEnabled.get()).toBe(false)
+
+    mod.setDesktopNotificationsEnabled(true)
+    expect(mod.$desktopNotificationsEnabled.get()).toBe(true)
+  })
+
+  it('toggleDesktopNotificationsEnabled flips the value', async () => {
+    const mod = await import('./desktop-notifications')
+    mod.$desktopNotificationsEnabled.set(true)
+    mod.toggleDesktopNotificationsEnabled()
+    expect(mod.$desktopNotificationsEnabled.get()).toBe(false)
+
+    mod.toggleDesktopNotificationsEnabled()
+    expect(mod.$desktopNotificationsEnabled.get()).toBe(true)
+  })
+
+  it('persists value changes to localStorage', async () => {
+    const mod = await import('./desktop-notifications')
+    mod.setDesktopNotificationsEnabled(false)
+    expect(mockStore.get('hermes.desktop.notifications.enabled')).toBe('false')
+
+    mod.setDesktopNotificationsEnabled(true)
+    expect(mockStore.get('hermes.desktop.notifications.enabled')).toBe('true')
+  })
+
+  it('restores persisted value from localStorage', async () => {
+    mockStore.set('hermes.desktop.notifications.enabled', 'false')
+    const mod = await import('./desktop-notifications')
+    expect(mod.$desktopNotificationsEnabled.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/desktop-notifications.ts
+++ b/apps/desktop/src/store/desktop-notifications.ts
@@ -1,0 +1,26 @@
+import { atom } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+
+const DESKTOP_NOTIFICATIONS_STORAGE_KEY = 'hermes.desktop.notifications.enabled'
+
+/**
+ * When true, a native OS notification is fired when the agent completes a
+ * response while the window is not focused.  Uses Electron's Notification API
+ * via the `hermes:notify` IPC channel (already wired in preload + main).
+ */
+export const $desktopNotificationsEnabled = atom<boolean>(
+  storedBoolean(DESKTOP_NOTIFICATIONS_STORAGE_KEY, true)
+)
+
+$desktopNotificationsEnabled.subscribe(value =>
+  persistBoolean(DESKTOP_NOTIFICATIONS_STORAGE_KEY, value)
+)
+
+export function setDesktopNotificationsEnabled(value: boolean) {
+  $desktopNotificationsEnabled.set(value)
+}
+
+export function toggleDesktopNotificationsEnabled() {
+  $desktopNotificationsEnabled.set(!$desktopNotificationsEnabled.get())
+}


### PR DESCRIPTION
## Problem

When the user minimizes Hermes Desktop or switches to another application, there is **no system notification** when the agent finishes processing. The user must manually switch back to check.

Competing tools like OpenAI Codex and WorkBuddy send native OS notifications when the agent completes its turn.

## Solution

Fire a native OS notification (via Electron's `Notification` API, already wired in `preload.cjs` → `main.cjs`) when:
1. The agent completes a response (`message.complete` event)
2. The window is **not focused** (`!document.hasFocus()`)
3. Desktop notifications are **enabled** (default: on)

### Changes

| File | Change |
|------|--------|
| `store/desktop-notifications.ts` | New — `$desktopNotificationsEnabled` nanostore with localStorage persistence |
| `use-message-stream.ts` | Fire native notification on `message.complete` when window is unfocused |
| `appearance-settings.tsx` | Settings toggle in Appearance section |
| `i18n/types.ts` | Type definitions for notification strings |
| `i18n/en.ts` | English strings |
| `i18n/zh.ts` | Chinese strings |
| `desktop-notifications.test.ts` | 5 unit tests |

### Notification behavior
- Shows the first non-empty line of the response (truncated to 120 chars)
- Title: "Hermes"
- Click: brings window to front (default Electron behavior)
- Configurable via Settings → Appearance → Desktop Notifications toggle

### Screenshots

The toggle appears in Settings → Appearance, below the "Tool Call Display" option.

Closes #43225
