### PR TITLE
fix(cli): check both venv and .venv directories in _venv_scripts_dir()

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6430,11 +6430,13 @@ def _is_windows() -> bool:
 
 def _venv_scripts_dir() -> Path | None:
     """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
-    if not venv_dir.is_dir():
-        return None
-    scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
-    return scripts if scripts.is_dir() else None
+    for venv_name in ("venv", ".venv"):
+        venv_dir = PROJECT_ROOT / venv_name
+        if venv_dir.is_dir():
+            scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
+            if scripts.is_dir():
+                return scripts
+    return None
 
 
 def _hermes_exe_shims(scripts_dir: Path) -> list[Path]:

--- a/tests/hermes_cli/test_venv_scripts_dir.py
+++ b/tests/hermes_cli/test_venv_scripts_dir.py
@@ -1,0 +1,82 @@
+"""Tests for _venv_scripts_dir() — verifying it discovers both 'venv' and '.venv'."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import hermes_cli.main as cli_main
+
+
+class TestVenvScriptsDir:
+    """_venv_scripts_dir must find venv scripts regardless of directory name."""
+
+    @staticmethod
+    def _run(tmp_path: Path, venv_name: str, *, is_windows: bool = False):
+        """Create a fake venv layout and run _venv_scripts_dir."""
+        venv_dir = tmp_path / venv_name
+        subdir = "Scripts" if is_windows else "bin"
+        scripts = venv_dir / subdir
+        scripts.mkdir(parents=True, exist_ok=True)
+
+        with patch.object(cli_main, "PROJECT_ROOT", tmp_path), \
+             patch.object(cli_main, "_is_windows", return_value=is_windows):
+            return cli_main._venv_scripts_dir()
+
+    def test_finds_venv(self, tmp_path: Path):
+        result = self._run(tmp_path, "venv")
+        assert result == tmp_path / "venv" / "bin"
+
+    def test_finds_dotvenv(self, tmp_path: Path):
+        result = self._run(tmp_path, ".venv")
+        assert result == tmp_path / ".venv" / "bin"
+
+    def test_venv_takes_precedence_over_dotvenv(self, tmp_path: Path):
+        """When both exist, 'venv' should be preferred (backwards compat)."""
+        self._run(tmp_path, "venv")
+        self._run(tmp_path, ".venv")
+        result = self._run(tmp_path, "venv")  # both exist now
+        assert result == tmp_path / "venv" / "bin"
+
+    def test_returns_none_when_neither_exists(self, tmp_path: Path):
+        with patch.object(cli_main, "PROJECT_ROOT", tmp_path), \
+             patch.object(cli_main, "_is_windows", return_value=False):
+            assert cli_main._venv_scripts_dir() is None
+
+    def test_windows_scripts_dir(self, tmp_path: Path):
+        result = self._run(tmp_path, ".venv", is_windows=True)
+        assert result == tmp_path / ".venv" / "Scripts"
+
+    def test_venv_without_bin_scripts_returns_none(self, tmp_path: Path):
+        """venv dir exists but no bin/Scripts subdir → try .venv, then None."""
+        venv_dir = tmp_path / "venv"
+        venv_dir.mkdir()
+        # No bin/ subdir
+
+        with patch.object(cli_main, "PROJECT_ROOT", tmp_path), \
+             patch.object(cli_main, "_is_windows", return_value=False):
+            assert cli_main._venv_scripts_dir() is None
+
+    def test_dotvenv_without_bin_scripts_returns_none(self, tmp_path: Path):
+        """Only .venv exists but no bin/ subdir → None."""
+        venv_dir = tmp_path / ".venv"
+        venv_dir.mkdir()
+        # No bin/ subdir
+
+        with patch.object(cli_main, "PROJECT_ROOT", tmp_path), \
+             patch.object(cli_main, "_is_windows", return_value=False):
+            assert cli_main._venv_scripts_dir() is None
+
+    def test_venv_no_scripts_dotvenv_has_scripts(self, tmp_path: Path):
+        """venv exists but has no bin/; .venv has bin/ → returns .venv/bin."""
+        # venv without bin
+        (tmp_path / "venv").mkdir()
+        # .venv with bin
+        (tmp_path / ".venv" / "bin").mkdir(parents=True)
+
+        with patch.object(cli_main, "PROJECT_ROOT", tmp_path), \
+             patch.object(cli_main, "_is_windows", return_value=False):
+            result = cli_main._venv_scripts_dir()
+        assert result == tmp_path / ".venv" / "bin"


### PR DESCRIPTION
## What does this PR do?

Fixes `_venv_scripts_dir()` to check both `venv` and `.venv` directories, so `hermes update` and related commands work correctly when users have `.venv` as their virtual environment directory (the default for `uv`, `python -m venv`, and many modern Python tools).

## Related Issue

Fixes #43250

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: `_venv_scripts_dir()` now iterates over `("venv", ".venv")` with `venv` taking precedence for backwards compatibility. Previously only checked `venv`, causing `hermes update` to fail on Windows (and any platform) when `.venv` was used.
- `tests/hermes_cli/test_venv_scripts_dir.py`: 8 tests covering both directory names, precedence, Windows `Scripts/` vs POSIX `bin/`, missing subdirs, and fallback behavior.

## How to Test

1. Run `pytest tests/hermes_cli/test_venv_scripts_dir.py -v` — all 8 tests should pass
2. On a project using `.venv`: `hermes update` should no longer crash with missing scripts dir
3. On a project using `venv`: behavior is unchanged (backwards compatible)
4. On a project with both `venv` and `.venv`: `venv` takes precedence

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_venv_scripts_dir()` in `hermes_cli/main.py` (callers: 4 in main.py, 2 in tests)
- Blast radius: LOW — only affects venv script directory discovery on Windows during `hermes update`
- Related patterns: `_hermes_exe_shims()`, `_quarantine_running_hermes_exe()` — all called with `_venv_scripts_dir()` result
