### PR TITLE
Fix/terminal handler args normalization

### DIFF
--- a/tests/tools/test_terminal_none_command_guard.py
+++ b/tests/tools/test_terminal_none_command_guard.py
@@ -1,8 +1,13 @@
 """Regression tests for invalid/None terminal command handling."""
 
 import json
+from unittest.mock import patch
 
-from tools.terminal_tool import _transform_sudo_command, terminal_tool
+from tools.terminal_tool import (
+    _handle_terminal,
+    _transform_sudo_command,
+    terminal_tool,
+)
 
 
 def test_transform_sudo_command_none_returns_cleanly():
@@ -19,3 +24,93 @@ def test_terminal_tool_none_command_returns_clean_error():
     assert result["status"] == "error"
     assert "expected string" in result["error"].lower()
     assert "nonetype" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# _handle_terminal argument normalization + missing-command validation
+#
+# The production failure path is args={} (empty/absent tool arguments
+# normalized upstream to "{}"), which must produce a structured, actionable
+# error WITHOUT ever calling terminal_tool with command=None.
+# ---------------------------------------------------------------------------
+
+
+def _assert_missing_command_error(raw_result):
+    result = json.loads(raw_result)
+    assert result["status"] == "error"
+    assert result["exit_code"] == -1
+    assert "command" in result["error"].lower()
+    return result
+
+
+def test_handle_terminal_empty_dict_returns_structured_error():
+    """args={} (the reported production path) → structured error, no dispatch."""
+    with patch("tools.terminal_tool.terminal_tool") as mock_tt:
+        _assert_missing_command_error(_handle_terminal({}))
+    mock_tt.assert_not_called()
+
+
+def test_handle_terminal_command_none_returns_structured_error():
+    with patch("tools.terminal_tool.terminal_tool") as mock_tt:
+        _assert_missing_command_error(_handle_terminal({"command": None}))
+    mock_tt.assert_not_called()
+
+
+def test_handle_terminal_command_empty_string_returns_structured_error():
+    with patch("tools.terminal_tool.terminal_tool") as mock_tt:
+        _assert_missing_command_error(_handle_terminal({"command": ""}))
+        _assert_missing_command_error(_handle_terminal({"command": "   "}))
+    mock_tt.assert_not_called()
+
+
+def test_handle_terminal_none_args_returns_structured_error():
+    """Defensive: args=None normalizes to {} → missing-command error."""
+    with patch("tools.terminal_tool.terminal_tool") as mock_tt:
+        _assert_missing_command_error(_handle_terminal(None))
+    mock_tt.assert_not_called()
+
+
+def test_handle_terminal_invalid_type_args_returns_structured_error():
+    with patch("tools.terminal_tool.terminal_tool") as mock_tt:
+        result = json.loads(_handle_terminal(12345))  # type: ignore[arg-type]
+    assert result["status"] == "error"
+    assert "expected dict or string" in result["error"].lower()
+    mock_tt.assert_not_called()
+
+
+def test_handle_terminal_valid_dict_command_dispatches():
+    with patch("tools.terminal_tool.terminal_tool", return_value='{"ok":true}') as mock_tt:
+        _handle_terminal({"command": "echo ok"})
+    _, kwargs = mock_tt.call_args
+    assert kwargs["command"] == "echo ok"
+
+
+def test_handle_terminal_bare_string_command_dispatches():
+    """args is a bare string → wrapped into {"command": str} and dispatched."""
+    with patch("tools.terminal_tool.terminal_tool", return_value='{"ok":true}') as mock_tt:
+        _handle_terminal("echo ok")
+    _, kwargs = mock_tt.call_args
+    assert kwargs["command"] == "echo ok"
+
+
+def test_handle_terminal_task_id_only_from_dispatch_kwargs():
+    """task_id comes from the trusted dispatch kwarg, NOT from model args."""
+    with patch("tools.terminal_tool.terminal_tool", return_value='{"ok":true}') as mock_tt:
+        _handle_terminal({"command": "echo ok"}, task_id="trusted-task")
+    _, kwargs = mock_tt.call_args
+    assert kwargs["task_id"] == "trusted-task"
+
+
+def test_handle_terminal_ignores_model_supplied_task_id():
+    """A model-supplied task_id in args must NOT influence isolation."""
+    with patch("tools.terminal_tool.terminal_tool", return_value='{"ok":true}') as mock_tt:
+        _handle_terminal({"command": "echo ok", "task_id": "evil"})
+    _, kwargs = mock_tt.call_args
+    assert kwargs["task_id"] is None
+
+    with patch("tools.terminal_tool.terminal_tool", return_value='{"ok":true}') as mock_tt:
+        _handle_terminal(
+            {"command": "echo ok", "task_id": "evil"}, task_id="trusted-task"
+        )
+    _, kwargs = mock_tt.call_args
+    assert kwargs["task_id"] == "trusted-task"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2628,16 +2628,40 @@ TERMINAL_SCHEMA = {
 }
 
 
-def _handle_terminal(args, **kw):
+def _handle_terminal(args=None, **kw):
+    """Normalize terminal tool arguments before dispatching to terminal_tool."""
+    if isinstance(args, str):
+        args = {"command": args}
+    elif args is None:
+        args = {}
+    elif not isinstance(args, dict):
+        return json.dumps({
+            "output": "",
+            "exit_code": -1,
+            "error": (
+                "Invalid terminal args: expected dict or string, "
+                f"got {type(args).__name__}"
+            ),
+            "status": "error",
+        }, ensure_ascii=False)
+
+    command = args.get("command") or kw.get("command")
+
     return terminal_tool(
-        command=args.get("command"),
-        background=args.get("background", False),
-        timeout=args.get("timeout"),
-        task_id=kw.get("task_id"),
-        workdir=args.get("workdir"),
-        pty=args.get("pty", False),
-        notify_on_complete=args.get("notify_on_complete", False),
-        watch_patterns=args.get("watch_patterns"),
+        command=command,
+        background=args.get("background", kw.get("background", False)),
+        timeout=args.get("timeout", kw.get("timeout")),
+        task_id=kw.get("task_id", args.get("task_id")),
+        workdir=args.get("workdir", kw.get("workdir")),
+        pty=args.get("pty", kw.get("pty", False)),
+        notify_on_complete=args.get(
+            "notify_on_complete",
+            kw.get("notify_on_complete", False),
+        ),
+        watch_patterns=args.get(
+            "watch_patterns",
+            kw.get("watch_patterns"),
+        ),
     )
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2629,7 +2629,21 @@ TERMINAL_SCHEMA = {
 
 
 def _handle_terminal(args=None, **kw):
-    """Normalize terminal tool arguments before dispatching to terminal_tool."""
+    """Normalize terminal tool arguments before dispatching to terminal_tool.
+
+    Defensively coerces the argument shape (None / bare string / non-dict) and
+    then enforces the schema-``required`` ``command`` field, which is otherwise
+    never validated on the dispatch path. A terminal call arriving with empty
+    or absent arguments is normalized upstream to ``{}`` (see
+    ``conversation_loop`` empty-args handling and ``handle_function_call``
+    non-dict coercion), which previously reached ``terminal_tool`` as
+    ``command=None`` and surfaced the cryptic ``expected string, got NoneType``
+    error. We return an explicit, model-actionable error here instead.
+
+    Execution-control identity (``task_id``) is read ONLY from the trusted
+    dispatch kwargs, never from model-supplied args — ``task_id`` selects the
+    container/sandbox isolation key and must not be influenced by tool input.
+    """
     if isinstance(args, str):
         args = {"command": args}
     elif args is None:
@@ -2645,23 +2659,27 @@ def _handle_terminal(args=None, **kw):
             "status": "error",
         }, ensure_ascii=False)
 
-    command = args.get("command") or kw.get("command")
+    command = args.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return json.dumps({
+            "output": "",
+            "exit_code": -1,
+            "error": (
+                "terminal: missing required 'command' string argument. "
+                "Provide a non-empty shell command to run."
+            ),
+            "status": "error",
+        }, ensure_ascii=False)
 
     return terminal_tool(
         command=command,
-        background=args.get("background", kw.get("background", False)),
-        timeout=args.get("timeout", kw.get("timeout")),
-        task_id=kw.get("task_id", args.get("task_id")),
-        workdir=args.get("workdir", kw.get("workdir")),
-        pty=args.get("pty", kw.get("pty", False)),
-        notify_on_complete=args.get(
-            "notify_on_complete",
-            kw.get("notify_on_complete", False),
-        ),
-        watch_patterns=args.get(
-            "watch_patterns",
-            kw.get("watch_patterns"),
-        ),
+        background=args.get("background", False),
+        timeout=args.get("timeout"),
+        task_id=kw.get("task_id"),
+        workdir=args.get("workdir"),
+        pty=args.get("pty", False),
+        notify_on_complete=args.get("notify_on_complete", False),
+        watch_patterns=args.get("watch_patterns"),
     )
 
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

