### PR TITLE
fix(gateway): prefer legacy `launchctl load` over detached fallback on macOS 26

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3102,6 +3102,49 @@ def _launchctl_domain_unsupported(returncode: int) -> bool:
     return returncode in _LAUNCHCTL_DOMAIN_UNSUPPORTED_CODES
 
 
+def _launchctl_load_legacy(plist_path: "Path") -> bool:
+    """Try legacy `launchctl load` as a fallback when the modern bootstrap API fails.
+
+    On macOS 26 (Tahoe/Darwin 25.x), `launchctl bootstrap user/<uid>` returns
+    exit 5 even though `launchctl load` still works and provides full launchd
+    management (auto-start at login, KeepAlive respawn). Returns True on success.
+    """
+    try:
+        subprocess.run(
+            ["launchctl", "load", str(plist_path)],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _run_launchctl(args: list[str], *, timeout: float) -> "subprocess.CompletedProcess":
+    """Run a launchctl subcommand with stderr captured.
+
+    launchctl writes alarming diagnostics to stderr (e.g. "Bootstrap failed: 5:
+    Input/output error", "Could not find service ...") even for conditions we
+    recover from via the legacy-load / detached fallbacks. Capturing keeps the
+    CLI output clean; genuine failures re-surface the captured stderr through
+    `_launchctl_failed` before propagating.
+    """
+    return subprocess.run(
+        args, check=True, capture_output=True, text=True, timeout=timeout
+    )
+
+
+def _launchctl_failed(
+    exc: subprocess.CalledProcessError,
+) -> subprocess.CalledProcessError:
+    """Echo a captured launchctl failure's stderr before the error propagates."""
+    err = (exc.stderr or "").strip()
+    if err:
+        print(err, file=sys.stderr)
+    return exc
+
+
 def _gateway_run_command() -> list[str]:
     """Build the `python -m hermes_cli.main [--profile X] gateway run --replace` argv.
 
@@ -3334,16 +3377,16 @@ def launchd_install(force: bool = False):
     plist_path.write_text(generate_launchd_plist())
 
     try:
-        subprocess.run(
+        _run_launchctl(
             ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-            check=True,
             timeout=30,
         )
     except subprocess.CalledProcessError as e:
         if not _launchctl_domain_unsupported(e.returncode):
-            raise
-        _launchd_fallback_to_detached(f"launchctl bootstrap exit {e.returncode}")
-        return
+            raise _launchctl_failed(e)
+        if not _launchctl_load_legacy(plist_path):
+            _launchd_fallback_to_detached(f"launchctl bootstrap exit {e.returncode}")
+            return
 
     print()
     print("✓ Service installed and loaded!")
@@ -3381,54 +3424,51 @@ def launchd_start():
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
         try:
-            subprocess.run(
+            _run_launchctl(
                 ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-                check=True,
                 timeout=30,
             )
-            subprocess.run(
+            _run_launchctl(
                 ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
-                check=True,
                 timeout=30,
             )
         except subprocess.CalledProcessError as e:
             if not _launchctl_domain_unsupported(e.returncode):
-                raise
-            _launchd_fallback_to_detached(f"launchctl exit {e.returncode}")
-            return
+                raise _launchctl_failed(e)
+            if not _launchctl_load_legacy(plist_path):
+                _launchd_fallback_to_detached(f"launchctl exit {e.returncode}")
+                return
         print("✓ Service started")
         return
 
     refresh_launchd_plist_if_needed()
     try:
-        subprocess.run(
+        _run_launchctl(
             ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
-            check=True,
             timeout=30,
         )
     except subprocess.CalledProcessError as e:
         if not _launchd_error_indicates_unloaded(e):
-            raise
+            raise _launchctl_failed(e)
         # Job not loaded in this domain — re-bootstrap the plist and retry.
         print("↻ launchd job was unloaded; reloading service definition")
         try:
-            subprocess.run(
+            _run_launchctl(
                 ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-                check=True,
                 timeout=30,
             )
-            subprocess.run(
+            _run_launchctl(
                 ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
-                check=True,
                 timeout=30,
             )
         except subprocess.CalledProcessError as e2:
             # Even a fresh bootstrap can't manage the domain on this host —
-            # degrade to a detached background process (issue #23387).
+            # try legacy `launchctl load` before degrading to a detached process.
             if not _launchctl_domain_unsupported(e2.returncode):
-                raise
-            _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
-            return
+                raise _launchctl_failed(e2)
+            if not _launchctl_load_legacy(plist_path):
+                _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
+                return
     print("✓ Service started")
 
 
@@ -3537,32 +3577,36 @@ def launchd_restart():
                     print(
                         f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
                     )
-        subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+        _run_launchctl(["launchctl", "kickstart", "-k", target], timeout=90)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:
         if not _launchd_error_indicates_unloaded(e):
             # Not a "job unloaded" code. If the domain is fundamentally
-            # unmanageable (error 5), degrade to detached; the old process was
-            # already drained/terminated above. Otherwise re-raise.
+            # unmanageable (error 5), try the legacy load path before degrading
+            # to detached; the old process was already drained/terminated above.
             if _launchctl_domain_unsupported(e.returncode):
+                plist_path_k = get_launchd_plist_path()
+                if _launchctl_load_legacy(plist_path_k):
+                    print("✓ Service restarted")
+                    return
                 _launchd_fallback_to_detached(f"launchctl kickstart exit {e.returncode}")
                 return
-            raise
+            raise _launchctl_failed(e)
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
         try:
-            subprocess.run(
+            _run_launchctl(
                 ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-                check=True,
                 timeout=30,
             )
-            subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
+            _run_launchctl(["launchctl", "kickstart", target], timeout=30)
         except subprocess.CalledProcessError as e2:
             if not _launchctl_domain_unsupported(e2.returncode):
-                raise
-            _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
-            return
+                raise _launchctl_failed(e2)
+            if not _launchctl_load_legacy(plist_path):
+                _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
+                return
         print("✓ Service restarted")
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -743,6 +743,11 @@ class TestLaunchdServiceRecovery:
                 raise gateway_cli.subprocess.CalledProcessError(
                     5, cmd, stderr="Input/output error"
                 )
+            if cmd[:2] == ["launchctl", "load"]:
+                # Legacy load also fails → only then degrade to detached.
+                raise gateway_cli.subprocess.CalledProcessError(
+                    1, cmd, stderr="load failed"
+                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
@@ -766,6 +771,11 @@ class TestLaunchdServiceRecovery:
             if cmd[:2] == ["launchctl", "bootstrap"]:
                 raise gateway_cli.subprocess.CalledProcessError(
                     5, cmd, stderr="Input/output error"
+                )
+            if cmd[:2] == ["launchctl", "load"]:
+                # Legacy load also fails → only then degrade to detached.
+                raise gateway_cli.subprocess.CalledProcessError(
+                    1, cmd, stderr="load failed"
                 )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -796,6 +806,11 @@ class TestLaunchdServiceRecovery:
                 raise gateway_cli.subprocess.CalledProcessError(
                     5, cmd, stderr="Input/output error"
                 )
+            if cmd[:2] == ["launchctl", "load"]:
+                # Legacy load also fails → only then degrade to detached.
+                raise gateway_cli.subprocess.CalledProcessError(
+                    1, cmd, stderr="load failed"
+                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
@@ -808,6 +823,120 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_restart()
 
         assert spawned == [True]
+
+    def test_launchd_install_uses_legacy_load_when_bootstrap_unsupported(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """macOS 26: bootstrap exit 5 should recover via `launchctl load`, not detached.
+
+        On macOS 26 (Tahoe) `launchctl bootstrap user/<uid>` returns 5 even
+        though the legacy `launchctl load` still works and keeps full launchd
+        management (auto-start at login, KeepAlive respawn). Prefer it over the
+        unmanaged detached process.
+        """
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd and cmd[0] == "launchctl":
+                calls.append(cmd)
+            if cmd[:2] == ["launchctl", "bootstrap"]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    5, cmd, stderr="Input/output error"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        spawned = []
+        monkeypatch.setattr(
+            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
+        )
+
+        gateway_cli.launchd_install(force=True)
+
+        assert spawned == []
+        assert ["launchctl", "load", str(plist_path)] in calls
+        assert "Service installed and loaded" in capsys.readouterr().out
+
+    def test_launchd_start_uses_legacy_load_when_rebootstrap_unsupported(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """macOS 26: when the job is unloaded and bootstrap returns 5, load it."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_if_needed", lambda: False)
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd and cmd[0] == "launchctl":
+                calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", target]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    125, cmd, stderr="Domain does not support specified action"
+                )
+            if cmd[:2] == ["launchctl", "bootstrap"]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    5, cmd, stderr="Input/output error"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        spawned = []
+        monkeypatch.setattr(
+            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
+        )
+
+        gateway_cli.launchd_start()
+
+        assert spawned == []
+        assert ["launchctl", "load", str(plist_path)] in calls
+        assert "Service started" in capsys.readouterr().out
+
+    def test_launchd_restart_uses_legacy_load_on_error_5(self, tmp_path, monkeypatch, capsys):
+        """macOS 26: kickstart -k exit 5 should recover via `launchctl load`."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True
+        )
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd and cmd[0] == "launchctl":
+                calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", "-k", target]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    5, cmd, stderr="Input/output error"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        spawned = []
+        monkeypatch.setattr(
+            gateway_cli, "_spawn_detached_gateway", lambda: spawned.append(True) or True
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert spawned == []
+        assert ["launchctl", "load", str(plist_path)] in calls
+        assert "Service restarted" in capsys.readouterr().out
 
     def test_launchd_stop_tolerates_domain_unsupported_bootout(self, monkeypatch, capsys):
         """bootout exit 125 (macOS 26) must fall through to PID-based kill, not raise."""


### PR DESCRIPTION
## Problem

On macOS 26 (Tahoe / Darwin 25.x), `launchctl bootstrap user/<uid>` returns exit **5** ("Input/output error") even though the legacy `launchctl load` still works and keeps **full launchd management** — auto-start at login and `KeepAlive` respawn.

Today, when bootstrap hits exit 5/125, `hermes gateway start/restart/install` degrades straight to an **unmanaged detached background process**. The user sees:

```
$ hermes gateway restart
Could not find service "ai.hermes.gateway" in domain for uid: 501
↻ launchd job was unloaded; reloading
Bootstrap failed: 5: Input/output error
Try re-running the command as root for richer errors.
⚠ launchd cannot manage the gateway on this macOS version (launchctl exit 5).
✓ Started gateway as a background process instead
  It will NOT auto-start at login or auto-restart on crash.
```

So on every affected host the gateway silently loses auto-start and crash-restart — even though launchd *can* still manage it via `launchctl load`.

## Fix

1. **Insert a `launchctl load` attempt before the detached fallback** in all three paths (`launchd_install`, `launchd_start`, `launchd_restart`). On macOS 26 hosts the gateway stays under launchd supervision; it only degrades to detached when even the legacy load fails.

2. **Route launchctl calls through a `_run_launchctl` helper that captures stderr**, so the alarming-but-expected diagnostics launchctl emits for conditions we recover from ("Bootstrap failed: 5…", "Could not find service…") no longer leak to the terminal. Genuine failures re-surface the captured stderr via `_launchctl_failed` before propagating.

After the fix, the same command is clean and the service stays launchd-managed:

```
$ hermes gateway restart
↻ launchd job was unloaded; reloading
✓ Service restarted
```

## Notes

- `LimitLoadToSessionType: [Aqua, Background]` is **left untouched** — removing it does not affect the bootstrap-5 behavior, and it's covered by `test_launchd_plist_supports_aqua_and_background_sessions` (issue #23387).
- The detached fallback remains intact for hosts where `launchctl load` genuinely fails.

## Testing

- Updated the three existing `*_falls_back_to_detached*` tests so legacy `load` also fails, preserving detached-path coverage.
- Added three tests asserting the legacy-load recovery path is taken and no detached process is spawned (`launchd_install`, `launchd_start`, `launchd_restart`).
- `pytest tests/hermes_cli/test_gateway_service.py -k launchd` → **27 passed**.
- `ruff check` → clean.
- Verified manually on macOS 26.5.1: `hermes gateway restart` now stays launchd-managed with clean output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)