### PR TITLE
fix(cli): make _venv_scripts_dir() check .venv before venv

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6430,11 +6430,14 @@ def _is_windows() -> bool:
 
 def _venv_scripts_dir() -> Path | None:
     """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
-    if not venv_dir.is_dir():
-        return None
-    scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
-    return scripts if scripts.is_dir() else None
+    # Check .venv first (uv default), then venv (legacy/default venv)
+    for venv_name in (".venv", "venv"):
+        venv_dir = PROJECT_ROOT / venv_name
+        if venv_dir.is_dir():
+            scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
+            if scripts.is_dir():
+                return scripts
+    return None
 
 
 def _hermes_exe_shims(scripts_dir: Path) -> list[Path]:


### PR DESCRIPTION
## Summary

The `_venv_scripts_dir()` function in `hermes_cli/main.py` only checked for the `venv` directory, ignoring the `.venv` directory that `uv` creates by default (and which is the recommended default in the project's AGENTS.md).

## Changes

- Updated `_venv_scripts_dir()` to check for both `.venv` and `venv` directories
- `.venv` is checked first (uv default), then `venv` (legacy/default)
- This aligns with the pattern used elsewhere in the codebase (e.g., `doctor.py`, `gateway.py`)

## Testing

- All existing tests in `tests/hermes_cli/test_verify_core_dependencies.py` pass
- All existing tests in `tests/hermes_cli/test_update_concurrent_quarantine.py` pass
- All update-related CLI tests pass
- Manual verification confirms `.venv` takes precedence over `venv`

Fixes #43250