### PR TITLE
fix(tests): make runtime-provider resolution tests hermetic against ambient HERMES_LLM_BASE_URL

### DIFF
--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -8,6 +8,21 @@ import pytest
 from hermes_cli import runtime_provider as rp
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_ambient_env(monkeypatch):
+    """Keep these tests hermetic against the developer's real environment.
+
+    Importing ``run_agent`` (which other test modules in the same pytest
+    process legitimately do) loads the user's ``~/.hermes/.env`` into
+    ``os.environ`` as a side effect. ``HERMES_LLM_BASE_URL`` is the
+    resolver's highest-priority base-url override, so a developer machine
+    with a real local-proxy entry in ``.env`` makes dozens of these tests
+    fail depending on module import order. Clear it unconditionally; tests
+    that exercise the override set it explicitly via monkeypatch.
+    """
+    monkeypatch.delenv("HERMES_LLM_BASE_URL", raising=False)
+
+
 def _fake_invoke_jwt(ttl_seconds=3600):
     header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').decode().rstrip("=")
     payload = base64.urlsafe_b64encode(


### PR DESCRIPTION
## What
On a developer machine whose `~/.hermes/.env` contains a real `HERMES_LLM_BASE_URL` (e.g. a local proxy/router), 25 tests in `tests/hermes_cli/test_runtime_provider_resolution.py` fail whenever any test module that imports `run_agent` is collected in the same pytest invocation — importing `run_agent` loads the user's `.env` into `os.environ` as a side effect, and `HERMES_LLM_BASE_URL` is the resolver's highest-priority base-url override.

## Repro
With a real `.env` containing `HERMES_LLM_BASE_URL`:
```
pytest tests/run_agent/test_run_agent.py tests/hermes_cli/test_runtime_provider_resolution.py
```

## Fix
An autouse fixture clears the variable for this module; the tests that exercise the override behavior set it explicitly via monkeypatch. Verified 127/127 pass both clean and with a deliberately poisoned ambient environment.