### PR TITLE
fix: make macOS desktop self-update swap+relaunch fail-fast and recoverable

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3010,9 +3010,11 @@ async function applyUpdatesPosixInApp(opts: any) {
   emitUpdateProgress({ stage: 'restart', message: 'Installing the updated app and restarting…', percent: 95 })
 
   // Detached swapper: wait for THIS process to exit (so the bundle is free),
-  // ditto the rebuilt app over the running one, clear quarantine, relaunch.
+  // then atomically replace the running .app, clear quarantine, and reopen it.
+  // If the swap fails, fall back to launching the freshly rebuilt bundle
+  // directly so we do not leave the user with a dead quit.
   const swapScript = `#!/bin/bash
-set -u
+set -euo pipefail
 APP_PID=${process.pid}
 SRC=${shellQuote(rebuiltApp)}
 DST=${shellQuote(targetApp)}
@@ -3020,13 +3022,21 @@ for _ in $(seq 1 240); do
   kill -0 "$APP_PID" 2>/dev/null || break
   sleep 0.5
 done
+cleanup() { rm -rf "$DST.hermes-update-old" 2>/dev/null || true; }
+trap cleanup EXIT
 if [ "$SRC" != "$DST" ]; then
-  if /usr/bin/ditto "$SRC" "$DST.hermes-update-new"; then
-    rm -rf "$DST.hermes-update-old" 2>/dev/null || true
-    mv "$DST" "$DST.hermes-update-old" 2>/dev/null || rm -rf "$DST"
-    mv "$DST.hermes-update-new" "$DST"
-    rm -rf "$DST.hermes-update-old" 2>/dev/null || true
+  if ! /usr/bin/ditto "$SRC" "$DST.hermes-update-new"; then
+    echo "[updates] ditto failed" >&2
+    /usr/bin/open "$SRC"
+    exit 0
   fi
+  mv "$DST" "$DST.hermes-update-old" 2>/dev/null || rm -rf "$DST"
+  if ! mv "$DST.hermes-update-new" "$DST"; then
+    echo "[updates] destination replace failed" >&2
+    /usr/bin/open "$SRC"
+    exit 0
+  fi
+  rm -rf "$DST.hermes-update-old" 2>/dev/null || true
 fi
 /usr/bin/xattr -dr com.apple.quarantine "$DST" 2>/dev/null || true
 /usr/bin/open "$DST"


### PR DESCRIPTION
## Why
Revives #38410, which was closed after an old force-push left its branch without the changes the description promised. The original commit was recovered from the fork's pre-force-push branch head and rebased onto current main.

The macOS in-app updater can quit `Hermes.app` and never reinstall/reopen — matching the reported "Update now does not actually update" behavior. The detached swap script gated only `ditto` on success and fell through silently when the bundle swap failed, leaving the user on the old build (or with no app at all) after a dead quit.

## What changed
- `apps/desktop/electron/main.cjs`: the `applyUpdatesPosixInApp` swap script now runs `set -euo pipefail`, detects `ditto` and destination-replace failures immediately, cleans up the `.hermes-update-old` staging copy via an EXIT trap, and on any swap failure falls back to opening the freshly rebuilt bundle directly instead of leaving the user with a dead quit.

Unlike #38410, this does **not** touch `hermes_state.py`: the `PRAGMA busy_timeout = 5000` half of that PR is superseded by the BEGIN IMMEDIATE + jitter-retry redesign (#3385), which deliberately keeps the SQLite busy handler short and handles contention with application-level retries.

## How to review
Review the `swapScript` template in `applyUpdatesPosixInApp` (`apps/desktop/electron/main.cjs`, ~line 1815). The invariant: on ANY swap failure the user ends up with a working app launched (the rebuilt bundle via the `open "$SRC"` fallback) and no orphaned `.hermes-update-*` staging copies.

## Evidence
Functional simulation of the rendered swap script with `/usr/bin/open` and `/usr/bin/xattr` stubbed:
- Happy path: destination replaced with the new bundle, relaunch targets the destination, no staging leftovers, rc=0.
- `ditto`-failure path (source missing): destination untouched (old bundle intact), `[updates] ditto failed` logged to stderr, fallback open targets the rebuilt source bundle, no leftovers, rc=0.

## Verification
- `node --check apps/desktop/electron/main.cjs`
- `bash -n` on the rendered swap script
- The two functional simulations above
- Trigger the macOS in-app update path; confirm a forced swap failure (e.g. make the staging `ditto` fail) opens the rebuilt `release/mac-arm64/Hermes.app` instead of dead-quitting, and a normal update still replaces `/Applications/Hermes.app`.

## Risks & gaps
- If moving the old bundle aside fails AND `rm -rf` of it also fails, `set -e` aborts with the original app intact but no relaunch (the user reopens manually) — strictly better than the prior silent fall-through.
- The `open "$SRC"` fallback launches the rebuilt bundle from the build tree rather than `/Applications`; this avoids a no-app state but may not match the user's preferred installed location (same trade-off as reviewed in #38410).
