### PR TITLE
fix(feishu): prevent lost final replies without message IDs

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -684,6 +684,10 @@ class GatewayConfig:
     
     # Delivery settings
     always_log_local: bool = True  # Always save cron outputs to local files
+    # Bounded drain window for in-flight final-response sends after gateway
+    # cancellation/shutdown. Configurable via
+    # ``gateway.final_send_cancel_drain_seconds``.
+    final_send_cancel_drain_seconds: float = 5.0
     # Drop outbound "silence narration" messages (e.g. *(silent)*, 🔇, a bare
     # ".") pre-send. These are model hallucinations emitted when a persona has
     # nothing actionable to say; in bot-to-bot channels they mirror back and
@@ -817,6 +821,7 @@ class GatewayConfig:
             "sessions_dir": str(self.sessions_dir),
             "write_sessions_json": self.write_sessions_json,
             "always_log_local": self.always_log_local,
+            "final_send_cancel_drain_seconds": self.final_send_cancel_drain_seconds,
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
             "stt_echo_transcripts": self.stt_echo_transcripts,
@@ -913,6 +918,13 @@ class GatewayConfig:
             "pair",
         )
 
+        final_send_cancel_drain_seconds = _coerce_float(
+            data.get("final_send_cancel_drain_seconds", nested_gateway.get("final_send_cancel_drain_seconds")),
+            5.0,
+        )
+        if final_send_cancel_drain_seconds < 0:
+            final_send_cancel_drain_seconds = 5.0
+
         try:
             session_store_max_age_days = int(data.get("session_store_max_age_days", 90))
             session_store_max_age_days = max(session_store_max_age_days, 0)
@@ -929,6 +941,7 @@ class GatewayConfig:
             sessions_dir=sessions_dir,
             write_sessions_json=_coerce_bool(data.get("write_sessions_json"), True),
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
+            final_send_cancel_drain_seconds=final_send_cancel_drain_seconds,
             filter_silence_narration=_coerce_bool(
                 data.get("filter_silence_narration"), True
             ),
@@ -1081,6 +1094,11 @@ def load_gateway_config() -> GatewayConfig:
 
             if "always_log_local" in yaml_cfg:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]
+
+            if "final_send_cancel_drain_seconds" in yaml_cfg:
+                gw_data["final_send_cancel_drain_seconds"] = yaml_cfg["final_send_cancel_drain_seconds"]
+            elif isinstance(gateway_cfg, dict) and "final_send_cancel_drain_seconds" in gateway_cfg:
+                gw_data["final_send_cancel_drain_seconds"] = gateway_cfg["final_send_cancel_drain_seconds"]
 
             # write_sessions_json: top-level wins; nested gateway.* fallback
             # (matches the gateway.streaming precedence pattern).

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -52,6 +52,14 @@ def _float_env(name: str, default: float) -> float:
         return default
 
 
+def _coerce_nonnegative_float(value, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
+
+
 def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) -> dict | None:
     """Build platform-aware thread metadata for adapter sends.
 
@@ -5026,13 +5034,78 @@ class BasePlatformAdapter(ABC):
                 if text_content and not _tts_caption_delivered:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
                     _reply_anchor = _reply_anchor_for_event(event)
-                    result = await self._send_with_retry(
-                        chat_id=event.source.chat_id,
-                        content=text_content,
-                        reply_to=_reply_anchor,
-                        metadata=_final_thread_metadata,
+                    delivery_uuid = str(uuid.uuid4())
+                    if _final_thread_metadata is not None:
+                        _final_thread_metadata = dict(_final_thread_metadata)
+                        _final_thread_metadata["delivery_uuid"] = delivery_uuid
+                    else:
+                        _final_thread_metadata = {"delivery_uuid": delivery_uuid}
+                    send_task = asyncio.create_task(
+                        self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=text_content,
+                            reply_to=_reply_anchor,
+                            metadata=_final_thread_metadata,
+                        )
                     )
+                    send_cancelled = False
+                    try:
+                        result = await asyncio.shield(send_task)
+                    except asyncio.CancelledError:
+                        send_cancelled = True
+                        drain_timeout = _coerce_nonnegative_float(
+                            getattr(self, "final_send_cancel_drain_seconds", 5.0),
+                            5.0,
+                        )
+                        logger.warning(
+                            "[%s] Final response send cancelled while in flight for %s; "
+                            "waiting up to %.1fs for delivery result delivery_uuid=%s",
+                            self.name,
+                            event.source.chat_id,
+                            drain_timeout,
+                            delivery_uuid,
+                        )
+                        try:
+                            result = await asyncio.wait_for(asyncio.shield(send_task), timeout=drain_timeout)
+                        except asyncio.TimeoutError:
+                            logger.error(
+                                "[%s] Final response delivery result unavailable after cancellation "
+                                "for %s delivery_uuid=%s",
+                                self.name,
+                                event.source.chat_id,
+                                delivery_uuid,
+                            )
+                            send_task.cancel()
+                            raise asyncio.CancelledError
                     _record_delivery(result)
+                    if getattr(result, "success", False):
+                        message_id = getattr(result, "message_id", None)
+                        if self.platform == Platform.FEISHU and not message_id:
+                            logger.warning(
+                                "[%s] Feishu response send returned success without message_id "
+                                "chat_id=%s delivery_uuid=%s",
+                                self.name,
+                                event.source.chat_id,
+                                delivery_uuid,
+                            )
+                        else:
+                            logger.info(
+                                "[%s] Response sent to %s message_id=%s delivery_uuid=%s",
+                                self.name,
+                                event.source.chat_id,
+                                message_id or "<none>",
+                                delivery_uuid,
+                            )
+                    else:
+                        logger.error(
+                            "[%s] Response send failed to %s delivery_uuid=%s: %s",
+                            self.name,
+                            event.source.chat_id,
+                            delivery_uuid,
+                            getattr(result, "error", None) or "unknown error",
+                        )
+                    if send_cancelled:
+                        raise asyncio.CancelledError
 
                     # Schedule auto-deletion of system-notice replies.
                     # Detached so the handler returns immediately; errors

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7161,6 +7161,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
             adapter._busy_text_mode = self._busy_text_mode
+            adapter.final_send_cancel_drain_seconds = self.config.final_send_cancel_drain_seconds
             
             # Try to connect
             logger.info("Connecting to %s...", platform.value)
@@ -7992,6 +7993,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                     adapter.set_message_handler(self._handle_message)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
+                    adapter.final_send_cancel_drain_seconds = self.config.final_send_cancel_drain_seconds
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
                     adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
@@ -8710,6 +8712,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
             adapter._busy_text_mode = self._busy_text_mode
+            adapter.final_send_cancel_drain_seconds = self.config.final_send_cancel_drain_seconds
 
             try:
                 with _profile_runtime_scope(profile_home):

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1900,15 +1900,19 @@ class FeishuAdapter(BasePlatformAdapter):
         last_response = None
 
         try:
-            for chunk in chunks:
+            for chunk_index, chunk in enumerate(chunks):
                 msg_type, payload = self._build_outbound_payload(chunk)
+                chunk_metadata = metadata
+                if metadata and metadata.get("delivery_uuid") and len(chunks) > 1:
+                    chunk_metadata = dict(metadata)
+                    chunk_metadata["delivery_uuid"] = f"{metadata['delivery_uuid']}-{chunk_index}"
                 try:
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type=msg_type,
                         payload=payload,
                         reply_to=reply_to,
-                        metadata=metadata,
+                        metadata=chunk_metadata,
                     )
                 except Exception as exc:
                     if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
@@ -1919,7 +1923,7 @@ class FeishuAdapter(BasePlatformAdapter):
                         msg_type="text",
                         payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
                         reply_to=reply_to,
-                        metadata=metadata,
+                        metadata=chunk_metadata,
                     )
                 if (
                     msg_type == "post"
@@ -1932,7 +1936,7 @@ class FeishuAdapter(BasePlatformAdapter):
                         msg_type="text",
                         payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
                         reply_to=reply_to,
-                        metadata=metadata,
+                        metadata=chunk_metadata,
                     )
                 last_response = response
 
@@ -4611,6 +4615,7 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
         effective_reply_to = reply_to
+        delivery_uuid = str((metadata or {}).get("delivery_uuid") or uuid.uuid4())
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
         reply_in_thread = bool((metadata or {}).get("thread_id"))
@@ -4619,7 +4624,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 content=payload,
                 msg_type=msg_type,
                 reply_in_thread=reply_in_thread,
-                uuid_value=str(uuid.uuid4()),
+                uuid_value=delivery_uuid,
             )
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
@@ -4633,7 +4638,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 receive_id=_thread_id,
                 msg_type=msg_type,
                 content=payload,
-                uuid_value=str(uuid.uuid4()),
+                uuid_value=delivery_uuid,
             )
             request = self._build_create_message_request("thread_id", body)
         else:
@@ -4649,7 +4654,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 receive_id=receive_id,
                 msg_type=msg_type,
                 content=payload,
-                uuid_value=str(uuid.uuid4()),
+                uuid_value=delivery_uuid,
             )
             request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)

--- a/tests/gateway/test_delivery_reliability.py
+++ b/tests/gateway/test_delivery_reliability.py
@@ -1,0 +1,207 @@
+"""Delivery reliability regression tests for gateway final replies."""
+
+import asyncio
+from types import SimpleNamespace
+import unittest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.session import SessionSource
+
+
+class _SlowFinalSendAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True), Platform.FEISHU)
+        self.started = asyncio.Event()
+        self.sent = asyncio.Event()
+        self.metadata = None
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {}
+
+    async def send(self, chat_id: str, content: str, reply_to=None, metadata=None):
+        return SendResult(True, message_id="om_visible")
+
+    async def send_typing(self, chat_id: str, metadata=None):
+        return None
+
+    async def _send_with_retry(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to=None,
+        metadata=None,
+        max_retries: int = 2,
+        base_delay: float = 2.0,
+    ):
+        self.started.set()
+        await asyncio.sleep(0.05)
+        self.metadata = metadata
+        self.sent.set()
+        return SendResult(True, message_id="om_visible")
+
+
+class _HangingFinalSendAdapter(_SlowFinalSendAdapter):
+    async def _send_with_retry(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to=None,
+        metadata=None,
+        max_retries: int = 2,
+        base_delay: float = 2.0,
+    ):
+        self.started.set()
+        self.metadata = metadata
+        await asyncio.Event().wait()
+
+
+class TestFinalResponseDeliveryReliability(unittest.IsolatedAsyncioTestCase):
+    async def test_final_response_send_drains_after_cancellation_and_reraises(self):
+        adapter = _SlowFinalSendAdapter()
+
+        async def handler(event):
+            return "final response"
+
+        adapter.set_message_handler(handler)
+        event = MessageEvent(
+            text="hello",
+            source=SessionSource(
+                platform=Platform.FEISHU,
+                chat_id="oc_chat",
+                chat_type="group",
+                user_id="ou_user",
+                message_id="om_inbound",
+            ),
+            message_id="om_inbound",
+        )
+
+        task = asyncio.create_task(adapter._process_message_background(event, "feishu:oc_chat"))
+        await adapter.started.wait()
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
+        self.assertTrue(adapter.sent.is_set())
+        metadata = adapter.metadata
+        self.assertIsNotNone(metadata)
+        assert metadata is not None
+        self.assertTrue(metadata.get("notify"))
+        self.assertTrue(metadata.get("delivery_uuid"))
+
+    async def test_cancelled_final_response_send_timeout_preserves_cancellation(self):
+        adapter = _HangingFinalSendAdapter()
+        adapter.final_send_cancel_drain_seconds = 0.01
+
+        async def handler(event):
+            return "final response"
+
+        adapter.set_message_handler(handler)
+        event = MessageEvent(
+            text="hello",
+            source=SessionSource(platform=Platform.FEISHU, chat_id="oc_chat", chat_type="group"),
+            message_id="om_inbound",
+        )
+
+        task = asyncio.create_task(adapter._process_message_background(event, "feishu:oc_chat"))
+        await adapter.started.wait()
+        task.cancel()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
+        self.assertTrue(task.cancelled())
+
+
+class TestGatewayDeliveryConfig(unittest.TestCase):
+    def test_final_send_cancel_drain_seconds_loads_from_nested_gateway_config(self):
+        from gateway.config import GatewayConfig
+
+        config = GatewayConfig.from_dict({"gateway": {"final_send_cancel_drain_seconds": 2.5}})
+
+        self.assertEqual(config.final_send_cancel_drain_seconds, 2.5)
+
+    def test_final_send_cancel_drain_seconds_rejects_negative_values(self):
+        from gateway.config import GatewayConfig
+
+        config = GatewayConfig.from_dict({"gateway": {"final_send_cancel_drain_seconds": -1}})
+
+        self.assertEqual(config.final_send_cancel_drain_seconds, 5.0)
+
+
+class TestFeishuDeliveryUuid(unittest.IsolatedAsyncioTestCase):
+    async def test_send_reuses_stable_delivery_uuid_for_retry(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._client = object()
+        object.__setattr__(adapter, "MAX_MESSAGE_LENGTH", 4000)
+        object.__setattr__(adapter, "format_message", lambda content: content)
+        object.__setattr__(adapter, "truncate_message", lambda content, *args, **kwargs: [content])
+        object.__setattr__(adapter, "_build_outbound_payload", lambda content: ("text", '{"text":"hello"}'))
+        object.__setattr__(adapter, "_response_succeeded", lambda response: True)
+        object.__setattr__(adapter, "_extract_response_field", lambda response, field_name: "om_visible")
+        adapter._finalize_send_result = FeishuAdapter._finalize_send_result.__get__(adapter, FeishuAdapter)
+        seen = []
+
+        async def fake_send(**kwargs):
+            seen.append(kwargs["metadata"]["delivery_uuid"])
+            return SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_visible"))
+
+        adapter._feishu_send_with_retry = fake_send
+        result = await adapter.send("oc_chat", "hello", metadata={"delivery_uuid": "stable-uuid"})
+
+        self.assertTrue(result.success)
+        self.assertEqual(seen, ["stable-uuid"])
+
+    async def test_send_suffixes_delivery_uuid_for_split_chunks(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._client = object()
+        object.__setattr__(adapter, "MAX_MESSAGE_LENGTH", 5)
+        object.__setattr__(adapter, "format_message", lambda content: content)
+        object.__setattr__(adapter, "truncate_message", lambda content, *args, **kwargs: ["one", "two"])
+        object.__setattr__(adapter, "_build_outbound_payload", lambda content: ("text", f'{{"text":"{content}"}}'))
+        object.__setattr__(adapter, "_response_succeeded", lambda response: True)
+        object.__setattr__(adapter, "_extract_response_field", lambda response, field_name: "om_visible")
+        adapter._finalize_send_result = FeishuAdapter._finalize_send_result.__get__(adapter, FeishuAdapter)
+        seen = []
+
+        async def fake_send(**kwargs):
+            seen.append(kwargs["metadata"]["delivery_uuid"])
+            return SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_visible"))
+
+        adapter._feishu_send_with_retry = fake_send
+        result = await adapter.send("oc_chat", "one two", metadata={"delivery_uuid": "stable-uuid"})
+
+        self.assertTrue(result.success)
+        self.assertEqual(seen, ["stable-uuid-0", "stable-uuid-1"])
+
+    async def test_success_without_message_id_logs_warning(self):
+        adapter = _SlowFinalSendAdapter()
+
+        async def handler(event):
+            return "final response"
+
+        async def no_id_send(*args, **kwargs):
+            return SendResult(True, message_id=None)
+
+        adapter._send_with_retry = no_id_send
+        adapter.set_message_handler(handler)
+        event = MessageEvent(
+            text="hello",
+            source=SessionSource(platform=Platform.FEISHU, chat_id="oc_chat", chat_type="group"),
+            message_id="om_inbound",
+        )
+
+        with self.assertLogs("gateway.platforms.base", level="WARNING") as logs:
+            await adapter._process_message_background(event, "feishu:oc_chat")
+
+        self.assertTrue(any("without message_id" in line for line in logs.output))


### PR DESCRIPTION
## Modified content
- Prevent generated Feishu/Lark final replies from disappearing without a recorded message ID.
- Preserve final response delivery through gateway shutdown/cancellation.
- Reuse stable Feishu idempotency UUIDs across retries.
- Add delivery logging/warnings when successful Feishu sends do not return a `message_id`.

## Problem
A user-visible final reply can be generated by Hermes but still be lost during Feishu/Lark delivery if the gateway task is cancelled or the gateway is shutting down before the send completes.

The practical failure mode is:

1. the agent finishes generating the final response;
2. the gateway logs `Sending response ...`;
3. the Feishu send is interrupted before the API result is recorded;
4. Hermes never logs or stores the Feishu `message_id` for that reply;
5. the user does not see the reply in the chat, and operators cannot trace, verify, or safely retry that delivery.

This is especially painful for group-chat replies because the system appears to have answered, but there is no message ID / UID proving that the reply was actually delivered.

Feishu also supports client-provided UUID idempotency, but the adapter generated a fresh UUID for each retry. That means retry attempts were not idempotent and could create duplicate messages instead of safely retrying the same delivery.

## Solution
- Create a per-final-response `delivery_uuid` in the base gateway response path.
- Send final responses through an `asyncio.shield()`ed task.
- If the outer gateway task is cancelled, wait up to `gateway.final_send_cancel_drain_seconds` seconds for the shielded send to finish, record the delivery result, then re-raise cancellation.
- Pass the stable `delivery_uuid` through message metadata to Feishu and use it as the Feishu API `uuid` for replies/messages.
- Derive chunk-specific UUID suffixes when a response is split, so separate chunks do not share the same idempotency key.
- Include `delivery_uuid` in delivery logs and warn when a successful Feishu response does not include a `message_id`.
- Configure the drain timeout through `config.yaml` (`gateway.final_send_cancel_drain_seconds`) instead of a new environment variable.

## Tests
```bash
python -m pytest tests/gateway/test_delivery_reliability.py tests/gateway/test_feishu.py tests/gateway/test_config.py -q -o 'addopts='
```

Result:
```text
316 passed, 5 warnings
```

Focused coverage added for:
- cancellation-drain final response delivery
- stable delivery UUID reuse across Feishu retries
- Feishu success without `message_id` warning behavior
- split message chunk UUID suffixing
