### PR TITLE
fix: _session_info returns '' instead of 'none' when reasoning is off

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2046,11 +2046,11 @@ def _session_info(agent, session: dict | None = None) -> dict:
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
     reasoning_effort = ""
-    if (
-        isinstance(reasoning_config, dict)
-        and reasoning_config.get("enabled") is not False
-    ):
-        reasoning_effort = str(reasoning_config.get("effort", "") or "")
+    if isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is False:
+            reasoning_effort = "none"
+        elif reasoning_config.get("enabled") is not False:
+            reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or ""
     # Effective approval-bypass state — the same three sources that
     # check_all_command_guards() ORs together: persistent config


### PR DESCRIPTION
## Problem

When the user disables thinking via Desktop toggle, `config.set` correctly sets `reasoning_config = {'enabled': False}`, but `_session_info` returns an empty string for `reasoning_effort` because the condition skips entirely when `enabled is False`.

The frontend (`use-session-actions.ts:250`) stores this value in its atom, and `formatModelStatusLabel` interprets empty string as default (`Medium`), causing the status bar to revert from "Off" back to "Med" on the next conversation turn.

## Fix

In `_session_info()`, when `reasoning_config.get("enabled") is False`, explicitly return `"none"` instead of leaving `reasoning_effort` as `""`.

## Root Cause Chain

1. User clicks Thinking off → `patchReasoning('none')` → `config.set('reasoning', 'none')` → `reasoning_config = {"enabled": False}` ✅
2. Next turn → `_session_info` reads `reasoning_config` → `enabled is False` → skips the existing condition → returns `reasoning_effort: ""` ❌
3. Frontend `use-session-actions.ts` sets atom to `""` → `formatModelStatusLabel` falls back to `'Med'` → display reverts to "Med" ❌

## Verification

Tested locally across 3+ conversation turns:
- Set Off → stays Off ✅
- Toggle On → shows Med ✅
- Toggle Off again → shows Off ✅