### PR TITLE
fix(cron): pass shell scripts to bash with forward slashes

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -30,7 +30,7 @@ except ImportError:
         import msvcrt
     except ImportError:
         msvcrt = None
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import List, Optional
 
 # Add parent directory to path for imports BEFORE repo-level imports.
@@ -913,6 +913,11 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
+def _bash_script_arg(path: PurePath) -> str:
+    """Return a script path in the form bash expects on every platform."""
+    return path.as_posix()
+
+
 def _run_job_script(script_path: str) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -987,7 +992,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        argv = [_bash, str(path)]
+        argv = [_bash, _bash_script_arg(path)]
     else:
         argv = [sys.executable, str(path)]
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -11,7 +11,7 @@ import json
 import os
 import sys
 import textwrap
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -88,6 +88,17 @@ class TestJobScriptField:
 
 class TestRunJobScript:
     """Test the _run_job_script() function."""
+
+    def test_bash_script_arg_uses_forward_slashes_for_windows_paths(self):
+        from cron.scheduler import _bash_script_arg
+
+        path = PureWindowsPath(
+            r"C:\Users\graem\AppData\Local\hermes\scripts\cron-watchdog.sh"
+        )
+
+        assert _bash_script_arg(path) == (
+            "C:/Users/graem/AppData/Local/hermes/scripts/cron-watchdog.sh"
+        )
 
     def test_successful_script(self, cron_env):
         from cron.scheduler import _run_job_script


### PR DESCRIPTION
## Summary
- Pass `.sh` and `.bash` cron script paths to bash with forward slashes.
- Keep Python script execution unchanged.
- Add regression coverage for Windows-style script paths.

Fixes #43073

## Tests
- `.\.venv\Scripts\python.exe -m pytest tests/cron/test_cron_script.py --timeout-method=thread`
- `.\.venv\Scripts\python.exe -m pytest tests/tools/test_windows_native_support.py::TestCronSchedulerBashResolution --timeout-method=thread`
- `.\.venv\Scripts\python.exe -m ruff check cron/scheduler.py tests/cron/test_cron_script.py`
