### PR TITLE
fix(tui): return "none" for reasoning_effort when Thinking toggle is off

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3531,6 +3531,39 @@ def test_session_info_includes_mcp_servers(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# reasoning_effort: Desktop Thinking toggle must not revert to "Med".
+# When reasoning_config.enabled is False, _session_info must return "none"
+# instead of empty string — otherwise the frontend falls back to "medium".
+# ---------------------------------------------------------------------------
+
+
+def test_session_info_reasoning_effort_disabled():
+    """reasoning_config.enabled=False → reasoning_effort="none" (not "")."""
+    agent = types.SimpleNamespace(
+        tools=[], model="", reasoning_config={"enabled": False}
+    )
+    info = server._session_info(agent)
+    assert info["reasoning_effort"] == "none"
+
+
+def test_session_info_reasoning_effort_explicit_effort():
+    """reasoning_config with enabled=True returns the configured effort."""
+    agent = types.SimpleNamespace(
+        tools=[], model="",
+        reasoning_config={"enabled": True, "effort": "high"},
+    )
+    info = server._session_info(agent)
+    assert info["reasoning_effort"] == "high"
+
+
+def test_session_info_reasoning_effort_no_config():
+    """No reasoning_config → reasoning_effort stays empty string."""
+    agent = types.SimpleNamespace(tools=[], model="", reasoning_config=None)
+    info = server._session_info(agent)
+    assert info["reasoning_effort"] == ""
+
+
+# ---------------------------------------------------------------------------
 # History-mutating commands must reject while session.running is True.
 # Without these guards, prompt.submit's post-run history write either
 # clobbers the mutation (version matches) or silently drops the agent's

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2046,11 +2046,11 @@ def _session_info(agent, session: dict | None = None) -> dict:
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
     reasoning_effort = ""
-    if (
-        isinstance(reasoning_config, dict)
-        and reasoning_config.get("enabled") is not False
-    ):
-        reasoning_effort = str(reasoning_config.get("effort", "") or "")
+    if isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is False:
+            reasoning_effort = "none"
+        elif reasoning_config.get("enabled") is not False:
+            reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or ""
     # Effective approval-bypass state — the same three sources that
     # check_all_command_guards() ORs together: persistent config


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop Thinking toggle reverting from "Off" back to "Med" after one conversation turn. When `reasoning_config.enabled` is `False`, `_session_info()` now returns `"none"` instead of an empty string, preventing the frontend from falling back to the default "medium" display.

## Related Issue

Fixes #43275

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: When `reasoning_config.enabled is False`, explicitly return `"none"` for `reasoning_effort` instead of leaving it as `""`. The empty string caused the Desktop frontend to fall back to "medium" on the next `session.info` event.
- `tests/test_tui_gateway_server.py`: Added 3 regression tests covering the disabled, enabled-with-explicit-effort, and no-config cases.

## How to Test

1. Open Hermes Desktop and start a conversation
2. Turn off the Thinking toggle in the model-edit-submenu
3. Send 2+ messages and verify the status bar continues showing "Off" (not reverting to "Med")
4. Turn Thinking back on and verify it shows the configured effort level
5. Run `pytest tests/test_tui_gateway_server.py::test_session_info_reasoning_effort_disabled tests/test_tui_gateway_server.py::test_session_info_reasoning_effort_explicit_effort tests/test_tui_gateway_server.py::test_session_info_reasoning_effort_no_config -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tui_gateway/server.py::_session_info()` (reasoning_effort field, called on every `session.info` event)
- Blast radius: LOW — single field in session info dict, only affects Desktop/TUI display
- Related patterns: Frontend `use-session-actions.ts:250` interprets empty string as default "medium"; returning "none" prevents the fallback
