### PR TITLE
fix(kanban): refuse to create DB for archived boards

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1439,6 +1439,27 @@ def connect(
         path = db_path
     else:
         path = kanban_db_path(board=board)
+    # Guard against resurrecting archived/deleted boards: if board.json
+    # marks the board as archived and the DB doesn't already exist on
+    # disk, refuse to create it.  Stale dashboard/gateway watch paths
+    # can hand us an archived slug — without this guard the mkdir +
+    # init_db below creates an empty stub that list_boards() treats as
+    # an active board.  See #43243.
+    if board is not None and not path.exists():
+        slug = _normalize_board_slug(board) or DEFAULT_BOARD
+        if slug != DEFAULT_BOARD:
+            meta_path = board_metadata_path(slug)
+            if meta_path.exists():
+                try:
+                    import json as _json
+                    raw = _json.loads(meta_path.read_text(encoding="utf-8"))
+                    if isinstance(raw, dict) and raw.get("archived"):
+                        raise ValueError(
+                            f"Board '{slug}' is archived; refusing to "
+                            f"create a new database for it."
+                        )
+                except (OSError, _json.JSONDecodeError):
+                    pass
     path.parent.mkdir(parents=True, exist_ok=True)
     with _cross_process_init_lock(path):
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
@@ -1543,6 +1564,23 @@ def init_db(
         path = db_path
     else:
         path = kanban_db_path(board=board)
+    # Guard against resurrecting archived/deleted boards — same logic
+    # as in connect().  See #43243.
+    if board is not None and not path.exists():
+        slug = _normalize_board_slug(board) or DEFAULT_BOARD
+        if slug != DEFAULT_BOARD:
+            meta_path = board_metadata_path(slug)
+            if meta_path.exists():
+                try:
+                    import json as _json
+                    raw = _json.loads(meta_path.read_text(encoding="utf-8"))
+                    if isinstance(raw, dict) and raw.get("archived"):
+                        raise ValueError(
+                            f"Board '{slug}' is archived; refusing to "
+                            f"create a new database for it."
+                        )
+                except (OSError, _json.JSONDecodeError):
+                    pass
     path.parent.mkdir(parents=True, exist_ok=True)
     resolved = str(path.resolve())
     # Clear the cache entry so the underlying connect() re-runs the

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4372,3 +4372,86 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Archived board resurrection guard (#43243)
+# ---------------------------------------------------------------------------
+
+
+class TestArchivedBoardResurrectionGuard:
+    """connect() and init_db() must refuse to create a DB for archived boards."""
+
+    def test_connect_refuses_archived_board(self, tmp_path, monkeypatch):
+        """connect(board='old') raises ValueError when board.json says archived."""
+        monkeypatch.setattr(kb, "boards_root", lambda: tmp_path / "boards")
+        boards = tmp_path / "boards"
+        board_dir = boards / "old"
+        board_dir.mkdir(parents=True)
+        # Write archived board.json
+        import json
+        (board_dir / "board.json").write_text(
+            json.dumps({"slug": "old", "archived": True, "name": "Old"}),
+            encoding="utf-8",
+        )
+        # No kanban.db exists yet — connect should refuse to create it
+        assert not (board_dir / "kanban.db").exists()
+        with pytest.raises(ValueError, match="archived"):
+            kb.connect(board="old")
+        # DB must NOT have been created
+        assert not (board_dir / "kanban.db").exists()
+
+    def test_init_db_refuses_archived_board(self, tmp_path, monkeypatch):
+        """init_db(board='old') raises ValueError when board.json says archived."""
+        monkeypatch.setattr(kb, "boards_root", lambda: tmp_path / "boards")
+        boards = tmp_path / "boards"
+        board_dir = boards / "old"
+        board_dir.mkdir(parents=True)
+        import json
+        (board_dir / "board.json").write_text(
+            json.dumps({"slug": "old", "archived": True, "name": "Old"}),
+            encoding="utf-8",
+        )
+        assert not (board_dir / "kanban.db").exists()
+        with pytest.raises(ValueError, match="archived"):
+            kb.init_db(board="old")
+        assert not (board_dir / "kanban.db").exists()
+
+    def test_connect_allows_non_archived_board(self, tmp_path, monkeypatch):
+        """connect(board='active') works normally when board.json says not archived."""
+        monkeypatch.setattr(kb, "boards_root", lambda: tmp_path / "boards")
+        boards = tmp_path / "boards"
+        board_dir = boards / "active"
+        board_dir.mkdir(parents=True)
+        import json
+        (board_dir / "board.json").write_text(
+            json.dumps({"slug": "active", "archived": False, "name": "Active"}),
+            encoding="utf-8",
+        )
+        conn = kb.connect(board="active")
+        try:
+            # Should work — schema initialized
+            conn.execute("SELECT 1").fetchone()
+        finally:
+            conn.close()
+
+    def test_connect_allows_archived_board_when_db_exists(self, tmp_path, monkeypatch):
+        """connect(board='old') works if kanban.db already exists on disk
+        (e.g., admin wants to read data from an archived board)."""
+        monkeypatch.setattr(kb, "boards_root", lambda: tmp_path / "boards")
+        boards = tmp_path / "boards"
+        board_dir = boards / "old"
+        board_dir.mkdir(parents=True)
+        import json
+        (board_dir / "board.json").write_text(
+            json.dumps({"slug": "old", "archived": True, "name": "Old"}),
+            encoding="utf-8",
+        )
+        # Pre-create an empty DB file so the guard's `not path.exists()` is False
+        (board_dir / "kanban.db").touch()
+        # connect() should proceed (the guard only fires when DB is missing)
+        conn = kb.connect(board="old")
+        try:
+            conn.execute("SELECT 1").fetchone()
+        finally:
+            conn.close()


### PR DESCRIPTION
## What does this PR do?

Adds a guard in `connect()` and `init_db()` to refuse creating a new database for archived Kanban boards. Stale dashboard/gateway watch paths that pass an archived board slug no longer create empty `kanban.db` stubs that resurrect the board in the UI.

## Related Issue

Fixes #43243

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: Add archived-board guard in `connect()` and `init_db()` — if `board.json` marks the board as archived and the DB doesn't already exist on disk, raise `ValueError` instead of creating an empty stub
- `tests/hermes_cli/test_kanban_db.py`: Add `TestArchivedBoardResurrectionGuard` class with 4 tests covering: archived board refused, non-archived board allowed, existing DB on archived board still works

## How to Test

1. Create a Kanban board: `hermes kanban boards create test-board`
2. Archive it: `hermes kanban boards archive test-board`
3. Verify the board doesn't reappear after gateway restart or dashboard reconnect
4. Run `pytest tests/hermes_cli/test_kanban_db.py::TestArchivedBoardResurrectionGuard -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/kanban_db.py` → `connect()`, `init_db()` (archived board guard)
- Blast radius: LOW — guard only fires for archived boards with missing DB; existing DBs and non-archived boards are unaffected
- Related patterns: `board_metadata_path()` → `board.json` → `archived` field
