### PR TITLE
fix: show restored sessions in pickers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11296,7 +11296,11 @@ def main():
 
         if action == "list":
             sessions = db.list_sessions_rich(
-                source=args.source, exclude_sources=_exclude, limit=args.limit
+                source=args.source,
+                exclude_sources=_exclude,
+                limit=args.limit,
+                include_children=True,
+                project_compression_tips=False,
             )
             if not sessions:
                 print("No sessions found.")
@@ -11404,7 +11408,11 @@ def main():
             source = getattr(args, "source", None)
             _browse_exclude = None if source else ["tool"]
             sessions = db.list_sessions_rich(
-                source=source, exclude_sources=_browse_exclude, limit=limit
+                source=source,
+                exclude_sources=_browse_exclude,
+                limit=limit,
+                include_children=True,
+                project_compression_tips=False,
             )
             db.close()
             if not sessions:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1819,6 +1819,8 @@ async def get_sessions(
                 include_archived=include_archived,
                 archived_only=archived_only,
                 order_by_last_active=order == "recent",
+                include_children=True,
+                project_compression_tips=False,
             )
             total = db.session_count(
                 source=source or None,
@@ -1826,7 +1828,7 @@ async def get_sessions(
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,
-                exclude_children=True,
+                exclude_children=False,
             )
             now = time.time()
             for s in sessions:
@@ -1925,6 +1927,8 @@ async def get_profiles_sessions(
                 include_archived=include_archived,
                 archived_only=archived_only,
                 order_by_last_active=order == "recent",
+                include_children=True,
+                project_compression_tips=False,
             )
             profile_total = db.session_count(
                 source=source_filter,
@@ -1932,7 +1936,7 @@ async def get_profiles_sessions(
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,
-                exclude_children=True,
+                exclude_children=False,
             )
             total += profile_total
             profile_totals[name] = profile_total

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3479,9 +3479,21 @@ def _(rid, params: dict) -> dict:
         # short; the compression-tip projection in ``list_sessions_rich``
         # can also merge rows.
         fetch_limit = max(limit * 2, 200)
+        # The Desktop/TUI session picker should expose every stored
+        # conversation row, including compression continuations and empty
+        # shells. The default list_sessions_rich() view intentionally collapses
+        # compression chains into one logical conversation, which can make
+        # restored sessions look like they disappeared even though state.db
+        # still has them. For the picker, show raw stored rows and let resume
+        # handle the selected id directly.
         rows = [
             s
-            for s in db.list_sessions_rich(source=None, limit=fetch_limit)
+            for s in db.list_sessions_rich(
+                source=None,
+                limit=fetch_limit,
+                include_children=True,
+                project_compression_tips=False,
+            )
             if (s.get("source") or "").strip().lower() not in deny
         ][:limit]
         return _ok(


### PR DESCRIPTION
## Summary
- include compression-child/restored session rows in CLI session list/browse
- include child rows in web session APIs and counts
- include raw stored rows in the TUI/Desktop session picker so restored sessions do not disappear

## Test Plan
- `python3.12 -m py_compile hermes_cli/main.py hermes_cli/web_server.py tui_gateway/server.py`
- `/Users/talors.hall/.hermes/tmp/hermes-py312-test-venv/bin/python -m pytest tests/test_tui_gateway_server.py::test_session_list_returns_clean_error_when_state_db_is_unavailable tests/test_tui_gateway_server.py::test_session_most_recent_returns_first_non_denied tests/test_hermes_state.py -q -o 'addopts='` — 264 passed
- broader `tests/test_tui_gateway_server.py tests/test_hermes_state.py` run: 513 passed, 1 existing browser.manage environment-sensitive failure unrelated to these session-listing changes
