### PR TITLE
fix(gateway): include .venv/bin in the systemd service PATH

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2663,8 +2663,19 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
 
     candidates = []
 
-    venv_bin = project_root / "venv" / "bin"
-    if _is_dir(venv_bin):
+    # Probe ``.venv`` before ``venv`` — same order/preference as
+    # _detect_venv_dir() and get_python_path(). Hardcoding only ``venv`` left
+    # the service PATH without the venv's bin for the modern ``.venv`` layout
+    # (e.g. ``uv venv .venv``), so venv-installed console scripts went missing.
+    venv_bin = next(
+        (
+            project_root / name / "bin"
+            for name in (".venv", "venv")
+            if _is_dir(project_root / name / "bin")
+        ),
+        None,
+    )
+    if venv_bin is not None:
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -20,3 +20,43 @@ def test_service_path_includes_node_modules_when_present(tmp_path):
     assert str(nm_bin) in dirs
 
 
+def test_service_path_includes_hermes_home_node_modules(tmp_path):
+    """Service PATH should include ~/.hermes/node_modules/.bin when it exists."""
+    hermes_nm = tmp_path / ".hermes" / "node_modules" / ".bin"
+    hermes_nm.mkdir(parents=True)
+    from hermes_cli.gateway import _build_service_path_dirs
+    with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
+        dirs = _build_service_path_dirs(project_root=tmp_path)
+    assert str(hermes_nm) in dirs
+
+
+def test_service_path_includes_dotvenv_bin(tmp_path):
+    """Service PATH must include .venv/bin for the modern .venv layout (the
+    project / _detect_venv_dir() prefer .venv; hardcoding only 'venv' missed it)."""
+    dotvenv_bin = tmp_path / ".venv" / "bin"
+    dotvenv_bin.mkdir(parents=True)
+    from hermes_cli.gateway import _build_service_path_dirs
+    with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
+        dirs = _build_service_path_dirs(project_root=tmp_path)
+    assert str(dotvenv_bin) in dirs
+
+
+def test_service_path_includes_legacy_venv_bin(tmp_path):
+    """The legacy 'venv' layout still works."""
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    from hermes_cli.gateway import _build_service_path_dirs
+    with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
+        dirs = _build_service_path_dirs(project_root=tmp_path)
+    assert str(venv_bin) in dirs
+
+
+def test_service_path_prefers_dotvenv_over_venv(tmp_path):
+    """When both exist, .venv wins (matches _detect_venv_dir order)."""
+    (tmp_path / ".venv" / "bin").mkdir(parents=True)
+    (tmp_path / "venv" / "bin").mkdir(parents=True)
+    from hermes_cli.gateway import _build_service_path_dirs
+    with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
+        dirs = _build_service_path_dirs(project_root=tmp_path)
+    assert str(tmp_path / ".venv" / "bin") in dirs
+    assert str(tmp_path / "venv" / "bin") not in dirs


### PR DESCRIPTION
## What & why

`_build_service_path_dirs()` (used by `generate_systemd_unit()`) hardcoded the venv bin as `<project_root>/venv/bin`:

```python
venv_bin = project_root / "venv" / "bin"
if _is_dir(venv_bin):
    candidates.append(str(venv_bin))
elif sys.prefix != sys.base_prefix:
    candidates.append(str(Path(sys.prefix) / "bin"))
```

But the rest of the file already prefers the **modern `.venv` layout** — `_detect_venv_dir()` probes `(".venv", "venv")` in that order, and `get_python_path()` builds `ExecStart` from it. So for a `.venv` install (e.g. `uv venv .venv`, which is what the installer and `scripts/run_tests.sh` use), the generated service unit's `PATH` was **missing the venv's bin**. Console scripts installed into the venv (entry-point CLIs the gateway may shell out to) then weren't found in the running service's environment.

The `sys.prefix` fallback only papers over this when the unit is generated from *inside* an active venv whose `sys.prefix` happens to be the right one — not the general case.

## Fix

Probe `.venv` then `venv` under `project_root`, matching `_detect_venv_dir()`'s order, and keep the `sys.prefix` fallback:

```python
venv_bin = next(
    (project_root / name / "bin"
     for name in (".venv", "venv")
     if _is_dir(project_root / name / "bin")),
    None,
)
if venv_bin is not None:
    candidates.append(str(venv_bin))
elif sys.prefix != sys.base_prefix:
    candidates.append(str(Path(sys.prefix) / "bin"))
```

## How to test

```bash
scripts/run_tests.sh tests/hermes_cli/test_gateway_service_paths.py   # 6 passed
```

Adds tests for the `.venv` layout, the legacy `venv` layout, and `.venv`-wins-when-both-exist (the new `.venv` test fails on the old code). Existing service-path tests are unchanged.

## Scope

`_build_service_path_dirs` is the **systemd** (Linux) PATH builder, so `/bin` is correct here. Related: **#43250** reports the same `.venv`-vs-`venv` blindness in the separate Windows-update helper `_venv_scripts_dir()` — this PR fixes a different, currently-unreported site (the systemd service PATH).

## Platforms

Linux/systemd service generation; pure path logic, verified via the CI-parity runner.