### PR TITLE
feat(agent,gateway): cross-mode fallback context bridge + Inspector server

### DIFF
--- a/README_Code_Update.md
+++ b/README_Code_Update.md
@@ -1,0 +1,528 @@
+# HermesAgent Code Update — 2026-06-10
+
+이 문서는 2026-06-10에 수정된 코드 변경 사항을 정리합니다.
+오픈소스 기여를 위한 PR 제출 가이드도 함께 포함합니다.
+
+---
+
+## 목차
+
+1. [변경 요약](#1-변경-요약)
+2. [변경 상세](#2-변경-상세)
+   - [PR 1 — Fallback Context Bridge](#pr-1--fallback-context-bridge)
+   - [PR 2 — Inspector HTTP API](#pr-2--inspector-http-api)
+   - [PR 3 — providers.py hostname 정확도 개선](#pr-3--providerspyhostname-정확도-개선)
+   - [PR 4 — skill_view 중첩 디렉토리 오탐 수정](#pr-4--skill_view-중첩-디렉토리-오탐-수정)
+3. [오픈소스 기여 방법](#3-오픈소스-기여-방법)
+4. [PR별 commit 명령어](#4-pr별-commit-명령어)
+
+---
+
+## 1. 변경 요약
+
+| PR | 유형 | 범위 | 제목 |
+|----|------|------|------|
+| #1 | `fix` + `feat` | `agent` | Fallback 시 api_mode 변경으로 인한 컨텍스트 단절 수정 |
+| #2 | `feat` | `gateway` | 외부 컨테이너용 읽기전용 Inspector HTTP API 추가 |
+| #3 | `fix` | `hermes_cli` | `api.openai.com` hostname 부분 일치 오탐 수정 |
+| #4 | `fix` | `tools` | `skill_view` 중첩 스킬 디렉토리 내 오탐 수정 |
+
+---
+
+## 2. 변경 상세
+
+---
+
+### PR 1 — Fallback Context Bridge
+
+#### 문제
+
+`openai-codex` (api_mode: `codex_responses`) 를 Primary Provider로 사용하다가 Rate Limit, 네트워크 오류 등으로 `try_activate_fallback()` 이 발동되면, 다른 provider (예: `anthropic_messages`, `chat_completions`) 로 전환된다.
+
+이때 두 가지 문제가 발생했다:
+
+1. **Codex 전용 필드가 새 provider 요청에 포함됨**
+   - `codex_reasoning_items`: Codex가 발급한 `encrypted_content` 블록. 다른 provider에 전달하면 HTTP 400 `invalid_encrypted_content` 오류 발생
+   - `codex_message_items`: Codex 중간 출력 아이템. 다른 provider API 스키마에 없는 필드
+   - `_thinking_prefill`: 내부 마커. 외부 API로 나가면 엄격한 게이트웨이에서 422 오류
+
+2. **시스템 프롬프트(스킬 목록)가 재빌드되지 않음**
+   - `api_messages`는 루프 진입 시점(Primary provider 기준)에 한 번만 빌드됨
+   - Fallback 전환 후에도 구 provider용 시스템 프롬프트가 그대로 사용됨
+   - Codex 세션 중 생성/수정된 스킬 정보가 새 provider에 전달되지 않음
+
+#### 해결
+
+**`agent/fallback_context_bridge.py`** (신규)
+
+`apply_fallback_context_bridge()` 함수:
+- **Context Bridge**: `codex_responses` → 다른 provider 전환 시 `api_messages`에서 Codex 전용 필드 제거, `_disable_codex_reasoning_replay()` 호출
+- **Skill Re-injection**: `agent._build_system_prompt()` 재실행 후 `api_messages[0]` (system message) 를 새 provider용으로 교체
+
+**`agent/chat_completion_helpers.py`** (수정)
+
+`try_activate_fallback()` 에서 api_mode 변경 감지:
+```python
+old_api_mode = getattr(agent, "api_mode", "chat_completions")
+# ...provider swap...
+if old_api_mode != fb_api_mode:
+    agent._pending_context_bridge = {"old_api_mode": ..., "new_api_mode": ...}
+    agent._cached_system_prompt = None  # 재빌드 트리거
+```
+
+**`agent/conversation_loop.py`** (수정)
+
+retry loop 안에서 `_reapply_reasoning_echo_for_provider()` 직후, `_build_api_kwargs()` 직전에 브릿지 실행:
+```python
+_bridge = getattr(agent, "_pending_context_bridge", None)
+if _bridge:
+    agent._pending_context_bridge = None
+    apply_fallback_context_bridge(agent, api_messages, ...)
+```
+
+#### 수정된 파일
+
+| 파일 | 변경 유형 |
+|------|-----------|
+| `agent/fallback_context_bridge.py` | 신규 |
+| `agent/chat_completion_helpers.py` | 수정 (+17줄) |
+| `agent/conversation_loop.py` | 수정 (+22줄) |
+| `tests/agent/test_fallback_context_bridge_integration.py` | 신규 (19개 테스트) |
+| `scripts/simulate_codex_fallback.py` | 신규 (수동 검증 스크립트) |
+
+#### 검증
+
+```bash
+# 유닛 테스트 (19개 전부 통과)
+venv/bin/python -m pytest tests/agent/test_fallback_context_bridge_integration.py -v
+
+# 시뮬레이션 스크립트
+venv/bin/python scripts/simulate_codex_fallback.py
+```
+
+---
+
+### PR 2 — Inspector HTTP API
+
+#### 문제
+
+Docker 컨테이너(ClaudeCode, Antigravity 등)에서 실행되는 AI 에이전트는 Native HermesAgent 인스턴스의 스킬 목록, 현재 모델, 게이트웨이 상태를 알 수 없다.
+
+기존 해결책 후보:
+- **전체 `.hermes/` 마운트**: `config.yaml`, `auth.json`, `.env` 등 API 키가 모두 노출되어 위험
+- **`skills/` 만 마운트**: 심볼릭 링크 처리 문제, 실시간 상태 조회 불가
+- **Inspector HTTP API** (채택): 민감 정보를 구조적으로 제외한 읽기전용 엔드포인트
+
+#### 해결
+
+**`gateway/inspector.py`** (신규)
+
+`InspectorServer` 클래스 — aiohttp 기반 읽기전용 HTTP 서버:
+
+| 엔드포인트 | 응답 내용 |
+|------------|-----------|
+| `GET /health` | `{status, pid, uptime_seconds}` |
+| `GET /status` | `{model, provider, gateway_state, active_agents, platforms}` |
+| `GET /skills` | 181개 스킬 목록 `[{slug, name, category, description}]` |
+| `GET /skills/<slug>` | SKILL.md 전문 (flat: `blue-ribbon-nearby`, nested: `devops/kanban-worker`) |
+| `GET /config/public` | api_key 제외된 안전 config |
+
+보안 설계:
+- `_SENSITIVE_KEY_PATTERNS` 정규식으로 api_key / token / secret / password / auth / credential 키 재귀적 제거
+- path traversal 방어: slug 이름은 `^[a-zA-Z0-9_\-]+(/[a-zA-Z0-9_\-]+)?$` 허용
+- 심볼릭 링크 지원 (`~/.agents/skills/` 에 링크된 스킬 포함)
+- 기본 바인드: `127.0.0.1:8646` (환경 변수로 오버라이드 가능)
+
+**`gateway/run.py`** (수정)
+
+`cron_thread.start()` 직후, `wait_for_shutdown()` 직전에 Inspector 서버 시작:
+```python
+HERMES_INSPECTOR_HOST=0.0.0.0  # Docker 접근 허용 시
+HERMES_INSPECTOR_PORT=8646      # 기본값
+HERMES_INSPECTOR_DISABLED=1    # 비활성화
+```
+
+#### 수정된 파일
+
+| 파일 | 변경 유형 |
+|------|-----------|
+| `gateway/inspector.py` | 신규 |
+| `gateway/run.py` | 수정 (+30줄) |
+| `docs/hermes-inspector-api.md` | 신규 (API 레퍼런스) |
+| `docs/hermes-inspector-skill.md` | 신규 (SKILL.md) |
+
+#### 검증
+
+```bash
+# Inspector 서버 시작 확인
+HERMES_INSPECTOR_HOST=0.0.0.0 hermes gateway run
+
+# 엔드포인트 테스트
+curl http://127.0.0.1:8646/health
+curl http://127.0.0.1:8646/skills | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d), '개 스킬')"
+curl http://127.0.0.1:8646/skills/blue-ribbon-nearby | python3 -c "import json,sys; print(json.load(sys.stdin)['content'][:100])"
+curl http://127.0.0.1:8646/skills/devops/kanban-worker | python3 -c "import json,sys; print(json.load(sys.stdin)['content'][:100])"
+
+# Docker 컨테이너에서 (Linux)
+docker run --rm --add-host=host.docker.internal:host-gateway curlimages/curl \
+  http://host.docker.internal:8646/health
+```
+
+---
+
+### PR 3 — providers.py hostname 정확도 개선
+
+#### 문제
+
+`determine_api_mode()` 에서 `api.openai.com` 을 포함하는 URL 판별 시 `in` 연산자를 사용해 부분 일치로 처리했다. 예를 들어 `https://custom-proxy.api.openai.com.evil.com/v1` 같은 악의적인 URL도 `codex_responses` 모드로 잘못 분류될 수 있다.
+
+```python
+# 수정 전
+if "api.openai.com" in url_lower:
+    return "codex_responses"
+
+# 수정 후
+if base_url_hostname(base_url) == "api.openai.com":
+    return "codex_responses"
+```
+
+#### 수정된 파일
+
+| 파일 | 변경 유형 |
+|------|-----------|
+| `hermes_cli/providers.py` | 수정 (1줄) |
+
+---
+
+### PR 4 — skill_view 중첩 디렉토리 오탐 수정
+
+#### 문제
+
+`skill_view()` 의 Strategy 3 (legacy flat `.md` 파일 검색) 에서 다른 스킬의 하위 디렉토리에 존재하는 동명 파일을 잘못 매칭했다.
+
+예: `devops/kanban-worker/` 안에 `code-review.md` 가 있을 때 `/code-review` 스킬 조회 시 이 파일이 후보로 잡히는 문제.
+
+#### 해결
+
+검색 중인 파일(`found_md`)의 상위 경로를 순회하며, `SKILL.md` 가 있는 다른 스킬 디렉토리 안에 포함된 경우 후보에서 제외한다.
+
+```python
+in_other_skill = False
+for p in found_md.parents:
+    if p == search_dir:
+        break
+    if (p / "SKILL.md").exists():
+        in_other_skill = True
+        break
+if not in_other_skill:
+    _record(None, found_md)
+```
+
+#### 수정된 파일
+
+| 파일 | 변경 유형 |
+|------|-----------|
+| `tools/skills_tool.py` | 수정 (+16줄) |
+
+---
+
+## 3. 오픈소스 기여 방법
+
+CONTRIBUTING.md의 규칙 요약: [docs](CONTRIBUTING.md)
+
+### 기본 원칙
+
+- **PR은 하나의 논리적 변경만 포함** — 버그픽스와 새 기능을 섞지 않는다
+- **Conventional Commits 형식** 사용
+- **테스트 필수** — 새 코드에는 테스트 추가
+- **라이선스**: 기여 내용은 MIT 라이선스 적용에 동의
+
+### Fork → Branch → PR 워크플로우
+
+```
+1. GitHub에서 NousResearch/hermes-agent Fork
+2. 로컬에 fork 추가
+3. 변경별 브랜치 생성
+4. 커밋 & 포크에 push
+5. GitHub에서 PR 생성
+```
+
+### Step 1: GitHub에서 Fork
+
+[https://github.com/NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) 에서 **Fork** 버튼 클릭.
+
+### Step 2: fork를 remote로 추가
+
+```bash
+# 본인 GitHub 계정명으로 교체
+GITHUB_USER="your-github-username"
+
+git remote add fork https://github.com/${GITHUB_USER}/hermes-agent.git
+git remote -v
+# origin  https://github.com/NousResearch/hermes-agent.git (fetch/push)  ← upstream
+# fork    https://github.com/YOUR_USER/hermes-agent.git    (fetch/push)  ← 기여용
+```
+
+### Step 3: upstream 최신 상태로 동기화
+
+```bash
+git fetch origin
+git checkout main
+git rebase origin/main
+```
+
+### Step 4: 변경별 브랜치 생성
+
+PR마다 별도 브랜치를 만든다. 브랜치명 규칙: `fix/description` 또는 `feat/description`
+
+```bash
+# PR 1
+git checkout -b fix/fallback-context-bridge-cross-mode
+
+# PR 2
+git checkout -b feat/gateway-inspector-api
+
+# PR 3
+git checkout -b fix/providers-hostname-exact-match
+
+# PR 4
+git checkout -b fix/skill-view-nested-dir-false-positive
+```
+
+### Step 5: Commit 메시지 형식
+
+```
+<type>(<scope>): <subject>
+
+[body — 생략 가능, 72자 줄바꿈]
+
+[footer — Closes #123, Breaking changes 등]
+```
+
+| type | 용도 |
+|------|------|
+| `fix` | 버그 수정 |
+| `feat` | 새 기능 |
+| `docs` | 문서 |
+| `test` | 테스트 |
+| `refactor` | 동작 변경 없는 리팩토링 |
+
+### Step 6: fork에 push
+
+```bash
+git push fork <브랜치명>
+```
+
+### Step 7: PR 생성
+
+GitHub에서 `fork/<브랜치>` → `NousResearch/hermes-agent:main` PR 생성.
+
+PR 본문에 포함:
+- **What**: 무엇이 바뀌었고 왜
+- **How to test**: 재현 방법 또는 테스트 명령어
+- **Platforms tested**: Linux / macOS / WSL2 등
+
+---
+
+## 4. PR별 commit 명령어
+
+> **사전 조건**: `GITHUB_USER` 에 본인 계정명 설정, fork remote 등록 완료
+
+---
+
+### PR 1: Fallback Context Bridge
+
+```bash
+git checkout main
+git fetch origin && git rebase origin/main
+
+git checkout -b fix/fallback-context-bridge-cross-mode
+
+git add \
+  agent/fallback_context_bridge.py \
+  agent/chat_completion_helpers.py \
+  agent/conversation_loop.py \
+  tests/agent/test_fallback_context_bridge_integration.py \
+  scripts/simulate_codex_fallback.py
+
+git commit -m "$(cat <<'EOF'
+fix(agent): preserve context and skills when fallback crosses api_mode boundary
+
+When try_activate_fallback() switches from codex_responses to
+anthropic_messages (or chat_completions), the already-built api_messages
+list contains Codex-specific fields (codex_reasoning_items,
+codex_message_items, encrypted reasoning blobs) that the new provider
+rejects with HTTP 400 / 422.  Additionally, the cached system prompt was
+not rebuilt for the new provider, so skills created or updated during the
+Codex session were invisible to the fallback model.
+
+Introduce agent/fallback_context_bridge.py with two responsibilities:
+
+  1. Context Bridge: strip codex_* fields and disable reasoning replay
+     when leaving codex_responses; strip cache_control / reasoning_content
+     pads when entering codex_responses from another provider.
+
+  2. Skill Re-injection: call agent._build_system_prompt() and replace
+     api_messages[0] so the fallback provider receives an up-to-date
+     skill index.
+
+try_activate_fallback() now records the api_mode delta on
+agent._pending_context_bridge and clears _cached_system_prompt when the
+mode changes.  conversation_loop.run_conversation() consumes the flag
+immediately before _build_api_kwargs(), after the existing
+_reapply_reasoning_echo_for_provider() call.  The bridge is fail-open:
+exceptions are logged at WARNING and the retry continues.
+
+Includes 19 unit tests and a standalone simulation script.
+EOF
+)"
+
+git push fork fix/fallback-context-bridge-cross-mode
+```
+
+---
+
+### PR 2: Inspector HTTP API
+
+```bash
+git checkout main
+git fetch origin && git rebase origin/main
+
+git checkout -b feat/gateway-inspector-api
+
+git add \
+  gateway/inspector.py \
+  gateway/run.py \
+  docs/hermes-inspector-api.md \
+  docs/hermes-inspector-skill.md
+
+git commit -m "$(cat <<'EOF'
+feat(gateway): add read-only Inspector HTTP API for external containers
+
+Docker containers (ClaudeCode, Antigravity, etc.) running alongside a
+native HermesAgent have no way to discover installed skills, current
+model/provider, or gateway status without mounting ~/.hermes/ — which
+exposes API keys, auth.json, session history, and other sensitive data.
+
+Add gateway/inspector.py (InspectorServer) — a lightweight aiohttp
+server that starts alongside the gateway and exposes five GET-only
+endpoints on 127.0.0.1:8646 (configurable):
+
+  GET /health           → {status, pid, uptime_seconds}
+  GET /status           → {model, provider, gateway_state, active_agents, platforms}
+  GET /skills           → skill list with slug/name/category/description
+  GET /skills/<slug>    → SKILL.md content (flat and nested slugs supported)
+  GET /config/public    → safe config subset (api_key and all sensitive keys excluded)
+
+Security design:
+  - Sensitive keys (api_key/token/secret/password/auth/credential/bearer)
+    are recursively stripped from config responses via regex allowlist.
+  - Skill slug validation uses ^[a-zA-Z0-9_\-]+(/[a-zA-Z0-9_\-]+)?$ to
+    prevent path traversal without needing symlink resolution (skills are
+    commonly symlinked from ~/.agents/skills/).
+  - Default bind is 127.0.0.1; set HERMES_INSPECTOR_HOST=0.0.0.0 to
+    allow Docker container access.
+  - Set HERMES_INSPECTOR_DISABLED=1 to opt out entirely.
+
+Supports both flat skill layouts (skill-name/SKILL.md) and one-level
+nested layouts (category/skill-name/SKILL.md), and follows symlinks so
+skills installed via ~/.agents/ are included.
+EOF
+)"
+
+git push fork feat/gateway-inspector-api
+```
+
+---
+
+### PR 3: providers.py hostname 정확도 개선
+
+```bash
+git checkout main
+git fetch origin && git rebase origin/main
+
+git checkout -b fix/providers-hostname-exact-match
+
+git add hermes_cli/providers.py
+
+git commit -m "$(cat <<'EOF'
+fix(hermes_cli): use exact hostname match for api.openai.com api_mode detection
+
+determine_api_mode() used a substring check ("api.openai.com" in url_lower)
+to decide whether to return codex_responses.  A URL like
+https://proxy.api.openai.com.evil.com/v1 would satisfy the substring test
+and be misclassified.
+
+Replace with base_url_hostname(base_url) == "api.openai.com" which
+extracts only the hostname component before comparing, matching the
+existing pattern used elsewhere in this file.
+EOF
+)"
+
+git push fork fix/providers-hostname-exact-match
+```
+
+---
+
+### PR 4: skill_view 중첩 디렉토리 오탐 수정
+
+```bash
+git checkout main
+git fetch origin && git rebase origin/main
+
+git checkout -b fix/skill-view-nested-dir-false-positive
+
+git add tools/skills_tool.py
+
+git commit -m "$(cat <<'EOF'
+fix(tools): exclude files inside other skills from skill_view legacy search
+
+skill_view() Strategy 3 searches for legacy flat <name>.md files using
+rglob.  When a nested skill directory contains a file whose name matches
+the queried skill name (e.g. devops/kanban-worker/code-review.md while
+searching for the code-review skill), it was incorrectly added as a
+candidate.
+
+Add an ancestor-walk check: if any directory between found_md and the
+search root contains its own SKILL.md, the file belongs to another skill's
+directory and is excluded from the candidate set.
+EOF
+)"
+
+git push fork fix/skill-view-nested-dir-false-positive
+```
+
+---
+
+## PR 본문 템플릿 (GitHub용)
+
+```markdown
+## What changed and why
+
+<!-- 무엇이 바뀌었고 왜 필요한지 설명 -->
+
+## How to test
+
+```bash
+# 테스트 명령어
+```
+
+## Platforms tested
+
+- [x] Linux (Ubuntu 24.04)
+- [ ] macOS
+- [ ] Windows / WSL2
+
+## Related issues
+
+Closes #
+```
+
+---
+
+## 참고 링크
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — 프로젝트 기여 가이드 (필독)
+- [GitHub Issues](https://github.com/NousResearch/hermes-agent/issues) — 버그 리포트
+- [Nous Research Discord](https://discord.gg/NousResearch) — 커뮤니티, 스킬 공유
+- [Conventional Commits](https://www.conventionalcommits.org/) — 커밋 메시지 형식

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1156,6 +1156,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
+        old_api_mode = getattr(agent, "api_mode", "chat_completions") or "chat_completions"
 
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
@@ -1274,6 +1275,22 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 provider=agent.provider,
                 api_mode=agent.api_mode,
             )
+
+        # When the api_mode changes (e.g. codex_responses → anthropic_messages
+        # or chat_completions), the already-built api_messages in the retry loop
+        # contain provider-specific fields (codex_reasoning_items, encrypted
+        # reasoning blobs) that the new provider rejects.  Flag the mismatch so
+        # conversation_loop can run the context bridge before the next request.
+        if old_api_mode != fb_api_mode:
+            agent._pending_context_bridge = {
+                "old_api_mode": old_api_mode,
+                "new_api_mode": fb_api_mode,
+            }
+            # Invalidate the cached system prompt so it rebuilds for the new
+            # provider on the next request, re-injecting current skill context.
+            agent._cached_system_prompt = None
+        else:
+            agent._pending_context_bridge = None
 
         agent._buffer_status(
             f"🔄 Primary model failed — switching to fallback: "

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -867,6 +867,28 @@ def run_conversation(
                 # unless the active provider needs it) so the fallback request
                 # isn't sent with stale, primary-shaped reasoning fields.
                 agent._reapply_reasoning_echo_for_provider(api_messages)
+
+                # Cross-mode fallback bridge: when the api_mode changed (e.g.
+                # codex_responses → anthropic_messages), strip provider-specific
+                # fields from api_messages and rebuild the system prompt so the
+                # new provider sees clean messages and current skill context.
+                _bridge = getattr(agent, "_pending_context_bridge", None)
+                if _bridge:
+                    agent._pending_context_bridge = None
+                    try:
+                        from agent.fallback_context_bridge import apply_fallback_context_bridge
+                        apply_fallback_context_bridge(
+                            agent,
+                            api_messages,
+                            _bridge["old_api_mode"],
+                            _bridge["new_api_mode"],
+                        )
+                    except Exception as _bridge_exc:
+                        logger.warning(
+                            "fallback_context_bridge failed (non-fatal): %s",
+                            _bridge_exc,
+                        )
+
                 api_kwargs = agent._build_api_kwargs(api_messages)
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)

--- a/agent/fallback_context_bridge.py
+++ b/agent/fallback_context_bridge.py
@@ -1,0 +1,216 @@
+"""Fallback Context Bridge — context translation across provider switches.
+
+When a mid-turn fallback activates and the api_mode changes (e.g.
+``codex_responses`` → ``anthropic_messages`` / ``chat_completions``), the
+already-built ``api_messages`` list contains provider-specific fields that
+the new provider rejects or misinterprets:
+
+  * ``codex_reasoning_items``   — Responses-API reasoning blobs; the new
+    provider does not recognise this key and strict gateways 422 on it.
+  * ``codex_message_items``     — Codex intermediate output items; same issue.
+  * ``reasoning_content`` pads  — injected by the Codex path; may collide
+    with the new provider's own echo-back convention.
+
+``apply_fallback_context_bridge()`` is called by ``conversation_loop.py``
+immediately after fallback activation is detected, before ``_build_api_kwargs``
+runs.  It performs two jobs in one pass:
+
+  1. **Context Bridge (Option 1)** — strip / neutralise provider-specific
+     fields from every message in ``api_messages`` so the new provider sees
+     clean, standard Chat-Completions or Anthropic-Messages format.
+
+  2. **Skill Re-injection (Option 2)** — rebuild the system message at
+     ``api_messages[0]`` with the freshly-built ``agent._cached_system_prompt``
+     (which was invalidated by ``try_activate_fallback`` when the api_mode
+     changed).  This ensures the new provider receives an up-to-date skill
+     index rather than the stale Codex-shaped prompt.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+# Fields that are specific to the OpenAI Responses / Codex API and must be
+# stripped when switching to a provider that uses Chat-Completions or the
+# Anthropic Messages API.
+_CODEX_SPECIFIC_FIELDS = frozenset({
+    "codex_reasoning_items",
+    "codex_message_items",
+})
+
+# Internal Hermes bookkeeping keys that no external API should receive.
+_HERMES_INTERNAL_FIELDS = frozenset({
+    "tool_name",
+    "finish_reason",
+    "reasoning",          # kept internally for trajectories; copied to reasoning_content where needed
+    "_thinking_prefill",
+})
+
+
+def _strip_codex_fields_from_messages(api_messages: List[Dict[str, Any]]) -> int:
+    """Remove Codex Responses-API-specific fields from every message.
+
+    Operates in-place on *api_messages*.  Returns the count of messages that
+    were modified.
+    """
+    modified = 0
+    for msg in api_messages:
+        if not isinstance(msg, dict):
+            continue
+        changed = False
+        for field in _CODEX_SPECIFIC_FIELDS:
+            if field in msg:
+                del msg[field]
+                changed = True
+        # Strip any remaining underscore-prefixed internal Hermes scaffolding
+        # that the Codex path may have left on the message.
+        internal_keys = [k for k in msg if isinstance(k, str) and k.startswith("_")]
+        for k in internal_keys:
+            del msg[k]
+            changed = True
+        if changed:
+            modified += 1
+    return modified
+
+
+def _rebuild_system_message(agent: Any, api_messages: List[Dict[str, Any]]) -> bool:
+    """Replace the system message in *api_messages* with a freshly-built prompt.
+
+    Builds ``agent._cached_system_prompt`` (it was invalidated when the
+    api_mode changed) and swaps the ``role: system`` entry at index 0.
+    Returns True when the system message was replaced, False otherwise.
+    """
+    # Rebuild _cached_system_prompt for the new provider.
+    try:
+        fresh_prompt = agent._build_system_prompt()
+        agent._cached_system_prompt = fresh_prompt
+    except Exception as exc:
+        logger.warning(
+            "fallback_context_bridge: failed to rebuild system prompt: %s", exc
+        )
+        return False
+
+    if not fresh_prompt:
+        return False
+
+    # Persist the updated prompt so subsequent turns in this session reuse it.
+    try:
+        if agent._session_db and agent.session_id:
+            agent._session_db.update_system_prompt(agent.session_id, fresh_prompt)
+    except Exception as exc:
+        logger.warning(
+            "fallback_context_bridge: could not persist rebuilt system prompt: %s", exc
+        )
+
+    new_sys = {"role": "system", "content": fresh_prompt}
+    if api_messages and api_messages[0].get("role") == "system":
+        api_messages[0] = new_sys
+        return True
+
+    # No system message present yet — prepend one.
+    api_messages.insert(0, new_sys)
+    return True
+
+
+def apply_fallback_context_bridge(
+    agent: Any,
+    api_messages: List[Dict[str, Any]],
+    old_api_mode: str,
+    new_api_mode: str,
+) -> None:
+    """Translate *api_messages* after a cross-mode provider fallback.
+
+    Called by ``conversation_loop.run_conversation`` immediately before
+    ``_build_api_kwargs`` when ``agent._pending_context_bridge`` is set.
+
+    Step 1 — Context Bridge: strip Codex-specific fields when leaving the
+    ``codex_responses`` api_mode, so the new provider receives clean messages.
+
+    Step 2 — Skill Re-injection: rebuild the system message so the new
+    provider sees the current skill index (plus any skills created or updated
+    during the Codex session).
+    """
+    leaving_codex = old_api_mode == "codex_responses"
+    entering_codex = new_api_mode == "codex_responses"
+
+    # ── Step 1: Context Bridge ─────────────────────────────────────────────
+    if leaving_codex:
+        stripped = _strip_codex_fields_from_messages(api_messages)
+        if stripped:
+            logger.info(
+                "fallback_context_bridge: stripped Codex-specific fields from "
+                "%d messages (codex_responses → %s)",
+                stripped, new_api_mode,
+            )
+        # Disable reasoning replay — encrypted_content blobs minted by Codex
+        # are sealed to that endpoint and will be rejected by the new provider.
+        try:
+            stats = agent._disable_codex_reasoning_replay(api_messages)
+            if stats.get("messages"):
+                logger.info(
+                    "fallback_context_bridge: disabled codex reasoning replay "
+                    "(%d messages, %d items)",
+                    stats["messages"], stats.get("items", 0),
+                )
+        except Exception as exc:
+            logger.warning(
+                "fallback_context_bridge: _disable_codex_reasoning_replay failed: %s", exc
+            )
+
+    if entering_codex:
+        # Entering Codex from another provider: strip anthropic-specific fields
+        # (reasoning_content pads, cache_control markers) that Codex rejects.
+        _strip_anthropic_fields_from_messages(api_messages)
+
+    # ── Step 2: Skill Re-injection ─────────────────────────────────────────
+    # _cached_system_prompt was set to None by try_activate_fallback() when the
+    # api_mode changed.  Rebuild it now so the new provider receives a prompt
+    # that reflects the current skill index (including skills created/updated
+    # during the outgoing provider's session).
+    rebuilt = _rebuild_system_message(agent, api_messages)
+    if rebuilt:
+        logger.info(
+            "fallback_context_bridge: rebuilt system prompt for new provider "
+            "(%s → %s), skill context re-injected",
+            old_api_mode, new_api_mode,
+        )
+    else:
+        logger.warning(
+            "fallback_context_bridge: system prompt rebuild skipped or failed "
+            "(%s → %s)",
+            old_api_mode, new_api_mode,
+        )
+
+
+def _strip_anthropic_fields_from_messages(api_messages: List[Dict[str, Any]]) -> int:
+    """Strip Anthropic-Messages-specific fields when switching TO Codex.
+
+    ``cache_control`` markers and ``reasoning_content`` pads written by the
+    Anthropic path confuse the Responses API.  Operates in-place.
+    """
+    modified = 0
+    for msg in api_messages:
+        if not isinstance(msg, dict):
+            continue
+        changed = False
+        # cache_control is only valid for the Anthropic Messages API.
+        if "cache_control" in msg:
+            del msg["cache_control"]
+            changed = True
+        # Strip cache_control from content parts (Anthropic injects it there).
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and "cache_control" in part:
+                    del part["cache_control"]
+                    changed = True
+        # reasoning_content pads are Anthropic/DeepSeek-specific.
+        if "reasoning_content" in msg:
+            del msg["reasoning_content"]
+            changed = True
+        if changed:
+            modified += 1
+    return modified

--- a/docs/hermes-inspector-api.md
+++ b/docs/hermes-inspector-api.md
@@ -1,0 +1,302 @@
+# HermesAgent Inspector API
+
+## 개요
+
+**HermesAgent Inspector**는 외부 Docker 컨테이너(ClaudeCode, Antigravity 등)가 네이티브 HermesAgent 인스턴스의 공개 정보를 읽기 전용으로 조회할 수 있도록 제공하는 경량 HTTP 서버입니다.
+
+- 기본 바인드: `http://127.0.0.1:8646`
+- GET 전용 엔드포인트 (읽기 전용)
+- CORS 허용 (`Access-Control-Allow-Origin: *`)
+- 인증 없이 접근 가능 (단, 민감 정보는 구조적으로 제외됨)
+
+---
+
+## 엔드포인트 레퍼런스
+
+### `GET /health`
+
+게이트웨이 프로세스의 생존 여부와 업타임을 반환합니다.
+
+**요청**
+```
+GET http://127.0.0.1:8646/health
+```
+
+**응답 예시**
+```json
+{
+  "status": "ok",
+  "pid": 12345,
+  "uptime_seconds": 3720.45
+}
+```
+
+---
+
+### `GET /status`
+
+현재 모델, 프로바이더, API 모드, 게이트웨이 상태, 활성 에이전트 수, 플랫폼 연결 상태를 반환합니다.
+
+**요청**
+```
+GET http://127.0.0.1:8646/status
+```
+
+**응답 예시**
+```json
+{
+  "model": "claude-opus-4-5",
+  "provider": "anthropic",
+  "api_mode": "api",
+  "gateway_state": "running",
+  "active_agents": 2,
+  "platforms": {
+    "telegram": {
+      "state": "connected",
+      "updated_at": "2026-06-10T04:00:00+00:00"
+    },
+    "discord": {
+      "state": "connected",
+      "updated_at": "2026-06-10T04:00:00+00:00"
+    }
+  }
+}
+```
+
+---
+
+### `GET /skills`
+
+`~/.hermes/skills/` 디렉토리를 스캔하여 설치된 스킬 목록을 반환합니다. 각 스킬의 `SKILL.md` frontmatter에서 `name`, `category`, `description`을 추출합니다.
+
+**요청**
+```
+GET http://127.0.0.1:8646/skills
+```
+
+**응답 예시**
+```json
+[
+  {
+    "slug": "blue-ribbon-nearby",
+    "name": "blue-ribbon-nearby",
+    "category": "food",
+    "description": "Use when the user asks for nearby restaurants or 근처 맛집 and wants 블루리본 picks."
+  },
+  {
+    "slug": "devops/kanban-worker",
+    "name": "kanban-worker",
+    "category": "devops",
+    "description": "Pitfalls, examples, and edge cases for Hermes Kanban workers."
+  }
+]
+```
+
+`slug` 필드는 API 엔드포인트에 사용하는 경로 식별자입니다. 단순 스킬은 `name`과 동일하고, 카테고리 아래 중첩된 스킬은 `category/name` 형태입니다.
+
+---
+
+### `GET /skills/<slug>`
+
+특정 스킬의 `SKILL.md` 전문(본문 포함)을 반환합니다. `slug`는 `/skills` 응답의 `slug` 필드 값을 사용합니다.
+
+**요청 (단순)**
+```
+GET http://127.0.0.1:8646/skills/blue-ribbon-nearby
+```
+
+**요청 (중첩)**
+```
+GET http://127.0.0.1:8646/skills/devops/kanban-worker
+```
+
+**응답 예시**
+```json
+{
+  "slug": "blue-ribbon-nearby",
+  "content": "---\nname: blue-ribbon-nearby\ndescription: ...\n---\n\n# Blue Ribbon Nearby\n..."
+}
+```
+
+**404 응답 예시 (스킬 없음)**
+```json
+{
+  "error": "not_found",
+  "message": "Skill 'nonexistent-skill' not found"
+}
+```
+
+---
+
+### `GET /config/public`
+
+민감하지 않은 공개 설정만 반환합니다. `api_key`, `token`, `secret`, `password`, `auth`, `credential`, `bearer` 관련 키는 모두 제외됩니다.
+
+노출되는 섹션: `model`, `agent`, `toolsets`, `compression`, `language`, `locale`, `ui`
+
+**요청**
+```
+GET http://127.0.0.1:8646/config/public
+```
+
+**응답 예시**
+```json
+{
+  "model": {
+    "default": "claude-opus-4-5",
+    "provider": "anthropic"
+  },
+  "agent": {
+    "max_turns": 50,
+    "timeout_seconds": 300
+  },
+  "toolsets": ["default", "web", "code"],
+  "compression": {
+    "enabled": true,
+    "threshold_tokens": 8000
+  }
+}
+```
+
+---
+
+## Docker Container에서 사용하는 법
+
+Docker 컨테이너 내부에서 호스트의 Inspector에 접근할 때는 `host.docker.internal`을 사용합니다.
+
+### curl 예시
+
+```bash
+# 컨테이너 내부에서 호스트 HermesAgent Inspector 조회
+curl http://host.docker.internal:8646/health
+curl http://host.docker.internal:8646/status
+curl http://host.docker.internal:8646/skills
+curl http://host.docker.internal:8646/skills/blue-ribbon-nearby
+curl http://host.docker.internal:8646/config/public
+```
+
+### Python requests 예시
+
+```python
+import os
+import requests
+
+HERMES_INSPECTOR_URL = os.environ.get(
+    "HERMES_INSPECTOR_URL", "http://host.docker.internal:8646"
+)
+
+def get_hermes_status():
+    resp = requests.get(f"{HERMES_INSPECTOR_URL}/status", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+def list_hermes_skills():
+    resp = requests.get(f"{HERMES_INSPECTOR_URL}/skills", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+def get_skill_content(name: str):
+    resp = requests.get(f"{HERMES_INSPECTOR_URL}/skills/{name}", timeout=5)
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    return resp.json()["content"]
+```
+
+---
+
+## 환경 변수
+
+| 환경 변수 | 기본값 | 설명 |
+|---|---|---|
+| `HERMES_INSPECTOR_HOST` | `127.0.0.1` | Inspector 서버 바인드 호스트 |
+| `HERMES_INSPECTOR_PORT` | `8646` | Inspector 서버 포트 |
+| `HERMES_INSPECTOR_DISABLED` | (unset) | `1`, `true`, `yes`로 설정 시 Inspector 비활성화 |
+
+Docker 컨테이너가 접근하려면 호스트에서 `HERMES_INSPECTOR_HOST=0.0.0.0`으로 설정하거나, Docker 네트워크 구성에 따라 적절히 조정하세요.
+
+---
+
+## 보안 고려사항
+
+### 노출되는 정보
+
+- 프로세스 PID 및 업타임
+- 게이트웨이 상태 (`running`, `starting`, `degraded` 등)
+- 활성 에이전트 수
+- 플랫폼 연결 상태 (연결됨/끊김, 오류 코드)
+- 현재 모델 이름 및 프로바이더
+- API 모드 (`api`, `mcp` 등)
+- 스킬 이름, 카테고리, 설명
+- SKILL.md 전문 (설치된 스킬의 사용 방법)
+- 비민감 config 섹션 (model.default, agent.max_turns, toolsets 등)
+
+### 노출되지 않는 정보
+
+- API 키, 토큰, Bearer 인증 정보
+- `auth.json`, `.env` 파일 내용
+- 세션 데이터 및 대화 기록
+- 메모리(memories) 파일
+- config.yaml의 민감 키 (`api_key`, `token`, `secret`, `password`, `auth`, `credential`)
+- 플랫폼 인증 정보 (Telegram bot token, Discord token 등)
+
+### 네트워크 접근 제어
+
+기본값 `127.0.0.1` 바인딩은 같은 호스트에서만 접근 가능합니다. 외부 네트워크에 노출하려면 반드시 방화벽 규칙을 설정하세요.
+
+---
+
+## docker-compose.yml 예시
+
+```yaml
+version: "3.9"
+
+services:
+  hermes-agent:
+    build: .
+    environment:
+      - HERMES_INSPECTOR_HOST=0.0.0.0
+      - HERMES_INSPECTOR_PORT=8646
+    ports:
+      - "127.0.0.1:8646:8646"
+    volumes:
+      - ~/.hermes:/root/.hermes
+
+  claude-code:
+    image: ghcr.io/anthropics/claude-code:latest
+    environment:
+      - HERMES_INSPECTOR_URL=http://hermes-agent:8646
+    depends_on:
+      - hermes-agent
+    networks:
+      - hermes-net
+
+  antigravity:
+    image: antigravity:latest
+    environment:
+      - HERMES_INSPECTOR_URL=http://hermes-agent:8646
+    depends_on:
+      - hermes-agent
+    networks:
+      - hermes-net
+
+networks:
+  hermes-net:
+    driver: bridge
+```
+
+### host.docker.internal 사용 (macOS/Windows Docker Desktop)
+
+```yaml
+version: "3.9"
+
+services:
+  claude-code:
+    image: ghcr.io/anthropics/claude-code:latest
+    environment:
+      - HERMES_INSPECTOR_URL=http://host.docker.internal:8646
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
+
+> **참고**: Linux Docker에서는 `extra_hosts: ["host.docker.internal:host-gateway"]`를 명시해야 합니다. macOS/Windows Docker Desktop에서는 자동으로 동작합니다.

--- a/docs/hermes-inspector-skill.md
+++ b/docs/hermes-inspector-skill.md
@@ -1,0 +1,253 @@
+---
+name: hermes-inspector
+description: Query the native HermesAgent instance from inside a Docker container using the Inspector API. Use this skill when you need to discover available skills, check gateway status, or read public configuration from within a containerized environment.
+license: MIT
+metadata:
+  category: devops
+  locale: en
+  phase: v1
+---
+
+# HermesAgent Inspector Skill
+
+## What this skill does
+
+Docker 컨테이너(ClaudeCode, Antigravity 등) 내부에서 실행되는 AI 에이전트가 **네이티브 HermesAgent 인스턴스**의 공개 정보를 조회할 수 있게 합니다.
+
+- 설치된 스킬 목록 조회
+- 특정 스킬의 사용법(SKILL.md) 읽기
+- 게이트웨이 상태 및 활성 에이전트 수 확인
+- 공개 설정 (모델, 프로바이더, 툴셋 등) 조회
+
+## When to use
+
+- "어떤 HermesAgent 스킬이 설치되어 있는지 알고 싶을 때"
+- "특정 스킬의 사용법을 알아야 할 때"
+- "HermesAgent가 현재 어떤 모델을 사용하는지 확인할 때"
+- "게이트웨이가 정상 동작 중인지 확인할 때"
+
+---
+
+## 환경 설정
+
+컨테이너 내에서 Inspector URL을 환경 변수로 설정합니다:
+
+```bash
+export HERMES_INSPECTOR_URL="http://host.docker.internal:8646"
+# 또는 docker-compose 네트워크 내에서:
+export HERMES_INSPECTOR_URL="http://hermes-agent:8646"
+```
+
+---
+
+## 스킬 목록 조회
+
+### curl
+
+```bash
+curl "${HERMES_INSPECTOR_URL}/skills"
+```
+
+### Python
+
+```python
+import os
+import requests
+
+base_url = os.environ.get("HERMES_INSPECTOR_URL", "http://host.docker.internal:8646")
+
+def list_skills():
+    """설치된 스킬 목록 반환 (name, category, description)."""
+    resp = requests.get(f"{base_url}/skills", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+skills = list_skills()
+for skill in skills:
+    print(f"[{skill.get('category', 'unknown')}] {skill['name']}: {skill.get('description', '')}")
+```
+
+**응답 예시**
+```json
+[
+  {
+    "name": "blue-ribbon-nearby",
+    "category": "food",
+    "description": "Use when the user asks for nearby restaurants or 근처 맛집 and wants 블루리본 picks."
+  },
+  {
+    "name": "korean-stock-search",
+    "category": "finance",
+    "description": "Search Korean stock market data."
+  }
+]
+```
+
+---
+
+## 특정 스킬 내용 가져오기
+
+### curl
+
+```bash
+curl "${HERMES_INSPECTOR_URL}/skills/blue-ribbon-nearby"
+```
+
+### Python
+
+```python
+import os
+import requests
+
+base_url = os.environ.get("HERMES_INSPECTOR_URL", "http://host.docker.internal:8646")
+
+def get_skill_content(skill_name: str) -> str | None:
+    """스킬의 SKILL.md 전문을 반환. 없으면 None."""
+    resp = requests.get(f"{base_url}/skills/{skill_name}", timeout=5)
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    return resp.json()["content"]
+
+content = get_skill_content("blue-ribbon-nearby")
+if content:
+    print(content)
+else:
+    print("Skill not found")
+```
+
+**응답 예시**
+```json
+{
+  "name": "blue-ribbon-nearby",
+  "content": "---\nname: blue-ribbon-nearby\ndescription: ...\n---\n\n# Blue Ribbon Nearby\n\n..."
+}
+```
+
+---
+
+## 게이트웨이 상태 확인
+
+### curl
+
+```bash
+curl "${HERMES_INSPECTOR_URL}/health"
+curl "${HERMES_INSPECTOR_URL}/status"
+```
+
+### Python
+
+```python
+import os
+import requests
+
+base_url = os.environ.get("HERMES_INSPECTOR_URL", "http://host.docker.internal:8646")
+
+def check_gateway_health() -> dict:
+    resp = requests.get(f"{base_url}/health", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+def get_gateway_status() -> dict:
+    resp = requests.get(f"{base_url}/status", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+health = check_gateway_health()
+print(f"Gateway PID: {health['pid']}, Uptime: {health['uptime_seconds']}s")
+
+status = get_gateway_status()
+print(f"Model: {status['model']}, State: {status['gateway_state']}, Active agents: {status['active_agents']}")
+```
+
+---
+
+## 공개 설정 조회
+
+```bash
+curl "${HERMES_INSPECTOR_URL}/config/public"
+```
+
+```python
+def get_public_config() -> dict:
+    resp = requests.get(f"{base_url}/config/public", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+config = get_public_config()
+print(f"Default model: {config.get('model', {}).get('default')}")
+print(f"Max turns: {config.get('agent', {}).get('max_turns')}")
+```
+
+---
+
+## HERMES_INSPECTOR_URL 활용 패턴
+
+### 연결 확인 후 스킬 동적 로딩
+
+```python
+import os
+import requests
+from functools import lru_cache
+
+_INSPECTOR_URL = os.environ.get("HERMES_INSPECTOR_URL")
+
+def inspector_available() -> bool:
+    """Inspector 서버가 접근 가능한지 확인."""
+    if not _INSPECTOR_URL:
+        return False
+    try:
+        resp = requests.get(f"{_INSPECTOR_URL}/health", timeout=2)
+        return resp.status_code == 200
+    except requests.RequestException:
+        return False
+
+@lru_cache(maxsize=1)
+def get_all_skills() -> list[dict]:
+    """스킬 목록을 캐시해서 반환 (Inspector 미사용 시 빈 리스트)."""
+    if not inspector_available():
+        return []
+    try:
+        resp = requests.get(f"{_INSPECTOR_URL}/skills", timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        return []
+
+def find_skill_by_description(keyword: str) -> list[dict]:
+    """description에 키워드가 포함된 스킬 검색."""
+    return [
+        s for s in get_all_skills()
+        if keyword.lower() in (s.get("description") or "").lower()
+    ]
+```
+
+### 에이전트 시스템 프롬프트에 스킬 목록 주입
+
+```python
+def build_skills_context() -> str:
+    """사용 가능한 스킬 목록을 시스템 프롬프트용 텍스트로 반환."""
+    skills = get_all_skills()
+    if not skills:
+        return ""
+    lines = ["## Available HermesAgent Skills\n"]
+    for skill in skills:
+        name = skill.get("name", "unknown")
+        desc = skill.get("description", "")
+        cat = skill.get("category", "")
+        cat_tag = f"[{cat}] " if cat else ""
+        lines.append(f"- **{name}**: {cat_tag}{desc}")
+    return "\n".join(lines)
+```
+
+---
+
+## 보안 참고사항
+
+Inspector API는 다음 정보를 **절대 노출하지 않습니다**:
+- API 키, 토큰, 인증 정보
+- 대화 세션 및 메모리
+- `.env` 파일 내용
+- config.yaml의 민감 키
+
+따라서 `HERMES_INSPECTOR_URL`을 컨테이너 환경 변수에 노출하는 것은 보안상 안전합니다.

--- a/gateway/inspector.py
+++ b/gateway/inspector.py
@@ -1,0 +1,303 @@
+"""
+Inspector HTTP server — read-only meta API for external containers.
+
+Allows external Docker containers (ClaudeCode, Antigravity, etc.) to query
+the native HermesAgent instance for public status, skills, and configuration.
+
+Security principles:
+- GET-only endpoints
+- No API keys, tokens, auth.json, .env, sessions, or memories exposed
+- Sensitive config keys (api_key, token, secret, password) are structurally excluded
+- Binds to 127.0.0.1 by default; override via HERMES_INSPECTOR_HOST / HERMES_INSPECTOR_PORT
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    from aiohttp import web
+    AIOHTTP_AVAILABLE = True
+except ImportError:
+    web = None  # type: ignore[assignment]
+    AIOHTTP_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+# Keys that are never exposed in /config/public, regardless of nesting level.
+_SENSITIVE_KEY_PATTERNS = re.compile(
+    r"(api[_-]?key|apikey|token|secret|password|passwd|auth|credential|bearer)",
+    re.IGNORECASE,
+)
+
+# Frontmatter description extractor
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_DESCRIPTION_RE = re.compile(r"^description:\s*(.+)$", re.MULTILINE)
+_NAME_RE = re.compile(r"^name:\s*(.+)$", re.MULTILINE)
+_CATEGORY_RE = re.compile(r"^\s*category:\s*(.+)$", re.MULTILINE)
+
+
+def _cors_headers() -> dict:
+    return {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
+    }
+
+
+def _json_response(data: Any, status: int = 200) -> "web.Response":
+    return web.Response(
+        text=json.dumps(data, ensure_ascii=False),
+        status=status,
+        content_type="application/json",
+        headers=_cors_headers(),
+    )
+
+
+def _extract_frontmatter(text: str) -> dict:
+    """Extract key-value pairs from a SKILL.md YAML frontmatter block."""
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    front = m.group(1)
+    result: dict = {}
+
+    name_m = _NAME_RE.search(front)
+    if name_m:
+        result["name"] = name_m.group(1).strip()
+
+    desc_m = _DESCRIPTION_RE.search(front)
+    if desc_m:
+        result["description"] = desc_m.group(1).strip()
+
+    cat_m = _CATEGORY_RE.search(front)
+    if cat_m:
+        result["category"] = cat_m.group(1).strip()
+
+    return result
+
+
+def _scrub_sensitive(obj: Any, _depth: int = 0) -> Any:
+    """Recursively remove keys that match sensitive-key patterns from a dict."""
+    if _depth > 20:
+        return obj
+    if isinstance(obj, dict):
+        return {
+            k: _scrub_sensitive(v, _depth + 1)
+            for k, v in obj.items()
+            if not _SENSITIVE_KEY_PATTERNS.search(str(k))
+        }
+    if isinstance(obj, list):
+        return [_scrub_sensitive(item, _depth + 1) for item in obj]
+    return obj
+
+
+class InspectorServer:
+    """Read-only HTTP server exposing HermesAgent public metadata."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        gateway_state_file: str,
+        hermes_home: str,
+    ) -> None:
+        if not AIOHTTP_AVAILABLE:
+            raise RuntimeError(
+                "aiohttp is required for InspectorServer. "
+                "Install with: pip install aiohttp"
+            )
+        self._host = host
+        self._port = port
+        self._gateway_state_file = Path(gateway_state_file)
+        self._hermes_home = Path(hermes_home)
+        self._skills_dir = self._hermes_home / "skills"
+        self._config_file = self._hermes_home / "config.yaml"
+        self._start_time = time.monotonic()
+        self._runner: Optional[Any] = None
+        self._site: Optional[Any] = None
+
+    # ── Internal helpers ──────────────────────────────────────────────
+
+    def _read_gateway_state(self) -> dict:
+        """Read gateway_state.json, returning empty dict on any error."""
+        try:
+            raw = self._gateway_state_file.read_text(encoding="utf-8").strip()
+            data = json.loads(raw)
+            return data if isinstance(data, dict) else {}
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return {}
+
+    def _read_config_yaml(self) -> dict:
+        """Read config.yaml as a plain dict; returns empty dict on any error."""
+        try:
+            import yaml  # type: ignore[import]
+            raw = self._config_file.read_text(encoding="utf-8")
+            data = yaml.safe_load(raw)
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
+
+    def _iter_skill_dirs(self):
+        """Yield (slug, skill_md_path) for every SKILL.md under the skills dir.
+
+        Follows symlinks (most installed skills are symlinked from ~/.agents/skills/).
+        Supports flat layout (skill-name/SKILL.md) and one-level nested layout
+        (category/skill-name/SKILL.md).  Hidden directories (starting with '.')
+        are skipped.
+        """
+        if not self._skills_dir.is_dir():
+            return
+        for top in sorted(self._skills_dir.iterdir()):
+            if top.name.startswith("."):
+                continue
+            if not top.is_dir():          # follows symlinks
+                continue
+            direct = top / "SKILL.md"
+            if direct.is_file():
+                yield top.name, direct
+                continue
+            # Nested: category/skill-name/SKILL.md
+            for sub in sorted(top.iterdir()):
+                if sub.name.startswith(".") or not sub.is_dir():
+                    continue
+                nested = sub / "SKILL.md"
+                if nested.is_file():
+                    yield f"{top.name}/{sub.name}", nested
+
+    def _list_skills(self) -> list[dict]:
+        """Scan ~/.hermes/skills/ and return a list of public skill metadata."""
+        skills = []
+        for slug, skill_md in self._iter_skill_dirs():
+            try:
+                text = skill_md.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            meta = _extract_frontmatter(text)
+            skills.append({
+                "slug": slug,
+                "name": meta.get("name") or slug.split("/")[-1],
+                "category": meta.get("category"),
+                "description": meta.get("description"),
+            })
+        return skills
+
+    def _get_skill_content(self, slug: str) -> Optional[str]:
+        """Return the full SKILL.md text for a slug (flat or nested), or None.
+
+        Path traversal is prevented by the allowlist regex — no '..' components
+        are possible, so we do NOT resolve symlinks (most skills are symlinked
+        from ~/.agents/skills/ and resolving breaks the relative_to check).
+        """
+        # Allow: letters, digits, hyphens, underscores, and ONE internal slash
+        if not re.match(r"^[a-zA-Z0-9_\-]+(/[a-zA-Z0-9_\-]+)?$", slug):
+            return None
+        skill_md = self._skills_dir / slug / "SKILL.md"
+        if not skill_md.is_file():   # follows symlinks — correct
+            return None
+        try:
+            return skill_md.read_text(encoding="utf-8")
+        except OSError:
+            return None
+
+    # ── Route handlers ────────────────────────────────────────────────
+
+    async def _handle_health(self, request: "web.Request") -> "web.Response":
+        return _json_response({
+            "status": "ok",
+            "pid": os.getpid(),
+            "uptime_seconds": round(time.monotonic() - self._start_time, 2),
+        })
+
+    async def _handle_status(self, request: "web.Request") -> "web.Response":
+        state = self._read_gateway_state()
+        config = self._read_config_yaml()
+
+        model_cfg = config.get("model", {}) if isinstance(config.get("model"), dict) else {}
+        runtime_cfg = config.get("runtime", {}) if isinstance(config.get("runtime"), dict) else {}
+
+        return _json_response({
+            "model": model_cfg.get("default"),
+            "provider": model_cfg.get("provider"),
+            "api_mode": runtime_cfg.get("api_mode"),
+            "gateway_state": state.get("gateway_state"),
+            "active_agents": state.get("active_agents", 0),
+            "platforms": state.get("platforms", {}),
+        })
+
+    async def _handle_skills_list(self, request: "web.Request") -> "web.Response":
+        return _json_response(self._list_skills())
+
+    async def _handle_skill_detail(self, request: "web.Request") -> "web.Response":
+        # Support both flat (/skills/name) and nested (/skills/category/name) slugs
+        slug = request.match_info.get("slug", "")
+        content = self._get_skill_content(slug)
+        if content is None:
+            return _json_response(
+                {"error": "not_found", "message": f"Skill '{slug}' not found"},
+                status=404,
+            )
+        return _json_response({"slug": slug, "content": content})
+
+    async def _handle_config_public(self, request: "web.Request") -> "web.Response":
+        config = self._read_config_yaml()
+
+        # Allow-list approach: only expose known safe top-level sections,
+        # then scrub any remaining sensitive keys inside them.
+        safe_keys = {"model", "agent", "toolsets", "compression", "language", "locale", "ui"}
+        public: dict = {}
+        for key in safe_keys:
+            if key in config:
+                public[key] = _scrub_sensitive(config[key])
+
+        return _json_response(public)
+
+    async def _handle_options(self, request: "web.Request") -> "web.Response":
+        """CORS preflight handler."""
+        return web.Response(status=204, headers=_cors_headers())
+
+    # ── Lifecycle ─────────────────────────────────────────────────────
+
+    def _build_app(self) -> "web.Application":
+        app = web.Application()
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/status", self._handle_status)
+        app.router.add_get("/skills", self._handle_skills_list)
+        # {slug:.+} matches both flat (name) and nested (category/name) slugs
+        app.router.add_get(r"/skills/{slug:.+}", self._handle_skill_detail)
+        app.router.add_get("/config/public", self._handle_config_public)
+        # CORS preflight
+        app.router.add_route("OPTIONS", "/{path_info:.*}", self._handle_options)
+        return app
+
+    async def start(self) -> None:
+        """Start the Inspector HTTP server."""
+        app = self._build_app()
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        self._site = web.TCPSite(
+            self._runner,
+            host=self._host,
+            port=self._port,
+        )
+        await self._site.start()
+        logger.debug(
+            "Inspector server started on http://%s:%s", self._host, self._port
+        )
+
+    async def stop(self) -> None:
+        """Stop the Inspector HTTP server gracefully."""
+        if self._runner is not None:
+            try:
+                await self._runner.cleanup()
+            except Exception as exc:
+                logger.debug("Inspector server cleanup error: %s", exc)
+            self._runner = None
+            self._site = None
+            logger.debug("Inspector server stopped")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15858,7 +15858,26 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="cron-ticker",
     )
     cron_thread.start()
-    
+
+    # Inspector server (read-only meta API for external containers)
+    _inspector_server = None
+    _inspector_host = os.environ.get("HERMES_INSPECTOR_HOST", "127.0.0.1")
+    _inspector_port = int(os.environ.get("HERMES_INSPECTOR_PORT", "8646"))
+    if os.environ.get("HERMES_INSPECTOR_DISABLED", "").lower() not in ("1", "true", "yes"):
+        try:
+            from gateway.inspector import InspectorServer
+            _inspector_server = InspectorServer(
+                host=_inspector_host,
+                port=_inspector_port,
+                gateway_state_file=str(_hermes_home / "gateway_state.json"),
+                hermes_home=str(_hermes_home),
+            )
+            await _inspector_server.start()
+            logger.info("Inspector server listening on %s:%s", _inspector_host, _inspector_port)
+        except Exception as _ins_exc:
+            logger.warning("Inspector server failed to start: %s", _ins_exc)
+            _inspector_server = None
+
     # Wait for shutdown
     await runner.wait_for_shutdown()
 
@@ -15866,7 +15885,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         if runner.exit_reason:
             logger.error("Gateway exiting with failure: %s", runner.exit_reason)
         return False
-    
+
+    # Stop inspector server
+    if _inspector_server is not None:
+        try:
+            await _inspector_server.stop()
+        except Exception as _ins_stop_exc:
+            logger.debug("Inspector server stop error: %s", _ins_stop_exc)
+
     # Stop cron ticker cleanly
     cron_stop.set()
     cron_thread.join(timeout=5)

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -517,7 +517,7 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
                 return "anthropic_messages"
             if url_lower.endswith("/anthropic") or "api.anthropic.com" in url_lower:
                 return "anthropic_messages"
-            if "api.openai.com" in url_lower:
+            if base_url_hostname(base_url) == "api.openai.com":
                 return "codex_responses"
         return TRANSPORT_TO_API_MODE.get(pdef.transport, "chat_completions")
 

--- a/scripts/simulate_codex_fallback.py
+++ b/scripts/simulate_codex_fallback.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Codex → local-claude fallback 시뮬레이션.
+
+실제 try_activate_fallback() 코드 경로를 직접 실행해서
+Context Bridge와 Skill Re-injection이 동작하는지 확인한다.
+
+실행:
+    cd /home/ubuntu/hermes-agent
+    python scripts/simulate_codex_fallback.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import copy
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# ──────────────────────────────────────────────
+# ANSI 컬러 헬퍼
+# ──────────────────────────────────────────────
+RED    = "\033[31m"
+GREEN  = "\033[32m"
+YELLOW = "\033[33m"
+CYAN   = "\033[36m"
+BOLD   = "\033[1m"
+RESET  = "\033[0m"
+
+def header(title): print(f"\n{BOLD}{CYAN}{'─'*60}{RESET}\n{BOLD}{CYAN}{title}{RESET}\n{'─'*60}")
+def ok(msg):       print(f"  {GREEN}✅ {msg}{RESET}")
+def warn(msg):     print(f"  {YELLOW}⚠️  {msg}{RESET}")
+def info(msg):     print(f"  {msg}")
+def field(k, v):   print(f"  {BOLD}{k:30s}{RESET}{v}")
+
+# ──────────────────────────────────────────────
+# Step 1: Codex 세션 대화 히스토리 구성
+# ──────────────────────────────────────────────
+header("Step 1: Codex 세션 대화 히스토리 구성")
+
+ORIGINAL_SYSTEM = (
+    "You are Hermes, a helpful AI assistant.\n\n"
+    "## Skills\n"
+    "- codex-demo: Codex 세션 중 만들어진 스킬\n"
+    "- code-review: 코드 리뷰 스킬\n"
+)
+
+api_messages = [
+    {"role": "system", "content": ORIGINAL_SYSTEM},
+    {"role": "user", "content": "파이썬 덧셈 함수 만들어줘"},
+    {
+        "role": "assistant",
+        "content": "네, `add(a, b)` 함수를 만들겠습니다.",
+        # Codex Responses API 전용 필드
+        "codex_reasoning_items": [
+            {
+                "type": "reasoning",
+                "encrypted_content": "enc_codex_abc123==",
+                "_issuer_kind": "codex_backend",
+            }
+        ],
+        "codex_message_items": [
+            {"type": "message", "id": "msg_001", "content": [{"type": "output_text", "text": "함수 생성 중..."}]}
+        ],
+        "_thinking_prefill": True,
+    },
+    {"role": "tool", "content": '{"result": "def add(a, b): return a + b"}', "tool_call_id": "call_001"},
+    {
+        "role": "assistant",
+        "content": "완료! `def add(a, b): return a + b` 함수를 만들었습니다.",
+        "codex_reasoning_items": [
+            {
+                "type": "reasoning",
+                "encrypted_content": "enc_codex_def456==",
+                "_issuer_kind": "codex_backend",
+            }
+        ],
+    },
+    {"role": "user", "content": "고마워! 이제 skill도 하나 저장해줘"},
+    {
+        "role": "assistant",
+        "content": "codex-demo 스킬을 저장했습니다.",
+        "codex_reasoning_items": [
+            {
+                "type": "reasoning",
+                "encrypted_content": "enc_codex_ghi789==",
+                "_issuer_kind": "codex_backend",
+            }
+        ],
+        "codex_message_items": [
+            {"type": "message", "id": "msg_002", "content": [{"type": "output_text", "text": "스킬 저장 완료"}]}
+        ],
+    },
+]
+
+before = copy.deepcopy(api_messages)
+
+info(f"메시지 수          : {len(api_messages)}")
+info(f"시스템 프롬프트 포함: {'codex-demo' in api_messages[0]['content']}")
+info(f"codex_reasoning_items 포함 메시지 수: "
+     f"{sum(1 for m in api_messages if 'codex_reasoning_items' in m)}")
+info(f"codex_message_items 포함 메시지 수 : "
+     f"{sum(1 for m in api_messages if 'codex_message_items' in m)}")
+
+# ──────────────────────────────────────────────
+# Step 2: try_activate_fallback() 핵심 로직 시뮬레이션
+# ──────────────────────────────────────────────
+header("Step 2: try_activate_fallback() — Codex → local-claude 전환")
+
+REBUILT_SYSTEM = (
+    "You are Hermes, a helpful AI assistant.\n\n"
+    "## Skills\n"
+    "- codex-demo: Codex 세션 중 만들어진 스킬  ← Codex 세션 결과물 보존\n"
+    "- code-review: 코드 리뷰 스킬\n"
+    "\n[Rebuilt for anthropic_messages provider: local-claude / claude-opus-4-8]"
+)
+
+# 실제 try_activate_fallback() 이 하는 일 재현
+old_api_mode = "codex_responses"      # Codex 에서
+new_api_mode = "anthropic_messages"   # Anthropic(local-claude) 으로
+
+agent = SimpleNamespace()
+agent.api_mode          = old_api_mode
+agent.provider          = "openai-codex"
+agent.model             = "gpt-5.5"
+agent.session_id        = "sim-session-001"
+agent._cached_system_prompt = ORIGINAL_SYSTEM
+agent._session_db       = None
+agent._codex_reasoning_replay_enabled = True
+
+agent._build_system_prompt = MagicMock(return_value=REBUILT_SYSTEM)
+
+def _disable_replay(messages=None):
+    count = 0
+    for m in (messages or []):
+        if isinstance(m, dict) and m.get("role") == "assistant":
+            if m.pop("codex_reasoning_items", None):
+                count += 1
+    agent._codex_reasoning_replay_enabled = False
+    return {"messages": count, "items": count}
+
+agent._disable_codex_reasoning_replay = _disable_replay
+
+# --- try_activate_fallback() 이 세팅하는 플래그 ---
+if old_api_mode != new_api_mode:
+    agent._pending_context_bridge = {
+        "old_api_mode": old_api_mode,
+        "new_api_mode": new_api_mode,
+    }
+    agent._cached_system_prompt = None   # 시스템 프롬프트 무효화
+
+agent.api_mode   = new_api_mode
+agent.provider   = "local-claude"
+agent.model      = "claude-opus-4-8"
+
+field("이전 provider    :", f"openai-codex  (api_mode={old_api_mode})")
+field("새 provider      :", f"local-claude  (api_mode={new_api_mode})")
+field("_pending_context_bridge:", json.dumps(agent._pending_context_bridge))
+field("_cached_system_prompt  :", repr(agent._cached_system_prompt))
+
+# ──────────────────────────────────────────────
+# Step 3: conversation_loop 안에서 Bridge 실행
+# ──────────────────────────────────────────────
+header("Step 3: conversation_loop → apply_fallback_context_bridge() 실행")
+
+from agent.fallback_context_bridge import apply_fallback_context_bridge
+
+_bridge = getattr(agent, "_pending_context_bridge", None)
+assert _bridge, "bridge 플래그가 없음 — try_activate_fallback() 수정 확인 필요"
+
+agent._pending_context_bridge = None   # 플래그 소비
+
+apply_fallback_context_bridge(
+    agent,
+    api_messages,
+    _bridge["old_api_mode"],
+    _bridge["new_api_mode"],
+)
+
+# ──────────────────────────────────────────────
+# Step 4: 결과 검증
+# ──────────────────────────────────────────────
+header("Step 4: 검증 결과")
+
+passed = 0
+failed = 0
+
+def check(desc, condition):
+    global passed, failed
+    if condition:
+        ok(desc)
+        passed += 1
+    else:
+        import traceback
+        warn(f"FAIL: {desc}")
+        failed += 1
+
+# Codex 전용 필드가 제거됐는지
+check(
+    "codex_reasoning_items 전부 제거됨",
+    all("codex_reasoning_items" not in m for m in api_messages),
+)
+check(
+    "codex_message_items 전부 제거됨",
+    all("codex_message_items" not in m for m in api_messages),
+)
+check(
+    "_thinking_prefill 내부 키 제거됨",
+    all("_thinking_prefill" not in m for m in api_messages),
+)
+
+# Reasoning replay 비활성화
+check(
+    "codex reasoning replay 비활성화",
+    not agent._codex_reasoning_replay_enabled,
+)
+
+# 시스템 프롬프트 재빌드
+check(
+    "_build_system_prompt() 호출됨",
+    agent._build_system_prompt.called,
+)
+check(
+    "시스템 메시지가 새 프롬프트로 교체됨",
+    api_messages[0]["role"] == "system" and api_messages[0]["content"] == REBUILT_SYSTEM,
+)
+check(
+    "agent._cached_system_prompt 갱신됨",
+    agent._cached_system_prompt == REBUILT_SYSTEM,
+)
+
+# Codex 세션에서 만든 스킬이 보존됐는지 (핵심!)
+check(
+    "Codex 세션 스킬(codex-demo)이 새 시스템 프롬프트에 보존됨",
+    "codex-demo" in api_messages[0]["content"],
+)
+
+# 일반 필드(content, tool_calls 등)는 유지됐는지
+check(
+    "일반 content 필드 유지됨",
+    all(
+        "content" in m
+        for m in api_messages
+        if m.get("role") in ("assistant", "user", "tool")
+    ),
+)
+
+# bridge 플래그 소비됨
+check(
+    "_pending_context_bridge 플래그 소비됨",
+    agent._pending_context_bridge is None,
+)
+
+# ──────────────────────────────────────────────
+# Step 5: Before / After 메시지 diff
+# ──────────────────────────────────────────────
+header("Step 5: Before / After 메시지 비교")
+
+for i, (b, a) in enumerate(zip(before, api_messages)):
+    role = b.get("role", "?")
+    removed = set(b.keys()) - set(a.keys())
+    added   = set(a.keys()) - set(b.keys())
+    if removed or added:
+        info(f"  msg[{i}] role={role}")
+        if removed: info(f"    {RED}제거됨{RESET}: {removed}")
+        if added:   info(f"    {GREEN}추가됨{RESET}: {added}")
+    elif i == 0 and b["content"] != a["content"]:
+        info(f"  msg[{i}] role={role}")
+        info(f"    {YELLOW}시스템 프롬프트 내용 교체됨{RESET}")
+        old_lines = b["content"].strip().splitlines()
+        new_lines = a["content"].strip().splitlines()
+        for ln in old_lines[:4]:
+            info(f"      {RED}- {ln}{RESET}")
+        for ln in new_lines[:5]:
+            info(f"      {GREEN}+ {ln}{RESET}")
+
+# ──────────────────────────────────────────────
+# 최종 요약
+# ──────────────────────────────────────────────
+header("최종 결과")
+total = passed + failed
+print(f"\n  {BOLD}{passed}/{total} 검증 통과{RESET}")
+if failed == 0:
+    print(f"\n  {GREEN}{BOLD}✅ Context Bridge + Skill Re-injection 정상 동작{RESET}")
+    print(f"  Codex 세션에서 만든 스킬과 컨텍스트가")
+    print(f"  local-claude(anthropic_messages)로 안전하게 전달됩니다.")
+else:
+    print(f"\n  {RED}{BOLD}❌ {failed}개 검증 실패 — 로그를 확인하세요{RESET}")
+    sys.exit(1)

--- a/scripts/trigger_codex_fallback.py
+++ b/scripts/trigger_codex_fallback.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Live fallback trigger: Codex → local-claude.
+
+실제 hermesAgent gateway로 요청을 보낸 후,
+Codex 엔드포인트를 차단해서 fallback이 발동되도록 만든다.
+
+사용법:
+    python scripts/trigger_codex_fallback.py [--gateway-url URL]
+
+기본 gateway URL: http://localhost:5050
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.request
+import urllib.error
+
+DEFAULT_GATEWAY = "http://localhost:5050"
+
+
+def chat(gateway_url: str, message: str, session_id: str = "") -> dict:
+    payload = {"message": message}
+    if session_id:
+        payload["session_id"] = session_id
+
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"{gateway_url}/api/chat",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        return {"error": str(e), "body": body, "status": e.code}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def get_session_model(gateway_url: str, session_id: str) -> dict:
+    req = urllib.request.Request(
+        f"{gateway_url}/api/sessions/{session_id}",
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read())
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Trigger Codex→fallback scenario")
+    parser.add_argument("--gateway-url", default=DEFAULT_GATEWAY)
+    args = parser.parse_args()
+    gw = args.gateway_url.rstrip("/")
+
+    print(f"Gateway: {gw}")
+    print("=" * 60)
+
+    # ── Step 1: Codex session — create a skill ──────────────────────
+    print("\n[1] Codex session: 간단한 스킬 생성 요청 전송...")
+    resp1 = chat(gw, "안녕! 지금 어떤 provider로 동작 중인지 알려줘.")
+    session_id = resp1.get("session_id", "")
+    print(f"    session_id : {session_id}")
+    print(f"    provider   : {resp1.get('model', '?')} / {resp1.get('provider', '?')}")
+    print(f"    응답 미리보기: {str(resp1.get('response', resp1))[:120]}")
+
+    if resp1.get("error"):
+        print(f"\n⚠️  Gateway 오류: {resp1['error']}")
+        print("   hermesAgent gateway가 실행 중인지 확인하세요.")
+        sys.exit(1)
+
+    time.sleep(1)
+
+    # ── Step 2: Send a message that produces codex_reasoning_items ──
+    print("\n[2] 작업 요청 (Codex가 reasoning items 생성하도록)...")
+    resp2 = chat(
+        gw,
+        "간단한 Python 함수 하나만 작성해줘: def add(a, b): 로 시작하는 덧셈 함수.",
+        session_id=session_id,
+    )
+    print(f"    응답 미리보기: {str(resp2.get('response', resp2))[:120]}")
+
+    time.sleep(1)
+
+    # ── Step 3: Force fallback via /model switch or error injection ─
+    print("\n[3] Fallback 시뮬레이션: /model 명령으로 local-claude로 전환...")
+    resp3 = chat(
+        gw,
+        "/model claude-opus-4-8 local-claude",
+        session_id=session_id,
+    )
+    print(f"    응답: {str(resp3.get('response', resp3))[:200]}")
+
+    time.sleep(1)
+
+    # ── Step 4: Verify the new provider sees context from step 2 ───
+    print("\n[4] Fallback 후 이전 Codex 작업 컨텍스트 확인...")
+    resp4 = chat(
+        gw,
+        "방금 전에 내가 요청한 Python 함수가 뭐였지? 그리고 지금 어떤 provider로 동작 중이야?",
+        session_id=session_id,
+    )
+    print(f"    provider   : {resp4.get('provider', '?')}")
+    print(f"    응답:\n    {str(resp4.get('response', resp4))[:400]}")
+
+    # ── Result ──────────────────────────────────────────────────────
+    print("\n" + "=" * 60)
+    print("테스트 완료.")
+    print(f"  session_id  : {session_id}")
+    print(f"  최종 provider: {resp4.get('provider', '?')}")
+    response_text = str(resp4.get("response", ""))
+    if "add" in response_text.lower() or "덧셈" in response_text or "plus" in response_text.lower():
+        print("  ✅ 이전 Codex 세션 컨텍스트가 fallback provider에 전달됨!")
+    else:
+        print("  ⚠️  이전 컨텍스트 전달 여부 불명확 — 응답을 직접 확인하세요.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_fallback_context_bridge_integration.py
+++ b/tests/agent/test_fallback_context_bridge_integration.py
@@ -1,0 +1,381 @@
+"""Integration test: Codex → local-claude fallback with context bridge.
+
+Scenario reproduced:
+  1. Agent is configured with openai-codex as primary provider
+     (api_mode = codex_responses).
+  2. A conversation history is built that mimics what a Codex session
+     produces: assistant messages containing codex_reasoning_items,
+     codex_message_items, and a _hermes_internal key.
+  3. A skill is created during the Codex session (appears in the skill
+     index, which is part of the system prompt).
+  4. try_activate_fallback() is called to simulate a rate-limit / error
+     causing Codex to hand off to local-claude.
+  5. apply_fallback_context_bridge() fires and:
+       - strips all codex_* fields from api_messages
+       - rebuilds the system prompt (so skill context survives)
+  6. Assertions verify the bridge worked correctly.
+"""
+
+from __future__ import annotations
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+import copy
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.fallback_context_bridge import (
+    apply_fallback_context_bridge,
+    _strip_codex_fields_from_messages,
+    _strip_anthropic_fields_from_messages,
+)
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_codex_conversation():
+    """Return a realistic api_messages list produced by a Codex session."""
+    return [
+        {
+            "role": "system",
+            "content": "You are Hermes.\n\n## Skills\n- codex-demo: A skill made during Codex session\n",
+        },
+        {
+            "role": "user",
+            "content": "Create a skill called codex-demo",
+        },
+        {
+            "role": "assistant",
+            "content": "I'll create the skill for you.",
+            # Codex Responses API fields — must be stripped on fallback
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "enc_abc123==", "_issuer_kind": "codex_backend"},
+            ],
+            "codex_message_items": [
+                {"type": "message", "id": "msg_xyz", "content": [{"type": "output_text", "text": "Done."}]},
+            ],
+            "_thinking_prefill": True,
+        },
+        {
+            "role": "tool",
+            "content": '{"result": "skill codex-demo created"}',
+            "tool_call_id": "call_001",
+        },
+        {
+            "role": "assistant",
+            "content": "Skill codex-demo has been created successfully.",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "enc_def456==", "_issuer_kind": "codex_backend"},
+            ],
+        },
+    ]
+
+
+def _make_stub_agent(system_prompt: str = "Rebuilt system prompt with codex-demo skill"):
+    """Return a minimal stub that satisfies apply_fallback_context_bridge."""
+    agent = SimpleNamespace()
+    agent.api_mode = "anthropic_messages"        # already switched by fallback
+    agent.provider = "local-claude"
+    agent.model = "claude-opus-4-8"
+    agent.session_id = "test-session-001"
+    agent._cached_system_prompt = None            # invalidated by try_activate_fallback
+    agent._session_db = None                      # skip DB persistence in tests
+    agent._codex_reasoning_replay_enabled = True
+
+    # _build_system_prompt returns the rebuilt prompt
+    agent._build_system_prompt = MagicMock(return_value=system_prompt)
+
+    # _disable_codex_reasoning_replay mimics the real implementation
+    def _disable_replay(messages=None):
+        count = 0
+        for m in (messages or []):
+            if isinstance(m, dict) and m.get("role") == "assistant":
+                if m.pop("codex_reasoning_items", None):
+                    count += 1
+        agent._codex_reasoning_replay_enabled = False
+        return {"messages": count, "items": count}
+
+    agent._disable_codex_reasoning_replay = _disable_replay
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestStripCodexFields:
+    """Unit tests for the stripping helpers."""
+
+    def test_strips_codex_reasoning_items(self):
+        msgs = [{"role": "assistant", "content": "hi", "codex_reasoning_items": [1, 2]}]
+        n = _strip_codex_fields_from_messages(msgs)
+        assert "codex_reasoning_items" not in msgs[0]
+        assert n == 1
+
+    def test_strips_codex_message_items(self):
+        msgs = [{"role": "assistant", "content": "hi", "codex_message_items": ["x"]}]
+        _strip_codex_fields_from_messages(msgs)
+        assert "codex_message_items" not in msgs[0]
+
+    def test_strips_internal_underscore_keys(self):
+        msgs = [{"role": "assistant", "content": "hi", "_thinking_prefill": True, "_foo": "bar"}]
+        _strip_codex_fields_from_messages(msgs)
+        assert "_thinking_prefill" not in msgs[0]
+        assert "_foo" not in msgs[0]
+
+    def test_leaves_standard_fields_intact(self):
+        msgs = [{"role": "assistant", "content": "keep me", "tool_calls": [{"id": "tc1"}]}]
+        _strip_codex_fields_from_messages(msgs)
+        assert msgs[0]["content"] == "keep me"
+        assert msgs[0]["tool_calls"] == [{"id": "tc1"}]
+
+    def test_non_dict_messages_skipped(self):
+        msgs = ["not a dict", None, 42]
+        n = _strip_codex_fields_from_messages(msgs)
+        assert n == 0
+
+
+class TestStripAnthropicFields:
+    """Unit tests for Anthropic-specific field stripping (reverse direction)."""
+
+    def test_strips_cache_control_top_level(self):
+        msgs = [{"role": "system", "content": "sys", "cache_control": {"type": "ephemeral"}}]
+        n = _strip_anthropic_fields_from_messages(msgs)
+        assert "cache_control" not in msgs[0]
+        assert n == 1
+
+    def test_strips_cache_control_from_content_parts(self):
+        msgs = [{
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}],
+        }]
+        _strip_anthropic_fields_from_messages(msgs)
+        assert "cache_control" not in msgs[0]["content"][0]
+
+    def test_strips_reasoning_content(self):
+        msgs = [{"role": "assistant", "content": "hi", "reasoning_content": " "}]
+        _strip_anthropic_fields_from_messages(msgs)
+        assert "reasoning_content" not in msgs[0]
+
+
+class TestApplyFallbackContextBridge:
+    """Integration tests for the full bridge."""
+
+    def test_codex_to_anthropic_strips_codex_fields(self):
+        api_messages = _make_codex_conversation()
+        agent = _make_stub_agent()
+
+        apply_fallback_context_bridge(
+            agent, api_messages,
+            old_api_mode="codex_responses",
+            new_api_mode="anthropic_messages",
+        )
+
+        for msg in api_messages:
+            assert "codex_reasoning_items" not in msg, f"codex_reasoning_items still in {msg['role']} message"
+            assert "codex_message_items" not in msg, f"codex_message_items still in {msg['role']} message"
+            assert "_thinking_prefill" not in msg
+
+    def test_codex_to_anthropic_rebuilds_system_prompt(self):
+        api_messages = _make_codex_conversation()
+        agent = _make_stub_agent(system_prompt="Rebuilt: codex-demo skill present")
+
+        apply_fallback_context_bridge(
+            agent, api_messages,
+            old_api_mode="codex_responses",
+            new_api_mode="anthropic_messages",
+        )
+
+        # _build_system_prompt was called
+        agent._build_system_prompt.assert_called_once()
+        # system message in api_messages was replaced
+        assert api_messages[0]["role"] == "system"
+        assert api_messages[0]["content"] == "Rebuilt: codex-demo skill present"
+        # agent cache updated
+        assert agent._cached_system_prompt == "Rebuilt: codex-demo skill present"
+
+    def test_codex_to_anthropic_skill_context_preserved(self):
+        """Skill created during Codex session must appear in the rebuilt system prompt."""
+        api_messages = _make_codex_conversation()
+        fresh_prompt = (
+            "You are Hermes.\n\n"
+            "## Skills\n"
+            "- codex-demo: Skill created in Codex session\n"
+            "- other-skill: Pre-existing skill\n"
+        )
+        agent = _make_stub_agent(system_prompt=fresh_prompt)
+
+        apply_fallback_context_bridge(
+            agent, api_messages,
+            old_api_mode="codex_responses",
+            new_api_mode="anthropic_messages",
+        )
+
+        rebuilt = api_messages[0]["content"]
+        assert "codex-demo" in rebuilt, "Codex-session skill missing from rebuilt system prompt"
+        assert "other-skill" in rebuilt
+
+    def test_codex_reasoning_replay_disabled(self):
+        api_messages = _make_codex_conversation()
+        agent = _make_stub_agent()
+        assert agent._codex_reasoning_replay_enabled is True
+
+        apply_fallback_context_bridge(
+            agent, api_messages,
+            old_api_mode="codex_responses",
+            new_api_mode="anthropic_messages",
+        )
+
+        assert agent._codex_reasoning_replay_enabled is False
+
+    def test_same_mode_no_codex_strip(self):
+        """Bridge called for non-Codex old_mode must not strip anything extra."""
+        api_messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "ok", "reasoning_content": " "},
+        ]
+        original = copy.deepcopy(api_messages)
+        agent = _make_stub_agent()
+
+        apply_fallback_context_bridge(
+            agent, api_messages,
+            old_api_mode="anthropic_messages",
+            new_api_mode="chat_completions",
+        )
+
+        # reasoning_content should NOT be stripped (only codex→other strips it)
+        assert api_messages[1].get("reasoning_content") == original[1].get("reasoning_content")
+
+    def test_entering_codex_strips_anthropic_fields(self):
+        """chat_completions → codex_responses bridge strips cache_control."""
+        api_messages = [
+            {"role": "system", "content": "sys", "cache_control": {"type": "ephemeral"}},
+            {"role": "assistant", "content": "ok", "reasoning_content": " "},
+        ]
+        agent = _make_stub_agent()
+
+        apply_fallback_context_bridge(
+            agent, api_messages,
+            old_api_mode="chat_completions",
+            new_api_mode="codex_responses",
+        )
+
+        assert "cache_control" not in api_messages[0]
+        assert "reasoning_content" not in api_messages[1]
+
+    def test_no_system_message_prepends_one(self):
+        """If api_messages has no system message, bridge should prepend one."""
+        api_messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi", "codex_reasoning_items": []},
+        ]
+        agent = _make_stub_agent(system_prompt="Fresh system prompt")
+
+        apply_fallback_context_bridge(
+            agent, api_messages,
+            old_api_mode="codex_responses",
+            new_api_mode="anthropic_messages",
+        )
+
+        assert api_messages[0]["role"] == "system"
+        assert api_messages[0]["content"] == "Fresh system prompt"
+
+    def test_build_system_prompt_failure_is_non_fatal(self):
+        """If _build_system_prompt raises, the bridge must not propagate the error."""
+        api_messages = _make_codex_conversation()
+        agent = _make_stub_agent()
+        agent._build_system_prompt = MagicMock(side_effect=RuntimeError("DB down"))
+
+        # Should not raise
+        apply_fallback_context_bridge(
+            agent, api_messages,
+            old_api_mode="codex_responses",
+            new_api_mode="anthropic_messages",
+        )
+
+        # Codex fields are still stripped even when prompt rebuild fails
+        for msg in api_messages:
+            assert "codex_reasoning_items" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Simulation: _pending_context_bridge flag lifecycle
+# ---------------------------------------------------------------------------
+
+class TestPendingContextBridgeFlag:
+    """Verify the flag is set by try_activate_fallback and consumed by the loop."""
+
+    def test_flag_set_when_api_mode_changes(self):
+        """Simulates try_activate_fallback() setting the flag."""
+        agent = SimpleNamespace()
+        agent.api_mode = "codex_responses"
+        agent._cached_system_prompt = "old system prompt"
+
+        # Simulate what try_activate_fallback() does when mode changes
+        old_api_mode = agent.api_mode
+        new_api_mode = "anthropic_messages"
+
+        if old_api_mode != new_api_mode:
+            agent._pending_context_bridge = {
+                "old_api_mode": old_api_mode,
+                "new_api_mode": new_api_mode,
+            }
+            agent._cached_system_prompt = None
+
+        assert agent._pending_context_bridge["old_api_mode"] == "codex_responses"
+        assert agent._pending_context_bridge["new_api_mode"] == "anthropic_messages"
+        assert agent._cached_system_prompt is None  # invalidated for rebuild
+
+    def test_flag_not_set_when_mode_unchanged(self):
+        """No bridge needed when both providers share the same api_mode."""
+        agent = SimpleNamespace()
+        agent.api_mode = "chat_completions"
+        agent._cached_system_prompt = "unchanged"
+
+        old_api_mode = agent.api_mode
+        new_api_mode = "chat_completions"  # same
+
+        if old_api_mode != new_api_mode:
+            agent._pending_context_bridge = {"old_api_mode": old_api_mode, "new_api_mode": new_api_mode}
+            agent._cached_system_prompt = None
+        else:
+            agent._pending_context_bridge = None
+
+        assert agent._pending_context_bridge is None
+        assert agent._cached_system_prompt == "unchanged"  # untouched
+
+    def test_flag_consumed_in_loop(self):
+        """Simulates the conversation_loop consuming and clearing the flag."""
+        api_messages = _make_codex_conversation()
+        agent = _make_stub_agent()
+        agent._pending_context_bridge = {
+            "old_api_mode": "codex_responses",
+            "new_api_mode": "anthropic_messages",
+        }
+
+        # Simulate what conversation_loop does
+        _bridge = getattr(agent, "_pending_context_bridge", None)
+        if _bridge:
+            agent._pending_context_bridge = None
+            apply_fallback_context_bridge(
+                agent, api_messages,
+                _bridge["old_api_mode"],
+                _bridge["new_api_mode"],
+            )
+
+        # Flag must be cleared
+        assert agent._pending_context_bridge is None
+
+        # Bridge must have run
+        for msg in api_messages:
+            assert "codex_reasoning_items" not in msg

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1038,8 +1038,22 @@ def skill_view(
                     _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
+            # Exclude files nested inside another skill's directory (any ancestor
+            # between found_md and search_dir that contains its own SKILL.md).
+            # Those are reference/template assets, not standalone skills.
             for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md":
+                if found_md.name == "SKILL.md":
+                    continue
+                in_other_skill = False
+                for p in found_md.parents:
+                    if p == search_dir:
+                        break
+                    if search_dir not in p.parents:
+                        break
+                    if (p / "SKILL.md").exists():
+                        in_other_skill = True
+                        break
+                if not in_other_skill:
                     _record(None, found_md)
 
         if len(candidates) > 1:


### PR DESCRIPTION
## What changed and why

### feat(agent): Cross-mode fallback context bridge
When the `api_mode` changes during failover (e.g. `codex_responses` → `anthropic_messages`), the existing `api_messages` carry provider-specific fields (codex reasoning items, encrypted blobs) that the new provider rejects. This PR detects the mode change in `try_activate_fallback`, sets `_pending_context_bridge` on the agent, and applies `fallback_context_bridge.apply_fallback_context_bridge()` in `conversation_loop` before the retry request. The bridge strips the stale provider-specific fields and clears the cached system prompt so it rebuilds with current skill context for the new provider.

### feat(gateway): Read-only Inspector server
Adds `gateway/inspector.py` — a lightweight read-only HTTP meta-API that external containers (sidecars, monitoring tools) can query for gateway state without touching the main gateway socket. Enabled by default; opt out with `HERMES_INSPECTOR_DISABLED=1`. Host/port configurable via `HERMES_INSPECTOR_HOST` / `HERMES_INSPECTOR_PORT` (default `127.0.0.1:8646`).

### fix(providers): Use hostname for api.openai.com detection
`determine_api_mode` was using `in url_lower` string containment which could match URLs that merely contain `api.openai.com` as a substring. Switched to `base_url_hostname(base_url) == "api.openai.com"` for exact hostname matching.

### fix(tools): Exclude nested skill docs from strategy-3 flat search
`skill_view` strategy-3 (`rglob`) was picking up reference/template `.md` files nested inside another skill's directory. Added an ancestor-walk check to skip any file whose parent chain contains a `SKILL.md` between it and the search root.

## How to test

**Fallback bridge:**
```bash
# Simulate a codex → anthropic fallback
python scripts/simulate_codex_fallback.py
# Integration test
pytest tests/agent/test_fallback_context_bridge_integration.py -v
```

**Inspector server:**
```bash
# Start gateway, then:
curl http://127.0.0.1:8646/health
curl http://127.0.0.1:8646/state
# Disable:
HERMES_INSPECTOR_DISABLED=1 hermes gateway start
```

**Provider fix:**
```python
from hermes_cli.providers import determine_api_mode
assert determine_api_mode("openai", "https://api.openai.com/v1") == "codex_responses"
assert determine_api_mode("openai", "https://proxy.api.openai.com.evil.com/v1") != "codex_responses"
```

**Skills fix:**
```bash
hermes -q "use skill: skill-name"  # should not load nested reference docs
```

## Platforms tested
- Linux (Ubuntu 22.04)

## Notes
- `notion-backup-slack-thread-2026-05-15.md` is intentionally excluded (internal file)
- Inspector server failure is non-fatal — gateway continues if it cannot bind