### PR TITLE
fix: size voice playback timeout to audio duration

### DIFF
--- a/contributors/emails/x7peeps@users.noreply.github.com
+++ b/contributors/emails/x7peeps@users.noreply.github.com
@@ -1,0 +1,2 @@
+x7peeps
+# PR #43291 salvage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,9 @@ tts-premium = ["elevenlabs==1.59.0"]
 voice = [
   # Local STT pulls in wheel-only transitive deps (ctranslate2, onnxruntime).
   "faster-whisper==1.2.1",
+  # Used directly by voice playback to size system-player timeouts from
+  # container metadata. Keep explicit even though faster-whisper also pulls it.
+  "av==17.0.0",
   "sounddevice==0.5.5",
   "numpy==2.4.3",
 ]

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -642,15 +642,21 @@ class TestPlayAudioFile:
         monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}" if cmd in {"ffplay", "aplay"} else None)
 
         mock_proc = MagicMock()
-        mock_proc.wait.side_effect = [subprocess.TimeoutExpired(["ffplay"], 300), 0]
+        mock_proc.wait.side_effect = [
+            subprocess.TimeoutExpired(["ffplay"], 300),
+            subprocess.TimeoutExpired(["ffplay"], 10),
+        ]
         mock_popen = MagicMock(return_value=mock_proc)
         monkeypatch.setattr("subprocess.Popen", mock_popen)
 
+        import tools.voice_mode as voice_mode
         from tools.voice_mode import play_audio_file
 
         assert play_audio_file(sample_wav) is False
         assert mock_popen.call_count == 1
+        assert mock_proc.wait.call_count == 2
         mock_proc.kill.assert_called_once()
+        assert voice_mode._active_playback is None
 
 
 # ============================================================================

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -589,6 +589,70 @@ class TestPlayAudioFile:
         mock_sd_obj.play.assert_called_once()
         mock_sd_obj.stop.assert_called_once()
 
+    def test_uses_audio_duration_for_system_player_timeout(self, monkeypatch, tmp_path):
+        audio_path = tmp_path / "long.ogg"
+        audio_path.write_bytes(b"fake ogg bytes")
+
+        monkeypatch.setattr("platform.system", lambda: "Linux")
+        monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}" if cmd == "ffplay" else None)
+
+        mock_container = MagicMock()
+        mock_container.duration = 326_726_500
+        mock_av = MagicMock(time_base=1_000_000)
+        mock_av.open.return_value.__enter__.return_value = mock_container
+        monkeypatch.setattr("tools.voice_mode._import_av", lambda: mock_av)
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+        mock_popen = MagicMock(return_value=mock_proc)
+        monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+        from tools.voice_mode import play_audio_file
+
+        assert play_audio_file(str(audio_path)) is True
+
+        timeout = mock_proc.wait.call_args.kwargs["timeout"]
+        assert timeout > 326.726500
+        assert timeout != 300
+
+    def test_does_not_offer_aplay_for_ogg_playback(self, monkeypatch, tmp_path):
+        audio_path = tmp_path / "speech.ogg"
+        audio_path.write_bytes(b"fake ogg bytes")
+
+        monkeypatch.setattr("platform.system", lambda: "Linux")
+        monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}" if cmd == "aplay" else None)
+
+        mock_popen = MagicMock()
+        monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+        from tools.voice_mode import play_audio_file
+
+        assert play_audio_file(str(audio_path)) is False
+        mock_popen.assert_not_called()
+
+    def test_player_timeout_does_not_fall_through_to_next_player(self, monkeypatch, sample_wav):
+        import subprocess
+
+        def _fail_import():
+            raise ImportError("no sounddevice")
+
+        monkeypatch.setattr("tools.voice_mode._import_audio", _fail_import)
+        monkeypatch.setattr("platform.system", lambda: "Linux")
+        monkeypatch.setattr("shutil.which", lambda cmd: f"/usr/bin/{cmd}" if cmd in {"ffplay", "aplay"} else None)
+
+        mock_proc = MagicMock()
+        mock_proc.wait.side_effect = [subprocess.TimeoutExpired(["ffplay"], 300), 0]
+        mock_popen = MagicMock(return_value=mock_proc)
+        monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+        from tools.voice_mode import play_audio_file
+
+        assert play_audio_file(sample_wav) is False
+        assert mock_popen.call_count == 1
+        mock_proc.kill.assert_called_once()
+
+
 # ============================================================================
 # macOS output policy (no sounddevice for OUTPUT -> avoids TCC prompt)
 # ============================================================================

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -5,7 +5,7 @@ STT dispatch via tools.transcription_tools, and TTS playback via
 sounddevice or system audio players.
 
 Dependencies (optional):
-    pip install sounddevice numpy
+    pip install av sounddevice numpy
     or: uv sync --extra voice
 """
 
@@ -41,6 +41,12 @@ def _import_audio():
     import sounddevice as sd
     import numpy as np
     return sd, np
+
+
+def _import_av():
+    """Lazy-import PyAV for container metadata inspection."""
+    import av
+    return av
 
 
 def _import_numpy():
@@ -1488,6 +1494,41 @@ def _split_wav_for_transcription(wav_path: str, *, max_file_size: int) -> List[s
 # Global reference to the active playback process so it can be interrupted.
 _active_playback: Optional[subprocess.Popen] = None
 _playback_lock = threading.Lock()
+_SYSTEM_PLAYER_FALLBACK_TIMEOUT = 300.0
+_SYSTEM_PLAYER_TIMEOUT_GRACE = 10.0
+_SYSTEM_PLAYER_MIN_TIMEOUT = 30.0
+_SYSTEM_PLAYER_MAX_TIMEOUT = 6 * 60 * 60.0
+
+
+def _audio_duration(file_path: str) -> Optional[float]:
+    """Return the media container duration in seconds using PyAV."""
+    try:
+        av = _import_av()
+        with av.open(file_path) as container:
+            if container.duration is None:
+                return None
+            duration = float(container.duration / av.time_base)
+    except Exception:
+        return None
+    if not math.isfinite(duration) or duration <= 0:
+        return None
+    return duration
+
+
+def _system_player_timeout(file_path: str) -> float:
+    """Bound player waits while allowing legitimate long-form audio to finish."""
+    duration = _audio_duration(file_path)
+    if duration is None:
+        return _SYSTEM_PLAYER_FALLBACK_TIMEOUT
+    return min(
+        max(duration + _SYSTEM_PLAYER_TIMEOUT_GRACE, _SYSTEM_PLAYER_MIN_TIMEOUT),
+        _SYSTEM_PLAYER_MAX_TIMEOUT,
+    )
+
+
+def _aplay_supports_file(file_path: str) -> bool:
+    """Return whether bare `aplay <file>` is appropriate for this file."""
+    return os.path.splitext(file_path)[1].lower() in {".wav", ".wave"}
 
 
 def stop_playback() -> None:
@@ -1685,9 +1726,10 @@ def _play_audio_file_impl(file_path: str) -> bool:
                 pass  # WSL path resolution failed; fall through to ffplay/aplay
 
     players.append(["ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet", file_path])
-    if system == "Linux":
+    if system == "Linux" and _aplay_supports_file(file_path):
         players.append(["aplay", "-q", file_path])
 
+    playback_timeout = _system_player_timeout(file_path)
     for cmd in players:
         exe = shutil.which(cmd[0])
         if exe:
@@ -1705,7 +1747,7 @@ def _play_audio_file_impl(file_path: str) -> bool:
                 )
                 with _playback_lock:
                     _active_playback = proc
-                proc.wait(timeout=300)
+                proc.wait(timeout=playback_timeout)
                 rc = proc.returncode
                 with _playback_lock:
                     _active_playback = None
@@ -1721,6 +1763,7 @@ def _play_audio_file_impl(file_path: str) -> bool:
                 proc.wait()
                 with _playback_lock:
                     _active_playback = None
+                return False
             except Exception as e:
                 logger.debug("System player %s failed: %s", cmd[0], e)
                 with _playback_lock:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1760,7 +1760,10 @@ def _play_audio_file_impl(file_path: str) -> bool:
             except subprocess.TimeoutExpired:
                 logger.warning("System player %s timed out, killing process", cmd[0])
                 proc.kill()
-                proc.wait()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    pass
                 with _playback_lock:
                     _active_playback = None
                 return False

--- a/uv.lock
+++ b/uv.lock
@@ -1771,6 +1771,7 @@ vertex = [
     { name = "google-auth" },
 ]
 voice = [
+    { name = "av" },
     { name = "faster-whisper" },
     { name = "numpy" },
     { name = "sounddevice" },
@@ -1813,6 +1814,7 @@ requires-dist = [
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = "==2.2.42" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = "==0.87.0" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = "==0.31.0" },
+    { name = "av", marker = "extra == 'voice'", specifier = "==17.0.0" },
     { name = "azure-identity", marker = "extra == 'azure-identity'", specifier = "==1.25.3" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },
     { name = "brotlicffi", marker = "extra == 'messaging'", specifier = "==1.2.0.1" },


### PR DESCRIPTION
## Summary
- Fix long-form voice playback being killed when TTS output exceeds the fixed 300s external-player timeout.
- Size external audio-player waits from the probed audio duration, with fallback/min/max bounds for safety.
- Avoid falling back to bare `aplay` for Ogg/compressed output after a timeout, which can produce unpleasant noise until manually killed.

## Problem
Long TTS responses can generate audio longer than five minutes. The previous playback guard always waited at most 300 seconds for external players such as `ffplay`, so healthy long-form playback could be treated as hung and killed mid-response.

After that timeout, Linux playback could fall through to `aplay` even for Ogg/compressed files. Because `aplay` is meant for WAV/PCM-style input rather than generic compressed audio, this can turn the remaining fallback attempt into loud noise for another fixed timeout window unless the user manually kills it.

## Test plan
- `scripts/run_tests.sh tests/tools/test_voice_mode.py`
- Dogfooded in the runtime TUI with Irodori command TTS on a long generated Ogg response; playback completed from the user's perspective with no `System player ... timed out` warning and no residual `ffplay`/`aplay`/`mpv`/`pw-play`/`paplay` processes.
