### PR TITLE
fix: preserve custom OpenAI vision endpoint

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1755,6 +1755,32 @@ def _read_main_provider() -> str:
     return ""
 
 
+def _read_main_runtime_credentials() -> Tuple[str, str, str]:
+    """Read model.base_url/api_key/api_mode from config.yaml.
+
+    ``_read_main_provider`` / ``_read_main_model`` intentionally expose only
+    routing identity.  Vision auto-routing also needs the live credential
+    surface for OpenAI-compatible gateways saved under ``model`` so it does not
+    rebuild an auxiliary client against a provider default endpoint.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        model_cfg = cfg.get("model", {})
+        if isinstance(model_cfg, dict):
+            base_url = model_cfg.get("base_url", "")
+            api_key = model_cfg.get("api_key", "")
+            api_mode = model_cfg.get("api_mode", "")
+            return (
+                base_url.strip() if isinstance(base_url, str) else "",
+                api_key.strip() if isinstance(api_key, str) else "",
+                api_mode.strip() if isinstance(api_mode, str) else "",
+            )
+    except Exception:
+        pass
+    return "", "", ""
+
+
 # Process-local override set by AIAgent at session/turn start. Single-threaded
 # per turn — no lock needed. Cleared by ``clear_runtime_main()``.
 _RUNTIME_MAIN_PROVIDER: str = ""
@@ -4181,6 +4207,23 @@ def resolve_vision_provider_client(
         #   2. OpenRouter  (vision-capable aggregator fallback)
         #   3. Nous Portal (vision-capable aggregator fallback)
         #   4. Stop
+        runtime = _normalize_main_runtime(None)
+        cfg_base_url, cfg_api_key, cfg_api_mode = _read_main_runtime_credentials()
+        runtime_base_url = (
+            str(runtime.get("base_url") or "")
+            or _RUNTIME_MAIN_BASE_URL
+            or cfg_base_url
+        )
+        runtime_api_key = (
+            runtime.get("api_key")
+            or _RUNTIME_MAIN_API_KEY
+            or cfg_api_key
+        )
+        runtime_api_mode = (
+            str(runtime.get("api_mode") or "")
+            or _RUNTIME_MAIN_API_MODE
+            or cfg_api_mode
+        )
         main_provider = _read_main_provider()
         main_model = _read_main_model()
         if main_provider and main_provider not in {"auto", ""}:
@@ -4226,9 +4269,24 @@ def resolve_vision_provider_client(
                     main_provider,
                 )
             else:
+                rpc_provider = main_provider
+                explicit_base_url = None
+                explicit_api_key = None
+                if runtime_base_url and (
+                    main_provider == "custom"
+                    or main_provider.startswith("custom:")
+                    or main_provider == "openai-api"
+                ):
+                    rpc_provider = "custom" if main_provider.startswith("custom:") else main_provider
+                    explicit_base_url = runtime_base_url
+                    explicit_api_key = runtime_api_key or None
+                elif runtime_api_key:
+                    explicit_api_key = runtime_api_key
                 rpc_client, rpc_model = resolve_provider_client(
-                    main_provider, vision_model,
-                    api_mode=resolved_api_mode,
+                    rpc_provider, vision_model,
+                    explicit_base_url=explicit_base_url,
+                    explicit_api_key=explicit_api_key,
+                    api_mode=runtime_api_mode or resolved_api_mode,
                     is_vision=True)
                 if rpc_client is not None:
                     logger.info(

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -16,6 +16,16 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 
+class _FakeAsyncOpenAI:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.base_url = kwargs.get("base_url")
+        self.api_key = kwargs.get("api_key")
+        _FakeAsyncOpenAI.instances.append(self)
+
+
 
 # ── Text aux tasks — _resolve_auto ──────────────────────────────────────────
 
@@ -267,6 +277,90 @@ class TestResolveVisionMainFirst:
         # Should use mimo-v2.5 (vision override), not mimo-v2-pro (text main)
         assert mock_resolve.call_args.args[1] == "mimo-v2.5"
         assert mock_resolve.call_args.kwargs.get("is_vision") is True
+
+    def test_openai_api_main_vision_inherits_custom_base_url_for_async_client(self):
+        """openai-api vision auto must keep the live custom gateway URL."""
+        import agent.auxiliary_client as mod
+
+        _FakeAsyncOpenAI.instances.clear()
+        mod.clear_runtime_main()
+        try:
+            mod.set_runtime_main(
+                "openai-api",
+                "vision-main-model",
+                base_url="https://gateway.example/v1",
+                api_key="gateway-key",
+            )
+            with patch(
+                "agent.auxiliary_client._read_main_provider", return_value="openai-api",
+            ), patch(
+                "agent.auxiliary_client._read_main_model", return_value="vision-main-model",
+            ), patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", None, None, None, None),
+            ), patch(
+                "hermes_cli.auth.resolve_api_key_provider_credentials",
+                return_value={
+                    "provider": "openai-api",
+                    "api_key": "official-openai-key",
+                    "base_url": "https://api.openai.com/v1",
+                },
+            ), patch(
+                "openai.AsyncOpenAI", _FakeAsyncOpenAI,
+            ):
+                provider, client, model = mod.resolve_vision_provider_client(
+                    async_mode=True)
+        finally:
+            mod.clear_runtime_main()
+
+        assert provider == "openai-api"
+        assert client is _FakeAsyncOpenAI.instances[-1]
+        assert model == "vision-main-model"
+        assert client.kwargs["api_key"] == "gateway-key"
+        assert client.kwargs["base_url"].rstrip("/") == "https://gateway.example/v1"
+
+    def test_openai_api_main_vision_inherits_custom_base_url_from_config(self, tmp_path, monkeypatch):
+        """Config-only vision auto must honor model.base_url/model.api_key."""
+        import agent.auxiliary_client as mod
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: vision-main-model\n"
+            "  provider: openai-api\n"
+            "  base_url: https://gateway.example/v1\n"
+            "  api_key: gateway-key\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        _FakeAsyncOpenAI.instances.clear()
+        mod.clear_runtime_main()
+        try:
+            with patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", None, None, None, None),
+            ), patch(
+                "hermes_cli.auth.resolve_api_key_provider_credentials",
+                return_value={
+                    "provider": "openai-api",
+                    "api_key": "official-openai-key",
+                    "base_url": "https://api.openai.com/v1",
+                },
+            ), patch(
+                "openai.AsyncOpenAI", _FakeAsyncOpenAI,
+            ):
+                provider, client, model = mod.resolve_vision_provider_client(
+                    async_mode=True)
+        finally:
+            mod.clear_runtime_main()
+
+        assert provider == "openai-api"
+        assert client is _FakeAsyncOpenAI.instances[-1]
+        assert model == "vision-main-model"
+        assert client.kwargs["api_key"] == "gateway-key"
+        assert client.kwargs["base_url"].rstrip("/") == "https://gateway.example/v1"
 
     def test_copilot_vision_sets_vision_header(self, monkeypatch):
         """Copilot vision requests include the header required for vision routing."""


### PR DESCRIPTION
## Summary
- Preserve the active/configured OpenAI-compatible base URL and API key when `auxiliary.vision.provider=auto` uses the main `openai-api` provider.
- Prevent vision analysis from rebuilding an auxiliary client against the default OpenAI endpoint when the main model is served through a custom gateway.
- Add regression coverage for both runtime and config-only routing.

## Test Plan
- `uv run --with pytest python -m pytest tests/agent/test_auxiliary_main_first.py tests/agent/test_set_runtime_main_custom_provider.py -q -o 'addopts='`