### PR TITLE
fix(tests): update-command platform-gate tests spawn a real detached hermes update

### DIFF
--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -382,6 +382,21 @@ class TestUpdateCommandPlatformGate:
     interfaces (ACP, API server, webhooks) must be blocked.
     """
 
+    @pytest.fixture(autouse=True)
+    def block_real_update_spawn(self, tmp_path):
+        """Stop a passing gate from spawning a REAL detached ``setsid hermes
+        update --gateway`` against this checkout.  On detached-HEAD CI
+        checkouts (every pull_request run) that update switches the working
+        tree to origin/main and the restore step is skipped when detached,
+        poisoning every test process started afterwards.
+        """
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen"):
+            yield
+
     @pytest.mark.asyncio
     async def test_blocks_programmatic_interface(self, monkeypatch):
         """``Platform.WEBHOOK`` is not a messaging platform and must be


### PR DESCRIPTION
## What does this PR do?

Four tests in `tests/gateway/test_update_command.py` (`TestUpdateCommandPlatformGate`: the DISCORD/MATTERMOST/HOMEASSISTANT registry-fallback tests and the TELEGRAM allowlist test) call `_handle_update_command` with no `subprocess.Popen` mock. When the gate passes, the handler spawns a REAL detached `setsid hermes update --gateway` against whatever checkout the tests run in.

On a detached-HEAD checkout (which is what `actions/checkout` produces for every `pull_request` event) the spawned update prints "switching to main for update", checks out `main`, and the restore step is skipped because `current_branch` is the literal string `HEAD` (`hermes_cli/main.py`, the `if current_branch not in {branch, "HEAD"}` guard). The working tree is silently left on `main`, so every test process that starts after the spawn runs against the wrong code. The failures look like unrelated flakes in whatever tests happen to run later.

This PR adds a class-scoped autouse fixture that mocks `gateway.run._hermes_home`, `shutil.which`, and `subprocess.Popen` for the platform-gate tests, using the same mocking idiom the file already uses in `test_spawns_setsid`. Pure addition, no test logic changed.

## Related Issue

No existing issue found (searched PRs and issues for the test names and spawn behavior).

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/gateway/test_update_command.py`: new `block_real_update_spawn` autouse fixture in `TestUpdateCommandPlatformGate` (+15 lines, addition only).

## How to Test

1. On a clean checkout: `git checkout --detach HEAD~1` (simulates a PR-event checkout).
2. `pytest 'tests/gateway/test_update_command.py' -k mattermost -q` (passes), then wait ~60s.
3. `git reflog -3` on current main shows `checkout: moving from <sha> to main` and the tree is now on `main`: the test spawned a real update. With this PR, step 3 shows no checkout and HEAD stays detached.
4. `pytest tests/gateway/test_update_command.py -q`: 35 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the affected tests and all pass (35/35 in the file)
- [x] I've added tests for my changes (the fixture protects the existing tests)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] Documentation: N/A (test-only)
- [x] cli-config.yaml.example: N/A
- [x] CONTRIBUTING/AGENTS: N/A
- [x] Cross-platform: N/A (test-only, mocks are platform-neutral)