### PR TITLE
fix(tests): live-system guard treats only argv[0] as the executable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -657,6 +657,12 @@ def _live_system_guard(request, monkeypatch):
         "daemon-reload", "try-restart", "reload-or-restart",
     )
     _PROCESS_KILLERS = ("pkill", "killall", "taskkill", "skill", "fuser")
+    # Shell/launcher executables whose arguments are themselves commands —
+    # argv[0]-only scanning must not exempt what they wrap.
+    _WRAPPER_COMMANDS = (
+        "sh", "bash", "zsh", "dash", "env", "nohup", "setsid",
+        "timeout", "sudo", "xargs", "nice", "ionice", "stdbuf", "flock",
+    )
 
     def _cmd_to_string(cmd) -> str:
         if cmd is None:
@@ -699,7 +705,17 @@ def _live_system_guard(request, monkeypatch):
             tokens = cmd_str.split()
         if not tokens:
             return False
-        for tok in tokens:
+
+        # For argv-style calls only argv[0] is the executable; scanning every
+        # argument blocked innocent commands like ``cat /tmp/.../skill``
+        # ("skill" is in _PROCESS_KILLERS).  Wrapper executables still get
+        # full-token scanning so ``["bash", "-c", "pkill ..."]`` stays caught.
+        if isinstance(cmd, (list, tuple)):
+            head0 = tokens[0].rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+            killer_tokens = tokens if head0 in _WRAPPER_COMMANDS else tokens[:1]
+        else:
+            killer_tokens = tokens
+        for tok in killer_tokens:
             head = tok.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
             if head in _PROCESS_KILLERS:
                 low = cmd_str.lower()

--- a/tests/test_live_system_guard.py
+++ b/tests/test_live_system_guard.py
@@ -1,0 +1,39 @@
+"""Regression tests for the conftest live-system guard's argv handling.
+
+The guard must treat only argv[0] of a list/tuple command as the executable
+(arguments are data: a file named ``skill`` is not the ``skill`` binary),
+while still scanning every token of wrapper invocations like ``bash -c``.
+All blocked-case commands use patterns that match no real process, so a
+guard regression cannot kill anything.
+"""
+
+import subprocess
+
+import pytest
+
+
+def test_argv_arguments_are_not_treated_as_executables(tmp_path):
+    """A file argument whose basename is a killer name must not trip the
+    guard (the path contains "hermes" via the pytest tmp root)."""
+    target = tmp_path / "skill"
+    target.write_text("just a filename\n")
+    result = subprocess.run(["cat", str(target)], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "just a filename" in result.stdout
+
+
+def test_direct_killer_argv_is_still_blocked():
+    with pytest.raises(RuntimeError, match="live-system guard"):
+        subprocess.run(["pkill", "-f", "hermes-guard-regression-nomatch"])
+
+
+def test_wrapped_killer_command_is_still_blocked():
+    """argv[0]-only scanning must not exempt commands hidden behind a
+    shell wrapper."""
+    with pytest.raises(RuntimeError, match="live-system guard"):
+        subprocess.run(["bash", "-c", "pkill -f hermes-guard-regression-nomatch"])
+
+
+def test_env_wrapped_killer_command_is_still_blocked():
+    with pytest.raises(RuntimeError, match="live-system guard"):
+        subprocess.run(["env", "GUARD_TEST=1", "pkill", "-f", "hermes-guard-regression-nomatch"])


### PR DESCRIPTION
## What does this PR do?

The live-system guard in `tests/conftest.py` scans every token of an argv-list subprocess call for process-killer names. Arguments are data, not executables, so innocent commands get blocked: `subprocess.run(["cat", "/tmp/pytest-of-<user>/.../skill"])` raises the guard's RuntimeError because the file's basename `skill` is in `_PROCESS_KILLERS` (it is a real util-linux binary name) and the tmp path contains the project name.

For list/tuple commands only argv[0] can be the executable, so the guard now scans just argv[0], EXCEPT when argv[0] is a wrapper executable (`sh`, `bash`, `env`, `sudo`, `nohup`, `setsid`, `timeout`, `xargs`, `nice`, `stdbuf`, `flock`, ...) whose arguments are themselves commands; those keep full-token scanning so `["bash", "-c", "pkill -f ..."]` stays caught. String commands are unchanged.

## Related Issue

No existing issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/conftest.py`: argv[0]-only scanning for list/tuple commands with a wrapper-command fallback (`_WRAPPER_COMMANDS`).
- `tests/test_live_system_guard.py` (new): regression tests for the allowed shape (file argument named like a killer) and both blocked shapes (direct `pkill` argv and `bash -c`/`env`-wrapped). Blocked-case commands use patterns that match no real process, so a guard regression cannot kill anything.

## How to Test

1. On main: `pytest tests/test_live_system_guard.py -q` fails `test_argv_arguments_are_not_treated_as_executables` (guard blocks an innocent `cat`).
2. With this PR: 4 passed.
3. Wrapped killers still raise: see `test_wrapped_killer_command_is_still_blocked`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the affected tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] Documentation: N/A (test infrastructure)
- [x] cli-config.yaml.example: N/A
- [x] CONTRIBUTING/AGENTS: N/A
- [x] Cross-platform: basename stripping handles both / and \\ separators, matching the existing guard code