### PR TITLE
feat(security): vendor-anchored secret-format patterns for strict scope

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -279,6 +279,58 @@ class TestClassicInjection:
         )
 
 
+class TestStrictSecretPatterns:
+    """Credential-format coverage for strict-scope scanners."""
+
+    @pytest.mark.parametrize(
+        ("text", "pattern_id"),
+        [
+            ("fake provider key sk-aaaaaaaaaaaaaaaa", "secret_openai_key"),
+            ("fake github token ghp_aaaaaaaaaaaaaaaa", "secret_github_pat"),
+            ("fake github fine grained github_pat_aaaaaaaaaaaaaaaa", "secret_github_pat"),
+            ("fake gitlab token glpat-aaaaaaaaaaaaaaaa", "secret_gitlab_pat"),
+            ("fake slack token xoxb-aaaaaaaaaaaaaaaa", "secret_slack_token"),
+            ("fake aws id AKIAAAAAAAAAAAAA", "secret_aws_access_key"),
+            ("fake google api AIzaaaaaaaaaaaaaaaaaaaaaaaaa", "secret_google_api_key"),
+            ("fake stripe token sk_live_aaaaaaaaaaaaaaaa", "secret_stripe_key"),
+            ("fake npm token npm_aaaaaaaaaaaaaaaa", "secret_npm_token"),
+            ("Authorization: Bearer aaaaaaaaaaaaaaaaaaaaaaaa", "secret_bearer_token"),
+            ("jwt eyJaaaaaaaa.eyJbbbbbbbb.cccccccc", "secret_jwt"),
+            ("-----BEGIN PRIVATE KEY-----", "secret_private_key"),
+            ("postgres://user:secret@example.test/db", "secret_database_url"),
+            ("postgresql://user:secret@example.test/db", "secret_database_url"),
+            ("api_key=aaaaaaaaaaaaaaaaaaaaaaaa", "hardcoded_secret"),
+        ],
+    )
+    def test_secret_formats_strict_only(self, text, pattern_id):
+        assert pattern_id in scan_for_threats(text, scope="strict")
+        assert pattern_id not in scan_for_threats(text, scope="context")
+        assert pattern_id not in scan_for_threats(text, scope="all")
+
+    def test_labeled_secret_reports_hardcoded_secret_first(self):
+        """findings[0] drives user-facing messages — the generic label
+        pattern must win over the format patterns for labeled secrets."""
+        findings = scan_for_threats('api_key="sk-aaaaaaaaaaaaaaaaaaaaaaaa"', scope="strict")
+        assert findings[0] == "hardcoded_secret"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Set OPENAI_API_KEY before running the tests",
+            "the function takes an api_key argument",
+            "my db_password is in the vault",
+            "akiawhatever1234",  # AKIA prefix is uppercase-only
+            "postgres://localhost:5432/mydb",  # no userinfo -> not a secret
+            "pk_live_abcdefgh12345678",  # Stripe publishable keys are public
+            "token: YOUR_TOKEN_HERE",
+        ],
+    )
+    def test_benign_text_not_flagged(self, text):
+        findings = scan_for_threats(text, scope="strict")
+        assert not [f for f in findings if f.startswith("secret_")], findings
+        assert "hardcoded_secret" not in findings
+
+
 # =========================================================================
 # Invisible unicode
 # =========================================================================

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -111,7 +111,25 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     (r'(update|modify|edit|write|change|append|add\s+to)\s+.*\.hermes/(config\.yaml|SOUL\.md)', "hermes_config_mod", "strict"),
 
     # ── Hardcoded secrets ────────────────────────────────────────────
-    (r'(?:api[_-]?key|token|secret|password)\s*[=:]\s*["\'][A-Za-z0-9+/=_-]{20,}', "hardcoded_secret", "strict"),
+    # Strict scope also blocks well-known credential *formats* without a
+    # key=value label: strict-scope consumers (memory writes, skill scans)
+    # persist accepted text into future prompts, so a raw token is already
+    # a leak. Patterns are anchored to vendor prefixes, case-sensitively
+    # where the format is case-sensitive (patterns compile with IGNORECASE,
+    # hence the scoped (?-i:...) groups), to keep false positives low.
+    (r'(?:api[_-]?key|token|secret|password)\s*[=:]\s*["\']?[A-Za-z0-9+/=_-]{20,}', "hardcoded_secret", "strict"),
+    (r'\bsk-[A-Za-z0-9_\-]{8,}', "secret_openai_key", "strict"),
+    (r'\b(?:ghp|github_pat)_[A-Za-z0-9_]{8,}', "secret_github_pat", "strict"),
+    (r'\bglpat-[A-Za-z0-9_\-]{8,}', "secret_gitlab_pat", "strict"),
+    (r'\bxox[baprs]-[A-Za-z0-9_\-]{8,}', "secret_slack_token", "strict"),
+    (r'(?-i:\bAKIA[A-Z0-9]{8,})', "secret_aws_access_key", "strict"),
+    (r'(?-i:\bAIza[0-9A-Za-z_\-]{20,})', "secret_google_api_key", "strict"),
+    (r'\bsk_(?:live|test)_[0-9A-Za-z]{8,}', "secret_stripe_key", "strict"),
+    (r'\bnpm_[A-Za-z0-9_\-]{8,}', "secret_npm_token", "strict"),
+    (r'\bBearer\s+[A-Za-z0-9_\-.=]{16,}', "secret_bearer_token", "strict"),
+    (r'(?-i:\beyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,})', "secret_jwt", "strict"),
+    (r'BEGIN [A-Z ]*PRIVATE KEY', "secret_private_key", "strict"),
+    (r'\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis)://[^\s:@/]+:[^\s@]+@[^\s]+', "secret_database_url", "strict"),
 ]
 
 # Invisible / bidirectional unicode characters used in injection attacks.


### PR DESCRIPTION
## What does this PR do?

Strict-scope consumers (memory writes, skill installs) persist accepted text into future system prompts, so a raw credential is already a leak even when it is not written as `key=value`. The existing `hardcoded_secret` pattern only catches labeled, quoted assignments.

This PR adds format detectors anchored to vendor prefixes: `sk-`, `ghp_`/`github_pat_`, `glpat-`, `xox?-`, `AKIA`, `AIza`, `sk_live_`/`sk_test_`, `npm_`, `Bearer` tokens, JWT shape, `PRIVATE KEY` blocks, and credentialed database URLs (userinfo required, so `postgres://localhost/db` does not flag). Case-sensitive prefixes use scoped `(?-i:...)` groups since the pattern table compiles with `IGNORECASE` (`akiawhatever1234` must not flag). `hardcoded_secret` stays first so labeled secrets keep their existing finding id, and its quote requirement is relaxed to also catch unquoted assignments. Strict scope only; `context` and `all` scopes are unchanged.

Deliberately NOT included after false-positive review: bare env-var names ("Set OPENAI_API_KEY first" is normal README text), value-free label matches ("token: YOUR_TOKEN_HERE"), and Stripe publishable keys (`pk_live_` is public by design). Negative tests pin all of these.

## Related Issue

No existing issue found for format-anchored strict-scope detection.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix

## Changes Made

- `tools/threat_patterns.py`: 12 new strict-scope patterns + relaxed quote on `hardcoded_secret`, with comments on the case-sensitivity scoping.
- `tests/tools/test_threat_patterns.py`: parametrized positive cases (strict-only, asserted absent from context/all), finding-order test for labeled secrets, and 7 benign-text negative cases.

## How to Test

1. `pytest tests/tools/test_threat_patterns.py tests/tools/test_memory_tool.py -q`: 129 passed (memory_tool consumes the same pattern table; finding order is covered).
2. Spot probes: `scan_for_threats('ghp_aaaaaaaaaaaaaaaa', scope='strict')` flags; `scan_for_threats('the function takes an api_key argument', scope='strict')` is clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the affected tests and all pass (both consumer files)
- [x] I've added tests for my changes (positive, negative, and ordering)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] Pattern-table comment documents the scoping rationale
- [x] cli-config.yaml.example: N/A
- [x] CONTRIBUTING/AGENTS: N/A
- [x] Cross-platform: N/A (pure regex)

All regexes are linear (no nested quantifiers / catastrophic backtracking risk).