### PR TITLE
fix(gateway): detect the active launchd domain (#42995)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3067,12 +3067,66 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
+_resolved_launchd_domain: str | None = None
+
+
 def _launchd_domain() -> str:
-    # The `user/<uid>` domain (vs the older `gui/<uid>`) is reachable from
-    # non-Aqua/background sessions (SSH, headless, login items) and is the only
-    # one that supports service management on macOS 26+. `gui/<uid>` returns
-    # error 125 ("Domain does not support specified action") there. See #23387.
-    return f"user/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    """Return the launchd domain that actually manages the gateway service.
+
+    Hermes needs to work in both Aqua login sessions and Background/headless
+    sessions. On newer macOS releases neither `gui/<uid>` nor `user/<uid>` is
+    universally correct, so we probe the loaded service first, then fall back
+    to the current launchctl manager as a heuristic.
+    """
+    global _resolved_launchd_domain
+    if _resolved_launchd_domain is not None:
+        return _resolved_launchd_domain
+
+    uid = os.getuid()  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    label = get_launchd_label()
+    gui_domain = f"gui/{uid}"
+    user_domain = f"user/{uid}"
+
+    for domain in (gui_domain, user_domain):
+        try:
+            subprocess.run(
+                ["launchctl", "print", f"{domain}/{label}"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            _resolved_launchd_domain = domain
+            return domain
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            FileNotFoundError,
+            OSError,
+        ):
+            pass
+
+    try:
+        result = subprocess.run(
+            ["launchctl", "managername"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if (result.stdout or "").strip() == "Aqua":
+            _resolved_launchd_domain = gui_domain
+            return gui_domain
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        OSError,
+    ):
+        pass
+
+    _resolved_launchd_domain = user_domain
+    return user_domain
 
 
 # On macOS, exit code 125 ("Domain does not support specified action") and

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -451,6 +451,14 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceRecovery:
+    @pytest.fixture(autouse=True)
+    def _pin_launchd_domain(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli, "_resolved_launchd_domain", f"user/{os.getuid()}"
+        )
+        yield
+        monkeypatch.setattr(gateway_cli, "_resolved_launchd_domain", None)
+
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
@@ -679,9 +687,21 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
-    def test_launchd_domain_uses_user_domain(self):
-        # The user/<uid> domain (not gui/<uid>) is the one reachable from
-        # non-Aqua/background sessions on macOS 26+ (issue #23387).
+    def test_launchd_domain_uses_user_domain(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_resolved_launchd_domain", None)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd == ["launchctl", "print", f"gui/{os.getuid()}/ai.hermes.gateway"]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    113, cmd, stderr="Could not find service"
+                )
+            if cmd == ["launchctl", "print", f"user/{os.getuid()}/ai.hermes.gateway"]:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"Unexpected launchctl call: {cmd!r}")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
         assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
 
     def test_launchctl_domain_unsupported_recognizes_macos26_codes(self):
@@ -834,6 +854,83 @@ class TestLaunchdServiceRecovery:
         assert exc.value.code == 1
         out = capsys.readouterr().out
         assert "nohup hermes gateway run" in out
+
+
+class TestLaunchdDomainDetection:
+    @pytest.fixture(autouse=True)
+    def _reset_launchd_domain(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_resolved_launchd_domain", None)
+        yield
+        monkeypatch.setattr(gateway_cli, "_resolved_launchd_domain", None)
+
+    def test_launchd_domain_prefers_gui_when_service_is_loaded(self, monkeypatch):
+        monkeypatch.setattr(os, "getuid", lambda: 501)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "print", "gui/501/ai.hermes.gateway"]:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"Unexpected launchctl call: {cmd!r}")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._launchd_domain() == "gui/501"
+        assert calls == [["launchctl", "print", "gui/501/ai.hermes.gateway"]]
+
+    def test_launchd_domain_uses_managername_for_fresh_aqua_session(self, monkeypatch):
+        monkeypatch.setattr(os, "getuid", lambda: 501)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[:2] == ["launchctl", "print"]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    113, cmd, stderr="Could not find service"
+                )
+            if cmd == ["launchctl", "managername"]:
+                return SimpleNamespace(returncode=0, stdout="Aqua\n", stderr="")
+            raise AssertionError(f"Unexpected launchctl call: {cmd!r}")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._launchd_domain() == "gui/501"
+
+    def test_launchd_domain_defaults_to_user_when_probes_fail(self, monkeypatch):
+        monkeypatch.setattr(os, "getuid", lambda: 501)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[:2] == ["launchctl", "print"]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    113, cmd, stderr="Could not find service"
+                )
+            if cmd == ["launchctl", "managername"]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    1, cmd, stderr="manager unavailable"
+                )
+            raise AssertionError(f"Unexpected launchctl call: {cmd!r}")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._launchd_domain() == "user/501"
+
+    def test_launchd_domain_caches_probe_result(self, monkeypatch):
+        monkeypatch.setattr(os, "getuid", lambda: 501)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "print", "gui/501/ai.hermes.gateway"]:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"Unexpected launchctl call: {cmd!r}")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._launchd_domain() == "gui/501"
+        assert gateway_cli._launchd_domain() == "gui/501"
+        assert calls == [["launchctl", "print", "gui/501/ai.hermes.gateway"]]
 
 
 class TestGatewayServiceDetection:


### PR DESCRIPTION
## What does this PR do?

Fixes a macOS launchd regression where `hermes gateway start` / `restart` can target the wrong launchd domain and fall back to a detached background process.

The current gateway lifecycle code hardcodes `user/<uid>` for launchd management. In Aqua sessions, the same LaunchAgent can instead be loaded under `gui/<uid>`, so Hermes ends up running `kickstart` / `bootstrap` against the wrong domain, reports `Could not find service` plus `Bootstrap failed: 5`, and drops auto-start-at-login / crash-restart by switching to the detached fallback.

This patch keeps the existing launchd fallback behavior intact, but makes the domain selection source-aware: probe `gui/<uid>` and `user/<uid>` for the loaded service first, then use `launchctl managername` as the fresh-install heuristic. That keeps Background/headless sessions on the current `user/<uid>` path while fixing Aqua-session management.

## Related Issue

Fixes #42995

Related: #40831, #23387

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Why this is the right fix

The failure is explained by source, not just environment: `_launchd_domain()` always returned `user/<uid>`, but the affected macOS reports show the service can live under `gui/<uid>` in Aqua sessions. Once Hermes chooses the wrong domain, the rest of the failure chain follows naturally: `kickstart` cannot find the service, `bootstrap` retries the wrong place, and the existing error handling degrades to detached mode.

This patch is intentionally narrow. It changes only domain detection and adds regression coverage around that behavior. It does not widen the detached fallback, change service templates, or alter non-macOS lifecycle logic.

## Changes Made

- Update `hermes_cli/gateway.py` so `_launchd_domain()`:
  - probes `gui/<uid>` and `user/<uid>` for the active Hermes LaunchAgent
  - falls back to `launchctl managername` for fresh installs where neither domain is loaded yet
  - caches the resolved domain for the current CLI invocation
- Update `tests/hermes_cli/test_gateway_service.py` with focused launchd-domain regression tests for:
  - Aqua sessions where the service is loaded under `gui/<uid>`
  - fallback to `user/<uid>` when `gui/<uid>` is absent
  - fresh Aqua sessions resolved via `managername`
  - cache behavior and deterministic existing launchd recovery tests

## How to Test

1. In an Aqua macOS session where the Hermes LaunchAgent is loaded under `gui/<uid>`, run `hermes gateway start` or `hermes gateway restart` and verify Hermes manages the existing service instead of dropping to detached fallback.
2. Run `pytest tests/hermes_cli/test_gateway_service.py -k launchd -q`.
3. Run `ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`.

## Compatibility Notes

- Aqua sessions: Hermes now prefers `gui/<uid>` when that is where the service is actually loaded.
- Background/headless sessions: when `gui/<uid>` is unavailable, Hermes still falls back to the existing `user/<uid>` path.
- Fresh installs: if neither domain has the service yet, Hermes uses `launchctl managername` to distinguish Aqua from non-Aqua sessions before choosing the initial domain.
- Unknown runtimes: if probing fails entirely, the code still defaults to `user/<uid>`, preserving the current background-session bias.

## Validation Logs

```text
Static/source proof:
- `_launchd_domain()` on current main hardcoded `user/<uid>`.
- Issue #42995 / #40831 evidence shows Aqua-session services can be loaded under `gui/<uid>`.

Automated checks:
- ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py -> passed
- pytest tests/hermes_cli/test_gateway_service.py -k launchd -q -> 28 passed, 121 deselected

Baseline note:
- `pytest tests/hermes_cli/test_gateway_service.py -q` has pre-existing user-systemd failures on this macOS host both before and after the patch; they are unrelated to this launchd-only change.
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7 with targeted launchd validation and regression tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — launchd-only change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
