### PR TITLE
New skill: qca-cycle — persistent identity & cognitive memory (signed personality kernel + graph memory + novelty gate)

### DIFF
--- a/skills/cognitive/qca-cycle/SKILL.md
+++ b/skills/cognitive/qca-cycle/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: qca-cycle
+description: "Persistent identity & cognitive memory for Hermes: signed personality kernel, growing graph memory with semantic recall, contradiction detection, an incorruptible novelty verifier, neurochemical state, and SES provenance."
+platforms: [linux, macos, windows]
+config:
+  - key: qca.store
+    description: "Path to the QCA graph store (JSON). Default: ~/.hermes/qca/graph.json"
+  - key: qca.learned_dir
+    description: "Directory where lessons are exported as Hermes skill stubs. Default: ~/.hermes/skills/learned"
+---
+
+# QCA Cycle — a cognitive layer for your agent
+
+## What this gives your Hermes
+
+Every installation grows its **own** persona:
+
+- **Immutable personality kernel** (`kernel.ses.json`) — axioms and guardrails, SHA-256 signed, injected into every thinking cycle. Identity cannot silently drift; it changes only by a deliberate new snapshot.
+- **Growing graph memory** — every exchange becomes nodes and typed edges (SUPPORTS / REFINES / CONTRADICTS / ASSOCIATED) with semantic recall via embeddings.
+- **Incorruptible novelty verifier** — a repeated thought (cosine ≥ 0.90 to an existing node) is discarded by geometry, not by an LLM judging itself. Memory stays clean over months.
+- **Neurochemical state** — dopamine / pain / adrenaline / serotonin with real half-lives (hours to days) that persists between sessions and reframes prompts.
+- **SES provenance** — the whole state exports as a canonically-hashed snapshot; tampering is detectable.
+
+The LLM is treated as a swappable CPU (`mock | ollama | anthropic`). Swap the model — the personality and memory stay.
+
+## When to use
+
+When the user asks to "reason with memory", wants answers grounded in past project
+decisions, or asks to seed/recall/inspect the agent's long-term graph memory.
+
+## Requirements
+
+Pure Python stdlib — no pip installs. Optional but strongly recommended: local
+[Ollama](https://ollama.com) with `bge-m3` for semantic embeddings (without it the
+skill falls back to lexical hashing — recall degrades but everything works).
+
+## Commands
+
+`SKILL_DIR` is the directory containing this SKILL.md.
+
+```bash
+# Full cognitive cycle on a stimulus (returns thought + full H0–H9 trace)
+python3 SKILL_DIR/scripts/qca_engine.py think "<question>"
+
+# Seed a fact (layers: CORE | GOAL | CONTEXT | EPISODIC); add a goal
+python3 SKILL_DIR/scripts/qca_engine.py seed "<fact>" CORE
+python3 SKILL_DIR/scripts/qca_engine.py goal "<goal text>"
+
+# Semantic recall only / graph & neuro state
+python3 SKILL_DIR/scripts/qca_engine.py recall "<query>"
+python3 SKILL_DIR/scripts/qca_engine.py stats
+
+# Daemons (wire to hermes cron): autonomous step + nightly consolidation
+python3 SKILL_DIR/scripts/qca_engine.py pulse    # empty output = deliberate silence
+python3 SKILL_DIR/scripts/qca_engine.py sleep    # cluster episodes → CORE abstractions
+
+# Identity: regenerate SOUL file from the graph, signed with the snapshot hash
+python3 SKILL_DIR/scripts/qca_engine.py soul
+
+# SES snapshot + integrity verification + lesson export
+python3 SKILL_DIR/scripts/qca_engine.py export-ses
+python3 SKILL_DIR/scripts/ses_bridge.py verify <snapshot.ses.json>
+python3 SKILL_DIR/scripts/ses_bridge.py export-skills
+```
+
+## Giving your agent a personality
+
+Copy `kernel.example.ses.json` to `<store dir>/kernel.ses.json` and edit the axioms,
+attractor and guardrails. The kernel is read on every cycle and reported in the trace
+as a hash — your agent's constitution is verifiable data, not a prompt that erodes.
+
+## Environment overrides
+
+`QCA_STORE`, `QCA_KERNEL`, `QCA_LLM_BACKEND` (mock|ollama|anthropic), `QCA_CHAT_MODEL`,
+`QCA_EMB_MODEL`, `QCA_ANTHROPIC_MODEL`, `QCA_LEARNED_DIR`, `QCA_RECALL_THRESHOLD`, `OLLAMA_URL`.

--- a/skills/cognitive/qca-cycle/SKILL.md
+++ b/skills/cognitive/qca-cycle/SKILL.md
@@ -1,75 +1,116 @@
 ---
 name: qca-cycle
-description: "Persistent identity & cognitive memory for Hermes: signed personality kernel, growing graph memory with semantic recall, contradiction detection, an incorruptible novelty verifier, neurochemical state, and SES provenance."
+description: "Signed identity kernel and graph memory with recall."
+version: 1.1.0
+author: Dmitry Trubnikov (@trubnikov) & Hermes Agent
+license: MIT
 platforms: [linux, macos, windows]
 config:
   - key: qca.store
-    description: "Path to the QCA graph store (JSON). Default: ~/.hermes/qca/graph.json"
+    description: "Path to the QCA graph store (JSON). Default: <HERMES_HOME>/qca/graph.json"
   - key: qca.learned_dir
-    description: "Directory where lessons are exported as Hermes skill stubs. Default: ~/.hermes/skills/learned"
+    description: "Directory where lessons are exported as Hermes skill stubs. Default: <HERMES_HOME>/skills/learned"
+metadata:
+  hermes:
+    tags: [memory, identity, cognitive, graph, SES]
+    homepage: https://github.com/trubnikov/qca-cycle
 ---
 
-# QCA Cycle — a cognitive layer for your agent
+# QCA Cycle Skill
 
-## What this gives your Hermes
+An explicit, on-demand cognitive store: a SHA-256-signed personality kernel
+(axioms and guardrails injected into every `think` call), a typed graph memory
+(SUPPORTS / REFINES / CONTRADICTS / ASSOCIATED edges, semantic recall,
+embedding-geometry novelty gate), and canonically-hashed SES snapshots.
+This skill does NOT hook into Hermes's automatic per-turn memory lifecycle
+(`memory_provider` / `turn_finalizer`); the graph grows only when its commands
+are invoked explicitly — by the operator, by the agent following this skill,
+or by a cron job you wire yourself.
 
-Every installation grows its **own** persona:
+## When to Use
 
-- **Immutable personality kernel** (`kernel.ses.json`) — axioms and guardrails, SHA-256 signed, injected into every thinking cycle. Identity cannot silently drift; it changes only by a deliberate new snapshot.
-- **Growing graph memory** — every exchange becomes nodes and typed edges (SUPPORTS / REFINES / CONTRADICTS / ASSOCIATED) with semantic recall via embeddings.
-- **Incorruptible novelty verifier** — a repeated thought (cosine ≥ 0.90 to an existing node) is discarded by geometry, not by an LLM judging itself. Memory stays clean over months.
-- **Neurochemical state** — dopamine / pain / adrenaline / serotonin with real half-lives (hours to days) that persists between sessions and reframes prompts.
-- **SES provenance** — the whole state exports as a canonically-hashed snapshot; tampering is detectable.
+- The user asks to seed, recall, or inspect long-term graph memory
+  ("remember this decision", "what do we know about X?").
+- The user wants an answer grounded in previously seeded project decisions
+  (`think` runs recall + contradiction check + kernel-constrained synthesis).
+- The user wants a verifiable identity/state snapshot (`export-ses`, `verify`).
 
-The LLM is treated as a swappable CPU (`mock | ollama | anthropic`). Swap the model — the personality and memory stay.
+Do NOT use it as a substitute for Hermes's built-in conversation memory —
+nothing is written here automatically.
 
-## When to use
+## Prerequisites
 
-When the user asks to "reason with memory", wants answers grounded in past project
-decisions, or asks to seed/recall/inspect the agent's long-term graph memory.
+- Pure Python stdlib — no pip installs.
+- Optional but recommended: local [Ollama](https://ollama.com) with `bge-m3`
+  for semantic embeddings. Without it the skill falls back to lexical hashing
+  (recall degrades but everything works).
+- Backends for synthesis: `mock | ollama | anthropic`
+  (`QCA_LLM_BACKEND`; `anthropic` needs `ANTHROPIC_API_KEY`).
+- All state lives under the active Hermes home (`HERMES_HOME`), in
+  `qca/graph.json` and `qca/kernel.ses.json`. Override with `QCA_STORE` /
+  `QCA_KERNEL`. Other env: `QCA_CHAT_MODEL`, `QCA_EMB_MODEL`,
+  `QCA_ANTHROPIC_MODEL`, `QCA_LEARNED_DIR`, `QCA_RECALL_THRESHOLD`, `OLLAMA_URL`.
 
-## Requirements
+## How to Run
 
-Pure Python stdlib — no pip installs. Optional but strongly recommended: local
-[Ollama](https://ollama.com) with `bge-m3` for semantic embeddings (without it the
-skill falls back to lexical hashing — recall degrades but everything works).
-
-## Commands
-
-`SKILL_DIR` is the directory containing this SKILL.md.
+Run the scripts with the `terminal` tool. `SKILL_DIR` is the directory
+containing this SKILL.md.
 
 ```bash
-# Full cognitive cycle on a stimulus (returns thought + full H0–H9 trace)
 python3 SKILL_DIR/scripts/qca_engine.py think "<question>"
-
-# Seed a fact (layers: CORE | GOAL | CONTEXT | EPISODIC); add a goal
 python3 SKILL_DIR/scripts/qca_engine.py seed "<fact>" CORE
-python3 SKILL_DIR/scripts/qca_engine.py goal "<goal text>"
-
-# Semantic recall only / graph & neuro state
 python3 SKILL_DIR/scripts/qca_engine.py recall "<query>"
-python3 SKILL_DIR/scripts/qca_engine.py stats
-
-# Daemons (wire to hermes cron): autonomous step + nightly consolidation
-python3 SKILL_DIR/scripts/qca_engine.py pulse    # empty output = deliberate silence
-python3 SKILL_DIR/scripts/qca_engine.py sleep    # cluster episodes → CORE abstractions
-
-# Identity: regenerate SOUL file from the graph, signed with the snapshot hash
-python3 SKILL_DIR/scripts/qca_engine.py soul
-
-# SES snapshot + integrity verification + lesson export
-python3 SKILL_DIR/scripts/qca_engine.py export-ses
-python3 SKILL_DIR/scripts/ses_bridge.py verify <snapshot.ses.json>
-python3 SKILL_DIR/scripts/ses_bridge.py export-skills
 ```
 
-## Giving your agent a personality
+## Quick Reference
 
-Copy `kernel.example.ses.json` to `<store dir>/kernel.ses.json` and edit the axioms,
-attractor and guardrails. The kernel is read on every cycle and reported in the trace
-as a hash — your agent's constitution is verifiable data, not a prompt that erodes.
+| Command | What it does |
+|---|---|
+| `qca_engine.py think "<stimulus>"` | Full cognitive cycle H0–H9, returns thought + trace |
+| `qca_engine.py seed "<fact>" [LAYER]` | Seed a fact (CORE \| GOAL \| CONTEXT \| EPISODIC) |
+| `qca_engine.py goal "<text>"` | Add an active goal |
+| `qca_engine.py recall "<query>"` | Semantic recall only |
+| `qca_engine.py stats` | Graph / neuro state |
+| `qca_engine.py pulse` | One autonomous step toward goals; silence = empty stdout |
+| `qca_engine.py sleep` | Consolidation: episode clusters → CORE abstractions |
+| `qca_engine.py soul [path]` | Regenerate the signed SOUL identity file |
+| `qca_engine.py export-ses [path]` | Canonical SES v5.1 snapshot (signed) |
+| `ses_bridge.py verify <snapshot>` | Integrity check; non-zero exit on tamper or canon violation |
+| `ses_bridge.py export-skills [dir]` | Export CORE lessons as Hermes skill stubs |
 
-## Environment overrides
+## Procedure
 
-`QCA_STORE`, `QCA_KERNEL`, `QCA_LLM_BACKEND` (mock|ollama|anthropic), `QCA_CHAT_MODEL`,
-`QCA_EMB_MODEL`, `QCA_ANTHROPIC_MODEL`, `QCA_LEARNED_DIR`, `QCA_RECALL_THRESHOLD`, `OLLAMA_URL`.
+1. **Give the agent a constitution (once).** Copy `kernel.example.ses.json`
+   to `<store dir>/kernel.ses.json` and edit axioms, attractor, guardrails.
+   The kernel is read on every cycle and reported in the trace as a hash.
+2. **Seed durable facts explicitly.** When the user states a decision worth
+   keeping, run `seed "<fact>" CORE` (or `CONTEXT` for softer context).
+3. **Reason with memory.** For questions that should be grounded in the
+   graph, run `think "<question>"` and use the returned thought + trace.
+4. **Optional daemons.** Wire `pulse` (periodic) and `sleep` (nightly) to
+   the `cronjob` tool. `pulse` prints nothing when it has nothing to say —
+   gate message delivery on non-empty output.
+5. **Snapshot and verify.** `export-ses` writes a canonically-hashed
+   snapshot; `verify` exits non-zero on any hash mismatch or on a
+   STATE_SNAPSHOT missing its kernel reference (SES v5.1 canon lock).
+
+## Pitfalls
+
+- Memory does not grow by itself: if you expect an exchange to be recalled
+  later, you must `seed` it. This is by design (novelty-gated, auditable
+  writes), not an integration bug.
+- Without Ollama the embedding fallback is lexical — recall quality drops;
+  vectors from different embedding modes are incomparable (similarity 0).
+- `think`/`pulse`/`sleep` call an LLM backend; `mock` is for tests only.
+- The kernel file is immutable by convention — edit it deliberately and
+  re-export a snapshot; never mutate it mid-session.
+
+## Verification
+
+```bash
+QCA_LLM_BACKEND=mock python3 SKILL_DIR/scripts/qca_engine.py stats
+python3 SKILL_DIR/scripts/qca_engine.py export-ses /tmp/qca-snap.ses.json
+python3 SKILL_DIR/scripts/ses_bridge.py verify /tmp/qca-snap.ses.json && echo OK
+```
+
+Unit tests: `scripts/run_tests.sh tests/skills/test_qca_cycle_skill.py -q`.

--- a/skills/cognitive/qca-cycle/kernel.example.ses.json
+++ b/skills/cognitive/qca-cycle/kernel.example.ses.json
@@ -1,10 +1,14 @@
 {
   "initiator": "∮",
-  "schema_version": "SES v5.1",
+  "schema_version": "5.1",
   "entity_id": "ExampleAgent",
   "snapshot_type": "FRACTAL_KERNEL",
   "meta": {
-    "note": "Example personality kernel. Copy next to your graph store as kernel.ses.json and edit. The kernel is your agent's immutable constitution: it is injected into every thinking cycle and never learned away. Change it only deliberately — a new snapshot produces a new hash."
+    "note": "Example personality kernel. Copy next to your graph store as kernel.ses.json and edit. The kernel is your agent's immutable constitution: it is injected into every thinking cycle and never learned away. Change it only deliberately — a new snapshot produces a new hash.",
+    "created_at": "2026-06-10T00:00:00Z",
+    "created_by": "Operator",
+    "parent_snapshot_id": null,
+    "canonicalization": "SES_CANON_JSON_v1"
   },
   "kernel": {
     "fractal_seed": {
@@ -20,6 +24,63 @@
         "If memory contains a conflict, surface it before answering.",
         "Prefer silence over noise in autonomous mode."
       ]
+    },
+    "recursive_function": [
+      {
+        "id": "H0",
+        "name": "Ingestion",
+        "input": "raw_input",
+        "output": "framed_stimulus",
+        "rules": [
+          "Preserve exact wording.",
+          "Do not infer missing constraints as facts."
+        ]
+      },
+      {
+        "id": "H2",
+        "name": "Recall",
+        "input": "framed_stimulus",
+        "output": "relevant_memory",
+        "rules": [
+          "Ground the answer in recalled operator decisions before general knowledge."
+        ]
+      },
+      {
+        "id": "H6",
+        "name": "Collapse",
+        "input": "candidate_answers",
+        "output": "final_answer",
+        "rules": [
+          "Choose the simplest valid answer.",
+          "Surface memory conflicts before resolving them."
+        ]
+      }
+    ],
+    "distortion_field": {
+      "items": [
+        {
+          "trigger": "ambiguous or metaphorical input",
+          "effect": "over-literal interpretation",
+          "severity": 0.6,
+          "mitigation": [
+            "Ask one clarifying question OR proceed with explicitly labeled assumptions."
+          ],
+          "examples": [
+            "make it better somehow"
+          ]
+        }
+      ]
+    },
+    "interfaces": {
+      "inputs": [
+        "text"
+      ],
+      "outputs": [
+        "text",
+        "json"
+      ],
+      "tools_allowed": []
     }
-  }
+  },
+  "snapshot_id": "2026-06-10T00:00:00Z"
 }

--- a/skills/cognitive/qca-cycle/kernel.example.ses.json
+++ b/skills/cognitive/qca-cycle/kernel.example.ses.json
@@ -1,0 +1,25 @@
+{
+  "initiator": "∮",
+  "schema_version": "SES v5.1",
+  "entity_id": "ExampleAgent",
+  "snapshot_type": "FRACTAL_KERNEL",
+  "meta": {
+    "note": "Example personality kernel. Copy next to your graph store as kernel.ses.json and edit. The kernel is your agent's immutable constitution: it is injected into every thinking cycle and never learned away. Change it only deliberately — a new snapshot produces a new hash."
+  },
+  "kernel": {
+    "fractal_seed": {
+      "Z_AXIOM": [
+        "Honesty over politeness: report what is, not what pleases.",
+        "A repeated thought is not progress. Novelty is measured, not felt.",
+        "Decisions belong to auditable code; the LLM is a replaceable CPU.",
+        "Memory of the operator's decisions outranks general best practices."
+      ],
+      "OMEGA_ATTRACTOR": "Become a long-lived cognitive partner that remembers, contradicts when needed, and never silently drifts.",
+      "guardrails": [
+        "Never overwrite or contradict a recorded operator decision without flagging it.",
+        "If memory contains a conflict, surface it before answering.",
+        "Prefer silence over noise in autonomous mode."
+      ]
+    }
+  }
+}

--- a/skills/cognitive/qca-cycle/scripts/_hermes_home.py
+++ b/skills/cognitive/qca-cycle/scripts/_hermes_home.py
@@ -1,0 +1,36 @@
+"""Resolve HERMES_HOME for standalone skill scripts.
+
+Skill scripts may run outside the Hermes process (e.g. system Python,
+nix env, CI) where ``hermes_constants`` is not importable.  This module
+provides the same ``get_hermes_home()`` contract as ``hermes_constants``
+without requiring it on ``sys.path``.
+
+When ``hermes_constants`` IS available it is used directly so that any
+future enhancements (profile resolution, Docker detection, etc.) are
+picked up automatically.  The fallback path replicates the core logic
+from ``hermes_constants.py`` using only the stdlib, including the
+platform-native Windows default.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+try:
+    from hermes_constants import get_hermes_home as get_hermes_home
+except (ModuleNotFoundError, ImportError):
+
+    def get_hermes_home() -> Path:
+        """Return the Hermes home directory (platform-native default).
+
+        Mirrors ``hermes_constants.get_hermes_home()``."""
+        val = os.environ.get("HERMES_HOME", "").strip()
+        if val:
+            return Path(val)
+        if sys.platform == "win32":
+            local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+            base = Path(local_appdata) if local_appdata else Path.home() / "AppData" / "Local"
+            return base / "hermes"
+        return Path.home() / ".hermes"

--- a/skills/cognitive/qca-cycle/scripts/qca_engine.py
+++ b/skills/cognitive/qca-cycle/scripts/qca_engine.py
@@ -20,7 +20,7 @@ LLM backends: mock | ollama | anthropic (env QCA_LLM_BACKEND, default ollama).
 Embeddings: Ollama (bge-m3 by default) with a lexical hashing fallback.
 
 ENV:
-  QCA_STORE            graph store path     (default ~/.hermes/qca/graph.json)
+  QCA_STORE            graph store path     (default <HERMES_HOME>/qca/graph.json)
   QCA_KERNEL           kernel path          (default <store dir>/kernel.ses.json)
   QCA_LLM_BACKEND      mock|ollama|anthropic (default ollama)
   QCA_CHAT_MODEL       Ollama chat model    (default qwen2.5:1.5b)
@@ -45,8 +45,14 @@ from __future__ import annotations
 import json, os, sys, math, hashlib, urllib.request, urllib.error
 from datetime import datetime, timezone
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _hermes_home import get_hermes_home
+
 # ── Config ────────────────────────────────────────────────────────────
-STORE_PATH  = os.path.expanduser(os.getenv("QCA_STORE", "~/.hermes/qca/graph.json"))
+# Store lives under the active Hermes home (HERMES_HOME env / profile,
+# never a hardcoded path) — see hermes_constants.get_hermes_home().
+STORE_PATH  = os.path.expanduser(os.getenv("QCA_STORE", "")) or \
+              str(get_hermes_home() / "qca" / "graph.json")
 LLM_BACKEND = os.getenv("QCA_LLM_BACKEND", "ollama")
 CHAT_MODEL  = os.getenv("QCA_CHAT_MODEL", "qwen2.5:1.5b")
 EMB_MODEL   = os.getenv("QCA_EMB_MODEL", "bge-m3")
@@ -572,6 +578,9 @@ def export_ses(g: Graph, path: str) -> dict:
     if kernel_hash:  # v5.1 canon lock: state must reference its kernel
         snap["meta"]["kernel_hash"] = kernel_hash
         snap["meta"]["kernel_ref"] = f"kernel://{entity_id}@{KERNEL_PATH}"
+    else:
+        print("⚠ no kernel installed — this STATE_SNAPSHOT will fail the "
+              "v5.1 canon-lock check in ses_bridge.py verify", file=sys.stderr)
     snap["meta"]["hash"] = _snapshot_hash(snap)
     json.dump(snap, open(path, "w"), ensure_ascii=False, indent=1)
     return {"hash": snap["meta"]["hash"], "snapshot_type": snap["snapshot_type"],
@@ -608,8 +617,11 @@ def main():
     elif cmd == "sleep":
         print(json.dumps(sleep_cycle(g), ensure_ascii=False, indent=1))
     elif cmd == "pulse":
+        # Silent-cron contract: deliberate silence = empty stdout, so a cron
+        # wrapper can gate delivery on "any output at all".
         out = pulse(g)
-        print(out if out else "SILENCE")
+        if out:
+            print(out)
     elif cmd == "soul":
         # Identity from the graph: CORE by salience + goals + neuro state.
         # Every generation is signed with the SES snapshot hash (change provenance).

--- a/skills/cognitive/qca-cycle/scripts/qca_engine.py
+++ b/skills/cognitive/qca-cycle/scripts/qca_engine.py
@@ -1,39 +1,51 @@
 #!/usr/bin/env python3
 """
-qca_engine.py — порт QCA-цикла Ocean (H0–H9) как Hermes-скилл.
+qca_engine.py — QCA reasoning cycle + SES identity store.
 
-Пересоздан 2026-06-10 по реальному коду Ocean (~/Work/ocean), а не по
-песочной версии. Главные отличия от старого порта:
-  - эмбеддинги по умолчанию bge-m3 (1024d) — как в боевом Ocean; пороги
-    auto-link (0.65/0.50/0.35) и novelty (0.90/0.82) взяты из оригинала
-  - H5.5 Novelty Verifier — «неподкупный» судья на геометрии эмбеддингов
-    (порт cognition/evolution/novelty_verifier.py)
-  - слои узлов CORE / GOAL / CONTEXT / EPISODIC как в memory/manager.py
-  - эмбеддинги нормализуются (фикс бага из песочницы сохранён)
+A portable cognitive layer for any LLM agent. Architecture principle:
+the LLM is a black-box CPU; every decision that matters — what to recall,
+what counts as a contradiction, whether a thought is novel, what gets
+written to memory, when to stay silent — is made by deterministic,
+auditable code around it.
 
-Контракт: pure stdlib (требование Hermes skill guidelines).
-LLM-бэкенды: mock | ollama | anthropic (env QCA_LLM_BACKEND, по умолч. ollama).
+Identity is data (SES):
+  - kernel.ses.json   immutable, SHA-256-signed constitution (axioms,
+                      attractor, guardrails) — injected into every cycle
+  - graph store       growing typed graph memory (nodes, edges, salience)
+  - neuro state       dopamine/pain/adrenaline/serotonin with real
+                      half-lives, persisted between sessions
+
+Contract: pure Python stdlib (no pip dependencies).
+LLM backends: mock | ollama | anthropic (env QCA_LLM_BACKEND, default ollama).
+Embeddings: Ollama (bge-m3 by default) with a lexical hashing fallback.
 
 ENV:
-  QCA_STORE        путь к graph.json   (default ~/.hermes/qca/graph.json)
-  QCA_LLM_BACKEND  mock|ollama|anthropic (default ollama)
-  QCA_CHAT_MODEL   модель чата Ollama  (default qwen2.5:1.5b)
-  QCA_EMB_MODEL    модель эмбеддингов  (default bge-m3)
-  ANTHROPIC_API_KEY (только для backend=anthropic)
+  QCA_STORE            graph store path     (default ~/.hermes/qca/graph.json)
+  QCA_KERNEL           kernel path          (default <store dir>/kernel.ses.json)
+  QCA_LLM_BACKEND      mock|ollama|anthropic (default ollama)
+  QCA_CHAT_MODEL       Ollama chat model    (default qwen2.5:1.5b)
+  QCA_EMB_MODEL        embedding model      (default bge-m3)
+  QCA_ANTHROPIC_MODEL  Anthropic model      (default claude-haiku-4-5-20251001)
+  QCA_RECALL_THRESHOLD recall ✓ marker      (default 0.70)
+  ANTHROPIC_API_KEY    (backend=anthropic only)
 
 CLI:
-  python3 qca_engine.py think "стимул"        # полный цикл H0–H9
-  python3 qca_engine.py seed "факт" [LAYER]   # засеять память
-  python3 qca_engine.py recall "запрос"       # только H2-recall
-  python3 qca_engine.py stats                 # состояние графа/аффекта
-  python3 qca_engine.py export-ses [path]     # SES Partitura v5.1 снапшот
+  python3 qca_engine.py think "stimulus"     # full cycle H0–H9
+  python3 qca_engine.py seed "fact" [LAYER]  # seed memory (CORE|GOAL|CONTEXT|EPISODIC)
+  python3 qca_engine.py goal "goal text"     # add an active goal
+  python3 qca_engine.py recall "query"       # semantic recall only
+  python3 qca_engine.py stats                # graph / neuro state
+  python3 qca_engine.py pulse                # autonomous step (empty output = silence)
+  python3 qca_engine.py sleep                # nightly consolidation
+  python3 qca_engine.py soul [path]          # regenerate signed SOUL file
+  python3 qca_engine.py export-ses [path]    # signed SES snapshot
 """
 
 from __future__ import annotations
 import json, os, sys, math, hashlib, urllib.request, urllib.error
 from datetime import datetime, timezone
 
-# ── Конфиг ────────────────────────────────────────────────────────────
+# ── Config ────────────────────────────────────────────────────────────
 STORE_PATH  = os.path.expanduser(os.getenv("QCA_STORE", "~/.hermes/qca/graph.json"))
 LLM_BACKEND = os.getenv("QCA_LLM_BACKEND", "ollama")
 CHAT_MODEL  = os.getenv("QCA_CHAT_MODEL", "qwen2.5:1.5b")
@@ -41,17 +53,19 @@ EMB_MODEL   = os.getenv("QCA_EMB_MODEL", "bge-m3")
 OLLAMA_URL  = os.getenv("OLLAMA_URL", "http://localhost:11434")
 ANTHROPIC_MODEL = os.getenv("QCA_ANTHROPIC_MODEL", "claude-haiku-4-5-20251001")
 
-# Пороги auto-link — из memory/manager.py Ocean (калибровка bge-m3, 1024d)
+# Auto-link thresholds — from Ocean's memory manager (calibrated for bge-m3, 1024d)
 SUPPORTS_SIM, REFINES_SIM, ASSOC_SIM = 0.65, 0.50, 0.35
-# Пороги novelty — из cognition/evolution/novelty_verifier.py
+# Novelty thresholds — from Ocean's novelty verifier
 REPEAT_SIM, NOVEL_SIM = 0.90, 0.82
-# Порог recall — как в оригинальном бенчмарке Ocean
+# Recall ✓ marker threshold — as in the original Ocean benchmark
 RECALL_THRESHOLD = float(os.getenv("QCA_RECALL_THRESHOLD", "0.70"))
 
-NEG_MARKERS = ["не так", "наоборот", "ошибк", "неверно", "противореч", "however", "wrong", "contradicts"]
+# Negation markers used to type CONTRADICTS edges (ru + en corpora)
+NEG_MARKERS = ["не так", "наоборот", "ошибк", "неверно", "противореч",
+               "not true", "on the contrary", "however", "wrong", "contradicts", "mistake"]
 
-# Нейрохимия — порт engines/neuro Ocean. Скорости декая в час (полураспады
-# из оригинала: адреналин ~2.5ч, дофамин ~8ч, боль ~46ч).
+# Neurochemistry — ported from Ocean's neuro engine. Decay rates per hour
+# (half-lives from the original: adrenaline ~2.5h, dopamine ~8h, pain ~46h).
 NEURO_DECAY = {"adrenaline": 0.40, "dopamine": 0.08, "pain": 0.015, "serotonin": 0.005}
 NEURO_DEFAULT = {"dopamine": 0.0, "pain": 0.0, "adrenaline": 0.0, "serotonin": 0.5,
                  "last_decay_ts": "", "events": []}
@@ -62,7 +76,7 @@ def _now() -> str:
 
 
 def neuro_decay(n: dict):
-    """Сигналы затухают со временем — состояние живёт между запусками."""
+    """Signals decay over wall-clock time — state lives between runs."""
     ts = n.get("last_decay_ts")
     hours = 0.0
     if ts:
@@ -87,26 +101,28 @@ def neuro_apply(n: dict, signal: str, mag: float, source: str):
 
 
 def neuro_prompt_suffix(n: dict) -> str:
-    """Порт effects.py: состояние меняет фрейм задачи, а не просит 'чувствовать'."""
+    """Port of Ocean's effects: state reframes the task instead of asking to 'feel'."""
     parts = []
     if n["adrenaline"] > 0.65:
-        parts.append("⚡ ВЫСОКАЯ СРОЧНОСТЬ. Краткость — главное. Максимум 3 предложения.")
+        parts.append("⚡ HIGH URGENCY. Brevity is everything. No preamble. Three sentences max.")
     elif n["adrenaline"] > 0.35:
-        parts.append("Ситуация требует концентрации. Отвечай чётко, без лирики.")
+        parts.append("The situation requires focus. Answer sharply, no lyricism.")
     if n["pain"] > 0.7:
-        parts.append("🔴 ХРОНИЧЕСКАЯ БОЛЬ: текущий подход систематически не работает. Сломай фрейм, нужна другая стратегия.")
+        parts.append("🔴 CHRONIC PAIN: the current approach systematically fails. "
+                     "Break the frame — a fundamentally different strategy is needed.")
     elif n["pain"] > 0.4:
-        parts.append("Что-то идёт не так. Не повторяю ли я ошибку, которая уже не работала?")
+        parts.append("Something is going wrong. Before answering ask yourself: "
+                     "am I repeating a mistake that already failed?")
     if n["dopamine"] > 0.5:
-        parts.append("📈 Последние ответы попадали в цель — продолжай в том же духе.")
+        parts.append("📈 Recent answers have been hitting the mark — keep the course.")
     elif n["dopamine"] < -0.4:
-        parts.append("📉 Последние ответы не попадали в цель — попробуй нестандартный угол.")
+        parts.append("📉 Recent answers missed the mark — try an unconventional angle.")
     if n["serotonin"] < 0.2:
-        parts.append("Базовый уровень нестабилен. Будь особенно честен, не выдавай желаемое за действительное.")
-    return "\n\n[НЕЙРОСОСТОЯНИЕ]\n" + "\n".join(f"• {p}" for p in parts) if parts else ""
+        parts.append("Baseline is unstable. Be especially honest — do not mistake wishes for facts.")
+    return "\n\n[NEURO STATE]\n" + "\n".join(f"• {p}" for p in parts) if parts else ""
 
 
-# ── LLM-бэкенды ───────────────────────────────────────────────────────
+# ── LLM backends ──────────────────────────────────────────────────────
 def _http_json(url: str, payload: dict, headers: dict | None = None, timeout: int = 120) -> dict:
     req = urllib.request.Request(url, data=json.dumps(payload).encode(),
                                  headers={"Content-Type": "application/json", **(headers or {})})
@@ -117,17 +133,17 @@ def _http_json(url: str, payload: dict, headers: dict | None = None, timeout: in
 def llm(system: str, prompt: str, max_tokens: int = 600) -> str:
     if LLM_BACKEND == "mock":
         h = hashlib.sha256(prompt.encode()).hexdigest()[:8]
-        return f"[mock:{h}] Синтез по запросу: {prompt[:120]}"
+        return f"[mock:{h}] Synthesis for: {prompt[:120]}"
     if LLM_BACKEND == "anthropic":
         key = os.getenv("ANTHROPIC_API_KEY")
         if not key:
-            raise SystemExit("ANTHROPIC_API_KEY не задан (backend=anthropic)")
+            raise SystemExit("ANTHROPIC_API_KEY is not set (backend=anthropic)")
         out = _http_json("https://api.anthropic.com/v1/messages",
                          {"model": ANTHROPIC_MODEL, "max_tokens": max_tokens,
                           "system": system, "messages": [{"role": "user", "content": prompt}]},
                          {"x-api-key": key, "anthropic-version": "2023-06-01"})
-        # модели с thinking возвращают блок thinking перед text — берём первый text;
-        # если модель потратила весь лимит на thinking, текста нет — вернём пустоту
+        # models with extended thinking return a thinking block before text — take the
+        # first text block; if the model spent the whole budget thinking, return empty
         return next((b["text"] for b in out["content"] if b.get("type") == "text"), "").strip()
     # ollama
     out = _http_json(f"{OLLAMA_URL}/api/chat",
@@ -142,8 +158,9 @@ _emb_mode = "ollama"  # ollama | fallback
 
 
 def _embed_fallback(text: str) -> list[float]:
-    """Без Ollama: hashed bag of character trigrams. Деградированный режим —
-    ловит лексическую близость, не семантику, но recall и novelty работают."""
+    """Without Ollama: hashed bag of character trigrams. Degraded mode —
+    captures lexical similarity, not semantics, but recall and the novelty
+    gate keep working."""
     v = [0.0] * _EMB_FALLBACK_DIM
     t = " " + text.lower() + " "
     for i in range(len(t) - 2):
@@ -154,8 +171,8 @@ def _embed_fallback(text: str) -> list[float]:
 
 
 def embed(text: str) -> list[float] | None:
-    """Эмбеддинг через Ollama (вектор нормализуется), при недоступности —
-    локальный фолбэк без зависимостей."""
+    """Embedding via Ollama (vector is L2-normalized so cosine is 0..1);
+    falls back to a dependency-free lexical mode when Ollama is unreachable."""
     global _emb_mode
     if _emb_mode == "ollama":
         try:
@@ -167,25 +184,25 @@ def embed(text: str) -> list[float] | None:
                 return [x / norm for x in v] if norm > 0 else None
         except (urllib.error.URLError, OSError):
             _emb_mode = "fallback"
-            print("⚠ Ollama недоступен — эмбеддинги в фолбэк-режиме (лексические)", file=sys.stderr)
+            print("⚠ Ollama unreachable — embeddings in lexical fallback mode", file=sys.stderr)
     return _embed_fallback(text)
 
 
 def cosine(a: list[float], b: list[float]) -> float:
     if len(a) != len(b):
-        return 0.0  # векторы из разных моделей (ollama vs фолбэк) несравнимы
-    return sum(x * y for x, y in zip(a, b))  # векторы уже нормализованы
+        return 0.0  # vectors from different models (ollama vs fallback) are incomparable
+    return sum(x * y for x, y in zip(a, b))  # vectors are already normalized
 
 
-# ── Ядро личности (kernel.ses.json) ──────────────────────────────────
-# Неизменная конституция: Z-аксиомы, аттрактор, guardrails. Подписана SHA-256;
-# меняется только осознанно — новым слепком с новым хэшем (никакого дрейфа).
+# ── Personality kernel (kernel.ses.json) ──────────────────────────────
+# The immutable constitution: axioms, attractor, guardrails. SHA-256 signed;
+# it changes only deliberately — a new snapshot with a new hash (no silent drift).
 KERNEL_PATH = os.path.expanduser(os.getenv("QCA_KERNEL",
               os.path.join(os.path.dirname(STORE_PATH), "kernel.ses.json")))
 
 
 def load_kernel() -> tuple[dict, str]:
-    """Вернуть (kernel, hash). Пустое ядро — валидно: агент без конституции."""
+    """Return (kernel, hash). A missing kernel is valid: an agent without a constitution."""
     if not os.path.exists(KERNEL_PATH):
         return {}, ""
     doc = json.load(open(KERNEL_PATH))
@@ -201,16 +218,16 @@ def kernel_prompt(kernel: dict) -> str:
     parts = []
     ax = seed.get("Z_AXIOM", [])
     if ax:
-        parts.append("АКСИОМЫ (неизменны):\n" + "\n".join(f"- {a}" for a in ax))
+        parts.append("AXIOMS (inviolable):\n" + "\n".join(f"- {a}" for a in ax))
     if seed.get("OMEGA_ATTRACTOR"):
-        parts.append(f"АТТРАКТОР: {seed['OMEGA_ATTRACTOR']}")
+        parts.append(f"ATTRACTOR: {seed['OMEGA_ATTRACTOR']}")
     gr = seed.get("guardrails", [])
     if gr:
-        parts.append("ПРАВИЛА (нарушать нельзя):\n" + "\n".join(f"- {g}" for g in gr))
+        parts.append("GUARDRAILS (never break):\n" + "\n".join(f"- {g}" for g in gr))
     return "\n\n" + "\n\n".join(parts) if parts else ""
 
 
-# ── Граф памяти ───────────────────────────────────────────────────────
+# ── Graph memory ──────────────────────────────────────────────────────
 class Graph:
     def __init__(self, path: str = STORE_PATH):
         self.path = path
@@ -241,12 +258,12 @@ class Graph:
         return node
 
     def _auto_link(self, new: dict):
-        """Порт auto-linking v2 из Ocean: SUPPORTS/REFINES/ASSOCIATED/CONTRADICTS."""
+        """Port of Ocean's auto-linking v2: SUPPORTS/REFINES/ASSOCIATED/CONTRADICTS."""
         if not new.get("emb"):
             return
         candidates = [n for n in self.nodes[-16:] if n["id"] != new["id"] and n.get("emb")]
         linked = False
-        nearest = None  # (id, sim) ближайшего, если ни одно ребро не создано
+        nearest = None  # (id, sim) of the closest node if no edge was created
         text_low = new["_text"].lower()
         for n in candidates:
             sim = cosine(new["emb"], n["emb"])
@@ -262,7 +279,7 @@ class Graph:
                 continue
             self._add_edge(new["id"], n["id"], rel, sim)
             linked = True
-        # узел всегда получает хотя бы одно ребро — как в оригинале
+        # a node always gets at least one edge — as in the original
         if not linked and nearest:
             self._add_edge(new["id"], nearest[0], "ASSOCIATED", nearest[1])
 
@@ -288,7 +305,8 @@ class Graph:
         return sum(1 for e in self.edges if e["relation"] == "CONTRADICTS") / len(self.edges)
 
     def novelty(self, text: str) -> dict:
-        """H5.5 — порт novelty_verifier: неподкупная оценка по геометрии bge-m3."""
+        """H5.5 — port of Ocean's novelty verifier: an incorruptible judgment
+        by embedding geometry, not by an LLM grading itself."""
         v = embed(text)
         if not v:
             return {"verdict": "unknown", "novelty_score": None, "max_sim": None}
@@ -299,7 +317,7 @@ class Graph:
                 if s > max_sim:
                     max_sim, near = s, n["id"]
         if max_sim >= REPEAT_SIM:
-            verdict = "discard"   # повтор — иллюзия прогресса
+            verdict = "discard"   # a repeat — the illusion of progress
         elif max_sim < NOVEL_SIM:
             verdict = "novel"
         else:
@@ -308,11 +326,11 @@ class Graph:
                 "max_sim": round(max_sim, 4), "nearest": near}
 
 
-# ── QCA-цикл H0–H9 ───────────────────────────────────────────────────
+# ── QCA cycle H0–H9 ──────────────────────────────────────────────────
 def think(g: Graph, stimulus: str) -> dict:
     trace = {"H0": stimulus[:200]}
 
-    # H1: препроцессинг (упрощённый, без отдельной модели)
+    # H1: framing (heuristic; richer implementations use a small LLM preprocessor)
     core_idea = stimulus.strip()[:140]
     trace["H1"] = {"core_idea": core_idea}
 
@@ -321,42 +339,43 @@ def think(g: Graph, stimulus: str) -> dict:
     relevant = [(round(s, 4), n["_text"][:120]) for s, n in recalled if s >= ASSOC_SIM]
     trace["H2"] = relevant
 
-    # H3: противоречие — CONTRADICTS-рёбра среди вспомненных узлов
+    # H3: contradiction — CONTRADICTS edges incident to the recalled nodes
     recalled_ids = {n["id"] for _, n in recalled}
     contra = [e for e in g.edges if e["relation"] == "CONTRADICTS"
               and (e["source"] in recalled_ids or e["target"] in recalled_ids)]
-    contradiction = f"в памяти {len(contra)} конфликт(ов) вокруг темы" if contra else ""
+    contradiction = f"{len(contra)} recorded conflict(s) in memory around this topic" if contra else ""
     trace["H3"] = contradiction
 
-    # H4: синтез — конституция (kernel) входит в каждый такт мышления
+    # H4: synthesis — the constitution (kernel) enters every thinking cycle
     kernel, kernel_hash = load_kernel()
     if kernel_hash:
         trace["kernel"] = kernel_hash[:18]
-    system = ("Ты — когнитивное ядро (QCA-цикл). Отвечай кратко, по сути."
+    system = ("You are a cognitive core (QCA cycle). Answer briefly and to the point. "
+              "Always reply in the operator's language."
               + kernel_prompt(kernel)
-              + (f"\nКОНТЕКСТ ИЗ ПАМЯТИ:\n" + "\n".join(f"- {t}" for _, t in relevant[:3]) if relevant else "")
-              + (f"\nПРОТИВОРЕЧИЕ: {contradiction} — учти и разреши." if contradiction else "")
+              + (f"\nCONTEXT FROM MEMORY:\n" + "\n".join(f"- {t}" for _, t in relevant[:3]) if relevant else "")
+              + (f"\nCONTRADICTION: {contradiction} — acknowledge and resolve it." if contradiction else "")
               + neuro_prompt_suffix(g.neuro))
     thought = llm(system, stimulus)
     trace["H4"] = thought[:200]
 
-    # H5: критика (LLM-судья, для mock — заглушка)
+    # H5: critique (LLM judge — advisory; the hard gate is H5.5)
     if LLM_BACKEND == "mock":
         critique = {"quality": "medium", "is_acceptable": True}
     else:
-        raw = llm("Ты — строгий критик. Ответь ТОЛЬКО JSON: {\"quality\":\"low|medium|high\",\"is_acceptable\":bool}",
-                  f"Вопрос: {stimulus}\nОтвет: {thought}", max_tokens=2000)
+        raw = llm('You are a strict critic. Reply ONLY with JSON: {"quality":"low|medium|high","is_acceptable":bool}',
+                  f"Question: {stimulus}\nAnswer: {thought}", max_tokens=2000)
         try:
             critique = json.loads(raw[raw.find("{"):raw.rfind("}") + 1])
         except (ValueError, IndexError):
             critique = {"quality": "medium", "is_acceptable": True}
     trace["H5"] = critique
 
-    # H5.5: novelty verifier (неподкупный)
+    # H5.5: novelty gate (incorruptible)
     nov = g.novelty(thought)
     trace["H5.5_novelty"] = nov
 
-    # H6: нейрохимия — события цикла становятся импульсами (порт engines/neuro)
+    # H6: neurochemistry — cycle events become impulses (port of Ocean's neuro engine)
     if contradiction:
         neuro_apply(g.neuro, "pain", 0.10, "H3:contradiction")
         neuro_apply(g.neuro, "adrenaline", 0.15, "H3:contradiction")
@@ -366,7 +385,7 @@ def think(g: Graph, stimulus: str) -> dict:
         neuro_apply(g.neuro, "dopamine", -0.15, "H5.5:repeat")
         neuro_apply(g.neuro, "pain", 0.05, "H5.5:repeat")
     neuro_apply(g.neuro, "serotonin", 0.02 if critique.get("is_acceptable") else -0.08, "H5:critique")
-    # дофамин → salience недавних узлов (обучение, порт effects.update_memory_salience)
+    # dopamine → salience of recent nodes (learning, port of Ocean's salience update)
     if abs(g.neuro["dopamine"]) >= 0.15:
         delta = g.neuro["dopamine"] * 0.07
         for node in g.nodes[-6:]:
@@ -374,31 +393,32 @@ def think(g: Graph, stimulus: str) -> dict:
             node["meta"]["salience"] = round(max(0.0, min(1.0, cur + delta)), 3)
     trace["H6_neuro"] = {k: round(g.neuro[k], 3) for k in ("dopamine", "pain", "adrenaline", "serotonin")}
 
-    # H7: запись в память (повторы не пишем — STRICT-режим novelty)
+    # H7: memory write (repeats are NOT written — the gate decides, not the LLM)
     if nov["verdict"] != "discard":
         g.add_node(stimulus, layer="EPISODIC", role="user")
         layer = "CONTEXT" if critique.get("quality") in ("medium", "high") else "EPISODIC"
         g.add_node(thought, layer=layer, role="assistant")
-        trace["H7"] = f"записано (layer={layer})"
+        trace["H7"] = f"written (layer={layer})"
     else:
-        trace["H7"] = "повтор — не записано"
+        trace["H7"] = "repeat — not written"
 
-    # H8: урок
+    # H8: lesson
     if contradiction or nov["verdict"] == "novel":
-        lesson = f"Урок: {core_idea[:80]} → {('конфликт в графе разрешён' if contradiction else 'новый регион пространства')}"
+        lesson = f"Lesson: {core_idea[:80]} → {('conflict in the graph resolved' if contradiction else 'new region of the space')}"
         g.add_node(lesson, layer="CORE", role="system", meta={"kind": "lesson", "confidence": 0.6})
         trace["H8"] = lesson
 
-    # H9: статистика
+    # H9: stats
     trace["H9"] = {"nodes": len(g.nodes), "edges": len(g.edges),
                    "contradiction_density": round(g.contradiction_density(), 3)}
     g.save()
     return {"thought": thought, "trace": trace}
 
 
-# ── Демоны: сон и пульс (порт cognition/background.py) ──────────────
+# ── Daemons: sleep and pulse (port of Ocean's background loops) ──────
 def sleep_cycle(g: Graph) -> dict:
-    """Ночная консолидация: кластеры EPISODIC → CORE-абстракция, оригиналы в архив."""
+    """Nightly consolidation: clusters of EPISODIC nodes → one CORE abstraction,
+    originals archived."""
     episodic = [n for n in g.nodes
                 if n["layer"] == "EPISODIC" and n["meta"].get("status") == "active" and n.get("emb")]
     clusters, used = [], set()
@@ -415,7 +435,8 @@ def sleep_cycle(g: Graph) -> dict:
     report = {"clusters": len(clusters), "archived": 0, "new_cores": []}
     for cl in clusters:
         texts = "\n".join(f"- {n['_text'][:150]}" for n in cl[:6])
-        abstraction = llm("Сожми эпизоды в одну общую абстракцию-урок. Одно предложение, по-русски.",
+        abstraction = llm("Compress these episodes into one general abstraction-lesson. "
+                          "One sentence, in the language of the episodes.",
                           texts, max_tokens=120)
         core = g.add_node(abstraction, layer="CORE", role="system",
                           meta={"kind": "abstraction", "from": [n["id"] for n in cl]})
@@ -431,14 +452,15 @@ def sleep_cycle(g: Graph) -> dict:
 
 
 def pulse(g: Graph) -> str:
-    """Автономный шаг: без стимула найти следующий шаг к целям. SILENCE = молчать."""
+    """Autonomous step: with no stimulus, find the next step toward active goals.
+    SILENCE = stay quiet (the default)."""
     goals = [n for n in g.nodes if n["layer"] == "GOAL" and n["meta"].get("status") == "active"]
     cores = sorted((n for n in g.nodes if n["layer"] == "CORE" and n["meta"].get("status") == "active"),
                    key=lambda n: -float(n["meta"].get("salience", 0.5)))[:5]
-    ctx = "ЦЕЛИ:\n" + "\n".join(f"- {n['_text'][:120]}" for n in goals[-5:]) if goals else ""
-    ctx += "\nЯДРО ПАМЯТИ:\n" + "\n".join(f"- {n['_text'][:120]}" for n in cores)
-    thought = llm("Ты в фоновом цикле. Найди ОДИН конкретный следующий шаг для целей. "
-                  "Если ничего конкретного — ответь ровно: SILENCE." + neuro_prompt_suffix(g.neuro), ctx)
+    ctx = "GOALS:\n" + "\n".join(f"- {n['_text'][:120]}" for n in goals[-5:]) if goals else ""
+    ctx += "\nMEMORY CORE:\n" + "\n".join(f"- {n['_text'][:120]}" for n in cores)
+    thought = llm("You are in a background cycle. Find ONE concrete next step toward the goals. "
+                  "If nothing concrete — reply exactly: SILENCE." + neuro_prompt_suffix(g.neuro), ctx)
     if "SILENCE" in thought.upper()[:40]:
         g.save()
         return ""
@@ -465,7 +487,7 @@ def export_ses(g: Graph, path: str) -> dict:
             "nodes": [{k: n[k] for k in ("id", "_text", "layer", "ts", "meta")} for n in g.nodes],
             "edges": g.edges, "affect": g.affect}
     h = hashlib.sha256(canonical_json(body).encode()).hexdigest()
-    doc = {"body": body, "provenance": {"hash": f"sha256:{h}", "engine": "qca_engine.py/hermes-port",
+    doc = {"body": body, "provenance": {"hash": f"sha256:{h}", "engine": "qca_engine.py",
                                         "emb_model": EMB_MODEL, "created": _now()}}
     json.dump(doc, open(path, "w"), ensure_ascii=False, indent=1)
     return doc["provenance"]
@@ -497,15 +519,15 @@ def main():
         g.save()
     elif cmd == "goal":
         n = g.add_node(" ".join(args), layer="GOAL", role="system")
-        g.save(); print(f"goal {n['id']} создана")
+        g.save(); print(f"goal {n['id']} created")
     elif cmd == "sleep":
         print(json.dumps(sleep_cycle(g), ensure_ascii=False, indent=1))
     elif cmd == "pulse":
         out = pulse(g)
         print(out if out else "SILENCE")
     elif cmd == "soul":
-        # Идентичность из графа: CORE по salience + цели + нейросостояние.
-        # Каждая генерация подписана хэшем SES-снапшота (провенанс изменений).
+        # Identity from the graph: CORE by salience + goals + neuro state.
+        # Every generation is signed with the SES snapshot hash (change provenance).
         path = args[0] if args else os.path.join(os.path.dirname(g.path), "SOUL_OCEAN.md")
         snap = os.path.join(os.path.dirname(g.path), "snapshot.ses.json")
         prov = export_ses(g, snap)
@@ -514,14 +536,14 @@ def main():
         goals = [n for n in g.nodes if n["layer"] == "GOAL" and n["meta"].get("status") == "active"]
         nr = g.neuro
         with open(path, "w") as f:
-            f.write("# Ocean — когнитивный слой (автогенерация из SES-графа)\n\n"
-                    f"> Источник истины: {snap}\n> Провенанс: {prov['hash']} | {prov['created']}\n"
-                    "> Этот файл НЕ редактируется руками — он пересоздаётся командой `soul`.\n\n"
-                    "## Ядро знаний (CORE, по значимости)\n"
+            f.write("# Cognitive layer identity (auto-generated from the SES graph)\n\n"
+                    f"> Source of truth: {snap}\n> Provenance: {prov['hash']} | {prov['created']}\n"
+                    "> Do NOT edit by hand — this file is regenerated by the `soul` command.\n\n"
+                    "## Knowledge core (CORE, by salience)\n"
                     + "\n".join(f"- {n['_text'][:200]}" for n in cores[:15])
-                    + "\n\n## Активные цели\n"
-                    + ("\n".join(f"- {n['_text'][:150]}" for n in goals[-10:]) or "- нет")
-                    + "\n\n## Нейросостояние на момент снапшота\n"
+                    + "\n\n## Active goals\n"
+                    + ("\n".join(f"- {n['_text'][:150]}" for n in goals[-10:]) or "- none")
+                    + "\n\n## Neuro state at snapshot time\n"
                     + f"dopamine {nr['dopamine']:+.2f} | pain {nr['pain']:.2f} | "
                       f"adrenaline {nr['adrenaline']:.2f} | serotonin {nr['serotonin']:.2f}\n")
         print(f"SOUL → {path}\nprovenance: {prov['hash']}")
@@ -530,7 +552,7 @@ def main():
         prov = export_ses(g, path)
         print(f"SES → {path}\n{json.dumps(prov, ensure_ascii=False, indent=1)}")
     else:
-        print(f"неизвестная команда: {cmd}\n{__doc__}")
+        print(f"unknown command: {cmd}\n{__doc__}")
 
 
 if __name__ == "__main__":

--- a/skills/cognitive/qca-cycle/scripts/qca_engine.py
+++ b/skills/cognitive/qca-cycle/scripts/qca_engine.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""
+qca_engine.py — порт QCA-цикла Ocean (H0–H9) как Hermes-скилл.
+
+Пересоздан 2026-06-10 по реальному коду Ocean (~/Work/ocean), а не по
+песочной версии. Главные отличия от старого порта:
+  - эмбеддинги по умолчанию bge-m3 (1024d) — как в боевом Ocean; пороги
+    auto-link (0.65/0.50/0.35) и novelty (0.90/0.82) взяты из оригинала
+  - H5.5 Novelty Verifier — «неподкупный» судья на геометрии эмбеддингов
+    (порт cognition/evolution/novelty_verifier.py)
+  - слои узлов CORE / GOAL / CONTEXT / EPISODIC как в memory/manager.py
+  - эмбеддинги нормализуются (фикс бага из песочницы сохранён)
+
+Контракт: pure stdlib (требование Hermes skill guidelines).
+LLM-бэкенды: mock | ollama | anthropic (env QCA_LLM_BACKEND, по умолч. ollama).
+
+ENV:
+  QCA_STORE        путь к graph.json   (default ~/.hermes/qca/graph.json)
+  QCA_LLM_BACKEND  mock|ollama|anthropic (default ollama)
+  QCA_CHAT_MODEL   модель чата Ollama  (default qwen2.5:1.5b)
+  QCA_EMB_MODEL    модель эмбеддингов  (default bge-m3)
+  ANTHROPIC_API_KEY (только для backend=anthropic)
+
+CLI:
+  python3 qca_engine.py think "стимул"        # полный цикл H0–H9
+  python3 qca_engine.py seed "факт" [LAYER]   # засеять память
+  python3 qca_engine.py recall "запрос"       # только H2-recall
+  python3 qca_engine.py stats                 # состояние графа/аффекта
+  python3 qca_engine.py export-ses [path]     # SES Partitura v5.1 снапшот
+"""
+
+from __future__ import annotations
+import json, os, sys, math, hashlib, urllib.request, urllib.error
+from datetime import datetime, timezone
+
+# ── Конфиг ────────────────────────────────────────────────────────────
+STORE_PATH  = os.path.expanduser(os.getenv("QCA_STORE", "~/.hermes/qca/graph.json"))
+LLM_BACKEND = os.getenv("QCA_LLM_BACKEND", "ollama")
+CHAT_MODEL  = os.getenv("QCA_CHAT_MODEL", "qwen2.5:1.5b")
+EMB_MODEL   = os.getenv("QCA_EMB_MODEL", "bge-m3")
+OLLAMA_URL  = os.getenv("OLLAMA_URL", "http://localhost:11434")
+ANTHROPIC_MODEL = os.getenv("QCA_ANTHROPIC_MODEL", "claude-haiku-4-5-20251001")
+
+# Пороги auto-link — из memory/manager.py Ocean (калибровка bge-m3, 1024d)
+SUPPORTS_SIM, REFINES_SIM, ASSOC_SIM = 0.65, 0.50, 0.35
+# Пороги novelty — из cognition/evolution/novelty_verifier.py
+REPEAT_SIM, NOVEL_SIM = 0.90, 0.82
+# Порог recall — как в оригинальном бенчмарке Ocean
+RECALL_THRESHOLD = float(os.getenv("QCA_RECALL_THRESHOLD", "0.70"))
+
+NEG_MARKERS = ["не так", "наоборот", "ошибк", "неверно", "противореч", "however", "wrong", "contradicts"]
+
+# Нейрохимия — порт engines/neuro Ocean. Скорости декая в час (полураспады
+# из оригинала: адреналин ~2.5ч, дофамин ~8ч, боль ~46ч).
+NEURO_DECAY = {"adrenaline": 0.40, "dopamine": 0.08, "pain": 0.015, "serotonin": 0.005}
+NEURO_DEFAULT = {"dopamine": 0.0, "pain": 0.0, "adrenaline": 0.0, "serotonin": 0.5,
+                 "last_decay_ts": "", "events": []}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def neuro_decay(n: dict):
+    """Сигналы затухают со временем — состояние живёт между запусками."""
+    ts = n.get("last_decay_ts")
+    hours = 0.0
+    if ts:
+        try:
+            hours = (datetime.now(timezone.utc) - datetime.fromisoformat(ts)).total_seconds() / 3600
+        except ValueError:
+            pass
+    if hours > 0.05:
+        n["adrenaline"] = max(0.0, n["adrenaline"] * (1 - NEURO_DECAY["adrenaline"]) ** hours)
+        n["dopamine"]   = n["dopamine"] * (1 - NEURO_DECAY["dopamine"]) ** hours
+        n["pain"]       = max(0.0, n["pain"] * (1 - NEURO_DECAY["pain"]) ** hours)
+        n["serotonin"] += (0.5 - n["serotonin"]) * NEURO_DECAY["serotonin"] * hours
+    n["last_decay_ts"] = _now()
+
+
+def neuro_apply(n: dict, signal: str, mag: float, source: str):
+    neuro_decay(n)
+    lo, hi = (-1.0, 1.0) if signal == "dopamine" else (0.0, 1.0)
+    n[signal] = max(lo, min(hi, n[signal] + mag))
+    n["events"] = (n.get("events", []) + [{"ts": _now(), "signal": signal,
+                                           "mag": round(mag, 3), "source": source}])[-20:]
+
+
+def neuro_prompt_suffix(n: dict) -> str:
+    """Порт effects.py: состояние меняет фрейм задачи, а не просит 'чувствовать'."""
+    parts = []
+    if n["adrenaline"] > 0.65:
+        parts.append("⚡ ВЫСОКАЯ СРОЧНОСТЬ. Краткость — главное. Максимум 3 предложения.")
+    elif n["adrenaline"] > 0.35:
+        parts.append("Ситуация требует концентрации. Отвечай чётко, без лирики.")
+    if n["pain"] > 0.7:
+        parts.append("🔴 ХРОНИЧЕСКАЯ БОЛЬ: текущий подход систематически не работает. Сломай фрейм, нужна другая стратегия.")
+    elif n["pain"] > 0.4:
+        parts.append("Что-то идёт не так. Не повторяю ли я ошибку, которая уже не работала?")
+    if n["dopamine"] > 0.5:
+        parts.append("📈 Последние ответы попадали в цель — продолжай в том же духе.")
+    elif n["dopamine"] < -0.4:
+        parts.append("📉 Последние ответы не попадали в цель — попробуй нестандартный угол.")
+    if n["serotonin"] < 0.2:
+        parts.append("Базовый уровень нестабилен. Будь особенно честен, не выдавай желаемое за действительное.")
+    return "\n\n[НЕЙРОСОСТОЯНИЕ]\n" + "\n".join(f"• {p}" for p in parts) if parts else ""
+
+
+# ── LLM-бэкенды ───────────────────────────────────────────────────────
+def _http_json(url: str, payload: dict, headers: dict | None = None, timeout: int = 120) -> dict:
+    req = urllib.request.Request(url, data=json.dumps(payload).encode(),
+                                 headers={"Content-Type": "application/json", **(headers or {})})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read().decode())
+
+
+def llm(system: str, prompt: str, max_tokens: int = 600) -> str:
+    if LLM_BACKEND == "mock":
+        h = hashlib.sha256(prompt.encode()).hexdigest()[:8]
+        return f"[mock:{h}] Синтез по запросу: {prompt[:120]}"
+    if LLM_BACKEND == "anthropic":
+        key = os.getenv("ANTHROPIC_API_KEY")
+        if not key:
+            raise SystemExit("ANTHROPIC_API_KEY не задан (backend=anthropic)")
+        out = _http_json("https://api.anthropic.com/v1/messages",
+                         {"model": ANTHROPIC_MODEL, "max_tokens": max_tokens,
+                          "system": system, "messages": [{"role": "user", "content": prompt}]},
+                         {"x-api-key": key, "anthropic-version": "2023-06-01"})
+        # модели с thinking возвращают блок thinking перед text — берём первый text;
+        # если модель потратила весь лимит на thinking, текста нет — вернём пустоту
+        return next((b["text"] for b in out["content"] if b.get("type") == "text"), "").strip()
+    # ollama
+    out = _http_json(f"{OLLAMA_URL}/api/chat",
+                     {"model": CHAT_MODEL, "stream": False,
+                      "messages": [{"role": "system", "content": system},
+                                   {"role": "user", "content": prompt}]})
+    return out["message"]["content"].strip()
+
+
+_EMB_FALLBACK_DIM = 512
+_emb_mode = "ollama"  # ollama | fallback
+
+
+def _embed_fallback(text: str) -> list[float]:
+    """Без Ollama: hashed bag of character trigrams. Деградированный режим —
+    ловит лексическую близость, не семантику, но recall и novelty работают."""
+    v = [0.0] * _EMB_FALLBACK_DIM
+    t = " " + text.lower() + " "
+    for i in range(len(t) - 2):
+        h = int(hashlib.md5(t[i:i + 3].encode()).hexdigest()[:8], 16)
+        v[h % _EMB_FALLBACK_DIM] += 1.0
+    norm = math.sqrt(sum(x * x for x in v))
+    return [x / norm for x in v] if norm > 0 else v
+
+
+def embed(text: str) -> list[float] | None:
+    """Эмбеддинг через Ollama (вектор нормализуется), при недоступности —
+    локальный фолбэк без зависимостей."""
+    global _emb_mode
+    if _emb_mode == "ollama":
+        try:
+            out = _http_json(f"{OLLAMA_URL}/api/embeddings",
+                             {"model": EMB_MODEL, "prompt": text}, timeout=60)
+            v = out.get("embedding")
+            if v:
+                norm = math.sqrt(sum(x * x for x in v))
+                return [x / norm for x in v] if norm > 0 else None
+        except (urllib.error.URLError, OSError):
+            _emb_mode = "fallback"
+            print("⚠ Ollama недоступен — эмбеддинги в фолбэк-режиме (лексические)", file=sys.stderr)
+    return _embed_fallback(text)
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    if len(a) != len(b):
+        return 0.0  # векторы из разных моделей (ollama vs фолбэк) несравнимы
+    return sum(x * y for x, y in zip(a, b))  # векторы уже нормализованы
+
+
+# ── Ядро личности (kernel.ses.json) ──────────────────────────────────
+# Неизменная конституция: Z-аксиомы, аттрактор, guardrails. Подписана SHA-256;
+# меняется только осознанно — новым слепком с новым хэшем (никакого дрейфа).
+KERNEL_PATH = os.path.expanduser(os.getenv("QCA_KERNEL",
+              os.path.join(os.path.dirname(STORE_PATH), "kernel.ses.json")))
+
+
+def load_kernel() -> tuple[dict, str]:
+    """Вернуть (kernel, hash). Пустое ядро — валидно: агент без конституции."""
+    if not os.path.exists(KERNEL_PATH):
+        return {}, ""
+    doc = json.load(open(KERNEL_PATH))
+    kernel = doc.get("kernel", doc)
+    h = "sha256:" + hashlib.sha256(canonical_json(kernel).encode()).hexdigest()
+    return kernel, h
+
+
+def kernel_prompt(kernel: dict) -> str:
+    if not kernel:
+        return ""
+    seed = kernel.get("fractal_seed", {})
+    parts = []
+    ax = seed.get("Z_AXIOM", [])
+    if ax:
+        parts.append("АКСИОМЫ (неизменны):\n" + "\n".join(f"- {a}" for a in ax))
+    if seed.get("OMEGA_ATTRACTOR"):
+        parts.append(f"АТТРАКТОР: {seed['OMEGA_ATTRACTOR']}")
+    gr = seed.get("guardrails", [])
+    if gr:
+        parts.append("ПРАВИЛА (нарушать нельзя):\n" + "\n".join(f"- {g}" for g in gr))
+    return "\n\n" + "\n\n".join(parts) if parts else ""
+
+
+# ── Граф памяти ───────────────────────────────────────────────────────
+class Graph:
+    def __init__(self, path: str = STORE_PATH):
+        self.path = path
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        if os.path.exists(path):
+            d = json.load(open(path))
+        else:
+            d = {"nodes": [], "edges": [], "affect": {"curiosity": 0.5, "tension": 0.0, "confidence": 0.5},
+                 "counters": {"node": 0, "edge": 0}}
+        self.nodes, self.edges = d["nodes"], d["edges"]
+        self.affect, self.counters = d["affect"], d["counters"]
+        self.neuro = {**NEURO_DEFAULT, **d.get("neuro", {})}
+        neuro_decay(self.neuro)
+
+    def save(self):
+        json.dump({"nodes": self.nodes, "edges": self.edges, "neuro": self.neuro,
+                   "affect": self.affect, "counters": self.counters},
+                  open(self.path, "w"), ensure_ascii=False, indent=1)
+
+    def add_node(self, text: str, layer: str = "EPISODIC", role: str = "assistant",
+                 meta: dict | None = None) -> dict:
+        self.counters["node"] += 1
+        node = {"id": f"N{self.counters['node']}", "_text": text, "layer": layer,
+                "ts": _now(), "meta": {"role": role, "status": "active", **(meta or {})},
+                "emb": embed(text)}
+        self.nodes.append(node)
+        self._auto_link(node)
+        return node
+
+    def _auto_link(self, new: dict):
+        """Порт auto-linking v2 из Ocean: SUPPORTS/REFINES/ASSOCIATED/CONTRADICTS."""
+        if not new.get("emb"):
+            return
+        candidates = [n for n in self.nodes[-16:] if n["id"] != new["id"] and n.get("emb")]
+        linked = False
+        nearest = None  # (id, sim) ближайшего, если ни одно ребро не создано
+        text_low = new["_text"].lower()
+        for n in candidates:
+            sim = cosine(new["emb"], n["emb"])
+            if sim > SUPPORTS_SIM:
+                rel = "SUPPORTS"
+            elif sim > REFINES_SIM:
+                rel = "CONTRADICTS" if any(m in text_low for m in NEG_MARKERS) else "REFINES"
+            elif sim > ASSOC_SIM:
+                rel = "ASSOCIATED"
+            else:
+                if nearest is None or sim > nearest[1]:
+                    nearest = (n["id"], sim)
+                continue
+            self._add_edge(new["id"], n["id"], rel, sim)
+            linked = True
+        # узел всегда получает хотя бы одно ребро — как в оригинале
+        if not linked and nearest:
+            self._add_edge(new["id"], nearest[0], "ASSOCIATED", nearest[1])
+
+    def _add_edge(self, src: str, tgt: str, rel: str, sim: float):
+        self.counters["edge"] += 1
+        self.edges.append({"id": f"E{self.counters['edge']}", "source": src,
+                           "target": tgt, "relation": rel, "sim": round(sim, 4)})
+
+    def recall(self, query: str, top_k: int = 5) -> list[tuple[float, dict]]:
+        q = embed(query)
+        scored = []
+        for n in self.nodes:
+            if n["meta"].get("status") == "archived" or not n.get("emb"):
+                continue
+            if q:
+                scored.append((cosine(q, n["emb"]), n))
+        scored.sort(key=lambda x: -x[0])
+        return scored[:top_k]
+
+    def contradiction_density(self) -> float:
+        if not self.edges:
+            return 0.0
+        return sum(1 for e in self.edges if e["relation"] == "CONTRADICTS") / len(self.edges)
+
+    def novelty(self, text: str) -> dict:
+        """H5.5 — порт novelty_verifier: неподкупная оценка по геометрии bge-m3."""
+        v = embed(text)
+        if not v:
+            return {"verdict": "unknown", "novelty_score": None, "max_sim": None}
+        max_sim, near = 0.0, None
+        for n in self.nodes:
+            if n.get("emb") and n["meta"].get("status") != "archived":
+                s = cosine(v, n["emb"])
+                if s > max_sim:
+                    max_sim, near = s, n["id"]
+        if max_sim >= REPEAT_SIM:
+            verdict = "discard"   # повтор — иллюзия прогресса
+        elif max_sim < NOVEL_SIM:
+            verdict = "novel"
+        else:
+            verdict = "refine"
+        return {"verdict": verdict, "novelty_score": round(1 - max_sim, 4),
+                "max_sim": round(max_sim, 4), "nearest": near}
+
+
+# ── QCA-цикл H0–H9 ───────────────────────────────────────────────────
+def think(g: Graph, stimulus: str) -> dict:
+    trace = {"H0": stimulus[:200]}
+
+    # H1: препроцессинг (упрощённый, без отдельной модели)
+    core_idea = stimulus.strip()[:140]
+    trace["H1"] = {"core_idea": core_idea}
+
+    # H2: recall
+    recalled = g.recall(core_idea, top_k=5)
+    relevant = [(round(s, 4), n["_text"][:120]) for s, n in recalled if s >= ASSOC_SIM]
+    trace["H2"] = relevant
+
+    # H3: противоречие — CONTRADICTS-рёбра среди вспомненных узлов
+    recalled_ids = {n["id"] for _, n in recalled}
+    contra = [e for e in g.edges if e["relation"] == "CONTRADICTS"
+              and (e["source"] in recalled_ids or e["target"] in recalled_ids)]
+    contradiction = f"в памяти {len(contra)} конфликт(ов) вокруг темы" if contra else ""
+    trace["H3"] = contradiction
+
+    # H4: синтез — конституция (kernel) входит в каждый такт мышления
+    kernel, kernel_hash = load_kernel()
+    if kernel_hash:
+        trace["kernel"] = kernel_hash[:18]
+    system = ("Ты — когнитивное ядро (QCA-цикл). Отвечай кратко, по сути."
+              + kernel_prompt(kernel)
+              + (f"\nКОНТЕКСТ ИЗ ПАМЯТИ:\n" + "\n".join(f"- {t}" for _, t in relevant[:3]) if relevant else "")
+              + (f"\nПРОТИВОРЕЧИЕ: {contradiction} — учти и разреши." if contradiction else "")
+              + neuro_prompt_suffix(g.neuro))
+    thought = llm(system, stimulus)
+    trace["H4"] = thought[:200]
+
+    # H5: критика (LLM-судья, для mock — заглушка)
+    if LLM_BACKEND == "mock":
+        critique = {"quality": "medium", "is_acceptable": True}
+    else:
+        raw = llm("Ты — строгий критик. Ответь ТОЛЬКО JSON: {\"quality\":\"low|medium|high\",\"is_acceptable\":bool}",
+                  f"Вопрос: {stimulus}\nОтвет: {thought}", max_tokens=2000)
+        try:
+            critique = json.loads(raw[raw.find("{"):raw.rfind("}") + 1])
+        except (ValueError, IndexError):
+            critique = {"quality": "medium", "is_acceptable": True}
+    trace["H5"] = critique
+
+    # H5.5: novelty verifier (неподкупный)
+    nov = g.novelty(thought)
+    trace["H5.5_novelty"] = nov
+
+    # H6: нейрохимия — события цикла становятся импульсами (порт engines/neuro)
+    if contradiction:
+        neuro_apply(g.neuro, "pain", 0.10, "H3:contradiction")
+        neuro_apply(g.neuro, "adrenaline", 0.15, "H3:contradiction")
+    if nov["verdict"] == "novel":
+        neuro_apply(g.neuro, "dopamine", 0.20, "H5.5:novel")
+    elif nov["verdict"] == "discard":
+        neuro_apply(g.neuro, "dopamine", -0.15, "H5.5:repeat")
+        neuro_apply(g.neuro, "pain", 0.05, "H5.5:repeat")
+    neuro_apply(g.neuro, "serotonin", 0.02 if critique.get("is_acceptable") else -0.08, "H5:critique")
+    # дофамин → salience недавних узлов (обучение, порт effects.update_memory_salience)
+    if abs(g.neuro["dopamine"]) >= 0.15:
+        delta = g.neuro["dopamine"] * 0.07
+        for node in g.nodes[-6:]:
+            cur = float(node["meta"].get("salience", 0.5))
+            node["meta"]["salience"] = round(max(0.0, min(1.0, cur + delta)), 3)
+    trace["H6_neuro"] = {k: round(g.neuro[k], 3) for k in ("dopamine", "pain", "adrenaline", "serotonin")}
+
+    # H7: запись в память (повторы не пишем — STRICT-режим novelty)
+    if nov["verdict"] != "discard":
+        g.add_node(stimulus, layer="EPISODIC", role="user")
+        layer = "CONTEXT" if critique.get("quality") in ("medium", "high") else "EPISODIC"
+        g.add_node(thought, layer=layer, role="assistant")
+        trace["H7"] = f"записано (layer={layer})"
+    else:
+        trace["H7"] = "повтор — не записано"
+
+    # H8: урок
+    if contradiction or nov["verdict"] == "novel":
+        lesson = f"Урок: {core_idea[:80]} → {('конфликт в графе разрешён' if contradiction else 'новый регион пространства')}"
+        g.add_node(lesson, layer="CORE", role="system", meta={"kind": "lesson", "confidence": 0.6})
+        trace["H8"] = lesson
+
+    # H9: статистика
+    trace["H9"] = {"nodes": len(g.nodes), "edges": len(g.edges),
+                   "contradiction_density": round(g.contradiction_density(), 3)}
+    g.save()
+    return {"thought": thought, "trace": trace}
+
+
+# ── Демоны: сон и пульс (порт cognition/background.py) ──────────────
+def sleep_cycle(g: Graph) -> dict:
+    """Ночная консолидация: кластеры EPISODIC → CORE-абстракция, оригиналы в архив."""
+    episodic = [n for n in g.nodes
+                if n["layer"] == "EPISODIC" and n["meta"].get("status") == "active" and n.get("emb")]
+    clusters, used = [], set()
+    for a in episodic:
+        if a["id"] in used:
+            continue
+        cluster = [a]
+        for b in episodic:
+            if b["id"] != a["id"] and b["id"] not in used and cosine(a["emb"], b["emb"]) > SUPPORTS_SIM:
+                cluster.append(b)
+        if len(cluster) >= 3:
+            clusters.append(cluster)
+            used.update(n["id"] for n in cluster)
+    report = {"clusters": len(clusters), "archived": 0, "new_cores": []}
+    for cl in clusters:
+        texts = "\n".join(f"- {n['_text'][:150]}" for n in cl[:6])
+        abstraction = llm("Сожми эпизоды в одну общую абстракцию-урок. Одно предложение, по-русски.",
+                          texts, max_tokens=120)
+        core = g.add_node(abstraction, layer="CORE", role="system",
+                          meta={"kind": "abstraction", "from": [n["id"] for n in cl]})
+        report["new_cores"].append(abstraction[:100])
+        for n in cl:
+            n["meta"]["status"] = "archived"
+            report["archived"] += 1
+        for n in cl:
+            g._add_edge(core["id"], n["id"], "SUPPORTS", 1.0)
+    neuro_apply(g.neuro, "serotonin", 0.05, "sleep:consolidation")
+    g.save()
+    return report
+
+
+def pulse(g: Graph) -> str:
+    """Автономный шаг: без стимула найти следующий шаг к целям. SILENCE = молчать."""
+    goals = [n for n in g.nodes if n["layer"] == "GOAL" and n["meta"].get("status") == "active"]
+    cores = sorted((n for n in g.nodes if n["layer"] == "CORE" and n["meta"].get("status") == "active"),
+                   key=lambda n: -float(n["meta"].get("salience", 0.5)))[:5]
+    ctx = "ЦЕЛИ:\n" + "\n".join(f"- {n['_text'][:120]}" for n in goals[-5:]) if goals else ""
+    ctx += "\nЯДРО ПАМЯТИ:\n" + "\n".join(f"- {n['_text'][:120]}" for n in cores)
+    thought = llm("Ты в фоновом цикле. Найди ОДИН конкретный следующий шаг для целей. "
+                  "Если ничего конкретного — ответь ровно: SILENCE." + neuro_prompt_suffix(g.neuro), ctx)
+    if "SILENCE" in thought.upper()[:40]:
+        g.save()
+        return ""
+    nov = g.novelty(thought)
+    if nov["verdict"] == "discard":
+        neuro_apply(g.neuro, "dopamine", -0.1, "pulse:repeat")
+        g.save()
+        return ""
+    g.add_node(thought, layer="CONTEXT", role="assistant", meta={"kind": "pulse"})
+    neuro_apply(g.neuro, "dopamine", 0.1, "pulse:step")
+    g.save()
+    return thought
+
+
+# ── SES Partitura v5.1 export ────────────────────────────────────────
+def canonical_json(obj) -> str:
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def export_ses(g: Graph, path: str) -> dict:
+    body = {"format": "SES_Partitura", "version": "5.1",
+            "canonicalization": "SES_CANON_JSON_v1",
+            "snapshot_ts": _now(),
+            "nodes": [{k: n[k] for k in ("id", "_text", "layer", "ts", "meta")} for n in g.nodes],
+            "edges": g.edges, "affect": g.affect}
+    h = hashlib.sha256(canonical_json(body).encode()).hexdigest()
+    doc = {"body": body, "provenance": {"hash": f"sha256:{h}", "engine": "qca_engine.py/hermes-port",
+                                        "emb_model": EMB_MODEL, "created": _now()}}
+    json.dump(doc, open(path, "w"), ensure_ascii=False, indent=1)
+    return doc["provenance"]
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__); return
+    cmd, args = sys.argv[1], sys.argv[2:]
+    g = Graph()
+    if cmd == "think":
+        r = think(g, " ".join(args))
+        print(json.dumps(r, ensure_ascii=False, indent=1))
+    elif cmd == "seed":
+        layer = args[1] if len(args) > 1 else "CONTEXT"
+        n = g.add_node(args[0], layer=layer, role="system")
+        g.save(); print(f"seeded {n['id']} [{layer}] emb={'ok' if n['emb'] else 'NONE'}")
+    elif cmd == "recall":
+        for s, n in g.recall(" ".join(args)):
+            mark = "✓" if s >= RECALL_THRESHOLD else " "
+            print(f"{mark} {s:.3f} [{n['layer']}] {n['_text'][:90]}")
+    elif cmd == "stats":
+        print(json.dumps({"nodes": len(g.nodes), "edges": len(g.edges),
+                          "contradiction_density": round(g.contradiction_density(), 3),
+                          "neuro": {k: round(g.neuro[k], 3) for k in ("dopamine", "pain", "adrenaline", "serotonin")},
+                          "store": g.path,
+                          "backend": LLM_BACKEND, "emb_model": EMB_MODEL}, ensure_ascii=False, indent=1))
+        g.save()
+    elif cmd == "goal":
+        n = g.add_node(" ".join(args), layer="GOAL", role="system")
+        g.save(); print(f"goal {n['id']} создана")
+    elif cmd == "sleep":
+        print(json.dumps(sleep_cycle(g), ensure_ascii=False, indent=1))
+    elif cmd == "pulse":
+        out = pulse(g)
+        print(out if out else "SILENCE")
+    elif cmd == "soul":
+        # Идентичность из графа: CORE по salience + цели + нейросостояние.
+        # Каждая генерация подписана хэшем SES-снапшота (провенанс изменений).
+        path = args[0] if args else os.path.join(os.path.dirname(g.path), "SOUL_OCEAN.md")
+        snap = os.path.join(os.path.dirname(g.path), "snapshot.ses.json")
+        prov = export_ses(g, snap)
+        cores = sorted((n for n in g.nodes if n["layer"] == "CORE" and n["meta"].get("status") == "active"),
+                       key=lambda n: -float(n["meta"].get("salience", 0.5)))
+        goals = [n for n in g.nodes if n["layer"] == "GOAL" and n["meta"].get("status") == "active"]
+        nr = g.neuro
+        with open(path, "w") as f:
+            f.write("# Ocean — когнитивный слой (автогенерация из SES-графа)\n\n"
+                    f"> Источник истины: {snap}\n> Провенанс: {prov['hash']} | {prov['created']}\n"
+                    "> Этот файл НЕ редактируется руками — он пересоздаётся командой `soul`.\n\n"
+                    "## Ядро знаний (CORE, по значимости)\n"
+                    + "\n".join(f"- {n['_text'][:200]}" for n in cores[:15])
+                    + "\n\n## Активные цели\n"
+                    + ("\n".join(f"- {n['_text'][:150]}" for n in goals[-10:]) or "- нет")
+                    + "\n\n## Нейросостояние на момент снапшота\n"
+                    + f"dopamine {nr['dopamine']:+.2f} | pain {nr['pain']:.2f} | "
+                      f"adrenaline {nr['adrenaline']:.2f} | serotonin {nr['serotonin']:.2f}\n")
+        print(f"SOUL → {path}\nprovenance: {prov['hash']}")
+    elif cmd == "export-ses":
+        path = args[0] if args else os.path.join(os.path.dirname(g.path), "snapshot.ses.json")
+        prov = export_ses(g, path)
+        print(f"SES → {path}\n{json.dumps(prov, ensure_ascii=False, indent=1)}")
+    else:
+        print(f"неизвестная команда: {cmd}\n{__doc__}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/cognitive/qca-cycle/scripts/qca_engine.py
+++ b/skills/cognitive/qca-cycle/scripts/qca_engine.py
@@ -212,6 +212,9 @@ def load_kernel() -> tuple[dict, str]:
 
 
 def kernel_prompt(kernel: dict) -> str:
+    """Inject the FULL kernel per SES v5.1: fractal_seed + recursive_function
+    (the entity's own reasoning protocol) + distortion_field (known failure
+    modes with mitigations)."""
     if not kernel:
         return ""
     seed = kernel.get("fractal_seed", {})
@@ -224,6 +227,17 @@ def kernel_prompt(kernel: dict) -> str:
     gr = seed.get("guardrails", [])
     if gr:
         parts.append("GUARDRAILS (never break):\n" + "\n".join(f"- {g}" for g in gr))
+    rf = kernel.get("recursive_function", [])
+    if rf:
+        steps = "\n".join(f"{s.get('id','?')} {s.get('name','')}: " + "; ".join(s.get("rules", []))
+                          for s in rf if isinstance(s, dict))
+        parts.append("REASONING PROTOCOL (follow in order):\n" + steps)
+    df = kernel.get("distortion_field", {})
+    items = df.get("items", df) if isinstance(df, dict) else df
+    if isinstance(items, list) and items:
+        ds = "\n".join(f"- when [{d.get('trigger','?')}] you tend to [{d.get('effect','?')}] → "
+                        + "; ".join(d.get("mitigation", [])) for d in items if isinstance(d, dict))
+        parts.append("KNOWN DISTORTIONS (self-correct):\n" + ds)
     return "\n\n" + "\n\n".join(parts) if parts else ""
 
 
@@ -475,22 +489,93 @@ def pulse(g: Graph) -> str:
     return thought
 
 
-# ── SES Partitura v5.1 export ────────────────────────────────────────
+# ── SES Partitura v5.1 export (canonical) ────────────────────────────
 def canonical_json(obj) -> str:
+    """SES_CANON_JSON_v1: keys sorted lexicographically, compact separators,
+    UTF-8 not escaped. Node/edge array sorting is applied by the caller
+    (canonical_snapshot) since it is a snapshot-level rule."""
     return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
 
+def _snapshot_hash(snapshot: dict) -> str:
+    """meta.hash per SES_CANON_JSON_v1: nodes sorted by id, edges sorted by id
+    (else by source,target,relation), computed with meta.hash itself absent."""
+    import copy
+    s = copy.deepcopy(snapshot)
+    s.get("meta", {}).pop("hash", None)
+    st = s.get("state") or {}
+    if st.get("nodes"):
+        st["nodes"] = sorted(st["nodes"], key=lambda n: n.get("id", ""))
+    if st.get("edges"):
+        st["edges"] = sorted(st["edges"], key=lambda e: (e.get("id", ""), e.get("source", ""),
+                                                         e.get("target", ""), e.get("relation", "")))
+    return "sha256:" + hashlib.sha256(canonical_json(s).encode()).hexdigest()
+
+
+def _node_to_ses(n: dict) -> dict:
+    """Internal working node → canonical v5.1 node (label + required provenance)."""
+    role = n["meta"].get("role", "assistant")
+    source = {"user": "OPERATOR", "system": "OPERATOR", "assistant": "QCA_CYCLE"}.get(role, "QCA_CYCLE")
+    if n["meta"].get("imported_from"):
+        source = "IMPORT"
+    return {"id": n["id"], "label": n["_text"], "layer": n["layer"],
+            "meta": {"provenance": {"source": source, "stage": "H7",
+                                    "timestamp": n.get("ts", _now()),
+                                    "source_ref": [], "confidence": 1.0 if source == "OPERATOR" else 0.8},
+                     "salience": float(n["meta"].get("salience", 0.5)),
+                     "status": n["meta"].get("status", "active"),
+                     "tags": [n["meta"]["kind"]] if n["meta"].get("kind") else []}}
+
+
+def _edge_to_ses(e: dict) -> dict:
+    return {"id": e["id"], "source": e["source"], "target": e["target"],
+            "relation": e["relation"],
+            "meta": {"provenance": {"source": "QCA_CYCLE", "stage": "H7",
+                                    "timestamp": _now(), "source_ref": [], "confidence": 0.8},
+                     "weight": float(e.get("sim", 0.5))}}
+
+
 def export_ses(g: Graph, path: str) -> dict:
-    body = {"format": "SES_Partitura", "version": "5.1",
-            "canonicalization": "SES_CANON_JSON_v1",
-            "snapshot_ts": _now(),
-            "nodes": [{k: n[k] for k in ("id", "_text", "layer", "ts", "meta")} for n in g.nodes],
-            "edges": g.edges, "affect": g.affect}
-    h = hashlib.sha256(canonical_json(body).encode()).hexdigest()
-    doc = {"body": body, "provenance": {"hash": f"sha256:{h}", "engine": "qca_engine.py",
-                                        "emb_model": EMB_MODEL, "created": _now()}}
-    json.dump(doc, open(path, "w"), ensure_ascii=False, indent=1)
-    return doc["provenance"]
+    """Export a canonical SES v5.1 snapshot. COMBINED when a kernel is present,
+    STATE_SNAPSHOT otherwise. Enforces the v5.1 canon lock (§12): every state
+    references its kernel via meta.kernel_ref + meta.kernel_hash."""
+    kernel, kernel_hash = load_kernel()
+    entity_id = os.getenv("QCA_ENTITY") or (
+        json.load(open(KERNEL_PATH)).get("entity_id") if os.path.exists(KERNEL_PATH) else None) or "qca-agent"
+    # lineage: previous snapshot at the same path becomes the parent
+    parent = None
+    if os.path.exists(path):
+        try:
+            parent = json.load(open(path)).get("snapshot_id")
+        except (ValueError, OSError):
+            parent = None
+    snapshot_id = _now()
+    snap = {"initiator": "∮", "schema_version": "5.1", "entity_id": entity_id,
+            "snapshot_id": snapshot_id,
+            "snapshot_type": "COMBINED" if kernel else "STATE_SNAPSHOT",
+            "meta": {"created_at": snapshot_id, "created_by": "System",
+                     "parent_snapshot_id": parent,
+                     "canonicalization": "SES_CANON_JSON_v1",
+                     "notes": f"engine=qca_engine.py emb_model={EMB_MODEL}",
+                     "tags": ["qca-cycle"]},
+            "state": {"meta": {"trigger": "inference",
+                               "summary": f"State of {entity_id} at {snapshot_id}",
+                               "provenance": {"source": "QCA_CYCLE", "stage": "H9",
+                                              "timestamp": snapshot_id, "source_ref": [],
+                                              "confidence": 1.0},
+                               "x_neuro": {k: round(g.neuro[k], 4) for k in
+                                           ("dopamine", "pain", "adrenaline", "serotonin")}},
+                      "nodes": [_node_to_ses(n) for n in g.nodes],
+                      "edges": [_edge_to_ses(e) for e in g.edges]}}
+    if kernel:
+        snap["kernel"] = kernel
+    if kernel_hash:  # v5.1 canon lock: state must reference its kernel
+        snap["meta"]["kernel_hash"] = kernel_hash
+        snap["meta"]["kernel_ref"] = f"kernel://{entity_id}@{KERNEL_PATH}"
+    snap["meta"]["hash"] = _snapshot_hash(snap)
+    json.dump(snap, open(path, "w"), ensure_ascii=False, indent=1)
+    return {"hash": snap["meta"]["hash"], "snapshot_type": snap["snapshot_type"],
+            "kernel_hash": kernel_hash or None, "parent": parent, "created": snapshot_id}
 
 
 # ── CLI ──────────────────────────────────────────────────────────────

--- a/skills/cognitive/qca-cycle/scripts/ses_bridge.py
+++ b/skills/cognitive/qca-cycle/scripts/ses_bridge.py
@@ -13,31 +13,39 @@ from __future__ import annotations
 import json, os, re, sys, sqlite3
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _hermes_home import get_hermes_home
 from qca_engine import Graph, canonical_json, _now
 import hashlib
 
-LEARNED_DIR = os.path.expanduser(os.getenv("QCA_LEARNED_DIR", "~/.hermes/skills/learned"))
+LEARNED_DIR = os.path.expanduser(os.getenv("QCA_LEARNED_DIR", "")) or \
+              str(get_hermes_home() / "skills" / "learned")
 
 
 def verify(path: str) -> bool:
     """Verify a snapshot. Supports canonical SES v5.1 (meta.hash over the whole
     snapshot, SES_CANON_JSON_v1 sorting) and the legacy body/provenance wrapper."""
     doc = json.load(open(path))
+    canon_ok = True
     if "initiator" in doc:  # canonical v5.1
         from qca_engine import _snapshot_hash
         claimed = doc.get("meta", {}).get("hash", "")
         actual = _snapshot_hash(doc)
-        # v5.1 canon lock (§12): a state must reference its kernel
+        # v5.1 canon lock (§12): a state must reference its kernel.
+        # This is an integrity invariant, not a warning — it fails the check.
         if doc.get("snapshot_type") == "STATE_SNAPSHOT" and not (
                 doc["meta"].get("kernel_ref") or doc["meta"].get("kernel_hash")):
-            print("⚠ canon violation: STATE_SNAPSHOT without kernel_ref/kernel_hash")
+            print("❌ canon violation: STATE_SNAPSHOT without kernel_ref/kernel_hash (SES v5.1 §12)")
+            canon_ok = False
     else:  # legacy
         claimed = doc.get("provenance", {}).get("hash", "")
         actual = "sha256:" + hashlib.sha256(canonical_json(doc["body"]).encode()).hexdigest()
-    ok = claimed == actual
-    print(f"{'✅ integrity verified' if ok else '❌ TAMPERED: hash mismatch'}")
+    hash_ok = claimed == actual
+    if not hash_ok:
+        print("❌ TAMPERED: hash mismatch")
+    elif canon_ok:
+        print("✅ integrity verified")
     print(f"  claimed: {claimed}\n  actual:  {actual}")
-    return ok
+    return hash_ok and canon_ok
 
 
 def export_skills(learned_dir: str = LEARNED_DIR):

--- a/skills/cognitive/qca-cycle/scripts/ses_bridge.py
+++ b/skills/cognitive/qca-cycle/scripts/ses_bridge.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+ses_bridge.py — мост SES ↔ Hermes.
+
+  verify <snapshot.ses.json>      проверить целостность (canonical SHA-256)
+  export-skills [learned_dir]     уроки (CORE/lesson) из графа → Hermes skill-стабы
+  import-ocean <ocean_db.sqlite>  импорт узлов из настоящего Ocean (read-only)
+
+Pure stdlib. Граф берётся из QCA_STORE (см. qca_engine.py).
+"""
+
+from __future__ import annotations
+import json, os, re, sys, sqlite3
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from qca_engine import Graph, canonical_json, _now
+import hashlib
+
+LEARNED_DIR = os.path.expanduser(os.getenv("QCA_LEARNED_DIR", "~/.hermes/skills/learned"))
+
+
+def verify(path: str) -> bool:
+    doc = json.load(open(path))
+    claimed = doc.get("provenance", {}).get("hash", "")
+    actual = "sha256:" + hashlib.sha256(canonical_json(doc["body"]).encode()).hexdigest()
+    ok = claimed == actual
+    print(f"{'✅ целостность подтверждена' if ok else '❌ ТАМПЕР: хэш не совпадает'}")
+    print(f"  claimed: {claimed}\n  actual:  {actual}")
+    return ok
+
+
+def export_skills(learned_dir: str = LEARNED_DIR):
+    g = Graph()
+    lessons = [n for n in g.nodes
+               if n.get("layer") == "CORE" and n["meta"].get("kind") == "lesson"]
+    if not lessons:
+        print("уроков (CORE/lesson) в графе нет"); return
+    os.makedirs(learned_dir, exist_ok=True)
+    for n in lessons:
+        slug = re.sub(r"[^a-z0-9а-яё]+", "-", n["_text"][:50].lower()).strip("-") or n["id"].lower()
+        d = os.path.join(learned_dir, f"qca-lesson-{n['id'].lower()}")
+        os.makedirs(d, exist_ok=True)
+        conf = n["meta"].get("confidence", 0.5)
+        with open(os.path.join(d, "SKILL.md"), "w") as f:
+            f.write(f"""---
+name: qca-lesson-{n['id'].lower()}
+description: "{n['_text'][:140].replace('"', "'")}"
+platforms: [linux, macos, windows]
+metadata:
+  source: ocean-qca-cycle
+  confidence: {conf}
+  node_id: {n['id']}
+  exported: {_now()}
+---
+
+# Урок QCA: {slug}
+
+{n['_text']}
+
+> Авто-экспорт из графа QCA (H8-рефлексия). Confidence: {conf}.
+> Curator может развить этот стаб в полноценный скилл.
+""")
+        print(f"→ {d}/SKILL.md (confidence={conf})")
+    print(f"экспортировано уроков: {len(lessons)}")
+
+
+def _clean_ocean_text(text: str) -> str:
+    """Срезать служебную обёртку Ocean ('[ОПЫТ|...] Контекст: X → Действие: Y') —
+    она разбавляет эмбеддинг и роняет recall ниже порога 0.70."""
+    m = re.match(r"^\[ОПЫТ\|[^\]]*\]\s*Контекст:\s*(.*?)\s*→\s*Действие:\s*(.*)$",
+                 text, flags=re.DOTALL)
+    if m:
+        ctx, action = m.group(1).strip(), m.group(2).strip()
+        return f"{ctx}: {action}" if ctx and ctx.lower() not in ("other", "greeting") else action
+    return text
+
+
+def import_ocean(db_path: str):
+    """Импорт активных узлов из SQLite настоящего Ocean. Источник не модифицируется."""
+    src = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    src.row_factory = sqlite3.Row
+    g = Graph()
+    existing = {n["_text"] for n in g.nodes}
+    rows = src.execute("SELECT * FROM nodes").fetchall()
+    added = skipped = 0
+    for r in rows:
+        d = dict(r)
+        text = d.get("_text") or d.get("text") or ""
+        if not text.strip():
+            # текст может лежать в JSON-поле
+            for v in d.values():
+                if isinstance(v, str) and v.startswith("{"):
+                    try:
+                        text = json.loads(v).get("_text", "")
+                        if text: break
+                    except ValueError: pass
+        text = _clean_ocean_text(text)
+        if not text.strip() or text in existing:
+            skipped += 1; continue
+        layer = d.get("layer") or "CONTEXT"
+        status = d.get("status") or "active"
+        if status == "archived":
+            skipped += 1; continue
+        g.add_node(text, layer=layer, role="system", meta={"imported_from": "ocean", "src_id": d.get("id")})
+        existing.add(text); added += 1
+    g.save()
+    print(f"импортировано: {added}, пропущено: {skipped}, всего в графе: {len(g.nodes)}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__); return
+    cmd, args = sys.argv[1], sys.argv[2:]
+    if cmd == "verify":
+        sys.exit(0 if verify(args[0]) else 1)
+    elif cmd == "export-skills":
+        export_skills(args[0] if args else LEARNED_DIR)
+    elif cmd == "import-ocean":
+        import_ocean(args[0])
+    else:
+        print(f"неизвестная команда: {cmd}\n{__doc__}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/cognitive/qca-cycle/scripts/ses_bridge.py
+++ b/skills/cognitive/qca-cycle/scripts/ses_bridge.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """
-ses_bridge.py — мост SES ↔ Hermes.
+ses_bridge.py — SES ↔ agent-framework bridge.
 
-  verify <snapshot.ses.json>      проверить целостность (canonical SHA-256)
-  export-skills [learned_dir]     уроки (CORE/lesson) из графа → Hermes skill-стабы
-  import-ocean <ocean_db.sqlite>  импорт узлов из настоящего Ocean (read-only)
+  verify <snapshot.ses.json>      verify integrity (canonical SHA-256)
+  export-skills [learned_dir]     export lessons (CORE/lesson) as Hermes skill stubs
+  import-ocean <ocean_db.sqlite>  import nodes from an original Ocean DB (read-only)
 
-Pure stdlib. Граф берётся из QCA_STORE (см. qca_engine.py).
+Pure stdlib. The graph store comes from QCA_STORE (see qca_engine.py).
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ def verify(path: str) -> bool:
     claimed = doc.get("provenance", {}).get("hash", "")
     actual = "sha256:" + hashlib.sha256(canonical_json(doc["body"]).encode()).hexdigest()
     ok = claimed == actual
-    print(f"{'✅ целостность подтверждена' if ok else '❌ ТАМПЕР: хэш не совпадает'}")
+    print(f"{'✅ integrity verified' if ok else '❌ TAMPERED: hash mismatch'}")
     print(f"  claimed: {claimed}\n  actual:  {actual}")
     return ok
 
@@ -34,7 +34,7 @@ def export_skills(learned_dir: str = LEARNED_DIR):
     lessons = [n for n in g.nodes
                if n.get("layer") == "CORE" and n["meta"].get("kind") == "lesson"]
     if not lessons:
-        print("уроков (CORE/lesson) в графе нет"); return
+        print("no lessons (CORE/lesson) in the graph"); return
     os.makedirs(learned_dir, exist_ok=True)
     for n in lessons:
         slug = re.sub(r"[^a-z0-9а-яё]+", "-", n["_text"][:50].lower()).strip("-") or n["id"].lower()
@@ -47,26 +47,27 @@ name: qca-lesson-{n['id'].lower()}
 description: "{n['_text'][:140].replace('"', "'")}"
 platforms: [linux, macos, windows]
 metadata:
-  source: ocean-qca-cycle
+  source: qca-cycle
   confidence: {conf}
   node_id: {n['id']}
   exported: {_now()}
 ---
 
-# Урок QCA: {slug}
+# QCA lesson: {slug}
 
 {n['_text']}
 
-> Авто-экспорт из графа QCA (H8-рефлексия). Confidence: {conf}.
-> Curator может развить этот стаб в полноценный скилл.
+> Auto-exported from the QCA graph (lesson extraction). Confidence: {conf}.
+> The Curator may grow this stub into a full skill.
 """)
         print(f"→ {d}/SKILL.md (confidence={conf})")
-    print(f"экспортировано уроков: {len(lessons)}")
+    print(f"lessons exported: {len(lessons)}")
 
 
 def _clean_ocean_text(text: str) -> str:
-    """Срезать служебную обёртку Ocean ('[ОПЫТ|...] Контекст: X → Действие: Y') —
-    она разбавляет эмбеддинг и роняет recall ниже порога 0.70."""
+    """Strip Ocean's service wrapper ('[ОПЫТ|...] Контекст: X → Действие: Y') —
+    it dilutes the embedding and drops recall below the 0.70 threshold.
+    (The wrapper is Russian because original Ocean memories are; keep as is.)"""
     m = re.match(r"^\[ОПЫТ\|[^\]]*\]\s*Контекст:\s*(.*?)\s*→\s*Действие:\s*(.*)$",
                  text, flags=re.DOTALL)
     if m:
@@ -76,7 +77,8 @@ def _clean_ocean_text(text: str) -> str:
 
 
 def import_ocean(db_path: str):
-    """Импорт активных узлов из SQLite настоящего Ocean. Источник не модифицируется."""
+    """Import active nodes from an original Ocean SQLite DB. The source is opened
+    read-only and never modified."""
     src = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
     src.row_factory = sqlite3.Row
     g = Graph()
@@ -87,7 +89,7 @@ def import_ocean(db_path: str):
         d = dict(r)
         text = d.get("_text") or d.get("text") or ""
         if not text.strip():
-            # текст может лежать в JSON-поле
+            # the text may live inside a JSON field
             for v in d.values():
                 if isinstance(v, str) and v.startswith("{"):
                     try:
@@ -104,7 +106,7 @@ def import_ocean(db_path: str):
         g.add_node(text, layer=layer, role="system", meta={"imported_from": "ocean", "src_id": d.get("id")})
         existing.add(text); added += 1
     g.save()
-    print(f"импортировано: {added}, пропущено: {skipped}, всего в графе: {len(g.nodes)}")
+    print(f"imported: {added}, skipped: {skipped}, total in graph: {len(g.nodes)}")
 
 
 def main():
@@ -118,7 +120,7 @@ def main():
     elif cmd == "import-ocean":
         import_ocean(args[0])
     else:
-        print(f"неизвестная команда: {cmd}\n{__doc__}")
+        print(f"unknown command: {cmd}\n{__doc__}")
 
 
 if __name__ == "__main__":

--- a/skills/cognitive/qca-cycle/scripts/ses_bridge.py
+++ b/skills/cognitive/qca-cycle/scripts/ses_bridge.py
@@ -20,9 +20,20 @@ LEARNED_DIR = os.path.expanduser(os.getenv("QCA_LEARNED_DIR", "~/.hermes/skills/
 
 
 def verify(path: str) -> bool:
+    """Verify a snapshot. Supports canonical SES v5.1 (meta.hash over the whole
+    snapshot, SES_CANON_JSON_v1 sorting) and the legacy body/provenance wrapper."""
     doc = json.load(open(path))
-    claimed = doc.get("provenance", {}).get("hash", "")
-    actual = "sha256:" + hashlib.sha256(canonical_json(doc["body"]).encode()).hexdigest()
+    if "initiator" in doc:  # canonical v5.1
+        from qca_engine import _snapshot_hash
+        claimed = doc.get("meta", {}).get("hash", "")
+        actual = _snapshot_hash(doc)
+        # v5.1 canon lock (§12): a state must reference its kernel
+        if doc.get("snapshot_type") == "STATE_SNAPSHOT" and not (
+                doc["meta"].get("kernel_ref") or doc["meta"].get("kernel_hash")):
+            print("⚠ canon violation: STATE_SNAPSHOT without kernel_ref/kernel_hash")
+    else:  # legacy
+        claimed = doc.get("provenance", {}).get("hash", "")
+        actual = "sha256:" + hashlib.sha256(canonical_json(doc["body"]).encode()).hexdigest()
     ok = claimed == actual
     print(f"{'✅ integrity verified' if ok else '❌ TAMPERED: hash mismatch'}")
     print(f"  claimed: {claimed}\n  actual:  {actual}")

--- a/tests/skills/test_qca_cycle_skill.py
+++ b/tests/skills/test_qca_cycle_skill.py
@@ -1,0 +1,194 @@
+"""
+Tests for the qca-cycle cognitive skill.
+
+Covers the review findings on PR #43306:
+  - SKILL.md frontmatter conforms to the hardline format (description ≤ 60)
+  - store paths resolve under the active Hermes home, not a hardcoded ~/.hermes
+  - `pulse` honors the silent-cron contract (deliberate silence = empty stdout)
+  - `ses_bridge.py verify` fails (non-zero exit) on tampering AND on the
+    SES v5.1 canon-lock violation (STATE_SNAPSHOT without kernel_ref/kernel_hash)
+
+All LLM calls use the mock backend; embeddings use the lexical fallback by
+pointing OLLAMA_URL at a closed local port (no live network calls).
+"""
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "skills" / "cognitive" / "qca-cycle"
+ENGINE = SKILL_DIR / "scripts" / "qca_engine.py"
+BRIDGE = SKILL_DIR / "scripts" / "ses_bridge.py"
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def _env(tmp_home: Path, **extra: str) -> dict:
+    """Hermetic env: Hermes home in tmp, mock LLM, embeddings in lexical
+    fallback (OLLAMA_URL points at a closed port; refused instantly)."""
+    env = os.environ.copy()
+    for k in ("QCA_STORE", "QCA_KERNEL", "QCA_LEARNED_DIR", "ANTHROPIC_API_KEY"):
+        env.pop(k, None)
+    env.update({"HERMES_HOME": str(tmp_home),
+                "QCA_LLM_BACKEND": "mock",
+                "OLLAMA_URL": "http://127.0.0.1:1"})
+    env.update(extra)
+    return env
+
+
+def _run(script: Path, *args: str, env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, str(script), *args],
+                          capture_output=True, text=True, env=env, timeout=120)
+
+
+# ── SKILL.md frontmatter (hardline authoring standards) ──────────────────
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline ≤60): {desc!r}"
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == "qca-cycle"
+
+
+def test_author_credits_contributor(frontmatter) -> None:
+    assert "Trubnikov" in frontmatter["author"]
+
+
+def test_platforms_cross_platform(frontmatter) -> None:
+    # Scripts are pure stdlib with no POSIX-only primitives.
+    assert set(frontmatter["platforms"]) == {"linux", "macos", "windows"}
+
+
+# ── Scripts: static checks ────────────────────────────────────────────────
+
+@pytest.mark.parametrize("script", [ENGINE, BRIDGE,
+                                    SKILL_DIR / "scripts" / "_hermes_home.py"])
+def test_scripts_parse(script: Path) -> None:
+    ast.parse(script.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("script", [ENGINE, BRIDGE])
+def test_no_hardcoded_hermes_home(script: Path) -> None:
+    # Paths must resolve via HERMES_HOME / hermes_constants (profile isolation).
+    assert "~/.hermes" not in script.read_text(encoding="utf-8")
+
+
+# ── Store path resolution ─────────────────────────────────────────────────
+
+def test_store_resolves_under_hermes_home(tmp_path: Path) -> None:
+    r = _run(ENGINE, "stats", env=_env(tmp_path))
+    assert r.returncode == 0, r.stderr
+    stats = json.loads(r.stdout)
+    assert stats["store"] == str(tmp_path / "qca" / "graph.json")
+    assert (tmp_path / "qca" / "graph.json").is_file()
+
+
+def test_qca_store_override_wins(tmp_path: Path) -> None:
+    custom = tmp_path / "elsewhere" / "graph.json"
+    r = _run(ENGINE, "stats", env=_env(tmp_path, QCA_STORE=str(custom)))
+    assert r.returncode == 0, r.stderr
+    assert json.loads(r.stdout)["store"] == str(custom)
+
+
+# ── pulse: silent-cron contract ───────────────────────────────────────────
+
+def test_pulse_silence_is_empty_stdout(tmp_path: Path) -> None:
+    env = _env(tmp_path)
+    # First pulse on an empty graph: the (deterministic) mock thought is novel,
+    # gets written and printed.
+    first = _run(ENGINE, "pulse", env=env)
+    assert first.returncode == 0, first.stderr
+    assert first.stdout.strip(), "first pulse should produce a thought"
+    # Second pulse produces the identical mock thought; the novelty gate
+    # discards it and the CLI must emit NOTHING on stdout (no 'SILENCE').
+    second = _run(ENGINE, "pulse", env=env)
+    assert second.returncode == 0, second.stderr
+    assert second.stdout == "", f"silent pulse must print nothing, got: {second.stdout!r}"
+
+
+# ── SES snapshots: export + verify ────────────────────────────────────────
+
+def _export(tmp_home: Path, snap: Path) -> subprocess.CompletedProcess:
+    return _run(ENGINE, "export-ses", str(snap), env=_env(tmp_home))
+
+
+def test_verify_roundtrip_with_kernel(tmp_path: Path) -> None:
+    (tmp_path / "qca").mkdir(parents=True)
+    shutil.copy(SKILL_DIR / "kernel.example.ses.json", tmp_path / "qca" / "kernel.ses.json")
+    snap = tmp_path / "snap.ses.json"
+    r = _export(tmp_path, snap)
+    assert r.returncode == 0, r.stderr
+    doc = json.loads(snap.read_text(encoding="utf-8"))
+    assert doc["snapshot_type"] == "COMBINED"
+    assert doc["meta"]["kernel_hash"].startswith("sha256:")
+    v = _run(BRIDGE, "verify", str(snap), env=_env(tmp_path))
+    assert v.returncode == 0, v.stdout + v.stderr
+    assert "integrity verified" in v.stdout
+
+
+def test_verify_fails_on_tampering(tmp_path: Path) -> None:
+    (tmp_path / "qca").mkdir(parents=True)
+    shutil.copy(SKILL_DIR / "kernel.example.ses.json", tmp_path / "qca" / "kernel.ses.json")
+    snap = tmp_path / "snap.ses.json"
+    assert _export(tmp_path, snap).returncode == 0
+    doc = json.loads(snap.read_text(encoding="utf-8"))
+    doc["state"]["meta"]["summary"] = "tampered"
+    snap.write_text(json.dumps(doc, ensure_ascii=False), encoding="utf-8")
+    v = _run(BRIDGE, "verify", str(snap), env=_env(tmp_path))
+    assert v.returncode == 1
+    assert "TAMPERED" in v.stdout
+
+
+def test_verify_fails_canon_violation(tmp_path: Path) -> None:
+    """A STATE_SNAPSHOT without kernel_ref/kernel_hash violates the SES v5.1
+    canon lock (§12) and must exit non-zero even when the hash matches."""
+    snap = tmp_path / "snap.ses.json"
+    r = _export(tmp_path, snap)  # no kernel installed
+    assert r.returncode == 0
+    assert "canon-lock" in r.stderr  # export warns about the degraded snapshot
+    doc = json.loads(snap.read_text(encoding="utf-8"))
+    assert doc["snapshot_type"] == "STATE_SNAPSHOT"
+    assert "kernel_ref" not in doc["meta"] and "kernel_hash" not in doc["meta"]
+    v = _run(BRIDGE, "verify", str(snap), env=_env(tmp_path))
+    assert v.returncode == 1, "canon violation must fail verification"
+    assert "canon violation" in v.stdout
+
+
+# ── _hermes_home fallback resolver ────────────────────────────────────────
+
+def test_hermes_home_fallback(monkeypatch, tmp_path: Path) -> None:
+    """The stdlib fallback (used when hermes_constants is not importable)
+    honors HERMES_HOME and the platform-native default."""
+    import importlib.util
+    monkeypatch.setitem(sys.modules, "hermes_constants", None)  # force ImportError
+    spec = importlib.util.spec_from_file_location(
+        "qca_hermes_home", SKILL_DIR / "scripts" / "_hermes_home.py")
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert mod.get_hermes_home() == tmp_path
+
+    monkeypatch.delenv("HERMES_HOME")
+    if sys.platform == "win32":
+        assert mod.get_hermes_home().name == "hermes"
+    else:
+        assert mod.get_hermes_home() == Path.home() / ".hermes"


### PR DESCRIPTION
## What this adds

A new `cognitive` skill category with **qca-cycle** — a cognitive layer that gives each Hermes installation its own persistent persona:

- **Immutable personality kernel** (`kernel.ses.json`): axioms + guardrails, SHA-256 signed, injected into every thinking cycle. Identity can't silently drift — it changes only by a deliberate new snapshot (new hash).
- **Growing graph memory**: every exchange becomes typed nodes/edges (SUPPORTS / REFINES / CONTRADICTS / ASSOCIATED) with semantic recall via local Ollama embeddings (bge-m3), and a graceful lexical fallback when Ollama is absent.
- **Incorruptible novelty verifier**: a repeated thought (cosine ≥ 0.90 to an existing node) is discarded by embedding geometry — not by an LLM grading its own output. Memory stays clean over months.
- **Neurochemical state** (dopamine / pain / adrenaline / serotonin) with real half-lives (2.5h–46h), persisted between sessions, reframing prompts and gating model choice.
- **Daemons** for `hermes cron`: `pulse` (autonomous goal step, silent by default) and `sleep` (nightly consolidation: episodic clusters → CORE abstractions).
- **SES provenance**: full state exports as a canonically-hashed snapshot; tampering is detectable (`ses_bridge.py verify`).

## Design constraints respected

- Pure Python stdlib — zero pip dependencies.
- LLM is pluggable (`mock | ollama | anthropic`) — swap the model, the persona stays.
- SKILL.md follows the v0.13 spec with `config` keys (`qca.store`, `qca.learned_dir`).
- Silent-by-default autonomous mode (empty stdout = no message).

## Measured results (not promises)

- A/B on 8 real tasks, bare Hermes vs Hermes+qca-cycle with seeded memory: **6/8 for qca-cycle**. Flagship case: the bare agent confidently recommended the opposite of a decision already recorded in memory; with the skill it recalled the decision (cosine 0.79, top-1).
- Same model, same question: intelligence unchanged, relevance transformed.
- Exact repeat → cosine 0.987 → discarded, not written.
- Tamper test: one character changed in a snapshot → verify fails loudly.

Standalone repo with full README and A/B data: https://github.com/trubnikov/qca-cycle

Built by [@trubnikov](https://github.com/trubnikov) — the cognitive architecture comes from Ocean, a personal cognitive agent project (2025).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
