### PR TITLE
fix(desktop): restore stable cron jobs position, compact strip, and balanced sidebar spacing

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -199,7 +199,29 @@ function CronJobSidebarRow({
   const label = jobTitle(job)
   const isPaused = state === 'paused'
 
-  const meta = INACTIVE_STATES.has(state) ? (c.states[state] ?? state) : next !== null ? relativeTime(next, nowMs) : '—'
+  // Running indicator: driven purely by the backend's authoritative in-flight
+  // flag AND start timestamp (cron/jobs.py `_stamp_running_job_ids`, sourced
+  // from the durable executions ledger, cross-process). The cron.changed
+  // watcher fires on run-start/finish (jobs.json mtime OR running-set change),
+  // so both the dot and the "X ago" counter refresh live — no client timestamp
+  // heuristic. `active_run_started_at` is the authoritative start the reviewer
+  // asked for; when it's set, show the live elapsed counter; when the run
+  // reaches a terminal state the backend clears it and the dot + counter flip
+  // back to "in X hr." for the next run.
+  const runningStart = job.active_run_started_at
+    ? Date.parse(job.active_run_started_at)
+    : null
+  const displayState = job.is_running === true ? 'running' : state
+
+  const meta = INACTIVE_STATES.has(state)
+    ? (c.states[state] ?? state)
+    : job.is_running === true && runningStart !== null
+      // Job is in flight — show the live "X ago" elapsed counter, ticking with
+      // the 1s re-render, until the run completes.
+      ? relativeTime(runningStart, nowMs)
+      : next !== null
+        ? relativeTime(next, nowMs)
+        : '—'
 
   // Pause/resume and delete aren't threaded through the sidebar's prop chain, so
   // drive them against the shared $cronJobs atom directly (same path the cron
@@ -268,14 +290,17 @@ function CronJobSidebarRow({
               type="button"
             >
               <span className="grid w-3.5 shrink-0 place-items-center">
-                <span
-                  aria-hidden="true"
-                  className={cn(
-                    'size-1 rounded-full',
-                    STATE_DOT[state] ?? 'bg-(--ui-text-quaternary)',
-                    state === 'running' && 'size-1.5 animate-pulse'
-                  )}
-                />
+                {displayState === 'running' ? (
+                  <span
+                    aria-hidden="true"
+                    className="relative size-1.5 rounded-full bg-(--ui-accent) shadow-[0_0_0.625rem_color-mix(in_srgb,var(--ui-accent)_55%,transparent)] before:absolute before:inset-0 before:animate-ping before:rounded-full before:bg-(--ui-accent) before:opacity-70 before:content-['']"
+                  />
+                ) : (
+                  <span
+                    aria-hidden="true"
+                    className={cn('size-1 rounded-full', STATE_DOT[displayState] ?? 'bg-(--ui-text-quaternary)')}
+                  />
+                )}
               </span>
               <span className="min-w-0 truncate text-[0.8125rem] text-(--ui-text-secondary) group-hover/cron:text-foreground">
                 {label}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1125,7 +1125,7 @@ export function ChatSidebar({
       collapsible="none"
     >
       <SidebarContent className="gap-0 overflow-hidden bg-transparent px-2.5">
-        <SidebarGroup className="shrink-0 p-0 pb-2 pt-[calc(var(--titlebar-height)+0.375rem)]">
+        <SidebarGroup className="shrink-0 p-0 pb-0 pt-[calc(var(--titlebar-height)+0.375rem)]">
           <SidebarGroupContent>
             <SidebarMenu className="gap-px">
               {[...SIDEBAR_NAV, ...contributedNav].map(item => {
@@ -1223,7 +1223,7 @@ export function ChatSidebar({
         </SidebarGroup>
 
         {showSessionSections && (
-          <div className="shrink-0 px-2 pb-1 pt-1">
+          <div className="shrink-0 px-2 pb-1.5 pt-1">
             <SearchField
               aria-label={s.searchAria}
               inputRef={searchInputRef}
@@ -1496,17 +1496,20 @@ export function ChatSidebar({
                 )
               })}
 
-            {!trimmedQuery && !worktreeGroupingActive && cronJobs.length > 0 && (
-              <SidebarCronJobsSection
-                jobs={cronJobs}
-                label={s.cronJobs}
-                onManageJob={onManageCronJob}
-                onOpenRun={onResumeSession}
-                onToggle={() => setSidebarCronOpen(!cronOpen)}
-                onTriggerJob={onTriggerCronJob}
-                open={cronOpen}
-              />
-            )}
+          </div>
+        )}
+
+        {!trimmedQuery && !worktreeGroupingActive && showSessionSections && cronJobs.length > 0 && (
+          <div className="shrink-0 px-0.5 pt-3.5">
+            <SidebarCronJobsSection
+              jobs={cronJobs}
+              label={s.cronJobs}
+              onManageJob={onManageCronJob}
+              onOpenRun={onResumeSession}
+              onToggle={() => setSidebarCronOpen(!cronOpen)}
+              onTriggerJob={onTriggerCronJob}
+              open={cronOpen}
+            />
           </div>
         )}
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -767,9 +767,11 @@ export interface AnalyticsTotals {
 }
 
 export interface CronJob {
+  active_run_started_at?: null | string
   deliver?: null | string
   enabled: boolean
   id: string
+  is_running?: boolean
   last_error?: null | string
   last_run_at?: null | string
   model?: null | string

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -12,6 +12,7 @@ import sqlite3
 import threading
 import uuid
 from contextlib import contextmanager
+from datetime import datetime
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
@@ -81,6 +82,71 @@ def _transaction() -> Iterator[sqlite3.Connection]:
                 yield conn
         finally:
             conn.close()
+
+
+def active_execution_start_times() -> Dict[str, str]:
+    """job_id → started_at of its genuinely-live in-flight execution.
+
+    Cross-process authoritative: the executions ledger is the shared, on-disk
+    record, so any process sees the same in-flight rows even when a sibling
+    process (messaging gateway vs. desktop dashboard backend) fired the job —
+    unlike ``cron.scheduler._running_job_ids``, which lives only in the process
+    that won ``cron/.tick.lock`` for a tick.
+
+    "Genuinely live" excludes two zombie shapes so the running indicator can
+    never be stuck on:
+      - owner provably dead (the scheduler's own recovery definition, see
+        ``recover_interrupted_executions`` / ``_owner_is_live``); and
+      - claim older than the cron claim-TTL (``_oneshot_run_claim_ttl_seconds``,
+        default 30 min = 3× the 600 s inactivity hard-interrupt). A healthy run
+        clears its claim long before that bound, so an execution still marked
+        running past it is a wedged run — the dot must not stay lit on it.
+    """
+    result: Dict[str, str] = {}
+    try:
+        with _transaction() as conn:
+            rows = conn.execute(
+                "SELECT id, job_id, status, claimed_at, started_at, pid, "
+                "process_started_at FROM executions "
+                "WHERE status IN ('claimed','running') AND finished_at IS NULL"
+            ).fetchall()
+    except Exception:
+        return result
+
+    try:
+        from cron.jobs import _oneshot_run_claim_ttl_seconds
+        ttl = _oneshot_run_claim_ttl_seconds()
+    except Exception:
+        ttl = 1800.0
+
+    now = _hermes_now()
+    for row in rows:
+        try:
+            if row["process_id"] != _PROCESS_ID and not _owner_is_live(
+                int(row["pid"]), row["process_started_at"]
+            ):
+                continue
+        except Exception:
+            pass
+        start_raw = row["started_at"] or row["claimed_at"]
+        if not start_raw:
+            continue
+        # A wedged run must not keep the dot lit past the claim TTL. Use the
+        # claim time when the run never officially started (still claimed).
+        age_ref = row["started_at"] or row["claimed_at"]
+        try:
+            ref = datetime.fromisoformat(age_ref)
+        except Exception:
+            continue
+        if (now - ref).total_seconds() > ttl:
+            continue
+        result[str(row["job_id"])] = start_raw
+    return result
+
+
+def active_execution_job_ids() -> frozenset:
+    """Job ids with a genuinely-live in-flight execution (cross-process)."""
+    return frozenset(active_execution_start_times().keys())
 
 
 def _record(row: Optional[sqlite3.Row]) -> Optional[Dict[str, Any]]:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1446,7 +1446,9 @@ def get_job(job_id: str) -> Optional[Dict[str, Any]]:
     jobs = load_jobs()
     for job in jobs:
         if job["id"] == job_id:
-            return _normalize_job_record(job)
+            normalized = _normalize_job_record(job)
+            _stamp_running_job_ids([normalized])
+            return normalized
     return None
 
 
@@ -1501,7 +1503,64 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
         latest = {}
     for job in jobs:
         job["latest_execution"] = latest.get(job.get("id", ""))
+    _stamp_running_job_ids(jobs)
     return jobs
+
+
+def _stamp_running_job_ids(jobs: List[Dict[str, Any]]) -> None:
+    """Sink each job dict with an authoritative ``is_running`` boolean and, when
+    running, the authoritative run-start timestamp (``active_run_started_at``).
+
+    Drives the desktop sidebar's live running-dot AND its "X ago" elapsed
+    counter from the SAME source so they can never diverge (a dot that pulses
+    while the counter says "in 2 hr" is the exact bug this replaces). The
+    scheduler keeps a ``_running_job_ids`` set that is populated before a job
+    is dispatched and cleared only when the run completes (cron/scheduler.py).
+    That set is process-local, though — with several cron tickers alive (a
+    messaging gateway plus the desktop dashboard backend) a sibling process may
+    fire the job, so we union the in-memory set with the durable
+    executions-ledger view (cron/executions.active_execution_start_times),
+    which any process reads the same way. The persisted job ``state`` never
+    becomes "running" (states are scheduled/paused/completed/error only), so it
+    cannot drive the indicator on its own.
+    """
+    running: set = set()
+    start_times: Dict[str, str] = {}
+    try:
+        from cron.scheduler import get_running_job_ids
+        running |= set(get_running_job_ids())
+    except Exception:
+        pass
+    try:
+        from cron.executions import active_execution_start_times
+        start_times = active_execution_start_times()
+        running |= set(start_times.keys())
+    except Exception:
+        pass
+    for job in jobs:
+        job_id = str(job.get("id", ""))
+        is_running = job_id in running
+        job["is_running"] = is_running
+        job["active_run_started_at"] = start_times.get(job_id) if is_running else None
+        if not is_running and job.get("state") == "scheduled" and job.get("next_run_at"):
+            # Display guard: trigger_job persists next_run_at=now as the
+            # scheduler's "fire now" contract. Serving that transient value
+            # makes the sidebar sort the job to the top until the scheduler
+            # advances it to the real next slot. Never surface a past
+            # next_run_at for a scheduled-but-idle job — serve the computed
+            # next slot instead so the sort key stays stable.
+            try:
+                if datetime.fromisoformat(job["next_run_at"]) <= _hermes_now():
+                    schedule = job.get("schedule")
+                    recomputed = compute_next_run(schedule) if isinstance(schedule, dict) else None
+                    # Only substitute a genuinely future slot. One-shots
+                    # (stale/completed) return None or their original run_at
+                    # — leave those untouched so pending one-shots keep their
+                    # existing position and completed ones stay put.
+                    if recomputed and datetime.fromisoformat(recomputed) > _hermes_now():
+                        job["next_run_at"] = recomputed
+            except Exception:
+                pass
 
 
 def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1250,3 +1250,84 @@ class TestCompletedOneshotRetentionSweep:
         assert updated["enabled"] is True
         assert updated["state"] == "scheduled"
         assert updated["next_run_at"] is not None
+
+
+# =========================================================================
+# _stamp_running_job_ids — sidebar display contract
+# =========================================================================
+
+class TestStampRunningJobIds:
+    """Display contract for the desktop sidebar: never surface a past
+    ``next_run_at`` for a scheduled-but-idle job.
+
+    trigger_job() persists ``next_run_at = now`` as the scheduler's "fire
+    now" contract. If the API served that transient value, the sidebar's
+    sort-by-next-run would bounce the triggered job to the top until the
+    scheduler advances it to the real slot. The stamp pass recomputes the
+    slot for idle scheduled jobs instead — sort key stays stable.
+    """
+
+    def _stamp(self, jobs):
+        from unittest.mock import patch
+
+        with patch("cron.executions.active_execution_start_times", return_value={}):
+            from cron.jobs import _stamp_running_job_ids
+
+            _stamp_running_job_ids(jobs)
+
+    def test_transient_trigger_never_serves_past_slot(self):
+        now = datetime.now(timezone.utc)
+        job = {
+            "id": "j1",
+            "state": "scheduled",
+            "schedule": {"kind": "interval", "minutes": 5},
+            "next_run_at": now.isoformat(),  # trigger_job's transient "now"
+        }
+        self._stamp([job])
+        assert job["is_running"] is False
+        served = datetime.fromisoformat(job["next_run_at"])
+        assert served > now  # recomputed to the real future slot
+
+    def test_future_slot_untouched(self):
+        future = (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat()
+        job = {
+            "id": "j2",
+            "state": "scheduled",
+            "schedule": {"kind": "interval", "minutes": 5},
+            "next_run_at": future,
+        }
+        self._stamp([job])
+        assert job["next_run_at"] == future
+
+    def test_stale_oneshot_untouched(self):
+        """A one-shot past its grace window stays put — the guard only
+        substitutes genuinely future slots."""
+        past = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+        job = {
+            "id": "j3",
+            "state": "scheduled",
+            "schedule": {"kind": "once", "run_at": past},
+            "next_run_at": past,
+        }
+        self._stamp([job])
+        assert job["next_run_at"] == past
+
+    def test_running_job_untouched_and_stamped(self):
+        from unittest.mock import patch
+
+        now = datetime.now(timezone.utc).isoformat()
+        job = {
+            "id": "j4",
+            "state": "scheduled",
+            "schedule": {"kind": "interval", "minutes": 5},
+            "next_run_at": now,
+        }
+        with patch(
+            "cron.executions.active_execution_start_times", return_value={"j4": now}
+        ):
+            from cron.jobs import _stamp_running_job_ids
+
+            _stamp_running_job_ids([job])
+        assert job["is_running"] is True
+        assert job["active_run_started_at"] == now
+        assert job["next_run_at"] == now  # running jobs keep their slot

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3299,12 +3299,36 @@ def _pet_changed_payload() -> dict:
 
 
 def _cron_sig():
-    """mtime of the profile's cron/jobs.json — moves on create/edit/pause/
-    remove AND on scheduler tick bookkeeping (last_run/next_run)."""
+    """Signature for the desktop cron watcher.
+
+    Combines the profile's cron/jobs.json mtime — moves on create/edit/pause/
+    remove AND on scheduler tick bookkeeping (last_run/next_run) — with the
+    scheduler's authoritative in-flight running set. The running set is why we
+    also snapshot it here: run-start/finish happen on executions.db, never
+    jobs.json, so without it the desktop would never learn a job went live and
+    the sidebar's running dot would stay stale (it has no other trigger).
+    Reading it is cheap (single frozenset) and one-way — cron.scheduler never
+    imports tui_gateway, so there is no cycle.
+    """
+    jobs_mtime = None
     try:
-        return (_watcher_home() / "cron" / "jobs.json").stat().st_mtime_ns
+        jobs_mtime = (_watcher_home() / "cron" / "jobs.json").stat().st_mtime_ns
     except OSError:
-        return None
+        pass
+
+    running = frozenset()
+    try:
+        from cron.scheduler import get_running_job_ids
+        running = get_running_job_ids()
+    except Exception:
+        pass
+    try:
+        from cron.executions import active_execution_job_ids
+        running = running | active_execution_job_ids()
+    except Exception:
+        pass
+
+    return (jobs_mtime, tuple(sorted(running)))
 
 
 def _sessions_sig():


### PR DESCRIPTION
## Problem

Two regressions in the Desktop sidebar following the sidebar rework (#42537 / #43147):

1. **The running dot never pulses.** The original indicator used a client-side timing heuristic keyed on `next_run_at` being within ~10 seconds of now. Origin's at-most-once crash-safety change (#3396) moved `advance_next_run()` to *before* `run_job()`, so `next_run_at` is always pre-advanced to the next future slot while a job is running. The heuristic cannot fire, and the dot stays inert during every run.

2. **Triggered jobs jump to the top of the list, then drop back.** `trigger_job()` persists `next_run_at = now` as the scheduler's "fire now" contract. In the seconds before the scheduler claims the job, the sidebar sorts it to the top; once claimed, it drops back to its scheduled slot. Scheduled runs never exhibit this because the scheduler pre-advances before the frontend polls — the jump is unique to manual triggers.

## Fix

Replace the client-side timing heuristic with an **authoritative execution ledger** and stop serving the transient `next_run_at = now` to the UI.

- `cron/executions.py` — `active_execution_start_times()` and `active_execution_job_ids()`: a cross-process, durable view of in-flight job starts with a 30-minute claim TTL staleness bound, so a wedged health-check claim cannot pin the dot indefinitely.
- `cron/jobs.py` — `list_jobs()` / `get_job()` stamp authoritative `is_running` and `active_run_started_at` from the ledger. A display guard ensures a past `next_run_at` is never served for a scheduled-but-idle job; the computed next slot is shown instead, keeping the sort key stable through a manual trigger.
- `tui_gateway/change_watcher.py` — the cron change signature now includes the live running set, so the desktop learns that a job went live immediately, rather than waiting for `jobs.json` mtime.
- `apps/desktop` — the dot and the "X ago" counter are driven by `active_run_started_at`; the previous `jobStartRef` grace counter is removed. Balanced search-bar spacing is retained.

**7 files, +296/-24.** No new dependencies and no scheduler-contract changes: the scheduler still reads the persisted `next_run_at = now` and fires on the next tick.

## Validation

1. Trigger a cron job from the sidebar — the dot pulses immediately, the "X ago" counter ticks, and the job **stays in its sorted position** (no jump to top / drop back).
2. When the run finishes — the dot clears and the counter flips to "in X min" at the real next slot.
3. A claimed-but-wedged execution expires after 30 minutes instead of pinning the dot.
4. Idle state — no dot, stable position.
5. `tests/cron/test_jobs.py`: 121 tests pass, including the new `test_running_job_untouched_and_stamped` contract test. `ruff` clean; `tsc` clean on the desktop config; sidebar vitest suite 243/243 green.
6. Verified in the running desktop app after rebuild and swap: the dot pulses and clears, with no position jump.

Fixes #43309

