### PR TITLE
fix(agent): warn when configured memory provider fails to activate

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1185,7 +1185,26 @@ def init_agent(
                     agent._memory_manager.initialize_all(**_init_kwargs)
                     _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
                 else:
-                    _ra().logger.debug("Memory provider '%s' not found or not available", _mem_provider_name)
+                    # The user explicitly configured this provider in
+                    # config.yaml, so failing to activate it must be loud:
+                    # at DEBUG this degrades to a silent, indefinite memory
+                    # outage (the agent runs with built-in memory only and
+                    # nothing ever says so).
+                    if _mp is None:
+                        _ra().logger.warning(
+                            "Memory provider '%s' is configured but its plugin "
+                            "could not be found or loaded; continuing without "
+                            "external memory. Run 'hermes memory status' to "
+                            "diagnose.",
+                            _mem_provider_name,
+                        )
+                    else:
+                        _ra().logger.warning(
+                            "Memory provider '%s' is configured but reports "
+                            "unavailable; continuing without external memory. "
+                            "Run 'hermes memory status' to diagnose.",
+                            _mem_provider_name,
+                        )
                     agent._memory_manager = None
         except Exception as _mpe:
             _ra().logger.warning("Memory provider plugin init failed: %s", _mpe)

--- a/tests/agent/test_memory_provider_activation_warning.py
+++ b/tests/agent/test_memory_provider_activation_warning.py
@@ -1,0 +1,119 @@
+"""Regression: a configured-but-broken memory provider must fail LOUD.
+
+``agent_init`` activates the external memory provider named in
+``config.yaml``'s ``memory.provider``. Before the fix, the failure branch
+(plugin missing, or ``is_available()`` False) logged at DEBUG — invisible at
+the default INFO level — so an agent whose configured provider had silently
+died kept running with built-in memory only and nothing ever said so. A
+provider the user explicitly configured failing to activate is a WARNING,
+matching the surrounding ``Memory provider plugin init failed`` idiom.
+
+These tests build a real AIAgent (mirroring the harness in
+``tests/agent/test_compression_logging_session_context.py``) with a config
+that names a provider, force the two failure shapes, and assert a WARNING
+naming the provider is emitted and the agent degrades to built-in memory.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _build_agent(tmp_path: Path, load_mem_return):
+    """Construct an AIAgent with memory.provider configured and the plugin
+    loader patched to return *load_mem_return*."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "MEM_WARN_TEST_SESSION"
+    db.create_session(session_id, source="cli")
+
+    fake_cfg = {"memory": {"provider": "ghost-provider"}}
+
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}), \
+         patch("hermes_cli.config.load_config", return_value=fake_cfg), \
+         patch("plugins.memory.load_memory_provider", return_value=load_mem_return):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+    return agent
+
+
+def _provider_warnings(caplog):
+    return [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "ghost-provider" in r.getMessage()
+    ]
+
+
+def test_missing_provider_plugin_warns(tmp_path: Path, caplog) -> None:
+    """Configured provider whose plugin can't be found/loaded → WARNING."""
+    with caplog.at_level(logging.WARNING):
+        agent = _build_agent(tmp_path, load_mem_return=None)
+
+    warnings = _provider_warnings(caplog)
+    assert warnings, (
+        "expected a WARNING naming the configured provider when its plugin "
+        f"is missing; got records: {[r.getMessage() for r in caplog.records]}"
+    )
+    assert "could not be found" in warnings[0].getMessage()
+    assert agent._memory_manager is None
+
+
+def test_unavailable_provider_warns(tmp_path: Path, caplog) -> None:
+    """Configured provider that loads but reports unavailable → WARNING."""
+    broken = MagicMock()
+    broken.is_available.return_value = False
+
+    with caplog.at_level(logging.WARNING):
+        agent = _build_agent(tmp_path, load_mem_return=broken)
+
+    warnings = _provider_warnings(caplog)
+    assert warnings, (
+        "expected a WARNING naming the configured provider when it reports "
+        f"unavailable; got records: {[r.getMessage() for r in caplog.records]}"
+    )
+    assert "unavailable" in warnings[0].getMessage()
+    assert agent._memory_manager is None
+
+
+def test_no_warning_when_no_provider_configured(tmp_path: Path, caplog) -> None:
+    """No memory.provider in config → no spurious warning."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "MEM_WARN_TEST_SESSION_NONE"
+    db.create_session(session_id, source="cli")
+
+    with caplog.at_level(logging.WARNING), \
+         patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}), \
+         patch("hermes_cli.config.load_config", return_value={"memory": {}}):
+        from run_agent import AIAgent
+
+        AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+
+    assert not [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "memory provider" in r.getMessage().lower()
+    ]


### PR DESCRIPTION
## What does this PR do?

A memory provider explicitly named in `config.yaml`'s `memory.provider` that fails to activate — plugin missing, or `is_available()` returning `False` — was logged at **DEBUG**, which is invisible at the default INFO level. The agent then runs indefinitely with built-in memory only, and nothing ever says so. In practice this turns a dead local memory daemon or a broken plugin install into a silent, open-ended memory outage (we hit exactly this: a configured provider was down for ~a week with zero log evidence at default verbosity).

This PR logs the failure at **WARNING** (matching the adjacent `Memory provider plugin init failed` idiom at the same call site), distinguishes *plugin not found* from *provider reports unavailable*, and points the user at `hermes memory status` for diagnosis. A provider the user explicitly configured failing to honor that config is warning-worthy by definition.

## Related Issue

No existing issue found (searched open PRs/issues for memory-provider silent-failure reports).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py` — in the external-provider activation block, replace the single DEBUG line in the failure branch with two WARNING messages (plugin-not-found vs provider-unavailable), each naming the configured provider and suggesting `hermes memory status`. Behavior is otherwise unchanged (`agent._memory_manager` still degrades to `None`).
- `tests/agent/test_memory_provider_activation_warning.py` — new regression tests: (1) configured provider whose plugin can't be loaded → WARNING; (2) provider that loads but reports unavailable → WARNING; (3) no provider configured → no spurious warning. Tests build a real `AIAgent` mirroring the harness in `tests/agent/test_compression_logging_session_context.py`, with `hermes_cli.config.load_config` and `plugins.memory.load_memory_provider` patched.

## How to Test

1. `pytest tests/agent/test_memory_provider_activation_warning.py -q` → 3 passed.
2. `pytest tests/agent/test_memory_provider.py -q` → 80 passed (no regressions in the provider/manager suite).
3. Manual repro: set `memory.provider: hindsight` in `~/.hermes/config.yaml` on a machine where the hindsight packages are not importable, run any `hermes -z` one-shot, and watch the log. Before: nothing at INFO. After: `WARNING ... Memory provider 'hindsight' is configured but reports unavailable; continuing without external memory. Run 'hermes memory status' to diagnose.`

Also ran the full `tests/agent/` directory: 174 passed, 1 failed — the failure is `test_anthropic_adapter.py::test_falls_back_to_claude_code_credentials`, which fails identically on a clean `upstream/main` checkout on this machine (it is not hermetic: it mocks `Path.home()` but not the macOS-Keychain credential reader, so any Mac with Claude Code logged in shadows the fake credentials file). Unrelated to this change; happy to file separately.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent): ...`)
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (one commit, two files)
- [x] I've run the targeted suites above and they pass (`tests/agent/` 174/175 — the 1 failure is a pre-existing, environment-sensitive test unrelated to this change, details above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0), Python 3.11

### Documentation & Housekeeping

- [x] Relevant documentation — N/A (log-severity change, no API/config surface)
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure `logging` call change, no OS-specific code paths
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Before (default INFO level, provider dead): no output — agent silently runs without external memory.

After:
```
WARNING run_agent: Memory provider 'hindsight' is configured but reports unavailable; continuing without external memory. Run 'hermes memory status' to diagnose.
```
