### PR TITLE
fix(docker): route leading-dash CMD args to hermes (e.g. -p <profile>)

### DIFF
--- a/docker/main-wrapper.sh
+++ b/docker/main-wrapper.sh
@@ -73,7 +73,11 @@ if [ $# -eq 0 ]; then
     drop hermes
 fi
 
-if command -v "$1" >/dev/null 2>&1; then
+# `--` stops option parsing: without it, a hermes global flag as the first arg
+# (e.g. `docker run <image> -p viewer gateway run`) makes `command -v -p` treat
+# `-p` as an option to `command` and report success, mis-routing the args to the
+# bare-executable branch instead of `hermes -p viewer gateway run` (#43295).
+if command -v -- "$1" >/dev/null 2>&1; then
     # Bare executable — pass through directly.
     drop "$@"
 fi

--- a/tests/test_docker_main_wrapper_arg_routing.py
+++ b/tests/test_docker_main_wrapper_arg_routing.py
@@ -1,0 +1,37 @@
+"""main-wrapper.sh must route hermes global flags to `hermes <args>`.
+
+Regression for #43295: `docker run <image> -p viewer gateway run` lost the
+`-p viewer` and started a default `hermes gateway run`. The cause is the
+executable-detection probe — `command -v "$1"` parses a leading-dash first arg
+(`-p`) as an *option to `command`* and reports success, so the args were routed
+to the bare-executable branch (`exec "$@"`) instead of `hermes "$@"`. The fix
+is `command -v -- "$1"`, which stops option parsing.
+"""
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MAIN_WRAPPER = REPO_ROOT / "docker" / "main-wrapper.sh"
+
+
+def test_wrapper_uses_end_of_options_for_command_v():
+    text = MAIN_WRAPPER.read_text(encoding="utf-8")
+    assert 'command -v -- "$1"' in text, (
+        "main-wrapper.sh must use `command -v -- \"$1\"` so a leading-dash CMD "
+        "arg (e.g. `-p <profile>`) routes to `hermes <args>`"
+    )
+    # Guard against regression to the unsafe bare form.
+    assert 'command -v "$1"' not in text
+
+
+def test_command_v_dashdash_routes_leading_dash_to_hermes():
+    """Behavioral check in a real POSIX shell: a hermes flag is NOT detected as
+    an executable (so it falls through to the `hermes <args>` branch), while a
+    genuine bare executable still is."""
+    # `-p` (a hermes global flag) must NOT match -> routes to `hermes -p ...`.
+    assert subprocess.run(["sh", "-c", 'command -v -- "-p" >/dev/null 2>&1']).returncode != 0
+    # A real executable still matches -> routes around hermes (sleep/bash/sh).
+    assert subprocess.run(["sh", "-c", 'command -v -- "sh" >/dev/null 2>&1']).returncode == 0
+    # And the OLD bare form is what mis-detected `-p` as "found" (documents the bug).
+    assert subprocess.run(["sh", "-c", 'command -v "-p" >/dev/null 2>&1']).returncode == 0


### PR DESCRIPTION
## What & why — closes #43295

A profile-specific gateway in Docker Compose never starts:

```yaml
command: ["-p", "viewer", "gateway", "run"]   # want: hermes -p viewer gateway run
```

The container instead runs the default `hermes gateway run` (or fails), dropping `-p viewer`.

`docker/main-wrapper.sh` routes the container CMD:

```sh
if [ $# -eq 0 ]; then drop hermes; fi              # no args  -> hermes
if command -v "$1" >/dev/null 2>&1; then drop "$@"; fi  # bare executable -> exec directly
drop hermes "$@"                                    # else     -> hermes <args>
```

The middle probe is meant to detect a bare executable (`sleep`, `bash`) so `docker run <image> sleep 1` runs `sleep` directly. But when the first arg is a **hermes global flag** like `-p`, `command -v "$1"` becomes `command -v -p` — and `-p` is parsed as an **option to `command` itself** (not a name to look up), which returns success. The args are then mis-routed to the bare-executable branch (`drop "$@"`) instead of `drop hermes "$@"`.

Verified in both dash and sh:

```
$ command -v "-p"    ; echo $?   # 0  (BUG: -p taken as an option, "found")
$ command -v -- "-p" ; echo $?   # 1  (FIX: -p looked up as a name, not found)
```

## Fix

One line — stop option parsing with `--`:

```diff
-if command -v "$1" >/dev/null 2>&1; then
+if command -v -- "$1" >/dev/null 2>&1; then
```

Now a leading-dash first arg is always looked up as a *name*. Real executables (`sleep`, `bash`, `sh`) still match and route directly; hermes flags (`-p`, `--profile`, …) and subcommands fall through to `hermes "$@"`, so `-p viewer gateway run` correctly becomes `hermes -p viewer gateway run`.

## How to test

```bash
scripts/run_tests.sh tests/test_docker_main_wrapper_arg_routing.py   # 2 passed
```

Adds a static check (the wrapper uses `command -v -- "$1"`, not the bare form) and a behavioral check in a real POSIX shell (`-p` is not detected as an executable while `sh` is; the old bare form mis-detects `-p`). The Docker integration tests in `tests/docker/test_main_invocation.py` exercise the same routing end-to-end when a built image is available.

## Platforms

POSIX shell change in the container entrypoint; verified in dash and sh.