### PR TITLE
fix(dashboard): defer skills sync to background thread on startup (#43232)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10078,7 +10078,18 @@ def cmd_dashboard(args):
     # skills picker / agent skill discovery sees the bundled library.
     # cmd_chat does this in its own pre-dispatch block; the dashboard
     # backend is the desktop's primary entrypoint and needs the same.
-    _sync_bundled_skills_quietly()
+    #
+    # Run in a background thread: on NAS-mounted HERMES_HOME (Synology,
+    # NFS, CIFS) the skills sync performs synchronous file I/O that can
+    # put the Python process into D state (kernel uninterruptible sleep),
+    # blocking dashboard startup indefinitely.  Running it in the
+    # background lets the uvicorn server start accepting requests while
+    # the sync completes.
+    threading.Thread(
+        target=_sync_bundled_skills_quietly,
+        daemon=True,
+        name="dashboard-skills-sync",
+    ).start()
 
     if "HERMES_WEB_DIST" not in os.environ and not getattr(args, "skip_build", False):
         if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):


### PR DESCRIPTION
Fixes #43232. On NAS-mounted HERMES_HOME (Synology NFS/CIFS), the dashboard startup path calls _sync_bundled_skills_quietly() synchronously. The skills sync performs file I/O on HERMES_HOME that can block in D state (kernel uninterruptible sleep) when the filesystem is slow, preventing the dashboard server from ever starting. This change moves the skills sync into a daemon thread so uvicorn starts accepting requests immediately while the sync completes in the background.