### PR TITLE
fix(skills): resolve skill_view by frontmatter name when dir name differs

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -373,6 +373,26 @@ class TestSkillView:
         assert result["name"] == "my-skill"
         assert "Step 1" in result["content"]
 
+    def test_view_skill_by_frontmatter_name_when_dir_differs(self, tmp_path):
+        # The on-disk directory ("alias-dir") differs from the skill's
+        # frontmatter name ("real-skill-name"). skills_list() exposes the
+        # frontmatter name, so skill_view(name) must resolve it too.
+        skill_dir = tmp_path / "alias-dir"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: real-skill-name\n"
+            "description: A skill whose directory name differs from its name.\n"
+            "---\n\n"
+            "# real-skill-name\n\n"
+            "Step 1: Do the thing.\n"
+        )
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            raw = skill_view("real-skill-name")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "Step 1" in result["content"]
+
     def test_skill_view_applies_template_vars(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1032,9 +1032,20 @@ def skill_view(
                     _record(None, categorized_path.with_suffix(".md"))
 
             # Strategy 2: recursive by directory name (catches nested skills
-            # like "foundations/runtime/explore-codebase" called by bare name).
+            # like "foundations/runtime/explore-codebase" called by bare name),
+            # plus frontmatter `name:` lookup. `skills_list()` exposes the
+            # frontmatter name, so `skill_view(name)` must accept it too even
+            # when the on-disk directory is a shorter category/alias.
             for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
                 if found_skill_md.parent.name == name:
+                    _record(found_skill_md.parent, found_skill_md)
+                    continue
+                try:
+                    fm_content = found_skill_md.read_text(encoding="utf-8")
+                    fm, _ = _parse_frontmatter(fm_content)
+                except Exception:
+                    fm = {}
+                if fm.get("name") == name:
                     _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.


### PR DESCRIPTION
## Summary

Allow `skill_view` to resolve a skill by its frontmatter `name:` when the on-disk directory name differs.

`skills_list()` surfaces each skill's frontmatter `name:`, but `skill_view()` previously only matched on the on-disk directory name (Strategy 2). When a skill's directory is a shorter category/alias that differs from its frontmatter name, `skill_view(name)` failed to find it. The recursive Strategy-2 walk now also matches frontmatter `name:`, guarded by a try/except so an unreadable/malformed `SKILL.md` can't break discovery.

## Context

This is a single-concern salvage of one part of #39682, lifted onto current `main`. The original PR shipped this change **without a test**; this PR adds one. The other concerns in #39682 are already resolved upstream (Desktop `dist/**` and nested-category plugin discovery both landed on `main` separately), and the Langfuse data-URI fix from that PR is sent as its own PR.

## Test Plan

```bash
venv/bin/python -m pytest tests/tools/test_skills_tool.py -q
```

- 87 passed (adds `test_view_skill_by_frontmatter_name_when_dir_differs`).
- RED-GREEN verified: the new test **fails on current `main`** (skill not found) and **passes with this change**, proving it exercises the new frontmatter-name lookup path.
- `ruff check` clean on touched files.

Co-authored-by: foras910521-lab <foras910521-lab@users.noreply.github.com>
