### PR TITLE
fix(dashboard): point webhook-disabled hint at Channels page

### DIFF
--- a/web/src/pages/WebhooksPage.tsx
+++ b/web/src/pages/WebhooksPage.tsx
@@ -381,8 +381,8 @@ export default function WebhooksPage() {
             <div className="flex flex-col gap-1">
               <span className="font-medium">Webhook platform disabled</span>
               <span className="text-muted-foreground">
-                The webhook platform must be enabled in your messaging settings
-                before you can create subscriptions. Enable it, then return to
+                The webhook platform must be enabled on the Channels page before
+                you can create subscriptions. Enable it there, then return to
                 this page.
               </span>
             </div>


### PR DESCRIPTION
## Summary
The Webhooks dashboard page now tells users to enable the webhook platform on the **Channels** page — where it actually lives — instead of a nonexistent "messaging settings".

Reported by AllenKll [PUS]: the "Webhook platform disabled" card said *"must be enabled in your messaging settings"*, but there is no "messaging settings" page. Every other dashboard page refers to it as the Channels page (nav label, EnvPage, CronPage all say "configured on the Channels page" / "Set one up under Channels").

## Changes
- `web/src/pages/WebhooksPage.tsx`: disabled-state hint text `in your messaging settings` → `on the Channels page`. Hardcoded string, no i18n key involved.

## Validation
| | Before | After |
|---|---|---|
| Disabled-card text | "enabled in your messaging settings" | "enabled on the Channels page" |

## Infographic
![webhooks-hint-rerouted](https://v3b.fal.media/files/b/0a9db212/G_qi_WAepVeJl_diZpB7F_biwlgz2Q.png)
