### PR TITLE
fix(discord): propagate role_authorized flag so DISCORD_ALLOWED_ROLES works end-to-end

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -207,6 +207,11 @@ class GatewayAuthorizationMixin:
         if platform_allow_all_var and os.getenv(platform_allow_all_var, "").lower() in {"true", "1", "yes"}:
             return True
 
+        # Adapter-verified role auth: the Discord adapter already confirmed the
+        # user holds a role in DISCORD_ALLOWED_ROLES before dispatching the message.
+        if getattr(source, "role_authorized", False):
+            return True
+
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
             if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -209,7 +209,10 @@ class GatewayAuthorizationMixin:
 
         # Adapter-verified role auth: the Discord adapter already confirmed the
         # user holds a role in DISCORD_ALLOWED_ROLES before dispatching the message.
-        if getattr(source, "role_authorized", False):
+        # Compare with ``is True`` so the real bool field authorizes while a
+        # MagicMock source (test fixtures using ``object.__new__`` runners with
+        # mock sources) does not auto-truthy through this gate (see pitfall #13).
+        if getattr(source, "role_authorized", False) is True:
             return True
 
         if getattr(source, "is_bot", False):

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4651,6 +4651,7 @@ class BasePlatformAdapter(ABC):
         guild_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None,
         message_id: Optional[str] = None,
+        role_authorized: bool = False,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform."""
         # Normalize empty topic to None
@@ -4671,6 +4672,7 @@ class BasePlatformAdapter(ABC):
             guild_id=str(guild_id) if guild_id else None,
             parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
             message_id=str(message_id) if message_id else None,
+            role_authorized=role_authorized,
         )
     
     @abstractmethod

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -91,6 +91,7 @@ class SessionSource:
     guild_id: Optional[str] = None  # Discord guild / Slack workspace / Matrix server scope
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
+    role_authorized: bool = False  # True when adapter granted access via role (not user ID)
     
     @property
     def description(self) -> str:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -789,6 +789,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 # Must run BEFORE the user allowlist check so that bots
                 # permitted by DISCORD_ALLOW_BOTS are not rejected for
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
+                _role_authorized = False
                 if getattr(message.author, "bot", False):
                     allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
                     if allow_bots == "none":
@@ -812,6 +813,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         is_dm=_is_dm,
                     ):
                         return
+                    _role_authorized = bool(getattr(self, "_allowed_role_ids", set()))
                 
                 # Multi-agent filtering: if the message mentions specific bots
                 # but NOT this bot, the sender is talking to another agent —
@@ -853,7 +855,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         if "*" not in _free_channels and not (_channel_ids & _free_channels):
                             return
 
-                await self._handle_message(message)
+                await self._handle_message(message, role_authorized=_role_authorized)
 
             @self._client.event
             async def on_voice_state_update(member, before, after):
@@ -4702,7 +4704,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     raise Exception(f"HTTP {resp.status}")
                 return await resp.read()
 
-    async def _handle_message(self, message: DiscordMessage) -> None:
+    async def _handle_message(self, message: DiscordMessage, role_authorized: bool = False) -> None:
         """Handle incoming Discord messages."""
         # In server channels (not DMs), require the bot to be @mentioned
         # UNLESS the channel is in the free-response list or the message is
@@ -4886,6 +4888,7 @@ class DiscordAdapter(BasePlatformAdapter):
             guild_id=str(guild.id) if guild else None,
             parent_chat_id=parent_channel_id,
             message_id=str(message.id),
+            role_authorized=role_authorized,
         )
 
         # Build media URLs -- download image attachments to local cache so the

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1503,6 +1503,7 @@ AUTHOR_MAP = {
     "singhsanidhya741@gmail.com": "sanidhyasin",  # PR #40403 salvage (model.default_headers for custom OpenAI-compatible providers, #40033)
     "josephjohnson.joel@gmail.com": "JoelJJohnson",  # PR #39913 salvage (Windows ConPTY dashboard chat bridge)
     "andreas@schwarz-ketsch.de": "Nea74",  # PR #40022 co-author credit (same Windows ConPTY bridge design)
+    "chanhokyim@gmail.com": "joel611",  # PR #33958 salvage (DISCORD_ALLOWED_ROLES role_authorized gateway flag)
 }
 
 


### PR DESCRIPTION
## Summary
`DISCORD_ALLOWED_ROLES` now works on its own — sharing the bot with a team by role no longer requires also setting `DISCORD_ALLOWED_USERS`.

Root cause: the Discord adapter's `_is_allowed_user` honors `DISCORD_ALLOWED_ROLES`, so a role-authorized message passed intake. But the gateway's `_is_user_authorized` re-checked authorization and only read `DISCORD_ALLOWED_USERS`. With no users allowlist set, the role-authorized user fell through to default-deny and was rejected. Discord doesn't set `enforces_own_access_policy`, so the #34515 empty-allowlist escape hatch never covered it.

## Changes
- `gateway/session.py`: add `role_authorized: bool = False` to `SessionSource`.
- `gateway/platforms/base.py`: thread `role_authorized` through `build_source`.
- `plugins/platforms/discord/adapter.py`: set the flag after the adapter's guild-scoped role check passes; pass it into `_handle_message` → `build_source`.
- `gateway/authz_mixin.py`: `_is_user_authorized` honors `source.role_authorized` early.

## Validation
| Scenario (only `DISCORD_ALLOWED_ROLES` set) | Before | After |
|---|---|---|
| Role-authorized user (`role_authorized=True`) | rejected | authorized |
| Non-role user (`role_authorized=False`) | rejected | rejected (default-deny preserved) |

- E2E: built a Discord `SessionSource` with no env allowlists; `role_authorized=True` → authorized, `role_authorized=False` → denied. Flag is set server-side only after the adapter's real role match (incl. DM cross-guild guard), not spoofable from the wire.
- 74 gateway authz tests pass (`test_discord_bot_auth_bypass`, `test_config_driven_access_policy`, `test_unauthorized_dm_behavior`, `test_busy_session_auth_bypass`).

Salvage of #33958 by @joel611 — commit cherry-picked onto current main with authorship preserved. Closes #33958.


## Infographic

![DISCORD_ALLOWED_ROLES role_authorized fix](https://v3b.fal.media/files/b/0a9db254/yy4DDKeU6g_DJ_1QDd7Fz_WdtyyO15.png)
