### PR TITLE
fix(web): pass Firecrawl scrape timeout

### DIFF
--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -55,6 +55,9 @@ from tools.website_policy import check_website_access
 
 logger = logging.getLogger(__name__)
 
+FIRECRAWL_SCRAPE_TIMEOUT_SECONDS = 60
+FIRECRAWL_SCRAPE_TIMEOUT_MS = FIRECRAWL_SCRAPE_TIMEOUT_SECONDS * 1000
+
 
 # ---------------------------------------------------------------------------
 # Lazy Firecrawl SDK proxy
@@ -488,8 +491,9 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                             _get_firecrawl_client().scrape,
                             url=url,
                             formats=formats,
+                            timeout=FIRECRAWL_SCRAPE_TIMEOUT_MS,
                         ),
-                        timeout=60,
+                        timeout=FIRECRAWL_SCRAPE_TIMEOUT_SECONDS,
                     )
                 except asyncio.TimeoutError:
                     logger.warning("Firecrawl scrape timed out for %s", url)
@@ -499,8 +503,9 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                             "title": "",
                             "content": "",
                             "error": (
-                                "Scrape timed out after 60s — page may be too large "
-                                "or unresponsive. Try browser_navigate instead."
+                                f"Scrape timed out after {FIRECRAWL_SCRAPE_TIMEOUT_SECONDS}s — "
+                                "page may be too large or unresponsive. "
+                                "Try browser_navigate instead."
                             ),
                         }
                     )

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -353,6 +353,52 @@ class TestAsyncExtractDispatch:
         assert p is not None
         assert inspect.iscoroutinefunction(p.extract) is True
 
+    def test_firecrawl_extract_passes_timeout_to_scrape(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        scrape_calls: list[dict[str, object]] = []
+
+        class DummyFirecrawlClient:
+            def scrape(self, **kwargs: object) -> dict[str, object]:
+                scrape_calls.append(kwargs)
+                return {
+                    "markdown": "example body",
+                    "metadata": {
+                        "title": "Example",
+                        "sourceURL": kwargs["url"],
+                    },
+                }
+
+        monkeypatch.setattr(
+            firecrawl_provider,
+            "_get_firecrawl_client",
+            lambda: DummyFirecrawlClient(),
+        )
+        monkeypatch.setattr(
+            firecrawl_provider,
+            "check_website_access",
+            lambda _url: None,
+        )
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+        result = asyncio.run(
+            firecrawl_provider.FirecrawlWebSearchProvider().extract(
+                ["https://example.com/slow"],
+                format="markdown",
+            )
+        )
+
+        assert scrape_calls == [
+            {
+                "url": "https://example.com/slow",
+                "formats": ["markdown"],
+                "timeout": 60000,
+            }
+        ]
+        assert result[0]["content"] == "example body"
+
     def test_exa_extract_is_sync(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import get_provider

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -427,7 +427,8 @@ class TestWebToolPolicy:
             pytest.fail(f"unexpected URL checked: {url}")
 
         class FakeFirecrawlClient:
-            def scrape(self, url, formats):
+            def scrape(self, url, formats, timeout):
+                assert timeout == firecrawl_provider.FIRECRAWL_SCRAPE_TIMEOUT_MS
                 return {
                     "markdown": "secret content",
                     "metadata": {


### PR DESCRIPTION
## Summary
- Pass Firecrawl's server-side `timeout` option when scraping so it matches Hermes' existing 60s `asyncio.wait_for` guard.
- Centralize the Firecrawl scrape timeout constants used by the SDK call and user-facing timeout message.
- Add a regression test that exercises the async extract path and asserts the scrape call includes `timeout=60000`.

Fixes #43272

## Test Plan
- [x] `uv run --frozen --extra dev pytest tests/plugins/web/test_web_search_provider_plugins.py -q`
- [x] `git diff --check`
- [x] `uv run --frozen --extra dev ruff check plugins/web/firecrawl/provider.py tests/plugins/web/test_web_search_provider_plugins.py`
