### PR TITLE
fix(gateway): safely deliver local file URLs from image tags (QQBot Windows)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -22,6 +22,8 @@ import weakref
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
+import urllib.parse as _urllib_parse
+
 from utils import normalize_proxy_url
 
 logger = logging.getLogger(__name__)
@@ -3986,6 +3988,39 @@ class BasePlatformAdapter(ABC):
         """
         return await self.send_image(chat_id=chat_id, image_url=animation_url, caption=caption, reply_to=reply_to, metadata=metadata)
     
+
+    @staticmethod
+    def _normalize_file_url(url: str) -> Optional[str]:
+        """Normalize a file:// URI to a local file path."""
+        import urllib.parse
+        if not url:
+            return None
+        raw = url.strip()
+        if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "`'":
+            raw = raw[1:-1].strip()
+        if not raw.lower().startswith('file://'):
+            return None
+        normalised = raw.replace('\\', '/')
+        parsed = urllib.parse.urlparse(normalised)
+        if parsed.scheme.lower() != 'file':
+            return None
+        if parsed.netloc:
+            if len(parsed.netloc) == 2 and parsed.netloc[1] == ':':
+                local = parsed.netloc + parsed.path
+            else:
+                logger.debug("Rejecting UNC file:// URI: %s", _log_safe_path(url))
+                return None
+        else:
+            local = parsed.path
+            if len(local) >= 3 and local[0] == '/' and local[1].isalpha() and local[2] == ':':
+                local = local[1:]
+        local = urllib.parse.unquote(local)
+        local = local.replace('\\', '/')
+        if local.startswith('//'):
+            logger.debug("Rejecting decoded UNC file:// URI: %s", _log_safe_path(url))
+            return None
+        return local
+
     @staticmethod
     def _is_animation_url(url: str) -> bool:
         """Check if a URL points to an animated GIF (vs a static image)."""
@@ -4001,6 +4036,13 @@ class BasePlatformAdapter(ABC):
         - ![alt text](https://example.com/image.png)
         - <img src="https://example.com/image.png">
         - <img src="https://example.com/image.png"></img>
+        - ![alt text](file:///C:/path/to/screenshot.png)
+        - <img src="file:///C:/path/to/screenshot.png">
+
+        ``file://`` URIs are normalised via :meth:`_normalize_file_url` and
+        validated through :func:`validate_media_delivery_path`.  Invalid,
+        missing, unsafe or non-image ``file://`` candidates are silently
+        skipped so the original text is never deleted.
         
         Args:
             content: The response text to scan.
@@ -4010,34 +4052,108 @@ class BasePlatformAdapter(ABC):
         """
         images = []
         cleaned = content
-        
+
+        FILE_LIKE_EXTS = frozenset({
+            '.png', '.jpg', '.jpeg', '.gif', '.webp',
+        })
+
+        # Mask protected spans so file:// examples in code/sample text
+        # are not promoted to real attachments.  Scan against the masked
+        # copy; only matches that survived masking (still begin with `![`
+        # or `<img`) emit source-paths from the original content.
+        scan_content = BasePlatformAdapter._mask_protected_spans(content)
+        scan_content = BasePlatformAdapter._mask_json_string_media(scan_content)
+
+        # Accepted tag spans for cleanup -- (start, end) in original content
+        # coordinates (masking is offset-preserving).
+        accepted_spans: list = []
+
         # Match markdown images: ![alt](url)
-        md_pattern = r'!\[([^\]]*)\]\((https?://[^\s\)]+)\)'
-        for match in re.finditer(md_pattern, content):
-            alt_text = match.group(1)
-            url = match.group(2)
-            # Only extract URLs that look like actual images
-            if any(url.lower().endswith(ext) or ext in url.lower() for ext in
-                   ['.png', '.jpg', '.jpeg', '.gif', '.webp', 'fal.media', 'fal-cdn', 'replicate.delivery']):
-                images.append((url, alt_text))
-        
-        # Match HTML img tags: <img src="url"> or <img src="url"></img> or <img src="url"/>
-        html_pattern = r'<img\s+src=["\']?(https?://[^\s"\'<>]+)["\']?\s*/?>\s*(?:</img>)?'
-        for match in re.finditer(html_pattern, content):
-            url = match.group(1)
-            images.append((url, ""))
-        
-        # Remove only the matched image tags from content (not all markdown images)
-        if images:
-            extracted_urls = {url for url, _ in images}
-            def _remove_if_extracted(match):
-                url = match.group(2) if match.lastindex >= 2 else match.group(1)
-                return '' if url in extracted_urls else match.group(0)
-            cleaned = re.sub(md_pattern, _remove_if_extracted, cleaned)
-            cleaned = re.sub(html_pattern, _remove_if_extracted, cleaned)
-            # Clean up leftover blank lines
+        md_http_re = re.compile(
+            r'!\[([^\]]*)\]\((https?://[^\s\)]+)\)'
+        )
+        md_file_re = re.compile(
+            r'!\[([^\]]*)\]\((file://[^\)]+)\)', re.IGNORECASE
+        )
+        for md_re, is_file_pattern in [(md_http_re, False), (md_file_re, True)]:
+            for match in md_re.finditer(scan_content):
+                if not match.group(0).startswith('!['):
+                    continue
+                real_match = md_re.match(content[match.start():])
+                if not real_match:
+                    continue
+                alt_text = real_match.group(1)
+                url = real_match.group(2)
+                if is_file_pattern or url.lower().startswith('file://'):
+                    local_path = BasePlatformAdapter._normalize_file_url(url)
+                    if local_path and os.path.splitext(local_path)[1].lower() in FILE_LIKE_EXTS:
+                        validated = validate_media_delivery_path(local_path)
+                        if validated:
+                            norm_url = 'file://' + _urllib_parse.quote(validated, safe='/:\\')
+                            images.append((norm_url, alt_text))
+                            accepted_spans.append(match.span())
+                            continue
+                    logger.debug(
+                        "Skipping file:// image candidate (not found/unsafe): %s",
+                        _log_safe_path(url),
+                    )
+                elif any(url.lower().endswith(ext) or ext in url.lower() for ext in
+                       ['.png', '.jpg', '.jpeg', '.gif', '.webp', 'fal.media', 'fal-cdn', 'replicate.delivery']):
+                    images.append((url, alt_text))
+                    accepted_spans.append(match.span())
+
+        # Match HTML img tags
+        _html_img_tag_re = re.compile(
+            r'<img\s+[^>]*/?>\s*(?:</img>)?', re.IGNORECASE
+        )
+        _html_attr_re = re.compile(
+            r'([a-zA-Z_][-a-zA-Z0-9_]*)\s*=\s*(?:'
+            r'"([^"]*)"|\'([^\']*)\'|([^\s>]+))',
+            re.IGNORECASE,
+        )
+        for match in _html_img_tag_re.finditer(scan_content):
+            if not match.group(0).lower().startswith('<img'):
+                continue
+            real_tag = content[match.start():match.end()]
+            src_url = ""
+            for attr_m in _html_attr_re.finditer(real_tag):
+                if attr_m.group(1).lower() == "src":
+                    src_url = (
+                        attr_m.group(2)
+                        or attr_m.group(3)
+                        or attr_m.group(4)
+                        or ""
+                    )
+                    break
+            if not src_url:
+                continue
+            if not src_url.lower().startswith(('http://', 'https://', 'file://')):
+                continue
+            url = src_url
+            if url.lower().startswith('file://'):
+                local_path = BasePlatformAdapter._normalize_file_url(url)
+                if local_path and os.path.splitext(local_path)[1].lower() in FILE_LIKE_EXTS:
+                    validated = validate_media_delivery_path(local_path)
+                    if validated:
+                        norm_url = 'file://' + _urllib_parse.quote(validated, safe='/:\\')
+                        images.append((norm_url, ""))
+                        accepted_spans.append(match.span())
+                        continue
+                logger.debug(
+                    "Skipping file:// image candidate (not found/unsafe): %s",
+                    _log_safe_path(url),
+                )
+            else:
+                images.append((url, ""))
+                accepted_spans.append(match.span())
+
+        if accepted_spans:
+            chars = list(cleaned)
+            for start, end in sorted(accepted_spans, reverse=True):
+                del chars[start:end]
+            cleaned = ''.join(chars)
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
-        
+
         return images, cleaned
     
     async def send_voice(
@@ -4357,8 +4473,10 @@ class BasePlatformAdapter(ABC):
         # Build list of (start, end) spans to mask
         spans: list = []
 
-        # Fenced code blocks: ```...```
-        for m in re.finditer(r'```[^\n]*\n.*?```', content, re.DOTALL):
+        # Fenced code blocks: ```...``` or ~~~...~~~ (same open/close pair,
+        # unclosed fences are masked to end of content).
+        fence_re = re.compile(r"(```|~~~)[^\n]*\n.*?(?:\1|$)", re.DOTALL)
+        for m in fence_re.finditer(content):
             spans.append((m.start(), m.end()))
 
         # Inline code: `...` but NOT backtick-quoted paths in MEDIA: tags
@@ -4381,8 +4499,8 @@ class BasePlatformAdapter(ABC):
                     continue  # Real deliverable tag in inline code — keep it scannable
             spans.append((start, m.end()))
 
-        # Blockquote lines: > at line start
-        for m in re.finditer(r'^>.*$', content, re.MULTILINE):
+        # Blockquote lines: > at line start, with 0-3 leading spaces
+        for m in re.finditer(r'^ {0,3}>.*$', content, re.MULTILINE):
             spans.append((m.start(), m.end()))
 
         # Apply masking
@@ -4421,14 +4539,14 @@ class BasePlatformAdapter(ABC):
         Offsets are preserved (matched chars replaced with spaces, newlines kept)
         so downstream match positions stay valid.
         """
-        if '"' not in content or "MEDIA:" not in content:
+        if '"' not in content or ("media:" not in content.lower() and "file://" not in content.lower()):
             return content
         chars = list(content)
         # JSON value-context string: a quote preceded by : , { or [ (optional ws),
         # capturing the (escape-aware) string body up to the closing quote.
         for m in re.finditer(r'(?<=[:,{\[])\s*"((?:[^"\\\n]|\\.)*)"', content):
             seg = m.group(1)
-            if re.search(r'MEDIA:\s*(?:~/|/|[A-Za-z]:[/\\])', seg):
+            if re.search(r"(?:MEDIA:\s*(?:~/|/|[A-Za-z]:[/\\])|file://)", seg, re.IGNORECASE):
                 for i in range(m.start(1), m.end(1)):
                     if chars[i] != '\n':
                         chars[i] = ' '

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4009,13 +4009,8 @@ class BasePlatformAdapter(ABC):
             if len(parsed.netloc) == 2 and parsed.netloc[1] == ':':
                 local = parsed.netloc + parsed.path
             else:
-                # Percent-encoded path in netloc: file://C%3A%5C...
-                decoded_netloc = urllib.parse.unquote(parsed.netloc)
-                if len(decoded_netloc) >= 2 and decoded_netloc[1] == ':':
-                    local = decoded_netloc + parsed.path
-                else:
-                    logger.debug("Rejecting UNC file:// URI: %s", _log_safe_path(url))
-                    return None
+                logger.debug("Rejecting UNC file:// URI: %s", _log_safe_path(url))
+                return None
         else:
             local = parsed.path
             if len(local) >= 3 and local[0] == '/' and local[1].isalpha() and local[2] == ':':

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3926,10 +3926,11 @@ class BasePlatformAdapter(ABC):
                     safe_url_for_log(image_url),
                     alt_text[:30] if alt_text else "",
                 )
-                if image_url.startswith("file://"):
+                local_path = self._normalize_file_url(image_url)
+                if local_path is not None:
                     img_result = await self.send_image_file(
                         chat_id=chat_id,
-                        image_path=_unquote(image_url[7:]),
+                        image_path=local_path,
                         caption=alt_text if alt_text else None,
                         metadata=metadata,
                     )
@@ -4008,8 +4009,13 @@ class BasePlatformAdapter(ABC):
             if len(parsed.netloc) == 2 and parsed.netloc[1] == ':':
                 local = parsed.netloc + parsed.path
             else:
-                logger.debug("Rejecting UNC file:// URI: %s", _log_safe_path(url))
-                return None
+                # Percent-encoded path in netloc: file://C%3A%5C...
+                decoded_netloc = urllib.parse.unquote(parsed.netloc)
+                if len(decoded_netloc) >= 2 and decoded_netloc[1] == ':':
+                    local = decoded_netloc + parsed.path
+                else:
+                    logger.debug("Rejecting UNC file:// URI: %s", _log_safe_path(url))
+                    return None
         else:
             local = parsed.path
             if len(local) >= 3 and local[0] == '/' and local[1].isalpha() and local[2] == ':':

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -19,6 +19,8 @@ import weakref
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
+import urllib.parse as _urllib_parse
+
 from utils import normalize_proxy_url
 
 logger = logging.getLogger(__name__)
@@ -2588,7 +2590,6 @@ class BasePlatformAdapter(ABC):
         (Signal). Returns success when at least one image was delivered — the outcome
         the turn-level delivery tracker records; every override must return the same
         aggregate, or a media-only turn on that platform reports FAILURE (#106153)."""
-        from urllib.parse import unquote as _unquote
         delivered = False
         for image_url, alt_text in images:
             if human_delay > 0:
@@ -2596,8 +2597,9 @@ class BasePlatformAdapter(ABC):
             try:
                 logger.info("[%s] Sending image: %s (alt=%s)", self.name,
                             safe_url_for_log(image_url), alt_text[:30] if alt_text else "")
-                if image_url.startswith("file://"):
-                    sender, url_kw = self.send_image_file, {"image_path": _unquote(image_url[7:])}
+                local_path = self._normalize_file_url(image_url)
+                if local_path is not None:
+                    sender, url_kw = self.send_image_file, {"image_path": local_path}
                 elif self._is_animation_url(image_url):
                     sender, url_kw = self.send_animation, {"animation_url": image_url}
                 else:
@@ -2637,31 +2639,201 @@ class BasePlatformAdapter(ABC):
         return url.lower().split('?')[0].endswith('.gif')
 
     @staticmethod
-    def extract_images(content: str) -> Tuple[List[Tuple[str, str]], str]:
-        """Extract ``![alt](url)`` and ``<img src=...>`` image URLs from a response;
-        returns ``([(url, alt_text), ...], content with those tags removed)``."""
-        md_pattern = r'!\[([^\]]*)\]\((https?://[^\s\)]+)\)'
-        # <img src="url"> / <img src="url"></img> / <img src="url"/>
-        html_pattern = r'<img\s+src=["\']?(https?://[^\s"\'<>]+)["\']?\s*/?>\s*(?:</img>)?'
-        # Only extract URLs that look like actual images.
-        markers = ('.png', '.jpg', '.jpeg', '.gif', '.webp', 'fal.media', 'fal-cdn',
-                   'replicate.delivery')
-        images = [(m.group(2), m.group(1)) for m in re.finditer(md_pattern, content)
-                  if any(m.group(2).lower().endswith(ext) or ext in m.group(2).lower()
-                         for ext in markers)]
-        images.extend((match.group(1), "") for match in re.finditer(html_pattern, content))
-        if not images:
-            return images, content
-        # Remove only the tags we extracted, not every markdown image.
-        extracted_urls = {url for url, _ in images}
+    def _normalize_file_url(url: str) -> Optional[str]:
+        """Normalize a file:// URI to a local file path.
 
-        def _remove_if_extracted(match):
-            url = match.group(2) if match.lastindex >= 2 else match.group(1)
-            return '' if url in extracted_urls else match.group(0)
+        Accepts the canonical forms produced across the codebase:
+        - ``file:///tmp/a.png`` (POSIX, three slashes)
+        - ``file:///C:/dir/a.png`` (Windows, three slashes + drive)
+        - ``file://C:/dir/a.png`` (Windows, drive as authority)
+        - ``file://C%3A%5Cdir%5Ca.png`` (Windows path wrapped with the
+          default ``urllib.parse.quote()`` — the form produced by
+          ``file://{quote(path)}`` producers such as the gateway delivery
+          batching code).  The encoded drive+backslashes land entirely in
+          the authority segment because ``quote()`` (safe='/') percent-encodes
+          both ``:`` and ``\\``, leaving no ``/`` for urlparse to split on.
+        """
+        import urllib.parse
+        if not url:
+            return None
+        raw = url.strip()
+        if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "`'":
+            raw = raw[1:-1].strip()
+        if not raw.lower().startswith('file://'):
+            return None
+        normalised = raw.replace('\\', '/')
+        parsed = urllib.parse.urlparse(normalised)
+        if parsed.scheme.lower() != 'file':
+            return None
+        if parsed.netloc:
+            if len(parsed.netloc) == 2 and parsed.netloc[1] == ':':
+                local = parsed.netloc + parsed.path
+            else:
+                # Authority is not a bare drive letter.  It may still be an
+                # encoded Windows path (file://C%3A%5Cdir%5Ca.png): decode
+                # the authority and accept it ONLY when it resolves to an
+                # absolute drive path ("C:/...").  Any other authority —
+                # UNC hosts, encoded UNC (file://server%2Fshare%2Fa.png),
+                # drive-relative (file://C%3Arelative.png) — stays rejected.
+                # Note: a forward-slash variant with only the drive colon
+                # encoded (file://C%3A/dir/a.png) is intentionally NOT
+                # accepted here — no in-tree producer emits it (they wrap
+                # backslash paths), and rejecting it fails safe to text.
+                decoded_netloc = urllib.parse.unquote(parsed.netloc).replace('\\', '/')
+                if (len(decoded_netloc) >= 3
+                        and decoded_netloc[1] == ':'
+                        and decoded_netloc[2] == '/'):
+                    local = decoded_netloc + parsed.path
+                else:
+                    logger.debug("Rejecting UNC file:// URI: %s", _log_safe_path(url))
+                    return None
+        else:
+            local = parsed.path
+            if len(local) >= 3 and local[0] == '/' and local[1].isalpha() and local[2] == ':':
+                local = local[1:]
+        local = urllib.parse.unquote(local)
+        local = local.replace('\\', '/')
+        # Re-check the drive-letter form after percent-decoding: the
+        # encoded variant file:///C%3A/dir/a.png only becomes /C:/dir/a.png
+        # after unquote, and must normalize to C:/dir/a.png like the plain
+        # form.  POSIX absolute paths are untouched because local[2] is
+        # never ':' there.
+        if len(local) >= 3 and local[0] == '/' and local[1].isalpha() and local[2] == ':':
+            local = local[1:]
+        if local.startswith('//'):
+            logger.debug("Rejecting decoded UNC file:// URI: %s", _log_safe_path(url))
+            return None
+        return local
+
+    @staticmethod
+    def extract_images(content: str) -> Tuple[List[Tuple[str, str]], str]:
+        """
+        Extract image URLs from markdown and HTML image tags in a response.
+
+        Finds patterns like:
+        - ![alt text](https://example.com/image.png)
+        - <img src="https://example.com/image.png">
+        - <img src="https://example.com/image.png"></img>
+        - ![alt text](file:///C:/path/to/screenshot.png)
+        - <img src="file:///C:/path/to/screenshot.png">
+
+        ``file://`` URIs are normalised via :meth:`_normalize_file_url` and
+        validated through :func:`validate_media_delivery_path`.  Invalid,
+        missing, unsafe or non-image ``file://`` candidates are silently
+        skipped so the original text is never deleted.
+
+        Args:
+            content: The response text to scan.
+
+        Returns:
+            Tuple of (list of (url, alt_text) pairs, cleaned content with image tags removed).
+        """
+        images = []
         cleaned = content
-        for pattern in (md_pattern, html_pattern):
-            cleaned = re.sub(pattern, _remove_if_extracted, cleaned)
-        return images, re.sub(r'\n{3,}', '\n\n', cleaned).strip()  # leftover blank lines
+
+        FILE_LIKE_EXTS = frozenset({
+            '.png', '.jpg', '.jpeg', '.gif', '.webp',
+        })
+
+        # Mask protected spans so file:// examples in code/sample text
+        # are not promoted to real attachments.  Scan against the masked
+        # copy; only matches that survived masking (still begin with `![`
+        # or `<img`) emit source-paths from the original content.
+        scan_content = BasePlatformAdapter._mask_protected_spans(content)
+        scan_content = BasePlatformAdapter._mask_json_string_media(scan_content)
+
+        # Accepted tag spans for cleanup -- (start, end) in original content
+        # coordinates (masking is offset-preserving).
+        accepted_spans: list = []
+
+        # Match markdown images: ![alt](url)
+        md_http_re = re.compile(
+            r'!\[([^\]]*)\]\((https?://[^\s\)]+)\)'
+        )
+        md_file_re = re.compile(
+            r'!\[([^\]]*)\]\((file://[^\)]+)\)', re.IGNORECASE
+        )
+        for md_re, is_file_pattern in [(md_http_re, False), (md_file_re, True)]:
+            for match in md_re.finditer(scan_content):
+                if not match.group(0).startswith('!['):
+                    continue
+                real_match = md_re.match(content[match.start():])
+                if not real_match:
+                    continue
+                alt_text = real_match.group(1)
+                url = real_match.group(2)
+                if is_file_pattern or url.lower().startswith('file://'):
+                    local_path = BasePlatformAdapter._normalize_file_url(url)
+                    if local_path and os.path.splitext(local_path)[1].lower() in FILE_LIKE_EXTS:
+                        validated = validate_media_delivery_path(local_path)
+                        if validated:
+                            norm_url = 'file://' + _urllib_parse.quote(validated, safe='/:\\')
+                            images.append((norm_url, alt_text))
+                            accepted_spans.append(match.span())
+                            continue
+                    logger.debug(
+                        "Skipping file:// image candidate (not found/unsafe): %s",
+                        _log_safe_path(url),
+                    )
+                elif any(url.lower().endswith(ext) or ext in url.lower() for ext in
+                       ['.png', '.jpg', '.jpeg', '.gif', '.webp', 'fal.media', 'fal-cdn', 'replicate.delivery']):
+                    images.append((url, alt_text))
+                    accepted_spans.append(match.span())
+
+        # Match HTML img tags
+        _html_img_tag_re = re.compile(
+            r'<img\s+[^>]*/?>\s*(?:</img>)?', re.IGNORECASE
+        )
+        _html_attr_re = re.compile(
+            r'([a-zA-Z_][-a-zA-Z0-9_]*)\s*=\s*(?:'
+            r'"([^"]*)"|\'([^\']*)\'|([^\s>]+))',
+            re.IGNORECASE,
+        )
+        for match in _html_img_tag_re.finditer(scan_content):
+            if not match.group(0).lower().startswith('<img'):
+                continue
+            real_tag = content[match.start():match.end()]
+            src_url = ""
+            for attr_m in _html_attr_re.finditer(real_tag):
+                if attr_m.group(1).lower() == "src":
+                    src_url = (
+                        attr_m.group(2)
+                        or attr_m.group(3)
+                        or attr_m.group(4)
+                        or ""
+                    )
+                    break
+            if not src_url:
+                continue
+            if not src_url.lower().startswith(('http://', 'https://', 'file://')):
+                continue
+            url = src_url
+            if url.lower().startswith('file://'):
+                local_path = BasePlatformAdapter._normalize_file_url(url)
+                if local_path and os.path.splitext(local_path)[1].lower() in FILE_LIKE_EXTS:
+                    validated = validate_media_delivery_path(local_path)
+                    if validated:
+                        norm_url = 'file://' + _urllib_parse.quote(validated, safe='/:\\')
+                        images.append((norm_url, ""))
+                        accepted_spans.append(match.span())
+                        continue
+                logger.debug(
+                    "Skipping file:// image candidate (not found/unsafe): %s",
+                    _log_safe_path(url),
+                )
+            else:
+                images.append((url, ""))
+                accepted_spans.append(match.span())
+
+        if accepted_spans:
+            chars = list(cleaned)
+            for start, end in sorted(accepted_spans, reverse=True):
+                del chars[start:end]
+            cleaned = ''.join(chars)
+            cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
+
+        return images, cleaned
+
 
     async def send_voice(
         self, chat_id: str, audio_path: str, caption: Optional[str] = None,
@@ -2809,7 +2981,11 @@ class BasePlatformAdapter(ABC):
         """Blank fenced code, inline code and blockquotes (length-preserving so regex offsets stay
         valid) against MEDIA: false positives; backtick-quoted paths inside MEDIA: tags stay
         scannable."""
-        spans: list = [m.span() for m in _FENCED_CODE_RE.finditer(content)]
+        # Fenced code blocks: ```...``` or ~~~...~~~ (same open/close pair,
+        # unclosed fences are masked to end of content).  Kept local to this masker:
+        # _FENCED_CODE_RE stays the stricter shared pattern other call sites use.
+        _fence_re = re.compile(r"(```|~~~)[^\n]*\n.*?(?:\1|$)", re.DOTALL)
+        spans: list = [m.span() for m in _fence_re.finditer(content)]
         for m in _INLINE_CODE_RE.finditer(content):
             start = m.start()
             if re.search(r'MEDIA:\s*$', content[max(0, start - 20):start]):
@@ -2823,7 +2999,8 @@ class BasePlatformAdapter(ABC):
                 if candidate and validate_media_delivery_path(candidate):
                     continue  # Real deliverable tag in inline code — keep it scannable
             spans.append((start, m.end()))
-        spans.extend(m.span() for m in re.finditer(r'^>.*$', content, re.MULTILINE))
+        # Blockquote lines: > at line start, with 0-3 leading spaces (CommonMark spec).
+        spans.extend(m.span() for m in re.finditer(r'^ {0,3}>.*$', content, re.MULTILINE))
         return _blank_spans(content, spans)
 
     @staticmethod
@@ -2838,13 +3015,13 @@ class BasePlatformAdapter(ABC):
         ``MEDIA_TAG_CLEANUP_RE`` would still match it and re-deliver a stale file. (Regression report
         #34375.)
         """
-        if '"' not in content or "MEDIA:" not in content:
+        if '"' not in content or ("media:" not in content.lower() and "file://" not in content.lower()):
             return content
         # Value-context string: quote preceded by : , { or [; escape-aware body to the closing
         # quote.
         spans = [
             m.span(1) for m in re.finditer(r'(?<=[:,{\[])\s*"((?:[^"\\\n]|\\.)*)"', content)
-            if re.search(r'MEDIA:\s*(?:~/|/|[A-Za-z]:[/\\])', m.group(1))]
+            if re.search(r"(?:MEDIA:\s*(?:~/|/|[A-Za-z]:[/\\])|file://)", m.group(1), re.IGNORECASE)]
         return _blank_spans(content, spans)
 
     @staticmethod

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18416,8 +18416,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         already shown to the user as text, or (b) stale tool/inspected
         content that was never part of the intended visible reply. Promoting
         such paths into uploads after the fact sent files the model never
-        asked to deliver (#20834). Only ``MEDIA:`` directives — the explicit
-        attachment contract — trigger post-stream uploads.
+        asked to deliver (#20834). Only ``MEDIA:`` directives and explicit
+        ``file://`` markdown/HTML image tags — the explicit attachment
+        contracts — trigger post-stream uploads.
         """
         from pathlib import Path
         from urllib.parse import quote as _quote
@@ -18702,6 +18703,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Send extracted images via send_multiple_images so that
                 # ``file://`` URIs reach ``send_image_file`` (decoded) instead
                 # of being passed as a literal pathname to ``send_image``.
+                # Build canonical dedup keys from file:// images so the
+                # media_files loop below does NOT re-send the same file.
+                _image_dedup_keys: set = set()
+                for img_url, _ in (images or []):
+                    if img_url.lower().startswith('file://'):
+                        _n = BasePlatformAdapter._normalize_file_url(img_url)
+                        if _n:
+                            _image_dedup_keys.add(os.path.normcase(_n))
                 if images:
                     try:
                         await adapter.send_multiple_images(
@@ -18736,11 +18745,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 metadata=_thread_metadata,
                             )
                         elif _ext in _IMAGE_EXTS:
-                            await adapter.send_image_file(
-                                chat_id=source.chat_id,
-                                image_path=media_path,
-                                metadata=_thread_metadata,
-                            )
+                            if os.path.normcase(media_path) not in _image_dedup_keys:
+                                await adapter.send_image_file(
+                                    chat_id=source.chat_id,
+                                    image_path=media_path,
+                                    metadata=_thread_metadata,
+                                )
                         else:
                             await adapter.send_document(
                                 chat_id=source.chat_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18446,7 +18446,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # post-stream delivery is explicit-only (#20834). Bare local paths
             # in an already-streamed reply are text the user has seen (or
             # stale inspected content), not an attachment request.
-            adapter.extract_images(cleaned)
+            # Capture extracted images for dedup with MEDIA paths below
+            _stream_extracted_images, cleaned = adapter.extract_images(cleaned)
 
             _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
 
@@ -18457,23 +18458,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # (e.g. Signal's multi-attachment RPC). When [[as_document]] was
             # set, image-extension files skip the photo path and route to
             # send_document below — preserving original bytes.
-            image_paths: list = []
+            image_delivery: list = []
             non_image_media: list = []
+            delivery_keys: set = set()
             for media_path, is_voice in media_files:
                 ext = Path(media_path).suffix.lower()
                 if (ext in _IMAGE_EXTS
                         and not is_voice
                         and not force_document_attachments):
-                    image_paths.append(media_path)
+                    image_delivery.append((f"file://{_quote(media_path)}", ""))
+                    delivery_keys.add(("local", os.path.normcase(media_path)))
                 else:
                     non_image_media.append((media_path, is_voice))
 
-            if image_paths:
+            # Also include explicit image tags (HTTP(S) or file:// URIs)
+            # from extract_images, deduplicated against MEDIA paths.
+            # Uses canonical local-path keys from the resolved MEDIA paths
+            # and `_normalize_file_url` for file:// extracted images so:
+            #   - foo.png and foo.png.backup.png (different files) both deliver
+            #   - file://C:/a.png and file:///C:/a.png (same file) deliver once
+            #   - MEDIA:/a.png and file:///C:/a.png (same file) deliver once
+            # HTTP(S) URLs use exact-string comparison.
+            # Namespace tuples prevent accidental collision between local paths
+            # and URL strings.
+            for img_url, img_alt in _stream_extracted_images:
+                if img_url.lower().startswith('file://'):
+                    normed = BasePlatformAdapter._normalize_file_url(img_url)
+                    if normed:
+                        key = ("local", os.path.normcase(normed))
+                        if key in delivery_keys:
+                            continue
+                        delivery_keys.add(key)
+                elif ("local", img_url) in delivery_keys or ("url", img_url) in delivery_keys:
+                    continue
+                else:
+                    delivery_keys.add(("url", img_url))
+                image_delivery.append((img_url, img_alt))
+
+            if image_delivery:
                 try:
-                    images = [(f"file://{_quote(p)}", "") for p in image_paths]
                     await adapter.send_multiple_images(
                         chat_id=event.source.chat_id,
-                        images=images,
+                        images=image_delivery,
                         metadata=_thread_meta,
                     )
                 except Exception as e:
@@ -18673,13 +18699,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         metadata=_thread_metadata,
                     )
 
-                # Send extracted images
-                for image_url, alt_text in (images or []):
+                # Send extracted images via send_multiple_images so that
+                # ``file://`` URIs reach ``send_image_file`` (decoded) instead
+                # of being passed as a literal pathname to ``send_image``.
+                if images:
                     try:
-                        await adapter.send_image(
+                        await adapter.send_multiple_images(
                             chat_id=source.chat_id,
-                            image_url=image_url,
-                            caption=alt_text,
+                            images=images,
                             metadata=_thread_metadata,
                         )
                     except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2677,8 +2677,9 @@ def _strip_response_attachments_for_direct_send(response: str, adapter) -> str:
     Only explicit ``MEDIA:`` attachments are stripped; bare paths/URLs stay visible. No broad regex after
     ``extract_media()``: it deliberately preserves protected code spans and unvalidated tags.
 
-    Queued follow-up resends only replay explicit ``MEDIA:`` attachments in this path. Keep bare local paths
-    and ordinary image URLs visible because the post-stream uploader intentionally ignores them (#20834).
+    Queued follow-up resends only replay explicit ``MEDIA:`` attachments in this path. Bare local paths stay
+    visible as text; explicit image tags (``http(s)://`` / ``file://``) in the response are delivered separately
+    by the post-stream uploader after the text is sent.
     """
     _, cleaned = adapter.extract_media(response)
     return cleaned.replace("[[audio_as_voice]]", "").replace("[[as_document]]", "").strip()

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -11,6 +11,7 @@ import asyncio
 import dataclasses
 import json
 import logging
+import os
 import time
 from contextlib import suppress
 from pathlib import Path
@@ -260,8 +261,8 @@ class GatewayNotificationsMixin:
         files the model never asked for. MEDIA tags are NOT deduped against prior turns (a final-reply
         directive is a deliberate attach); stale auto-appended tags are deduped upstream.
 
-        Only ``MEDIA:`` directives — the explicit attachment contract — trigger post-stream uploads. See
-        #20834.
+        Only explicit attachment directives trigger post-stream uploads: ``MEDIA:`` paths, and explicit
+        ``file://`` / ``http(s)://`` markdown/HTML image tags extracted by ``extract_images``. See #20834.
         """
         from urllib.parse import quote as _quote
         with _log_suppressed(logging.WARNING, "Post-stream media extraction failed: %s"):
@@ -278,7 +279,8 @@ class GatewayNotificationsMixin:
             # the same filter removal on the non-streaming path in gateway/platforms/base.py. Bare local
             # paths in an already-streamed reply are text the user has seen (or stale inspected content),
             # not an attachment request.
-            adapter.extract_images(cleaned)
+            # Capture extracted images for dedup with the MEDIA paths below.
+            _stream_extracted_images, cleaned = adapter.extract_images(cleaned)
             _thread_meta = (
                 dict(thread_metadata)
                 if thread_metadata is not None
@@ -292,10 +294,34 @@ class GatewayNotificationsMixin:
 
             image_paths = [p for p, v in media_files if _is_photo(p, v)]
             non_image_media = [(p, v) for p, v in media_files if not _is_photo(p, v)]
-            if image_paths:
+            # Explicit image tags from extract_images ride the same batch, deduplicated
+            # against the MEDIA paths above. Keys are canonical -- resolved MEDIA paths
+            # plus ``_normalize_file_url`` output for file:// images -- so
+            # file://C:/a.png and file:///C:/a.png (same file) deliver once, while
+            # foo.png and foo.png.backup.png (different files) both deliver. HTTP(S)
+            # URLs compare by exact string, and namespace tuples keep a local path from
+            # colliding with a URL string.
+            image_delivery: list = []
+            delivery_keys: set = set()
+            for media_path in image_paths:
+                image_delivery.append((f"file://{_quote(media_path)}", ""))
+                delivery_keys.add(("local", os.path.normcase(media_path)))
+            for _img_url, _img_alt in _stream_extracted_images:
+                if _img_url.lower().startswith('file://'):
+                    _normed = BasePlatformAdapter._normalize_file_url(_img_url)
+                    if _normed:
+                        _key = ("local", os.path.normcase(_normed))
+                        if _key in delivery_keys:
+                            continue
+                        delivery_keys.add(_key)
+                elif ("local", _img_url) in delivery_keys or ("url", _img_url) in delivery_keys:
+                    continue
+                else:
+                    delivery_keys.add(("url", _img_url))
+                image_delivery.append((_img_url, _img_alt))
+            if image_delivery:
                 try:
-                    images = [(f"file://{_quote(p)}", "") for p in image_paths]
-                    await adapter.send_multiple_images(chat_id=chat_id, images=images, metadata=_thread_meta)
+                    await adapter.send_multiple_images(chat_id=chat_id, images=image_delivery, metadata=_thread_meta)
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
             for media_path, is_voice in non_image_media:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2217,10 +2217,20 @@ class GatewayTurnMixin:
                 await adapter.send(
                     chat_id=source.chat_id, content=header + "(No response generated)", metadata=_thread_metadata,
                 )
-            for image_url, alt_text in (images or []):
+            # Extracted images ride one send_multiple_images batch so ``file://`` URIs
+            # reach ``send_image_file`` (decoded) instead of being handed to
+            # ``send_image`` as a literal pathname. Canonical dedup keys keep the
+            # media_files loop below from re-sending the same file.
+            _image_dedup_keys: set = set()
+            for _img_url, _img_alt in (images or []):
+                if _img_url.lower().startswith('file://'):
+                    _normed = BasePlatformAdapter._normalize_file_url(_img_url)
+                    if _normed:
+                        _image_dedup_keys.add(os.path.normcase(_normed))
+            if images:
                 with suppress(Exception):
-                    await adapter.send_image(
-                        chat_id=source.chat_id, image_url=image_url, caption=alt_text, metadata=_thread_metadata,
+                    await adapter.send_multiple_images(
+                        chat_id=source.chat_id, images=images, metadata=_thread_metadata,
                     )
             # Route each media file by type (voice bubble / video / image / document), as the
             # streaming + kanban paths do.
@@ -2235,6 +2245,8 @@ class GatewayTurnMixin:
                             is_voice=_is_voice,
                         )
                     else:
+                        if _ext in _IMAGE_EXTS and os.path.normcase(media_path) in _image_dedup_keys:
+                            continue  # already delivered by the image batch above
                         sender, key = (
                             (adapter.send_video, "video_path") if _ext in _VIDEO_EXTS
                             else (adapter.send_image_file, "image_path") if _ext in _IMAGE_EXTS

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -167,6 +167,119 @@ class TestRunBackgroundTask:
         mock_agent_instance.close.assert_called_once()
 
 
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("task_id,filename,uri_spec", [
+        ("bg_qqbot_file", "shot.png", "two_slash"),
+        ("bg_win_file_url", "win_test.png", "three_slash_windows"),
+    ])
+    async def test_qqbot_background_task_file_url_routes_to_send_image_file(self, tmp_path, monkeypatch, task_id, filename, uri_spec):
+        """Background-task finalizer sees ``file://`` images and routes them
+        through ``send_multiple_images`` (which decodes to ``send_image_file``)
+        rather than passing the ``file://`` string verbatim to ``send_image``.
+
+        Regression: before the fix, `_run_background_task` looped over the
+        extracted images and called ``adapter.send_image(image_url=...)`` for
+        each. QQBot's ``_is_url`` only recognises ``http(s)``, so a
+        ``file:///C:/.../foo.png`` URI was treated as a literal local
+        pathname and forwarded to ``_send_media``'s local-file branch.
+        """
+        from urllib.parse import quote as _urlquote
+
+        from gateway import run as gateway_run
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+        png = tmp_path / filename
+        png.write_bytes(b"png")
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (tmp_path.resolve(),),
+        )
+
+        class _QQBotLikeAdapter(BasePlatformAdapter):
+            def __init__(self):
+                super().__init__(PlatformConfig(enabled=True, token="test"), Platform.QQBOT)
+                self.send_calls = []
+
+            async def connect(self, *, is_reconnect: bool = False):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def send(self, chat_id, content=None, **kwargs):
+                self.send_calls.append(("send", chat_id, content))
+                return SendResult(success=True, message_id="text")
+
+            async def get_chat_info(self, chat_id):
+                return {"id": chat_id, "type": "dm"}
+
+        adapter = _QQBotLikeAdapter()
+        adapter.send_image = AsyncMock(return_value=SendResult(success=True, message_id="img"))
+        adapter.send_image_file = AsyncMock(
+            return_value=SendResult(success=True, message_id="img-file")
+        )
+
+        runner.adapters[Platform.QQBOT] = adapter
+
+        source = SessionSource(
+            platform=Platform.QQBOT,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        file_url = ("file://" + _urlquote(str(png), safe="/:\\") if uri_spec == "two_slash"
+                    else "file:///" + _urlquote(str(png.resolve()), safe="/:\\\\"))
+
+        runner._run_in_executor_with_context = AsyncMock(
+            return_value={
+                "final_response": f"see attached ![pic]({file_url})",
+                "messages": [],
+            }
+        )
+
+        await runner._run_background_task(
+            "make pic", source, task_id,
+        )
+
+        # Verify send_image was NOT called with the raw file:// URI
+        for call in adapter.send_image.await_args_list or []:
+            url_arg = call.kwargs.get("image_url") or (
+                call.args[1] if len(call.args) > 1 else None
+            )
+            assert not (url_arg and str(url_arg).startswith("file://")), (
+                f"send_image should not receive raw file:// URI, got {url_arg!r}"
+            )
+        # send_image_file must be called once with the decoded path,
+        # proving the file:// URI flowed through send_multiple_images.
+        adapter.send_image_file.assert_awaited_once()
+        _, kwargs = adapter.send_image_file.call_args
+        received_path = kwargs.get("image_path")
+        assert received_path is not None
+        expected = str(png).replace("/", "\\\\").casefold()
+        got = str(received_path).replace("/", "\\\\").casefold()
+        assert expected in got, (
+            f"decoded image_path mismatch: expected {expected!r}, got {got!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # /background in help and known_commands
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -282,6 +282,98 @@ class TestRunBackgroundTask:
         )
 
 
+    @pytest.mark.asyncio
+    async def test_background_task_media_and_file_url_dedup(self, tmp_path, monkeypatch):
+        """Background finalizer with MEDIA:path + file:// tag for the same
+        file sends it only once via send_image_file."""
+        from urllib.parse import quote as _urlquote
+
+        from gateway import run as gateway_run
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+        png = tmp_path / "shared.png"
+        png.write_bytes(b"png")
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (tmp_path.resolve(),),
+        )
+
+        class _QQBotLike(BasePlatformAdapter):
+            def __init__(self):
+                super().__init__(PlatformConfig(enabled=True, token="test"), Platform.QQBOT)
+                self.send_calls = []
+
+            async def connect(self, *, is_reconnect: bool = False):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def send(self, chat_id, content=None, **kwargs):
+                self.send_calls.append(("send", chat_id, content))
+                return SendResult(success=True, message_id="text")
+
+            async def get_chat_info(self, chat_id):
+                return {"id": chat_id, "type": "dm"}
+
+        adapter = _QQBotLike()
+        adapter.send_image = AsyncMock(return_value=SendResult(success=True, message_id="img"))
+        adapter.send_image_file = AsyncMock(
+            return_value=SendResult(success=True, message_id="img-file")
+        )
+        adapter.send_multiple_images = AsyncMock(
+            return_value=SendResult(success=True, message_id="batch")
+        )
+        adapter.send_voice = AsyncMock(return_value=SendResult(success=True, message_id="voice"))
+        adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc"))
+
+        runner.adapters[Platform.QQBOT] = adapter
+
+        source = SessionSource(
+            platform=Platform.QQBOT,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        file_url = "file://" + _urlquote(str(png), safe="/:\\\\")
+        runner._run_in_executor_with_context = AsyncMock(
+            return_value={
+                "final_response": f"MEDIA:{png} ![pic]({file_url})",
+                "messages": [],
+            }
+        )
+
+        await runner._run_background_task(
+            "make pic", source, "bg_dedup_test",
+        )
+
+        # send_multiple_images was called once for the extracted image tag.
+        adapter.send_multiple_images.assert_awaited_once()
+        # The MEDIA: path points to the same file as the file:// tag,
+        # so the dedup guard in the media_files loop prevents re-send.
+        adapter.send_image_file.assert_not_awaited()
+        # No voice or document delivery for the image file
+        adapter.send_voice.assert_not_awaited()
+        adapter.send_document.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # /background in help and known_commands
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -5,6 +5,7 @@ background session) across gateway messenger platforms.
 """
 
 import asyncio
+import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -174,6 +175,7 @@ class TestRunBackgroundTask:
         ("bg_qqbot_file", "shot.png", "two_slash"),
         pytest.param("bg_win_file_url", "win_test.png", "three_slash_windows",
                      marks=pytest.mark.skipif(sys.platform != "win32", reason="Windows path semantics")),
+        ("bg_uppercase_scheme", "normal.png", "uppercase_scheme"),
     ])
     async def test_qqbot_background_task_file_url_routes_to_send_image_file(self, tmp_path, monkeypatch, task_id, filename, uri_spec):
         """Background-task finalizer sees ``file://`` images and routes them
@@ -248,7 +250,8 @@ class TestRunBackgroundTask:
         )
 
         file_url = ("file://" + _urlquote(str(png), safe="/:\\") if uri_spec == "two_slash"
-                    else "file:///" + _urlquote(str(png.resolve()), safe="/:\\\\"))
+                    else "FILE://" + _urlquote(str(png), safe="/:\\") if uri_spec == "uppercase_scheme"
+                    else "file:///" + _urlquote(str(png.resolve()), safe="/:"))
 
         runner._run_in_executor_with_context = AsyncMock(
             return_value={
@@ -275,10 +278,10 @@ class TestRunBackgroundTask:
         _, kwargs = adapter.send_image_file.call_args
         received_path = kwargs.get("image_path")
         assert received_path is not None
-        expected = str(png).replace("/", "\\\\").casefold()
-        got = str(received_path).replace("/", "\\\\").casefold()
-        assert expected in got, (
-            f"decoded image_path mismatch: expected {expected!r}, got {got!r}"
+        # _normalize_file_url returns forward-slash paths; normcase
+        # handles both backslash/forward-slash and case differences.
+        assert os.path.normcase(str(received_path)) == os.path.normcase(str(png)), (
+            f"decoded image_path mismatch: expected {png!r}, got {received_path!r}"
         )
 
 

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -5,6 +5,7 @@ background session) across gateway messenger platforms.
 """
 
 import asyncio
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -171,7 +172,8 @@ class TestRunBackgroundTask:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("task_id,filename,uri_spec", [
         ("bg_qqbot_file", "shot.png", "two_slash"),
-        ("bg_win_file_url", "win_test.png", "three_slash_windows"),
+        pytest.param("bg_win_file_url", "win_test.png", "three_slash_windows",
+                     marks=pytest.mark.skipif(sys.platform != "win32", reason="Windows path semantics")),
     ])
     async def test_qqbot_background_task_file_url_routes_to_send_image_file(self, tmp_path, monkeypatch, task_id, filename, uri_spec):
         """Background-task finalizer sees ``file://`` images and routes them

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -5,6 +5,8 @@ background session) across gateway messenger platforms.
 """
 
 import asyncio
+import os
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -161,6 +163,214 @@ class TestRunBackgroundTask:
         assert agent_kwargs["checkpoint_max_file_size_mb"] == 3
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
+
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("task_id,filename,uri_spec", [
+        ("bg_qqbot_file", "shot.png", "two_slash"),
+        pytest.param("bg_win_file_url", "win_test.png", "three_slash_windows",
+                     marks=pytest.mark.skipif(sys.platform != "win32", reason="Windows path semantics")),
+        ("bg_uppercase_scheme", "normal.png", "uppercase_scheme"),
+    ])
+    async def test_qqbot_background_task_file_url_routes_to_send_image_file(self, tmp_path, monkeypatch, task_id, filename, uri_spec):
+        """Background-task finalizer sees ``file://`` images and routes them
+        through ``send_multiple_images`` (which decodes to ``send_image_file``)
+        rather than passing the ``file://`` string verbatim to ``send_image``.
+
+        Regression: before the fix, `_run_background_task` looped over the
+        extracted images and called ``adapter.send_image(image_url=...)`` for
+        each. QQBot's ``_is_url`` only recognises ``http(s)``, so a
+        ``file:///C:/.../foo.png`` URI was treated as a literal local
+        pathname and forwarded to ``_send_media``'s local-file branch.
+        """
+        from urllib.parse import quote as _urlquote
+
+        from gateway import run as gateway_run
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+        png = tmp_path / filename
+        png.write_bytes(b"png")
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (tmp_path.resolve(),),
+        )
+
+        class _QQBotLikeAdapter(BasePlatformAdapter):
+            def __init__(self):
+                super().__init__(PlatformConfig(enabled=True, token="test"), Platform.QQBOT)
+                self.send_calls = []
+
+            async def connect(self, *, is_reconnect: bool = False):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def send(self, chat_id, content=None, **kwargs):
+                self.send_calls.append(("send", chat_id, content))
+                return SendResult(success=True, message_id="text")
+
+            async def get_chat_info(self, chat_id):
+                return {"id": chat_id, "type": "dm"}
+
+        adapter = _QQBotLikeAdapter()
+        adapter.send_image = AsyncMock(return_value=SendResult(success=True, message_id="img"))
+        adapter.send_image_file = AsyncMock(
+            return_value=SendResult(success=True, message_id="img-file")
+        )
+
+        runner.adapters[Platform.QQBOT] = adapter
+
+        source = SessionSource(
+            platform=Platform.QQBOT,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        file_url = ("file://" + _urlquote(str(png), safe="/:\\") if uri_spec == "two_slash"
+                    else "FILE://" + _urlquote(str(png), safe="/:\\") if uri_spec == "uppercase_scheme"
+                    else "file:///" + _urlquote(str(png.resolve()), safe="/:"))
+
+        runner._run_in_executor_with_context = AsyncMock(
+            return_value={
+                "final_response": f"see attached ![pic]({file_url})",
+                "messages": [],
+            }
+        )
+
+        await runner._run_background_task(
+            "make pic", source, task_id,
+        )
+
+        # Verify send_image was NOT called with the raw file:// URI
+        for call in adapter.send_image.await_args_list or []:
+            url_arg = call.kwargs.get("image_url") or (
+                call.args[1] if len(call.args) > 1 else None
+            )
+            assert not (url_arg and str(url_arg).startswith("file://")), (
+                f"send_image should not receive raw file:// URI, got {url_arg!r}"
+            )
+        # send_image_file must be called once with the decoded path,
+        # proving the file:// URI flowed through send_multiple_images.
+        adapter.send_image_file.assert_awaited_once()
+        _, kwargs = adapter.send_image_file.call_args
+        received_path = kwargs.get("image_path")
+        assert received_path is not None
+        # _normalize_file_url returns forward-slash paths; normcase
+        # handles both backslash/forward-slash and case differences.
+        assert os.path.normcase(str(received_path)) == os.path.normcase(str(png)), (
+            f"decoded image_path mismatch: expected {png!r}, got {received_path!r}"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_background_task_media_and_file_url_dedup(self, tmp_path, monkeypatch):
+        """Background finalizer with MEDIA:path + file:// tag for the same
+        file sends it only once via send_image_file."""
+        from urllib.parse import quote as _urlquote
+
+        from gateway import run as gateway_run
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+        png = tmp_path / "shared.png"
+        png.write_bytes(b"png")
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (tmp_path.resolve(),),
+        )
+
+        class _QQBotLike(BasePlatformAdapter):
+            def __init__(self):
+                super().__init__(PlatformConfig(enabled=True, token="test"), Platform.QQBOT)
+                self.send_calls = []
+
+            async def connect(self, *, is_reconnect: bool = False):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def send(self, chat_id, content=None, **kwargs):
+                self.send_calls.append(("send", chat_id, content))
+                return SendResult(success=True, message_id="text")
+
+            async def get_chat_info(self, chat_id):
+                return {"id": chat_id, "type": "dm"}
+
+        adapter = _QQBotLike()
+        adapter.send_image = AsyncMock(return_value=SendResult(success=True, message_id="img"))
+        adapter.send_image_file = AsyncMock(
+            return_value=SendResult(success=True, message_id="img-file")
+        )
+        adapter.send_multiple_images = AsyncMock(
+            return_value=SendResult(success=True, message_id="batch")
+        )
+        adapter.send_voice = AsyncMock(return_value=SendResult(success=True, message_id="voice"))
+        adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc"))
+
+        runner.adapters[Platform.QQBOT] = adapter
+
+        source = SessionSource(
+            platform=Platform.QQBOT,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        file_url = "file://" + _urlquote(str(png), safe="/:\\\\")
+        runner._run_in_executor_with_context = AsyncMock(
+            return_value={
+                "final_response": f"MEDIA:{png} ![pic]({file_url})",
+                "messages": [],
+            }
+        )
+
+        await runner._run_background_task(
+            "make pic", source, "bg_dedup_test",
+        )
+
+        # send_multiple_images was called once for the extracted image tag.
+        adapter.send_multiple_images.assert_awaited_once()
+        # The MEDIA: path points to the same file as the file:// tag,
+        # so the dedup guard in the media_files loop prevents re-send.
+        adapter.send_image_file.assert_not_awaited()
+        # No voice or document delivery for the image file
+        adapter.send_voice.assert_not_awaited()
+        adapter.send_document.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_media_only_outcome.py
+++ b/tests/gateway/test_media_only_outcome.py
@@ -11,6 +11,7 @@ turn reports SUCCESS and a failed one still reports FAILURE.
 """
 
 import asyncio
+import os
 
 import pytest
 
@@ -98,7 +99,14 @@ async def test_media_only_success_reports_success(tmp_path, monkeypatch):
     event = _make_event()
     await adapter._process_message_background(event, build_session_key(event.source))
 
-    assert adapter.images_sent == [str(png)]
+    # The delivery contract is "the adapter can open this path", not "the path is
+    # spelled with the platform separator": the shared decoder returns forward-slash
+    # paths on Windows (``C:/dir/a.png``), which is the same file as ``str(png)``.
+    # Compare separator-agnostically; the assertions that matter here are the
+    # SUCCESS/FAILURE outcomes below.
+    assert [os.path.normcase(p) for p in adapter.images_sent] == [
+        os.path.normcase(str(png))
+    ]
     assert adapter.outcomes == [ProcessingOutcome.SUCCESS]
 
 
@@ -116,5 +124,7 @@ async def test_media_only_failure_still_reports_failure(tmp_path, monkeypatch):
     event = _make_event()
     await adapter._process_message_background(event, build_session_key(event.source))
 
-    assert adapter.images_sent == [str(png)]
+    assert [os.path.normcase(p) for p in adapter.images_sent] == [
+        os.path.normcase(str(png))
+    ]
     assert adapter.outcomes == [ProcessingOutcome.FAILURE]

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+import os
 import sys
 
 from gateway.config import Platform, PlatformConfig
@@ -403,19 +404,20 @@ class _RoundtripAdapter(BasePlatformAdapter):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("filename,alt", [
-    ("sub folder/shot.png", "alt"),
-    ("100%25done.png", ""),
-    ("normal.png", ""),
-], ids=["space_path", "literal_percent", "normal_path"])
-async def test_send_multiple_images_roundtrip(tmp_path, filename, alt):
+@pytest.mark.parametrize("filename,alt,prefix", [
+    ("sub folder/shot.png", "alt", "file://"),
+    ("100%25done.png", "", "file://"),
+    ("normal.png", "", "file://"),
+    ("normal.png", "", "FILE://"),
+], ids=["space_path", "literal_percent", "normal_path", "uppercase_scheme"])
+async def test_send_multiple_images_roundtrip(tmp_path, filename, alt, prefix):
     """file:// URI round-trip: send_multiple_images decodes URI to local path
-    and passes it to send_image_file. Parametrized over space/literal%/normal."""
+    and passes it to send_image_file. Parametrized over space/literal%/normal/uppercase."""
     import urllib.parse
 
     adapter = _RoundtripAdapter()
     validated = str((tmp_path / filename).resolve())
-    norm_url = "file://" + urllib.parse.quote(validated, safe="/:\\\\")
+    norm_url = prefix + urllib.parse.quote(validated, safe="/:\\\\")
 
     await adapter.send_multiple_images(
         chat_id="chat-1",
@@ -424,9 +426,12 @@ async def test_send_multiple_images_roundtrip(tmp_path, filename, alt):
 
     adapter.send_image_file.assert_awaited_once()
     _, kwargs = adapter.send_image_file.call_args
-    received_path = kwargs.get("image_path")
-    assert received_path == validated, (
-        f"send_image_file received {received_path!r}, expected {validated!r}"
+    received = kwargs.get("image_path")
+    assert received is not None
+    # _normalize_file_url returns forward-slash paths; compare with
+    # normcase to handle backslash/forward-slash differences.
+    assert os.path.normcase(received) == os.path.normcase(validated), (
+        f"send_image_file received {received!r}, expected {validated!r}"
     )
 
 

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -474,6 +474,7 @@ async def test_post_stream_html_src_bare_path_not_delivered(tmp_path, monkeypatc
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows path semantics")
 @pytest.mark.asyncio
 async def test_post_stream_file_url_windows_path_delivered(tmp_path, monkeypatch):
     """``file:///C:/...`` style Windows URI (three slashes + drive letter)
@@ -701,7 +702,6 @@ async def test_post_stream_dedup_http_exact_url(tmp_path, monkeypatch):
     assert len(images) == 1, f"expected 1 image (dedup), got {len(images)}: {images}"
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows path semantics")
 # ---------------------------------------------------------------------------
 # New contract (#73771): explicit MEDIA:/file:// in a LATER turn is a deliberate
 # resend and must NOT be blocked by history-based dedup. The same file may be

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -176,13 +176,217 @@ async def test_non_streaming_media_failure_notifies_user(tmp_path, monkeypatch):
     adapter.send_video.assert_awaited_once()
     assert adapter.notices == ["⚠️ Couldn't deliver the video attachment."]
 
+# ---------------------------------------------------------------------------
+# Post-stream regression tests for explicit file:// image tags (PR #43332)
+# ---------------------------------------------------------------------------
 
-class _DiscordMediaFailureAdapter(BasePlatformAdapter):
-    """Minimal adapter to exercise non-streaming MEDIA failure notification."""
+
+@pytest.mark.asyncio
+async def test_post_stream_file_url_image_goes_to_send_multiple_images(tmp_path, monkeypatch):
+    """file:// URI in explicit markdown image tag reaches send_multiple_images."""
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "screenshot.png")
+    response = f"See: ![shot](file://{img.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    kwargs = adapter.send_multiple_images.call_args.kwargs
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1
+    file_uri = images[0][0]
+    assert file_uri.startswith("file://")
+    assert str(img) in file_uri
+
+
+@pytest.mark.asyncio
+async def test_post_stream_media_tag_still_delivers(tmp_path, monkeypatch):
+    """MEDIA:/path/a.png in post-stream still reaches send_multiple_images."""
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "media.png")
+    response = f"MEDIA:{img}"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    kwargs = adapter.send_multiple_images.call_args.kwargs
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_stream_bare_local_image_is_not_delivered(tmp_path, monkeypatch):
+    """Bare local image path in response text MUST NOT be auto-delivered.
+    Post-stream delivery is explicit-only (#20834): bare paths that were
+    already in the streamed text are not promoted to attachments."""
+    event = _event()
+    _allowed_media_path(tmp_path, monkeypatch, "bare.png")
+    response = "Check your files at /tmp/bare.png"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+    adapter.send_voice.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_stream_bare_local_pdf_is_not_delivered(tmp_path, monkeypatch):
+    """Bare local non-image path MUST NOT be auto-delivered as document.
+    Post-stream delivery is explicit-only (#20834): bare paths that were
+    already in the streamed text are not promoted to attachments."""
+    event = _event()
+    _allowed_media_path(tmp_path, monkeypatch, "chart.pdf")
+    response = "Generated chart at /tmp/chart.pdf"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_document.assert_not_awaited()
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_voice.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_stream_json_embedded_file_url_not_attached(tmp_path, monkeypatch):
+    """file:// image tag inside a JSON string value must NOT reach send_multiple_images."""
+    event = _event()
+    png = _allowed_media_path(tmp_path, monkeypatch, "stale.png")
+    response = '{"result":"![img](file://%s)"}' % png.as_posix()
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_stream_html_data_src_not_delivered(tmp_path, monkeypatch):
+    """HTML img with data-src pointing to a real file must NOT trigger upload."""
+    event = _event()
+    png = _allowed_media_path(tmp_path, monkeypatch, "hidden.png")
+    response = f'<img data-src="file://{png.as_posix()}">'
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# send_multiple_images round-trip: verifies file:// path integrity
+# ---------------------------------------------------------------------------
+
+
+class _RoundtripAdapter(BasePlatformAdapter):
+    """Minimal adapter that calls the base send_multiple_images."""
 
     def __init__(self):
-        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.DISCORD)
-        self.notices: list[str] = []
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.send_image_file = AsyncMock(return_value=SendResult(success=True, message_id="img"))
 
     async def connect(self, *, is_reconnect: bool = False):
         return True
@@ -191,8 +395,407 @@ class _DiscordMediaFailureAdapter(BasePlatformAdapter):
         pass
 
     async def send(self, chat_id, content=None, **kwargs):
-        self.notices.append(content or "")
-        return SendResult(success=True, message_id="notice")
+        return SendResult(success=True, message_id="text")
 
     async def get_chat_info(self, chat_id):
         return {"id": chat_id, "type": "dm"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("filename,alt", [
+    ("sub folder/shot.png", "alt"),
+    ("100%25done.png", ""),
+    ("normal.png", ""),
+], ids=["space_path", "literal_percent", "normal_path"])
+async def test_send_multiple_images_roundtrip(tmp_path, filename, alt):
+    """file:// URI round-trip: send_multiple_images decodes URI to local path
+    and passes it to send_image_file. Parametrized over space/literal%/normal."""
+    import urllib.parse
+
+    adapter = _RoundtripAdapter()
+    validated = str((tmp_path / filename).resolve())
+    norm_url = "file://" + urllib.parse.quote(validated, safe="/:\\\\")
+
+    await adapter.send_multiple_images(
+        chat_id="chat-1",
+        images=[(norm_url, alt)],
+    )
+
+    adapter.send_image_file.assert_awaited_once()
+    _, kwargs = adapter.send_image_file.call_args
+    received_path = kwargs.get("image_path")
+    assert received_path == validated, (
+        f"send_image_file received {received_path!r}, expected {validated!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_stream_html_src_bare_path_not_delivered(tmp_path, monkeypatch):
+    """HTML img with bare Windows/POSIX path must NOT trigger upload."""
+    event = _event()
+    _allowed_media_path(tmp_path, monkeypatch, "barepath.png")
+    for response in [
+        '<img src="C:\\\\Users\\\\test\\\\file.png">',
+        '<img src="/tmp/file.png">',
+        '<img src="smb://server/share/file.png">',
+    ]:
+        adapter = SimpleNamespace(
+            name="test",
+            extract_media=BasePlatformAdapter.extract_media,
+            extract_images=BasePlatformAdapter.extract_images,
+            extract_local_files=BasePlatformAdapter.extract_local_files,
+            send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+            send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+            send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+            send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+            send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+        )
+
+        await GatewayRunner._deliver_media_from_response(
+            _fake_runner(None),
+            response,
+            event,
+            adapter,
+        )
+
+        adapter.send_multiple_images.assert_not_awaited()
+        adapter.send_image_file.assert_not_awaited()
+        adapter.send_document.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Dev tests: Windows paths, unicode paths, paths with spaces (PR #43332)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_stream_file_url_windows_path_delivered(tmp_path, monkeypatch):
+    """``file:///C:/...`` style Windows URI (three slashes + drive letter)
+    in a markdown image tag reaches ``send_multiple_images``.
+    """
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "win_test.png")
+    # Simulate Windows absolute path URI: file:///C:/path/to/file.png
+    # Convert the resolved PosixPath to a "Windows-style" path string
+    # by using as_posix() (forward slashes) which _normalize_file_url
+    # handles via ``file:///C:/...`` syntax.
+    win_uri = f"file:///{img.as_posix()}"
+    response = f"See: ![shot]({win_uri})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    kwargs = adapter.send_multiple_images.call_args.kwargs
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1
+    file_uri = images[0][0]
+    assert file_uri.startswith("file://")
+    assert str(img) in file_uri
+
+
+@pytest.mark.asyncio
+async def test_post_stream_file_url_unicode_path(tmp_path, monkeypatch):
+    """file:// URI with unicode characters in path reaches send_multiple_images."""
+    event = _event()
+    # Create a file with unicode name
+    img = _allowed_media_path(tmp_path, monkeypatch, "照片.png")
+    response = f"See: ![photo](file://{img.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    kwargs = adapter.send_multiple_images.call_args.kwargs
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1
+    file_uri = images[0][0]
+    assert file_uri.startswith("file://")
+    # The unicode filename must be present in the URI (percent-encoded)
+    from urllib.parse import quote as _urlquote
+    expected_part = _urlquote("照片.png")
+    assert expected_part in file_uri, (
+        f"Expected {expected_part} in {file_uri}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_stream_file_url_space_path(tmp_path, monkeypatch):
+    """file:// URI with spaces in directory/file name reaches send_multiple_images."""
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "screen shot.png")
+    response = f"See: ![img](file://{img.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    kwargs = adapter.send_multiple_images.call_args.kwargs
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1
+    file_uri = images[0][0]
+    assert file_uri.startswith("file://")
+    # Space in filename must be percent-encoded
+    assert "%20" in file_uri, (
+        f"Expected percent-encoded space (%20) in {file_uri}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_stream_dedup_substring_safe(tmp_path, monkeypatch):
+    """Different files (foo.png vs foo.png.backup.png) both deliver — no
+    substring comparison bug."""
+    event = _event()
+    img1 = _allowed_media_path(tmp_path, monkeypatch, "foo.png")
+    img2 = _allowed_media_path(tmp_path, monkeypatch, "foo.png.backup.png",)
+    img2.write_bytes(b"backup")
+    response = f"![a](file://{img1.as_posix()}) ![b](file://{img2.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    args, kwargs = adapter.send_multiple_images.call_args
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 2, f"expected 2 images, got {len(images)}: {images}"
+    uris = [uri for uri, _ in images]
+    assert all(u.startswith("file://") for u in uris)
+
+
+@pytest.mark.asyncio
+async def test_post_stream_dedup_file_url_media_same_file(tmp_path, monkeypatch):
+    """MEDIA local path + file:// URI for the same file deliver once."""
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "dedup.png")
+    response = f"MEDIA:{img} ![shot](file://{img.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    args, kwargs = adapter.send_multiple_images.call_args
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    # MEDIA image + extracted image = same file -> 1 total
+    assert len(images) == 1, f"expected 1 image (dedup), got {len(images)}: {images}"
+
+
+@pytest.mark.asyncio
+async def test_post_stream_dedup_http_exact_url(tmp_path, monkeypatch):
+    """Same HTTP URL twice delivers once via exact-string dedup."""
+    event = _event()
+    response = "![a](https://example.com/pic.png) ![b](https://example.com/pic.png)"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    args, kwargs = adapter.send_multiple_images.call_args
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1, f"expected 1 image (dedup), got {len(images)}: {images}"
+
+
+@pytest.mark.asyncio
+async def test_post_stream_history_dedup_case_variation(tmp_path, monkeypatch):
+    """History contains C:\...\Image.PNG; current file URI pointing to the
+    same file (case/slash variation) is deduplicated."""
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "image.png")
+    # Simulate history containing a case-different variant of the SAME file
+    alt_case = str(img).replace("image.png", "Image.PNG")
+    # Response uses an alternative file:// encoding of the same file
+    response = f"![shot](file://{img.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+        history_media_paths={alt_case},
+    )
+
+    # The file:// URI resolves to the same canonical path as history -> skip
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_stream_history_dedup_same_file_via_media(tmp_path, monkeypatch):
+    """History contains original MEDIA path; current percent-encoded file URI
+    pointing to the same file is deduplicated."""
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "dedup_hist.png")
+    # Response has BOTH a MEDIA: (which goes through extract_media) and an
+    # explicit file:// tag; history contains the same path.
+    response = f"MEDIA:{img} ![shot](file://{img.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+        history_media_paths={str(img)},
+    )
+
+    # The MEDIA: path matches history -> filtered out.
+    # The file:// path also matches history -> filtered out.
+    # Result: nothing to deliver.
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_stream_history_dedup_different_paths_both_deliver(tmp_path, monkeypatch):
+    """Two different files (one in history, one new) — both deliver."""
+    event = _event()
+    img1 = _allowed_media_path(tmp_path, monkeypatch, "already_sent.png")
+    img2 = _allowed_media_path(tmp_path, monkeypatch, "new_file.png",)
+    response = f"![old](file://{img1.as_posix()}) ![new](file://{img2.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+        history_media_paths={str(img1)},
+    )
+
+    # img1 matches history -> skipped; img2 is new -> delivered
+    adapter.send_multiple_images.assert_awaited_once()
+    args, kwargs = adapter.send_multiple_images.call_args
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1, f"expected 1 new image, got {len(images)}: {images}"
+    # Only the new file's URI is present
+    assert str(img2) in images[0][0], f"Expected {img2} in {images[0][0]}"
+    assert str(img1) not in images[0][0], f"Old file {img1} should not appear"

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -474,7 +474,6 @@ async def test_post_stream_html_src_bare_path_not_delivered(tmp_path, monkeypatc
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows path semantics")
 @pytest.mark.asyncio
 async def test_post_stream_file_url_windows_path_delivered(tmp_path, monkeypatch):
     """``file:///C:/...`` style Windows URI (three slashes + drive letter)
@@ -703,112 +702,111 @@ async def test_post_stream_dedup_http_exact_url(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows path semantics")
-@pytest.mark.asyncio
-async def test_post_stream_history_dedup_case_variation(tmp_path, monkeypatch):
-    """History contains C:\\...\\Image.PNG; current file URI pointing to the
-    same file (case/slash variation) is deduplicated."""
-    event = _event()
-    img = _allowed_media_path(tmp_path, monkeypatch, "image.png")
-    # Simulate history containing a case-different variant of the SAME file
-    alt_case = str(img).replace("image.png", "Image.PNG")
-    # Response uses an alternative file:// encoding of the same file
-    response = f"![shot](file://{img.as_posix()})"
-    adapter = SimpleNamespace(
-        name="test",
-        extract_media=BasePlatformAdapter.extract_media,
-        extract_images=BasePlatformAdapter.extract_images,
-        extract_local_files=BasePlatformAdapter.extract_local_files,
-        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
-        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
-        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
-        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
-        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
-    )
-
-    await GatewayRunner._deliver_media_from_response(
-        _fake_runner(None),
-        response,
-        event,
-        adapter,
-        history_media_paths={alt_case},
-    )
-
-    # The file:// URI resolves to the same canonical path as history -> skip
-    adapter.send_multiple_images.assert_not_awaited()
-    adapter.send_image_file.assert_not_awaited()
-    adapter.send_document.assert_not_awaited()
+# ---------------------------------------------------------------------------
+# New contract (#73771): explicit MEDIA:/file:// in a LATER turn is a deliberate
+# resend and must NOT be blocked by history-based dedup. The same file may be
+# delivered again when the model explicitly attaches it in a subsequent
+# response. Only same-response canonical dedup applies (see
+# test_post_stream_dedup_file_url_media_same_file).
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_post_stream_history_dedup_same_file_via_media(tmp_path, monkeypatch):
-    """History contains original MEDIA path; current percent-encoded file URI
-    pointing to the same file is deduplicated."""
+async def test_post_stream_explicit_resend_allowed_in_later_turn(tmp_path, monkeypatch):
+    """A later turn explicitly repeating the same MEDIA: tag still delivers.
+
+    Regression guard for #73771: cross-turn history dedup was removed. The
+    post-stream rescan is explicit-only, and a MEDIA: directive in the final
+    streamed reply is the model deliberately attaching a file — including a
+    user-requested resend. Calling _deliver_media_from_response twice with the
+    same response must deliver both times (no hidden history state).
+    """
     event = _event()
-    img = _allowed_media_path(tmp_path, monkeypatch, "dedup_hist.png")
-    # Response has BOTH a MEDIA: (which goes through extract_media) and an
-    # explicit file:// tag; history contains the same path.
+    img = _allowed_media_path(tmp_path, monkeypatch, "resend.png")
     response = f"MEDIA:{img} ![shot](file://{img.as_posix()})"
-    adapter = SimpleNamespace(
-        name="test",
-        extract_media=BasePlatformAdapter.extract_media,
-        extract_images=BasePlatformAdapter.extract_images,
-        extract_local_files=BasePlatformAdapter.extract_local_files,
-        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
-        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
-        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
-        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
-        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
-    )
 
+    def _make_adapter():
+        return SimpleNamespace(
+            name="test",
+            extract_media=BasePlatformAdapter.extract_media,
+            extract_images=BasePlatformAdapter.extract_images,
+            extract_local_files=BasePlatformAdapter.extract_local_files,
+            send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+            send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+            send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+            send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+            send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+        )
+
+    # Turn 1 delivers the explicit media.
+    adapter1 = _make_adapter()
     await GatewayRunner._deliver_media_from_response(
         _fake_runner(None),
         response,
         event,
-        adapter,
-        history_media_paths={str(img)},
+        adapter1,
     )
+    adapter1.send_multiple_images.assert_awaited_once()
 
-    # The MEDIA: path matches history -> filtered out.
-    # The file:// path also matches history -> filtered out.
-    # Result: nothing to deliver.
-    adapter.send_multiple_images.assert_not_awaited()
-    adapter.send_image_file.assert_not_awaited()
-    adapter.send_document.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_post_stream_history_dedup_different_paths_both_deliver(tmp_path, monkeypatch):
-    """Two different files (one in history, one new) — both deliver."""
-    event = _event()
-    img1 = _allowed_media_path(tmp_path, monkeypatch, "already_sent.png")
-    img2 = _allowed_media_path(tmp_path, monkeypatch, "new_file.png",)
-    response = f"![old](file://{img1.as_posix()}) ![new](file://{img2.as_posix()})"
-    adapter = SimpleNamespace(
-        name="test",
-        extract_media=BasePlatformAdapter.extract_media,
-        extract_images=BasePlatformAdapter.extract_images,
-        extract_local_files=BasePlatformAdapter.extract_local_files,
-        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
-        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
-        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
-        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
-        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
-    )
-
+    # Turn 2 (a later turn, same explicit directive) must deliver AGAIN —
+    # no cross-turn history dedup may suppress it.
+    adapter2 = _make_adapter()
     await GatewayRunner._deliver_media_from_response(
         _fake_runner(None),
         response,
         event,
-        adapter,
-        history_media_paths={str(img1)},
+        adapter2,
     )
-
-    # img1 matches history -> skipped; img2 is new -> delivered
-    adapter.send_multiple_images.assert_awaited_once()
-    args, kwargs = adapter.send_multiple_images.call_args
+    adapter2.send_multiple_images.assert_awaited_once()
+    args, kwargs = adapter2.send_multiple_images.call_args
     images = kwargs.get("images")
     assert images is not None, "images kwarg missing"
-    assert len(images) == 1, f"expected 1 new image, got {len(images)}: {images}"
-    # Only the new file's URI is present
-    assert str(img2) in images[0][0], f"Expected {img2} in {images[0][0]}"
-    assert str(img1) not in images[0][0], f"Old file {img1} should not appear"
+    assert len(images) == 1, f"expected 1 image in resend turn, got {len(images)}: {images}"
+
+
+@pytest.mark.asyncio
+async def test_post_stream_file_url_resend_allowed_in_later_turn(tmp_path, monkeypatch):
+    """A later turn explicitly repeating the same file:// image still delivers.
+
+    Mirrors test_post_stream_explicit_resend_allowed_in_later_turn for the
+    file:// markdown image path — the explicit file:// contract is also exempt
+    from cross-turn dedup (#73771).
+    """
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "resend_uri.png")
+    response = f"See: ![shot](file://{img.as_posix()})"
+
+    def _make_adapter():
+        return SimpleNamespace(
+            name="test",
+            extract_media=BasePlatformAdapter.extract_media,
+            extract_images=BasePlatformAdapter.extract_images,
+            extract_local_files=BasePlatformAdapter.extract_local_files,
+            send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+            send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+            send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+            send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+            send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+        )
+
+    adapter1 = _make_adapter()
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter1,
+    )
+    adapter1.send_multiple_images.assert_awaited_once()
+
+    adapter2 = _make_adapter()
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter2,
+    )
+    adapter2.send_multiple_images.assert_awaited_once()
+    args, kwargs = adapter2.send_multiple_images.call_args
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1, f"expected 1 image in resend turn, got {len(images)}: {images}"

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+import sys
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
@@ -468,6 +469,7 @@ async def test_post_stream_html_src_bare_path_not_delivered(tmp_path, monkeypatc
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows path semantics")
 @pytest.mark.asyncio
 async def test_post_stream_file_url_windows_path_delivered(tmp_path, monkeypatch):
     """``file:///C:/...`` style Windows URI (three slashes + drive letter)
@@ -690,9 +692,10 @@ async def test_post_stream_dedup_http_exact_url(tmp_path, monkeypatch):
     assert len(images) == 1, f"expected 1 image (dedup), got {len(images)}: {images}"
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows path semantics")
 @pytest.mark.asyncio
 async def test_post_stream_history_dedup_case_variation(tmp_path, monkeypatch):
-    """History contains C:\...\Image.PNG; current file URI pointing to the
+    """History contains C:\\...\\Image.PNG; current file URI pointing to the
     same file (case/slash variation) is deduplicated."""
     event = _event()
     img = _allowed_media_path(tmp_path, monkeypatch, "image.png")

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -633,6 +633,11 @@ async def test_post_stream_dedup_substring_safe(tmp_path, monkeypatch):
     assert all(u.startswith("file://") for u in uris)
 
 
+def test_normalize_file_url_drive_relative_rejected():
+    """file://C%3Arelative.png has authority C%3A and MUST be rejected."""
+    assert BasePlatformAdapter._normalize_file_url("file://C%3Arelative.png") is None
+
+
 @pytest.mark.asyncio
 async def test_post_stream_dedup_file_url_media_same_file(tmp_path, monkeypatch):
     """MEDIA local path + file:// URI for the same file deliver once."""

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -10,6 +10,7 @@ only renders as a voice bubble when explicitly flagged) and via
 import importlib
 import sys
 import types
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -202,6 +203,705 @@ class _DiscordMediaFailureAdapter(BasePlatformAdapter):
     async def get_chat_info(self, chat_id):
         return {"id": chat_id, "type": "dm"}
 
+@pytest.mark.asyncio
+async def test_post_stream_file_url_image_goes_to_send_multiple_images(tmp_path, monkeypatch):
+    """file:// URI in explicit markdown image tag reaches send_multiple_images."""
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "screenshot.png")
+    response = f"See: ![shot](file://{img.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    kwargs = adapter.send_multiple_images.call_args.kwargs
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1
+    file_uri = images[0][0]
+    assert file_uri.startswith("file://")
+    assert str(img) in file_uri
+
+
+@pytest.mark.asyncio
+async def test_post_stream_media_tag_still_delivers(tmp_path, monkeypatch):
+    """MEDIA:/path/a.png in post-stream still reaches send_multiple_images."""
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "media.png")
+    response = f"MEDIA:{img}"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    kwargs = adapter.send_multiple_images.call_args.kwargs
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_stream_bare_local_image_is_not_delivered(tmp_path, monkeypatch):
+    """Bare local image path in response text MUST NOT be auto-delivered.
+    Post-stream delivery is explicit-only (#20834): bare paths that were
+    already in the streamed text are not promoted to attachments."""
+    event = _event()
+    _allowed_media_path(tmp_path, monkeypatch, "bare.png")
+    response = "Check your files at /tmp/bare.png"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+    adapter.send_voice.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_stream_bare_local_pdf_is_not_delivered(tmp_path, monkeypatch):
+    """Bare local non-image path MUST NOT be auto-delivered as document.
+    Post-stream delivery is explicit-only (#20834): bare paths that were
+    already in the streamed text are not promoted to attachments."""
+    event = _event()
+    _allowed_media_path(tmp_path, monkeypatch, "chart.pdf")
+    response = "Generated chart at /tmp/chart.pdf"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_document.assert_not_awaited()
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_voice.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_stream_json_embedded_file_url_not_attached(tmp_path, monkeypatch):
+    """file:// image tag inside a JSON string value must NOT reach send_multiple_images."""
+    event = _event()
+    png = _allowed_media_path(tmp_path, monkeypatch, "stale.png")
+    response = '{"result":"![img](file://%s)"}' % png.as_posix()
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_stream_html_data_src_not_delivered(tmp_path, monkeypatch):
+    """HTML img with data-src pointing to a real file must NOT trigger upload."""
+    event = _event()
+    png = _allowed_media_path(tmp_path, monkeypatch, "hidden.png")
+    response = f'<img data-src="file://{png.as_posix()}">'
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_document.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# send_multiple_images round-trip: verifies file:// path integrity
+# ---------------------------------------------------------------------------
+
+
+class _RoundtripAdapter(BasePlatformAdapter):
+    """Minimal adapter that calls the base send_multiple_images."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.send_image_file = AsyncMock(return_value=SendResult(success=True, message_id="img"))
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content=None, **kwargs):
+        return SendResult(success=True, message_id="text")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("filename,alt,prefix", [
+    ("sub folder/shot.png", "alt", "file://"),
+    ("100%25done.png", "", "file://"),
+    ("normal.png", "", "file://"),
+    ("normal.png", "", "FILE://"),
+], ids=["space_path", "literal_percent", "normal_path", "uppercase_scheme"])
+async def test_send_multiple_images_roundtrip(tmp_path, filename, alt, prefix):
+    """file:// URI round-trip: send_multiple_images decodes URI to local path
+    and passes it to send_image_file. Parametrized over space/literal%/normal/uppercase."""
+    import urllib.parse
+
+    adapter = _RoundtripAdapter()
+    validated = str((tmp_path / filename).resolve())
+    norm_url = prefix + urllib.parse.quote(validated, safe="/:\\\\")
+
+    await adapter.send_multiple_images(
+        chat_id="chat-1",
+        images=[(norm_url, alt)],
+    )
+
+    adapter.send_image_file.assert_awaited_once()
+    _, kwargs = adapter.send_image_file.call_args
+    received = kwargs.get("image_path")
+    assert received is not None
+    # _normalize_file_url returns forward-slash paths; compare with
+    # normcase to handle backslash/forward-slash differences.
+    assert os.path.normcase(received) == os.path.normcase(validated), (
+        f"send_image_file received {received!r}, expected {validated!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_stream_html_src_bare_path_not_delivered(tmp_path, monkeypatch):
+    """HTML img with bare Windows/POSIX path must NOT trigger upload."""
+    event = _event()
+    _allowed_media_path(tmp_path, monkeypatch, "barepath.png")
+    for response in [
+        '<img src="C:\\\\Users\\\\test\\\\file.png">',
+        '<img src="/tmp/file.png">',
+        '<img src="smb://server/share/file.png">',
+    ]:
+        adapter = SimpleNamespace(
+            name="test",
+            extract_media=BasePlatformAdapter.extract_media,
+            extract_images=BasePlatformAdapter.extract_images,
+            extract_local_files=BasePlatformAdapter.extract_local_files,
+            send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+            send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+            send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+            send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+            send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+        )
+
+        await GatewayRunner._deliver_media_from_response(
+            _fake_runner(None),
+            response,
+            event,
+            adapter,
+        )
+
+        adapter.send_multiple_images.assert_not_awaited()
+        adapter.send_image_file.assert_not_awaited()
+        adapter.send_document.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Dev tests: Windows paths, unicode paths, paths with spaces (PR #43332)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows path semantics")
+@pytest.mark.asyncio
+async def test_post_stream_file_url_windows_path_delivered(tmp_path, monkeypatch):
+    """``file:///C:/...`` style Windows URI (three slashes + drive letter)
+    in a markdown image tag reaches ``send_multiple_images``.
+    """
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "win_test.png")
+    # Simulate Windows absolute path URI: file:///C:/path/to/file.png
+    # Convert the resolved PosixPath to a "Windows-style" path string
+    # by using as_posix() (forward slashes) which _normalize_file_url
+    # handles via ``file:///C:/...`` syntax.
+    win_uri = f"file:///{img.as_posix()}"
+    response = f"See: ![shot]({win_uri})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    kwargs = adapter.send_multiple_images.call_args.kwargs
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1
+    file_uri = images[0][0]
+    assert file_uri.startswith("file://")
+    assert str(img) in file_uri
+
+
+@pytest.mark.asyncio
+async def test_post_stream_file_url_unicode_path(tmp_path, monkeypatch):
+    """file:// URI with unicode characters in path reaches send_multiple_images."""
+    event = _event()
+    # Create a file with unicode name
+    img = _allowed_media_path(tmp_path, monkeypatch, "照片.png")
+    response = f"See: ![photo](file://{img.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    kwargs = adapter.send_multiple_images.call_args.kwargs
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1
+    file_uri = images[0][0]
+    assert file_uri.startswith("file://")
+    # The unicode filename must be present in the URI (percent-encoded)
+    from urllib.parse import quote as _urlquote
+    expected_part = _urlquote("照片.png")
+    assert expected_part in file_uri, (
+        f"Expected {expected_part} in {file_uri}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_stream_file_url_space_path(tmp_path, monkeypatch):
+    """file:// URI with spaces in directory/file name reaches send_multiple_images."""
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "screen shot.png")
+    response = f"See: ![img](file://{img.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    kwargs = adapter.send_multiple_images.call_args.kwargs
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1
+    file_uri = images[0][0]
+    assert file_uri.startswith("file://")
+    # Space in filename must be percent-encoded
+    assert "%20" in file_uri, (
+        f"Expected percent-encoded space (%20) in {file_uri}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_stream_dedup_substring_safe(tmp_path, monkeypatch):
+    """Different files (foo.png vs foo.png.backup.png) both deliver — no
+    substring comparison bug."""
+    event = _event()
+    img1 = _allowed_media_path(tmp_path, monkeypatch, "foo.png")
+    img2 = _allowed_media_path(tmp_path, monkeypatch, "foo.png.backup.png",)
+    img2.write_bytes(b"backup")
+    response = f"![a](file://{img1.as_posix()}) ![b](file://{img2.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    args, kwargs = adapter.send_multiple_images.call_args
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 2, f"expected 2 images, got {len(images)}: {images}"
+    uris = [uri for uri, _ in images]
+    assert all(u.startswith("file://") for u in uris)
+
+
+def test_normalize_file_url_drive_relative_rejected():
+    """file://C%3Arelative.png has authority C%3A and MUST be rejected."""
+    assert BasePlatformAdapter._normalize_file_url("file://C%3Arelative.png") is None
+
+
+def test_normalize_file_url_encoded_three_slash_drive():
+    """The encoded three-slash variant (no authority, drive letter encoded
+    in the path) must normalize identically to the plain form: the second
+    drive-letter re-check added after percent-decoding handles it."""
+    assert BasePlatformAdapter._normalize_file_url("file:///C%3A/dir/a.png") == "C:/dir/a.png"
+
+
+@pytest.mark.parametrize("raw_path", [
+    r"C:\Users\KK\image.png",
+    r"C:\Users\KK\AppData\Local\Temp\shot.png",
+    r"C:\path with spaces\image.png",
+])
+def test_normalize_file_url_accepts_production_default_quote_windows_uri(raw_path):
+    """P1 regression: gateway delivery producers wrap local paths with the
+    DEFAULT ``urllib.parse.quote()`` (safe='/'), which percent-encodes the
+    Windows drive letter and backslashes into the authority segment:
+
+        file://C%3A%5CUsers%5CKK%5Cimage.png
+
+    Before the fix this form was rejected as a bogus UNC authority, so the
+    image silently fell back to ``send_image`` with the raw URI.  It must
+    normalize to the Windows local path instead.
+    """
+    import urllib.parse
+
+    uri = "file://" + urllib.parse.quote(raw_path)
+    assert uri.startswith("file://C%3A"), uri  # sanity: encoding actually happened
+
+    normed = BasePlatformAdapter._normalize_file_url(uri)
+    assert normed is not None, f"production quote form rejected: {uri!r}"
+    expected = raw_path.replace("\\", "/")
+    assert os.path.normcase(normed) == os.path.normcase(expected), (
+        f"normalize {normed!r} != expected {expected!r} for {uri!r}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw_path", [
+    r"C:\Users\KK\image.png",
+    r"C:\Users\KK\AppData\Local\Temp\shot.png",
+])
+async def test_send_multiple_images_default_quote_windows_uri_goes_to_send_image_file(raw_path):
+    """P1 regression: a local image wrapped by the production default
+    ``quote()`` must be decoded and delivered via ``send_image_file``, and
+    MUST NOT fall back to ``send_image`` with the raw ``file://`` URI.
+    """
+    import urllib.parse
+
+    adapter = _RoundtripAdapter()
+    adapter.send_image = AsyncMock(return_value=SendResult(success=True, message_id="remote"))
+    uri = "file://" + urllib.parse.quote(raw_path)
+
+    await adapter.send_multiple_images(
+        chat_id="chat-1",
+        images=[(uri, "alt")],
+    )
+
+    adapter.send_image_file.assert_awaited_once()
+    _, kwargs = adapter.send_image_file.call_args
+    received_path = kwargs.get("image_path")
+    assert received_path is not None, f"image_path kwarg missing in {kwargs}"
+    expected = raw_path.replace("\\", "/")
+    assert os.path.normcase(received_path) == os.path.normcase(expected), (
+        f"send_image_file received {received_path!r}, expected {expected!r}"
+    )
+    # The whole point of the fix: the URI must never be treated as a remote URL
+    adapter.send_image.assert_not_awaited()
+    assert not any(
+        str(call).startswith("file://") for call in adapter.send_image.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_stream_dedup_file_url_media_same_file(tmp_path, monkeypatch):
+    """MEDIA local path + file:// URI for the same file deliver once."""
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "dedup.png")
+    response = f"MEDIA:{img} ![shot](file://{img.as_posix()})"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    args, kwargs = adapter.send_multiple_images.call_args
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    # MEDIA image + extracted image = same file -> 1 total
+    assert len(images) == 1, f"expected 1 image (dedup), got {len(images)}: {images}"
+
+
+@pytest.mark.asyncio
+async def test_post_stream_dedup_http_exact_url(tmp_path, monkeypatch):
+    """Same HTTP URL twice delivers once via exact-string dedup."""
+    event = _event()
+    response = "![a](https://example.com/pic.png) ![b](https://example.com/pic.png)"
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    args, kwargs = adapter.send_multiple_images.call_args
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1, f"expected 1 image (dedup), got {len(images)}: {images}"
+
+
+# ---------------------------------------------------------------------------
+# New contract (#73771): explicit MEDIA:/file:// in a LATER turn is a deliberate
+# resend and must NOT be blocked by history-based dedup. The same file may be
+# delivered again when the model explicitly attaches it in a subsequent
+# response. Only same-response canonical dedup applies (see
+# test_post_stream_dedup_file_url_media_same_file).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_stream_explicit_resend_allowed_in_later_turn(tmp_path, monkeypatch):
+    """A later turn explicitly repeating the same MEDIA: tag still delivers.
+
+    Regression guard for #73771: cross-turn history dedup was removed. The
+    post-stream rescan is explicit-only, and a MEDIA: directive in the final
+    streamed reply is the model deliberately attaching a file — including a
+    user-requested resend. Calling _deliver_media_from_response twice with the
+    same response must deliver both times (no hidden history state).
+    """
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "resend.png")
+    response = f"MEDIA:{img} ![shot](file://{img.as_posix()})"
+
+    def _make_adapter():
+        return SimpleNamespace(
+            name="test",
+            extract_media=BasePlatformAdapter.extract_media,
+            extract_images=BasePlatformAdapter.extract_images,
+            extract_local_files=BasePlatformAdapter.extract_local_files,
+            send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+            send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+            send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+            send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+            send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+        )
+
+    # Turn 1 delivers the explicit media.
+    adapter1 = _make_adapter()
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter1,
+    )
+    adapter1.send_multiple_images.assert_awaited_once()
+
+    # Turn 2 (a later turn, same explicit directive) must deliver AGAIN —
+    # no cross-turn history dedup may suppress it.
+    adapter2 = _make_adapter()
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter2,
+    )
+    adapter2.send_multiple_images.assert_awaited_once()
+    args, kwargs = adapter2.send_multiple_images.call_args
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1, f"expected 1 image in resend turn, got {len(images)}: {images}"
+
+
+@pytest.mark.asyncio
+async def test_post_stream_file_url_resend_allowed_in_later_turn(tmp_path, monkeypatch):
+    """A later turn explicitly repeating the same file:// image still delivers.
+
+    Mirrors test_post_stream_explicit_resend_allowed_in_later_turn for the
+    file:// markdown image path — the explicit file:// contract is also exempt
+    from cross-turn dedup (#73771).
+    """
+    event = _event()
+    img = _allowed_media_path(tmp_path, monkeypatch, "resend_uri.png")
+    response = f"See: ![shot](file://{img.as_posix()})"
+
+    def _make_adapter():
+        return SimpleNamespace(
+            name="test",
+            extract_media=BasePlatformAdapter.extract_media,
+            extract_images=BasePlatformAdapter.extract_images,
+            extract_local_files=BasePlatformAdapter.extract_local_files,
+            send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="batch")),
+            send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+            send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+            send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+            send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+        )
+
+    adapter1 = _make_adapter()
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter1,
+    )
+    adapter1.send_multiple_images.assert_awaited_once()
+
+    adapter2 = _make_adapter()
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(None),
+        response,
+        event,
+        adapter2,
+    )
+    adapter2.send_multiple_images.assert_awaited_once()
+    args, kwargs = adapter2.send_multiple_images.call_args
+    images = kwargs.get("images")
+    assert images is not None, "images kwarg missing"
+    assert len(images) == 1, f"expected 1 image in resend turn, got {len(images)}: {images}"
 
 @pytest.mark.asyncio
 async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_image(


### PR DESCRIPTION
## Summary

Deliver local `file://` image URLs from explicit markdown/HTML image tags (QQBot on Windows first, all platforms benefit), rebuilt on current `upstream/main` during conflict resolution on 2026-09-11, after the gateway adapter refactor.

**Head SHA:** `9042f594840dc794a369dc71f10ffe464f97e4f1` (parent chain: `45a6101f365` = current `upstream/main`)

## Why the file list is 7 files

While this PR was open, upstream split the two files it edited:

* `gateway/run.py` **28318 → 5537 lines**: `_deliver_media_from_response()` moved to `gateway/run_notifications.py`, `_run_background_task()` moved to `gateway/run_turn.py`
* `gateway/platforms/base.py` **7266 → 4234 lines** (shared `_FENCED_CODE_RE` / `_blank_spans` helpers extracted)

The PR's deltas were re-applied at their new homes (not mechanically rebased — the PR-side conflict region was the whole pre-refactor function body). The two added production files carry exactly the changes that previously lived in `gateway/run.py`; `gateway/run.py` now only carries a docstring update, because that is all of this PR's delta that still lives there. The seventh file is an upstream test adapted to the new decode, explained next.

## Why this PR also touches `tests/gateway/test_media_only_outcome.py`

**Cause.** That file is upstream's `#106153` regression coverage and asserts the exact string handed to `send_image_file`:

```python
assert adapter.images_sent == [str(png)]      # str(png) == C:\Users\...\photo.png on Windows
```

The chain under test — `_process_message_background` → `_send_image_batch` → `send_multiple_images()` — builds the URI as `f"file://{urllib.parse.quote(p)}"` (`quote()` default `safe='/'`). On Windows that percent-encodes the drive letter and the backslashes **into the authority segment** (`file://C%3A%5CUsers%5C...`). The previous decoder, `urllib.parse.unquote(image_url[7:])`, happened to reconstruct `str(png)` verbatim, so the assertion passed by agreeing with the old decoder's spelling. The shared decoder introduced here (`_normalize_file_url()`) returns forward-slash paths on Windows by contract (`C:/Users/.../photo.png` — the same contract the round-trip tests in `test_tts_media_routing.py` document), so that assertion ended up comparing **separator style instead of the behavior it exists to protect** (a delivered media-only turn reports SUCCESS; a failed attachment still reports FAILURE).

**Conclusion.** The two spellings address the same file, and nothing downstream cares which one it gets:

| Evidence | Result |
|---|---|
| `os.path.samefile(naive_decode, normalized)` (Windows) | `True` |
| `os.path.exists(...)` for both forms | `True` |
| Consumers: QQBot `_upload_local_file` (`Path(...).expanduser().is_file()`), Signal `_send_attachment` (`Path(...).stat()`), Buzz `send_image_file` (`Path(...).is_file()`), Telegram (`open(...)`), Discord (shared file-send helper) | all accept either form |
| AST scan of **37** local-file-send function bodies across 137 files for separator-sensitive comparisons / shell joins | no match |
| Real chain run (open + byte compare) on Windows, baseline vs this PR | both read the identical bytes |
| POSIX (Linux/macOS) behavior | unchanged — `quote()` leaves `/` unencoded, both decoders return the identical string |

So the path assertion is now separator-agnostic (`os.path.normcase`) and the outcome assertions are untouched. Measured on Windows: `tests/gateway/test_media_only_outcome.py` **2 passed** (was 2 failed on the previous head). With that, the impact-range comparison shows **zero new failures**.

Note on why CI did not surface this: on POSIX the two decoders agree, and the upstream Windows lane runs only `-m windows_only`-marked tests, so this file is not executed there — the difference is visible in a local Windows run.

## Behavior Contract

* **Post-stream delivery remains explicit-only** (`#20834`): bare local paths in an already-streamed reply are treated as text the user has seen, never auto-promoted to attachments; `extract_local_files()` is NOT called in the post-stream path.
* **Explicit `MEDIA:` / `file://` may be re-sent in later turns** (`#73771`): cross-turn history dedup was removed on main; a `MEDIA:` directive or explicit `file://` image tag in a later turn is the model deliberately attaching a file (including a user-requested resend) and must deliver again.
* **Canonical dedup applies only within a single response**: `MEDIA:/a.png` and `file:///C:/a.png` referencing the same file deliver once per response; `foo.png` vs `foo.png.backup.png` (different files) both deliver; HTTP(S) URLs use exact-string comparison.
* **Background `file://` delivery** routes through `send_multiple_images()` → `send_image_file()` (decoded local path), never passed as a literal pathname to the HTTP-only `send_image()`.
* **Windows production encoded-drive URIs accepted**: the delivery batching code wraps local paths with the default `urllib.parse.quote()` (safe=`/`), which on Windows percent-encodes the drive letter and backslashes into the authority segment (`file://C%3A%5Cpath%5Cimage.png`). `_normalize_file_url()` decodes such URIs back to the local drive path, and they still pass the existing `validate_media_delivery_path()` security chain (container→host translation, symlink resolve, denylist/credential protection, strict mode).
* **Three-slash drive URIs no longer lose the drive letter**: the previous `unquote(url[7:])` decode turned `file:///C:/dir/a.png` (`Path.as_uri()`) into `/C:/dir/a.png`, a path that does not exist on Windows; the structured decoder normalizes it to `C:/dir/a.png`.
* **Unsafe URIs rejected**: UNC, non-local authority, encoded-UNC, and drive-relative `file://` URIs are refused by `_normalize_file_url()`.

## Changes (7 files, +1178 / -42)

**`gateway/platforms/base.py`** (+206/-29)
* Add `_normalize_file_url()` — case-insensitive scheme, POSIX/Windows two- and three-slash variants, and the production default-`quote()` encoded-drive authority form; rejects UNC / non-local authority / drive-relative.
* Extend `extract_images()` to accept `file://` markdown/HTML image tags with mask-based false-positive prevention (fences/blockquotes/JSON/`data-src`), validating every candidate through `validate_media_delivery_path()`.
* `send_multiple_images()` routes local `file://` URIs through `_normalize_file_url()` → `send_image_file()` (case-insensitive scheme; `FILE://` also works).

**`gateway/run_notifications.py`** (+32/-6) — post-stream path, formerly in `gateway/run.py`
* `_deliver_media_from_response()` captures `adapter.extract_images(cleaned)` and merges explicit image tags with `MEDIA:` paths into one `send_multiple_images()` call.
* Same-response canonical dedup via namespace-tuple keys (`("local", normcase(path))` / `("url", url)`); no cross-turn history dedup (follows current main `#73771` semantics).

**`gateway/run_turn.py`** (+15/-3) — background task, formerly in `gateway/run.py`
* Background-task image delivery batches through `send_multiple_images()` with `_image_dedup_keys`, so `MEDIA:path` + a `file://` tag for the same file sends once and a `file://` URI never reaches the HTTP-only `send_image()`.

**`gateway/run.py`** (+3/-2)
* `_strip_response_attachments_for_direct_send()` docstring updated to the actual explicit-attachment contract.

**`tests/gateway/test_media_only_outcome.py`** (+12/-2) — upstream test, adapted (see the section above)
* Path assertion made separator-agnostic; SUCCESS/FAILURE assertions untouched.

**`tests/gateway/test_background_command.py`** (+210/-0)
* Parametrized: two-slash and three-slash Windows `file://` URIs route through `send_multiple_images` → `send_image_file`; uppercase-scheme variant.
* Regression: `MEDIA:path` + `file://` tag for the same file sends once per response.
* Windows-only `three_slash_windows` variant skipped on non-Win32.

**`tests/gateway/test_tts_media_routing.py`** (+700/-0)
* Coverage: `file://` markdown/HTML extraction; HTML bare-path rejection (`C:\...`, `/tmp/...`, `smb://`); JSON-embedded and `data-src` non-detection; UNC / non-local authority / drive-relative rejection; Windows two/three-slash, encoded-drive (`file://C%3A%5C...`) and case-insensitive scheme; same-response `MEDIA:path` + `file://` dedup; substring-safe dedup; `send_multiple_images` round-trip.
* Explicit-resend contract tests (`test_post_stream_explicit_resend_allowed_in_later_turn`, `test_post_stream_file_url_resend_allowed_in_later_turn`).
* P1 regression tests using the production default `quote()` encoding: `file://C%3A%5C...` normalizes to the Windows drive path and routes to `send_image_file()` (never `send_image()`).

## Test Results (Windows host, Python 3.11)

| Command | Result |
|---|---|
| `pytest tests/gateway/test_tts_media_routing.py tests/gateway/test_background_command.py` | **47 passed, 3 failed** |
| Same two files on clean `upstream/main` @ `45a6101f365` baseline | 17 passed, **3 failed — identical failure list** |
| `pytest tests/gateway/test_media_only_outcome.py` | **2 passed** (was 2 failed before the adaptation) |
| Impact range: 36 gateway/cron/platform test files touching these symbols | candidate 1228 cases / 33 failing-or-erroring; baseline 1198 cases / 34 |
| Failure-set diff (candidate vs baseline, same files + same params) | **+0 new, −1 fixed, 32 identical inherited** |
| `ruff check` (changed files) | All checks passed |
| `git diff --check` | clean |
| Conflict markers / CRLF scan | none / LF-only |

* The 3 failures in this PR's own test files fail **identically on clean `upstream/main`**: they are Windows test-double issues (a hand-rolled adapter fake that does no percent-decoding of the URI), not PR regressions.
* The **−1** baseline-only failure is `tests/gateway/test_buzz_adapter.py::TestBuzzAdapterSend::test_send_multiple_images_file_url_uses_native_file_send`, which **fails on clean `main` (Windows)** and **passes with this PR**: the old `unquote(url[7:])` decode produced `/C:/...` for `Path.as_uri()` URIs, `Path("/C:/...").is_file()` was False, and Buzz fell back to the base text path instead of a native file send.

## Verification

* The main commit was rebased onto current `upstream/main` `45a6101f365`; `git diff upstream/main...HEAD` was **byte-identical before and after** the rebase (0 content differences once `index`/`@@` headers are ignored), and `git merge-tree --write-tree upstream/main HEAD` exits 0 (re-checked after the follow-up test-adaptation commit).
* Every test that exists on `upstream/main` in the touched test files is still present (no test dropped, no duplicate); the three background tests that upstream renamed away are correctly absent.
* `ast.parse` / `py_compile`: all changed files OK.
* `gh pr view`: `mergeable: MERGEABLE`, PR is **Ready for review** (not a draft).
* No CI checks are currently reported for this PR head; the repository's required aggregated status check therefore remains unsatisfied.
