### PR TITLE
fix(telegram): bound and refresh general httpx pool

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -81,6 +81,7 @@ from gateway.platforms.base import (
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     utf16_len,
 )
+from gateway.platforms._http_client_limits import platform_httpx_limits
 from gateway.platforms.telegram_network import (
     TelegramFallbackTransport,
     discover_fallback_ips,
@@ -902,48 +903,45 @@ class TelegramAdapter(BasePlatformAdapter):
             return {"link_preview_options": LinkPreviewOptions(is_disabled=True)}
         return {"disable_web_page_preview": True}
 
-    async def _drain_polling_connections(self) -> None:
-        """Reset the httpx connection pool used for getUpdates polling.
+    async def _drain_request_connections(self, request_index: int, label: str) -> None:
+        """Reset one PTB HTTPXRequest connection pool by tuple index.
 
-        Network errors (especially through proxies like sing-box) can leave
-        httpx connections in a half-closed state that still occupy pool slots.
-        After enough reconnect cycles the pool fills up entirely, causing
-        ``Pool timeout: All connections in the connection pool are occupied.``
-
-        We reset ONLY ``_request[0]`` (the getUpdates request) — the general
-        request (``_request[1]``) is left untouched so concurrent
-        ``send_message`` / ``edit_message`` calls are never interrupted.
-
-        Implementation note: accesses ``Bot._request[0]`` which is the
-        get-updates ``BaseRequest`` in the PTB 22.x internal tuple
-        ``(get_updates_request, general_request)``.  There is no public
-        accessor for the polling request; review if upgrading to PTB 23+.
+        PTB 22.x stores two request clients at ``Bot._request``:
+        ``[0]`` for getUpdates polling and ``[1]`` for normal Bot API calls
+        such as send_message/edit_message/set_my_commands. Network errors
+        through proxies can leave either pool holding stale half-closed
+        sockets, so reset the affected pool before retrying/reconnecting.
         """
         if not (self._app and self._app.bot):
             return
         try:
-            # PTB 22.x: _request is a (get_updates, general) tuple;
-            # no public accessor exists for the polling request.
-            polling_req = self._app.bot._request[0]  # noqa: SLF001
+            # PTB 22.x: _request is a (get_updates, general) tuple.
+            request = self._app.bot._request[request_index]  # noqa: SLF001
         except Exception:
             return
         try:
-            await polling_req.shutdown()
+            await request.shutdown()
         except Exception:
             logger.debug(
-                "[%s] Polling request shutdown failed (non-fatal)",
-                self.name, exc_info=True,
+                "[%s] %s request shutdown failed (non-fatal)",
+                self.name, label, exc_info=True,
             )
         try:
-            await polling_req.initialize()
-            logger.debug(
-                "[%s] Polling request pool drained before reconnect", self.name
-            )
+            await request.initialize()
+            logger.info("[%s] %s request pool refreshed", self.name, label)
         except Exception:
             logger.debug(
-                "[%s] Polling request re-initialize failed (non-fatal)",
-                self.name, exc_info=True,
+                "[%s] %s request re-initialize failed (non-fatal)",
+                self.name, label, exc_info=True,
             )
+
+    async def _drain_polling_connections(self) -> None:
+        """Reset the httpx connection pool used for getUpdates polling."""
+        await self._drain_request_connections(0, "Polling")
+
+    async def _drain_general_connections(self) -> None:
+        """Reset the httpx connection pool used for general Bot API calls."""
+        await self._drain_request_connections(1, "General")
 
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
@@ -1003,6 +1001,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] Telegram polling resumed after network error (attempt %d)",
                 self.name, attempt,
             )
+            await self._drain_general_connections()
             self._polling_network_error_count = 0
             # start_polling() returning is necessary but not sufficient:
             # PTB's Updater can be left in a state where `running` is True
@@ -1560,13 +1559,25 @@ class TelegramAdapter(BasePlatformAdapter):
                 except (TypeError, ValueError):
                     return default
 
+            connection_pool_size = _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 20)
             request_kwargs = {
-                "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 512),
+                "connection_pool_size": connection_pool_size,
                 "pool_timeout": _env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
                 "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
                 "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
             }
+            httpx_kwargs = {}
+            httpx_limits = platform_httpx_limits()
+            if httpx_limits is not None:
+                max_keepalive = getattr(httpx_limits, "max_keepalive_connections", None)
+                if max_keepalive is not None:
+                    max_keepalive = min(max_keepalive, connection_pool_size)
+                httpx_kwargs["limits"] = type(httpx_limits)(
+                    max_connections=connection_pool_size,
+                    max_keepalive_connections=max_keepalive,
+                    keepalive_expiry=getattr(httpx_limits, "keepalive_expiry", None),
+                )
 
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in {"1", "true", "yes", "on"})
             fallback_ips = self._fallback_ips()
@@ -1590,21 +1601,31 @@ class TelegramAdapter(BasePlatformAdapter):
                 # polling reconnect + bot API bootstrap/delete_webhook calls.
                 request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+                    httpx_kwargs={
+                        **httpx_kwargs,
+                        "transport": TelegramFallbackTransport(fallback_ips),
+                    },
                 )
                 get_updates_request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+                    httpx_kwargs={
+                        **httpx_kwargs,
+                        "transport": TelegramFallbackTransport(fallback_ips),
+                    },
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
-                request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                request = HTTPXRequest(
+                    **request_kwargs, proxy=proxy_url, httpx_kwargs=httpx_kwargs
+                )
+                get_updates_request = HTTPXRequest(
+                    **request_kwargs, proxy=proxy_url, httpx_kwargs=httpx_kwargs
+                )
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
-                request = HTTPXRequest(**request_kwargs)
-                get_updates_request = HTTPXRequest(**request_kwargs)
+                request = HTTPXRequest(**request_kwargs, httpx_kwargs=httpx_kwargs)
+                get_updates_request = HTTPXRequest(**request_kwargs, httpx_kwargs=httpx_kwargs)
 
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
@@ -2059,7 +2080,9 @@ class TelegramAdapter(BasePlatformAdapter):
                             and not self._looks_like_connect_timeout(send_err)
                             and not self._looks_like_pool_timeout(send_err)
                         ):
+                            await self._drain_general_connections()
                             raise
+                        await self._drain_general_connections()
                         if _send_attempt < 2:
                             wait = 2 ** _send_attempt
                             logger.warning("[%s] Network error on send (attempt %d/3), retrying in %ds: %s",

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -44,7 +44,16 @@ def _no_auto_discovery(monkeypatch):
         return []
     monkeypatch.setattr("gateway.platforms.telegram.discover_fallback_ips", _noop)
     # Mock HTTPXRequest so the builder chain doesn't fail
-    monkeypatch.setattr("gateway.platforms.telegram.HTTPXRequest", lambda **kwargs: MagicMock())
+    requests = []
+
+    def _fake_request(**kwargs):
+        req = MagicMock()
+        req.kwargs = kwargs
+        requests.append(req)
+        return req
+
+    monkeypatch.setattr("gateway.platforms.telegram.HTTPXRequest", _fake_request)
+    return requests
 
 
 @pytest.mark.asyncio
@@ -62,6 +71,54 @@ async def test_connect_rejects_same_host_token_lock(monkeypatch):
     assert adapter.fatal_error_code == "telegram-bot-token_lock"
     assert adapter.has_fatal_error is True
     assert "already in use" in adapter.fatal_error_message
+
+
+@pytest.mark.asyncio
+async def test_connect_uses_bounded_httpx_limits(monkeypatch, _no_auto_discovery):
+    """Telegram requests use a smaller pool and short keepalive limits."""
+    monkeypatch.delenv("HERMES_TELEGRAM_HTTP_POOL_SIZE", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_HTTPX_MAX_KEEPALIVE", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY", raising=False)
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    updater = SimpleNamespace(start_polling=AsyncMock(), stop=AsyncMock(), running=True)
+    bot = SimpleNamespace(set_my_commands=AsyncMock(), delete_webhook=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert len(_no_auto_discovery) == 2
+    for req in _no_auto_discovery:
+        assert req.kwargs["connection_pool_size"] == 20
+        limits = req.kwargs["httpx_kwargs"]["limits"]
+        assert limits.max_connections == 20
+        assert limits.max_keepalive_connections <= 10
+        assert limits.keepalive_expiry == 2.0
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -12,6 +12,8 @@ import sys
 import types
 from types import SimpleNamespace
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from gateway.config import PlatformConfig, Platform
@@ -131,6 +133,7 @@ def _make_adapter():
     adapter._polling_conflict_count = 0
     adapter._polling_network_error_count = 0
     adapter._polling_error_callback_ref = None
+    adapter._app = None
     adapter.platform = Platform.TELEGRAM
     return adapter
 
@@ -1390,6 +1393,53 @@ async def test_thread_fallback_only_fires_once():
     # Second chunk: should use thread_id=None directly (effective_thread_id
     # was cleared per-chunk but the metadata doesn't change between chunks)
     # The key point: the message was delivered despite the invalid thread
+
+
+@pytest.mark.asyncio
+async def test_drain_general_connections_resets_general_request_only():
+    """The general Bot API pool (_request[1]) can be refreshed explicitly."""
+    adapter = _make_adapter()
+
+    polling_req = SimpleNamespace(shutdown=AsyncMock(), initialize=AsyncMock())
+    general_req = SimpleNamespace(shutdown=AsyncMock(), initialize=AsyncMock())
+    adapter._app = SimpleNamespace(
+        bot=SimpleNamespace(_request=(polling_req, general_req))
+    )
+
+    await adapter._drain_general_connections()
+
+    polling_req.shutdown.assert_not_called()
+    polling_req.initialize.assert_not_called()
+    general_req.shutdown.assert_awaited_once()
+    general_req.initialize.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_refreshes_general_pool_before_retrying_network_error():
+    """Send-path network errors refresh the general pool before retrying."""
+    adapter = _make_adapter()
+
+    attempt = [0]
+    refreshes = [0]
+
+    async def mock_send_message(**kwargs):
+        attempt[0] += 1
+        if attempt[0] == 1:
+            raise FakeNetworkError("connection reset")
+        return SimpleNamespace(message_id=203)
+
+    async def mock_drain_general_connections():
+        refreshes[0] += 1
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+    adapter._drain_general_connections = mock_drain_general_connections
+
+    result = await adapter.send(chat_id="123", content="test message")
+
+    assert result.success is True
+    assert result.message_id == "203"
+    assert attempt[0] == 2
+    assert refreshes[0] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- bound Telegram `HTTPXRequest` pools to a smaller default and shared keepalive limits
- refresh the general Bot API request pool after polling reconnects and send-path network errors
- add regression tests for bounded HTTPX limits and general-pool refresh before retrying sends

## Motivation
Telegram's python-telegram-bot integration keeps separate httpx request pools for polling (`Bot._request[0]`) and general Bot API calls (`Bot._request[1]`). The adapter already refreshed the polling pool after reconnects, but send/edit/set-command calls can still get stuck behind stale half-closed connections in the general pool, especially when routed through HTTP proxies.

The old default pool size of 512 also makes stale connections accumulate for a long time before surfacing as pool exhaustion. This change keeps the pool bounded and gives keepalive sockets a short lifetime.

## Tests
- `python -m py_compile gateway/platforms/telegram.py tests/gateway/test_telegram_conflict.py tests/gateway/test_telegram_thread_fallback.py`
- `python -m pytest tests/gateway/test_telegram_conflict.py tests/gateway/test_telegram_thread_fallback.py`

Locally the targeted tests pass: `56 passed`.
