### PR TITLE
fix(model_metadata): MiniMax-M3 reports true 1M context, not 512K

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1838,6 +1838,17 @@ def get_model_context_length(
         from agent.models_dev import lookup_models_dev_context
         ctx = lookup_models_dev_context(effective_provider, model)
         if ctx:
+            # MiniMax M3: models.dev reports 512K but actual context is 1M.
+            # Prefer hardcoded catalog over stale probe value.
+            if _model_name_suggests_minimax_m3(model):
+                catalog = DEFAULT_CONTEXT_LENGTHS.get("minimax-m3")
+                if catalog and ctx < catalog:
+                    logger.info(
+                        "Rejecting models.dev context=%s for %r "
+                        "(MiniMax-M3 underreport); using hardcoded default %s",
+                        ctx, model, f"{catalog:,}",
+                    )
+                    ctx = catalog
             return ctx
 
     # 6. OpenRouter live API metadata — provider-unaware fallback.


### PR DESCRIPTION
## Summary
On the native `minimax` provider, MiniMax-M3 now reports its true 1,000,000-token context window instead of 512,000.

Root cause: in `get_model_context_length`, the models.dev probe returns 512K for M3 and `return ctx` fires immediately — short-circuiting before the hardcoded `minimax-m3: 1000000` catalog entry (step 8) can win. The 512K underreport then mis-sized pre-flight checks, compression thresholds, and prompt-cache sizing, triggering premature compression on long sessions.

Salvage of #42342 by @xiaoxinova, cherry-picked onto current main with authorship preserved.

## Changes
- `agent/model_metadata.py`: after the models.dev lookup returns, if the model is MiniMax-M3 (`_model_name_suggests_minimax_m3`) and the probed value is smaller than the catalog 1M, prefer the catalog value and log the rejection. Mirrors the existing Kimi-family underreport guards in the same function.

## Validation
| | Before | After |
|---|---|---|
| `minimax` provider, M3 (probe=512K) | 512,000 | 1,000,000 |
| M2.5 (probe=512K) | 512,000 | 512,000 (not clobbered) |
| M3 with correct 1M probe | 1,000,000 | 1,000,000 (preserved) |

E2E: resolved 1M across `MiniMax-M3`, `minimax/minimax-m3`, `minimax-m3` with models.dev mocked to underreport. Tests: `test_minimax_provider.py` 47/47, `test_model_metadata.py` 100/100.

Fixes #42333. Closes #42342.

## Infographic

![context-window-fix-1m](https://v3b.fal.media/files/b/0a9db28b/xH3ylyWnM4ufbnVbcM5KB_DLYL3r17.png)
