### PR TITLE
fix(providers): use hostname comparison for api.openai.com api_mode detection

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -517,7 +517,7 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
                 return "anthropic_messages"
             if url_lower.endswith("/anthropic") or "api.anthropic.com" in url_lower:
                 return "anthropic_messages"
-            if "api.openai.com" in url_lower:
+            if base_url_hostname(base_url) == "api.openai.com":
                 return "codex_responses"
         return TRANSPORT_TO_API_MODE.get(pdef.transport, "chat_completions")
 


### PR DESCRIPTION
## What changed and why

`determine_api_mode` was using `"api.openai.com" in url_lower` (string containment) which can match URLs that merely include that string as a substring — for example a reverse-proxy whose hostname ends with `.api.openai.com.evil.com`.

Switch to `base_url_hostname(base_url) == "api.openai.com"` so only the exact hostname triggers `codex_responses` mode.

## How to test

```python
from hermes_cli.providers import determine_api_mode
assert determine_api_mode("openai", "https://api.openai.com/v1") == "codex_responses"
assert determine_api_mode("openai", "https://proxy.api.openai.com.evil.com/v1") != "codex_responses"
assert determine_api_mode("openai", "https://my-api.openai.com.proxy.internal/v1") != "codex_responses"
```

## Platforms tested
- Linux (Ubuntu 22.04)

## Changes
- `hermes_cli/providers.py`: 1-line change, `in url_lower` → `base_url_hostname(base_url) ==`