### PR TITLE
fix(tools): exclude nested skill docs from strategy-3 flat search

### DIFF
--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1049,8 +1049,22 @@ def skill_view(
                     _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
+            # Exclude files nested inside another skill's directory (any ancestor
+            # between found_md and search_dir that contains its own SKILL.md).
+            # Those are reference/template assets, not standalone skills.
             for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md":
+                if found_md.name == "SKILL.md":
+                    continue
+                in_other_skill = False
+                for p in found_md.parents:
+                    if p == search_dir:
+                        break
+                    if search_dir not in p.parents:
+                        break
+                    if (p / "SKILL.md").exists():
+                        in_other_skill = True
+                        break
+                if not in_other_skill:
                     _record(None, found_md)
 
         if len(candidates) > 1:


### PR DESCRIPTION
## What changed and why

`skill_view` strategy-3 uses `rglob(f"{name}.md")` to find legacy flat skill docs. This was also picking up reference/template `.md` files that live *inside* another skill's directory (e.g. `skills/foundations/runtime/references/explore-codebase.md`) and returning them as match candidates for an unrelated skill name.

Added an ancestor-walk: if any directory between the found file and the search root contains a `SKILL.md`, the file belongs to that enclosing skill and is excluded from strategy-3 results.

## How to test

```bash
# Create a reference file inside an existing skill that happens to share a name:
mkdir -p ~/.hermes/skills/some-skill/references/
echo "# doc" > ~/.hermes/skills/some-skill/references/other-skill.md
hermes -q "view skill other-skill"
# Should NOT return the reference file from inside some-skill/
```

## Platforms tested
- Linux (Ubuntu 22.04)

## Changes
- `tools/skills_tool.py`: strategy-3 loop now skips files whose ancestor chain contains a `SKILL.md`