### PR TITLE
test(agent): make Claude Code credential tests hermetic on macOS with Keychain entries

### DIFF
--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -262,6 +262,13 @@ class TestIsClaudeCodeTokenValid:
 
 
 class TestResolveAnthropicToken:
+    @pytest.fixture(autouse=True)
+    def no_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_prefers_oauth_token_over_api_key(self, monkeypatch, tmp_path):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-mykey")
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
@@ -441,6 +448,13 @@ class TestWriteClaudeCodeCredentials:
 
 
 class TestResolveWithRefresh:
+    @pytest.fixture(autouse=True)
+    def no_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_auto_refresh_on_expired_creds(self, monkeypatch, tmp_path):
         """When cred file has expired token + refresh token, auto-refresh is attempted."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -488,6 +502,13 @@ class TestResolveWithRefresh:
 
 
 class TestRunOauthSetupToken:
+    @pytest.fixture(autouse=True)
+    def no_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_raises_when_claude_not_installed(self, monkeypatch):
         monkeypatch.setattr("shutil.which", lambda _: None)
         with pytest.raises(FileNotFoundError, match="claude.*CLI.*not installed"):


### PR DESCRIPTION
## What does this PR do?

Makes the Claude Code credential-resolution tests in `tests/agent/test_anthropic_adapter.py` hermetic on macOS machines that have real Claude Code Keychain credentials.

Today, 5 tests fail out of the box on any contributor Mac where Claude Code is (or has been) logged in:

```
FAILED tests/agent/test_anthropic_adapter.py::TestResolveAnthropicToken::test_falls_back_to_claude_code_credentials
FAILED tests/agent/test_anthropic_adapter.py::TestResolveAnthropicToken::test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token
FAILED tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken::test_returns_token_from_credential_files
FAILED tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken::test_returns_token_from_env_var
FAILED tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken::test_returns_none_when_no_creds_found
```

**Root cause:** these tests fake `~/.claude/.credentials.json` by monkeypatching `agent.anthropic_adapter.Path.home` to a `tmp_path`, but `read_claude_code_credentials()` (agent/anthropic_adapter.py) checks the macOS Keychain **first** via `_read_claude_code_credentials_from_keychain()` — which the tests never mocked. The developer's real (possibly expired) Keychain entry shadows the fake credentials file, so resolution returns the wrong token (or `None` after a failed live refresh) and the assertions fail, e.g. `AssertionError: assert None == 'cc-auto-token'`.

The remaining tests in `TestResolveAnthropicToken`, `TestResolveWithRefresh`, and `TestRunOauthSetupToken` currently pass only by luck of the local Keychain state (token expiry, refreshability), so the whole group is covered, not just the 5 currently-red tests.

**Fix:** reuse the exact pattern the file already established — `TestReadClaudeCodeCredentials` has an autouse `no_keychain` fixture that monkeypatches `_read_claude_code_credentials_from_keychain` to return `None`. This PR adds the same fixture to the three affected classes. No production code changes.

The other test files that touch this code path were audited and are already hermetic: they mock `resolve_anthropic_token` / `read_claude_code_credentials` at the function level, and `tests/agent/test_anthropic_keychain.py` mocks `subprocess.run` directly.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/agent/test_anthropic_adapter.py`: add an autouse `no_keychain` fixture (monkeypatch `agent.anthropic_adapter._read_claude_code_credentials_from_keychain` → `None`) to `TestResolveAnthropicToken`, `TestResolveWithRefresh`, and `TestRunOauthSetupToken`, mirroring the existing fixture on `TestReadClaudeCodeCredentials`. 21 insertions, no production code touched.

## How to Test

1. On a Mac where Claude Code is logged in (Keychain has a `Claude Code-credentials` entry), check out `main` and run `pytest tests/agent/test_anthropic_adapter.py -q` → 5 failures as listed above.
2. Check out this branch and run `pytest tests/agent/test_anthropic_adapter.py -q` → all 159 tests pass.
3. On Linux/CI (no Keychain), the suite passes both before and after — this change only removes host-state dependence.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (with Claude Code logged in — the failing configuration)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (clean `upstream/main`, macOS 15, Claude Code logged in):

```
======================== 5 failed, 154 passed in 8.06s =========================
```

After (this branch, same machine):

```
============================= 159 passed in 6.14s ==============================
```
