### PR TITLE
fix(auth): resolve anthropic credentials OAuth-first on the launch path

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5942,7 +5942,27 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     api_key = ""
     key_source = ""
-    api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig)
+    if provider_id == "anthropic":
+        # The registry tuple lists ANTHROPIC_API_KEY first because it also
+        # backs "is configured" checks, but the runtime credential must follow
+        # the adapter's documented OAuth-first order (ANTHROPIC_TOKEN →
+        # CLAUDE_CODE_OAUTH_TOKEN → Claude Code credential store with refresh
+        # → ANTHROPIC_API_KEY).  Iterating the tuple here would let a stale
+        # ANTHROPIC_API_KEY shadow a valid OAuth token and 401 every launch.
+        from agent.anthropic_adapter import resolve_anthropic_token
+        from hermes_cli.config import get_env_value
+        token = (resolve_anthropic_token() or "").strip()
+        if has_usable_secret(token):
+            api_key = token
+            key_source = next(
+                (
+                    var for var in pconfig.api_key_env_vars
+                    if (get_env_value(var) or "").strip() == token
+                ),
+                "claude-code-credentials",
+            )
+    if not api_key:
+        api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig)
 
     # No-auth LM Studio: substitute a placeholder so runtime / auxiliary_client
     # see the local server as configured. doctor still reports unconfigured

--- a/tests/hermes_cli/test_anthropic_credential_order.py
+++ b/tests/hermes_cli/test_anthropic_credential_order.py
@@ -1,0 +1,96 @@
+"""Regression tests for Anthropic launch-path credential resolution order.
+
+The anthropic registry tuple (``PROVIDER_REGISTRY["anthropic"].api_key_env_vars``)
+lists ANTHROPIC_API_KEY first because it also backs "is configured" checks.
+The runtime credential pick, however, must follow the adapter's documented
+OAuth-first order (``agent.anthropic_adapter.resolve_anthropic_token``):
+
+    ANTHROPIC_TOKEN → CLAUDE_CODE_OAUTH_TOKEN → Claude Code credential
+    store (with refresh) → ANTHROPIC_API_KEY
+
+Without that, a stale/revoked ANTHROPIC_API_KEY exported in the shell
+environment shadows a valid OAuth token and every launch fails with HTTP 401.
+"""
+
+import pytest
+
+from hermes_cli.auth import resolve_api_key_provider_credentials
+
+FAKE_OAUTH_TOKEN = "sk-ant-oat01-" + "g" * 60
+FAKE_STALE_API_KEY = "sk-ant-api03-" + "d" * 60
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_anthropic_sources(monkeypatch):
+    """Keep tests hermetic on developer machines (especially macOS).
+
+    ``resolve_anthropic_token`` reads the macOS Keychain and
+    ``~/.claude/.credentials.json`` — both live outside the per-test
+    HERMES_HOME isolation, so a developer's real Claude Code login would
+    leak into assertions.  Stub both readers to "nothing found".
+    """
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: None,
+    )
+    # Make sure no var from the host shell leaks in (conftest strips
+    # *_API_KEY/*_TOKEN already; explicit here for self-documentation).
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestResolveApiKeyProviderCredentialsAnthropic:
+    def test_oauth_token_beats_stale_api_key(self, monkeypatch):
+        """A valid CLAUDE_CODE_OAUTH_TOKEN must win over ANTHROPIC_API_KEY.
+
+        This is the launch-path regression: the registry tuple is
+        API-key-first, so the generic env-var iteration would return the
+        stale key and 401 every launch.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE_STALE_API_KEY)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", FAKE_OAUTH_TOKEN)
+
+        creds = resolve_api_key_provider_credentials("anthropic")
+
+        assert creds["api_key"] == FAKE_OAUTH_TOKEN
+        assert creds["api_key"] != FAKE_STALE_API_KEY
+        assert creds["source"] == "CLAUDE_CODE_OAUTH_TOKEN"
+
+    def test_anthropic_token_beats_stale_api_key(self, monkeypatch):
+        """ANTHROPIC_TOKEN (Hermes-persisted OAuth) also outranks the API key."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE_STALE_API_KEY)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", FAKE_OAUTH_TOKEN)
+
+        creds = resolve_api_key_provider_credentials("anthropic")
+
+        assert creds["api_key"] == FAKE_OAUTH_TOKEN
+        assert creds["source"] == "ANTHROPIC_TOKEN"
+
+    def test_api_key_still_used_when_only_api_key_present(self, monkeypatch):
+        """The API key remains a valid last-resort credential."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE_STALE_API_KEY)
+
+        creds = resolve_api_key_provider_credentials("anthropic")
+
+        assert creds["api_key"] == FAKE_STALE_API_KEY
+        assert creds["source"] == "ANTHROPIC_API_KEY"
+
+
+class TestRuntimeProviderLaunchPath:
+    def test_launch_path_resolves_oauth_first(self, monkeypatch):
+        """End-to-end launch resolution (hermes -z / chat) returns the OAuth
+        token, not the stale API key, when both are present."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE_STALE_API_KEY)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", FAKE_OAUTH_TOKEN)
+
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested="anthropic")
+
+        assert runtime["provider"] == "anthropic"
+        assert runtime["api_key"] == FAKE_OAUTH_TOKEN
+        assert runtime["api_key"] != FAKE_STALE_API_KEY


### PR DESCRIPTION
# What

Fixes the Anthropic launch-path credential pick so it follows the adapter's documented OAuth-first priority. Previously, with `model.provider: anthropic`, a stale/revoked `ANTHROPIC_API_KEY` exported in the shell environment shadowed a valid `CLAUDE_CODE_OAUTH_TOKEN` configured in `~/.hermes/.env`, causing every launch to fail with HTTP 401. Unsetting the dead env var made the same launch succeed.

Root cause: two contradictory resolution orders exist for the same provider.

- `agent/anthropic_adapter.py::resolve_anthropic_token()` — documented priority: `ANTHROPIC_TOKEN` → `CLAUDE_CODE_OAUTH_TOKEN` → Claude Code credential store (with automatic refresh) → `ANTHROPIC_API_KEY` last.
- `hermes_cli/auth.py::resolve_api_key_provider_credentials()` — resolved the runtime secret by iterating `PROVIDER_REGISTRY["anthropic"].api_key_env_vars = ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")` via `_resolve_api_key_provider_secret()` — API key FIRST.

A CLI-resolved key then wins inside the agent (`agent/agent_init.py`: `api_key or resolve_anthropic_token()`), so the dead key is what gets sent.

The fix delegates the anthropic secret pick in `resolve_api_key_provider_credentials()` to `resolve_anthropic_token()`, keeping one source of truth for the order (and gaining Claude Code token refresh) instead of reordering the registry tuple — the tuple also backs "is configured" checks (`get_api_key_provider_status`, `is_provider_explicitly_configured`) whose semantics must not change. If the adapter finds nothing, the previous generic env-var / credential-pool fallback still runs, so behavior for API-key-only setups is unchanged.

## Related Issue

N/A — reproduced locally (macOS, `model.provider: anthropic`, valid `CLAUDE_CODE_OAUTH_TOKEN` in `~/.hermes/.env`, stale `ANTHROPIC_API_KEY` exported in the shell).

## Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made

- `hermes_cli/auth.py` — `resolve_api_key_provider_credentials()`: for `provider_id == "anthropic"`, resolve the secret via `agent.anthropic_adapter.resolve_anthropic_token()` (OAuth-first, refresh-capable) before falling back to the generic `api_key_env_vars` iteration. The reported `source` is the matching env var name, or `claude-code-credentials` when the token came from the Claude Code credential store.
- `tests/hermes_cli/test_anthropic_credential_order.py` — new regression tests:
  - OAuth token wins over a stale `ANTHROPIC_API_KEY` when both are present (fails without the fix).
  - `ANTHROPIC_TOKEN` also wins over the API key.
  - API key still resolves when it is the only credential (fallback preserved).
  - End-to-end `resolve_runtime_provider(requested="anthropic")` returns the OAuth token.
  - Tests are hermetic on macOS: both `_read_claude_code_credentials_from_keychain` and `read_claude_code_credentials` are monkeypatched to return `None` so a developer's real Claude Code login can't leak into assertions.

## How to Test

```bash
# Regression tests (the first test fails without the fix in this PR)
pytest tests/hermes_cli/test_anthropic_credential_order.py -v

# Neighbouring suites
pytest tests/agent/test_anthropic_adapter.py tests/hermes_cli/test_api_key_providers.py tests/tools/test_credential_pool_env_fallback.py
```

Manual reproduction:

1. Configure `model.provider: anthropic` and put a valid `CLAUDE_CODE_OAUTH_TOKEN` in `~/.hermes/.env`.
2. Export a stale/revoked `ANTHROPIC_API_KEY` in the shell.
3. Run `hermes -z "hello"`. Before this fix, surfaces that resolve through the generic API-key machinery send the dead key and fail with 401; after, the OAuth token is used.

Note: 5 pre-existing failures in `tests/agent/test_anthropic_adapter.py` (`TestResolveAnthropicToken::test_falls_back_to_claude_code_credentials`, `test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token`, and the three `TestRunOauthSetupToken` tests) reproduce identically on a clean `upstream/main` checkout on macOS — they read the real Keychain / `~/.claude/.credentials.json` without mocking. They are unrelated to this change and are being addressed separately.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
