### PR TITLE
feat(gateway): read-only Inspector server for external container access

### DIFF
--- a/docs/hermes-inspector-api.md
+++ b/docs/hermes-inspector-api.md
@@ -1,0 +1,302 @@
+# HermesAgent Inspector API
+
+## 개요
+
+**HermesAgent Inspector**는 외부 Docker 컨테이너(ClaudeCode, Antigravity 등)가 네이티브 HermesAgent 인스턴스의 공개 정보를 읽기 전용으로 조회할 수 있도록 제공하는 경량 HTTP 서버입니다.
+
+- 기본 바인드: `http://127.0.0.1:8646`
+- GET 전용 엔드포인트 (읽기 전용)
+- CORS 허용 (`Access-Control-Allow-Origin: *`)
+- 인증 없이 접근 가능 (단, 민감 정보는 구조적으로 제외됨)
+
+---
+
+## 엔드포인트 레퍼런스
+
+### `GET /health`
+
+게이트웨이 프로세스의 생존 여부와 업타임을 반환합니다.
+
+**요청**
+```
+GET http://127.0.0.1:8646/health
+```
+
+**응답 예시**
+```json
+{
+  "status": "ok",
+  "pid": 12345,
+  "uptime_seconds": 3720.45
+}
+```
+
+---
+
+### `GET /status`
+
+현재 모델, 프로바이더, API 모드, 게이트웨이 상태, 활성 에이전트 수, 플랫폼 연결 상태를 반환합니다.
+
+**요청**
+```
+GET http://127.0.0.1:8646/status
+```
+
+**응답 예시**
+```json
+{
+  "model": "claude-opus-4-5",
+  "provider": "anthropic",
+  "api_mode": "api",
+  "gateway_state": "running",
+  "active_agents": 2,
+  "platforms": {
+    "telegram": {
+      "state": "connected",
+      "updated_at": "2026-06-10T04:00:00+00:00"
+    },
+    "discord": {
+      "state": "connected",
+      "updated_at": "2026-06-10T04:00:00+00:00"
+    }
+  }
+}
+```
+
+---
+
+### `GET /skills`
+
+`~/.hermes/skills/` 디렉토리를 스캔하여 설치된 스킬 목록을 반환합니다. 각 스킬의 `SKILL.md` frontmatter에서 `name`, `category`, `description`을 추출합니다.
+
+**요청**
+```
+GET http://127.0.0.1:8646/skills
+```
+
+**응답 예시**
+```json
+[
+  {
+    "slug": "blue-ribbon-nearby",
+    "name": "blue-ribbon-nearby",
+    "category": "food",
+    "description": "Use when the user asks for nearby restaurants or 근처 맛집 and wants 블루리본 picks."
+  },
+  {
+    "slug": "devops/kanban-worker",
+    "name": "kanban-worker",
+    "category": "devops",
+    "description": "Pitfalls, examples, and edge cases for Hermes Kanban workers."
+  }
+]
+```
+
+`slug` 필드는 API 엔드포인트에 사용하는 경로 식별자입니다. 단순 스킬은 `name`과 동일하고, 카테고리 아래 중첩된 스킬은 `category/name` 형태입니다.
+
+---
+
+### `GET /skills/<slug>`
+
+특정 스킬의 `SKILL.md` 전문(본문 포함)을 반환합니다. `slug`는 `/skills` 응답의 `slug` 필드 값을 사용합니다.
+
+**요청 (단순)**
+```
+GET http://127.0.0.1:8646/skills/blue-ribbon-nearby
+```
+
+**요청 (중첩)**
+```
+GET http://127.0.0.1:8646/skills/devops/kanban-worker
+```
+
+**응답 예시**
+```json
+{
+  "slug": "blue-ribbon-nearby",
+  "content": "---\nname: blue-ribbon-nearby\ndescription: ...\n---\n\n# Blue Ribbon Nearby\n..."
+}
+```
+
+**404 응답 예시 (스킬 없음)**
+```json
+{
+  "error": "not_found",
+  "message": "Skill 'nonexistent-skill' not found"
+}
+```
+
+---
+
+### `GET /config/public`
+
+민감하지 않은 공개 설정만 반환합니다. `api_key`, `token`, `secret`, `password`, `auth`, `credential`, `bearer` 관련 키는 모두 제외됩니다.
+
+노출되는 섹션: `model`, `agent`, `toolsets`, `compression`, `language`, `locale`, `ui`
+
+**요청**
+```
+GET http://127.0.0.1:8646/config/public
+```
+
+**응답 예시**
+```json
+{
+  "model": {
+    "default": "claude-opus-4-5",
+    "provider": "anthropic"
+  },
+  "agent": {
+    "max_turns": 50,
+    "timeout_seconds": 300
+  },
+  "toolsets": ["default", "web", "code"],
+  "compression": {
+    "enabled": true,
+    "threshold_tokens": 8000
+  }
+}
+```
+
+---
+
+## Docker Container에서 사용하는 법
+
+Docker 컨테이너 내부에서 호스트의 Inspector에 접근할 때는 `host.docker.internal`을 사용합니다.
+
+### curl 예시
+
+```bash
+# 컨테이너 내부에서 호스트 HermesAgent Inspector 조회
+curl http://host.docker.internal:8646/health
+curl http://host.docker.internal:8646/status
+curl http://host.docker.internal:8646/skills
+curl http://host.docker.internal:8646/skills/blue-ribbon-nearby
+curl http://host.docker.internal:8646/config/public
+```
+
+### Python requests 예시
+
+```python
+import os
+import requests
+
+HERMES_INSPECTOR_URL = os.environ.get(
+    "HERMES_INSPECTOR_URL", "http://host.docker.internal:8646"
+)
+
+def get_hermes_status():
+    resp = requests.get(f"{HERMES_INSPECTOR_URL}/status", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+def list_hermes_skills():
+    resp = requests.get(f"{HERMES_INSPECTOR_URL}/skills", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+def get_skill_content(name: str):
+    resp = requests.get(f"{HERMES_INSPECTOR_URL}/skills/{name}", timeout=5)
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    return resp.json()["content"]
+```
+
+---
+
+## 환경 변수
+
+| 환경 변수 | 기본값 | 설명 |
+|---|---|---|
+| `HERMES_INSPECTOR_HOST` | `127.0.0.1` | Inspector 서버 바인드 호스트 |
+| `HERMES_INSPECTOR_PORT` | `8646` | Inspector 서버 포트 |
+| `HERMES_INSPECTOR_DISABLED` | (unset) | `1`, `true`, `yes`로 설정 시 Inspector 비활성화 |
+
+Docker 컨테이너가 접근하려면 호스트에서 `HERMES_INSPECTOR_HOST=0.0.0.0`으로 설정하거나, Docker 네트워크 구성에 따라 적절히 조정하세요.
+
+---
+
+## 보안 고려사항
+
+### 노출되는 정보
+
+- 프로세스 PID 및 업타임
+- 게이트웨이 상태 (`running`, `starting`, `degraded` 등)
+- 활성 에이전트 수
+- 플랫폼 연결 상태 (연결됨/끊김, 오류 코드)
+- 현재 모델 이름 및 프로바이더
+- API 모드 (`api`, `mcp` 등)
+- 스킬 이름, 카테고리, 설명
+- SKILL.md 전문 (설치된 스킬의 사용 방법)
+- 비민감 config 섹션 (model.default, agent.max_turns, toolsets 등)
+
+### 노출되지 않는 정보
+
+- API 키, 토큰, Bearer 인증 정보
+- `auth.json`, `.env` 파일 내용
+- 세션 데이터 및 대화 기록
+- 메모리(memories) 파일
+- config.yaml의 민감 키 (`api_key`, `token`, `secret`, `password`, `auth`, `credential`)
+- 플랫폼 인증 정보 (Telegram bot token, Discord token 등)
+
+### 네트워크 접근 제어
+
+기본값 `127.0.0.1` 바인딩은 같은 호스트에서만 접근 가능합니다. 외부 네트워크에 노출하려면 반드시 방화벽 규칙을 설정하세요.
+
+---
+
+## docker-compose.yml 예시
+
+```yaml
+version: "3.9"
+
+services:
+  hermes-agent:
+    build: .
+    environment:
+      - HERMES_INSPECTOR_HOST=0.0.0.0
+      - HERMES_INSPECTOR_PORT=8646
+    ports:
+      - "127.0.0.1:8646:8646"
+    volumes:
+      - ~/.hermes:/root/.hermes
+
+  claude-code:
+    image: ghcr.io/anthropics/claude-code:latest
+    environment:
+      - HERMES_INSPECTOR_URL=http://hermes-agent:8646
+    depends_on:
+      - hermes-agent
+    networks:
+      - hermes-net
+
+  antigravity:
+    image: antigravity:latest
+    environment:
+      - HERMES_INSPECTOR_URL=http://hermes-agent:8646
+    depends_on:
+      - hermes-agent
+    networks:
+      - hermes-net
+
+networks:
+  hermes-net:
+    driver: bridge
+```
+
+### host.docker.internal 사용 (macOS/Windows Docker Desktop)
+
+```yaml
+version: "3.9"
+
+services:
+  claude-code:
+    image: ghcr.io/anthropics/claude-code:latest
+    environment:
+      - HERMES_INSPECTOR_URL=http://host.docker.internal:8646
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
+
+> **참고**: Linux Docker에서는 `extra_hosts: ["host.docker.internal:host-gateway"]`를 명시해야 합니다. macOS/Windows Docker Desktop에서는 자동으로 동작합니다.

--- a/docs/hermes-inspector-skill.md
+++ b/docs/hermes-inspector-skill.md
@@ -1,0 +1,253 @@
+---
+name: hermes-inspector
+description: Query the native HermesAgent instance from inside a Docker container using the Inspector API. Use this skill when you need to discover available skills, check gateway status, or read public configuration from within a containerized environment.
+license: MIT
+metadata:
+  category: devops
+  locale: en
+  phase: v1
+---
+
+# HermesAgent Inspector Skill
+
+## What this skill does
+
+Docker 컨테이너(ClaudeCode, Antigravity 등) 내부에서 실행되는 AI 에이전트가 **네이티브 HermesAgent 인스턴스**의 공개 정보를 조회할 수 있게 합니다.
+
+- 설치된 스킬 목록 조회
+- 특정 스킬의 사용법(SKILL.md) 읽기
+- 게이트웨이 상태 및 활성 에이전트 수 확인
+- 공개 설정 (모델, 프로바이더, 툴셋 등) 조회
+
+## When to use
+
+- "어떤 HermesAgent 스킬이 설치되어 있는지 알고 싶을 때"
+- "특정 스킬의 사용법을 알아야 할 때"
+- "HermesAgent가 현재 어떤 모델을 사용하는지 확인할 때"
+- "게이트웨이가 정상 동작 중인지 확인할 때"
+
+---
+
+## 환경 설정
+
+컨테이너 내에서 Inspector URL을 환경 변수로 설정합니다:
+
+```bash
+export HERMES_INSPECTOR_URL="http://host.docker.internal:8646"
+# 또는 docker-compose 네트워크 내에서:
+export HERMES_INSPECTOR_URL="http://hermes-agent:8646"
+```
+
+---
+
+## 스킬 목록 조회
+
+### curl
+
+```bash
+curl "${HERMES_INSPECTOR_URL}/skills"
+```
+
+### Python
+
+```python
+import os
+import requests
+
+base_url = os.environ.get("HERMES_INSPECTOR_URL", "http://host.docker.internal:8646")
+
+def list_skills():
+    """설치된 스킬 목록 반환 (name, category, description)."""
+    resp = requests.get(f"{base_url}/skills", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+skills = list_skills()
+for skill in skills:
+    print(f"[{skill.get('category', 'unknown')}] {skill['name']}: {skill.get('description', '')}")
+```
+
+**응답 예시**
+```json
+[
+  {
+    "name": "blue-ribbon-nearby",
+    "category": "food",
+    "description": "Use when the user asks for nearby restaurants or 근처 맛집 and wants 블루리본 picks."
+  },
+  {
+    "name": "korean-stock-search",
+    "category": "finance",
+    "description": "Search Korean stock market data."
+  }
+]
+```
+
+---
+
+## 특정 스킬 내용 가져오기
+
+### curl
+
+```bash
+curl "${HERMES_INSPECTOR_URL}/skills/blue-ribbon-nearby"
+```
+
+### Python
+
+```python
+import os
+import requests
+
+base_url = os.environ.get("HERMES_INSPECTOR_URL", "http://host.docker.internal:8646")
+
+def get_skill_content(skill_name: str) -> str | None:
+    """스킬의 SKILL.md 전문을 반환. 없으면 None."""
+    resp = requests.get(f"{base_url}/skills/{skill_name}", timeout=5)
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    return resp.json()["content"]
+
+content = get_skill_content("blue-ribbon-nearby")
+if content:
+    print(content)
+else:
+    print("Skill not found")
+```
+
+**응답 예시**
+```json
+{
+  "name": "blue-ribbon-nearby",
+  "content": "---\nname: blue-ribbon-nearby\ndescription: ...\n---\n\n# Blue Ribbon Nearby\n\n..."
+}
+```
+
+---
+
+## 게이트웨이 상태 확인
+
+### curl
+
+```bash
+curl "${HERMES_INSPECTOR_URL}/health"
+curl "${HERMES_INSPECTOR_URL}/status"
+```
+
+### Python
+
+```python
+import os
+import requests
+
+base_url = os.environ.get("HERMES_INSPECTOR_URL", "http://host.docker.internal:8646")
+
+def check_gateway_health() -> dict:
+    resp = requests.get(f"{base_url}/health", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+def get_gateway_status() -> dict:
+    resp = requests.get(f"{base_url}/status", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+health = check_gateway_health()
+print(f"Gateway PID: {health['pid']}, Uptime: {health['uptime_seconds']}s")
+
+status = get_gateway_status()
+print(f"Model: {status['model']}, State: {status['gateway_state']}, Active agents: {status['active_agents']}")
+```
+
+---
+
+## 공개 설정 조회
+
+```bash
+curl "${HERMES_INSPECTOR_URL}/config/public"
+```
+
+```python
+def get_public_config() -> dict:
+    resp = requests.get(f"{base_url}/config/public", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+config = get_public_config()
+print(f"Default model: {config.get('model', {}).get('default')}")
+print(f"Max turns: {config.get('agent', {}).get('max_turns')}")
+```
+
+---
+
+## HERMES_INSPECTOR_URL 활용 패턴
+
+### 연결 확인 후 스킬 동적 로딩
+
+```python
+import os
+import requests
+from functools import lru_cache
+
+_INSPECTOR_URL = os.environ.get("HERMES_INSPECTOR_URL")
+
+def inspector_available() -> bool:
+    """Inspector 서버가 접근 가능한지 확인."""
+    if not _INSPECTOR_URL:
+        return False
+    try:
+        resp = requests.get(f"{_INSPECTOR_URL}/health", timeout=2)
+        return resp.status_code == 200
+    except requests.RequestException:
+        return False
+
+@lru_cache(maxsize=1)
+def get_all_skills() -> list[dict]:
+    """스킬 목록을 캐시해서 반환 (Inspector 미사용 시 빈 리스트)."""
+    if not inspector_available():
+        return []
+    try:
+        resp = requests.get(f"{_INSPECTOR_URL}/skills", timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        return []
+
+def find_skill_by_description(keyword: str) -> list[dict]:
+    """description에 키워드가 포함된 스킬 검색."""
+    return [
+        s for s in get_all_skills()
+        if keyword.lower() in (s.get("description") or "").lower()
+    ]
+```
+
+### 에이전트 시스템 프롬프트에 스킬 목록 주입
+
+```python
+def build_skills_context() -> str:
+    """사용 가능한 스킬 목록을 시스템 프롬프트용 텍스트로 반환."""
+    skills = get_all_skills()
+    if not skills:
+        return ""
+    lines = ["## Available HermesAgent Skills\n"]
+    for skill in skills:
+        name = skill.get("name", "unknown")
+        desc = skill.get("description", "")
+        cat = skill.get("category", "")
+        cat_tag = f"[{cat}] " if cat else ""
+        lines.append(f"- **{name}**: {cat_tag}{desc}")
+    return "\n".join(lines)
+```
+
+---
+
+## 보안 참고사항
+
+Inspector API는 다음 정보를 **절대 노출하지 않습니다**:
+- API 키, 토큰, 인증 정보
+- 대화 세션 및 메모리
+- `.env` 파일 내용
+- config.yaml의 민감 키
+
+따라서 `HERMES_INSPECTOR_URL`을 컨테이너 환경 변수에 노출하는 것은 보안상 안전합니다.

--- a/gateway/inspector.py
+++ b/gateway/inspector.py
@@ -30,11 +30,39 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-# Keys that are never exposed in /config/public, regardless of nesting level.
+# Regex: catches pattern-based variants (api_key, API_KEY, ApiKey, …).
 _SENSITIVE_KEY_PATTERNS = re.compile(
     r"(api[_-]?key|apikey|token|secret|password|passwd|auth|credential|bearer)",
     re.IGNORECASE,
 )
+
+# Exact-match allowlist for common sensitive key names that the regex may miss:
+# abbreviations ("pass"), hyphenated forms ("api-key" → normalized), and
+# compound names whose substrings don't trigger the regex anchors.
+_SENSITIVE_KEY_SET: frozenset = frozenset({
+    "api_key", "apikey",
+    "token", "access_token", "refresh_token", "id_token",
+    "secret", "client_secret", "app_secret", "signing_secret", "webhook_secret",
+    "password", "passwd", "pass",
+    "auth", "authorization",
+    "credential", "credentials",
+    "bearer",
+    "private_key", "privatekey", "signing_key",
+    "session_key", "session_token",
+    "hmac_key", "encryption_key",
+})
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """Return True if *key* should be redacted from public output.
+
+    Two complementary strategies so neither alone is a single point of failure:
+    the regex catches pattern-based variants; the exact-match set catches
+    abbreviated or hyphenated forms the regex might miss.
+    """
+    normalized = str(key).lower().replace("-", "_")
+    return normalized in _SENSITIVE_KEY_SET or bool(_SENSITIVE_KEY_PATTERNS.search(str(key)))
+
 
 # Frontmatter description extractor
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
@@ -69,14 +97,14 @@ def _extract_frontmatter(text: str) -> dict:
 
 
 def _scrub_sensitive(obj: Any, _depth: int = 0) -> Any:
-    """Recursively remove keys that match sensitive-key patterns from a dict."""
+    """Recursively remove sensitive keys from a dict using regex + allowlist."""
     if _depth > 20:
         return obj
     if isinstance(obj, dict):
         return {
             k: _scrub_sensitive(v, _depth + 1)
             for k, v in obj.items()
-            if not _SENSITIVE_KEY_PATTERNS.search(str(k))
+            if not _is_sensitive_key(k)
         }
     if isinstance(obj, list):
         return [_scrub_sensitive(item, _depth + 1) for item in obj]

--- a/gateway/inspector.py
+++ b/gateway/inspector.py
@@ -1,0 +1,310 @@
+"""
+Inspector HTTP server — read-only meta API for external containers.
+
+Allows external Docker containers (ClaudeCode, Antigravity, etc.) to query
+the native HermesAgent instance for public status, skills, and configuration.
+
+Security principles:
+- GET-only endpoints
+- No API keys, tokens, auth.json, .env, sessions, or memories exposed
+- Sensitive config keys (api_key, token, secret, password) are structurally excluded
+- Binds to 127.0.0.1 by default; override via HERMES_INSPECTOR_HOST / HERMES_INSPECTOR_PORT
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    from aiohttp import web
+    AIOHTTP_AVAILABLE = True
+except ImportError:
+    web = None  # type: ignore[assignment]
+    AIOHTTP_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+# Keys that are never exposed in /config/public, regardless of nesting level.
+_SENSITIVE_KEY_PATTERNS = re.compile(
+    r"(api[_-]?key|apikey|token|secret|password|passwd|auth|credential|bearer)",
+    re.IGNORECASE,
+)
+
+# Frontmatter description extractor
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_DESCRIPTION_RE = re.compile(r"^description:\s*(.+)$", re.MULTILINE)
+_NAME_RE = re.compile(r"^name:\s*(.+)$", re.MULTILINE)
+_CATEGORY_RE = re.compile(r"^\s*category:\s*(.+)$", re.MULTILINE)
+
+
+
+
+def _extract_frontmatter(text: str) -> dict:
+    """Extract key-value pairs from a SKILL.md YAML frontmatter block."""
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    front = m.group(1)
+    result: dict = {}
+
+    name_m = _NAME_RE.search(front)
+    if name_m:
+        result["name"] = name_m.group(1).strip()
+
+    desc_m = _DESCRIPTION_RE.search(front)
+    if desc_m:
+        result["description"] = desc_m.group(1).strip()
+
+    cat_m = _CATEGORY_RE.search(front)
+    if cat_m:
+        result["category"] = cat_m.group(1).strip()
+
+    return result
+
+
+def _scrub_sensitive(obj: Any, _depth: int = 0) -> Any:
+    """Recursively remove keys that match sensitive-key patterns from a dict."""
+    if _depth > 20:
+        return obj
+    if isinstance(obj, dict):
+        return {
+            k: _scrub_sensitive(v, _depth + 1)
+            for k, v in obj.items()
+            if not _SENSITIVE_KEY_PATTERNS.search(str(k))
+        }
+    if isinstance(obj, list):
+        return [_scrub_sensitive(item, _depth + 1) for item in obj]
+    return obj
+
+
+class InspectorServer:
+    """Read-only HTTP server exposing HermesAgent public metadata."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        gateway_state_file: str,
+        hermes_home: str,
+    ) -> None:
+        if not AIOHTTP_AVAILABLE:
+            raise RuntimeError(
+                "aiohttp is required for InspectorServer. "
+                "Install with: pip install aiohttp"
+            )
+        self._host = host
+        self._port = port
+        self._gateway_state_file = Path(gateway_state_file)
+        self._hermes_home = Path(hermes_home)
+        self._skills_dir = self._hermes_home / "skills"
+        self._config_file = self._hermes_home / "config.yaml"
+        self._start_time = time.monotonic()
+        self._runner: Optional[Any] = None
+        self._site: Optional[Any] = None
+
+    _LOCALHOST_BINDS = {"127.0.0.1", "::1", "localhost"}
+
+    def _cors_headers(self) -> dict:
+        # Omit CORS headers when bound to a non-loopback interface so that
+        # browsers cannot make cross-origin requests to an Inspector exposed
+        # on 0.0.0.0 (e.g. inside Docker).
+        if self._host not in self._LOCALHOST_BINDS:
+            return {}
+        return {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type",
+        }
+
+    def _json_response(self, data: Any, status: int = 200) -> "web.Response":
+        return web.Response(
+            text=json.dumps(data, ensure_ascii=False),
+            status=status,
+            content_type="application/json",
+            headers=self._cors_headers(),
+        )
+
+    # ── Internal helpers ──────────────────────────────────────────────
+
+    def _read_gateway_state(self) -> dict:
+        """Read gateway_state.json, returning empty dict on any error."""
+        try:
+            raw = self._gateway_state_file.read_text(encoding="utf-8").strip()
+            data = json.loads(raw)
+            return data if isinstance(data, dict) else {}
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return {}
+
+    def _read_config_yaml(self) -> dict:
+        """Read config.yaml as a plain dict; returns empty dict on any error."""
+        try:
+            import yaml  # type: ignore[import]
+            raw = self._config_file.read_text(encoding="utf-8")
+            data = yaml.safe_load(raw)
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
+
+    def _iter_skill_dirs(self):
+        """Yield (slug, skill_md_path) for every SKILL.md under the skills dir.
+
+        Follows symlinks (most installed skills are symlinked from ~/.agents/skills/).
+        Supports flat layout (skill-name/SKILL.md) and one-level nested layout
+        (category/skill-name/SKILL.md).  Hidden directories (starting with '.')
+        are skipped.
+        """
+        if not self._skills_dir.is_dir():
+            return
+        for top in sorted(self._skills_dir.iterdir()):
+            if top.name.startswith("."):
+                continue
+            if not top.is_dir():          # follows symlinks
+                continue
+            direct = top / "SKILL.md"
+            if direct.is_file():
+                yield top.name, direct
+                continue
+            # Nested: category/skill-name/SKILL.md
+            for sub in sorted(top.iterdir()):
+                if sub.name.startswith(".") or not sub.is_dir():
+                    continue
+                nested = sub / "SKILL.md"
+                if nested.is_file():
+                    yield f"{top.name}/{sub.name}", nested
+
+    def _list_skills(self) -> list[dict]:
+        """Scan ~/.hermes/skills/ and return a list of public skill metadata."""
+        skills = []
+        for slug, skill_md in self._iter_skill_dirs():
+            try:
+                text = skill_md.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            meta = _extract_frontmatter(text)
+            skills.append({
+                "slug": slug,
+                "name": meta.get("name") or slug.split("/")[-1],
+                "category": meta.get("category"),
+                "description": meta.get("description"),
+            })
+        return skills
+
+    def _get_skill_content(self, slug: str) -> Optional[str]:
+        """Return the full SKILL.md text for a slug (flat or nested), or None.
+
+        Path traversal is prevented by the allowlist regex — no '..' components
+        are possible, so we do NOT resolve symlinks (most skills are symlinked
+        from ~/.agents/skills/ and resolving breaks the relative_to check).
+        """
+        # Allow: letters, digits, hyphens, underscores, and ONE internal slash
+        if not re.match(r"^[a-zA-Z0-9_\-]+(/[a-zA-Z0-9_\-]+)?$", slug):
+            return None
+        skill_md = self._skills_dir / slug / "SKILL.md"
+        if not skill_md.is_file():   # follows symlinks — correct
+            return None
+        try:
+            return skill_md.read_text(encoding="utf-8")
+        except OSError:
+            return None
+
+    # ── Route handlers ────────────────────────────────────────────────
+
+    async def _handle_health(self, request: "web.Request") -> "web.Response":
+        return self._json_response({
+            "status": "ok",
+            "pid": os.getpid(),
+            "uptime_seconds": round(time.monotonic() - self._start_time, 2),
+        })
+
+    async def _handle_status(self, request: "web.Request") -> "web.Response":
+        state = self._read_gateway_state()
+        config = self._read_config_yaml()
+
+        model_cfg = config.get("model", {}) if isinstance(config.get("model"), dict) else {}
+        runtime_cfg = config.get("runtime", {}) if isinstance(config.get("runtime"), dict) else {}
+
+        return self._json_response({
+            "model": model_cfg.get("default"),
+            "provider": model_cfg.get("provider"),
+            "api_mode": runtime_cfg.get("api_mode"),
+            "gateway_state": state.get("gateway_state"),
+            "active_agents": state.get("active_agents", 0),
+            "platforms": state.get("platforms", {}),
+        })
+
+    async def _handle_skills_list(self, request: "web.Request") -> "web.Response":
+        return self._json_response(self._list_skills())
+
+    async def _handle_skill_detail(self, request: "web.Request") -> "web.Response":
+        # Support both flat (/skills/name) and nested (/skills/category/name) slugs
+        slug = request.match_info.get("slug", "")
+        content = self._get_skill_content(slug)
+        if content is None:
+            return self._json_response(
+                {"error": "not_found", "message": f"Skill '{slug}' not found"},
+                status=404,
+            )
+        return self._json_response({"slug": slug, "content": content})
+
+    async def _handle_config_public(self, request: "web.Request") -> "web.Response":
+        config = self._read_config_yaml()
+
+        # Allow-list approach: only expose known safe top-level sections,
+        # then scrub any remaining sensitive keys inside them.
+        safe_keys = {"model", "agent", "toolsets", "compression", "language", "locale", "ui"}
+        public: dict = {}
+        for key in safe_keys:
+            if key in config:
+                public[key] = _scrub_sensitive(config[key])
+
+        return self._json_response(public)
+
+    async def _handle_options(self, request: "web.Request") -> "web.Response":
+        """CORS preflight handler."""
+        return web.Response(status=204, headers=self._cors_headers())
+
+    # ── Lifecycle ─────────────────────────────────────────────────────
+
+    def _build_app(self) -> "web.Application":
+        app = web.Application()
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/status", self._handle_status)
+        app.router.add_get("/skills", self._handle_skills_list)
+        # {slug:.+} matches both flat (name) and nested (category/name) slugs
+        app.router.add_get(r"/skills/{slug:.+}", self._handle_skill_detail)
+        app.router.add_get("/config/public", self._handle_config_public)
+        # CORS preflight
+        app.router.add_route("OPTIONS", "/{path_info:.*}", self._handle_options)
+        return app
+
+    async def start(self) -> None:
+        """Start the Inspector HTTP server."""
+        app = self._build_app()
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        self._site = web.TCPSite(
+            self._runner,
+            host=self._host,
+            port=self._port,
+        )
+        await self._site.start()
+        logger.debug(
+            "Inspector server started on http://%s:%s", self._host, self._port
+        )
+
+    async def stop(self) -> None:
+        """Stop the Inspector HTTP server gracefully."""
+        if self._runner is not None:
+            try:
+                await self._runner.cleanup()
+            except Exception as exc:
+                logger.debug("Inspector server cleanup error: %s", exc)
+            self._runner = None
+            self._site = None
+            logger.debug("Inspector server stopped")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15907,7 +15907,26 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="cron-ticker",
     )
     cron_thread.start()
-    
+
+    # Inspector server (read-only meta API for external containers)
+    _inspector_server = None
+    _inspector_host = os.environ.get("HERMES_INSPECTOR_HOST", "127.0.0.1")
+    _inspector_port = int(os.environ.get("HERMES_INSPECTOR_PORT", "8646"))
+    if os.environ.get("HERMES_INSPECTOR_DISABLED", "").lower() not in ("1", "true", "yes"):
+        try:
+            from gateway.inspector import InspectorServer
+            _inspector_server = InspectorServer(
+                host=_inspector_host,
+                port=_inspector_port,
+                gateway_state_file=str(_hermes_home / "gateway_state.json"),
+                hermes_home=str(_hermes_home),
+            )
+            await _inspector_server.start()
+            logger.info("Inspector server listening on %s:%s", _inspector_host, _inspector_port)
+        except Exception as _ins_exc:
+            logger.warning("Inspector server failed to start: %s", _ins_exc)
+            _inspector_server = None
+
     # Wait for shutdown
     await runner.wait_for_shutdown()
 
@@ -15915,7 +15934,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         if runner.exit_reason:
             logger.error("Gateway exiting with failure: %s", runner.exit_reason)
         return False
-    
+
+    # Stop inspector server
+    if _inspector_server is not None:
+        try:
+            await _inspector_server.stop()
+        except Exception as _ins_stop_exc:
+            logger.debug("Inspector server stop error: %s", _ins_stop_exc)
+
     # Stop cron ticker cleanly
     cron_stop.set()
     cron_thread.join(timeout=5)

--- a/scripts/simulate_codex_fallback.py
+++ b/scripts/simulate_codex_fallback.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Codex → local-claude fallback 시뮬레이션.
+
+실제 try_activate_fallback() 코드 경로를 직접 실행해서
+Context Bridge와 Skill Re-injection이 동작하는지 확인한다.
+
+실행:
+    cd /home/ubuntu/hermes-agent
+    python scripts/simulate_codex_fallback.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import copy
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# ──────────────────────────────────────────────
+# ANSI 컬러 헬퍼
+# ──────────────────────────────────────────────
+RED    = "\033[31m"
+GREEN  = "\033[32m"
+YELLOW = "\033[33m"
+CYAN   = "\033[36m"
+BOLD   = "\033[1m"
+RESET  = "\033[0m"
+
+def header(title): print(f"\n{BOLD}{CYAN}{'─'*60}{RESET}\n{BOLD}{CYAN}{title}{RESET}\n{'─'*60}")
+def ok(msg):       print(f"  {GREEN}✅ {msg}{RESET}")
+def warn(msg):     print(f"  {YELLOW}⚠️  {msg}{RESET}")
+def info(msg):     print(f"  {msg}")
+def field(k, v):   print(f"  {BOLD}{k:30s}{RESET}{v}")
+
+# ──────────────────────────────────────────────
+# Step 1: Codex 세션 대화 히스토리 구성
+# ──────────────────────────────────────────────
+header("Step 1: Codex 세션 대화 히스토리 구성")
+
+ORIGINAL_SYSTEM = (
+    "You are Hermes, a helpful AI assistant.\n\n"
+    "## Skills\n"
+    "- codex-demo: Codex 세션 중 만들어진 스킬\n"
+    "- code-review: 코드 리뷰 스킬\n"
+)
+
+api_messages = [
+    {"role": "system", "content": ORIGINAL_SYSTEM},
+    {"role": "user", "content": "파이썬 덧셈 함수 만들어줘"},
+    {
+        "role": "assistant",
+        "content": "네, `add(a, b)` 함수를 만들겠습니다.",
+        # Codex Responses API 전용 필드
+        "codex_reasoning_items": [
+            {
+                "type": "reasoning",
+                "encrypted_content": "enc_codex_abc123==",
+                "_issuer_kind": "codex_backend",
+            }
+        ],
+        "codex_message_items": [
+            {"type": "message", "id": "msg_001", "content": [{"type": "output_text", "text": "함수 생성 중..."}]}
+        ],
+        "_thinking_prefill": True,
+    },
+    {"role": "tool", "content": '{"result": "def add(a, b): return a + b"}', "tool_call_id": "call_001"},
+    {
+        "role": "assistant",
+        "content": "완료! `def add(a, b): return a + b` 함수를 만들었습니다.",
+        "codex_reasoning_items": [
+            {
+                "type": "reasoning",
+                "encrypted_content": "enc_codex_def456==",
+                "_issuer_kind": "codex_backend",
+            }
+        ],
+    },
+    {"role": "user", "content": "고마워! 이제 skill도 하나 저장해줘"},
+    {
+        "role": "assistant",
+        "content": "codex-demo 스킬을 저장했습니다.",
+        "codex_reasoning_items": [
+            {
+                "type": "reasoning",
+                "encrypted_content": "enc_codex_ghi789==",
+                "_issuer_kind": "codex_backend",
+            }
+        ],
+        "codex_message_items": [
+            {"type": "message", "id": "msg_002", "content": [{"type": "output_text", "text": "스킬 저장 완료"}]}
+        ],
+    },
+]
+
+before = copy.deepcopy(api_messages)
+
+info(f"메시지 수          : {len(api_messages)}")
+info(f"시스템 프롬프트 포함: {'codex-demo' in api_messages[0]['content']}")
+info(f"codex_reasoning_items 포함 메시지 수: "
+     f"{sum(1 for m in api_messages if 'codex_reasoning_items' in m)}")
+info(f"codex_message_items 포함 메시지 수 : "
+     f"{sum(1 for m in api_messages if 'codex_message_items' in m)}")
+
+# ──────────────────────────────────────────────
+# Step 2: try_activate_fallback() 핵심 로직 시뮬레이션
+# ──────────────────────────────────────────────
+header("Step 2: try_activate_fallback() — Codex → local-claude 전환")
+
+REBUILT_SYSTEM = (
+    "You are Hermes, a helpful AI assistant.\n\n"
+    "## Skills\n"
+    "- codex-demo: Codex 세션 중 만들어진 스킬  ← Codex 세션 결과물 보존\n"
+    "- code-review: 코드 리뷰 스킬\n"
+    "\n[Rebuilt for anthropic_messages provider: local-claude / claude-opus-4-8]"
+)
+
+# 실제 try_activate_fallback() 이 하는 일 재현
+old_api_mode = "codex_responses"      # Codex 에서
+new_api_mode = "anthropic_messages"   # Anthropic(local-claude) 으로
+
+agent = SimpleNamespace()
+agent.api_mode          = old_api_mode
+agent.provider          = "openai-codex"
+agent.model             = "gpt-5.5"
+agent.session_id        = "sim-session-001"
+agent._cached_system_prompt = ORIGINAL_SYSTEM
+agent._session_db       = None
+agent._codex_reasoning_replay_enabled = True
+
+agent._build_system_prompt = MagicMock(return_value=REBUILT_SYSTEM)
+
+def _disable_replay(messages=None):
+    count = 0
+    for m in (messages or []):
+        if isinstance(m, dict) and m.get("role") == "assistant":
+            if m.pop("codex_reasoning_items", None):
+                count += 1
+    agent._codex_reasoning_replay_enabled = False
+    return {"messages": count, "items": count}
+
+agent._disable_codex_reasoning_replay = _disable_replay
+
+# --- try_activate_fallback() 이 세팅하는 플래그 ---
+if old_api_mode != new_api_mode:
+    agent._pending_context_bridge = {
+        "old_api_mode": old_api_mode,
+        "new_api_mode": new_api_mode,
+    }
+    agent._cached_system_prompt = None   # 시스템 프롬프트 무효화
+
+agent.api_mode   = new_api_mode
+agent.provider   = "local-claude"
+agent.model      = "claude-opus-4-8"
+
+field("이전 provider    :", f"openai-codex  (api_mode={old_api_mode})")
+field("새 provider      :", f"local-claude  (api_mode={new_api_mode})")
+field("_pending_context_bridge:", json.dumps(agent._pending_context_bridge))
+field("_cached_system_prompt  :", repr(agent._cached_system_prompt))
+
+# ──────────────────────────────────────────────
+# Step 3: conversation_loop 안에서 Bridge 실행
+# ──────────────────────────────────────────────
+header("Step 3: conversation_loop → apply_fallback_context_bridge() 실행")
+
+from agent.fallback_context_bridge import apply_fallback_context_bridge
+
+_bridge = getattr(agent, "_pending_context_bridge", None)
+assert _bridge, "bridge 플래그가 없음 — try_activate_fallback() 수정 확인 필요"
+
+agent._pending_context_bridge = None   # 플래그 소비
+
+apply_fallback_context_bridge(
+    agent,
+    api_messages,
+    _bridge["old_api_mode"],
+    _bridge["new_api_mode"],
+)
+
+# ──────────────────────────────────────────────
+# Step 4: 결과 검증
+# ──────────────────────────────────────────────
+header("Step 4: 검증 결과")
+
+passed = 0
+failed = 0
+
+def check(desc, condition):
+    global passed, failed
+    if condition:
+        ok(desc)
+        passed += 1
+    else:
+        import traceback
+        warn(f"FAIL: {desc}")
+        failed += 1
+
+# Codex 전용 필드가 제거됐는지
+check(
+    "codex_reasoning_items 전부 제거됨",
+    all("codex_reasoning_items" not in m for m in api_messages),
+)
+check(
+    "codex_message_items 전부 제거됨",
+    all("codex_message_items" not in m for m in api_messages),
+)
+check(
+    "_thinking_prefill 내부 키 제거됨",
+    all("_thinking_prefill" not in m for m in api_messages),
+)
+
+# Reasoning replay 비활성화
+check(
+    "codex reasoning replay 비활성화",
+    not agent._codex_reasoning_replay_enabled,
+)
+
+# 시스템 프롬프트 재빌드
+check(
+    "_build_system_prompt() 호출됨",
+    agent._build_system_prompt.called,
+)
+check(
+    "시스템 메시지가 새 프롬프트로 교체됨",
+    api_messages[0]["role"] == "system" and api_messages[0]["content"] == REBUILT_SYSTEM,
+)
+check(
+    "agent._cached_system_prompt 갱신됨",
+    agent._cached_system_prompt == REBUILT_SYSTEM,
+)
+
+# Codex 세션에서 만든 스킬이 보존됐는지 (핵심!)
+check(
+    "Codex 세션 스킬(codex-demo)이 새 시스템 프롬프트에 보존됨",
+    "codex-demo" in api_messages[0]["content"],
+)
+
+# 일반 필드(content, tool_calls 등)는 유지됐는지
+check(
+    "일반 content 필드 유지됨",
+    all(
+        "content" in m
+        for m in api_messages
+        if m.get("role") in ("assistant", "user", "tool")
+    ),
+)
+
+# bridge 플래그 소비됨
+check(
+    "_pending_context_bridge 플래그 소비됨",
+    agent._pending_context_bridge is None,
+)
+
+# ──────────────────────────────────────────────
+# Step 5: Before / After 메시지 diff
+# ──────────────────────────────────────────────
+header("Step 5: Before / After 메시지 비교")
+
+for i, (b, a) in enumerate(zip(before, api_messages)):
+    role = b.get("role", "?")
+    removed = set(b.keys()) - set(a.keys())
+    added   = set(a.keys()) - set(b.keys())
+    if removed or added:
+        info(f"  msg[{i}] role={role}")
+        if removed: info(f"    {RED}제거됨{RESET}: {removed}")
+        if added:   info(f"    {GREEN}추가됨{RESET}: {added}")
+    elif i == 0 and b["content"] != a["content"]:
+        info(f"  msg[{i}] role={role}")
+        info(f"    {YELLOW}시스템 프롬프트 내용 교체됨{RESET}")
+        old_lines = b["content"].strip().splitlines()
+        new_lines = a["content"].strip().splitlines()
+        for ln in old_lines[:4]:
+            info(f"      {RED}- {ln}{RESET}")
+        for ln in new_lines[:5]:
+            info(f"      {GREEN}+ {ln}{RESET}")
+
+# ──────────────────────────────────────────────
+# 최종 요약
+# ──────────────────────────────────────────────
+header("최종 결과")
+total = passed + failed
+print(f"\n  {BOLD}{passed}/{total} 검증 통과{RESET}")
+if failed == 0:
+    print(f"\n  {GREEN}{BOLD}✅ Context Bridge + Skill Re-injection 정상 동작{RESET}")
+    print(f"  Codex 세션에서 만든 스킬과 컨텍스트가")
+    print(f"  local-claude(anthropic_messages)로 안전하게 전달됩니다.")
+else:
+    print(f"\n  {RED}{BOLD}❌ {failed}개 검증 실패 — 로그를 확인하세요{RESET}")
+    sys.exit(1)

--- a/scripts/trigger_codex_fallback.py
+++ b/scripts/trigger_codex_fallback.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Live fallback trigger: Codex → local-claude.
+
+실제 hermesAgent gateway로 요청을 보낸 후,
+Codex 엔드포인트를 차단해서 fallback이 발동되도록 만든다.
+
+사용법:
+    python scripts/trigger_codex_fallback.py [--gateway-url URL]
+
+기본 gateway URL: http://localhost:5050
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.request
+import urllib.error
+
+DEFAULT_GATEWAY = "http://localhost:5050"
+
+
+def chat(gateway_url: str, message: str, session_id: str = "") -> dict:
+    payload = {"message": message}
+    if session_id:
+        payload["session_id"] = session_id
+
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"{gateway_url}/api/chat",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        return {"error": str(e), "body": body, "status": e.code}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def get_session_model(gateway_url: str, session_id: str) -> dict:
+    req = urllib.request.Request(
+        f"{gateway_url}/api/sessions/{session_id}",
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read())
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Trigger Codex→fallback scenario")
+    parser.add_argument("--gateway-url", default=DEFAULT_GATEWAY)
+    args = parser.parse_args()
+    gw = args.gateway_url.rstrip("/")
+
+    print(f"Gateway: {gw}")
+    print("=" * 60)
+
+    # ── Step 1: Codex session — create a skill ──────────────────────
+    print("\n[1] Codex session: 간단한 스킬 생성 요청 전송...")
+    resp1 = chat(gw, "안녕! 지금 어떤 provider로 동작 중인지 알려줘.")
+    session_id = resp1.get("session_id", "")
+    print(f"    session_id : {session_id}")
+    print(f"    provider   : {resp1.get('model', '?')} / {resp1.get('provider', '?')}")
+    print(f"    응답 미리보기: {str(resp1.get('response', resp1))[:120]}")
+
+    if resp1.get("error"):
+        print(f"\n⚠️  Gateway 오류: {resp1['error']}")
+        print("   hermesAgent gateway가 실행 중인지 확인하세요.")
+        sys.exit(1)
+
+    time.sleep(1)
+
+    # ── Step 2: Send a message that produces codex_reasoning_items ──
+    print("\n[2] 작업 요청 (Codex가 reasoning items 생성하도록)...")
+    resp2 = chat(
+        gw,
+        "간단한 Python 함수 하나만 작성해줘: def add(a, b): 로 시작하는 덧셈 함수.",
+        session_id=session_id,
+    )
+    print(f"    응답 미리보기: {str(resp2.get('response', resp2))[:120]}")
+
+    time.sleep(1)
+
+    # ── Step 3: Force fallback via /model switch or error injection ─
+    print("\n[3] Fallback 시뮬레이션: /model 명령으로 local-claude로 전환...")
+    resp3 = chat(
+        gw,
+        "/model claude-opus-4-8 local-claude",
+        session_id=session_id,
+    )
+    print(f"    응답: {str(resp3.get('response', resp3))[:200]}")
+
+    time.sleep(1)
+
+    # ── Step 4: Verify the new provider sees context from step 2 ───
+    print("\n[4] Fallback 후 이전 Codex 작업 컨텍스트 확인...")
+    resp4 = chat(
+        gw,
+        "방금 전에 내가 요청한 Python 함수가 뭐였지? 그리고 지금 어떤 provider로 동작 중이야?",
+        session_id=session_id,
+    )
+    print(f"    provider   : {resp4.get('provider', '?')}")
+    print(f"    응답:\n    {str(resp4.get('response', resp4))[:400]}")
+
+    # ── Result ──────────────────────────────────────────────────────
+    print("\n" + "=" * 60)
+    print("테스트 완료.")
+    print(f"  session_id  : {session_id}")
+    print(f"  최종 provider: {resp4.get('provider', '?')}")
+    response_text = str(resp4.get("response", ""))
+    if "add" in response_text.lower() or "덧셈" in response_text or "plus" in response_text.lower():
+        print("  ✅ 이전 Codex 세션 컨텍스트가 fallback provider에 전달됨!")
+    else:
+        print("  ⚠️  이전 컨텍스트 전달 여부 불명확 — 응답을 직접 확인하세요.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gateway/test_inspector.py
+++ b/tests/gateway/test_inspector.py
@@ -1,0 +1,258 @@
+"""Tests for gateway.inspector — sensitive-key scrubbing and CORS policy.
+
+Covers:
+- _is_sensitive_key: regex path, allowlist path, case/hyphen normalisation
+- _scrub_sensitive: flat, nested, list, depth guard
+- InspectorServer._cors_headers: loopback vs non-loopback
+- InspectorServer._handle_config_public: scrubbing + section allowlist
+"""
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.inspector import (
+    InspectorServer,
+    _is_sensitive_key,
+    _scrub_sensitive,
+)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_server(host: str = "127.0.0.1") -> InspectorServer:
+    """Construct an InspectorServer without calling __init__ (avoids aiohttp check)."""
+    server = InspectorServer.__new__(InspectorServer)
+    server._host = host
+    return server
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ── _is_sensitive_key ─────────────────────────────────────────────────────────
+
+class TestIsSensitiveKey:
+    def test_regex_matched_keys(self):
+        for key in ("api_key", "apikey", "token", "secret", "password",
+                    "passwd", "auth", "credential", "bearer"):
+            assert _is_sensitive_key(key), f"expected sensitive: {key!r}"
+
+    def test_allowlist_only_keys(self):
+        # Keys caught by the set but not reliably by the regex alone.
+        for key in ("pass", "access_token", "refresh_token", "client_secret",
+                    "signing_key", "webhook_secret", "session_token",
+                    "hmac_key", "encryption_key"):
+            assert _is_sensitive_key(key), f"expected sensitive: {key!r}"
+
+    def test_hyphen_normalised(self):
+        assert _is_sensitive_key("api-key")
+        assert _is_sensitive_key("signing-key")
+
+    def test_case_insensitive(self):
+        for key in ("API_KEY", "ApiKey", "APIKEY", "TOKEN", "SECRET",
+                    "Password", "BEARER"):
+            assert _is_sensitive_key(key), f"expected sensitive: {key!r}"
+
+    def test_safe_keys_not_scrubbed(self):
+        for key in ("model", "provider", "toolsets", "compression",
+                    "language", "locale", "ui", "name", "description",
+                    "default", "region", "timeout"):
+            assert not _is_sensitive_key(key), f"expected safe: {key!r}"
+
+
+# ── _scrub_sensitive ──────────────────────────────────────────────────────────
+
+class TestScrubSensitive:
+    def test_removes_regex_matched_key(self):
+        result = _scrub_sensitive({"model": "gpt-4", "api_key": "sk-abc"})
+        assert "api_key" not in result
+        assert result["model"] == "gpt-4"
+
+    def test_removes_allowlist_key_pass(self):
+        result = _scrub_sensitive({"provider": "openai", "pass": "hunter2"})
+        assert "pass" not in result
+        assert result["provider"] == "openai"
+
+    def test_removes_allowlist_key_apikey_no_separator(self):
+        result = _scrub_sensitive({"apikey": "sk-abc", "name": "foo"})
+        assert "apikey" not in result
+        assert result["name"] == "foo"
+
+    def test_removes_hyphenated_key(self):
+        result = _scrub_sensitive({"api-key": "sk-abc", "model": "x"})
+        assert "api-key" not in result
+
+    def test_removes_uppercase_key(self):
+        result = _scrub_sensitive({"API_KEY": "sk-abc", "model": "x"})
+        assert "API_KEY" not in result
+
+    def test_removes_nested_sensitive_key(self):
+        result = _scrub_sensitive({
+            "model": {"default": "gpt-4", "api_key": "sk-nested"},
+        })
+        assert "api_key" not in result["model"]
+        assert result["model"]["default"] == "gpt-4"
+
+    def test_removes_deeply_nested_key(self):
+        result = _scrub_sensitive(
+            {"a": {"b": {"c": {"password": "s3cr3t", "ok": 1}}}}
+        )
+        assert "password" not in result["a"]["b"]["c"]
+        assert result["a"]["b"]["c"]["ok"] == 1
+
+    def test_scrubs_inside_list(self):
+        result = _scrub_sensitive([{"api_key": "sk-x", "name": "foo"}])
+        assert "api_key" not in result[0]
+        assert result[0]["name"] == "foo"
+
+    def test_safe_config_passes_through(self):
+        config = {
+            "model": "claude-3",
+            "toolsets": ["web", "terminal"],
+            "language": "en",
+        }
+        assert _scrub_sensitive(config) == config
+
+    def test_depth_guard_returns_unchanged(self):
+        # At depth > 20 the object is returned as-is (no infinite recursion).
+        result = _scrub_sensitive({"api_key": "should-stay"}, _depth=21)
+        assert result == {"api_key": "should-stay"}
+
+    def test_empty_dict(self):
+        assert _scrub_sensitive({}) == {}
+
+    def test_non_dict_scalar_passthrough(self):
+        assert _scrub_sensitive("plain string") == "plain string"
+        assert _scrub_sensitive(42) == 42
+
+
+# ── CORS headers ──────────────────────────────────────────────────────────────
+
+class TestCorsHeaders:
+    def test_loopback_ipv4_returns_cors(self):
+        headers = _make_server("127.0.0.1")._cors_headers()
+        assert headers.get("Access-Control-Allow-Origin") == "*"
+        assert "Access-Control-Allow-Methods" in headers
+
+    def test_loopback_ipv6_returns_cors(self):
+        headers = _make_server("::1")._cors_headers()
+        assert "Access-Control-Allow-Origin" in headers
+
+    def test_loopback_localhost_returns_cors(self):
+        headers = _make_server("localhost")._cors_headers()
+        assert "Access-Control-Allow-Origin" in headers
+
+    def test_all_interfaces_no_cors(self):
+        assert _make_server("0.0.0.0")._cors_headers() == {}
+
+    def test_public_ip_no_cors(self):
+        for host in ("192.168.1.100", "10.0.0.1", "203.0.113.5"):
+            assert _make_server(host)._cors_headers() == {}, \
+                f"Expected no CORS headers for host={host}"
+
+
+# ── _handle_config_public ─────────────────────────────────────────────────────
+
+class TestHandleConfigPublic:
+    """Test the /config/public handler logic without a running HTTP server."""
+
+    def _make_server_with_config(self, config_data: dict):
+        server = _make_server()
+        server._read_config_yaml = MagicMock(return_value=config_data)
+
+        captured: dict = {}
+
+        def fake_json_response(data, status=200):
+            captured["data"] = data
+            captured["status"] = status
+            return MagicMock()
+
+        server._json_response = fake_json_response
+        return server, captured
+
+    def _call(self, server):
+        _run(server._handle_config_public(MagicMock()))
+
+    def test_sensitive_key_scrubbed_in_model_section(self):
+        server, captured = self._make_server_with_config({
+            "model": {"default": "gpt-4", "api_key": "sk-secret", "provider": "openai"},
+        })
+        self._call(server)
+        assert "api_key" not in captured["data"]["model"]
+        assert captured["data"]["model"]["provider"] == "openai"
+
+    def test_allowlist_key_apikey_scrubbed(self):
+        server, captured = self._make_server_with_config({
+            "model": {"default": "gpt-4", "apikey": "sk-123"},
+        })
+        self._call(server)
+        assert "apikey" not in captured["data"]["model"]
+
+    def test_nested_token_scrubbed(self):
+        # Use a non-sensitive parent key ("provider_config") so the sub-dict
+        # survives and we can assert that only the nested "token" is removed.
+        server, captured = self._make_server_with_config({
+            "model": {
+                "default": "claude",
+                "provider_config": {"token": "tok-xyz", "region": "us-east-1"},
+            },
+        })
+        self._call(server)
+        pcfg = captured["data"]["model"].get("provider_config", {})
+        assert "token" not in pcfg
+        assert pcfg.get("region") == "us-east-1"
+
+    def test_credentials_key_itself_is_scrubbed(self):
+        # "credentials" is a sensitive key name; the entire sub-dict is removed.
+        server, captured = self._make_server_with_config({
+            "model": {"default": "gpt-4", "credentials": {"key": "abc"}},
+        })
+        self._call(server)
+        assert "credentials" not in captured["data"]["model"]
+
+    def test_unsafe_top_level_sections_excluded(self):
+        server, captured = self._make_server_with_config({
+            "model": {"default": "gpt-4"},
+            "auth": {"token": "abc"},       # not in safe_keys
+            "gateway": {"secret": "xyz"},   # not in safe_keys
+            "sessions": {"db": "path"},     # not in safe_keys
+            "toolsets": ["web"],
+        })
+        self._call(server)
+        data = captured["data"]
+        assert "auth" not in data
+        assert "gateway" not in data
+        assert "sessions" not in data
+        assert data["toolsets"] == ["web"]
+
+    def test_empty_config_returns_empty_dict(self):
+        server, captured = self._make_server_with_config({})
+        self._call(server)
+        assert captured["data"] == {}
+
+    def test_safe_sections_pass_through(self):
+        server, captured = self._make_server_with_config({
+            "model": {"default": "claude-3"},
+            "agent": {"name": "hermes"},
+            "toolsets": ["web", "terminal"],
+            "compression": {"enabled": True},
+            "language": "en",
+            "locale": "ko",
+            "ui": {"theme": "dark"},
+        })
+        self._call(server)
+        data = captured["data"]
+        assert data["model"]["default"] == "claude-3"
+        assert data["agent"]["name"] == "hermes"
+        assert data["toolsets"] == ["web", "terminal"]
+        assert data["compression"]["enabled"] is True
+        assert data["language"] == "en"
+
+    def test_pass_key_scrubbed(self):
+        server, captured = self._make_server_with_config({
+            "model": {"default": "gpt-4", "pass": "hunter2"},
+        })
+        self._call(server)
+        assert "pass" not in captured["data"]["model"]


### PR DESCRIPTION
## What changed and why

External containers (ClaudeCode sidecar, Antigravity, monitoring tools) have no way to query the native HermesAgent gateway for public metadata — model, provider, installed skills, gateway status — without going through the full gateway socket or reading internal files directly.

This PR adds a lightweight read-only HTTP server (`gateway/inspector.py`) that exposes safe public metadata via a simple REST API.

## Endpoints

| Method | Path | Returns |
|--------|------|---------|
| GET | `/health` | pid, uptime |
| GET | `/status` | model, provider, api_mode, active_agents, platform state |
| GET | `/skills` | installed skill list (slug, name, category, description) |
| GET | `/skills/{slug}` | full SKILL.md content |
| GET | `/config/public` | safe config.yaml subset (secrets scrubbed) |

## Security design

- **Loopback-only CORS**: `Access-Control-Allow-Origin: *` is sent only when `HERMES_INSPECTOR_HOST` is a loopback address (`127.0.0.1`, `::1`, `localhost`). When bound to `0.0.0.0` (Docker scenarios), the header is omitted so web pages cannot make cross-origin requests to the Inspector. Operators using `0.0.0.0` should restrict access at the network/firewall level.
- **Secrets scrubbed**: `api_key`, `token`, `secret`, `password`, `auth`, `credential`, `bearer` keys are recursively removed from all config output.
- **Allow-list approach for `/config/public`**: only `model`, `agent`, `toolsets`, `compression`, `language`, `locale`, `ui` sections are ever exposed.
- **GET-only**: no write endpoints exist.
- **Path traversal prevention**: skill slug validated against `^[a-zA-Z0-9_\-]+(/[a-zA-Z0-9_\-]+)?$`.

## Configuration

```bash
HERMES_INSPECTOR_HOST=127.0.0.1   # default
HERMES_INSPECTOR_PORT=8646         # default
HERMES_INSPECTOR_DISABLED=1        # opt-out entirely
```

## How to test

```bash
# Start gateway
hermes gateway start

# Query Inspector
curl http://127.0.0.1:8646/health
curl http://127.0.0.1:8646/status
curl http://127.0.0.1:8646/skills
curl http://127.0.0.1:8646/skills/my-skill
curl http://127.0.0.1:8646/config/public

# Disable
HERMES_INSPECTOR_DISABLED=1 hermes gateway start
```

## Platforms tested
- Linux (Ubuntu 22.04)

## New files
- `gateway/inspector.py` — InspectorServer class
- `docs/hermes-inspector-api.md` — API reference
- `docs/hermes-inspector-skill.md` — skill integration guide