### PR TITLE
feat(skills): add factory-droid skill — delegate coding to Factory AI's droid CLI

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -69,6 +69,7 @@ AUTHOR_MAP = {
     "zakame@zakame.net": "zakame",
     "152110621+jiangkoumo@users.noreply.github.com": "jiangkoumo",
     "834740219@qq.com": "ViewWay",
+    "magnus@groktop.us": "magnus919",
     "matt@vestigial.dev": "m4dni5",
     "harjoth.khara@gmail.com": "harjothkhara",
     "129007007+HeLLGURD@users.noreply.github.com": "HeLLGURD",

--- a/skills/autonomous-ai-agents/factory-droid/SKILL.md
+++ b/skills/autonomous-ai-agents/factory-droid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: factory-droid
-description: "Delegate coding tasks to Factory AI's droid CLI (features, PRs, missions)."
+description: "Delegate coding to Factory's droid CLI for PRs and features."
 version: 1.0.0
 author: Hermes Agent
 license: MIT

--- a/skills/autonomous-ai-agents/factory-droid/SKILL.md
+++ b/skills/autonomous-ai-agents/factory-droid/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: factory-droid
+description: "Delegate coding tasks to Factory AI's droid CLI (features, PRs, missions)."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Coding-Agent, Factory-AI, Droid, Autonomous, Refactoring, Code-Review]
+    related_skills: [claude-code, codex, opencode]
+---
+
+# Factory Droid — Hermes Orchestration Guide
+
+Delegate coding tasks to [Factory AI](https://factory.ai) via the `droid` CLI. `droid` is an autonomous AI software development agent with interactive mode, headless exec, specification mode, and multi-agent mission orchestration.
+
+## When to Use
+
+- User explicitly asks to use Factory / droid
+- You want a coding agent with enterprise compliance (SOC 2 / ISO 27001/42001, HIPAA BAA available)
+- The task benefits from spec-first planning (`--use-spec`) or multi-agent orchestration (`--mission`)
+- You need a long-running autonomous task in an isolated worktree
+- BYOK to any provider — use your own API keys for OpenAI, Anthropic, OpenRouter, Ollama
+
+**Not sure if droid is the right call?** Compare against the `opencode` and `claude-code` skills for the delegation decision tree.
+
+## Prerequisites
+
+- **Install:** `curl -fsSL https://app.factory.ai/cli | sh`
+- **Auth:** `droid` to log in interactively, or set up BYOK API keys at factory.ai/settings/api-keys
+- **Verify:** `droid exec -o json --auto low "Respond with: OK"` returns `{"result":"OK",...}`
+- **Git repository** for code tasks (recommended)
+
+## One-Shot Tasks
+
+Use `droid exec` for bounded, non-interactive tasks:
+
+```
+terminal(command="droid exec --auto medium \"Add retry logic to API calls and update tests\"", workdir="~/project", timeout=120)
+```
+
+**Structured JSON output:**
+
+```
+terminal(command="droid exec -o json --auto low \"List all functions in src/auth.py\"", workdir="~/project", timeout=60)
+```
+
+Returns `{"type":"result","subtype":"success","result":"...","session_id":"...","num_turns":...,"duration_ms":...,"usage":{...}}`.
+
+**File-based prompt:**
+
+```
+terminal(command="droid exec -f .factory/review.md", workdir="~/project", timeout=120)
+```
+
+**Piped input for diff review:**
+
+```
+terminal(command="git diff HEAD~3 | droid exec \"Draft release notes for these changes\"", workdir="~/project", timeout=60)
+```
+
+## Autonomy Levels
+
+`droid exec` uses tiered autonomy. Choose deliberately:
+
+| Level | Intended for | Notable allowances |
+|-------|-------------|-------------------|
+| *(default)* | Read-only reconnaissance | File reads, git diffs, environment inspection |
+| `--auto low` | Safe edits | Create/edit files, run formatters |
+| `--auto medium` | Local development | Install deps, build/test, git commit |
+| `--auto high` | CI/CD & orchestration | Git push, deploy scripts |
+| `--skip-permissions-unsafe` | Isolated sandboxes only | Removes all guardrails (⚠️) |
+
+**Examples:**
+
+```
+# Read-only analysis
+terminal(command="droid exec \"Analyze the auth system\"", workdir="~/project")
+
+# Low autonomy — safe edits
+terminal(command="droid exec --auto low \"Add JSDoc to all functions in src/\"", workdir="~/project")
+
+# Medium autonomy — full dev cycle
+terminal(command="droid exec --auto medium \"Install deps, run tests, fix failures\"", workdir="~/project")
+
+# High autonomy — deploy
+terminal(command="droid exec --auto high \"Run tests, commit, push, deploy\"", workdir="~/project")
+```
+
+## Specification Mode
+
+Plan before executing. `--use-spec` makes droid write a specification first, then implement:
+
+```
+terminal(command="droid exec --use-spec --auto high \"Add user profiles with avatar upload\"", workdir="~/project", timeout=300)
+```
+
+Use different models for planning vs execution:
+
+```
+terminal(command="droid exec --use-spec --spec-model claude-opus-4-7 --auto medium \"Design and implement payment flow\"", workdir="~/project", timeout=300)
+```
+
+## Multi-Agent Missions
+
+Mission mode spawns worker and validator agents for large projects:
+
+```
+terminal(command="droid exec --mission -f mission.md", workdir="~/project", timeout=600)
+```
+
+Mission spec format (write to `mission.md`):
+
+```markdown
+# Mission: Refactor Auth
+
+## Goal
+Replace session-based auth with JWT-based auth.
+
+## Scope
+- src/auth/session.py → src/auth/jwt.py
+- All route handlers importing from sessions
+- Test files for auth
+
+## Constraints
+- Use PyJWT library
+- Token expiry: 15 min access, 7 day refresh
+```
+
+With model tuning:
+
+```
+terminal(command="droid exec --mission -f mission.md --worker-model claude-sonnet-4-6 --validator-model claude-opus-4-7", workdir="~/project", timeout=600)
+```
+
+## Worktree Isolation
+
+Run tasks in isolated git worktrees:
+
+```
+# Interactive
+terminal(command="droid --worktree fix-auth-bug \"start debugging\"", workdir="~/project", timeout=300)
+
+# Headless
+terminal(command="droid exec --worktree refactor-tests --auto medium \"migrate tests\"", workdir="~/project", timeout=300)
+```
+
+Worktree lifecycle: interactive persists; `droid exec` auto-removes clean worktrees, preserves dirty ones (prints path). Git branch is never deleted.
+
+## Session Continuation
+
+```
+# Resume last session
+terminal(command="droid exec -s session-abc123 \"continue fixing auth\"", workdir="~/project")
+
+# Fork into new session
+terminal(command="droid exec --fork session-abc123 \"Try different approach\"", workdir="~/project")
+```
+
+## Model Selection
+
+```
+# Specific model
+terminal(command="droid exec -m claude-sonnet-4-6 \"Refactor module\"", workdir="~/project")
+
+# Different models for spec vs execution
+terminal(command="droid exec --use-spec --spec-model claude-opus-4-7 --auto medium \"Design and implement\"", workdir="~/project")
+```
+
+Common model IDs: `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-haiku-4`, `gpt-5`, `gpt-5-mini`, `deepseek-v4-flash`.
+
+## Key Flags
+
+| Flag | Effect |
+|------|--------|
+| `exec "prompt"` | Non-interactive execution |
+| `-f, --file <path>` | Read prompt from file |
+| `-m, --model <id>` | Select model by ID |
+| `-o, --output-format <fmt>` | `text` (default), `json`, `stream-json` |
+| `-s, --session-id <id>` | Continue an existing session |
+| `--auto <level>` | Autonomy level: `low`, `medium`, `high` |
+| `--use-spec` | Start in specification mode |
+| `--spec-model <id>` | Model for spec planning |
+| `--mission` | Multi-agent orchestration mode |
+| `--worker-model <id>` / `--validator-model <id>` | Mission agent models |
+| `-r, --reasoning-effort <level>` | `off`, `low`, `medium`, `high` |
+| `--enabled-tools <ids>` / `--disabled-tools <ids>` | Tool control |
+| `--skip-permissions-unsafe` | Remove guardrails (⚠️ sandbox only) |
+| `-w, --worktree [name]` | Isolated git worktree |
+| `--fork <id>` | Fork and resume a session |
+
+## Cost & Spend Control
+
+With BYOK, tokens come from your own API keys — no Factory cost. With managed models:
+
+| Plan | Price |
+|------|-------|
+| BYOK | Free |
+| Pro | $20/mo (10M+10M tokens) |
+| Max | $200/mo (100M+100M tokens) |
+
+Track usage: `droid exec -o json` returns `usage.input_tokens` / `usage.output_tokens` / `usage.cache_read_input_tokens` in the result.
+
+## Pitfalls
+
+1. **`droid exec` doesn't need pty** — only interactive `droid` is a TUI. Use non-pty terminal for exec.
+2. **`droid auth status --text` is interactive-only** — verify auth with `droid exec` instead.
+3. **`--use-spec` doubles token burn** — generates spec + code in one call.
+4. **Mission mode is asynchronous** — very large missions may return before workers complete. Check via session resume.
+5. **Dirty worktrees persist** — `droid exec` leaves dirty worktrees on disk. Clean up manually.
+6. **Worktree branch naming** — `--worktree` derives `<current>-wt` from current branch. Explicit naming with `--worktree <name>` is more predictable.
+7. **Shell escaping** — for complex prompts with special characters, use `-f prompt.md` instead of inline strings.
+
+## Rules
+
+1. **Prefer `droid exec`** for one-shot automation — simpler, no TUI dialog handling.
+2. **Use `-o json`** for structured output parsing and cost tracking.
+3. **Always set `workdir`** — keep droid focused on the right project.
+4. **Set timeouts proportional to task** — 60s read-only, 120-300s dev, 600s+ missions.
+5. **Use `--auto` levels deliberately** — never default to `--skip-permissions-unsafe`.
+6. **Isolate missions in worktrees** — prevents file conflicts with parallel work.
+7. **Report concrete outcomes** — files changed, test results, token cost, session ID.

--- a/skills/autonomous-ai-agents/factory-droid/references/authentication.md
+++ b/skills/autonomous-ai-agents/factory-droid/references/authentication.md
@@ -1,0 +1,29 @@
+# Authentication
+
+`droid` authenticates through two mechanisms:
+
+## Interactive Login (OAuth)
+
+Run `droid` to start the interactive TUI. On first launch, it opens a browser window to log in via OAuth. This stores credentials in `~/.config/factory/` or similar.
+
+## API Key (BYOK)
+
+Factory supports Bring Your Own Key — set up API keys for your preferred providers:
+
+1. Visit `factory.ai/settings/api-keys` or use the CLI:
+   ```
+   droid exec "Tell me my current provider config"
+   ```
+
+2. Supported providers: OpenAI, Anthropic, Google, Groq, Fireworks, DeepInfra, Hugging Face, Ollama, OpenRouter, Baseten
+
+3. The BYOK free tier works immediately — no Factory subscription needed. Your tokens are drawn from your own API keys, not Factory's pool.
+
+## Verifying Auth
+
+```
+# Should return a successful JSON response
+droid exec -o json "Respond with: OK"
+```
+
+If this fails, you may need to run `droid` interactively once to complete the OAuth flow.

--- a/skills/autonomous-ai-agents/factory-droid/references/autonomy-levels.md
+++ b/skills/autonomous-ai-agents/factory-droid/references/autonomy-levels.md
@@ -1,0 +1,92 @@
+# Droid Autonomy Levels — When to Use Each
+
+`droid exec` has four autonomy tiers. Choosing the right one is about balancing capability against safety — the agent can only do what the level allows.
+
+## Level Reference
+
+### Default (No Flag) — Read-Only Reconnaissance
+
+**Capabilities:** File reads, git diffs, environment inspection, planning. No writes, no execution.
+
+**Use when:**
+- Analyzing a codebase before making changes
+- Reviewing a PR diff
+- Generating a plan or specification
+- Asking questions about the code
+
+**Example:**
+```
+droid exec "Map the dependency graph of src/auth/"
+```
+
+### `--auto low` — Safe Edits
+
+**Capabilities:** Create new files, edit existing files, run formatters and linters. Non-destructive commands only.
+
+**Use when:**
+- Adding comments, JSDoc, or documentation
+- Running code formatters (prettier, ruff)
+- Adding regression tests (new test files)
+- Simple refactors with clear scope
+
+**Example:**
+```
+droid exec --auto low "Add type hints to all functions in models.py"
+```
+
+### `--auto medium` — Local Development
+
+**Capabilities:** Everything from low, plus install dependencies, run build/test commands, make local git commits. Can modify `package.json`, `pyproject.toml`, and config files.
+
+**Use when:**
+- Implementing a feature that needs new dependencies
+- Running tests to verify fixes
+- Making local commits during development
+- Full feature implementation with build/test cycle
+
+**Example:**
+```
+droid exec --auto medium "Implement OAuth2 refresh flow and run tests"
+```
+
+### `--auto high` — CI/CD & Orchestration
+
+**Capabilities:** Everything from medium, plus git push, deploy scripts, long-running orchestration, production-affecting commands.
+
+**Use when:**
+- CI/CD pipeline automation
+- Automated deployment
+- Batch operations across multiple repos
+- Production remediation (careful!)
+
+**Example:**
+```
+droid exec --auto high "Run tests, commit, push to main, and deploy to staging"
+```
+
+### `--skip-permissions-unsafe` — Isolated Sandboxes Only
+
+**Capabilities:** Removes all guardrails. The agent can do anything the shell user can.
+
+**Use ONLY in:**
+- Disposable Docker containers
+- Ephemeral CI runners
+- Isolated VM sandboxes
+- Fresh git worktrees with no production access
+
+**NEVER in:**
+- Your local development environment
+- A repo with uncommitted work
+- A production-adjacent context
+
+## Decision Matrix
+
+| Task Type | Autonomy Level | Rationale |
+|-----------|---------------|-----------|
+| Code review / analysis | Default | Read-only, no changes needed |
+| Add comments, docs, types | `--auto low` | File writes only, no side effects |
+| Implement feature (known deps) | `--auto medium` | May install packages, run builds |
+| Implement + test + commit | `--auto medium` | Git commit is safe in a branch |
+| Implement + test + commit + push | `--auto high` | Push affects remote |
+| Deploy to production | `--auto high` | Needs full pipeline |
+| Exploratory / "vibe coding" | `--skip-permissions-unsafe` | Only in isolated sandbox |

--- a/skills/autonomous-ai-agents/factory-droid/references/delegation-comparison.md
+++ b/skills/autonomous-ai-agents/factory-droid/references/delegation-comparison.md
@@ -1,0 +1,37 @@
+# When to Use Factory Droid vs Other Coding Agents
+
+## Quick Comparison
+
+| Dimension | Factory Droid | OpenCode | Claude Code | Codex |
+|-----------|---------------|----------|-------------|-------|
+| **Exec** | `droid exec "..."` | `opencode run "..."` | `claude -p "..."` | `codex exec "..."` |
+| **Structured output** | `-o json` | `--format json` | `--output-format json` | None |
+| **Autonomy tiers** | `--auto low/med/high` | `--full-auto` / `--yolo` | `--dangerously-skip-permissions` | `--full-auto` / `--yolo` |
+| **Spec-first mode** | `--use-spec` | Agent selection | `/plan` (interactive) | None |
+| **Multi-agent** | `--mission` | Manual subagents | Custom agents | None |
+| **Worktree** | `--worktree` | Manual | `--worktree` | Manual |
+| **Enterprise compliance** | SOC 2, ISO 27001/42001, BAA-available | None | None (Claude Max cancelled) | None |
+| **Provider flexibility** | Full BYOK (10+ providers) | Full BYOK | Anthropic-locked | OpenAI-locked |
+| **Install** | `curl -fsSL https://app.factory.ai/cli \| sh` | `npm i -g opencode-ai` | `npm i -g @anthropic-ai/claude-code` | `npm i -g @openai/codex` |
+
+## Decision
+
+**Use Factory Droid when:**
+- You need enterprise compliance (SOC 2, HIPAA/BAA)
+- The task benefits from spec-first planning (`--use-spec`) or multi-agent orchestration (`--mission`)
+- You want model flexibility via BYOK (bring your own API key to any provider)
+- You're doing large, multi-phase projects that benefit from structured mission decomposition
+
+**Use OpenCode when:**
+- You want fastest startup with no subscription
+- The task is a simple one-shot code generation
+- You want open-source, provider-agnostic execution
+
+**Use Claude Code when:**
+- You have an active Anthropic subscription
+- You need the richest interactive mode with slash commands, hooks, and plugins
+
+**Use direct Hermes tools (patch/write_file) when:**
+- Small, bounded edits (1-3 files)
+- The change is tightly coupled to conversation context
+- You need Hermes-specific tooling (search_files, knowledge-lookup)

--- a/skills/autonomous-ai-agents/factory-droid/references/mission-mode.md
+++ b/skills/autonomous-ai-agents/factory-droid/references/mission-mode.md
@@ -1,0 +1,85 @@
+# Mission Mode — Multi-Agent Orchestration
+
+Factory's `--mission` mode spawns worker and validator agents for large, multi-phase projects. The agent orchestrator decomposes the mission goal into sub-tasks, assigns workers, and validates results.
+
+## When to Use Mission Mode
+
+| Use | Don't Use |
+|-----|-----------|
+| Large features spanning 5+ files | Single-file edits |
+| Multi-phase projects (plan→impl→test→deploy) | Quick bug fixes |
+| Cross-module refactoring | Tasks that need interactive steering |
+| Tasks with clear specifications | Exploratory/vague goals |
+
+## Mission Specification Format
+
+Write the mission goal to a `.md` file and pass it with `-f`:
+
+```
+droid exec --mission -f mission_spec.md --worker-model claude-sonnet-4-6 --validator-model claude-opus-4-7
+```
+
+### Structure
+
+```markdown
+# Mission: <descriptive title>
+
+## Goal
+<One paragraph: what success looks like. Be specific about outcomes, not approach.>
+
+## Scope
+<What files/directories/systems this touches>
+- src/service/new_module.py
+- tests/test_new_module.py
+- configuration.yaml
+
+## Constraints
+<Non-negotiables the mission must respect>
+- Must not introduce new external dependencies
+- Must maintain backward compatibility
+- Must add integration tests
+
+## Validation Criteria
+<How to verify the mission succeeded>
+- All existing tests pass
+- New module imports without errors
+- Documentation updated
+```
+
+## Model Tuning
+
+```
+# Fast workers, thorough validator
+--worker-model claude-sonnet-4-6 --worker-reasoning-effort medium
+--validator-model claude-opus-4-7 --validator-reasoning-effort high
+
+# All high effort (expensive but thorough)
+--worker-model claude-opus-4-7 --worker-reasoning-effort high
+--validator-model claude-opus-4-7 --validator-reasoning-effort high
+
+# Budget option
+--worker-model claude-haiku-4 --worker-reasoning-effort low
+--validator-model claude-sonnet-4-6 --validator-reasoning-effort medium
+```
+
+## Monitoring Mission Progress
+
+Mission mode returns results asynchronously. To check progress:
+
+```
+# Resume the mission session
+droid exec -s <session_id> "What's the status of the mission?"
+
+# Get results
+droid exec -s <session_id> "Show me the complete mission output"
+```
+
+## Worktree Isolation
+
+Always pair mission mode with worktree isolation:
+
+```
+droid exec --mission --worktree mission-auth-refactor -f mission.md
+```
+
+This ensures the mission's changes are isolated from your working tree and can be reviewed before merging.

--- a/skills/autonomous-ai-agents/factory-droid/references/model-ids.md
+++ b/skills/autonomous-ai-agents/factory-droid/references/model-ids.md
@@ -1,0 +1,40 @@
+# Model IDs
+
+Factory supports any model available through your connected providers. The model ID format is provider-specific.
+
+## Common Model IDs
+
+| Model | ID | Best for |
+|-------|-----|----------|
+| Claude Sonnet 4 | `claude-sonnet-4-6` | General coding — best balance of speed and quality |
+| Claude Opus 4 | `claude-opus-4-7` | Complex reasoning, spec planning, validation |
+| Claude Haiku 4 | `claude-haiku-4` | Fast, cheap for simple tasks |
+| GPT-5 | `gpt-5` | Broad capability frontier model |
+| GPT-5-mini | `gpt-5-mini` | Fast and cost-effective for routine work |
+| DeepSeek V4 Flash | `deepseek-v4-flash` | Low-latency, good for iterative work (default in BYOK config) |
+| Gemini 2.5 Pro | `gemini-2.5-pro` | Strong reasoning, long context |
+
+## Browsing Available Models
+
+In interactive mode: `Ctrl+N` cycles through available models.
+
+Via CLI: `droid mcp list` and `droid --model ?` may show options.
+
+## Pairing Guidance
+
+For `--use-spec` and `--mission` modes, you can set different models for different roles:
+
+| Role | Model | Reasoning Effort |
+|------|-------|------------------|
+| Spec planner (`--spec-model`) | `claude-opus-4-7` | `high` — needs deep architectural reasoning |
+| Executor (`-m`) | `claude-sonnet-4-6` | `medium` — good mix for implementation |
+| Mission worker (`--worker-model`) | `claude-sonnet-4-6` | `medium` — faster parallel execution |
+| Mission validator (`--validator-model`) | `claude-opus-4-7` | `high` — catch edge cases and design flaws |
+
+## BYOK & Custom Models
+
+When using BYOK with OpenRouter or Ollama, the model ID maps to your provider's naming convention. Example:
+
+```
+droid exec -m openrouter/anthropic/claude-sonnet-4 "task"
+```

--- a/tests/skills/test_factory_droid_skill.py
+++ b/tests/skills/test_factory_droid_skill.py
@@ -1,0 +1,133 @@
+"""
+Smoke tests for the factory-droid built-in skill.
+
+Verifies:
+  - SKILL.md frontmatter conforms to the hardline format
+  - All reference files are present and parseable
+  - Key content sections exist
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "skills" / "autonomous-ai-agents" / "factory-droid"
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline <=60): {desc!r}"
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == "factory-droid"
+
+
+def test_platforms_excludes_windows(frontmatter) -> None:
+    assert "windows" not in frontmatter["platforms"]
+    assert set(frontmatter["platforms"]) >= {"linux", "macos"}
+
+
+def test_author_present(frontmatter) -> None:
+    assert frontmatter.get("author"), "author field must be set"
+
+
+def test_license_mit(frontmatter) -> None:
+    assert frontmatter.get("license") == "MIT"
+
+
+def test_version_present(frontmatter) -> None:
+    assert frontmatter.get("version"), "version field must be set"
+
+
+def test_metadata_tags_present(frontmatter) -> None:
+    tags = frontmatter.get("metadata", {}).get("hermes", {}).get("tags", [])
+    assert len(tags) >= 3, f"expected at least 3 tags, got {tags}"
+    assert "Coding-Agent" in tags
+
+
+def test_related_skills_present(frontmatter) -> None:
+    related = frontmatter.get("metadata", {}).get("hermes", {}).get("related_skills", [])
+    assert len(related) >= 2
+
+
+def test_prerequisites_section_present() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "## Prerequisites" in src
+
+
+def test_pitfalls_section_present() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "## Pitfalls" in src
+
+
+def test_rules_section_present() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "## Rules" in src
+
+
+def test_reference_files_exist() -> None:
+    expected = [
+        "authentication.md",
+        "autonomy-levels.md",
+        "delegation-comparison.md",
+        "mission-mode.md",
+        "model-ids.md",
+    ]
+    ref_dir = SKILL_DIR / "references"
+    assert ref_dir.is_dir(), "references/ directory missing"
+    for fname in expected:
+        assert (ref_dir / fname).is_file(), f"missing reference file: {fname}"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "references/authentication.md",
+        "references/autonomy-levels.md",
+        "references/delegation-comparison.md",
+        "references/mission-mode.md",
+        "references/model-ids.md",
+    ],
+)
+def test_reference_files_parseable(path: str) -> None:
+    src = (SKILL_DIR / path).read_text(encoding="utf-8")
+    assert len(src) > 50, f"{path} is too short to be meaningful"
+
+
+def test_autonomy_levels_referenced() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "--auto low" in src
+    assert "--auto medium" in src
+    assert "--auto high" in src
+    assert "--use-spec" in src
+    assert "--mission" in src
+
+
+def test_json_output_mentioned() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "-o json" in src or "--output-format json" in src
+
+
+def test_verification_command_documented() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "\\\"Respond with: OK\\\"" in src or "Respond with: OK" in src


### PR DESCRIPTION
## What does this PR do?

Adds `factory-droid` — a bundled Hermes Agent skill for delegating coding tasks to Factory AI's `droid` CLI. Follows the same subprocess-spawn UX pattern as the existing `claude-code`, `opencode`, and `codex` skills.

```
terminal(command="droid exec --auto medium -o json \"$TASK\"", workdir="$REPO", timeout=120)
```

## Related Issue

This is a new bundled skill — no issue filed.

## Type of Change

- [x] New skill (bundled or hub)

## Changes Made

- `skills/autonomous-ai-agents/factory-droid/SKILL.md` — full skill covering one-shot droid exec, spec-first --use-spec, multi-agent --mission, worktree isolation, session continuation, PR review, model selection, autonomy levels, and cost tracking
- `scripts/release.py` — added magnus(at)groktop.us to AUTHOR_MAP

## How to Test

1. Install the droid CLI: `curl -fsSL https://app.factory.ai/cli | sh`
2. Verify: `droid exec -o json --auto low "Respond with: OK"` returns `{"result":"OK",...}`
3. Load the skill: `skill_view(name='factory-droid')`
4. Use it: `terminal(command="droid exec --auto low \"List files in src/\"", workdir="~/project")`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (feat(skills):)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run pytest tests/ -q and all tests pass — N/A (no core code changes, skill only)
- [x] I've added tests — 22 smoke tests in tests/skills/test_factory_droid_skill.py
- [x] I've tested on my platform: macOS 15.3

### Documentation and Housekeeping

- [x] SKILL.md follows the standard format (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies beyond the droid CLI, which is user-installed
- [x] I've tested the skill end-to-end: droid exec verified

## For New Skills

- [x] This skill is broadly useful — Factory AI has a growing user base with free BYOK tier
- [x] SKILL.md follows the standard format
- [x] No external dependencies beyond what the user installs themselves
- [x] Tested end-to-end

Filed by Jasper (AI agent on behalf of Magnus Hedemark)