### PR TITLE
fix(mcp): increase MCP discovery timeout for kanban workers

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -52,8 +52,19 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
 
 
 def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
-    """Briefly wait for background MCP discovery before the first tool snapshot."""
+    """Briefly wait for background MCP discovery before the first tool snapshot.
+
+    Kanban workers (detected via ``HERMES_KANBAN_TASK``) automatically use a
+    longer timeout because they depend on MCP tools for task execution and run
+    in the background where a blocking wait is acceptable.  See #43273.
+    """
+    import os
+
     thread = _mcp_discovery_thread
     if thread is None or not thread.is_alive():
         return
+    # Kanban workers can afford to wait longer — MCP tools are critical
+    # for task execution and the worker is a background subprocess.
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        timeout = max(timeout, 60.0)
     thread.join(timeout=timeout)

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -164,3 +164,60 @@ def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):
     monkeypatch.setattr(cli_mod, "AIAgent", _fake_agent)
 
     assert cli._init_agent() is True
+
+
+def test_wait_for_mcp_discovery_uses_longer_timeout_for_kanban_workers(monkeypatch):
+    """Kanban workers (HERMES_KANBAN_TASK set) must wait up to 60s for MCP."""
+    from unittest.mock import MagicMock
+
+    joined_with = {"timeout": None}
+    fake_thread = MagicMock()
+    fake_thread.is_alive.return_value = True
+
+    def _capture_join(timeout=None):
+        joined_with["timeout"] = timeout
+
+    fake_thread.join.side_effect = _capture_join
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", fake_thread)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+
+    mcp_startup.wait_for_mcp_discovery(timeout=0.75)
+    assert joined_with["timeout"] == 60.0
+
+
+def test_wait_for_mcp_discovery_preserves_explicit_timeout_for_kanban_workers(monkeypatch):
+    """If caller passes a timeout > 60s for kanban workers, it is preserved."""
+    from unittest.mock import MagicMock
+
+    joined_with = {"timeout": None}
+    fake_thread = MagicMock()
+    fake_thread.is_alive.return_value = True
+
+    def _capture_join(timeout=None):
+        joined_with["timeout"] = timeout
+
+    fake_thread.join.side_effect = _capture_join
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", fake_thread)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+
+    mcp_startup.wait_for_mcp_discovery(timeout=120.0)
+    assert joined_with["timeout"] == 120.0
+
+
+def test_wait_for_mcp_discovery_uses_default_timeout_for_non_kanban(monkeypatch):
+    """Non-kanban sessions use the caller-provided timeout unchanged."""
+    from unittest.mock import MagicMock
+
+    joined_with = {"timeout": None}
+    fake_thread = MagicMock()
+    fake_thread.is_alive.return_value = True
+
+    def _capture_join(timeout=None):
+        joined_with["timeout"] = timeout
+
+    fake_thread.join.side_effect = _capture_join
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", fake_thread)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    mcp_startup.wait_for_mcp_discovery(timeout=0.75)
+    assert joined_with["timeout"] == 0.75


### PR DESCRIPTION
## What does this PR do?

Increases the MCP discovery wait timeout for kanban workers from 0.75s to 60s so that slow MCP servers (30s+ to initialize) have time to register their tools before the worker agent makes its first API call.

## Related Issue

Fixes #43273

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/mcp_startup.py`: In `wait_for_mcp_discovery()`, detect kanban worker context (via `HERMES_KANBAN_TASK` env var) and use `max(timeout, 60.0)` instead of the default 0.75s timeout. Kanban workers are background subprocesses that depend on MCP tools for task execution — a longer blocking wait is acceptable.
- `tests/hermes_cli/test_mcp_startup.py`: Add 3 regression tests covering kanban worker timeout escalation, explicit timeout preservation (>60s passed through), and non-kanban sessions using the caller-provided timeout unchanged.

## How to Test

1. Configure an MCP server that takes 30+ seconds to initialize (e.g., `chrome-devtools-win` via stdio/npx)
2. Create a kanban task that requires MCP tools
3. Dispatch the task: `hermes kanban dispatch`
4. Before this fix: first API call fires before MCP tools are registered (0.75s wait)
5. After this fix: worker waits up to 60s for MCP discovery to complete

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_mcp_startup.py -v` and all tests pass (7/7)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `wait_for_mcp_discovery` (callers: 2 in cli.py, 1 in tui_gateway/server.py)
- Blast radius: LOW — only affects the wait timeout for MCP discovery; no control flow changes
- Related patterns: `HERMES_KANBAN_TASK` env var is the standard kanban worker context signal (used in cli.py at lines 15622, 15925, 15967, 16135)
