### PR TITLE
fix(config): preserve original .env file mode in remove_env_value (sibling of #33699)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5778,18 +5778,22 @@ def remove_env_value(key: str) -> bool:
                 f.flush()
                 os.fsync(f.fileno())
             atomic_replace(tmp_path, env_path)
+            # Preserve the original file mode (e.g. 0640 for Docker volume
+            # mounts) instead of letting _secure_file unconditionally tighten
+            # to 0600. Mirrors save_env_value().
             if original_mode is not None:
                 try:
                     os.chmod(env_path, original_mode)
                 except OSError:
                     pass
+            else:
+                _secure_file(env_path)
         except BaseException:
             try:
                 os.unlink(tmp_path)
             except OSError:
                 pass
             raise
-        _secure_file(env_path)
 
     os.environ.pop(key, None)
     invalidate_env_cache()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -354,6 +354,28 @@ class TestRemoveEnvValue:
             remove_env_value("ORPHAN_KEY")
             assert "ORPHAN_KEY" not in os.environ
 
+    def test_remove_env_value_preserves_existing_file_mode_on_posix(self, tmp_path):
+        """Regression: pre-existing .env mode (e.g. 0640 for a Docker
+        bind-mount the operator chose) survives a remove just as it does a
+        save. Previously _secure_file ran unconditionally after the
+        mode-restore branch and re-tightened to 0600 — the same bug fixed
+        in save_env_value (#33699), in the sibling remove path.
+        """
+        if os.name == "nt":
+            return
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("KEEP=value\nDROP=gone\n")
+        os.chmod(env_path, 0o640)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path), "DROP": "gone"}):
+            removed = remove_env_value("DROP")
+
+        assert removed is True
+        assert "DROP" not in env_path.read_text()
+        env_mode = env_path.stat().st_mode & 0o777
+        assert env_mode == 0o640, f"expected 0o640, got {oct(env_mode)}"
+
 
 class TestSaveConfigAtomicity:
     """Verify save_config uses atomic writes (tempfile + os.replace)."""


### PR DESCRIPTION
## What changed

Follow-up to #33699. That PR fixed `save_env_value()` so an operator-set `.env` file mode (e.g. `0640` for a Docker bind-mount) survives a config write instead of being re-tightened to `0600` by an unconditional `_secure_file()` call.

The **sibling `remove_env_value()` had the identical bug** and was not touched by #33699: it captures `original_mode`, restores it via `os.chmod`, and then **unconditionally** calls `_secure_file(env_path)` — clobbering the mode back to `0600` on every `hermes config remove KEY`.

This applies the exact same fix: move `_secure_file()` into the `else` branch so it only runs when no original mode was captured. A freshly written `.env` still gets `0600` hardening; an existing operator-set mode survives the remove.

## Why it matters

Narrow but real: an operator running Hermes in a container with a bind-mounted `.env` they deliberately `chmod 0640`'d (for group read) would have the mode preserved across `hermes config set` (after #33699) but silently re-tightened to `0600` on `hermes config remove`. Inconsistent behavior between the two sibling writers of the same file. AGENTS.md asks fixes to cover the whole bug class including sibling call paths — this closes the gap #33699 left.

The default path (fresh `.env` → `0600` hardening) is unaffected.

## Tests

Added `test_remove_env_value_preserves_existing_file_mode_on_posix` to `TestRemoveEnvValue`.

**Empirical bug-reproduction check (stale-pr-triage gate):** reverted only the `config.py` change (kept the test) and ran it against the unfixed `remove_env_value` → `AssertionError: expected 0o640, got 0o600`, confirming the test exercises the actual bug. With the fix applied it passes.

- `tests/hermes_cli/test_config.py`: 97 passed
- `tests/cron/test_file_permissions.py`: 8 passed
- ruff: clean

E2E (real `hermes_cli.config` against a temp `HERMES_HOME`): after both `save_env_value` and `remove_env_value`, a pre-existing `0640` `.env` stays `0640`.