### PR TITLE
fix(cli): add sys.stdout.flush() to all _cprint output paths

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2154,6 +2154,7 @@ def _cprint(text: str):
         from prompt_toolkit.application import get_app_or_none, run_in_terminal
     except Exception:
         _pt_print(_PT_ANSI(text))
+        sys.stdout.flush()
         return
 
     app = None
@@ -2168,12 +2169,13 @@ def _cprint(text: str):
     if app is None or not getattr(app, "_is_running", False):
         try:
             _pt_print(_PT_ANSI(text))
+            sys.stdout.flush()
         except Exception:
             # Fallback when stdout is not a real console (e.g. subprocess
             # worker logging to a file). prompt_toolkit raises
             # NoConsoleScreenBufferError (Windows) or OSError (other).
             try:
-                print(text)
+                print(text, flush=True)
             except Exception:
                 pass
         return
@@ -2184,6 +2186,7 @@ def _cprint(text: str):
         loop = None
     if loop is None:
         _pt_print(_PT_ANSI(text))
+        sys.stdout.flush()
         return
 
     import asyncio as _asyncio
@@ -2200,6 +2203,7 @@ def _cprint(text: str):
     # Same thread as the app's loop → safe to print directly.
     if current_loop is loop and loop.is_running():
         _pt_print(_PT_ANSI(text))
+        sys.stdout.flush()
         return
 
     # Cross-thread emission: ask the app's event loop to schedule a
@@ -2233,6 +2237,7 @@ def _cprint(text: str):
     except Exception:
         try:
             _pt_print(_PT_ANSI(text))
+            sys.stdout.flush()
         except Exception:
             pass
 


### PR DESCRIPTION
## Problem

`_cprint()` routes all CLI output through `prompt_toolkit`'s `print_formatted_text()` but never calls `sys.stdout.flush()`. On Windows PowerShell (and to a lesser extent on Linux when stdout is piped), streaming tokens accumulate in the buffer and only appear when the buffer fills or when the user presses Ctrl+C.

See #43238 for detailed root-cause analysis.

## Fix

Add `sys.stdout.flush()` after every `_pt_print()` call and use `flush=True` for the bare `print()` fallback. All 6 output paths in `_cprint()` are covered.

**Actual diff: +6 -1** (1 file changed — only `_cprint()` in `cli.py`)

| Path | Condition | Fix |
|------|-----------|-----|
| 1 | `prompt_toolkit` import failed | `sys.stdout.flush()` after `_pt_print` |
| 2 | No active app | `sys.stdout.flush()` after `_pt_print` |
| 3 | Fallback `print()` (no console) | `print(text, flush=True)` |
| 4 | No event loop | `sys.stdout.flush()` after `_pt_print` |
| 5 | Same thread as app loop | `sys.stdout.flush()` after `_pt_print` |
| 6 | Cross-thread fallback | `sys.stdout.flush()` after `_pt_print` |

## Note on diff size

The fork is behind upstream main. If the diff appears larger than expected, it includes unrelated upstream commits. The actual change is only the 6 flush additions listed above — no cleanup, no refactoring.

## Testing

- Change is purely additive — `flush()` is idempotent with no side effects
- `flush=True` on `print()` is the standard Python idiom
- No behavior change on systems where buffering was already adequate
- Manually verified all 6 code paths in `_cprint()` receive the fix

Supersedes #43244 (closed due to branch recreation). Closes #43238