### PR TITLE
fix(cli): roll back update when dependency sync fails

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4245,6 +4245,40 @@ def _capture_head_sha(git_cmd, cwd) -> str | None:
         return None
 
 
+def _rollback_checkout_after_failed_update(
+    git_cmd: list[str],
+    cwd: Path,
+    pre_pull_sha: str | None,
+    *,
+    failure_label: str,
+    retry_hint: str,
+) -> None:
+    """Reset the checkout back to ``pre_pull_sha`` after a post-pull failure."""
+    print()
+    print(f"✗ {failure_label}")
+    if pre_pull_sha:
+        print()
+        print(f"→ Rolling back to {pre_pull_sha[:10]}...")
+        rollback_result = subprocess.run(
+            git_cmd + ["reset", "--hard", pre_pull_sha],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        if rollback_result.returncode == 0:
+            print("  ✓ Rollback complete — your install is unchanged.")
+            print(f"  {retry_hint}")
+        else:
+            print("  ✗ Rollback failed. Recover manually with:")
+            print(f"    cd {cwd} && git reset --hard {pre_pull_sha}")
+            if rollback_result.stderr.strip():
+                print(f"    ({rollback_result.stderr.strip().splitlines()[0]})")
+    else:
+        print()
+        print("  Could not capture pre-pull SHA — recover manually with:")
+        print(f"    cd {cwd} && git reflog && git reset --hard <prev-sha>")
+
+
 def _validate_critical_files_syntax(root) -> tuple[bool, str | None, str | None]:
     """Compile each file in ``_UPDATE_CRITICAL_FILES`` to catch SyntaxErrors.
 
@@ -8239,35 +8273,21 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 PROJECT_ROOT
             )
             if not syntax_ok:
-                print()
-                print("✗ Pulled code has a syntax error in a critical file:")
-                print(f"  {failing_path}")
+                details = [f"Pulled code has a syntax error in a critical file:"]
+                if failing_path:
+                    details.append(f"  {failing_path}")
                 if syntax_error:
                     # py_compile errors can be multi-line; show the first
                     # ~6 lines so the user sees the actual SyntaxError text.
                     for line in str(syntax_error).splitlines()[:6]:
-                        print(f"    {line}")
-                if pre_pull_sha:
-                    print()
-                    print(f"→ Rolling back to {pre_pull_sha[:10]}...")
-                    rollback_result = subprocess.run(
-                        git_cmd + ["reset", "--hard", pre_pull_sha],
-                        cwd=PROJECT_ROOT,
-                        capture_output=True,
-                        text=True,
-                    )
-                    if rollback_result.returncode == 0:
-                        print("  ✓ Rollback complete — your install is unchanged.")
-                        print("  Try ``hermes update`` again later once a fix lands.")
-                    else:
-                        print("  ✗ Rollback failed. Recover manually with:")
-                        print(f"    cd {PROJECT_ROOT} && git reset --hard {pre_pull_sha}")
-                        if rollback_result.stderr.strip():
-                            print(f"    ({rollback_result.stderr.strip().splitlines()[0]})")
-                else:
-                    print()
-                    print("  Could not capture pre-pull SHA — recover manually with:")
-                    print(f"    cd {PROJECT_ROOT} && git reflog && git reset --hard <prev-sha>")
+                        details.append(f"    {line}")
+                _rollback_checkout_after_failed_update(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    pre_pull_sha,
+                    failure_label="\n".join(details),
+                    retry_hint="Try ``hermes update`` again later once a fix lands.",
+                )
                 sys.exit(1)
 
             update_succeeded = True
@@ -8339,9 +8359,19 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if _is_termux_env(uv_env) and _is_android_python():
                 print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
                 _install_psutil_android_compat([uv_bin, "pip"], env=uv_env)
-            _install_python_dependencies_with_optional_fallback(
-                [uv_bin, "pip"], env=uv_env, group=install_group
-            )
+            try:
+                _install_python_dependencies_with_optional_fallback(
+                    [uv_bin, "pip"], env=uv_env, group=install_group
+                )
+            except subprocess.CalledProcessError:
+                _rollback_checkout_after_failed_update(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    pre_pull_sha,
+                    failure_label="Updating Python dependencies failed after git pull.",
+                    retry_hint="Close running Hermes processes, then retry ``hermes update`` later.",
+                )
+                raise SystemExit(1) from None
         else:
             # Use sys.executable to explicitly call the venv's pip module,
             # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
@@ -8367,7 +8397,19 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if _is_termux_env() and _is_android_python():
                 print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
                 _install_psutil_android_compat(pip_cmd)
-            _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
+            try:
+                _install_python_dependencies_with_optional_fallback(
+                    pip_cmd, group=install_group
+                )
+            except subprocess.CalledProcessError:
+                _rollback_checkout_after_failed_update(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    pre_pull_sha,
+                    failure_label="Updating Python dependencies failed after git pull.",
+                    retry_hint="Close running Hermes processes, then retry ``hermes update`` later.",
+                )
+                raise SystemExit(1) from None
 
         _refresh_active_lazy_features()
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -301,6 +301,71 @@ class TestCmdUpdateBranchFallback:
                 "(no capture_output) so postinstall progress is visible"
             )
 
+    def test_update_rolls_back_when_dependency_sync_fails_after_pull(
+        self, mock_args, monkeypatch, capsys
+    ):
+        from hermes_cli import main as hm
+
+        commands: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            cmd_list = [str(part) for part in cmd]
+            commands.append(cmd_list)
+
+            if "fetch" in cmd_list and cmd_list[-2:] == ["origin", "main"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if cmd_list[-2:] == ["--abbrev-ref", "HEAD"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+            if cmd_list[-3:] == ["rev-list", "HEAD..origin/main", "--count"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="1\n", stderr="")
+            if cmd_list[-2:] == ["rev-parse", "HEAD"]:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="deadbeefcafebabe1234\n", stderr=""
+                )
+            if cmd_list[-4:] == ["pull", "--ff-only", "origin", "main"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if cmd_list[-3:] == ["reset", "--hard", "deadbeefcafebabe1234"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            raise AssertionError(f"Unexpected subprocess.run call: {cmd_list}")
+
+        monkeypatch.setattr(hm.subprocess, "run", fake_run)
+        monkeypatch.setattr(hm, "_run_pre_update_backup", lambda args: None)
+        monkeypatch.setattr(hm, "_discard_lockfile_churn", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            hm,
+            "_get_origin_url",
+            lambda *args, **kwargs: "https://github.com/NousResearch/hermes-agent.git",
+        )
+        monkeypatch.setattr(hm, "_resolve_update_branch", lambda args: "main")
+        monkeypatch.setattr(
+            hm, "_stash_local_changes_if_needed", lambda *args, **kwargs: None
+        )
+        monkeypatch.setattr(
+            hm, "_validate_critical_files_syntax", lambda root: (True, None, None)
+        )
+        monkeypatch.setattr(hm, "_invalidate_update_cache", lambda: None)
+        monkeypatch.setattr(hm, "_clear_bytecode_cache", lambda root: 0)
+        monkeypatch.setattr(
+            hm,
+            "_install_python_dependencies_with_optional_fallback",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                subprocess.CalledProcessError(2, ["uv", "pip", "install", "-e", ".[all]"])
+            ),
+        )
+        monkeypatch.setattr(hm.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(hm.sys.stdout, "isatty", lambda: True)
+
+        with patch("hermes_cli.managed_uv.ensure_uv", return_value="/usr/bin/uv"), patch(
+            "hermes_cli.managed_uv.update_managed_uv", return_value=None
+        ), pytest.raises(SystemExit) as exc:
+            hm.cmd_update(mock_args)
+
+        assert exc.value.code == 1
+        assert ["git", "reset", "--hard", "deadbeefcafebabe1234"] in commands
+        out = capsys.readouterr().out
+        assert "Updating Python dependencies failed after git pull." in out
+        assert "Rollback complete — your install is unchanged." in out
+
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""
         with patch("shutil.which", return_value=None), patch(


### PR DESCRIPTION
## What does this PR do?

Makes `hermes update` restore the pre-pull checkout when Python dependency installation fails after a successful `git pull`, so Windows desktop updates no longer strand the install on new code with a stale venv.

## What changed and why

- Added a shared rollback helper in `hermes_cli/main.py` for post-pull update failures.
- Reused that helper for the existing post-pull syntax guard so rollback messaging stays consistent.
- Wrapped both dependency-install paths (`uv pip` and fallback `pip`) so a hard install failure now resets the repo back to the captured pre-pull SHA instead of falling through into the Windows ZIP fallback with a half-updated tree.
- Added a regression test that simulates `git pull` succeeding and dependency sync failing, and asserts that `git reset --hard <pre-pull-sha>` runs before exit.
- This is intentionally a partial fix for #43268: it keeps the install bootable when lock contention blocks dependency updates, but it does not yet solve the underlying Windows file-lock contention or the bootstrap `.pyd` lock path.

## Related Issue

Refs #43268

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: added rollback-on-dependency-failure handling for `hermes update` and deduplicated rollback output through a helper.
- `tests/hermes_cli/test_cmd_update.py`: added a regression test for the `git pull` succeeded / dependency install failed path.

## How to Test

1. Run `/opt/homebrew/bin/timeout -k 30 480 pytest tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_cmd_update_docker.py tests/hermes_cli/test_managed_installs.py tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_update_concurrent_quarantine.py tests/hermes_cli/test_update_post_pull_syntax_guard.py tests/hermes_cli/test_update_yes_flag.py -q`.
2. Confirm the new regression test passes and asserts a `git reset --hard <pre-pull-sha>` on post-pull dependency failure.
3. Optionally simulate the failure path by mocking `_install_python_dependencies_with_optional_fallback()` to raise after a successful pull and verify the checkout is reset.
4. Note: the full bounded suite command `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` currently stops early in this environment on `tests/hermes_cli/test_dashboard_auth_401_reauth.py` because `fastapi` is missing, so that broad run does not reach the changed update-path tests locally.

## What platforms tested on

- macOS 15 / darwin-arm64 (local)
- Windows behavior covered by update-path unit tests only; not manually exercised in this worker

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Scoped checks run locally: `python scripts/check-windows-footguns.py hermes_cli/main.py tests/hermes_cli/test_cmd_update.py`, `git diff --check`, and `ruff check` on changed Python files all pass.
- Broad suite note: `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` stops early in this environment with `ModuleNotFoundError: No module named 'fastapi'` while collecting `tests/hermes_cli/test_dashboard_auth_401_reauth.py`.

<!-- autocontrib:worker-id=issue-new-6b43c0ea kind=pr-open -->