### PR TITLE
fix(gateway): return tuple for voice placeholder transcription

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11538,7 +11538,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # when we successfully transcribed the audio — it's redundant.
             _placeholder = "(The user sent a message with no text content)"
             if user_text and user_text.strip() == _placeholder:
-                return prefix
+                return prefix, successful_transcripts
             if user_text:
                 return f"{prefix}\n\n{user_text}", successful_transcripts
             return prefix, successful_transcripts

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -103,6 +103,31 @@ async def test_enrich_message_with_transcription_avoids_bogus_no_provider_messag
 
 
 @pytest.mark.asyncio
+async def test_enrich_message_with_transcription_returns_tuple_for_empty_content_placeholder():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "voice transcript",
+            "provider": "local_command",
+        },
+    ):
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "(The user sent a message with no text content)",
+            ["/tmp/voice.ogg"],
+        )
+
+    assert "voice transcript" in result
+    assert "(The user sent a message with no text content)" not in result
+    assert transcripts == ["voice transcript"]
+
+
+@pytest.mark.asyncio
 async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
     from gateway.run import GatewayRunner
 


### PR DESCRIPTION
## What does this PR do?

Fixes a Discord voice-only message crash in the gateway STT path.

`_enrich_message_with_transcription()` is typed and called as a two-value return: `(enriched_text, successful_transcripts)`. One successful transcription branch still returned a bare `prefix` string when the incoming message text matched Discord's empty-content placeholder. Fresh captionless Discord voice messages hit that branch, then `_prepare_inbound_message_text()` tried to unpack the string and raised `ValueError: too many values to unpack (expected 2)` before the agent saw the message.

This returns the expected tuple from that branch and adds a regression test for the placeholder-caption path.

Note: this overlaps existing open PRs #42090, #42710, and #42711, which appear to cover the same root cause.

## Related Issue

Fixes #42709

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: return `(prefix, successful_transcripts)` from the voice transcription empty-placeholder branch.
- `tests/gateway/test_stt_config.py`: add a regression test for successful transcription of Discord's empty-content placeholder message.

## How to Test

1. Send a captionless Discord voice message through the gateway on current `main`; the handler raises `ValueError: too many values to unpack (expected 2)`.
2. Apply this change.
3. Run `scripts/run_tests.sh -j 4 tests/gateway/test_stt_config.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted validation passed:

`scripts/run_tests.sh -j 4 tests/gateway/test_stt_config.py`

Result: 7 tests passed, 0 failed.
