### PR TITLE
fix(gateway): load send_message home channel env

### DIFF
--- a/tests/tools/test_send_message_runtime_env.py
+++ b/tests/tools/test_send_message_runtime_env.py
@@ -1,0 +1,57 @@
+"""Runtime env loading for send_message tool calls."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+from gateway.config import Platform
+from hermes_cli.config import get_hermes_home, invalidate_env_cache
+from tools.send_message_tool import send_message_tool
+
+
+def _run_async_immediately(coro):
+    return asyncio.run(coro)
+
+
+def test_bare_telegram_target_loads_home_channel_from_runtime_files(monkeypatch):
+    hermes_home = get_hermes_home()
+    (hermes_home / ".env").write_text(
+        "TELEGRAM_BOT_TOKEN=123:abc\n",
+        encoding="utf-8",
+    )
+    (hermes_home / "config.yaml").write_text(
+        "TELEGRAM_HOME_CHANNEL: '-2002'\n",
+        encoding="utf-8",
+    )
+    invalidate_env_cache()
+
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+
+    with patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "telegram",
+                    "message": "hello",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    assert result["note"] == "Sent to telegram home channel (chat_id: -2002)"
+    send_mock.assert_awaited_once()
+    args, kwargs = send_mock.await_args
+    assert args[0] is Platform.TELEGRAM
+    assert args[1].token == "123:abc"
+    assert args[2] == "-2002"
+    assert args[3] == "hello"
+    assert kwargs == {
+        "thread_id": None,
+        "media_files": [],
+        "force_document": False,
+    }

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -67,6 +67,63 @@ _GENERIC_SECRET_ASSIGN_RE = re.compile(
 )
 
 
+def _load_gateway_runtime_env() -> None:
+    """Load gateway env files needed by direct tool calls.
+
+    The CLI send command already bridges ~/.hermes/.env and top-level scalar
+    config.yaml values into os.environ before calling this tool. Gateway MCP
+    tool calls can arrive in a process that does not have those values loaded,
+    so do the same lightweight bridge here before load_gateway_config() runs.
+    """
+    try:
+        from hermes_cli.config import get_hermes_home, load_env
+    except Exception:
+        return
+
+    try:
+        for key, value in load_env().items():
+            os.environ[key] = str(value)
+    except Exception:
+        pass
+
+    try:
+        home = get_hermes_home()
+    except Exception:
+        return
+
+    config_path = home / "config.yaml"
+    if not config_path.exists():
+        return
+
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except Exception:
+        return
+
+    try:
+        with open(config_path, "r", encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh) or {}
+    except Exception:
+        return
+
+    try:
+        from hermes_cli.config import _expand_env_vars
+
+        raw = _expand_env_vars(raw)
+    except Exception:
+        pass
+
+    if not isinstance(raw, dict):
+        return
+
+    for key, value in raw.items():
+        if key in os.environ:
+            continue
+        if not isinstance(value, (str, int, float, bool)):
+            continue
+        os.environ[key] = str(value)
+
+
 def _sanitize_error_text(text) -> str:
     """Redact secrets from error text before surfacing it to users/models."""
     redacted = redact_sensitive_text(text)
@@ -213,6 +270,8 @@ def _handle_send(args):
     from tools.interrupt import is_interrupted
     if is_interrupted():
         return tool_error("Interrupted")
+
+    _load_gateway_runtime_env()
 
     try:
         from gateway.config import load_gateway_config, Platform


### PR DESCRIPTION
## What does this PR do?

Loads the gateway runtime environment before `send_message` resolves gateway config. This lets direct gateway tool calls pick up `~/.hermes/.env` values and top-level scalar values from `~/.hermes/config.yaml`, including `TELEGRAM_HOME_CHANNEL`, the same way `hermes send` already does.

## Related Issue

Fixes #43335

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added runtime env loading in `tools/send_message_tool.py` before `load_gateway_config()` runs.
- Added a regression test covering a bare `telegram` target with `TELEGRAM_BOT_TOKEN` in `.env` and `TELEGRAM_HOME_CHANNEL` in `config.yaml`.

## How to Test

1. `python -m pytest tests/tools/test_send_message_runtime_env.py tests/hermes_cli/test_send_cmd.py -q --timeout-method=thread`
2. `python -m ruff check tools/send_message_tool.py tests/tools/test_send_message_runtime_env.py`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: reuses existing config/env loading helpers
- [x] Tool descriptions or schemas update: N/A

## Screenshots / Logs

Focused tests and lint are listed above.