### PR TITLE
fix(gateway): bridge top-level telegram.home_channel from config.yaml

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1074,6 +1074,16 @@ def load_gateway_config() -> GatewayConfig:
                         "disable_topic_auto_rename",
                         telegram_cfg["disable_topic_auto_rename"],
                     )
+                # Bridge top-level `telegram.home_channel` into the platform
+                # data dict so PlatformConfig.from_dict() picks it up.  Without
+                # this, ``send_message`` (MCP tool path) cannot resolve the home
+                # channel when it was configured via the top-level telegram:
+                # shorthand instead of platforms.telegram.home_channel or the
+                # TELEGRAM_HOME_CHANNEL env var.  (#43335)
+                if "home_channel" in telegram_cfg:
+                    _tg_plat = platforms_data.setdefault(Platform.TELEGRAM.value, {})
+                    if "home_channel" not in _tg_plat:
+                        _tg_plat["home_channel"] = telegram_cfg["home_channel"]
                 # Prefer telegram.require_mention; fall back to the top-level shorthand.
                 _effective_rm = telegram_cfg.get("require_mention", yaml_cfg.get("require_mention"))
                 if _effective_rm is not None and not os.getenv("TELEGRAM_REQUIRE_MENTION"):

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -965,3 +965,67 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+    def test_bridges_telegram_home_channel_from_top_level_config_yaml(self, tmp_path, monkeypatch):
+        """Top-level telegram.home_channel in config.yaml must be bridged into
+        the platform data dict so send_message_tool (MCP path) can resolve it.
+        Regression test for #43335."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        # Top-level telegram: shorthand — NOT under platforms: or gateway.platforms:
+        config_path.write_text(
+            "telegram:\n"
+            "  enabled: true\n"
+            "  token: tg-token\n"
+            "  home_channel:\n"
+            "    platform: telegram\n"
+            "    chat_id: \"999888\"\n"
+            "    name: My Home\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        telegram = config.platforms[Platform.TELEGRAM]
+        assert telegram.home_channel is not None
+        assert telegram.home_channel == HomeChannel(
+            platform=Platform.TELEGRAM,
+            chat_id="999888",
+            name="My Home",
+        )
+
+    def test_top_level_home_channel_does_not_override_platforms_path(self, tmp_path, monkeypatch):
+        """When both platforms.telegram.home_channel and top-level telegram.home_channel
+        exist, the platforms: path (merged first) should win."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    enabled: true\n"
+            "    token: tg-token\n"
+            "    home_channel:\n"
+            "      platform: telegram\n"
+            "      chat_id: \"from_platforms\"\n"
+            "      name: Platforms Path\n"
+            "telegram:\n"
+            "  home_channel:\n"
+            "    platform: telegram\n"
+            "    chat_id: \"from_toplevel\"\n"
+            "    name: Top Level\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        telegram = config.platforms[Platform.TELEGRAM]
+        assert telegram.home_channel is not None
+        # platforms: path should take precedence (merged first)
+        assert telegram.home_channel.chat_id == "from_platforms"


### PR DESCRIPTION
## What does this PR do?

Bridge top-level `telegram.home_channel` from config.yaml into the platform data dict so `send_message` (MCP tool path) can resolve the home channel when configured via the top-level `telegram:` shorthand.

## Related Issue

Fixes #43335

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/config.py`: Add `home_channel` bridge in the telegram-specific section of `load_gateway_config()`, matching the existing pattern for `disable_topic_auto_rename` and other top-level settings. Uses `setdefault` so the `platforms:` path retains precedence.
- `tests/gateway/test_config.py`: Add 2 regression tests — one verifying the top-level bridge works, one verifying the `platforms:` path takes precedence when both exist.

## How to Test

1. Set `telegram.home_channel` in config.yaml under the top-level `telegram:` shorthand (not under `platforms:`)
2. Call `send_message(target="telegram")` via the MCP tool — should resolve to the configured home channel
3. Run `pytest tests/gateway/test_config.py -v -k home_channel` — all 3 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/config.py::load_gateway_config()` (callers: send_message_tool, gateway/run.py, session.py)
- Blast radius: LOW — additive bridge, uses `setdefault` to avoid overriding existing values
- Related patterns: Same bridge pattern as `disable_topic_auto_rename` (line 1070), `require_mention` (line 1077)
