### PR TITLE
feat: add cron maintenance drain mode

### DIFF
--- a/cron/maintenance.py
+++ b/cron/maintenance.py
@@ -1,0 +1,237 @@
+"""File-backed cron maintenance mode and running-job tracking."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from hermes_time import now as _hermes_now
+from utils import atomic_replace
+
+
+class MaintenanceStateError(RuntimeError):
+    """Raised when cron maintenance state exists but cannot be read."""
+
+
+_RUNNING_FILE_LOCK = threading.Lock()
+
+
+def _home(hermes_home: Path | str | None = None) -> Path:
+    return Path(hermes_home).expanduser() if hermes_home is not None else get_hermes_home()
+
+
+def maintenance_file(hermes_home: Path | str | None = None) -> Path:
+    return _home(hermes_home) / "cron" / "maintenance.json"
+
+
+def running_file(hermes_home: Path | str | None = None) -> Path:
+    return _home(hermes_home) / "cron" / "running.json"
+
+
+def _atomic_write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{threading.get_ident()}.{time.monotonic_ns()}.tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(tmp, path)
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass
+    except BaseException:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MaintenanceStateError(f"Could not read {path}: {exc}") from exc
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    dt = datetime.fromisoformat(text)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _now_aware() -> datetime:
+    current = _hermes_now()
+    if current.tzinfo is None:
+        return current.replace(tzinfo=timezone.utc)
+    return current
+
+
+def read_maintenance(hermes_home: Path | str | None = None) -> dict | None:
+    data = _read_json(maintenance_file(hermes_home))
+    if data is None:
+        return None
+    if not isinstance(data, dict):
+        raise MaintenanceStateError("maintenance.json must contain an object")
+    return data
+
+
+def is_maintenance_active(now: datetime | None = None, hermes_home: Path | str | None = None) -> bool:
+    try:
+        state = read_maintenance(hermes_home)
+    except MaintenanceStateError:
+        # Fail safe: a corrupt maintenance file should stop new cron dispatches.
+        return True
+    if not state or not state.get("active", True):
+        return False
+    until = state.get("until")
+    if until:
+        try:
+            until_dt = _parse_datetime(str(until))
+        except (TypeError, ValueError):
+            return True
+        current = now or _now_aware()
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=timezone.utc)
+        return current <= until_dt
+    return True
+
+
+def start_maintenance(until: str | None = None, reason: str = "maintenance", owner: str | None = None, hermes_home: Path | str | None = None) -> dict:
+    if until:
+        _parse_datetime(until)
+    state = {
+        "active": True,
+        "reason": reason or "maintenance",
+        "started_at": _now_aware().isoformat(),
+        "until": until,
+        "owner": owner or f"pid:{os.getpid()}",
+    }
+    _atomic_write_json(maintenance_file(hermes_home), state)
+    return state
+
+
+def stop_maintenance(hermes_home: Path | str | None = None) -> bool:
+    path = maintenance_file(hermes_home)
+    try:
+        path.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def list_running_jobs(hermes_home: Path | str | None = None, *, prune_stale: bool = True) -> list[dict]:
+    data = _read_json(running_file(hermes_home))
+    if data is None:
+        return []
+    if isinstance(data, dict):
+        jobs = data.get("jobs", [])
+    else:
+        jobs = data
+    if not isinstance(jobs, list):
+        raise MaintenanceStateError("running.json must contain a jobs list")
+    normalized = [j for j in jobs if isinstance(j, dict) and j.get("id")]
+    if prune_stale:
+        live = []
+        changed = False
+        for job in normalized:
+            pid = job.get("pid")
+            if pid is not None:
+                try:
+                    if not _pid_alive(int(pid)):
+                        changed = True
+                        continue
+                except (TypeError, ValueError):
+                    pass
+            live.append(job)
+        if changed:
+            _write_running_jobs(live, hermes_home)
+        normalized = live
+    return normalized
+
+
+def _write_running_jobs(jobs: list[dict], hermes_home: Path | str | None = None) -> None:
+    path = running_file(hermes_home)
+    if jobs:
+        _atomic_write_json(path, {"jobs": jobs})
+    else:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def record_job_started(job: dict, hermes_home: Path | str | None = None) -> None:
+    job_id = str(job.get("id") or "").strip()
+    if not job_id:
+        return
+    schedule = job.get("schedule")
+    if isinstance(schedule, dict):
+        schedule_display = job.get("schedule_display") or schedule.get("value")
+    else:
+        schedule_display = job.get("schedule_display") or schedule
+    with _RUNNING_FILE_LOCK:
+        try:
+            jobs = [j for j in list_running_jobs(hermes_home) if j.get("id") != job_id]
+        except MaintenanceStateError:
+            jobs = []
+        jobs.append({
+            "id": job_id,
+            "name": job.get("name"),
+            "started_at": _now_aware().isoformat(),
+            "pid": os.getpid(),
+            "schedule": schedule_display,
+            "workdir": job.get("workdir"),
+            "profile": job.get("profile"),
+        })
+        _write_running_jobs(jobs, hermes_home)
+
+
+def record_job_finished(job_id: str, hermes_home: Path | str | None = None) -> None:
+    with _RUNNING_FILE_LOCK:
+        try:
+            jobs = [j for j in list_running_jobs(hermes_home, prune_stale=False) if j.get("id") != job_id]
+        except MaintenanceStateError:
+            jobs = []
+        _write_running_jobs(jobs, hermes_home)
+
+
+def drain(timeout_seconds: float, poll_seconds: float = 5.0, hermes_home: Path | str | None = None) -> bool:
+    deadline = time.monotonic() + max(float(timeout_seconds), 0.0)
+    poll = max(float(poll_seconds), 0.1)
+    while True:
+        if not list_running_jobs(hermes_home):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(min(poll, max(0.0, deadline - time.monotonic())))

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -42,6 +42,7 @@ from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
+from cron.maintenance import is_maintenance_active, record_job_finished, record_job_started
 
 logger = logging.getLogger(__name__)
 
@@ -2085,6 +2086,11 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         return 0
 
     try:
+        if is_maintenance_active():
+            if verbose:
+                logger.info("Cron maintenance mode active — skipping due-job dispatch")
+            return 0
+
         due_jobs = get_due_jobs()
 
         if verbose and not due_jobs:
@@ -2205,6 +2211,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                     logger.info("Job '%s' already running — skipping", job.get("name", job_id))
                     return None
                 _running_job_ids.add(job_id)
+            record_job_started(job)
             _ctx = contextvars.copy_context()
 
             def _run_and_release(j=job, ctx=_ctx):
@@ -2213,6 +2220,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 finally:
                     with _running_lock:
                         _running_job_ids.discard(j["id"])
+                    record_job_finished(j["id"])
 
             return pool.submit(_run_and_release)
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -154,6 +154,124 @@ def cron_tick():
     tick(verbose=True)
 
 
+def _parse_duration_seconds(value) -> float:
+    text = str(value or "").strip().lower()
+    if not text:
+        raise ValueError("duration is required")
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)([smhd]?)", text)
+    if not match:
+        raise ValueError(f"invalid duration: {value!r}")
+    amount = float(match.group(1))
+    unit = match.group(2) or "s"
+    return amount * {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit]
+
+
+def cron_maintenance(args):
+    """Manage global cron maintenance mode."""
+    from cron.maintenance import (
+        MaintenanceStateError,
+        is_maintenance_active,
+        list_running_jobs,
+        read_maintenance,
+        start_maintenance,
+        stop_maintenance,
+    )
+
+    action = getattr(args, "maintenance_action", None) or "status"
+    if action == "start":
+        try:
+            state = start_maintenance(
+                until=getattr(args, "until", None),
+                reason=getattr(args, "reason", None) or "maintenance",
+                owner=getattr(args, "owner", None),
+            )
+        except Exception as exc:
+            print(color(f"Failed to start cron maintenance: {exc}", Colors.RED))
+            return 1
+        print(color("Cron maintenance mode started", Colors.GREEN))
+        print(f"  Reason: {state.get('reason')}")
+        if state.get("until"):
+            print(f"  Until:  {state.get('until')}")
+        print(f"  Owner:  {state.get('owner')}")
+        return 0
+
+    if action == "stop":
+        removed = stop_maintenance()
+        print(color("Cron maintenance mode stopped", Colors.GREEN) if removed else color("Cron maintenance mode was not active", Colors.YELLOW))
+        return 0
+
+    if action == "status":
+        try:
+            state = read_maintenance()
+            active = is_maintenance_active()
+            running = list_running_jobs()
+        except MaintenanceStateError as exc:
+            print(color(f"Cron maintenance state error: {exc}", Colors.RED))
+            print(color("Fail-safe: cron dispatch is treated as blocked while this file is corrupt.", Colors.YELLOW))
+            return 2
+        print(color("Cron maintenance: active", Colors.YELLOW) if active else color("Cron maintenance: inactive", Colors.GREEN))
+        if state:
+            print(f"  Reason: {state.get('reason')}")
+            print(f"  Started: {state.get('started_at')}")
+            if state.get("until"):
+                print(f"  Until:   {state.get('until')}")
+            print(f"  Owner:   {state.get('owner')}")
+        print(f"  Running jobs: {len(running)}")
+        return 0
+
+    print(f"Unknown cron maintenance command: {action}")
+    return 1
+
+
+def cron_running():
+    """List file-backed running cron jobs."""
+    from cron.maintenance import MaintenanceStateError, list_running_jobs
+
+    try:
+        jobs = list_running_jobs()
+    except MaintenanceStateError as exc:
+        print(color(f"Failed to read running cron jobs: {exc}", Colors.RED))
+        return 2
+    if not jobs:
+        print(color("No cron jobs currently running.", Colors.GREEN))
+        return 0
+    print(color("Running cron jobs:", Colors.CYAN))
+    for job in jobs:
+        print(f"  {job.get('id')}  {job.get('name') or '(unnamed)'}")
+        print(f"    Started: {job.get('started_at')}")
+        if job.get("pid"):
+            print(f"    PID:     {job.get('pid')}")
+        if job.get("workdir"):
+            print(f"    Workdir: {job.get('workdir')}")
+        if job.get("profile"):
+            print(f"    Profile: {job.get('profile')}")
+    return 0
+
+
+def cron_drain(args):
+    """Wait for running cron jobs to complete."""
+    from cron.maintenance import MaintenanceStateError, drain, list_running_jobs
+
+    try:
+        timeout = _parse_duration_seconds(getattr(args, "timeout", "45m"))
+        poll = _parse_duration_seconds(getattr(args, "poll", "5s"))
+    except ValueError as exc:
+        print(color(str(exc), Colors.RED))
+        return 1
+    try:
+        if drain(timeout, poll):
+            print(color("Cron drain complete: no running jobs.", Colors.GREEN))
+            return 0
+        running = list_running_jobs()
+    except MaintenanceStateError as exc:
+        print(color(f"Failed to drain cron jobs: {exc}", Colors.RED))
+        return 2
+    print(color(f"Cron drain timed out with {len(running)} running job(s).", Colors.RED))
+    for job in running:
+        print(f"  {job.get('id')}  {job.get('name') or '(unnamed)'}")
+    return 1
+
+
 def cron_status():
     """Show cron execution status."""
     from cron.jobs import list_jobs
@@ -342,6 +460,15 @@ def cron_command(args):
     if subcmd == "tick":
         cron_tick()
         return 0
+
+    if subcmd == "maintenance":
+        return cron_maintenance(args)
+
+    if subcmd == "running":
+        return cron_running()
+
+    if subcmd == "drain":
+        return cron_drain(args)
 
     if subcmd in {"create", "add"}:
         return cron_create(args)

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -164,6 +164,22 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     # cron status
     cron_subparsers.add_parser("status", help="Check if cron scheduler is running")
 
+    # cron maintenance
+    cron_maintenance = cron_subparsers.add_parser("maintenance", help="Manage global cron maintenance mode")
+    maintenance_subparsers = cron_maintenance.add_subparsers(dest="maintenance_action")
+    maintenance_start = maintenance_subparsers.add_parser("start", help="Start maintenance blackout mode")
+    maintenance_start.add_argument("--until", help="ISO timestamp when maintenance should expire")
+    maintenance_start.add_argument("--reason", default="maintenance", help="Reason recorded in maintenance state")
+    maintenance_start.add_argument("--owner", help="Owner recorded in maintenance state")
+    maintenance_subparsers.add_parser("stop", help="Stop maintenance blackout mode")
+    maintenance_subparsers.add_parser("status", help="Show maintenance status")
+
+    # cron running/drain
+    cron_subparsers.add_parser("running", help="List currently running cron jobs")
+    cron_drain = cron_subparsers.add_parser("drain", help="Wait for running cron jobs to complete")
+    cron_drain.add_argument("--timeout", default="45m", help="Maximum wait, e.g. 45m, 1h, 30s")
+    cron_drain.add_argument("--poll", default="5s", help="Poll interval, e.g. 5s")
+
     # cron tick (mostly for debugging)
     cron_tick = cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
     add_accept_hooks_flag(cron_tick)

--- a/tests/cron/test_cron_maintenance.py
+++ b/tests/cron/test_cron_maintenance.py
@@ -1,0 +1,125 @@
+"""Tests for file-backed cron maintenance mode."""
+
+from __future__ import annotations
+
+import time
+from datetime import timedelta
+
+import pytest
+
+from hermes_time import now as hermes_now
+
+
+@pytest.fixture()
+def maintenance_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "cron").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def test_start_status_stop_maintenance(maintenance_home):
+    from cron.maintenance import (
+        is_maintenance_active,
+        maintenance_file,
+        read_maintenance,
+        start_maintenance,
+        stop_maintenance,
+    )
+
+    until = (hermes_now() + timedelta(minutes=10)).isoformat()
+    state = start_maintenance(until=until, reason="daily-maintenance", owner="pytest")
+
+    assert maintenance_file().exists()
+    assert state["reason"] == "daily-maintenance"
+    loaded = read_maintenance()
+    assert loaded is not None
+    assert loaded["owner"] == "pytest"
+    assert is_maintenance_active()
+    assert stop_maintenance() is True
+    assert not is_maintenance_active()
+
+
+def test_expired_maintenance_is_inactive(maintenance_home):
+    from cron.maintenance import is_maintenance_active, start_maintenance
+
+    start_maintenance(until=(hermes_now() - timedelta(minutes=1)).isoformat())
+
+    assert not is_maintenance_active()
+
+
+def test_corrupt_maintenance_fails_closed(maintenance_home):
+    from cron.maintenance import is_maintenance_active, maintenance_file, read_maintenance, MaintenanceStateError
+
+    maintenance_file().write_text("{not-json", encoding="utf-8")
+
+    assert is_maintenance_active()
+    with pytest.raises(MaintenanceStateError):
+        read_maintenance()
+
+
+def test_record_running_job_lifecycle(maintenance_home):
+    from cron.maintenance import list_running_jobs, record_job_finished, record_job_started, running_file
+
+    record_job_started({"id": "job_1", "name": "Example", "schedule": {"value": "every 1h"}})
+
+    jobs = list_running_jobs()
+    assert [job["id"] for job in jobs] == ["job_1"]
+    assert jobs[0]["name"] == "Example"
+    assert running_file().exists()
+
+    record_job_finished("job_1")
+
+    assert list_running_jobs() == []
+    assert not running_file().exists()
+
+
+def test_drain_succeeds_when_empty_and_times_out_when_running(maintenance_home):
+    from cron.maintenance import drain, record_job_started
+
+    assert drain(timeout_seconds=0.1, poll_seconds=0.01)
+
+    record_job_started({"id": "job_1", "name": "Long"})
+    started = time.monotonic()
+
+    assert not drain(timeout_seconds=0.05, poll_seconds=0.01)
+    assert time.monotonic() - started >= 0.05
+
+
+def test_tick_skips_due_jobs_during_maintenance(maintenance_home, monkeypatch):
+    from cron.maintenance import start_maintenance
+    from cron import scheduler
+
+    start_maintenance(until=(hermes_now() + timedelta(minutes=5)).isoformat())
+
+    def should_not_query_due_jobs():
+        raise AssertionError("tick should not query due jobs during maintenance")
+
+    monkeypatch.setattr(scheduler, "get_due_jobs", should_not_query_due_jobs)
+
+    assert scheduler.tick(verbose=False, sync=True) == 0
+
+
+def test_tick_records_running_jobs(maintenance_home, monkeypatch):
+    from cron import scheduler
+    from cron.maintenance import list_running_jobs
+
+    seen_during_run = []
+    job = {"id": "job_1", "name": "Tracked", "schedule": {"value": "every 1h"}}
+
+    monkeypatch.setattr(scheduler, "get_due_jobs", lambda: [job])
+    monkeypatch.setattr(scheduler, "advance_next_run", lambda job_id: None)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda job_id, output: maintenance_home / "cron" / "output.txt")
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *args, **kwargs: None)
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {"cron": {"max_parallel_jobs": 1}})
+
+    def fake_run_job(running_job):
+        seen_during_run.extend(job["id"] for job in list_running_jobs())
+        return True, "output", "done", None
+
+    monkeypatch.setattr(scheduler, "run_job", fake_run_job)
+
+    assert scheduler.tick(verbose=False, sync=True) == 1
+    assert seen_during_run == ["job_1"]
+    assert list_running_jobs() == []

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -127,3 +127,55 @@ class TestCronCommandLifecycle:
 
         out = capsys.readouterr().out
         assert "Repeat:    ∞" in out
+
+
+class TestCronMaintenanceCommands:
+    def test_maintenance_start_status_stop(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        until = "2099-01-01T00:00:00+00:00"
+
+        rc = cron_command(
+            Namespace(
+                cron_command="maintenance",
+                maintenance_action="start",
+                until=until,
+                reason="daily-maintenance",
+                owner="pytest",
+            )
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Cron maintenance mode started" in out
+
+        rc = cron_command(Namespace(cron_command="maintenance", maintenance_action="status"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Cron maintenance: active" in out
+        assert "Running jobs: 0" in out
+
+        rc = cron_command(Namespace(cron_command="maintenance", maintenance_action="stop"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "stopped" in out
+
+    def test_running_and_drain_commands(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        from cron.maintenance import record_job_finished, record_job_started
+
+        rc = cron_command(Namespace(cron_command="running"))
+        assert rc == 0
+        assert "No cron jobs currently running" in capsys.readouterr().out
+
+        record_job_started({"id": "job_1", "name": "Tracked"})
+        rc = cron_command(Namespace(cron_command="running"))
+        assert rc == 0
+        assert "job_1" in capsys.readouterr().out
+
+        rc = cron_command(Namespace(cron_command="drain", timeout="0.01s", poll="0.01s"))
+        assert rc == 1
+        assert "timed out" in capsys.readouterr().out
+
+        record_job_finished("job_1")
+        rc = cron_command(Namespace(cron_command="drain", timeout="1s", poll="0.01s"))
+        assert rc == 0
+        assert "Cron drain complete" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- add file-backed cron maintenance/blackout state and running-job tracking
- add CLI commands for `hermes cron maintenance`, `hermes cron running`, and `hermes cron drain`
- make scheduler ticks skip dispatch during active maintenance without advancing due jobs
- cover maintenance state, drain behavior, and CLI wiring with tests

## Verification
- `venv/bin/python -m pytest tests/cron/test_cron_maintenance.py tests/hermes_cli/test_cron.py -q -o 'addopts='`
- `venv/bin/python -m pytest tests/cron/test_cron_maintenance.py tests/hermes_cli/test_cron.py tests/cron tests/tools/test_cronjob_tools.py -q -o 'addopts='`

## Notes
This supports external maintenance coordinators, such as systemd user timers, that need to pause cron dispatch, wait for currently running cron jobs to complete, then perform update/restart work safely.
