### PR TITLE
fix(gateway): send_message resolves home channel from config.yaml, not just env

### DIFF
--- a/tests/tools/test_send_message_home_channel_fallback.py
+++ b/tests/tools/test_send_message_home_channel_fallback.py
@@ -1,0 +1,50 @@
+"""send_message must resolve a platform home channel from env OR config.yaml.
+
+Regression for #43335: a Web-UI-managed gateway's process env can lack the
+bridged ``<PLATFORM>_HOME_CHANNEL`` even though config.yaml has it (set via
+``hermes config set <PLATFORM>_HOME_CHANNEL``). The gateway ``send_message``
+tool then reported "No home channel set" while the CLI ``hermes send`` worked.
+``_fallback_home_channel_id`` reads env first, then config.yaml, so both paths
+resolve the same channel.
+"""
+
+from unittest.mock import patch
+
+from tools.send_message_tool import _fallback_home_channel_id
+
+
+def test_reads_env_var_first(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "env-123")
+    with patch("hermes_cli.config.load_config", return_value={"TELEGRAM_HOME_CHANNEL": "cfg-999"}):
+        assert _fallback_home_channel_id("telegram") == "env-123"
+
+
+def test_falls_back_to_config_yaml_when_env_absent(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+    with patch("hermes_cli.config.load_config", return_value={"TELEGRAM_HOME_CHANNEL": "cfg-999"}):
+        assert _fallback_home_channel_id("telegram") == "cfg-999"
+
+
+def test_email_uses_override_key(monkeypatch):
+    # email reads EMAIL_HOME_ADDRESS, not EMAIL_HOME_CHANNEL.
+    monkeypatch.delenv("EMAIL_HOME_ADDRESS", raising=False)
+    with patch("hermes_cli.config.load_config", return_value={"EMAIL_HOME_ADDRESS": "a@b.com"}):
+        assert _fallback_home_channel_id("email") == "a@b.com"
+
+
+def test_empty_when_unset(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+    with patch("hermes_cli.config.load_config", return_value={}):
+        assert _fallback_home_channel_id("telegram") == ""
+
+
+def test_config_load_failure_is_safe(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+    with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+        assert _fallback_home_channel_id("telegram") == ""
+
+
+def test_whitespace_only_value_is_empty(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "   ")
+    with patch("hermes_cli.config.load_config", return_value={}):
+        assert _fallback_home_channel_id("telegram") == ""

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -49,6 +49,32 @@ _EMAIL_TARGET_RE = re.compile(r"^\s*[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2
 # generic "<PLATFORM>_HOME_CHANNEL" hint would point users at a variable that is
 # never read. Map the exceptions so the error guidance is actually actionable.
 _HOME_CHANNEL_ENV_OVERRIDES = {"email": "EMAIL_HOME_ADDRESS"}
+
+
+def _fallback_home_channel_id(platform_name: str) -> str:
+    """Resolve a platform's home-channel id when the gateway config has none.
+
+    The gateway process env can lack the bridged ``<PLATFORM>_HOME_CHANNEL``
+    (e.g. a Web-UI-managed gateway that never loaded ``.env``), yet config.yaml
+    still holds it — that is where ``hermes config set <PLATFORM>_HOME_CHANNEL``
+    writes the value. Check the env var first, then the config.yaml value, so
+    the gateway ``send_message`` tool resolves the same home channel the CLI
+    ``hermes send`` does (#43335). Returns ``""`` when neither source has it.
+    """
+    key = _HOME_CHANNEL_ENV_OVERRIDES.get(
+        platform_name, f"{platform_name.upper()}_HOME_CHANNEL"
+    )
+    val = os.getenv(key, "").strip()
+    if val:
+        return val
+    try:
+        from hermes_cli.config import load_config
+
+        return str((load_config() or {}).get(key, "") or "").strip()
+    except Exception:
+        return ""
+
+
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
 _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
@@ -265,11 +291,18 @@ def _handle_send(args):
     used_home_channel = False
     if not chat_id:
         home = config.get_home_channel(platform)
-        if not home and platform_name == "weixin":
-            wx_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
-            if wx_home:
+        if not home:
+            # Gateway config came up empty (commonly: the gateway process env
+            # lacks the bridged <PLATFORM>_HOME_CHANNEL). Fall back to env or
+            # config.yaml so the tool matches the CLI's resolution (#43335).
+            fallback_id = _fallback_home_channel_id(platform_name)
+            if fallback_id:
                 from gateway.config import HomeChannel
-                home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
+                home = HomeChannel(
+                    platform=platform,
+                    chat_id=fallback_id,
+                    name=f"{platform_name.title()} Home",
+                )
         if home:
             chat_id = home.chat_id
             used_home_channel = True


### PR DESCRIPTION
## What & why — closes #43335

The gateway's `send_message` tool reports **"No home channel set for telegram"** even when `TELEGRAM_HOME_CHANNEL` is configured, while the CLI `hermes send --to telegram` delivers fine.

Both paths call `load_gateway_config().get_home_channel(platform)`. That value is populated **only** from the process env:

```python
# gateway/config.py
telegram_home = os.getenv("TELEGRAM_HOME_CHANNEL")
if telegram_home and Platform.TELEGRAM in config.platforms:
    config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(chat_id=telegram_home, ...)
```

A Web-UI-managed gateway's **process env can lack `TELEGRAM_*`** (the reporter confirmed: "Gateway PID env: no TELEGRAM_* vars at all") — it was never bridged from `.env`. But config.yaml has the value, because `hermes config set TELEGRAM_HOME_CHANNEL <id>` (what the setup wizard tells users to run) writes a top-level `TELEGRAM_HOME_CHANNEL` key there. The CLI `hermes send` runs in a process that loaded `.env`, so its env has the var and it works; the in-gateway tool doesn't.

## Fix

Generalize the previous **weixin-only** env fallback into `_fallback_home_channel_id()`, which resolves `<PLATFORM>_HOME_CHANNEL` from **env first, then config.yaml**, for any platform:

```python
fallback_id = _fallback_home_channel_id(platform_name)   # env → config.yaml
if fallback_id:
    home = HomeChannel(platform=platform, chat_id=fallback_id, name=f"{platform_name.title()} Home")
```

So `send_message` now finds the same home channel the CLI does, regardless of whether the gateway process env carries the bridged var. The fallback fires **only** when the gateway config has no home channel, so the normal path is unchanged; weixin keeps its prior behavior and additionally gains the config.yaml source.

## How to test

```bash
scripts/run_tests.sh tests/tools/test_send_message_home_channel_fallback.py   # 6 passed
```

Covers env-first precedence, the config.yaml fallback when env is absent, the email override key (`EMAIL_HOME_ADDRESS`), empty/whitespace handling, and config-load failure being safe.

## Scope

Targeted tool-level fix for the reported symptom (the in-gateway tool not honoring config.yaml). The broader env-bridge inconsistency (why a managed gateway's env lacks the var) is orthogonal and left for separate work.

## Platforms

Shared gateway Python; verified via the CI-parity runner.