### PR TITLE
fix(cron): allow cron jobs to use the memory() tool

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1835,7 +1835,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             # Without a workdir, keep cwd context discovery disabled.
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
-            skip_memory=True,  # Cron system prompts would corrupt user representations
+            skip_memory=False,  # Cron is automation; _detect_external_drift() is the real safety net
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,


### PR DESCRIPTION
## Problem

Cron jobs are hardcoded with `skip_memory=True` at agent creation time, preventing the `memory()` tool from working in any cron job. The comment in `cron/scheduler.py:1801` states: *"Cron system prompts would corrupt user representations."*

This makes cron unable to perform its most natural automation tasks — memory health checks, periodic pruning, duplicate consolidation, or any scheduled maintenance that touches memory.

## Analysis

The upstream concern ("corrupt user representations") is already addressed by existing safety mechanisms that work regardless of call context:

| Mechanism | Location | What it protects |
|-----------|----------|-----------------|
| `_detect_external_drift()` | `tools/memory_tool.py:522` | Detects malformed writes via round-trip mismatch and entry-size overflow. Creates `.bak.<timestamp>` before refusing the mutation. |
| Atomic write + self-validating format | `tools/memory_tool.py:578` | Writes use atomic temp-file + rename. The §-delimited format is enforced on every write. |

Cron is Hermes' automation surface — scheduled health checks, memory pruning, data maintenance, and cleanup tasks all need memory access. A cron job cannot write to memory spontaneously any more than a normal chat can: it requires an explicit tool call through `run_conversation()`, governed by the same tool validation and drift detection.

## Fix

**1 file, +1/−1.** Replaces the hardcoded ban with `skip_memory=False`, relying on the existing drift detector as the real safety net. Cron jobs that misuse memory will be caught and backed up like any other session.

## Cross-Platform

No platform-specific code. Pure configuration change at agent creation time.

## Testing

1. Schedule a cron job with a prompt that invokes the memory() tool (e.g. "check my memory for issues")
2. Confirm `memory()` read works and write succeeds where intended
3. Confirm `_detect_external_drift()` still catches and backs up malformed writes

Fixes #43367