### PR TITLE
fix(stt): accept .oga and .opus voice notes for transcription

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -811,6 +811,16 @@ class TestValidateAudioFileEdgeCases:
             f.write_bytes(b"data")
             assert _validate_audio_file(str(f)) is None, f"Format {fmt} should be accepted"
 
+    def test_telegram_oga_and_opus_accepted(self, tmp_path):
+        # Telegram delivers voice notes as .oga (OGG/Opus); .opus is the
+        # bare-codec sibling. Both must pass validation or every inbound
+        # voice note fails before reaching any STT backend.
+        from tools.transcription_tools import _validate_audio_file
+        for fmt in (".oga", ".opus"):
+            f = tmp_path / f"voice{fmt}"
+            f.write_bytes(b"data")
+            assert _validate_audio_file(str(f)) is None
+
     def test_case_insensitive_extension(self, tmp_path):
         from tools.transcription_tools import _validate_audio_file
         f = tmp_path / "test.MP3"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -99,7 +99,7 @@ OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
 ELEVENLABS_STT_BASE_URL = os.getenv("ELEVENLABS_STT_BASE_URL", "https://api.elevenlabs.io/v1")
 
-SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
+SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".oga", ".opus", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 


### PR DESCRIPTION
## What does this PR do?

Telegram delivers voice notes as `.oga` (OGG/Opus container). `SUPPORTED_FORMATS` in `tools/transcription_tools.py` listed `.ogg` but not `.oga`, so `transcribe_audio()` rejected every inbound Telegram voice note with `Unsupported format: .oga` before it reached any STT backend. The gateway then replied "I couldn't transcribe your voice message."

The check sits upstream of provider dispatch, so this broke voice notes for all backends (local faster-whisper, Groq, OpenAI, Mistral, xAI) and any command-provider. The fix adds `.oga` and `.opus` to the allowlist.

## Related Issue

No existing issue. Bug and reproduction below.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/transcription_tools.py`: add `.oga` and `.opus` to `SUPPORTED_FORMATS`.
- `tests/tools/test_transcription_tools.py`: add `test_telegram_oga_and_opus_accepted` regression test.

## How to Test

Reproduce (before the fix): send a voice note to a Telegram gateway, or call `transcribe_audio("voice.oga")` — it returns `{"success": false, "error": "Unsupported format: .oga ..."}`.

After the fix:
```
pytest tests/tools/test_transcription_tools.py -q
# 108 passed
```
`_validate_audio_file()` now returns `None` (accepted) for `.oga` and `.opus`. Verified end to end on Ubuntu 24.04 with a real Telegram voice note routed to a command-provider STT backend.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/tools/test_transcription_tools.py -q` and all 108 tests pass
- [x] I've added a regression test for this change
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] No docs change needed — N/A
- [x] No config keys changed — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform: extension allowlist, no platform-specific code — N/A
