### PR TITLE
fix(google-workspace): decode literal shell escapes in gmail send/reply body

### DIFF
--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -31,6 +31,23 @@ from datetime import datetime, timedelta, timezone
 from email.mime.text import MIMEText
 from pathlib import Path
 
+
+
+def _decode_shell_escapes(text: str) -> str:
+    """Decode literal C-style escape sequences from shell arguments.
+
+    LLM agents frequently construct shell commands like:
+        --body "Line one\n\nLine two"
+    POSIX shells preserve ``\n`` inside ordinary double quotes, so the
+    script receives a literal backslash-n instead of a real newline.
+    This helper normalises the most common sequences so that ``MIMEText``
+    receives properly formatted content.
+    """
+    if "\\" not in text and "\n" not in text and "\t" not in text:
+        return text
+    return text.replace("\\n", "\n").replace("\\t", "\t")
+
+
 # Ensure sibling modules (_hermes_home) are importable when run standalone.
 _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
@@ -317,7 +334,7 @@ def gmail_get(args):
 
 def gmail_send(args):
     if _gws_binary():
-        message = MIMEText(args.body, "html" if args.html else "plain")
+        message = MIMEText(_decode_shell_escapes(args.body), "html" if args.html else "plain")
         message["To"] = args.to
         message["Subject"] = args.subject
         if args.cc:
@@ -339,7 +356,7 @@ def gmail_send(args):
         return
 
     service = build_service("gmail", "v1")
-    message = MIMEText(args.body, "html" if args.html else "plain")
+    message = MIMEText(_decode_shell_escapes(args.body), "html" if args.html else "plain")
     message["To"] = args.to
     message["Subject"] = args.subject
     if args.cc:
@@ -375,7 +392,7 @@ def gmail_reply(args):
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
 
-        message = MIMEText(args.body)
+        message = MIMEText(_decode_shell_escapes(args.body))
         message["To"] = headers.get("from", "")
         message["Subject"] = subject
         if args.from_header:
@@ -404,7 +421,7 @@ def gmail_reply(args):
     if not subject.startswith("Re:"):
         subject = f"Re: {subject}"
 
-    message = MIMEText(args.body)
+    message = MIMEText(_decode_shell_escapes(args.body))
     message["To"] = headers.get("from", "")
     message["Subject"] = subject
     if args.from_header:

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -484,3 +484,36 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+# --- _decode_shell_escapes tests ---
+
+
+class TestDecodeShellEscapes:
+    """Tests for literal shell-escape normalisation in gmail send/reply."""
+
+    def test_literal_newlines_decoded(self, api_module):
+        """Literal \\n from shell double-quotes becomes real newlines."""
+        result = api_module._decode_shell_escapes("Line one\\n\\nLine two")
+        assert result == "Line one\n\nLine two"
+
+    def test_literal_tabs_decoded(self, api_module):
+        result = api_module._decode_shell_escapes("col1\\tcol2")
+        assert result == "col1\tcol2"
+
+    def test_already_decoded_passthrough(self, api_module):
+        """Strings with real newlines are returned unchanged."""
+        text = "Line one\n\nLine two"
+        assert api_module._decode_shell_escapes(text) is text
+
+    def test_plain_text_passthrough(self, api_module):
+        assert api_module._decode_shell_escapes("Hello world") is "Hello world"
+
+    def test_empty_string(self, api_module):
+        assert api_module._decode_shell_escapes("") == ""
+
+    def test_mixed_real_and_literal(self, api_module):
+        """Real newlines stay; literal \\n are decoded."""
+        text = "Real\nhere\\nthere"
+        result = api_module._decode_shell_escapes(text)
+        assert result == "Real\nhere\nthere"


### PR DESCRIPTION
## What does this PR do?

Fixes Gmail send/reply sending literal `\n` text instead of real line breaks when an LLM agent constructs shell commands with escape sequences in double quotes.

## Related Issue

Fixes #43366

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `skills/productivity/google-workspace/scripts/google_api.py`: Add `_decode_shell_escapes()` helper that converts literal `\\n` and `\\t` to real newline/tab characters before passing `args.body` to `MIMEText`. Applied to all 4 call sites in `gmail_send` and `gmail_reply` (both gws-binary and Python-client paths).
- `tests/skills/test_google_workspace_api.py`: Add `TestDecodeShellEscapes` class with 6 tests covering literal newlines, literal tabs, already-decoded passthrough, plain text, empty string, and mixed real+literal input.

## How to Test

1. `pytest tests/skills/test_google_workspace_api.py -v` — all 22 tests pass
2. Manual: `python3 skills/productivity/google-workspace/scripts/google_api.py gmail send --to test@example.com --subject "test" --body "Line one\n\nLine two"` — the sent email should show proper paragraphs, not literal `\n`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `google_api.py` — `_decode_shell_escapes` (new function), `gmail_send` and `gmail_reply` (4 call sites updated)
- Blast radius: LOW — skill script only, no core module changes
- Related patterns: Shell argument escaping for LLM-generated commands
