### PR TITLE
fix(cli): delete profile directories with read-only file recovery

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -319,6 +319,43 @@ def _count_skills(profile_dir: Path) -> int:
     return count
 
 
+def _make_writable(func, path: str, exc_info):
+    """Rmtree error callback that retries after clearing immutable/read-only flags.
+
+    On macOS an immutable flag (uchg) can prevent deletion even with writable
+    permissions. We clear chflags first (best-effort), then chmod, then retry
+    the original function.
+    """
+    try:
+        path_obj = Path(path)
+    except Exception:
+        raise exc_info[1]
+
+    if not isinstance(exc_info[1], (PermissionError, OSError)):
+        raise exc_info[1]
+
+    try:
+        if hasattr(os, "chflags"):
+            try:
+                os.chflags(path, 0)
+            except (AttributeError, OSError):
+                pass
+    except Exception:
+        # pragma: no cover - defensive: leave deletion attempts unchanged
+        pass
+
+    try:
+        path_obj.chmod(path_obj.stat().st_mode | stat.S_IWUSR)
+    except (AttributeError, OSError):
+        pass
+
+    try:
+        func(path)
+    except Exception as e:
+        raise e from exc_info[1]
+
+
+
 # ---------------------------------------------------------------------------
 # CRUD operations
 # ---------------------------------------------------------------------------
@@ -570,7 +607,7 @@ def delete_profile(name: str, yes: bool = False) -> Path:
 
     # 4. Remove profile directory
     try:
-        shutil.rmtree(profile_dir)
+        shutil.rmtree(profile_dir, onerror=_make_writable)
         print(f"✓ Removed {profile_dir}")
     except Exception as e:
         print(f"⚠ Could not remove {profile_dir}: {e}")

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -196,6 +196,31 @@ class TestDeleteProfile:
             delete_profile("coder", yes=True)
         assert not profile_dir.is_dir()
 
+    def test_deletes_read_only_contents(self, profile_env):
+        """Profiles with read-only files should still delete (retries with chmod/chflags)."""
+        profile_dir = create_profile("coder", no_alias=True)
+        readonly_file = profile_dir / "readonly.txt"
+        readonly_file.write_text("locked")
+        readonly_file.chmod(0o400)
+
+        original_unlink = os.unlink
+        seen = {"count": 0}
+
+        def unlink_retry(path, *args, **kwargs):
+            seen["count"] += 1
+            if seen["count"] == 1:
+                # Simulate a macOS-style/read-only deletion failure for the first attempt
+                raise PermissionError("operation not permitted")
+            return original_unlink(path, *args, **kwargs)
+
+        # Mock gateway import to avoid real systemd/launchd interaction
+        with patch("hermes_cli.profiles._cleanup_gateway_service"):
+            with patch("hermes_cli.profiles.os.unlink", unlink_retry):
+                delete_profile("coder", yes=True)
+
+        assert seen["count"] >= 1
+        assert not profile_dir.is_dir()
+
     def test_default_raises_value_error(self, profile_env):
         with pytest.raises(ValueError, match="default"):
             delete_profile("default", yes=True)


### PR DESCRIPTION
## Summary
- Make `hermes profile delete` robust against read-only/immutable files by using a `shutil.rmtree` `onerror` handler.
- Added `_make_writable` in `hermes_cli/profiles.py` to clear filesystem-level write restrictions (`chmod` + best-effort `chflags`) and retry deletion.
- Added regression test proving profile deletion succeeds even when a delete fails first with a `PermissionError`.

## Testing
- `python3 -m py_compile hermes_cli/profiles.py tests/hermes_cli/test_profiles.py`
- `python3 -m pytest -o addopts='' -q tests/hermes_cli/test_profiles.py`

Closes #43339
