### PR TITLE
fix(params): recognize chatgpt-4o-latest as a max_completion_tokens model

### DIFF
--- a/tests/test_model_forces_max_completion_tokens.py
+++ b/tests/test_model_forces_max_completion_tokens.py
@@ -26,6 +26,14 @@ class TestPositiveCases:
         assert model_forces_max_completion_tokens("gpt-4o") is True
 
 
+    def test_chatgpt_4o_latest(self):
+        # OpenAI's ChatGPT-4o snapshot is a gpt-4o-family model whose name
+        # starts with "chatgpt-" rather than "gpt-", so the gpt-4o prefix
+        # missed it and it would have been sent the rejected max_tokens.
+        assert model_forces_max_completion_tokens("chatgpt-4o-latest") is True
+
+    def test_chatgpt_4o_latest_vendor_prefixed(self):
+        assert model_forces_max_completion_tokens("openai/chatgpt-4o-latest") is True
 
 
     def test_o1(self):
@@ -50,6 +58,11 @@ class TestNegativeCases:
         # Classic gpt-4 (non-omni) still uses max_tokens on chat completions.
         assert model_forces_max_completion_tokens("gpt-4") is False
 
+
+    def test_bare_chatgpt_is_not_matched(self):
+        # The match is anchored to the chatgpt-4o family, not a bare "chatgpt"
+        # prefix, so an unrelated "chatgpt"-named model is not coerced.
+        assert model_forces_max_completion_tokens("chatgpt") is False
 
     def test_claude_family(self):
         assert model_forces_max_completion_tokens("claude-3-opus") is False

--- a/utils.py
+++ b/utils.py
@@ -573,7 +573,8 @@ def model_forces_max_completion_tokens(model: str) -> bool:
     HTTP 400 ``unsupported_parameter`` — the caller must send
     ``max_completion_tokens`` instead. This covers:
 
-    - ``gpt-4o`` / ``gpt-4o-mini`` / ``gpt-4o-*``
+    - ``gpt-4o`` / ``gpt-4o-mini`` / ``gpt-4o-*`` (incl. ``chatgpt-4o-latest``,
+      OpenAI's ChatGPT-4o snapshot, whose name starts with ``chatgpt-`` not ``gpt-``)
     - ``gpt-4.1`` / ``gpt-4.1-*``
     - ``gpt-5`` / ``gpt-5.x`` / ``gpt-5-*``
     - ``o1`` / ``o1-*``
@@ -593,6 +594,7 @@ def model_forces_max_completion_tokens(model: str) -> bool:
         m = m.rsplit("/", 1)[-1]
     return (
         m.startswith("gpt-4o")
+        or m.startswith("chatgpt-4o")  # chatgpt-4o-latest is a gpt-4o snapshot
         or m.startswith("gpt-4.1")
         or m.startswith("gpt-5")
         or m.startswith("o1")


### PR DESCRIPTION
## What & why

`utils.model_forces_max_completion_tokens()` (added recently to pick the right token kwarg by model name on custom OpenAI-compatible endpoints) covers the gpt-4o family — its docstring lists `gpt-4o / gpt-4o-mini / gpt-4o-*`. But it prefix-matches `gpt-4o`, which **misses `chatgpt-4o-latest`**: OpenAI's ChatGPT-4o snapshot is a gpt-4o-family model whose name starts with `chatgpt-`, not `gpt-`.

On `api.openai.com` the URL check already forces `max_completion_tokens`, so this only bites a **third-party OpenAI-compatible endpoint** (custom gateway, OpenRouter, Azure proxy) serving `chatgpt-4o-latest` by name: the caller would send the rejected `max_tokens` and get a 400 `unsupported_parameter` — the exact failure this helper exists to prevent for the rest of the family.

## Fix

Match `chatgpt-4o*` alongside `gpt-4o*`:

```python
m.startswith("gpt-4o")
or m.startswith("chatgpt-4o")  # chatgpt-4o-latest is a gpt-4o snapshot
or m.startswith("gpt-4.1")
...
```

The match is anchored to `chatgpt-4o` (not a bare `chatgpt`), so unrelated `chatgpt`-named models aren't coerced.

## How to test

```bash
scripts/run_tests.sh tests/test_model_forces_max_completion_tokens.py   # 34 passed
```

Extends the existing suite with `chatgpt-4o-latest` (bare and `openai/`-prefixed) as positives and a guard that a bare `chatgpt` stays negative. The new positive fails on the old code.

## Platforms

Pure helper logic in `utils.py`; verified via the CI-parity runner.