### PR TITLE
fix: strip trailing /v1 from base_url for all anthropic_messages providers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3526,6 +3526,14 @@ def _save_custom_provider(
     if not isinstance(providers, list):
         providers = []
 
+    # Normalize base_url: strip trailing /v1 for anthropic_messages mode
+    # so the Anthropic SDK's own /v1/messages suffix doesn't produce a
+    # double /v1 path (e.g. /v1/v1/messages → 404 on custom providers
+    # like vLLM / Ollama).
+    import re as _re
+    if api_mode == "anthropic_messages" and base_url:
+        base_url = _re.sub(r"/v1/?$", "", base_url.rstrip("/"))
+
     # Check if this URL is already saved — update model/context_length if so
     for entry in providers:
         if isinstance(entry, dict) and entry.get("base_url", "").rstrip(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1065,17 +1065,15 @@ def switch_model(
     if not api_mode:
         api_mode = determine_api_mode(target_provider, base_url)
 
-    # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
-    # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
-    # trailing /v1 so the SDK constructs the correct path (e.g.
-    # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
-    # Mirrors the same logic in hermes_cli.runtime_provider.resolve_runtime_provider;
-    # without it, /model switches into an anthropic_messages-routed OpenCode
-    # model (e.g. `/model minimax-m2.7` on opencode-go, `/model claude-sonnet-4-6`
-    # on opencode-zen) hit a double /v1 and returned OpenCode's website 404 page.
+    # When api_mode is anthropic_messages, the Anthropic SDK appends its own
+    # /v1/messages to base_url.  If base_url already ends with /v1 (common for
+    # local model servers that follow the OpenAI-compatible convention), the SDK
+    # produces a double /v1 path (e.g. /v1/v1/messages → 404).
+    # Strip the trailing /v1 so the SDK constructs the correct path regardless
+    # of whether the provider is opencode-zen, opencode-go, or a custom provider
+    # (e.g. custom:vllm pointing at a local vLLM/Ollama server).
     if (
         api_mode == "anthropic_messages"
-        and target_provider in {"opencode-zen", "opencode-go"}
         and isinstance(base_url, str)
         and base_url
     ):


### PR DESCRIPTION
## Problem

The `/v1` stripping logic only guarded against double-/v1 paths for `opencode-zen` and `opencode-go` providers. When a custom provider (e.g. vLLM, Ollama) is configured with `api_mode: anthropic_messages` and a `base_url` ending in `/v1` — which the setup wizard actively suggests for local servers — the Anthropic SDK appends its own `/v1/messages`, producing `/v1/v1/messages` and a 404 error.

```
base_url: http://192.168.0.181:8000/v1
+ /v1/messages (added by Anthropic SDK)
= http://192.168.0.181:8000/v1/v1/messages → 404 Not Found ❌
```

## Fix

### 1. `model_switch.py`
Remove the `target_provider in {"opencode-zen", "opencode-go"}` guard so `/v1` is stripped for **all** `anthropic_messages` providers, including `custom:vllm`, `custom:ollama`, etc.

### 2. `main.py` — `_save_custom_provider()`
Normalize `base_url` on write: strip trailing `/v1` when `api_mode == "anthropic_messages"`. This prevents the bad config from surviving a save/restart cycle.

## Impact

- Fixes `/v1/v1/messages` 404 errors for custom providers using `anthropic_messages` mode
- No impact on `chat_completions` or `codex_responses` providers  
- No impact on OpenCode providers (they already had this fix)
