### PR TITLE
feat(desktop): add always-visible copy button to assistant message bubbles

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -213,6 +213,7 @@ const CenteredThreadSpinner: FC = () => {
 }
 
 const AssistantMessage: FC<{ onBranchInNewChat?: (messageId: string) => void }> = ({ onBranchInNewChat }) => {
+  const { t } = useI18n()
   const messageId = useAuiState(s => s.message.id)
   const content = useAuiState(s => s.message.content)
   const messageText = messageContentText(content)
@@ -243,9 +244,21 @@ const AssistantMessage: FC<{ onBranchInNewChat?: (messageId: string) => void }> 
       ref={enterRef}
     >
       <div
-        className="wrap-anywhere min-w-0 max-w-full overflow-hidden text-pretty text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground"
+        className="relative wrap-anywhere min-w-0 max-w-full overflow-visible text-pretty text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground"
         data-slot="aui_assistant-message-content"
       >
+        {messageText.trim().length > 0 && messageStatus !== 'running' && (
+          <div className="absolute -top-0.5 right-0 z-10 opacity-60 transition-opacity hover:opacity-100">
+            <CopyButton
+              appearance="icon"
+              buttonSize="icon"
+              className="size-6 text-muted-foreground/70 hover:text-foreground"
+              iconClassName="size-3"
+              label={t.common.copy}
+              text={messageText}
+            />
+          </div>
+        )}
         {hoistedTodos.length > 0 && <HoistedTodoPanel todos={hoistedTodos} />}
         <MessagePrimitive.Parts components={MESSAGE_PARTS_COMPONENTS} />
         {messageStatus === 'running' && <StreamStallIndicator activity={`${content.length}:${messageText.length}`} />}


### PR DESCRIPTION
## Problem

Copying a reply from Hermes Desktop requires manually selecting text with the mouse and pressing Cmd+C. This is especially inconvenient for users who frequently copy-paste responses into other applications (e.g., medical professionals copying patient replies into LINE OA or social media).

The existing copy button in the hover action bar is only visible when the user hovers over the message — it's not discoverable for non-technical users.

## Solution

Add a small, always-visible copy icon (📋) in the top-right corner of each assistant message bubble. The button:

- Uses the existing `CopyButton` component with `appearance="icon"` — no new dependencies
- Appears on every completed assistant message (hidden while streaming)
- Has subtle opacity (60% → 100% on hover) to avoid distracting from reading
- Uses the i18n system for the tooltip label
- Copies the full message text to clipboard in one click

## Changes

- `apps/desktop/src/components/assistant-ui/thread.tsx` — 14 lines added:
  - Added `useI18n()` hook to `AssistantMessage` component
  - Added `CopyButton` positioned absolutely in the top-right corner of the message content area
  - Changed content div from `overflow-hidden` to `overflow-visible` to allow the button to be visible

## Testing

- TypeScript compilation passes (no new errors)
- The change reuses the existing, well-tested `CopyButton` component
- No new dependencies or config changes

Closes #43256
