### PR TITLE
fix(config): preserve original .env file mode in sanitize_env_file (sibling of #33699)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5637,6 +5637,12 @@ def sanitize_env_file() -> int:
         fixes = sum(1 for a, b in zip(original_lines, sanitized) if a != b)
         fixes += abs(len(sanitized) - len(original_lines))
 
+    # Preserve original permissions so Docker volume mounts aren't clobbered.
+    original_mode = None
+    try:
+        original_mode = stat.S_IMODE(env_path.stat().st_mode)
+    except OSError:
+        pass
     fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix=".tmp", prefix=".env_")
     try:
         with os.fdopen(fd, "w", **write_kw) as f:
@@ -5644,13 +5650,21 @@ def sanitize_env_file() -> int:
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, env_path)
+        # Preserve the original file mode (e.g. 0640 for Docker volume mounts)
+        # instead of letting _secure_file unconditionally tighten to 0600.
+        if original_mode is not None:
+            try:
+                os.chmod(env_path, original_mode)
+            except OSError:
+                pass
+        else:
+            _secure_file(env_path)
     except BaseException:
         try:
             os.unlink(tmp_path)
         except OSError:
             pass
         raise
-    _secure_file(env_path)
     invalidate_env_cache()
     return fixes
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -538,6 +538,25 @@ class TestSanitizeEnvLines:
             fixes = sanitize_env_file()
             assert fixes == 0
 
+    def test_sanitize_env_file_preserves_existing_file_mode_on_posix(self, tmp_path):
+        """Regression: pre-existing .env mode (e.g. 0640 for a Docker
+        bind-mount) survives sanitize_env_file(). Previously _secure_file
+        ran unconditionally and re-tightened to 0600.
+        """
+        if os.name == "nt":
+            return
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("OPENROUTER_API_KEY=valFIRECRAWL_API_KEY=val2\n")
+        os.chmod(env_file, 0o640)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            fixes = sanitize_env_file()
+            assert fixes > 0
+
+        env_mode = env_file.stat().st_mode & 0o777
+        assert env_mode == 0o640, f"expected 0o640, got {oct(env_mode)}"
+
 
 class TestOptionalEnvVarsRegistry:
     """Verify that key env vars are registered in OPTIONAL_ENV_VARS."""


### PR DESCRIPTION
## Summary

- `sanitize_env_file()` called `_secure_file(env_path)` unconditionally after rewriting the file, tightening permissions to 0600 and clobbering any mode the operator had set (e.g. 0640 on Docker volume mounts).
- On Docker, `migrate_config()` calls `sanitize_env_file()` at every startup, so the clobber fires whenever the .env contains a concatenated entry — silently resetting the operator-chosen mode on each boot.
- `save_env_value()` received the same fix in #33699 (`e4a1b35`). This PR applies the identical pattern to `sanitize_env_file()`: capture `original_mode` before the write, restore it with `os.chmod` if present, and call `_secure_file()` only in the `else` branch for files that had no prior mode.

## Test plan

- [x] `test_sanitize_env_file_preserves_existing_file_mode_on_posix` — sets .env to 0640, triggers a sanitize rewrite, asserts mode stays 0640 (fails without the fix, passes with it)
- [x] Existing `TestSanitizeEnvLines` tests all pass
- [x] `TestSaveEnvValueSecure` and `TestRemoveEnvValue` tests unaffected