### PR TITLE
fix(gateway): stop typing after response delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4383,6 +4383,16 @@ class BasePlatformAdapter(ABC):
                         self.name, len(_response_pre_extract), event.source.chat_id,
                     )
 
+            # The user-visible reply has been delivered. Stop typing before
+            # post-delivery hooks/debounce cleanup so Discord does not keep
+            # refreshing "typing" after the response is already visible.
+            await _stop_typing_task()
+            try:
+                if hasattr(self, "stop_typing"):
+                    await self.stop_typing(event.source.chat_id)
+            except Exception:
+                pass
+
             # Determine overall success for the processing hook
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
             await self._run_processing_hook(

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -175,6 +175,52 @@ class TestBasePlatformTopicSessions:
         ]
 
     @pytest.mark.asyncio
+    async def test_process_message_background_stops_typing_before_complete_hook(self):
+        adapter = DummyTelegramAdapter()
+        keep_typing_cancelled = asyncio.Event()
+        complete_hook_seen = asyncio.Event()
+        stop_calls = []
+        order = []
+
+        async def handler(_event):
+            await asyncio.sleep(0)
+            return "ack"
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            try:
+                await asyncio.Event().wait()
+            finally:
+                order.append("typing-cancelled")
+                keep_typing_cancelled.set()
+
+        async def stop_typing(chat_id: str):
+            stop_calls.append(chat_id)
+            order.append("stop-typing")
+
+        async def on_processing_complete(event: MessageEvent, outcome: ProcessingOutcome) -> None:
+            order.append("complete")
+            assert keep_typing_cancelled.is_set()
+            adapter.processing_hooks.append(("complete", event.message_id, outcome))
+            complete_hook_seen.set()
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+        adapter.stop_typing = stop_typing
+        adapter.on_processing_complete = on_processing_complete
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert complete_hook_seen.is_set()
+        assert stop_calls
+        assert order.index("typing-cancelled") < order.index("complete")
+        assert order.index("stop-typing") < order.index("complete")
+        assert adapter.processing_hooks == [
+            ("start", "1"),
+            ("complete", "1", ProcessingOutcome.SUCCESS),
+        ]
+
+    @pytest.mark.asyncio
     async def test_process_message_background_marks_exception_unsuccessful(self):
         adapter = DummyTelegramAdapter()
 


### PR DESCRIPTION
## What does this PR do?

Stops gateway typing indicators immediately after the user-visible response is delivered, before post-delivery hooks and debounce cleanup continue running.

On Discord, the platform adapter keeps a persistent typing task that refreshes the typing endpoint every 12 seconds. The agent path already calls `stop_typing()` when the model result is ready, but the base adapter's generic `_keep_typing()` task can still recreate the platform typing loop while the final response is being sent and while post-delivery hooks run. That leaves the user seeing a completed reply while Hermes still appears to be typing.

This change cancels the generic typing task and calls the platform `stop_typing()` hook immediately after delivery. The existing final cleanup remains in place as a safety net for empty-response, error, cancellation, and late cleanup paths.

Existing related PRs reviewed before opening this:

- #25210 stops typing before first outbound delivery and includes broader tests.
- #29172 implements a broader stream-consumer/final-delivery stop signal.
- #38566 stops Discord typing before response delivery.
- #39693 makes a similar post-delivery hook ordering change but does not include a regression test.

## Related Issue

N/A - found from local Windows Discord gateway repro.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: stop the generic typing task and the platform typing loop immediately after user-visible delivery, before `on_processing_complete` hooks and debounce cleanup.
- `tests/gateway/test_base_topic_sessions.py`: add a regression test proving typing is stopped before the processing-complete hook observes the completed turn.

## How to Test

1. Run `scripts/run_tests.sh -j 4 tests/gateway/test_base_topic_sessions.py`.
2. Run a Discord gateway session.
3. Send a message that takes long enough to show the Discord typing indicator, then confirm the indicator does not keep refreshing after the reply is visible.

Focused local validation:

- `venv/Scripts/python.exe -m py_compile gateway/platforms/base.py tests/gateway/test_base_topic_sessions.py`
- `scripts/run_tests.sh -j 4 tests/gateway/test_base_topic_sessions.py` - 11 passed
- Windows AppData install: restarted local gateway and confirmed Discord + Home Assistant connected after the patch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 AppData desktop/gateway install

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## For New Skills

N/A

## Screenshots / Logs

Local Windows gateway log showed the user-visible Discord response sent before follow-on cron/background activity continued:

- `response ready: platform=discord ... time=319.6s`
- `[Discord] Sending response ...`

The patch moves typing cleanup to immediately after that delivery boundary so post-delivery work cannot keep the Discord typing loop alive.
