### PR TITLE
fix(session): respect reset policy on resume_pending instead of unconditional bypass

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -889,13 +889,16 @@ class SessionStore:
                 elif entry.resume_pending:
                     # Restart-interrupted session: preserve the session_id
                     # and return the existing entry so the transcript
-                    # reloads intact.  ``resume_pending`` is cleared after
-                    # the NEXT successful turn completes (not here), which
-                    # means a re-interrupted retry keeps trying — the
-                    # stuck-loop counter handles terminal escalation.
-                    entry.updated_at = now
-                    self._save()
-                    return entry
+                    # reloads intact, BUT still honour the session reset
+                    # policy.  If the session has crossed a daily or idle
+                    # boundary while the gateway was down, let it
+                    # auto-reset so the user starts fresh.
+                    reset_reason = self._should_reset(entry, source)
+                    if not reset_reason:
+                        entry.updated_at = now
+                        self._save()
+                        return entry
+                    # Fall through to auto-reset below.
                 else:
                     reset_reason = self._should_reset(entry, source)
                 if not reset_reason:


### PR DESCRIPTION
## Problem

When a session is marked `resume_pending` (after gateway restart/shutdown), `get_or_create_session()` returns the existing entry immediately without checking `_should_reset()`. This means that if the session crossed a daily or idle reset boundary while the gateway was down, the policy is silently ignored — the user keeps the same stale session, and auto-reset never fires for that session again as long as it keeps getting messages.

## Reproduction

1. Configure `session_reset.mode: both` with `at_hour: 5` and `idle_minutes: 300`
2. Let a session run past the daily boundary (after 05:00)
3. Restart the gateway (SIGTERM + restart)
4. The session is marked `resume_pending` by `suspend_recently_active()`
5. Next user message → `get_or_create_session()` hits the `elif entry.resume_pending:` branch → returns stale entry → no reset happens

## Fix

Call `_should_reset()` inside the `resume_pending` branch. If no reset is due, preserve the existing session_id as before. If a daily or idle boundary was crossed, fall through to the auto-reset path so the user starts fresh.

## Impact

Low/Medium — only affects sessions that (a) experienced a gateway restart AND (b) crossed a reset boundary during downtime. The fix is minimal (5 lines changed) and the fallthrough path is well-tested (identical to the `else:` branch below).