### PR TITLE
fix(memory): handle UNIQUE constraint in update_fact() (#43389)

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -276,11 +276,16 @@ class MemoryStore:
                 params.append(new_trust)
 
             params.append(fact_id)
-            self._conn.execute(
-                f"UPDATE facts SET {', '.join(assignments)} WHERE fact_id = ?",
-                params,
-            )
-            self._conn.commit()
+            try:
+                self._conn.execute(
+                    f"UPDATE facts SET {', '.join(assignments)} WHERE fact_id = ?",
+                    params,
+                )
+                self._conn.commit()
+            except sqlite3.IntegrityError:
+                # Duplicate content — reject the update, rollback, return False
+                self._conn.rollback()
+                return False
 
             # If content changed, re-extract entities
             if content is not None:


### PR DESCRIPTION
## Summary
Fixes the crash in `FactStore.update_fact()` when the new content value violates the UNIQUE constraint on the `facts.content` column.

## Problem
The `facts` table has a UNIQUE constraint on the `content` column. While `add_fact()` correctly handles duplicate content by catching `sqlite3.IntegrityError` and returning the existing fact_id, `update_fact()` had no such guard. When attempting to update a fact's content to a value that already exists in another row, the `UPDATE` statement would raise an unhandled `IntegrityError`, crashing the memory subsystem.

## Solution
Added a try/except block around the UPDATE statement in `update_fact()` to catch `sqlite3.IntegrityError`, rollback the transaction, and return `False` (rejecting the update). This follows the same pattern used in `add_fact()` for graceful duplicate handling.

## Testing
- Verified the fix handles the reproduction case from the issue
- All 597 memory-related tests pass
- Manual testing confirms:
  - Duplicate content update returns `False` and preserves original content
  - Valid content updates work correctly and return `True`

## Related
Fixes #43389
