### PR TITLE
fix: use UTF-8 encoding for subprocess text pipes on Windows

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -34,6 +34,7 @@ from typing import Sequence
 __all__ = [
     "IS_WINDOWS",
     "resolve_node_command",
+    "subprocess_text_encoding",
     "windows_detach_flags",
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
@@ -85,6 +86,38 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     if resolved:
         return [resolved, *argv]
     return [name, *argv]
+
+
+# -----------------------------------------------------------------------------
+# Text encoding for subprocess pipes (Windows GBK / UTF-8 mismatch)
+# -----------------------------------------------------------------------------
+
+
+def subprocess_text_encoding() -> str | None:
+    """Return the encoding to use for ``text=True`` subprocess calls.
+
+    On Windows, Python's default text-pipe encoding is
+    ``locale.getpreferredencoding()``, which returns a locale-specific
+    ANSI code page (e.g. ``cp936`` / GBK on Chinese Windows, ``cp932`` on
+    Japanese Windows, ``cp949`` on Korean Windows).  Most CLI tools
+    (git, pip, uv, npm, cargo, ...) emit UTF-8 regardless of the system
+    locale, so subprocess text-pipe reads fail with
+    ``UnicodeDecodeError`` when a UTF-8 multibyte sequence happens to
+    look like an illegal local-code-page byte.
+
+    This helper returns ``'utf-8'`` on Windows (matching what virtually
+    every modern CLI tool outputs) and ``None`` on POSIX (where the
+    default locale encoding is almost always UTF-8).
+
+    Callers that use ``subprocess.run(..., text=True)`` or
+    ``subprocess.Popen(..., text=True)`` should pass
+    ``encoding=subprocess_text_encoding()`` so output is decoded
+    correctly on CJK Windows systems.
+
+    Returns:
+        ``'utf-8'`` on Windows, ``None`` on non-Windows.
+    """
+    return "utf-8" if IS_WINDOWS else None
 
 
 # -----------------------------------------------------------------------------

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -23,6 +23,7 @@ from hermes_cli.config import (
     cfg_get,
     load_config, save_config, get_env_value, save_env_value,
 )
+from hermes_cli._subprocess_compat import subprocess_text_encoding as _subprocess_text_encoding
 from hermes_cli.colors import Colors, color
 from hermes_cli.nous_subscription import (
     apply_nous_managed_defaults,
@@ -611,6 +612,7 @@ def _pip_install(
             result = subprocess.run(
                 [uv_bin, "pip", "install", *args],
                 capture_output=capture_output, text=True, timeout=timeout,
+                encoding=_subprocess_text_encoding(),
                 env=uv_env,
             )
             if result.returncode == 0:
@@ -626,6 +628,7 @@ def _pip_install(
         probe = subprocess.run(
             pip_cmd + ["--version"],
             capture_output=True, text=True, timeout=15,
+            encoding=_subprocess_text_encoding(),
         )
         if probe.returncode != 0:
             raise FileNotFoundError("pip not in venv")
@@ -634,6 +637,7 @@ def _pip_install(
             subprocess.run(
                 [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
                 capture_output=True, text=True, timeout=120, check=True,
+                encoding=_subprocess_text_encoding(),
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             # Synthesize a result so callers see a clean failure path.
@@ -645,6 +649,7 @@ def _pip_install(
     return subprocess.run(
         pip_cmd + ["install", *args],
         capture_output=capture_output, text=True, timeout=timeout,
+        encoding=_subprocess_text_encoding(),
     )
 
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -61,6 +61,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from hermes_cli._subprocess_compat import subprocess_text_encoding as _subprocess_text_encoding
+
 logger = logging.getLogger(__name__)
 
 
@@ -364,7 +366,9 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         try:
             r = subprocess.run(
                 [uv_bin, "pip", "install", *specs],
-                capture_output=True, text=True, timeout=timeout, env=uv_env,
+                capture_output=True, text=True, timeout=timeout,
+                encoding=_subprocess_text_encoding(),
+                env=uv_env,
                 stdin=subprocess.DEVNULL,
             )
             if r.returncode == 0:
@@ -379,6 +383,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         probe = subprocess.run(
             pip_cmd + ["--version"],
             capture_output=True, text=True, timeout=15,
+            encoding=_subprocess_text_encoding(),
             stdin=subprocess.DEVNULL,
         )
         if probe.returncode != 0:
@@ -388,6 +393,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             subprocess.run(
                 [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
                 capture_output=True, text=True, timeout=120, check=True,
+                encoding=_subprocess_text_encoding(),
                 stdin=subprocess.DEVNULL,
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
@@ -398,6 +404,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         r = subprocess.run(
             pip_cmd + ["install", *specs],
             capture_output=True, text=True, timeout=timeout,
+            encoding=_subprocess_text_encoding(),
             stdin=subprocess.DEVNULL,
         )
         return _InstallResult(r.returncode == 0, r.stdout or "", r.stderr or "")


### PR DESCRIPTION
subprocess.run(text=True) uses locale.getpreferredencoding() for pipe encoding, which returns cp936/GBK on Chinese Windows (cp932 on Japanese, cp949 on Korean, etc.).  When pip/uv output contains UTF-8 multi-byte sequences (emoji, Unicode symbols), the GBK decoder fails with UnicodeDecodeError in _readerthread.

This was observed during 'hermes update' where pip install output for platform plugins (e.g. matrix -> mautrix) triggered the error. The update succeeded because _readerthread errors are non-fatal thread exceptions, but they pollute stderr and may hide real issues.

Add subprocess_text_encoding() to _subprocess_compat.py (returns 'utf-8' on Windows, None on POSIX — preserving existing behavior) and wire it into _pip_install() and _venv_install(), the two pip/uv install utility functions used during update.

The existing configure_windows_stdio() already sets PYTHONUTF8=1 and PYTHONIOENCODING=utf-8 for child Python processes, but these do not affect subprocess pipe encoding in the parent process.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

