### PR TITLE
fix: respect user choice when declining /v1 suffix in setup

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -163,6 +163,12 @@ MEMORY_GUIDANCE = (
     "workflows belong in skills, not memory."
 )
 
+KNOWLEDGE_ROUTER_GUIDANCE = (
+    "When knowledge_write is available, prefer it for durable knowledge writes. "
+    "Use dry_run for uncertain routing. Do not store task logs, raw transcripts, "
+    "secrets, verification markers, or build/test dumps unless explicitly requested."
+)
+
 SESSION_SEARCH_GUIDANCE = (
     "When the user references something from a past conversation or you suspect "
     "relevant cross-session context exists, use session_search to recall it before "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -31,6 +31,7 @@ from agent.prompt_builder import (
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
+    KNOWLEDGE_ROUTER_GUIDANCE,
     MEMORY_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PLATFORM_HINTS,
@@ -115,6 +116,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     tool_guidance = []
     if "memory" in agent.valid_tool_names:
         tool_guidance.append(MEMORY_GUIDANCE)
+    if "knowledge_write" in agent.valid_tool_names or "knowledge_route_decision" in agent.valid_tool_names:
+        tool_guidance.append(KNOWLEDGE_ROUTER_GUIDANCE)
     if "session_search" in agent.valid_tool_names:
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -702,6 +702,7 @@ def _model_flow_custom(config):
         h in _url_lower
         for h in ("localhost", "127.0.0.1", "0.0.0.0", ":11434", ":8080", ":5000")
     )
+    _user_declined_v1 = False
     if _looks_local and not _url_lower.endswith("/v1"):
         print()
         print(f"  Hint: Did you mean to add /v1 at the end?")
@@ -716,19 +717,27 @@ def _model_flow_custom(config):
             if base_url:
                 base_url = effective_url
             print(f"  Updated URL: {effective_url}")
+        else:
+            _user_declined_v1 = True
         print()
 
     from hermes_cli.models import probe_api_models
 
     probe = probe_api_models(effective_key, effective_url)
     if probe.get("used_fallback") and probe.get("resolved_base_url"):
-        print(
-            f"Warning: endpoint verification worked at {probe['resolved_base_url']}/models, "
-            f"not the exact URL you entered. Saving the working base URL instead."
-        )
-        effective_url = probe["resolved_base_url"]
-        if base_url:
-            base_url = effective_url
+        if _user_declined_v1:
+            print(
+                f"Note: endpoint verification found a working URL at {probe['resolved_base_url']}/models, "
+                f"but you explicitly declined /v1. Using your original URL: {effective_url}"
+            )
+        else:
+            print(
+                f"Warning: endpoint verification worked at {probe['resolved_base_url']}/models, "
+                f"not the exact URL you entered. Saving the working base URL instead."
+            )
+            effective_url = probe["resolved_base_url"]
+            if base_url:
+                base_url = effective_url
     elif probe.get("models") is not None:
         print(
             f"Verified endpoint via {probe.get('probed_url')} "

--- a/knowledge/__init__.py
+++ b/knowledge/__init__.py
@@ -1,0 +1,27 @@
+"""Knowledge routing package for durable Hermes knowledge writes.
+
+The package separates pure routing policy from backend adapters and tool
+wrappers. The core router is deterministic and can be tested without network or
+profile state.
+"""
+
+from knowledge.router import KnowledgeRouter, route_knowledge_write
+from knowledge.types import (
+    DuplicatePolicy,
+    KnowledgeDestination,
+    KnowledgeWriteRequest,
+    KnowledgeWriteResult,
+    RouteAction,
+    RouteDecision,
+)
+
+__all__ = [
+    "DuplicatePolicy",
+    "KnowledgeDestination",
+    "KnowledgeRouter",
+    "KnowledgeWriteRequest",
+    "KnowledgeWriteResult",
+    "RouteAction",
+    "RouteDecision",
+    "route_knowledge_write",
+]

--- a/knowledge/adapters/__init__.py
+++ b/knowledge/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Backend adapters for knowledge routing."""

--- a/knowledge/adapters/base.py
+++ b/knowledge/adapters/base.py
@@ -1,0 +1,47 @@
+"""Adapter contracts for knowledge routing backends."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Protocol
+
+from knowledge.types import KnowledgeWriteRequest
+
+
+@dataclass(frozen=True)
+class ExistingKnowledge:
+    id: str
+    title: str = ""
+    path: str = ""
+    score: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    success: bool
+    backend: str
+    action: str
+    id: str = ""
+    path: str = ""
+    error: str | None = None
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class KnowledgeAdapter(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    def search_existing(self, request: KnowledgeWriteRequest) -> list[ExistingKnowledge]:
+        return []
+
+    def write(self, request: KnowledgeWriteRequest) -> WriteResult: ...
+
+    def update(self, existing: ExistingKnowledge, request: KnowledgeWriteRequest) -> WriteResult:
+        return self.write(request)

--- a/knowledge/adapters/hindsight.py
+++ b/knowledge/adapters/hindsight.py
@@ -1,0 +1,37 @@
+"""Hindsight adapter for dynamic memory writes."""
+
+from __future__ import annotations
+
+import json
+
+from knowledge.adapters.base import WriteResult
+from knowledge.types import KnowledgeWriteRequest
+
+DEFAULT_CONTEXT = "Hermes knowledge router"
+
+
+class HindsightMemoryAdapter:
+    @property
+    def name(self) -> str:
+        return "hindsight"
+
+    def write(self, request: KnowledgeWriteRequest) -> WriteResult:
+        from plugins.memory.hindsight import HindsightMemoryProvider
+
+        provider = HindsightMemoryProvider()
+        provider.initialize("knowledge-router", platform="tool")
+        try:
+            result_text = provider.handle_tool_call(
+                "hindsight_retain",
+                {
+                    "content": request.content,
+                    "context": request.context or DEFAULT_CONTEXT,
+                    "tags": list(request.tags),
+                },
+            )
+            parsed = json.loads(result_text) if isinstance(result_text, str) else {}
+            if isinstance(parsed, dict) and parsed.get("error"):
+                return WriteResult(success=False, backend=self.name, action="retain", error=str(parsed["error"]), data=parsed)
+            return WriteResult(success=True, backend=self.name, action="retain", data=parsed if isinstance(parsed, dict) else {})
+        finally:
+            provider.shutdown()

--- a/knowledge/adapters/siyuan.py
+++ b/knowledge/adapters/siyuan.py
@@ -1,0 +1,265 @@
+"""SiYuan adapter for static knowledge documents.
+
+Uses SiYuan's HTTP API only; it never edits workspace `.sy` files directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+from typing import Any, Protocol
+import urllib.error
+import urllib.request
+
+from hermes_constants import get_hermes_home
+from knowledge.adapters.base import ExistingKnowledge, WriteResult
+from knowledge.types import KnowledgeWriteRequest
+
+DEFAULT_ENDPOINT = "http://127.0.0.1:6806"
+DEFAULT_NOTEBOOK = "Hermes"
+MAX_RETURN_TEXT_CHARS = 20_000
+MAX_SQL_CHARS = 2_000
+
+
+@dataclass(frozen=True)
+class SiYuanConfig:
+    endpoint: str
+    api_token: str
+    default_notebook: str = DEFAULT_NOTEBOOK
+
+    def redacted(self) -> dict[str, str]:
+        return {
+            "endpoint": self.endpoint,
+            "default_notebook": self.default_notebook,
+            "api_token": "[REDACTED]" if self.api_token else "",
+        }
+
+
+def _read_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    env: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        env[key.strip()] = value.strip().strip('"').strip("'")
+    return env
+
+
+def load_config() -> SiYuanConfig:
+    data: dict[str, Any] = {}
+    config_path = get_hermes_home() / "siyuan" / "config.json"
+    if config_path.exists():
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+
+    secret_env = _read_env_file(Path("/opt/siyuan/secrets/siyuan.env"))
+    endpoint = (
+        os.getenv("SIYUAN_ENDPOINT")
+        or data.get("local_endpoint")
+        or data.get("endpoint")
+        or DEFAULT_ENDPOINT
+    ).rstrip("/")
+    token = (
+        os.getenv("SIYUAN_API_TOKEN")
+        or data.get("api_token")
+        or secret_env.get("SIYUAN_API_TOKEN")
+        or ""
+    )
+    notebook = os.getenv("SIYUAN_DEFAULT_NOTEBOOK") or data.get("default_notebook") or DEFAULT_NOTEBOOK
+    return SiYuanConfig(endpoint=endpoint, api_token=token, default_notebook=notebook)
+
+
+class SiYuanAPIError(RuntimeError):
+    pass
+
+
+class SiYuanPoster(Protocol):
+    def post(self, path: str, payload: dict[str, Any]) -> Any: ...
+
+
+class SiYuanClient:
+    def __init__(self, config: SiYuanConfig | None = None):
+        self.config = config or load_config()
+        if not self.config.api_token:
+            raise SiYuanAPIError("SiYuan API token is not configured")
+
+    def post(self, path: str, payload: dict[str, Any]) -> Any:
+        if not path.startswith("/"):
+            path = "/" + path
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        req = urllib.request.Request(
+            self.config.endpoint + path,
+            data=body,
+            method="POST",
+            headers={
+                "Authorization": f"Token {self.config.api_token}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+                raw = resp.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:500]
+            raise SiYuanAPIError(f"HTTP {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise SiYuanAPIError(str(exc)) from exc
+
+        try:
+            parsed = json.loads(raw) if raw else {}
+        except json.JSONDecodeError as exc:
+            raise SiYuanAPIError(f"Invalid JSON response: {raw[:200]}") from exc
+        if isinstance(parsed, dict) and parsed.get("code", 0) != 0:
+            raise SiYuanAPIError(parsed.get("msg") or f"SiYuan API error code={parsed.get('code')}")
+        return parsed.get("data") if isinstance(parsed, dict) and "data" in parsed else parsed
+
+
+def _slugify_title(title: str) -> str:
+    text = re.sub(r"[\\/]+", "-", title.strip())
+    text = re.sub(r'[\x00-\x1f:*?"<>|#\[\]{}]+', "-", text)
+    text = re.sub(r"\s+", "-", text)
+    text = re.sub(r"-+", "-", text).strip("-.")
+    return text[:120] or "Untitled"
+
+
+def doc_path_for(title: str, path: str = "") -> str:
+    if path:
+        clean = path.strip()
+        return clean if clean.startswith("/") else "/" + clean
+    return "/" + _slugify_title(title)
+
+
+def _truncate(text: str, limit: int = MAX_RETURN_TEXT_CHARS) -> str:
+    return text if len(text) <= limit else text[:limit] + f"\n...[truncated {len(text) - limit} chars]"
+
+
+class SiYuanKnowledgeAdapter:
+    def __init__(self, client: SiYuanClient | None = None):
+        self.client = client or SiYuanClient(load_config())
+
+    @property
+    def name(self) -> str:
+        return "siyuan"
+
+    def ensure_notebook(self, name: str) -> str:
+        data = self.client.post("/api/notebook/lsNotebooks", {})
+        notebooks = data.get("notebooks", []) if isinstance(data, dict) else []
+        for notebook in notebooks:
+            if notebook.get("name") == name:
+                return notebook["id"]
+        created = self.client.post("/api/notebook/createNotebook", {"name": name})
+        notebook = created.get("notebook", created) if isinstance(created, dict) else {}
+        notebook_id = notebook.get("id")
+        if not notebook_id:
+            raise SiYuanAPIError(f"Failed to create notebook {name!r}")
+        return notebook_id
+
+    def search_existing(self, request: KnowledgeWriteRequest) -> list[ExistingKnowledge]:
+        query = (request.title or request.idempotency_key or "").strip()
+        if not query:
+            return []
+        data = self.client.post(
+            "/api/search/fullTextSearchBlock",
+            {"query": query[:500], "method": 0, "orderBy": 0, "groupBy": 0, "page": 1, "paths": []},
+        )
+        blocks = data.get("blocks", []) if isinstance(data, dict) else []
+        results: list[ExistingKnowledge] = []
+        normalized_title = (request.title or "").strip().casefold()
+        for block in blocks[:10]:
+            hpath = str(block.get("hPath") or block.get("path") or "")
+            content = str(block.get("content") or "")
+            score = 1.0 if normalized_title and normalized_title in (hpath + " " + content).casefold() else 0.5
+            results.append(
+                ExistingKnowledge(
+                    id=str(block.get("id") or ""),
+                    title=request.title or content[:80],
+                    path=hpath,
+                    score=score,
+                    metadata={"type": block.get("type")},
+                )
+            )
+        return results
+
+    def write(self, request: KnowledgeWriteRequest) -> WriteResult:
+        notebook = request.notebook or self.client.config.default_notebook
+        notebook_id = self.ensure_notebook(notebook)
+        path = doc_path_for(request.title, request.path)
+        data = self.client.post(
+            "/api/filetree/createDocWithMd",
+            {"notebook": notebook_id, "path": path, "markdown": request.content},
+        )
+        doc_id = ""
+        if isinstance(data, dict):
+            doc_id = str(data.get("id") or data.get("rootID") or "")
+        return WriteResult(
+            success=True,
+            backend=self.name,
+            action="create",
+            id=doc_id,
+            path=path,
+            data={"notebook": notebook, "notebook_id": notebook_id, "data": data},
+        )
+
+    def update(self, existing: ExistingKnowledge, request: KnowledgeWriteRequest) -> WriteResult:
+        if not existing.id:
+            return self.write(request)
+        data = self.client.post(
+            "/api/block/updateBlock",
+            {"id": existing.id, "dataType": "markdown", "data": request.content},
+        )
+        return WriteResult(
+            success=True,
+            backend=self.name,
+            action="update",
+            id=existing.id,
+            path=existing.path,
+            data={"data": data},
+        )
+
+
+def append_block(client: SiYuanPoster, block_id: str, markdown: str) -> dict[str, Any]:
+    data = client.post("/api/block/appendBlock", {"dataType": "markdown", "data": markdown, "parentID": block_id})
+    return {"success": True, "data": data}
+
+
+def export_markdown(client: SiYuanPoster, block_id: str) -> dict[str, Any]:
+    data = client.post("/api/export/exportMdContent", {"id": block_id})
+    markdown = data.get("content", data) if isinstance(data, dict) else data
+    return {"success": True, "markdown": _truncate(str(markdown))}
+
+
+def update_block(client: SiYuanPoster, block_id: str, markdown: str) -> dict[str, Any]:
+    data = client.post("/api/block/updateBlock", {"id": block_id, "dataType": "markdown", "data": markdown})
+    return {"success": True, "data": data}
+
+
+def search_blocks(client: SiYuanPoster, query: str, page: int = 1) -> dict[str, Any]:
+    data = client.post(
+        "/api/search/fullTextSearchBlock",
+        {"query": query[:500], "method": 0, "orderBy": 0, "groupBy": 0, "page": max(int(page or 1), 1), "paths": []},
+    )
+    blocks = data.get("blocks", []) if isinstance(data, dict) else []
+    compact = [
+        {"id": b.get("id"), "type": b.get("type"), "content": _truncate(str(b.get("content", "")), 800), "hPath": b.get("hPath")}
+        for b in blocks[:20]
+    ]
+    return {"success": True, "count": len(blocks), "blocks": compact}
+
+
+def run_sql(client: SiYuanPoster, stmt: str, allow_unsafe: bool = False) -> dict[str, Any]:
+    sql = (stmt or "").strip()
+    if not sql:
+        raise ValueError("stmt is required")
+    if len(sql) > MAX_SQL_CHARS:
+        raise ValueError(f"stmt exceeds {MAX_SQL_CHARS} characters")
+    simple_select = sql.lower().startswith("select") and ";" not in sql[:-1]
+    if not simple_select and not allow_unsafe:
+        raise ValueError("Only simple SELECT statements are supported unless allow_unsafe=true")
+    if simple_select and " limit " not in sql.lower():
+        sql = sql.rstrip(";") + " limit 20"
+    return {"success": True, "rows": client.post("/api/query/sql", {"stmt": sql})}

--- a/knowledge/policy.py
+++ b/knowledge/policy.py
@@ -1,0 +1,110 @@
+"""Configurable routing policy for durable knowledge writes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from knowledge.types import KnowledgeDestination, RouteAction, RouteDecision
+
+
+DEFAULT_STATIC_TYPES = frozenset({
+    "runbook",
+    "architecture",
+    "decision",
+    "postmortem",
+    "research",
+    "project_doc",
+    "api_doc",
+    "integration_doc",
+    "deployment",
+    "troubleshooting",
+    "deep_summary",
+    "knowledge",
+})
+DEFAULT_DYNAMIC_TYPES = frozenset({
+    "preference",
+    "user_preference",
+    "fact",
+    "lesson",
+    "entity",
+    "memory",
+    "correction",
+})
+DEFAULT_EPHEMERAL_TYPES = frozenset({
+    "task_log",
+    "session_log",
+    "transcript",
+    "scratch",
+    "temporary",
+    "progress",
+    "build_output",
+    "test_output",
+    "verification_marker",
+})
+
+
+@dataclass(frozen=True)
+class RoutePolicy:
+    static_types: frozenset[str] = DEFAULT_STATIC_TYPES
+    dynamic_types: frozenset[str] = DEFAULT_DYNAMIC_TYPES
+    ephemeral_types: frozenset[str] = DEFAULT_EPHEMERAL_TYPES
+    default_static_backend: str = "siyuan"
+    default_dynamic_backend: str = "hindsight"
+    unknown_policy: str = "dry_run"
+    duplicate_policy: str = "update_existing"
+    extra_static_types: frozenset[str] = field(default_factory=frozenset)
+    extra_dynamic_types: frozenset[str] = field(default_factory=frozenset)
+    extra_ephemeral_types: frozenset[str] = field(default_factory=frozenset)
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any] | None) -> "RoutePolicy":
+        router_cfg = ((config or {}).get("knowledge") or {}).get("router") or {}
+        def _set(name: str) -> frozenset[str]:
+            value = router_cfg.get(name) or []
+            if isinstance(value, str):
+                value = [p.strip() for p in value.split(",")]
+            return frozenset(str(v).strip().lower().replace("-", "_") for v in value if str(v).strip())
+        return cls(
+            default_static_backend=router_cfg.get("default_static_backend") or "siyuan",
+            default_dynamic_backend=router_cfg.get("default_dynamic_backend") or "hindsight",
+            unknown_policy=router_cfg.get("unknown_policy") or "dry_run",
+            duplicate_policy=router_cfg.get("duplicate_policy") or "update_existing",
+            extra_static_types=_set("extra_static_types"),
+            extra_dynamic_types=_set("extra_dynamic_types"),
+            extra_ephemeral_types=_set("extra_ephemeral_types"),
+        )
+
+    def decide(self, content_type: str) -> RouteDecision:
+        kind = (content_type or "").strip().lower().replace("-", "_")
+        if kind in self.static_types or kind in self.extra_static_types:
+            return RouteDecision(
+                destination=KnowledgeDestination.STATIC_KNOWLEDGE,
+                action=RouteAction.WRITE_DOCUMENT,
+                reason="static_reference",
+                requires_title=True,
+                snapshot=True,
+                content_type=kind,
+                backend=self.default_static_backend,
+            )
+        if kind in self.dynamic_types or kind in self.extra_dynamic_types:
+            return RouteDecision(
+                destination=KnowledgeDestination.DYNAMIC_MEMORY,
+                action=RouteAction.RETAIN_MEMORY,
+                reason="dynamic_memory",
+                content_type=kind,
+                backend=self.default_dynamic_backend,
+            )
+        if kind in self.ephemeral_types or kind in self.extra_ephemeral_types:
+            return RouteDecision(
+                destination=KnowledgeDestination.NONE,
+                action=RouteAction.SKIP,
+                reason="ephemeral_noise",
+                content_type=kind,
+            )
+        return RouteDecision(
+            destination=KnowledgeDestination.REVIEW,
+            action=RouteAction.DRY_RUN_ONLY,
+            reason="unknown_content_type",
+            content_type=kind,
+        )

--- a/knowledge/router.py
+++ b/knowledge/router.py
@@ -1,0 +1,193 @@
+"""Pure routing and orchestration for durable knowledge writes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from knowledge.adapters.base import ExistingKnowledge, KnowledgeAdapter
+from knowledge.policy import RoutePolicy
+from knowledge.types import (
+    DuplicatePolicy,
+    KnowledgeDestination,
+    KnowledgeWriteRequest,
+    KnowledgeWriteResult,
+    RouteAction,
+    RouteDecision,
+)
+
+MAX_KNOWLEDGE_CONTENT_CHARS = 120_000
+
+
+def route_knowledge_write(
+    request: KnowledgeWriteRequest,
+    policy: RoutePolicy | None = None,
+) -> RouteDecision:
+    if request.destination_override:
+        destination = request.destination_override
+        if destination is KnowledgeDestination.STATIC_KNOWLEDGE:
+            return RouteDecision(
+                destination=destination,
+                action=RouteAction.WRITE_DOCUMENT,
+                reason="destination_override",
+                requires_title=True,
+                snapshot=True,
+                content_type=request.content_type,
+                backend=(policy or RoutePolicy()).default_static_backend,
+            )
+        if destination is KnowledgeDestination.DYNAMIC_MEMORY:
+            return RouteDecision(
+                destination=destination,
+                action=RouteAction.RETAIN_MEMORY,
+                reason="destination_override",
+                content_type=request.content_type,
+                backend=(policy or RoutePolicy()).default_dynamic_backend,
+            )
+        return RouteDecision(
+            destination=destination,
+            action=RouteAction.DRY_RUN_ONLY if destination is KnowledgeDestination.REVIEW else RouteAction.SKIP,
+            reason="destination_override",
+            content_type=request.content_type,
+        )
+    return (policy or RoutePolicy()).decide(request.content_type)
+
+
+@dataclass
+class KnowledgeRouter:
+    static_adapter: KnowledgeAdapter
+    dynamic_adapter: KnowledgeAdapter
+    policy: RoutePolicy = RoutePolicy()
+
+    def write(self, request: KnowledgeWriteRequest) -> KnowledgeWriteResult:
+        if not request.content.strip():
+            return KnowledgeWriteResult(
+                success=False,
+                destination=KnowledgeDestination.REVIEW,
+                action="validate",
+                error="content is required",
+            )
+        if len(request.content) > MAX_KNOWLEDGE_CONTENT_CHARS:
+            return KnowledgeWriteResult(
+                success=False,
+                destination=KnowledgeDestination.REVIEW,
+                action="validate",
+                error=f"content exceeds {MAX_KNOWLEDGE_CONTENT_CHARS} characters",
+            )
+
+        decision = route_knowledge_write(request, self.policy)
+        if request.dry_run or decision.destination in {KnowledgeDestination.NONE, KnowledgeDestination.REVIEW}:
+            return KnowledgeWriteResult(
+                success=True,
+                destination=decision.destination,
+                action=str(decision.action),
+                written=False,
+                dry_run=True,
+                decision=decision,
+            )
+
+        if decision.requires_title and not request.title.strip():
+            return KnowledgeWriteResult(
+                success=False,
+                destination=decision.destination,
+                action="validate",
+                written=False,
+                decision=decision,
+                error="title is required for static knowledge writes",
+            )
+
+        if decision.destination is KnowledgeDestination.STATIC_KNOWLEDGE:
+            return self._write_static(request, decision)
+        if decision.destination is KnowledgeDestination.DYNAMIC_MEMORY:
+            return self._write_dynamic(request, decision)
+        return KnowledgeWriteResult(
+            success=False,
+            destination=decision.destination,
+            action=str(decision.action),
+            decision=decision,
+            error=f"Unsupported destination: {decision.destination}",
+        )
+
+    def _write_static(self, request: KnowledgeWriteRequest, decision: RouteDecision) -> KnowledgeWriteResult:
+        existing: list[ExistingKnowledge] = []
+        if request.duplicate_policy is not DuplicatePolicy.CREATE_NEW:
+            existing = self.static_adapter.search_existing(request)
+
+        if existing:
+            if request.duplicate_policy is DuplicatePolicy.SKIP_EXISTING:
+                return KnowledgeWriteResult(
+                    success=True,
+                    destination=decision.destination,
+                    action="skip_existing",
+                    written=False,
+                    decision=decision,
+                    existing=[item.to_dict() for item in existing],
+                )
+            if request.duplicate_policy is DuplicatePolicy.REVIEW:
+                return KnowledgeWriteResult(
+                    success=True,
+                    destination=KnowledgeDestination.REVIEW,
+                    action="review_existing",
+                    written=False,
+                    dry_run=True,
+                    decision=decision,
+                    existing=[item.to_dict() for item in existing],
+                )
+            if request.duplicate_policy is DuplicatePolicy.UPDATE_EXISTING:
+                wr = self.static_adapter.update(existing[0], request)
+                return KnowledgeWriteResult(
+                    success=wr.success,
+                    destination=decision.destination,
+                    action=wr.action,
+                    written=wr.success,
+                    id=wr.id,
+                    path=wr.path,
+                    backend=wr.backend,
+                    decision=decision,
+                    existing=[item.to_dict() for item in existing],
+                    error=wr.error,
+                    result=wr.data,
+                )
+
+        wr = self.static_adapter.write(request)
+        return KnowledgeWriteResult(
+            success=wr.success,
+            destination=decision.destination,
+            action=wr.action,
+            written=wr.success,
+            id=wr.id,
+            path=wr.path,
+            backend=wr.backend,
+            decision=decision,
+            error=wr.error,
+            result=wr.data,
+        )
+
+    def _write_dynamic(self, request: KnowledgeWriteRequest, decision: RouteDecision) -> KnowledgeWriteResult:
+        tags = tuple(dict.fromkeys((*request.tags, "knowledge-router", "hindsight")))
+        routed = KnowledgeWriteRequest(
+            content_type=request.content_type,
+            content=request.content,
+            title=request.title,
+            context=request.context,
+            tags=tags,
+            dry_run=request.dry_run,
+            destination_override=request.destination_override,
+            idempotency_key=request.idempotency_key,
+            update_mode=request.update_mode,
+            duplicate_policy=request.duplicate_policy,
+            metadata=request.metadata,
+            notebook=request.notebook,
+            path=request.path,
+        )
+        wr = self.dynamic_adapter.write(routed)
+        return KnowledgeWriteResult(
+            success=wr.success,
+            destination=decision.destination,
+            action=wr.action,
+            written=wr.success,
+            id=wr.id,
+            path=wr.path,
+            backend=wr.backend,
+            decision=decision,
+            error=wr.error,
+            result=wr.data,
+        )

--- a/knowledge/types.py
+++ b/knowledge/types.py
@@ -1,0 +1,107 @@
+"""Typed contracts for Hermes knowledge routing."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any, Mapping
+
+
+class KnowledgeDestination(StrEnum):
+    STATIC_KNOWLEDGE = "static_knowledge"
+    DYNAMIC_MEMORY = "dynamic_memory"
+    NONE = "none"
+    REVIEW = "review"
+
+
+class RouteAction(StrEnum):
+    WRITE_DOCUMENT = "write_document"
+    RETAIN_MEMORY = "retain_memory"
+    SKIP = "skip"
+    DRY_RUN_ONLY = "dry_run_only"
+
+
+class DuplicatePolicy(StrEnum):
+    UPDATE_EXISTING = "update_existing"
+    CREATE_NEW = "create_new"
+    SKIP_EXISTING = "skip_existing"
+    REVIEW = "review"
+
+
+def _normalize_content_type(value: str) -> str:
+    return (value or "").strip().lower().replace("-", "_")
+
+
+def normalize_tags(tags: tuple[str, ...] | list[str] | set[str] | str | None) -> tuple[str, ...]:
+    if tags is None:
+        raw: list[str] = []
+    elif isinstance(tags, str):
+        raw = [part.strip() for part in tags.split(",")]
+    else:
+        raw = [str(part).strip() for part in tags]
+    return tuple(dict.fromkeys(part for part in raw if part))
+
+
+@dataclass(frozen=True)
+class KnowledgeWriteRequest:
+    content_type: str
+    content: str
+    title: str = ""
+    context: str = ""
+    tags: tuple[str, ...] | list[str] | set[str] | str | None = field(default_factory=tuple)
+    dry_run: bool = False
+    destination_override: KnowledgeDestination | str | None = None
+    idempotency_key: str = ""
+    update_mode: str = ""
+    duplicate_policy: DuplicatePolicy | str = DuplicatePolicy.UPDATE_EXISTING
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    notebook: str = ""
+    path: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "content_type", _normalize_content_type(self.content_type))
+        object.__setattr__(self, "tags", normalize_tags(self.tags))
+        if isinstance(self.duplicate_policy, str):
+            object.__setattr__(self, "duplicate_policy", DuplicatePolicy(self.duplicate_policy))
+        if isinstance(self.destination_override, str) and self.destination_override:
+            object.__setattr__(self, "destination_override", KnowledgeDestination(self.destination_override))
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    destination: KnowledgeDestination
+    action: RouteAction
+    reason: str
+    requires_title: bool = False
+    snapshot: bool = False
+    content_type: str = ""
+    backend: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["destination"] = str(self.destination)
+        data["action"] = str(self.action)
+        return data
+
+
+@dataclass(frozen=True)
+class KnowledgeWriteResult:
+    success: bool
+    destination: KnowledgeDestination | str
+    action: str
+    written: bool = False
+    dry_run: bool = False
+    id: str = ""
+    path: str = ""
+    backend: str = ""
+    decision: RouteDecision | dict[str, Any] | None = None
+    existing: list[dict[str, Any]] = field(default_factory=list)
+    error: str | None = None
+    result: Mapping[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["destination"] = str(self.destination)
+        if isinstance(self.decision, RouteDecision):
+            data["decision"] = self.decision.to_dict()
+        return data

--- a/tests/knowledge/test_router_policy.py
+++ b/tests/knowledge/test_router_policy.py
@@ -1,0 +1,227 @@
+"""Tests for the standard knowledge routing layer.
+
+These tests intentionally target pure routing and adapter orchestration rather
+than SiYuan/Hindsight network details. The router should be deterministic,
+backend-agnostic, and safe to dry-run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from knowledge.adapters.base import ExistingKnowledge, KnowledgeAdapter, WriteResult
+from knowledge.adapters.siyuan import run_sql
+from knowledge.policy import RoutePolicy
+from knowledge.router import KnowledgeRouter, route_knowledge_write
+from knowledge.types import (
+    DuplicatePolicy,
+    KnowledgeDestination,
+    KnowledgeWriteRequest,
+    RouteAction,
+)
+
+
+@dataclass
+class FakeStaticAdapter(KnowledgeAdapter):
+    existing: list[ExistingKnowledge] = field(default_factory=list)
+    searches: list[KnowledgeWriteRequest] = field(default_factory=list)
+    writes: list[KnowledgeWriteRequest] = field(default_factory=list)
+    updates: list[tuple[str, KnowledgeWriteRequest]] = field(default_factory=list)
+
+    @property
+    def name(self) -> str:
+        return "fake-static"
+
+    def search_existing(self, request: KnowledgeWriteRequest) -> list[ExistingKnowledge]:
+        self.searches.append(request)
+        return list(self.existing)
+
+    def write(self, request: KnowledgeWriteRequest) -> WriteResult:
+        self.writes.append(request)
+        return WriteResult(success=True, backend=self.name, action="create", id="new-doc")
+
+    def update(self, existing: ExistingKnowledge, request: KnowledgeWriteRequest) -> WriteResult:
+        self.updates.append((existing.id, request))
+        return WriteResult(success=True, backend=self.name, action="update", id=existing.id)
+
+
+@dataclass
+class FakeDynamicAdapter(KnowledgeAdapter):
+    writes: list[KnowledgeWriteRequest] = field(default_factory=list)
+
+    @property
+    def name(self) -> str:
+        return "fake-dynamic"
+
+    def write(self, request: KnowledgeWriteRequest) -> WriteResult:
+        self.writes.append(request)
+        return WriteResult(success=True, backend=self.name, action="retain", id="memory-1")
+
+
+def test_route_static_reference_goes_to_static_knowledge():
+    decision = route_knowledge_write(
+        KnowledgeWriteRequest(content_type="runbook", title="Backup", content="# Backup")
+    )
+
+    assert decision.destination is KnowledgeDestination.STATIC_KNOWLEDGE
+    assert decision.action is RouteAction.WRITE_DOCUMENT
+    assert decision.reason == "static_reference"
+    assert decision.requires_title is True
+
+
+def test_route_dynamic_memory_goes_to_dynamic_backend():
+    decision = route_knowledge_write(
+        KnowledgeWriteRequest(content_type="user_preference", content="User prefers concise Chinese.")
+    )
+
+    assert decision.destination is KnowledgeDestination.DYNAMIC_MEMORY
+    assert decision.action is RouteAction.RETAIN_MEMORY
+    assert decision.requires_title is False
+
+
+def test_route_ephemeral_noise_skips_by_default():
+    decision = route_knowledge_write(
+        KnowledgeWriteRequest(content_type="task_log", content="pytest passed")
+    )
+
+    assert decision.destination is KnowledgeDestination.NONE
+    assert decision.action is RouteAction.SKIP
+    assert decision.reason == "ephemeral_noise"
+
+
+def test_unknown_content_type_is_review_only():
+    decision = route_knowledge_write(
+        KnowledgeWriteRequest(content_type="misc", content="unknown")
+    )
+
+    assert decision.destination is KnowledgeDestination.REVIEW
+    assert decision.action is RouteAction.DRY_RUN_ONLY
+    assert decision.reason == "unknown_content_type"
+
+
+def test_dry_run_does_not_call_adapters():
+    static = FakeStaticAdapter()
+    dynamic = FakeDynamicAdapter()
+    router = KnowledgeRouter(static_adapter=static, dynamic_adapter=dynamic)
+
+    result = router.write(
+        KnowledgeWriteRequest(
+            content_type="runbook",
+            title="Backup",
+            content="# Backup",
+            dry_run=True,
+        )
+    )
+
+    assert result.success is True
+    assert result.written is False
+    assert result.dry_run is True
+    assert static.searches == []
+    assert static.writes == []
+    assert dynamic.writes == []
+
+
+def test_static_write_updates_existing_when_duplicate_policy_requests_it():
+    existing = ExistingKnowledge(id="doc-1", title="Backup", path="/Backup", score=1.0)
+    static = FakeStaticAdapter(existing=[existing])
+    router = KnowledgeRouter(static_adapter=static, dynamic_adapter=FakeDynamicAdapter())
+
+    result = router.write(
+        KnowledgeWriteRequest(
+            content_type="runbook",
+            title="Backup",
+            content="# Updated",
+            duplicate_policy=DuplicatePolicy.UPDATE_EXISTING,
+        )
+    )
+
+    assert result.success is True
+    assert result.written is True
+    assert result.action == "update"
+    assert result.id == "doc-1"
+    assert static.searches
+    assert static.writes == []
+    assert static.updates == [("doc-1", static.updates[0][1])]
+
+
+def test_static_write_creates_when_no_existing_match():
+    static = FakeStaticAdapter(existing=[])
+    router = KnowledgeRouter(static_adapter=static, dynamic_adapter=FakeDynamicAdapter())
+
+    result = router.write(
+        KnowledgeWriteRequest(content_type="architecture", title="System", content="# System")
+    )
+
+    assert result.success is True
+    assert result.action == "create"
+    assert static.searches
+    assert len(static.writes) == 1
+
+
+def test_dynamic_write_retains_with_router_tags():
+    dynamic = FakeDynamicAdapter()
+    router = KnowledgeRouter(static_adapter=FakeStaticAdapter(), dynamic_adapter=dynamic)
+
+    result = router.write(
+        KnowledgeWriteRequest(
+            content_type="lesson",
+            content="Prefer official APIs.",
+            context="test context",
+            tags=("lesson",),
+        )
+    )
+
+    assert result.success is True
+    assert result.action == "retain"
+    assert len(dynamic.writes) == 1
+    request = dynamic.writes[0]
+    assert request.context == "test context"
+    assert request.tags == ("lesson", "knowledge-router", "hindsight")
+
+
+def test_static_write_requires_title():
+    router = KnowledgeRouter(static_adapter=FakeStaticAdapter(), dynamic_adapter=FakeDynamicAdapter())
+
+    result = router.write(KnowledgeWriteRequest(content_type="runbook", content="# Missing title"))
+
+    assert result.success is False
+    assert "title" in (result.error or "")
+
+
+def test_content_type_policy_is_configurable():
+    policy = RoutePolicy(static_types=frozenset({"playbook"}))
+
+    decision = route_knowledge_write(
+        KnowledgeWriteRequest(content_type="playbook", title="Ops", content="# Ops"),
+        policy=policy,
+    )
+
+    assert decision.destination is KnowledgeDestination.STATIC_KNOWLEDGE
+
+
+def test_siyuan_sql_allows_simple_select_by_default():
+    class Client:
+        def __init__(self):
+            self.payload = None
+
+        def post(self, path, payload):
+            self.payload = (path, payload)
+            return [{"id": "1"}]
+
+    client = Client()
+
+    result = run_sql(client, "select * from blocks")
+
+    assert result == {"success": True, "rows": [{"id": "1"}]}
+    assert client.payload == ("/api/query/sql", {"stmt": "select * from blocks limit 20"})
+
+
+def test_siyuan_sql_blocks_non_select_without_explicit_unsafe():
+    class Client:
+        def post(self, path, payload):  # pragma: no cover - must not be called
+            raise AssertionError("unexpected SQL call")
+
+    with pytest.raises(ValueError, match="allow_unsafe"):
+        run_sql(Client(), "delete from blocks")

--- a/tests/tools/test_knowledge_router_tool.py
+++ b/tests/tools/test_knowledge_router_tool.py
@@ -1,0 +1,133 @@
+"""Tests for the knowledge router tool wrapper and prompt guidance."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def test_knowledge_router_tools_register_with_registry():
+    import tools.knowledge_router_tool  # noqa: F401
+    from tools.registry import registry
+
+    assert registry.get_entry("knowledge_route_decision") is not None
+    assert registry.get_entry("knowledge_write") is not None
+    assert set(registry.get_tool_names_for_toolset("knowledge")) >= {
+        "knowledge_route_decision",
+        "knowledge_write",
+    }
+
+
+def test_builtin_discovery_imports_knowledge_and_siyuan_tool_modules():
+    from tools.registry import discover_builtin_tools, registry
+
+    modules = discover_builtin_tools()
+
+    assert "tools.knowledge_router_tool" in modules
+    assert "tools.siyuan_tool" in modules
+    assert registry.get_entry("siyuan_search") is not None
+
+
+def test_knowledge_route_decision_handler_returns_json():
+    from tools.knowledge_router_tool import handle_knowledge_route_decision
+
+    payload = json.loads(
+        handle_knowledge_route_decision(
+            {"content_type": "runbook", "title": "Backup", "content": "# Backup"}
+        )
+    )
+
+    assert payload["success"] is True
+    assert payload["decision"]["destination"] == "static_knowledge"
+    assert payload["decision"]["requires_title"] is True
+
+
+def test_knowledge_write_dry_run_does_not_call_router_write(monkeypatch):
+    from tools import knowledge_router_tool
+
+    router = MagicMock()
+    monkeypatch.setattr(knowledge_router_tool, "build_default_router", lambda: router)
+
+    payload = json.loads(
+        knowledge_router_tool.handle_knowledge_write(
+            {
+                "content_type": "task_log",
+                "content": "temporary test output",
+                "dry_run": True,
+            }
+        )
+    )
+
+    assert payload["success"] is True
+    assert payload["written"] is False
+    assert payload["decision"]["destination"] == "none"
+    router.write.assert_not_called()
+
+
+def test_knowledge_write_calls_default_router_for_real_write(monkeypatch):
+    from knowledge.types import KnowledgeWriteResult
+    from tools import knowledge_router_tool
+
+    router = MagicMock()
+    router.write.return_value = KnowledgeWriteResult(
+        success=True,
+        destination="dynamic_memory",
+        action="retain",
+        written=True,
+        id="mem-1",
+    )
+    monkeypatch.setattr(knowledge_router_tool, "build_default_router", lambda: router)
+
+    payload = json.loads(
+        knowledge_router_tool.handle_knowledge_write(
+            {"content_type": "lesson", "content": "Prefer official APIs."}
+        )
+    )
+
+    assert payload["success"] is True
+    assert payload["written"] is True
+    assert payload["destination"] == "dynamic_memory"
+    router.write.assert_called_once()
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _agent_with_tools(*tool_names: str) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+def test_knowledge_router_guidance_injected_only_when_tool_loaded():
+    from agent.prompt_builder import KNOWLEDGE_ROUTER_GUIDANCE
+
+    with_tools = _agent_with_tools("knowledge_write", "knowledge_route_decision")
+    assert KNOWLEDGE_ROUTER_GUIDANCE in with_tools._build_system_prompt()
+
+    without_tools = _agent_with_tools("web_search")
+    assert KNOWLEDGE_ROUTER_GUIDANCE not in without_tools._build_system_prompt()

--- a/tools/knowledge_router_tool.py
+++ b/tools/knowledge_router_tool.py
@@ -1,0 +1,141 @@
+"""Tool wrappers for the standard Hermes knowledge router."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hermes_cli.config import load_config
+from knowledge.adapters.hindsight import HindsightMemoryAdapter
+from knowledge.adapters.siyuan import SiYuanKnowledgeAdapter
+from knowledge.policy import RoutePolicy
+from knowledge.router import KnowledgeRouter, route_knowledge_write
+from knowledge.types import KnowledgeWriteRequest
+from tools.registry import registry, tool_error, tool_result
+
+
+def _request_from_args(args: dict[str, Any]) -> KnowledgeWriteRequest:
+    return KnowledgeWriteRequest(
+        content_type=args.get("content_type", ""),
+        title=args.get("title", "") or "",
+        content=args.get("content", "") or args.get("markdown", "") or "",
+        context=args.get("context", "") or "",
+        tags=args.get("tags") or (),
+        dry_run=bool(args.get("dry_run", False)),
+        destination_override=args.get("destination_override") or None,
+        idempotency_key=args.get("idempotency_key", "") or "",
+        update_mode=args.get("update_mode", "") or "",
+        duplicate_policy=args.get("duplicate_policy", "update_existing") or "update_existing",
+        metadata=args.get("metadata") or {},
+        notebook=args.get("notebook", "") or "",
+        path=args.get("path", "") or "",
+    )
+
+
+def build_default_router() -> KnowledgeRouter:
+    try:
+        policy = RoutePolicy.from_config(load_config())
+    except Exception:
+        policy = RoutePolicy()
+    return KnowledgeRouter(
+        static_adapter=SiYuanKnowledgeAdapter(),
+        dynamic_adapter=HindsightMemoryAdapter(),
+        policy=policy,
+    )
+
+
+def handle_knowledge_route_decision(args: dict[str, Any], **_: Any) -> str:
+    try:
+        request = _request_from_args({**args, "dry_run": True})
+        decision = route_knowledge_write(request)
+        return tool_result(success=True, decision=decision.to_dict())
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def handle_knowledge_write(args: dict[str, Any], **_: Any) -> str:
+    try:
+        request = _request_from_args(args)
+        decision = route_knowledge_write(request)
+        # Dry-run/review/skip must not construct backend adapters; constructing
+        # SiYuan/Hindsight may require credentials or network that are irrelevant
+        # to classification.
+        if request.dry_run or decision.destination in {"none", "review"}:
+            return tool_result(
+                success=True,
+                dry_run=True,
+                written=False,
+                destination=str(decision.destination),
+                action=str(decision.action),
+                decision=decision.to_dict(),
+            )
+        return tool_result(build_default_router().write(request).to_dict())
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+KNOWLEDGE_ROUTE_DECISION_SCHEMA = {
+    "name": "knowledge_route_decision",
+    "description": "Preferred dry-run classifier for durable knowledge routing. Use this when unsure whether content belongs in static knowledge, dynamic memory, skip, or review.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content_type": {"type": "string", "description": "runbook, architecture, user_preference, lesson, task_log, etc."},
+            "title": {"type": "string", "description": "Document title when relevant."},
+            "content": {"type": "string", "description": "Content to classify."},
+            "destination_override": {"type": "string", "enum": ["static_knowledge", "dynamic_memory", "none", "review"], "description": "Optional explicit destination for dry-run classification."},
+        },
+        "required": ["content_type"],
+    },
+}
+
+KNOWLEDGE_WRITE_SCHEMA = {
+    "name": "knowledge_write",
+    "description": (
+        "Preferred high-level durable knowledge write router for Hermes. Static docs go to the configured static backend; "
+        "dynamic preferences/facts/lessons go to the configured memory backend; ephemeral task logs are skipped. "
+        "Use dry_run=true to inspect routing before writing."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content_type": {"type": "string", "description": "Known type: runbook, architecture, decision, postmortem, research, api_doc, user_preference, fact, lesson, task_log."},
+            "title": {"type": "string", "description": "Required for static document writes."},
+            "content": {"type": "string", "description": "Markdown/document text or memory content."},
+            "notebook": {"type": "string", "description": "Optional static backend notebook override."},
+            "path": {"type": "string", "description": "Optional static backend document path override."},
+            "context": {"type": "string", "description": "Optional dynamic memory retain context."},
+            "tags": {"type": "array", "items": {"type": "string"}, "description": "Optional dynamic memory tags."},
+            "dry_run": {"type": "boolean", "description": "If true, only return the route decision."},
+            "destination_override": {"type": "string", "enum": ["static_knowledge", "dynamic_memory", "none", "review"], "description": "Optional explicit destination override."},
+            "idempotency_key": {"type": "string", "description": "Optional caller-supplied key for dedupe/update decisions."},
+            "update_mode": {"type": "string", "description": "Optional backend-specific update mode."},
+            "duplicate_policy": {"type": "string", "enum": ["update_existing", "create_new", "skip_existing", "review"], "description": "How to handle existing static knowledge matches."},
+            "metadata": {"type": "object", "description": "Optional structured metadata."},
+        },
+        "required": ["content_type", "content"],
+    },
+}
+
+
+def _check_knowledge_router_available() -> bool:
+    return True
+
+
+registry.register(
+    name="knowledge_route_decision",
+    toolset="knowledge",
+    schema=KNOWLEDGE_ROUTE_DECISION_SCHEMA,
+    handler=handle_knowledge_route_decision,
+    check_fn=_check_knowledge_router_available,
+    emoji="🧭",
+)
+registry.register(
+    name="knowledge_write",
+    toolset="knowledge",
+    schema=KNOWLEDGE_WRITE_SCHEMA,
+    handler=handle_knowledge_write,
+    check_fn=_check_knowledge_router_available,
+    emoji="🧠",
+    max_result_size_chars=30_000,
+)

--- a/tools/siyuan_tool.py
+++ b/tools/siyuan_tool.py
@@ -1,0 +1,183 @@
+"""SiYuan HTTP API tools for Hermes static knowledge operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from knowledge.adapters.siyuan import (
+    SiYuanClient,
+    SiYuanKnowledgeAdapter,
+    append_block,
+    export_markdown,
+    load_config,
+    run_sql,
+    search_blocks,
+    update_block,
+)
+from knowledge.policy import RoutePolicy
+from knowledge.types import KnowledgeWriteRequest
+from tools.registry import registry, tool_error, tool_result
+
+
+def classify_write_policy(content_type: str) -> dict[str, Any]:
+    decision = RoutePolicy().decide(content_type)
+    return decision.to_dict()
+
+
+def _client() -> SiYuanClient:
+    return SiYuanClient(load_config())
+
+
+def _handle_siyuan_write_policy(args: dict[str, Any], **_: Any) -> str:
+    return tool_result(classify_write_policy(args.get("content_type", "")))
+
+
+def _handle_siyuan_write_doc(args: dict[str, Any], **_: Any) -> str:
+    try:
+        request = KnowledgeWriteRequest(
+            content_type="runbook",
+            title=args.get("title", ""),
+            content=args.get("markdown", ""),
+            notebook=args.get("notebook", "") or "",
+            path=args.get("path", "") or "",
+            duplicate_policy=args.get("duplicate_policy", "create_new") or "create_new",
+        )
+        return tool_result(SiYuanKnowledgeAdapter().write(request).to_dict())
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def _handle_siyuan_append_doc(args: dict[str, Any], **_: Any) -> str:
+    try:
+        block_id = args.get("block_id")
+        markdown = args.get("markdown", "")
+        if not block_id:
+            return tool_error("block_id is required", success=False)
+        if not markdown.strip():
+            return tool_error("markdown is required", success=False)
+        return tool_result(append_block(_client(), block_id, markdown))
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def _handle_siyuan_search(args: dict[str, Any], **_: Any) -> str:
+    try:
+        query = (args.get("query") or "").strip()
+        if not query:
+            return tool_error("query is required", success=False)
+        return tool_result(search_blocks(_client(), query, int(args.get("page") or 1)))
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def _handle_siyuan_export_doc(args: dict[str, Any], **_: Any) -> str:
+    try:
+        block_id = args.get("block_id") or args.get("id")
+        if not block_id:
+            return tool_error("block_id is required", success=False)
+        return tool_result(export_markdown(_client(), block_id))
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def _handle_siyuan_update_block(args: dict[str, Any], **_: Any) -> str:
+    try:
+        block_id = args.get("block_id") or args.get("id")
+        markdown = args.get("markdown", "")
+        if not block_id:
+            return tool_error("block_id is required", success=False)
+        if not markdown.strip():
+            return tool_error("markdown is required", success=False)
+        return tool_result(update_block(_client(), block_id, markdown))
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def _handle_siyuan_sql(args: dict[str, Any], **_: Any) -> str:
+    try:
+        return tool_result(run_sql(_client(), args.get("stmt", ""), bool(args.get("allow_unsafe"))))
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+SIYUAN_WRITE_POLICY_SCHEMA = {
+    "name": "siyuan_write_policy",
+    "description": "Classify whether content belongs in dynamic memory, static knowledge, or nowhere before writing knowledge.",
+    "parameters": {"type": "object", "properties": {"content_type": {"type": "string"}}, "required": ["content_type"]},
+}
+SIYUAN_WRITE_DOC_SCHEMA = {
+    "name": "siyuan_write_doc",
+    "description": "Write curated static knowledge as a SiYuan document from Markdown. Do not use for raw chat logs or preferences.",
+    "parameters": {"type": "object", "properties": {"title": {"type": "string"}, "markdown": {"type": "string"}, "notebook": {"type": "string"}, "path": {"type": "string"}}, "required": ["title", "markdown"]},
+}
+SIYUAN_APPEND_DOC_SCHEMA = {"name": "siyuan_append_doc", "description": "Append Markdown under an existing SiYuan block/document ID.", "parameters": {"type": "object", "properties": {"block_id": {"type": "string"}, "markdown": {"type": "string"}}, "required": ["block_id", "markdown"]}}
+SIYUAN_SEARCH_SCHEMA = {"name": "siyuan_search", "description": "Search the SiYuan static knowledge base and return compact block matches.", "parameters": {"type": "object", "properties": {"query": {"type": "string"}, "page": {"type": "integer"}}, "required": ["query"]}}
+SIYUAN_EXPORT_DOC_SCHEMA = {"name": "siyuan_export_doc", "description": "Export a SiYuan document/block as Markdown by block ID for audit or snapshots.", "parameters": {"type": "object", "properties": {"block_id": {"type": "string"}, "id": {"type": "string"}}, "required": []}}
+SIYUAN_UPDATE_BLOCK_SCHEMA = {"name": "siyuan_update_block", "description": "Update an existing SiYuan block by ID using Markdown content.", "parameters": {"type": "object", "properties": {"block_id": {"type": "string"}, "id": {"type": "string"}, "markdown": {"type": "string"}}, "required": ["markdown"]}}
+SIYUAN_SQL_SCHEMA = {"name": "siyuan_sql", "description": "Run a bounded SiYuan SQL query. Defaults to simple SELECT-only and auto-adds LIMIT 20.", "parameters": {"type": "object", "properties": {"stmt": {"type": "string"}, "allow_unsafe": {"type": "boolean"}}, "required": ["stmt"]}}
+
+
+def _check_siyuan_available() -> bool:
+    try:
+        cfg = load_config()
+        return bool(cfg.endpoint and cfg.api_token)
+    except Exception:
+        return False
+
+
+registry.register(
+    name="siyuan_write_policy",
+    toolset="siyuan",
+    schema=SIYUAN_WRITE_POLICY_SCHEMA,
+    handler=_handle_siyuan_write_policy,
+    check_fn=_check_siyuan_available,
+    emoji="📚",
+)
+registry.register(
+    name="siyuan_write_doc",
+    toolset="siyuan",
+    schema=SIYUAN_WRITE_DOC_SCHEMA,
+    handler=_handle_siyuan_write_doc,
+    check_fn=_check_siyuan_available,
+    emoji="📚",
+)
+registry.register(
+    name="siyuan_append_doc",
+    toolset="siyuan",
+    schema=SIYUAN_APPEND_DOC_SCHEMA,
+    handler=_handle_siyuan_append_doc,
+    check_fn=_check_siyuan_available,
+    emoji="📚",
+)
+registry.register(
+    name="siyuan_search",
+    toolset="siyuan",
+    schema=SIYUAN_SEARCH_SCHEMA,
+    handler=_handle_siyuan_search,
+    check_fn=_check_siyuan_available,
+    emoji="📚",
+)
+registry.register(
+    name="siyuan_export_doc",
+    toolset="siyuan",
+    schema=SIYUAN_EXPORT_DOC_SCHEMA,
+    handler=_handle_siyuan_export_doc,
+    check_fn=_check_siyuan_available,
+    emoji="📚",
+)
+registry.register(
+    name="siyuan_update_block",
+    toolset="siyuan",
+    schema=SIYUAN_UPDATE_BLOCK_SCHEMA,
+    handler=_handle_siyuan_update_block,
+    check_fn=_check_siyuan_available,
+    emoji="📚",
+)
+registry.register(
+    name="siyuan_sql",
+    toolset="siyuan",
+    schema=SIYUAN_SQL_SCHEMA,
+    handler=_handle_siyuan_sql,
+    check_fn=_check_siyuan_available,
+    emoji="📚",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -46,8 +46,8 @@ _HERMES_CORE_TOOLS = [
     "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
     # Text-to-speech
     "text_to_speech",
-    # Planning & memory
-    "todo", "memory",
+    # Planning, memory, and durable knowledge routing
+    "todo", "memory", "knowledge_route_decision", "knowledge_write",
     # Session history search
     "session_search",
     # Clarifying questions


### PR DESCRIPTION
Fixes #43408

## Problem

When configuring a custom OpenAI-compatible API endpoint via `hermes setup`, the CLI prompts whether to add `/v1` suffix. However, even when the user explicitly answers `n`, the setup wizard still adds `/v1` during endpoint verification if it succeeds, overriding the user's choice.

## Root Cause

The `probe_api_models` function tries both the original URL and a `/v1` variant. If the `/v1` version succeeds, the setup flow unconditionally saves it with `used_fallback=True`, ignoring the user's explicit decline.

## Solution

Track when the user explicitly declined adding `/v1` and prevent the fallback URL from overriding their choice. The verification still runs (to help detect typos), but the original URL is preserved when the user said no.

## Changes

- Added `_user_declined_v1` flag to track explicit user choice
- Modified fallback handling to respect user's decision
- Updated messaging to clarify when verification found an alternate URL but user choice is being honored

## Testing

Manually tested with:
- Local API endpoint without `/v1`: user declines → original URL saved ✓
- Local API endpoint without `/v1`: user accepts → `/v1` added ✓
- Non-local endpoint: no prompt, behavior unchanged ✓