### PR TITLE
feat(api): add /api/audio/transcribe and /api/audio/speak endpoints to the API server

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2836,7 +2836,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "jobs_admin": False,
                 "memory_write_api": False,
                 "skills_api": True,
-                "audio_api": False,
+                "audio_api": True,
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
@@ -2960,7 +2960,7 @@ class APIServerAdapter(BasePlatformAdapter):
     # POST /api/audio/transcribe — voice dictation
     # ------------------------------------------------------
 
-    _MAX_TRANSCRIPTION_BYTES = 10 * 1024 * 1024  # 10 MB
+    _MAX_TRANSCRIPTION_BYTES = 7 * 1024 * 1024  # 7 MiB raw audio (safe under 10 MiB JSON+base64 limit)
 
     async def _handle_audio_transcribe(self, request: web.Request) -> web.Response:
         """Transcribe an audio recording sent as a base64 data-URL.
@@ -2968,6 +2968,9 @@ class APIServerAdapter(BasePlatformAdapter):
         Accepts JSON with ``data_url`` (required) and optional ``mime_type``.
         Returns ``{ok: bool, transcript: str, provider?: str}``.
         """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
         try:
             body = await request.json()
         except Exception:
@@ -3090,6 +3093,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         Returns ``{ok: bool, data_url: str, mime_type: str, provider?: str}``.
         """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
         try:
             body = await request.json()
         except Exception:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3075,6 +3075,102 @@ class APIServerAdapter(BasePlatformAdapter):
                 except OSError:
                     pass
 
+    # ------------------------------------------------------
+    # POST /api/audio/speak — text-to-speech synthesis
+    # ------------------------------------------------------
+
+    _MAX_SPEAK_TEXT_BYTES = 4096  # 4 KB of UTF-8 text
+
+    async def _handle_audio_speak(self, request: web.Request) -> web.Response:
+        """Synthesize speech from text and return as a base64 data URL.
+
+        Accepts JSON with ``text`` (required).  Delegates to the existing
+        TTS provider chain configured in ``~/.hermes/config.yaml`` under
+        ``tts.`` — Edge TTS (default), OpenAI, ElevenLabs, and others.
+
+        Returns ``{ok: bool, data_url: str, mime_type: str, provider?: str}``.
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(
+                {"ok": False, "error": "Invalid JSON body"},
+                status=400,
+            )
+
+        text = (body.get("text") or "").strip()
+        if not text:
+            return web.json_response(
+                {"ok": False, "error": "Text is required"},
+                status=400,
+            )
+        if len(text.encode("utf-8")) > self._MAX_SPEAK_TEXT_BYTES:
+            return web.json_response(
+                {"ok": False, "error": "Text is too long"},
+                status=413,
+            )
+
+        try:
+            from tools.tts_tool import text_to_speech_tool
+
+            result_json = await asyncio.to_thread(text_to_speech_tool, text)
+            result = json.loads(result_json) if isinstance(result_json, str) else result_json
+        except ImportError:
+            return web.json_response({
+                "ok": False,
+                "error": "TTS is not available — install TTS dependencies",
+            }, status=500)
+        except Exception as exc:
+            logger.exception("Speech synthesis failed")
+            return web.json_response({
+                "ok": False,
+                "error": f"Speech synthesis error: {exc}",
+            }, status=500)
+
+        if not isinstance(result, dict) or not result.get("success"):
+            return web.json_response({
+                "ok": False,
+                "error": result.get("error") if isinstance(result, dict) else "Speech synthesis failed",
+            }, status=400)
+
+        file_path = result.get("file_path")
+        if not file_path or not os.path.isfile(file_path):
+            return web.json_response({
+                "ok": False,
+                "error": "Audio file not found — synthesis produced no output",
+            }, status=500)
+
+        ext = os.path.splitext(file_path)[1].lower()
+        mime_type = {
+            ".mp3": "audio/mpeg",
+            ".ogg": "audio/ogg",
+            ".opus": "audio/ogg",
+            ".wav": "audio/wav",
+            ".flac": "audio/flac",
+        }.get(ext, "audio/mpeg")
+
+        try:
+            with open(file_path, "rb") as fh:
+                audio_bytes = fh.read()
+        except OSError as exc:
+            return web.json_response({
+                "ok": False,
+                "error": f"Could not read audio file: {exc}",
+            })
+        finally:
+            try:
+                os.unlink(file_path)
+            except OSError:
+                pass
+
+        encoded = base64.b64encode(audio_bytes).decode("ascii")
+        return web.json_response({
+            "ok": True,
+            "data_url": f"data:{mime_type};base64,{encoded}",
+            "mime_type": mime_type,
+            "provider": result.get("provider"),
+        })
+
     # ------------------------------------------------------------------
     # /api/sessions — thin client/session resource API
     # ------------------------------------------------------------------
@@ -6882,6 +6978,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/toolsets", self._handle_toolsets)
             # Voice dictation
             self._app.router.add_post("/api/audio/transcribe", self._handle_audio_transcribe)
+            # Text-to-speech synthesis
+            self._app.router.add_post("/api/audio/speak", self._handle_audio_speak)
             # Session/client control surface (thin wrappers over SessionDB + _run_agent)
             self._app.router.add_get("/api/sessions", self._handle_list_sessions)
             self._app.router.add_post("/api/sessions", self._handle_create_session)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -40,7 +40,12 @@ Requires:
 """
 
 import asyncio
+
 import errno
+
+import base64
+import binascii
+
 import hashlib
 import hmac
 import json
@@ -51,7 +56,11 @@ import logging
 import os
 import re
 import sqlite3
+
 import sys
+
+import tempfile
+
 import time
 import uuid
 from pathlib import Path
@@ -129,6 +138,7 @@ MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -2945,6 +2955,125 @@ class APIServerAdapter(BasePlatformAdapter):
             "platform": "api_server",
             "data": data,
         })
+
+    # ------------------------------------------------------
+    # POST /api/audio/transcribe — voice dictation
+    # ------------------------------------------------------
+
+    _MAX_TRANSCRIPTION_BYTES = 10 * 1024 * 1024  # 10 MB
+
+    async def _handle_audio_transcribe(self, request: web.Request) -> web.Response:
+        """Transcribe an audio recording sent as a base64 data-URL.
+
+        Accepts JSON with ``data_url`` (required) and optional ``mime_type``.
+        Returns ``{ok: bool, transcript: str, provider?: str}``.
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(
+                {"ok": False, "transcript": "", "error": "Invalid JSON body"},
+                status=400,
+            )
+
+        data_url = (body.get("data_url") or "").strip()
+        if not data_url.startswith("data:") or "," not in data_url:
+            return web.json_response(
+                {"ok": False, "transcript": "", "error": "Missing or invalid data_url"},
+                status=400,
+            )
+
+        header, encoded = data_url.split(",", 1)
+        if ";base64" not in header:
+            return web.json_response(
+                {"ok": False, "transcript": "", "error": "data_url must be base64-encoded"},
+                status=400,
+            )
+
+        mime_type = (body.get("mime_type") or header[5:].split(";", 1)[0] or "audio/webm").strip()
+        normalized_mime = mime_type.split(";", 1)[0].lower()
+        if not (normalized_mime.startswith("audio/") or normalized_mime == "video/webm"):
+            return web.json_response(
+                {"ok": False, "transcript": "", "error": "Payload must be an audio recording"},
+                status=400,
+            )
+
+        try:
+            audio_bytes = base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError):
+            return web.json_response(
+                {"ok": False, "transcript": "", "error": "Invalid base64 audio data"},
+                status=400,
+            )
+
+        if not audio_bytes:
+            return web.json_response(
+                {"ok": False, "transcript": "", "error": "Audio recording is empty"},
+                status=400,
+            )
+        if len(audio_bytes) > self._MAX_TRANSCRIPTION_BYTES:
+            return web.json_response(
+                {"ok": False, "transcript": "", "error": "Audio recording is too large"},
+                status=413,
+            )
+
+        # Determine file extension from mime type
+        ext_map = {
+            "audio/webm": ".webm",
+            "audio/wav": ".wav",
+            "audio/mp4": ".m4a",
+            "audio/mpeg": ".mp3",
+            "audio/ogg": ".ogg",
+            "audio/flac": ".flac",
+            "video/webm": ".webm",
+        }
+        suffix = ext_map.get(normalized_mime, ".webm")
+
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+                tmp.write(audio_bytes)
+                tmp_path = tmp.name
+
+            from tools.transcription_tools import transcribe_audio
+
+            result = await asyncio.to_thread(transcribe_audio, tmp_path)
+            success = bool(result.get("success"))
+            transcript = str(result.get("transcript") or "").strip()
+            provider = result.get("provider")
+            error = result.get("error")
+
+            if success and transcript:
+                return web.json_response({
+                    "ok": True,
+                    "transcript": transcript,
+                    "provider": provider,
+                })
+            else:
+                return web.json_response({
+                    "ok": False,
+                    "transcript": "",
+                    "error": error or "Transcription returned no text",
+                })
+        except ImportError:
+            return web.json_response({
+                "ok": False,
+                "transcript": "",
+                "error": "STT is not available — install transcription dependencies",
+            })
+        except Exception as exc:
+            logger.exception("Audio transcription failed")
+            return web.json_response({
+                "ok": False,
+                "transcript": "",
+                "error": f"Transcription error: {exc}",
+            })
+        finally:
+            if tmp_path:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
 
     # ------------------------------------------------------------------
     # /api/sessions — thin client/session resource API
@@ -6736,12 +6865,58 @@ class APIServerAdapter(BasePlatformAdapter):
             ]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
             assert self._app is not None
+
             # Native routes + multiplex /p/<profile>/… mirrors. Same handlers;
             # the profile-prefix middleware validates the prefix and scopes
             # config/credentials to that profile when multiplexing is on.
             for method, path, handler in self._http_route_table():
                 self._app.router.add_route(method, path, handler)
                 self._app.router.add_route(method, f"/p/{{profile}}{path}", handler)
+
+            self._app.router.add_get("/health", self._handle_health)
+            self._app.router.add_get("/health/detailed", self._handle_health_detailed)
+            self._app.router.add_get("/v1/health", self._handle_health)
+            self._app.router.add_get("/v1/models", self._handle_models)
+            self._app.router.add_get("/v1/capabilities", self._handle_capabilities)
+            self._app.router.add_get("/v1/skills", self._handle_skills)
+            self._app.router.add_get("/v1/toolsets", self._handle_toolsets)
+            # Voice dictation
+            self._app.router.add_post("/api/audio/transcribe", self._handle_audio_transcribe)
+            # Session/client control surface (thin wrappers over SessionDB + _run_agent)
+            self._app.router.add_get("/api/sessions", self._handle_list_sessions)
+            self._app.router.add_post("/api/sessions", self._handle_create_session)
+            self._app.router.add_get("/api/sessions/{session_id}", self._handle_get_session)
+            self._app.router.add_patch("/api/sessions/{session_id}", self._handle_patch_session)
+            self._app.router.add_delete("/api/sessions/{session_id}", self._handle_delete_session)
+            self._app.router.add_get("/api/sessions/{session_id}/messages", self._handle_session_messages)
+            self._app.router.add_post("/api/sessions/{session_id}/fork", self._handle_fork_session)
+            self._app.router.add_post("/api/sessions/{session_id}/chat", self._handle_session_chat)
+            self._app.router.add_post("/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream)
+            self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
+            self._app.router.add_post("/v1/responses", self._handle_responses)
+            self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
+            self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
+            # Cron jobs management API
+            self._app.router.add_get("/api/jobs", self._handle_list_jobs)
+            self._app.router.add_post("/api/jobs", self._handle_create_job)
+            self._app.router.add_get("/api/jobs/{job_id}", self._handle_get_job)
+            self._app.router.add_patch("/api/jobs/{job_id}", self._handle_update_job)
+            self._app.router.add_delete("/api/jobs/{job_id}", self._handle_delete_job)
+            self._app.router.add_post("/api/jobs/{job_id}/pause", self._handle_pause_job)
+            self._app.router.add_post("/api/jobs/{job_id}/resume", self._handle_resume_job)
+            self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
+
+            # Chronos managed-cron fire webhook (NAS → agent). Authenticated by a
+            # NAS-minted JWT (NOT API_SERVER_KEY), so it has its own auth path.
+            if _CRON_AVAILABLE:
+                self._app.router.add_post("/api/cron/fire", self._handle_cron_fire)
+            # Structured event streaming
+            self._app.router.add_post("/v1/runs", self._handle_runs)
+            self._app.router.add_get("/v1/runs/{run_id}", self._handle_get_run)
+            self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
+            self._app.router.add_post("/v1/runs/{run_id}/approval", self._handle_run_approval)
+            self._app.router.add_post("/v1/runs/{run_id}/stop", self._handle_stop_run)
+
             # Store the adapter after native routes are registered. Local Hermes-Relay
             # bootstrap shims use this key as a feature-detection hook; registering
             # native routes first lets those shims no-op instead of shadowing the

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -671,10 +671,15 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+
     app.router.add_post(
         "/api/platforms/{platform}/events",
         adapter._handle_platform_event_callback,
     )
+
+    app.router.add_post("/api/audio/transcribe", adapter._handle_audio_transcribe)
+    app.router.add_post("/api/audio/speak", adapter._handle_audio_speak)
+
     return app
 
 
@@ -4936,6 +4941,7 @@ class TestSessionKeyHeader:
 
 
 # ---------------------------------------------------------------------------
+
 # Per-client model routing (model_routes)
 # ---------------------------------------------------------------------------
 
@@ -5216,6 +5222,7 @@ class TestModelRoutesAgentCreation:
         assert adapter._session_model_override_for(None) is None
 
 
+
 # ---------------------------------------------------------------------------
 # Event-loop offloading for synchronous SessionDB calls (P1)
 # ---------------------------------------------------------------------------
@@ -5340,6 +5347,7 @@ class TestSessionDbOffEventLoop:
             hermes_state.SessionDB = original_class
             auth_adapter._session_db = None
             auth_adapter._session_db_lock = None
+
 
 
 # ---------------------------------------------------------------------------
@@ -5743,3 +5751,119 @@ class TestCreateAgentModelRecovery:
         )
 
         assert captured["model"] == "session-row/model"
+
+
+# /api/audio/speak — text-to-speech synthesis
+# ---------------------------------------------------------------------------
+
+
+class TestAudioSpeakEndpoint:
+    """Tests for the /api/audio/speak endpoint on the API server."""
+
+    @pytest.mark.asyncio
+    async def test_speak_requires_text(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/audio/speak", json={})
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["ok"] is False
+            assert "required" in str(data.get("error", "")).lower()
+
+    @pytest.mark.asyncio
+    async def test_speak_rejects_empty_text(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/audio/speak", json={"text": "   "})
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_speak_rejects_invalid_json(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/audio/speak", data="not json")
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_speak_returns_base64_data_url(self, adapter, tmp_path):
+        app = _create_app(adapter)
+
+        # Create a fake audio file that the mocked TTS will "produce"
+        audio_file = tmp_path / "speech.mp3"
+        audio_file.write_bytes(b"FAKE_MP3_DATA")
+
+        def fake_tts(text):
+            return json.dumps({
+                "success": True,
+                "file_path": str(audio_file),
+                "provider": "test",
+            })
+
+        with patch("tools.tts_tool.text_to_speech_tool", fake_tts):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post("/api/audio/speak", json={"text": "hello world"})
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["ok"] is True
+                assert data["mime_type"] == "audio/mpeg"
+                assert data["data_url"].startswith("data:audio/mpeg;base64,")
+                assert data["provider"] == "test"
+                # The handler removes the temp file after reading
+                assert not audio_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_speak_handles_tts_failure(self, adapter):
+        app = _create_app(adapter)
+
+        def fake_tts_error(text):
+            return json.dumps({"success": False, "error": "No TTS provider configured"})
+
+        with patch("tools.tts_tool.text_to_speech_tool", fake_tts_error):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post("/api/audio/speak", json={"text": "hello"})
+                assert resp.status == 400
+                data = await resp.json()
+                assert data["ok"] is False
+                assert "provider" in str(data.get("error", "")).lower()
+
+    @pytest.mark.asyncio
+    async def test_speak_handles_missing_file(self, adapter):
+        app = _create_app(adapter)
+
+        def fake_tts_no_file(text):
+            return json.dumps({"success": True, "file_path": "/nonexistent/audio.mp3"})
+
+        with patch("tools.tts_tool.text_to_speech_tool", fake_tts_no_file):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post("/api/audio/speak", json={"text": "hello"})
+                assert resp.status == 500
+                data = await resp.json()
+                assert data["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_speak_handles_different_audio_format(self, adapter, tmp_path):
+        app = _create_app(adapter)
+
+        audio_file = tmp_path / "speech.ogg"
+        audio_file.write_bytes(b"OGG_DATA")
+
+        def fake_tts_ogg(text):
+            return json.dumps({
+                "success": True,
+                "file_path": str(audio_file),
+            })
+
+        with patch("tools.tts_tool.text_to_speech_tool", fake_tts_ogg):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post("/api/audio/speak", json={"text": "hello"})
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["mime_type"] == "audio/ogg"
+                assert data["data_url"].startswith("data:audio/ogg;base64,")
+
+
+

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -5867,3 +5867,101 @@ class TestAudioSpeakEndpoint:
 
 
 
+
+    # --- auth tests ---
+
+    @pytest.mark.asyncio
+    async def test_speak_requires_auth(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/audio/speak", json={"text": "hello"})
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_transcribe_requires_auth(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/audio/transcribe", json={
+                "data_url": "data:audio/wav;base64,AAAA",
+                "mime_type": "audio/wav",
+            })
+            assert resp.status == 401
+
+
+# ---------------------------------------------------------------------------
+# /api/audio/transcribe — audio transcription
+# ---------------------------------------------------------------------------
+
+
+class TestAudioTranscribeEndpoint:
+    """Tests for the /api/audio/transcribe endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_transcribe_requires_data_url(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/audio/transcribe", json={})
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_transcribe_rejects_non_base64(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/audio/transcribe", json={
+                "data_url": "data:audio/wav,not-base64",
+                "mime_type": "audio/wav",
+            })
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_transcribe_empty_audio(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/audio/transcribe", json={
+                "data_url": "data:audio/wav;base64,",
+                "mime_type": "audio/wav",
+            })
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_transcribe_returns_transcript(self, adapter, tmp_path):
+        app = _create_app(adapter)
+
+        def fake_transcribe(file_path):
+            return {
+                "success": True,
+                "transcript": "hello world",
+                "provider": "test",
+            }
+
+        with patch("tools.transcription_tools.transcribe_audio", fake_transcribe):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post("/api/audio/transcribe", json={
+                    "data_url": "data:audio/wav;base64,UklGRg==",
+                    "mime_type": "audio/wav",
+                })
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["ok"] is True
+                assert data["transcript"] == "hello world"
+                assert data["provider"] == "test"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_rejects_non_audio_mime(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/audio/transcribe", json={
+                "data_url": "data:image/png;base64,AAAA",
+                "mime_type": "image/png",
+            })
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["ok"] is False
+
+


### PR DESCRIPTION
## Summary

Adds `POST /api/audio/transcribe` and `POST /api/audio/speak` to the Gateway API server (port 8642), completing the voice interface surface.

## Endpoints

| Endpoint | Input | Output |
|----------|-------|--------|
| `POST /api/audio/transcribe` | `{"data_url": "data:audio/wav;base64,...", "mime_type": "audio/wav"}` | `{"ok": true, "transcript": "...", "provider": "..."}` |
| `POST /api/audio/speak` | `{"text": "hello"}` | `{"ok": true, "data_url": "data:audio/mpeg;base64,...", "mime_type": "audio/mpeg", "provider": "edge"}` |

## Security review fixes (per @teknium1)

- [x] Both handlers now call `_check_auth()` — 401 returned without valid bearer token
- [x] `_MAX_TRANSCRIPTION_BYTES` lowered to 7 MiB (base64+JSON overhead fits within 10 MiB `MAX_REQUEST_BYTES`)
- [x] `/v1/capabilities` updated: `audio_api: true`
- [x] Auth tests added for both endpoints
- [x] Transcription endpoint tests added

## Tests — 14 total, all passing

**Speak (7 + 2 auth):** validation, happy path, TTS failure, missing file, OGG format, auth required  
**Transcribe (5):** missing data_url, non-base64, empty audio, happy path, non-audio MIME rejection

## Why this matters

1. **Symmetric voice API** — transcribe (input) + speak (output) on the same port/auth
2. **Ecosystem leverage** — Hermes has 10+ TTS providers; this endpoint makes them all available through the API server
3. **Desktop consolidation** — enables single-port (8642) operation for voice features
4. **Multi-modal foundation** — unified audio API is essential for future voice agents and meeting bots