### PR TITLE
feat(skills): add setup command

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -11,8 +11,10 @@ handler are thin wrappers that parse args and delegate.
 """
 
 import json
+import os
 import re
 import shutil
+import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -966,6 +968,170 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
     c.print(f"[bold green]Updated {len(updates)} skill(s).[/]\n")
 
 
+def _normalize_skill_lookup_name(name: str) -> str:
+    return str(name or "").strip().strip("/")
+
+
+def _declared_prerequisites(frontmatter: Dict[str, Any]) -> tuple[list[str], list[str]]:
+    """Return (commands, env vars) declared by a skill's frontmatter."""
+    prereqs = frontmatter.get("prerequisites")
+    commands: list[str] = []
+    env_vars: list[str] = []
+    if isinstance(prereqs, dict):
+        raw_commands = prereqs.get("commands") or []
+        raw_env = prereqs.get("env_vars") or []
+        if isinstance(raw_commands, str):
+            raw_commands = [raw_commands]
+        if isinstance(raw_env, str):
+            raw_env = [raw_env]
+        commands.extend(str(item).strip() for item in raw_commands if str(item).strip())
+        env_vars.extend(str(item).strip() for item in raw_env if str(item).strip())
+
+    required = frontmatter.get("required_environment_variables") or []
+    if isinstance(required, (str, dict)):
+        required = [required]
+    if isinstance(required, list):
+        for item in required:
+            if isinstance(item, str) and item.strip():
+                env_vars.append(item.strip())
+            elif isinstance(item, dict):
+                env_name = str(item.get("name") or item.get("env_var") or "").strip()
+                if env_name:
+                    env_vars.append(env_name)
+
+    return sorted(set(commands)), sorted(set(env_vars))
+
+
+def _find_installed_skill(
+    name: str,
+) -> tuple[Optional[Path], Optional[Dict[str, Any]], list[tuple[str, str, Path]]]:
+    """Find an installed skill by frontmatter name, directory name, or category/name."""
+    from agent.skill_utils import (
+        get_external_skills_dirs,
+        iter_skill_index_files,
+        parse_frontmatter,
+    )
+    from tools.skills_hub import SKILLS_DIR
+
+    query = _normalize_skill_lookup_name(name)
+    query_lower = query.lower()
+    matches: list[tuple[str, str, Path, Dict[str, Any]]] = []
+    dirs_to_scan: list[Path] = []
+    if SKILLS_DIR.exists():
+        dirs_to_scan.append(SKILLS_DIR)
+    dirs_to_scan.extend(get_external_skills_dirs())
+
+    for scan_dir in dirs_to_scan:
+        for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
+            if is_excluded_skill_path(skill_md):
+                continue
+            try:
+                rel = skill_md.parent.relative_to(scan_dir).as_posix()
+            except ValueError:
+                rel = skill_md.parent.name
+            try:
+                content = skill_md.read_text(encoding="utf-8")[:4000]
+                frontmatter, _body = parse_frontmatter(content)
+            except Exception:
+                frontmatter = {}
+            skill_name = str(frontmatter.get("name") or skill_md.parent.name).strip()
+            candidates = {skill_name.lower(), skill_md.parent.name.lower(), rel.lower()}
+            if query_lower in candidates:
+                matches.append((skill_name, rel, skill_md.parent, frontmatter))
+
+    if len(matches) == 1:
+        _skill_name, _rel, skill_dir, frontmatter = matches[0]
+        return skill_dir, frontmatter, []
+    return None, None, [(skill_name, rel, skill_dir) for skill_name, rel, skill_dir, _fm in matches]
+
+
+def do_setup(name: str, console: Optional[Console] = None,
+             check_only: bool = False, skip_confirm: bool = False) -> None:
+    """Run an installed skill's setup helper, or report its prerequisites."""
+    c = console or _console
+    skill_dir, frontmatter, matches = _find_installed_skill(name)
+    if matches:
+        c.print(
+            f"[bold red]Error:[/] Multiple installed skills match '{name}'. "
+            "Use category/name:\n"
+        )
+        table = Table()
+        table.add_column("Name", style="bold cyan")
+        table.add_column("Path", style="dim")
+        for skill_name, rel, _path in matches:
+            table.add_row(skill_name, rel)
+        c.print(table)
+        c.print()
+        return
+    if skill_dir is None or frontmatter is None:
+        c.print(f"[bold red]Error:[/] Installed skill '{name}' not found.\n")
+        c.print(
+            "[dim]Install it first with `hermes skills install ...`, then run "
+            "`hermes skills setup <name>`.[/]\n"
+        )
+        return
+
+    skill_name = str(frontmatter.get("name") or skill_dir.name)
+    setup_script = skill_dir / "scripts" / "setup.sh"
+    commands, env_vars = _declared_prerequisites(frontmatter)
+
+    c.print(f"[bold]Skill:[/] {skill_name}")
+    c.print(f"[bold]Path:[/] {skill_dir}")
+    if commands:
+        missing_commands = [cmd for cmd in commands if shutil.which(cmd) is None]
+        if missing_commands:
+            status = f"[yellow]missing: {', '.join(missing_commands)}[/]"
+        else:
+            status = "[green]ok[/]"
+        c.print(f"[bold]Declared commands:[/] {', '.join(commands)} ({status})")
+    if env_vars:
+        missing_env = [var for var in env_vars if not os.getenv(var)]
+        if missing_env:
+            status = f"[yellow]missing: {', '.join(missing_env)}[/]"
+        else:
+            status = "[green]ok[/]"
+        c.print(f"[bold]Declared env vars:[/] {', '.join(env_vars)} ({status})")
+
+    if not setup_script.exists():
+        c.print("[yellow]No setup script found.[/]")
+        if not commands and not env_vars:
+            c.print("[dim]This skill does not declare setup requirements.[/]")
+        c.print()
+        return
+
+    c.print(f"[bold]Setup script:[/] {setup_script}")
+    if check_only:
+        c.print("[dim]Check only; not running setup script.[/]\n")
+        return
+
+    if not skip_confirm:
+        c.print(f"\n[bold]Run setup for '{skill_name}'?[/]")
+        c.print(f"[dim]Command: bash {setup_script}[/]")
+        try:
+            answer = input("Confirm [y/N]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = "n"
+        if answer not in {"y", "yes"}:
+            c.print("[dim]Cancelled.[/]\n")
+            return
+
+    c.print(f"\n[bold]Running setup for '{skill_name}'...[/]\n")
+    result = subprocess.run(
+        ["bash", str(setup_script)],
+        cwd=str(skill_dir),
+        text=True,
+        capture_output=True,
+    )
+    if result.stdout:
+        c.print(result.stdout.rstrip())
+    if result.stderr:
+        c.print(result.stderr.rstrip(), style="red" if result.returncode else "yellow")
+    if result.returncode == 0:
+        c.print(f"\n[bold green]Setup complete for '{skill_name}'.[/]\n")
+    else:
+        c.print(f"\n[bold red]Setup failed for '{skill_name}' with exit code {result.returncode}.[/]\n")
+
+
 def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
              deep: bool = False) -> None:
     """Re-run security scan on installed hub skills.
@@ -1548,6 +1714,9 @@ def skills_command(args) -> None:
         do_install(args.identifier, category=args.category, force=args.force,
                    skip_confirm=getattr(args, "yes", False),
                    name_override=getattr(args, "name", "") or "")
+    elif action == "setup":
+        do_setup(args.name, check_only=getattr(args, "check", False),
+                 skip_confirm=getattr(args, "yes", False))
     elif action == "inspect":
         do_inspect(args.identifier)
     elif action == "list":
@@ -1597,7 +1766,7 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|setup|inspect|list|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 
@@ -1718,6 +1887,13 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
                    skip_confirm=skip_confirm, invalidate_cache=invalidate_cache,
                    name_override=name_override, console=c)
 
+    elif action == "setup":
+        if not args:
+            c.print("[bold red]Usage:[/] /skills setup <name-or-category/name> [--check]\n")
+            return
+        do_setup(args[0], console=c, check_only="--check" in args,
+                 skip_confirm=True)
+
     elif action == "inspect":
         if not args:
             c.print("[bold red]Usage:[/] /skills inspect <identifier>\n")
@@ -1819,6 +1995,7 @@ def _print_skills_help(console: Console) -> None:
         "  [cyan]browse[/] [--source official]   Browse all available skills (paginated)\n"
         "  [cyan]search[/] <query>              Search registries for skills\n"
         "  [cyan]install[/] <identifier>        Install a skill (with security scan)\n"
+        "  [cyan]setup[/] <name> [--check]      Run an installed skill's setup script\n"
         "  [cyan]inspect[/] <identifier>        Preview a skill without installing\n"
         "  [cyan]list[/] [--source hub|builtin|local] [--enabled-only]\n"
         "       List installed skills; --enabled-only filters to the active profile's live set\n"

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -91,6 +91,27 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Skip confirmation prompt (needed in TUI mode)",
     )
 
+    skills_setup = skills_subparsers.add_parser(
+        "setup",
+        help="Run an installed skill's setup script / dependency check",
+        description=(
+            "Run scripts/setup.sh for an installed skill when present. "
+            "Without a setup script, reports declared prerequisite commands/env vars."
+        ),
+    )
+    skills_setup.add_argument("name", help="Installed skill name or category/name")
+    skills_setup.add_argument(
+        "--check",
+        action="store_true",
+        help="Only report setup script and prerequisite status; do not run anything",
+    )
+    skills_setup.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip confirmation prompt before running the setup script",
+    )
+
     skills_inspect = skills_subparsers.add_parser(
         "inspect", help="Preview a skill without installing"
     )

--- a/optional-skills/creative/hyperframes/SKILL.md
+++ b/optional-skills/creative/hyperframes/SKILL.md
@@ -55,7 +55,13 @@ Full CLI reference: [references/cli.md](references/cli.md).
 ## Setup (one-time)
 
 ```bash
-bash "$(dirname "$(find ~/.hermes/skills -path '*/hyperframes/SKILL.md' 2>/dev/null | head -1)")/scripts/setup.sh"
+hermes skills setup hyperframes
+```
+
+For a dry run that only reports the setup script and declared prerequisites:
+
+```bash
+hermes skills setup hyperframes --check
 ```
 
 The script:

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,14 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import (
+    do_check,
+    do_install,
+    do_list,
+    do_setup,
+    do_update,
+    handle_skills_slash,
+)
 
 
 class _DummyLockFile:
@@ -247,6 +254,85 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
 
     assert installs == [("skills-sh/example/repo/hub-skill", "category", True)]
     assert "Updated 1 skill" in output
+
+
+def test_do_setup_check_reports_installed_skill_script_and_prereqs(monkeypatch, tmp_path):
+    import tools.skills_hub as hub
+
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "creative" / "hyperframes"
+    (skill_dir / "scripts").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: hyperframes\n"
+        "description: Video composition\n"
+        "prerequisites:\n"
+        "  commands: [definitely-missing-hyperframes-test-command]\n"
+        "  env_vars: [HYPERFRAMES_TEST_KEY]\n"
+        "---\n"
+        "# HyperFrames\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "scripts" / "setup.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    monkeypatch.setattr(hub, "SKILLS_DIR", skills_dir)
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_setup("hyperframes", console=console, check_only=True)
+    output = sink.getvalue()
+
+    assert "Skill:" in output
+    assert "hyperframes" in output
+    assert "scripts/setup.sh" in output
+    assert "definitely-missing-hyperframes-test-command" in output
+    assert "HYPERFRAMES_TEST_KEY" in output
+    assert "Check only" in output
+
+
+def test_do_setup_runs_installed_skill_setup_script(monkeypatch, tmp_path):
+    import tools.skills_hub as hub
+    import hermes_cli.skills_hub as cli_hub
+
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "creative" / "hyperframes"
+    (skill_dir / "scripts").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: hyperframes\ndescription: Video composition\n---\n# HyperFrames\n",
+        encoding="utf-8",
+    )
+    setup_script = skill_dir / "scripts" / "setup.sh"
+    setup_script.write_text("#!/usr/bin/env bash\necho setup\n", encoding="utf-8")
+    monkeypatch.setattr(hub, "SKILLS_DIR", skills_dir)
+
+    calls = []
+
+    def fake_run(cmd, cwd, text, capture_output):
+        calls.append((cmd, cwd, text, capture_output))
+        return type("R", (), {"returncode": 0, "stdout": "setup ok\n", "stderr": ""})()
+
+    monkeypatch.setattr(cli_hub.subprocess, "run", fake_run)
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_setup("creative/hyperframes", console=console, skip_confirm=True)
+    output = sink.getvalue()
+
+    assert calls == [(["bash", str(setup_script)], str(skill_dir), True, True)]
+    assert "setup ok" in output
+    assert "Setup complete" in output
+
+
+def test_handle_skills_slash_setup_skips_prompt(monkeypatch):
+    import hermes_cli.skills_hub as cli_hub
+
+    seen = {}
+
+    def fake_setup(name, console=None, check_only=False, skip_confirm=False):
+        seen.update({"name": name, "check_only": check_only, "skip_confirm": skip_confirm})
+
+    monkeypatch.setattr(cli_hub, "do_setup", fake_setup)
+    handle_skills_slash("/skills setup hyperframes --check")
+
+    assert seen == {"name": "hyperframes", "check_only": True, "skip_confirm": True}
 
 
 def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():

--- a/website/docs/guides/work-with-skills.md
+++ b/website/docs/guides/work-with-skills.md
@@ -105,6 +105,24 @@ What happens:
 2. It appears in your `skills_list` output
 3. It becomes available as a slash command
 
+Some skills also ship a setup helper for runtime dependencies (for example,
+installing a companion CLI or checking external commands like `ffmpeg`). Run it
+by skill name instead of hunting for `scripts/setup.sh` manually:
+
+```bash
+# Show declared prerequisites and whether a setup helper exists
+hermes skills setup hyperframes --check
+
+# Run the installed skill's scripts/setup.sh after confirmation
+hermes skills setup hyperframes
+
+# Non-interactive / scripted use
+hermes skills setup hyperframes --yes
+```
+
+If a skill has no setup script, the command reports its declared prerequisite
+commands and environment variables, then exits without running anything.
+
 :::tip
 Installed skills take effect in new sessions. If you want it available in the current session, use `/reset` to start fresh, or add `--now` to invalidate the prompt cache immediately (costs more tokens on the next turn).
 :::

--- a/website/docs/user-guide/skills/optional/creative/creative-hyperframes.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-hyperframes.md
@@ -69,7 +69,13 @@ Full CLI reference: [references/cli.md](https://github.com/NousResearch/hermes-a
 ## Setup (one-time)
 
 ```bash
-bash "$(dirname "$(find ~/.hermes/skills -path '*/hyperframes/SKILL.md' 2>/dev/null | head -1)")/scripts/setup.sh"
+hermes skills setup hyperframes
+```
+
+For a dry run that only reports the setup script and declared prerequisites:
+
+```bash
+hermes skills setup hyperframes --check
 ```
 
 The script:


### PR DESCRIPTION
## Summary
- add `hermes skills setup <name>` to run an installed skill's `scripts/setup.sh`
- add `--check` to report setup/prerequisite status without running anything, and `--yes` for non-interactive use
- wire the command into `/skills setup` and document HyperFrames using the new workflow

## Test Plan
- `python -m py_compile hermes_cli/skills_hub.py hermes_cli/subcommands/skills.py`
- `python -m pytest tests/hermes_cli/test_skills_hub.py tests/hermes_cli/test_skills_subparser.py -q -o 'addopts='`
- manual smoke test with a temporary `HERMES_HOME` containing a fake `hyperframes` skill and `scripts/setup.sh`
