### PR TITLE
fix(desktop): improve backend detection for source checkouts without managed venv

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1914,6 +1914,22 @@ function findPythonForRoot(root) {
   return findSystemPython()
 }
 
+/**
+ * Returns true when a source checkout has a managed venv Python (``.venv`` or
+ * ``venv``) alongside ``hermes_cli/main.py`` — the typical shape after
+ * install.ps1 / install.sh.  When *only* a system Python is available the
+ * backend resolver must smoke-test that ``hermes_cli`` is actually importable
+ * before trusting the candidate, since a system Python 3.11-3.13 with no
+ * ``hermes_cli`` installed (common on dev boxes) will otherwise produce a
+ * dead-on-arrival backend.
+ */
+function sourceRootHasVenvPython(root) {
+  const venvPaths = IS_WINDOWS
+    ? [path.join(root, '.venv', 'Scripts', 'python.exe'), path.join(root, 'venv', 'Scripts', 'python.exe')]
+    : [path.join(root, '.venv', 'bin', 'python'), path.join(root, 'venv', 'bin', 'python')]
+  return venvPaths.some(p => fileExists(p))
+}
+
 function findSystemPython() {
   if (!IS_WINDOWS) {
     // POSIX systems: PATH lookup is safe.
@@ -3679,8 +3695,11 @@ function resolveHermesBackend(backendArgs) {
   if (overrideRoot && isHermesSourceRoot(overrideRoot)) {
     const backend = createPythonBackend(overrideRoot, `Hermes source at ${overrideRoot}`, backendArgs)
 
-    if (backend) {
+    if (backend && (sourceRootHasVenvPython(overrideRoot) || canImportHermesCli(backend.command, { env: backend.env }))) {
       return backend
+    }
+    if (backend) {
+      rememberLog(`Overridden source root ${overrideRoot} has no venv Python and system Python ${backend.command} cannot import hermes_cli; falling through.`)
     }
   }
 
@@ -3691,8 +3710,11 @@ function resolveHermesBackend(backendArgs) {
   if (!IS_PACKAGED && isHermesSourceRoot(SOURCE_REPO_ROOT)) {
     const backend = createPythonBackend(SOURCE_REPO_ROOT, `Hermes source at ${SOURCE_REPO_ROOT}`, backendArgs)
 
-    if (backend) {
+    if (backend && (sourceRootHasVenvPython(SOURCE_REPO_ROOT) || canImportHermesCli(backend.command, { env: backend.env }))) {
       return backend
+    }
+    if (backend) {
+      rememberLog(`Source checkout has no venv Python and system Python ${backend.command} cannot import hermes_cli; falling through.`)
     }
   }
 


### PR DESCRIPTION
## Summary

When running from a source checkout without a managed venv, the backend resolver would return a system Python that could not import `hermes_cli`, producing a cryptic `ModuleNotFoundError` instead of falling through to the bootstrap path.

## Fix

- `sourceRootHasVenvPython()` helper mirrors `findPythonForRoot` venv discovery
- Steps 1 & 2 of `resolveHermesBackend()` now smoke-test with `canImportHermesCli(backend.command, { env: backend.env })` when no managed venv Python exists
- Failed smoke test → logged reason + fall through to next detection rung

## Security review fixes (per @teknium1)

- [x] Ported from `main.cjs` → `main.ts` (file was migrated in `39d09453f`)
- [x] `canImportHermesCli` now probes with `backend.env` so the candidate runs under the same `PYTHONPATH`/`HERMES_DESKTOP_PYTHON` environment it will get at launch
- [x] Rebased on current main (no conflicts)

## Notes

- The desktop app has no existing TypeScript test infrastructure for backend resolution. Regression coverage is manual: test with a source checkout that has system Python but no `hermes_cli` importable."