### PR TITLE
fix(agent): normalize MCP-style inputSchema in memory-provider tool injection

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1220,6 +1220,14 @@ def init_agent(
             _tname = _schema.get("name", "")
             if _tname and _tname in _existing_tool_names:
                 continue  # already registered via plugin path
+            # Normalize MCP-style inputSchema → parameters so that memory
+            # providers emitting MCP-format schemas are accepted by every
+            # OpenAI-compatible LLM endpoint (see issue #43403).
+            if "inputSchema" in _schema and "parameters" not in _schema:
+                from tools.mcp_tool import _normalize_mcp_input_schema
+                _schema["parameters"] = _normalize_mcp_input_schema(
+                    _schema.pop("inputSchema")
+                )
             _wrapped = {"type": "function", "function": _schema}
             agent.tools.append(_wrapped)
             if _tname:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1271,6 +1271,12 @@ class TestMemoryToolToolsetGate:
                 _tname = _schema.get("name", "")
                 if _tname and _tname in _existing:
                     continue
+                # Mirror agent_init.py: normalize MCP-style inputSchema → parameters
+                if "inputSchema" in _schema and "parameters" not in _schema:
+                    from tools.mcp_tool import _normalize_mcp_input_schema
+                    _schema["parameters"] = _normalize_mcp_input_schema(
+                        _schema.pop("inputSchema")
+                    )
                 tools.append({"type": "function", "function": _schema})
                 if _tname:
                     valid_tool_names.add(_tname)
@@ -1332,6 +1338,112 @@ class TestMemoryToolToolsetGate:
         mgr = self._mgr_with_tools("fact_store", "memory_search", "memory_add")
         tools, names = self._run_memory_injection(None, mgr)
         assert names == {"fact_store", "memory_search", "memory_add"}
+
+
+class TestMemoryProviderMcpSchemaNormalization:
+    """Issue #43403: memory providers emitting MCP-style schemas (with
+    \"inputSchema\" instead of \"parameters\") must have their schemas
+    normalized before injection.  Otherwise every OpenAI-compatible LLM
+    endpoint rejects the tool with a 400."""
+
+    @staticmethod
+    def _run_memory_injection(memory_manager):
+        """Simulate the injection block from agent_init.py (gate open)."""
+        tools = []
+        valid_tool_names = set()
+        if memory_manager and tools is not None:
+            _existing = set()
+            for _schema in memory_manager.get_all_tool_schemas():
+                _tname = _schema.get("name", "")
+                if _tname and _tname in _existing:
+                    continue
+                if "inputSchema" in _schema and "parameters" not in _schema:
+                    from tools.mcp_tool import _normalize_mcp_input_schema
+                    _schema["parameters"] = _normalize_mcp_input_schema(
+                        _schema.pop("inputSchema")
+                    )
+                tools.append({"type": "function", "function": _schema})
+                if _tname:
+                    valid_tool_names.add(_tname)
+                    _existing.add(_tname)
+        return tools, valid_tool_names
+
+    def test_input_schema_normalized_to_parameters(self):
+        """MCP-style inputSchema is converted to parameters."""
+        mgr = MemoryManager()
+        p = FakeMemoryProvider(
+            "mcp_provider",
+            tools=[{
+                "name": "brain_query",
+                "description": "Query the brain",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"q": {"type": "string", "description": "query"}},
+                    "required": ["q"],
+                },
+            }],
+        )
+        mgr.add_provider(p)
+        tools, names = self._run_memory_injection(mgr)
+        assert "brain_query" in names
+        fn = tools[0]["function"]
+        assert "parameters" in fn
+        assert "inputSchema" not in fn
+        assert fn["parameters"]["type"] == "object"
+        assert "q" in fn["parameters"]["properties"]
+
+    def test_parameters_passthrough_unchanged(self):
+        """Schemas already using parameters are not modified."""
+        mgr = MemoryManager()
+        p = FakeMemoryProvider(
+            "openai_provider",
+            tools=[{
+                "name": "fact_store",
+                "description": "Store facts",
+                "parameters": {"type": "object", "properties": {}},
+            }],
+        )
+        mgr.add_provider(p)
+        tools, names = self._run_memory_injection(mgr)
+        fn = tools[0]["function"]
+        assert "parameters" in fn
+        assert "inputSchema" not in fn
+        assert fn["parameters"] == {"type": "object", "properties": {}}
+
+    def test_both_keys_keeps_parameters(self):
+        """When both inputSchema and parameters exist, parameters wins."""
+        mgr = MemoryManager()
+        p = FakeMemoryProvider(
+            "mixed_provider",
+            tools=[{
+                "name": "mixed_tool",
+                "description": "Has both keys",
+                "parameters": {"type": "object", "properties": {"existing": {}}},
+                "inputSchema": {"type": "object", "properties": {"from_mcp": {}}},
+            }],
+        )
+        mgr.add_provider(p)
+        tools, names = self._run_memory_injection(mgr)
+        fn = tools[0]["function"]
+        # When both keys exist, the normalization guard skips — parameters stays
+        assert fn["parameters"] == {"type": "object", "properties": {"existing": {}}}
+        assert "inputSchema" in fn  # not popped
+
+    def test_null_input_schema_gets_default(self):
+        """inputSchema=None is normalized to a minimal object schema."""
+        mgr = MemoryManager()
+        p = FakeMemoryProvider(
+            "null_schema_provider",
+            tools=[{
+                "name": "null_tool",
+                "description": "Schema is None",
+                "inputSchema": None,
+            }],
+        )
+        mgr.add_provider(p)
+        tools, names = self._run_memory_injection(mgr)
+        fn = tools[0]["function"]
+        assert fn["parameters"] == {"type": "object", "properties": {}}
 
 
 class TestContextEngineToolsetGate:


### PR DESCRIPTION
## What does this PR do?

Normalizes MCP-style `inputSchema` to OpenAI `parameters` when injecting memory-provider tool schemas, preventing 400 errors from every LLM endpoint.

## Related Issue

Fixes #43403

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py`: In the memory-provider tool injection block, check if the schema uses MCP-style `inputSchema` instead of OpenAI `parameters`. If so, normalize it via the existing `_normalize_mcp_input_schema()` helper before wrapping.
- `tests/agent/test_memory_provider.py`: Added `TestMemoryProviderMcpSchemaNormalization` with 4 tests covering: `inputSchema` → `parameters` conversion, `parameters` passthrough, both-keys coexistence, and `null` inputSchema defaulting.

## How to Test

1. Install a memory provider that uses MCP-style schemas (e.g. `open-second-brain`)
2. Set `memory.provider` in `~/.hermes/config.yaml` to the MCP-based provider
3. Restart the gateway and have the agent call any memory-provider tool
4. Verify the tool call succeeds (no 400 error from the LLM)
5. Run `pytest tests/agent/test_memory_provider.py::TestMemoryProviderMcpSchemaNormalization -v` to verify the normalization logic

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/agent_init.py` L1219-1235 (memory-provider tool injection block)
- Analyzed: `tools/mcp_tool.py` `_normalize_mcp_input_schema` (reused normalization helper)
- Blast radius: LOW — only affects memory providers that emit MCP-format schemas; existing providers using `parameters` are untouched
- Related patterns: `tools/mcp_tool.py` already converts `inputSchema` → `parameters` for MCP plugin tools at L3204; this PR applies the same normalization to the memory-provider path
