### PR TITLE
fix(memory): use exact match (=) instead of LIKE in _resolve_entity

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -431,22 +431,23 @@ class MemoryStore:
         return candidates
 
     def _resolve_entity(self, name: str) -> int:
-        """Find an existing entity by name or alias (case-insensitive) or create one.
+        """Find an existing entity by exact name or alias match, or create one.
 
         Returns the entity_id.
         """
-        # Exact name match
+        # Exact name match (= avoids LIKE wildcard/case-sensitivity bugs)
         row = self._conn.execute(
-            "SELECT entity_id FROM entities WHERE name LIKE ?", (name,)
+            "SELECT entity_id FROM entities WHERE name = ?", (name,)
         ).fetchone()
         if row is not None:
             return int(row["entity_id"])
 
-        # Search aliases — aliases stored as comma-separated; use LIKE with % boundaries
+        # Search aliases — aliases stored as comma-separated; use INSTR to
+        # avoid LIKE wildcard issues (_ and %) in entity names.
         alias_row = self._conn.execute(
             """
             SELECT entity_id FROM entities
-            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%'
+            WHERE INSTR(',' || aliases || ',' , ',' || ? || ',') > 0
             """,
             (name,),
         ).fetchone()

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -1,0 +1,99 @@
+"""Tests for holographic MemoryStore._resolve_entity edge cases.
+
+Regression tests for LIKE → = / INSTR fix: LIKE treats _ and % as
+wildcards and is case-insensitive for ASCII, causing false matches and
+duplicate entity creation.
+"""
+
+import pytest
+
+
+@pytest.fixture()
+def store():
+    from plugins.memory.holographic.store import MemoryStore
+
+    return MemoryStore(":memory:")
+
+
+class TestResolveEntityExactMatch:
+    """_resolve_entity must use exact (=) comparison, not LIKE."""
+
+    def test_same_name_returns_same_id(self, store):
+        eid1 = store._resolve_entity("TestEntity")
+        eid2 = store._resolve_entity("TestEntity")
+        assert eid1 == eid2
+
+    def test_underscore_not_treated_as_wildcard(self, store):
+        """LIKE '_' matches any single char; = must not."""
+        eid1 = store._resolve_entity("test_entity")
+        eid2 = store._resolve_entity("testXentity")
+        assert eid1 != eid2
+
+    def test_percent_not_treated_as_wildcard(self, store):
+        """LIKE '%' matches any substring; = must not."""
+        eid1 = store._resolve_entity("test%entity")
+        eid2 = store._resolve_entity("test123entity")
+        assert eid1 != eid2
+
+    def test_case_sensitive(self, store):
+        """SQLite LIKE is case-insensitive for ASCII; = must be case-sensitive."""
+        eid1 = store._resolve_entity("Apple")
+        eid2 = store._resolve_entity("apple")
+        assert eid1 != eid2
+
+    def test_new_entity_created_on_miss(self, store):
+        eid1 = store._resolve_entity("alpha")
+        eid2 = store._resolve_entity("beta")
+        assert eid1 != eid2
+
+
+class TestResolveEntityAliasMatch:
+    """Alias search must also avoid LIKE wildcard pitfalls."""
+
+    def test_alias_resolves_to_existing_entity(self, store):
+        eid = store._resolve_entity("primary_name")
+        store._conn.execute(
+            "UPDATE entities SET aliases = ? WHERE entity_id = ?",
+            ("alt_name,another_name", eid),
+        )
+        store._conn.commit()
+        assert store._resolve_entity("alt_name") == eid
+
+    def test_underscore_in_alias_not_wildcard(self, store):
+        """INSTR-based alias search must not treat _ as wildcard."""
+        eid = store._resolve_entity("real_entity")
+        store._conn.execute(
+            "UPDATE entities SET aliases = ? WHERE entity_id = ?",
+            ("real_entity", eid),
+        )
+        store._conn.commit()
+        # "realXentity" should NOT match alias "real_entity"
+        other = store._resolve_entity("realXentity")
+        assert other != eid
+
+    def test_percent_in_alias_not_wildcard(self, store):
+        """INSTR-based alias search must not treat % as wildcard."""
+        eid = store._resolve_entity("widget")
+        store._conn.execute(
+            "UPDATE entities SET aliases = ? WHERE entity_id = ?",
+            ("widget%", eid),
+        )
+        store._conn.commit()
+        # "widget123" should NOT match alias "widget%"
+        other = store._resolve_entity("widget123")
+        assert other != eid
+
+    def test_alias_substring_does_not_match(self, store):
+        """INSTR must match exact comma-delimited token, not substring."""
+        eid = store._resolve_entity("foo")
+        store._conn.execute(
+            "UPDATE entities SET aliases = ? WHERE entity_id = ?",
+            ("foobar,baz", eid),
+        )
+        store._conn.commit()
+        # "foo" is NOT a standalone alias — "foobar" is
+        # Resolving "foo" should find via name match, not alias
+        assert store._resolve_entity("foo") == eid
+        # "bar" should NOT match
+        other = store._resolve_entity("bar")
+        assert other != eid


### PR DESCRIPTION
## What does this PR do?

Replaces `LIKE` with `=` for exact name matching and `INSTR` for alias searching in `_resolve_entity()`. This fixes wildcard and case-sensitivity bugs that caused duplicate entity creation and incorrect entity linking.

## Related Issue

Fixes #43394

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/holographic/store.py`: Changed `LIKE ?` to `= ?` for exact name match (line 440); replaced `LIKE '%,' || ? || ',%'` with `INSTR(',' || aliases || ',' , ',' || ? || ',') > 0` for alias search (line 449); updated docstring to reflect case-sensitive behavior
- `tests/plugins/memory/test_holographic_store.py`: Added 9 regression tests covering underscore wildcard, percent wildcard, case sensitivity, alias resolution, and alias wildcard edge cases

## How to Test

1. Run `pytest tests/plugins/memory/test_holographic_store.py -v` — all 9 tests should pass
2. Run `pytest tests/agent/test_memory_provider.py -v` — all 80 existing tests should still pass
3. Verify that `MemoryStore(":memory:")._resolve_entity("test_entity")` and `_resolve_entity("testXentity")` return different entity IDs (previously they matched due to `_` wildcard)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/memory/holographic/store.py::_resolve_entity` (callers: `add_fact`, `_link_fact_entity`)
- Blast radius: LOW — isolated to holographic memory provider's entity resolution
- Related patterns: SQLite `LIKE` wildcard behavior (`_` = single char, `%` = any substring); `INSTR` for exact substring matching without wildcard interpretation
