### PR TITLE
fix(memory): match entities by exact name, not LIKE wildcards

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -95,6 +95,15 @@ def _clamp_trust(value: float) -> float:
     return max(_TRUST_MIN, min(_TRUST_MAX, value))
 
 
+def _escape_like(value: str) -> str:
+    """Escape LIKE wildcards so ``value`` is matched literally under ESCAPE '\\'.
+
+    ``%`` and ``_`` are LIKE metacharacters; without escaping, an entity name
+    like ``test_entity`` would also match ``testXentity`` (#43394).
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 class MemoryStore:
     """SQLite-backed fact store with entity resolution and trust scoring."""
 
@@ -437,18 +446,24 @@ class MemoryStore:
         """
         # Exact name match
         row = self._conn.execute(
-            "SELECT entity_id FROM entities WHERE name LIKE ?", (name,)
+            # ``=`` with COLLATE NOCASE: case-insensitive *exact* match. The old
+            # ``LIKE`` treated ``_``/``%`` in the name as wildcards, so e.g.
+            # ``test_entity`` matched ``testXentity`` and linked the wrong (or a
+            # duplicate) entity (#43394).
+            "SELECT entity_id FROM entities WHERE name = ? COLLATE NOCASE", (name,)
         ).fetchone()
         if row is not None:
             return int(row["entity_id"])
 
-        # Search aliases — aliases stored as comma-separated; use LIKE with % boundaries
+        # Search aliases — stored comma-separated; match the exact ',name,'
+        # token. Escape ``%``/``_`` in the name so only the surrounding
+        # ``%,``/``,%`` act as boundary wildcards.
         alias_row = self._conn.execute(
             """
             SELECT entity_id FROM entities
-            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%'
+            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%' ESCAPE '\\'
             """,
-            (name,),
+            (_escape_like(name),),
         ).fetchone()
         if alias_row is not None:
             return int(alias_row["entity_id"])

--- a/tests/plugins/memory/test_holographic_store_resolve_entity.py
+++ b/tests/plugins/memory/test_holographic_store_resolve_entity.py
@@ -1,0 +1,73 @@
+"""MemoryStore._resolve_entity must match entity names exactly (case-insensitively).
+
+Regression for #43394: the lookup used SQL ``LIKE``, so ``_`` and ``%`` in an
+entity name acted as wildcards — ``test_entity`` matched ``testXentity`` and the
+fact was linked to the wrong (or a duplicate) entity. The exact-name match now
+uses ``= ? COLLATE NOCASE`` and the alias search escapes LIKE wildcards, while
+keeping the intended case-insensitive matching.
+"""
+
+from plugins.memory.holographic.store import MemoryStore, _escape_like
+
+
+def _store():
+    return MemoryStore(":memory:")
+
+
+def _name_of(store, entity_id):
+    return store._conn.execute(
+        "SELECT name FROM entities WHERE entity_id = ?", (entity_id,)
+    ).fetchone()["name"]
+
+
+def test_underscore_is_not_a_wildcard():
+    store = _store()
+    store._conn.execute("INSERT INTO entities (name) VALUES ('testXentity')")
+    store._conn.commit()
+    xid = store._conn.execute(
+        "SELECT entity_id FROM entities WHERE name='testXentity'"
+    ).fetchone()["entity_id"]
+
+    # 'test_entity' must NOT match 'testXentity' — a new, distinct entity.
+    rid = store._resolve_entity("test_entity")
+    assert rid != xid
+    assert _name_of(store, rid) == "test_entity"
+
+
+def test_percent_is_not_a_wildcard():
+    store = _store()
+    store._conn.execute("INSERT INTO entities (name) VALUES ('100percent')")
+    store._conn.commit()
+    pid = store._conn.execute(
+        "SELECT entity_id FROM entities WHERE name='100percent'"
+    ).fetchone()["entity_id"]
+    # '100%' would match everything-100-prefixed under LIKE; must not here.
+    assert store._resolve_entity("100%") != pid
+
+
+def test_case_insensitive_dedup_preserved():
+    store = _store()
+    first = store._resolve_entity("Apple")
+    again = store._resolve_entity("apple")
+    assert first == again  # same entity, not a duplicate
+
+
+def test_alias_exact_token_match():
+    store = _store()
+    store._conn.execute(
+        "INSERT INTO entities (name, aliases) VALUES ('SomeOrg', 'beta_user')"
+    )
+    store._conn.commit()
+    oid = store._conn.execute(
+        "SELECT entity_id FROM entities WHERE name='SomeOrg'"
+    ).fetchone()["entity_id"]
+
+    assert store._resolve_entity("beta_user") == oid       # exact alias matches
+    assert store._resolve_entity("betaYuser") != oid       # '_' not a wildcard
+
+
+def test_escape_like_helper():
+    assert _escape_like("a_b") == "a\\_b"
+    assert _escape_like("100%") == "100\\%"
+    assert _escape_like("a\\b") == "a\\\\b"
+    assert _escape_like("plain") == "plain"


### PR DESCRIPTION
## What & why — closes #43394

`MemoryStore._resolve_entity()` does an "exact name match" with SQL `LIKE`:

```sql
SELECT entity_id FROM entities WHERE name LIKE ?
```

But `_` and `%` are LIKE metacharacters, so the name being looked up is treated as a **pattern**. Resolving `test_entity` matches a stored `testXentity` (the `_` is a single-char wildcard), so the fact gets linked to the **wrong** entity — or, with the inverse casing/insert path, the entity graph fragments into duplicates. `entities.name` has no `UNIQUE` constraint, so nothing else catches it. The comma-delimited **alias** search (`... LIKE '%,' || ? || ',%'`) has the same flaw.

## Fix

- **Exact name:** `name = ? COLLATE NOCASE` — case-insensitive (preserving the documented behavior) but wildcard-free.
- **Alias token:** escape `%`/`_` in the name and add `ESCAPE '\'`, so only the surrounding `%,` / `,%` are boundary wildcards.
- New `_escape_like()` helper.

```python
# before
"SELECT entity_id FROM entities WHERE name LIKE ?", (name,)
# after
"SELECT entity_id FROM entities WHERE name = ? COLLATE NOCASE", (name,)
```

## How to test

```bash
scripts/run_tests.sh tests/plugins/memory/test_holographic_store_resolve_entity.py   # 5 passed
```

Covers: `test_entity` no longer false-matches `testXentity`; `100%` doesn't wildcard-match; case-insensitive dedup (`Apple`/`apple` → one entity) still works; alias exact-token match works while `_` in an alias isn't a wildcard; and the `_escape_like` helper. The `_`-wildcard test fails on the old code.

## Platforms

Pure SQLite plugin logic; verified via the CI-parity runner.