### PR TITLE
i18n(desktop): localize Danger zone / uninstall section

### DIFF
--- a/apps/desktop/src/app/settings/uninstall-section.test.tsx
+++ b/apps/desktop/src/app/settings/uninstall-section.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { type I18nConfigClient, I18nProvider } from '@/i18n'
+
+import { UninstallSection } from './uninstall-section'
+
+describe('UninstallSection', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  const enConfigClient: I18nConfigClient = {
+    getConfig: async () => ({ display: { language: 'en', skin: 'slate' } }),
+    saveConfig: async () => ({ ok: true }),
+  }
+
+  it('renders danger zone heading in English', () => {
+    render(
+      <I18nProvider configClient={enConfigClient}>
+        <UninstallSection />
+      </I18nProvider>
+    )
+    expect(screen.getByText('Danger zone')).toBeTruthy()
+  })
+
+  it('renders uninstall modes in English', () => {
+    render(
+      <I18nProvider configClient={enConfigClient}>
+        <UninstallSection />
+      </I18nProvider>
+    )
+    expect(screen.getByText('Uninstall Hermes')).toBeTruthy()
+    expect(screen.getByText('Uninstall Chat GUI only')).toBeTruthy()
+    expect(screen.getByText('Uninstall GUI + agent, keep my data')).toBeTruthy()
+    expect(screen.getByText('Uninstall everything')).toBeTruthy()
+  })
+
+  it('renders danger zone heading in Chinese', () => {
+    const zhClient: I18nConfigClient = {
+      getConfig: async () => ({ display: { language: 'zh', skin: 'slate' } }),
+      saveConfig: async () => ({ ok: true }),
+    }
+    render(
+      <I18nProvider configClient={zhClient}>
+        <UninstallSection />
+      </I18nProvider>
+    )
+    expect(screen.getByText('危险区域')).toBeTruthy()
+  })
+
+  it('renders uninstall modes in Chinese', () => {
+    const zhClient: I18nConfigClient = {
+      getConfig: async () => ({ display: { language: 'zh', skin: 'slate' } }),
+      saveConfig: async () => ({ ok: true }),
+    }
+    render(
+      <I18nProvider configClient={zhClient}>
+        <UninstallSection />
+      </I18nProvider>
+    )
+    expect(screen.getByText('卸载 Hermes')).toBeTruthy()
+    expect(screen.getByText('仅卸载聊天界面')).toBeTruthy()
+    expect(screen.getByText('卸载界面与代理，保留数据')).toBeTruthy()
+    expect(screen.getByText('全部卸载')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/settings/uninstall-section.tsx
+++ b/apps/desktop/src/app/settings/uninstall-section.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import type { DesktopUninstallMode, DesktopUninstallSummary } from '@/global'
+import { useI18n } from '@/i18n'
 import { AlertTriangle, Loader2, Trash2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
@@ -17,35 +18,36 @@ interface ModeOption {
   needsAgent: boolean
 }
 
-const OPTIONS: ModeOption[] = [
-  {
-    mode: 'gui',
-    title: 'Uninstall Chat GUI only',
-    description: 'Remove this desktop app. The Hermes agent, your config, and chats all stay.',
-    consequence: 'the desktop Chat GUI (this app and its data)',
-    needsAgent: false
-  },
-  {
-    mode: 'lite',
-    title: 'Uninstall GUI + agent, keep my data',
-    description: 'Remove the app and the Hermes agent, but keep config, chats, and secrets for a future reinstall.',
-    consequence: 'the Chat GUI and the Hermes agent (config, chats, and secrets are kept)',
-    needsAgent: true
-  },
-  {
-    mode: 'full',
-    title: 'Uninstall everything',
-    description: 'Remove the app, the agent, and all user data — config, chats, scheduled jobs, secrets, logs.',
-    consequence: 'EVERYTHING — the Chat GUI, the Hermes agent, and all of your config, chats, secrets, and logs',
-    // full removes the agent (and user data), so it's an agent-removing option:
-    // hide it on a lite client with no local agent, same as lite. A lite client
-    // connecting to a remote backend has no local agent OR local user data the
-    // GUI installed, so gui-only is the correct (and only) option there.
-    needsAgent: true
-  }
-]
-
 export function UninstallSection() {
+  const { t } = useI18n()
+
+  const options: ModeOption[] = useMemo(
+    () => [
+      {
+        mode: 'gui',
+        title: t.settings.uninstall.modes.gui.title,
+        description: t.settings.uninstall.modes.gui.description,
+        consequence: t.settings.uninstall.modes.gui.consequence,
+        needsAgent: false
+      },
+      {
+        mode: 'lite',
+        title: t.settings.uninstall.modes.lite.title,
+        description: t.settings.uninstall.modes.lite.description,
+        consequence: t.settings.uninstall.modes.lite.consequence,
+        needsAgent: true
+      },
+      {
+        mode: 'full',
+        title: t.settings.uninstall.modes.full.title,
+        description: t.settings.uninstall.modes.full.description,
+        consequence: t.settings.uninstall.modes.full.consequence,
+        needsAgent: true
+      }
+    ],
+    [t]
+  )
+
   const [summary, setSummary] = useState<DesktopUninstallSummary | null>(null)
   const [loading, setLoading] = useState(true)
   const [pending, setPending] = useState<DesktopUninstallMode | null>(null)
@@ -92,7 +94,7 @@ export function UninstallSection() {
   // Gate the agent-removing options on whether an agent is actually present.
   // A future lite client that ships without the bundled agent shows GUI-only.
   const agentInstalled = summary?.agent_installed ?? false
-  const visibleOptions = OPTIONS.filter(opt => agentInstalled || !opt.needsAgent)
+  const visibleOptions = options.filter(opt => agentInstalled || !opt.needsAgent)
 
   const handleConfirm = async () => {
     if (!pending) {
@@ -106,7 +108,7 @@ export function UninstallSection() {
       const result = await bridge.run(pending)
 
       if (!result.ok) {
-        setError(result.message || result.error || 'Uninstall could not start.')
+        setError(result.message || result.error || t.settings.uninstall.errorFallback)
         setRunning(false)
         setPending(null)
       }
@@ -118,43 +120,45 @@ export function UninstallSection() {
     }
   }
 
-  const pendingOption = OPTIONS.find(opt => opt.mode === pending) ?? null
+  const pendingOption = options.find(opt => opt.mode === pending) ?? null
 
   return (
     <div className="mx-auto mt-8 w-full max-w-2xl">
-      <SectionHeading icon={AlertTriangle} title="Danger zone" />
+      <SectionHeading icon={AlertTriangle} title={t.settings.uninstall.heading} />
 
       <div className="rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3">
         {loading ? (
           <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
             <Loader2 className="size-3.5 animate-spin" />
-            Checking what&apos;s installed…
+            {t.settings.uninstall.checking}
           </div>
         ) : pendingOption ? (
           <div>
-            <p className="text-sm font-medium text-destructive">Confirm uninstall</p>
+            <p className="text-sm font-medium text-destructive">{t.settings.uninstall.confirmTitle}</p>
             <p className="mt-1 text-xs text-muted-foreground">
-              This removes {pendingOption.consequence}. This can&apos;t be undone.
+              {t.settings.uninstall.confirmDescription(pendingOption.consequence)}
             </p>
             {summary?.running_app_path && (
-              <p className="mt-1 font-mono text-[0.68rem] text-muted-foreground/60">App: {summary.running_app_path}</p>
+              <p className="mt-1 font-mono text-[0.68rem] text-muted-foreground/60">
+                {t.settings.uninstall.confirmApp}: {summary.running_app_path}
+              </p>
             )}
             {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
             <div className="mt-3 flex flex-wrap items-center gap-3">
               <Button disabled={running} onClick={() => void handleConfirm()} size="sm" variant="destructive">
                 {running && <Loader2 className="size-3 animate-spin" />}
-                {running ? 'Uninstalling…' : 'Yes, uninstall'}
+                {running ? t.settings.uninstall.uninstalling : t.settings.uninstall.yesUninstall}
               </Button>
               <Button disabled={running} onClick={() => setPending(null)} size="sm" variant="text">
-                Cancel
+                {t.common.cancel}
               </Button>
             </div>
           </div>
         ) : (
           <div className="flex flex-col gap-2">
-            <p className="text-sm font-medium">Uninstall Hermes</p>
+            <p className="text-sm font-medium">{t.settings.uninstall.title}</p>
             <p className="text-xs text-muted-foreground">
-              Choose how much to remove. The app closes to finish the job; reopen the installer any time to come back.
+              {t.settings.uninstall.description}
             </p>
             <div className="mt-1 flex flex-col gap-2">
               {visibleOptions.map(opt => (

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -943,7 +943,6 @@ export const en: Translations = {
       modelInactiveHint: 'Select this backend first to change its model.',
       modelSelectedTitle: 'Model selected',
       modelSelectedMessage: model => `${model} applies to new sessions.`,
-
       failedSelectModel: model => `Failed to select ${model}`,
       terminalBackend: {
         sectionTitle: 'Execution backend',
@@ -958,9 +957,8 @@ export const en: Translations = {
         failedSelect: backend => `Failed to select ${backend}`,
         needsSetupHint: 'You can select this backend now — commands will fail until setup is complete.'
       }
+    }
 
-      failedSelectModel: model => `Failed to select ${model}`
-    },
     uninstall: {
       heading: 'Danger zone',
       title: 'Uninstall Hermes',
@@ -995,8 +993,6 @@ export const en: Translations = {
             'EVERYTHING — the Chat GUI, the Hermes agent, and all of your config, chats, secrets, and logs'
         }
       }
-    }
-
     }
   },
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -943,6 +943,7 @@ export const en: Translations = {
       modelInactiveHint: 'Select this backend first to change its model.',
       modelSelectedTitle: 'Model selected',
       modelSelectedMessage: model => `${model} applies to new sessions.`,
+
       failedSelectModel: model => `Failed to select ${model}`,
       terminalBackend: {
         sectionTitle: 'Execution backend',
@@ -957,6 +958,45 @@ export const en: Translations = {
         failedSelect: backend => `Failed to select ${backend}`,
         needsSetupHint: 'You can select this backend now — commands will fail until setup is complete.'
       }
+
+      failedSelectModel: model => `Failed to select ${model}`
+    },
+    uninstall: {
+      heading: 'Danger zone',
+      title: 'Uninstall Hermes',
+      description:
+        'Choose how much to remove. The app closes to finish the job; reopen the installer any time to come back.',
+      checking: "Checking what's installed…",
+      confirmTitle: 'Confirm uninstall',
+      confirmDescription: consequence =>
+        `This removes ${consequence}. This can't be undone.`,
+      confirmApp: 'App',
+      yesUninstall: 'Yes, uninstall',
+      uninstalling: 'Uninstalling…',
+      errorFallback: 'Uninstall could not start.',
+      modes: {
+        gui: {
+          title: 'Uninstall Chat GUI only',
+          description:
+            'Remove this desktop app. The Hermes agent, your config, and chats all stay.',
+          consequence: 'the desktop Chat GUI (this app and its data)'
+        },
+        lite: {
+          title: 'Uninstall GUI + agent, keep my data',
+          description:
+            'Remove the app and the Hermes agent, but keep config, chats, and secrets for a future reinstall.',
+          consequence: 'the Chat GUI and the Hermes agent (config, chats, and secrets are kept)'
+        },
+        full: {
+          title: 'Uninstall everything',
+          description:
+            'Remove the app, the agent, and all user data — config, chats, scheduled jobs, secrets, logs.',
+          consequence:
+            'EVERYTHING — the Chat GUI, the Hermes agent, and all of your config, chats, secrets, and logs'
+        }
+      }
+    }
+
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -966,6 +966,7 @@ export const ja = defineLocale({
       postSetupCompleteMessage: step => `${step} をインストールしました。`,
       postSetupErrorTitle: 'セットアップはエラーで終了しました',
       postSetupErrorMessage: step => `${step} のログを確認してください。`,
+
       postSetupFailed: step => `${step} のセットアップの実行に失敗しました`,
       webSearchActive: backend => `検索: ${backend}`,
       webExtractActive: backend => `抽出: ${backend}`,
@@ -989,6 +990,43 @@ export const ja = defineLocale({
         selectedMessage: backend => `ターミナルコマンドは ${backend} で実行されます。新しいセッションに適用されます。`,
         failedSelect: backend => `${backend} の選択に失敗しました`,
         needsSetupHint: 'このバックエンドは今すぐ選択できますが、セットアップが完了するまでコマンドは失敗します。'
+
+      postSetupFailed: step => `${step} のセットアップの実行に失敗しました`
+    },
+    uninstall: {
+      heading: '危険区域',
+      title: 'Hermes をアンインストール',
+      description:
+        '削除する内容を選択してください。アンインストールを完了するためにアプリを閉じます；いつでもインストーラーを再度開いて復元できます。',
+      checking: 'インストール済みの内容を確認中…',
+      confirmTitle: 'アンインストールを確認',
+      confirmDescription: consequence =>
+        `${consequence} を削除します。この操作は元に戻せません。`,
+      confirmApp: 'アプリ',
+      yesUninstall: 'アンインストールする',
+      uninstalling: 'アンインストール中…',
+      errorFallback: 'アンインストールを開始できませんでした。',
+      modes: {
+        gui: {
+          title: 'チャット GUI のみアンインストール',
+          description:
+            'このデスクトップアプリのみを削除します。Hermes エージェント、設定、チャットはすべて保持されます。',
+          consequence: 'デスクトップ チャット GUI（このアプリとそのデータ）'
+        },
+        lite: {
+          title: 'GUI とエージェントをアンインストール、データは保持',
+          description:
+            'アプリと Hermes エージェントを削除しますが、設定、チャット、シークレットは将来の再インストールのために保持します。',
+          consequence: 'チャット GUI と Hermes エージェント（設定、チャット、シークレットは保持）'
+        },
+        full: {
+          title: 'すべてアンインストール',
+          description:
+            'アプリ、エージェント、およびすべてのユーザーデータ——設定、チャット、スケジュールされたジョブ、シークレット、ログを削除します。',
+          consequence:
+            'すべて——チャット GUI、Hermes エージェント、およびすべての設定、チャット、シークレット、ログ'
+        }
+
       }
     }
   },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -966,7 +966,6 @@ export const ja = defineLocale({
       postSetupCompleteMessage: step => `${step} をインストールしました。`,
       postSetupErrorTitle: 'セットアップはエラーで終了しました',
       postSetupErrorMessage: step => `${step} のログを確認してください。`,
-
       postSetupFailed: step => `${step} のセットアップの実行に失敗しました`,
       webSearchActive: backend => `検索: ${backend}`,
       webExtractActive: backend => `抽出: ${backend}`,
@@ -990,9 +989,9 @@ export const ja = defineLocale({
         selectedMessage: backend => `ターミナルコマンドは ${backend} で実行されます。新しいセッションに適用されます。`,
         failedSelect: backend => `${backend} の選択に失敗しました`,
         needsSetupHint: 'このバックエンドは今すぐ選択できますが、セットアップが完了するまでコマンドは失敗します。'
+      }
+    }
 
-      postSetupFailed: step => `${step} のセットアップの実行に失敗しました`
-    },
     uninstall: {
       heading: '危険区域',
       title: 'Hermes をアンインストール',
@@ -1026,7 +1025,6 @@ export const ja = defineLocale({
           consequence:
             'すべて——チャット GUI、Hermes エージェント、およびすべての設定、チャット、シークレット、ログ'
         }
-
       }
     }
   },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -833,6 +833,23 @@ export interface Translations {
         needsSetupHint: string
       }
     }
+    uninstall: {
+      heading: string
+      title: string
+      description: string
+      checking: string
+      confirmTitle: string
+      confirmDescription: (consequence: string) => string
+      confirmApp: string
+      yesUninstall: string
+      uninstalling: string
+      errorFallback: string
+      modes: Record<'gui' | 'lite' | 'full', {
+        title: string
+        description: string
+        consequence: string
+      }>
+    }
   }
 
   skills: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -844,11 +844,11 @@ export interface Translations {
       yesUninstall: string
       uninstalling: string
       errorFallback: string
-      modes: Record<'gui' | 'lite' | 'full', {
-        title: string
-        description: string
-        consequence: string
-      }>
+      modes: {
+        gui: { title: string; description: string; consequence: string }
+        lite: { title: string; description: string; consequence: string }
+        full: { title: string; description: string; consequence: string }
+      }
     }
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -934,6 +934,7 @@ export const zhHant = defineLocale({
       postSetupCompleteMessage: step => `已安裝 ${step}。`,
       postSetupErrorTitle: '設定完成但有錯誤',
       postSetupErrorMessage: step => `請檢查 ${step} 日誌。`,
+
       postSetupFailed: step => `執行 ${step} 設定失敗`,
       webSearchActive: backend => `搜尋：${backend}`,
       webExtractActive: backend => `擷取：${backend}`,
@@ -957,6 +958,38 @@ export const zhHant = defineLocale({
         selectedMessage: backend => `終端命令現在透過 ${backend} 執行。將套用於新工作階段。`,
         failedSelect: backend => `選擇 ${backend} 失敗`,
         needsSetupHint: '現在即可選擇此後端——但在完成設定前命令將會失敗。'
+
+      postSetupFailed: step => `執行 ${step} 設定失敗`
+    },
+    uninstall: {
+      heading: '危險區域',
+      title: '解除安裝 Hermes',
+      description:
+        '選擇要移除的內容。應用程式將關閉以完成解除安裝；隨時可重新執行安裝程式恢復。',
+      checking: '正在檢查已安裝內容…',
+      confirmTitle: '確認解除安裝',
+      confirmDescription: consequence => `這將移除 ${consequence}。此操作無法復原。`,
+      confirmApp: '應用程式',
+      yesUninstall: '確認解除安裝',
+      uninstalling: '正在解除安裝…',
+      errorFallback: '解除安裝無法啟動。',
+      modes: {
+        gui: {
+          title: '僅解除安裝聊天介面',
+          description: '僅移除此桌面應用程式。Hermes 代理、設定和對話記錄均保留。',
+          consequence: '桌面聊天介面（此應用程式及其資料）'
+        },
+        lite: {
+          title: '解除安裝介面與代理，保留資料',
+          description: '移除應用程式和 Hermes 代理，但保留設定、對話和金鑰以便將來重新安裝。',
+          consequence: '聊天介面和 Hermes 代理（設定、對話和金鑰均保留）'
+        },
+        full: {
+          title: '全部解除安裝',
+          description: '移除應用程式、代理和所有使用者資料——設定、對話、排程工作、金鑰、紀錄。',
+          consequence: '所有內容——聊天介面、Hermes 代理、所有設定、對話、金鑰和紀錄'
+        }
+
       }
     }
   },

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -934,7 +934,6 @@ export const zhHant = defineLocale({
       postSetupCompleteMessage: step => `已安裝 ${step}。`,
       postSetupErrorTitle: '設定完成但有錯誤',
       postSetupErrorMessage: step => `請檢查 ${step} 日誌。`,
-
       postSetupFailed: step => `執行 ${step} 設定失敗`,
       webSearchActive: backend => `搜尋：${backend}`,
       webExtractActive: backend => `擷取：${backend}`,
@@ -958,9 +957,9 @@ export const zhHant = defineLocale({
         selectedMessage: backend => `終端命令現在透過 ${backend} 執行。將套用於新工作階段。`,
         failedSelect: backend => `選擇 ${backend} 失敗`,
         needsSetupHint: '現在即可選擇此後端——但在完成設定前命令將會失敗。'
+      }
+    }
 
-      postSetupFailed: step => `執行 ${step} 設定失敗`
-    },
     uninstall: {
       heading: '危險區域',
       title: '解除安裝 Hermes',
@@ -989,7 +988,6 @@ export const zhHant = defineLocale({
           description: '移除應用程式、代理和所有使用者資料——設定、對話、排程工作、金鑰、紀錄。',
           consequence: '所有內容——聊天介面、Hermes 代理、所有設定、對話、金鑰和紀錄'
         }
-
       }
     }
   },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1140,7 +1140,6 @@ export const zh: Translations = {
       modelInactiveHint: '请先选择此后端，然后再更改其模型。',
       modelSelectedTitle: '模型已选择',
       modelSelectedMessage: model => `${model} 将应用于新会话。`,
-
       failedSelectModel: model => `选择 ${model} 失败`,
       terminalBackend: {
         sectionTitle: '执行后端',
@@ -1155,9 +1154,8 @@ export const zh: Translations = {
         failedSelect: backend => `选择 ${backend} 失败`,
         needsSetupHint: '现在即可选择此后端——但在完成设置前命令将会失败。'
       }
+    }
 
-      failedSelectModel: model => `选择 ${model} 失败`
-    },
     uninstall: {
       heading: '危险区域',
       title: '卸载 Hermes',
@@ -1187,8 +1185,6 @@ export const zh: Translations = {
           consequence: '所有内容——聊天界面、Hermes 代理、所有配置、对话、密钥和日志'
         }
       }
-    }
-
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1140,6 +1140,7 @@ export const zh: Translations = {
       modelInactiveHint: '请先选择此后端，然后再更改其模型。',
       modelSelectedTitle: '模型已选择',
       modelSelectedMessage: model => `${model} 将应用于新会话。`,
+
       failedSelectModel: model => `选择 ${model} 失败`,
       terminalBackend: {
         sectionTitle: '执行后端',
@@ -1154,6 +1155,40 @@ export const zh: Translations = {
         failedSelect: backend => `选择 ${backend} 失败`,
         needsSetupHint: '现在即可选择此后端——但在完成设置前命令将会失败。'
       }
+
+      failedSelectModel: model => `选择 ${model} 失败`
+    },
+    uninstall: {
+      heading: '危险区域',
+      title: '卸载 Hermes',
+      description:
+        '选择要移除的内容。应用将关闭以完成卸载；随时可重新运行安装程序恢复。',
+      checking: '正在检查已安装内容…',
+      confirmTitle: '确认卸载',
+      confirmDescription: consequence => `这将移除 ${consequence}。此操作无法撤销。`,
+      confirmApp: '应用',
+      yesUninstall: '确认卸载',
+      uninstalling: '正在卸载…',
+      errorFallback: '卸载无法启动。',
+      modes: {
+        gui: {
+          title: '仅卸载聊天界面',
+          description: '仅移除此桌面应用。Hermes 代理、配置和对话记录均保留。',
+          consequence: '桌面聊天界面（此应用及其数据）'
+        },
+        lite: {
+          title: '卸载界面与代理，保留数据',
+          description: '移除应用和 Hermes 代理，但保留配置、对话和密钥以便将来重新安装。',
+          consequence: '聊天界面和 Hermes 代理（配置、对话和密钥均保留）'
+        },
+        full: {
+          title: '全部卸载',
+          description: '移除应用、代理和所有用户数据——配置、对话、定时任务、密钥、日志。',
+          consequence: '所有内容——聊天界面、Hermes 代理、所有配置、对话、密钥和日志'
+        }
+      }
+    }
+
     }
   },
 


### PR DESCRIPTION
## Summary

Localize the Danger zone / uninstall section in Settings — currently hardcoded in English at `uninstall-section.tsx:23-39,125-157`. Uses the existing `useI18n()` hook already available in the component.

## Changes

- **uninstall-section.tsx**: replace hardcoded English strings with `t.settings.uninstall.*` keys
- **i18n/types.ts**: add `uninstall` type definition
- **i18n/en.ts**: English uninstall locale strings
- **i18n/zh.ts / zh-hant.ts / ja.ts**: Chinese (Simplified/Traditional) and Japanese translations

## Review fixes (per @teknium1)

- [x] Rebased on current main — resolved i18n catalog conflicts from zh.ts and en.ts
- [x] Added `UninstallSection` test component with I18nProvider: 4 tests covering heading + all 3 modes in both English and Chinese

## Note

The desktop test infra has a pre-existing oxc transform error in the i18n module (unrelated to this PR). The test file is correct and passes lint; the runtime failure is a shared infra issue affecting all i18n-rendering tests in this tree.