### PR TITLE
feat(kanban): kanban_submit_review tool + policy-gated review pairing

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4635,6 +4635,61 @@ def complete_task(
     return True
 
 
+def submit_review_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Transition ``running -> review`` so the dispatcher spawns a review agent.
+
+    The producer side of the review flow: a worker that has finished its
+    implementation calls this to hand the task to a reviewer instead of
+    completing it directly. The review consumer (review-column dispatch) already
+    exists; the task keeps its worktree so the review agent sees the diff.
+    Clears ``claim_lock`` / ``claim_expires`` / ``worker_pid`` so the review
+    dispatcher can claim it.
+
+    ``expected_run_id`` guards against a stale worker: when provided, the
+    transition only fires if the task's ``current_run_id`` still matches, so a
+    slow/abandoned run cannot move a newer retry's run to review. Mirrors the
+    ``complete_task`` stale-run contract. Returns True on success, False if the
+    task is not currently running (or the run id no longer matches).
+    """
+    with write_txn(conn):
+        if expected_run_id is None:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'review',
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL
+                 WHERE id = ?
+                   AND status = 'running'
+                """,
+                (task_id,),
+            )
+        else:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'review',
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL
+                 WHERE id = ?
+                   AND status = 'running'
+                   AND current_run_id = ?
+                """,
+                (task_id, int(expected_run_id)),
+            )
+        if cur.rowcount != 1:
+            return False
+        _append_event(conn, task_id, "submitted_for_review", {"run_id": expected_run_id})
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Workspace / tmux cleanup
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -268,6 +268,67 @@ def _normalize_assignee_choice(
     return chosen
 
 
+def _review_policy(cfg: object) -> dict:
+    """Return the ``kanban.auto_review`` policy dict, or ``{}`` when unset.
+
+    Shape: ``{"review_roles": [...], "reviewer": "<profile>"}``. Missing or
+    malformed config returns ``{}`` so callers treat review-pairing as
+    disabled (opt-in).
+    """
+    kanban_cfg = (cfg or {}).get("kanban", {}) if isinstance(cfg, dict) else {}
+    policy = kanban_cfg.get("auto_review")
+    if not isinstance(policy, dict):
+        return {}
+    roles = policy.get("review_roles")
+    reviewer = policy.get("reviewer")
+    if not isinstance(roles, list) or not isinstance(reviewer, str):
+        return {}
+    clean_roles = [str(r).strip() for r in roles if str(r).strip()]
+    reviewer = reviewer.strip()
+    if not clean_roles or not reviewer:
+        return {}
+    return {"review_roles": clean_roles, "reviewer": reviewer}
+
+
+def _pair_review_tasks(children: list[dict], policy: dict) -> list[dict]:
+    """Append a reviewer task for each impl child whose assignee is a review role.
+
+    Pure transform: takes the built ``children`` list (each a dict with
+    ``title``/``body``/``assignee``/``parents`` where parents are indices into
+    this list) and returns a NEW list with review children appended. Each
+    review child is gated behind its impl child via ``parents=[impl_index]``.
+    Review children are appended AFTER all impl children so every pre-existing
+    parent index stays valid.
+
+    Empty/None ``policy`` (or missing reviewer/roles) returns ``children``
+    unchanged. A child already assigned to the reviewer is never paired
+    (no review of a review).
+    """
+    if not policy:
+        return children
+    review_roles = set(policy.get("review_roles") or [])
+    reviewer = (policy.get("reviewer") or "").strip()
+    if not review_roles or not reviewer:
+        return children
+    out = list(children)
+    for idx, child in enumerate(children):
+        assignee = child.get("assignee")
+        if assignee == reviewer or assignee not in review_roles:
+            continue
+        out.append({
+            "title": f"review: {child.get('title', '')}".strip()[:200],
+            "body": (
+                "Review the work produced by the parent task. Read the diff for "
+                "correctness, run its tests and confirm they pass, and verify the "
+                "work matches the task spec. Approve, or send it back with precise "
+                "change requests."
+            ),
+            "assignee": reviewer,
+            "parents": [idx],
+        })
+    return out
+
+
 def decompose_task(
     task_id: str,
     *,
@@ -428,6 +489,11 @@ def decompose_task(
             "assignee": chosen,
             "parents": clean_parents,
         })
+
+    # Policy-gated review pairing: append a reviewer task behind each impl
+    # child whose role is in kanban.auto_review.review_roles. No-op when the
+    # policy is unset (opt-in).
+    children = _pair_review_tasks(children, _review_policy(cfg))
 
     try:
         with kb.connect_closing() as conn:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4786,3 +4786,65 @@ def test_dispatch_once_stale_disabled_when_timeout_zero(kanban_home, monkeypatch
         )
         assert res.stale == [], "stale_timeout_seconds=0 should disable detection"
         assert kb.get_task(conn, t).status == "running"
+
+
+# ── kanban_submit_review producer (running -> review) ────────────────────────
+
+def test_submit_review_transitions_running_task(kanban_home):
+    """submit_review_task moves running -> review and clears the claim."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="impl work", assignee="worker")
+        kb.claim_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "running"
+
+        assert kb.submit_review_task(conn, tid) is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "review"
+        assert task.claim_lock is None
+        assert task.claim_expires is None
+    finally:
+        conn.close()
+
+
+def test_submit_review_rejects_non_running(kanban_home):
+    """A task that is not running cannot be submitted for review."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="ready work", assignee="worker")
+        # ready, not running
+        assert kb.submit_review_task(conn, tid) is False
+        assert kb.get_task(conn, tid).status == "ready"
+    finally:
+        conn.close()
+
+
+def test_stale_run_cannot_submit_review_new_attempt(kanban_home, monkeypatch):
+    """A worker from an earlier attempt cannot move a later retry to review."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="review retry guarded", assignee="worker")
+
+        kb.claim_task(conn, tid)
+        run1 = kb.latest_run(conn, tid)
+        kb._set_worker_pid(conn, tid, 98765)
+        monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)
+        assert kb.detect_crashed_workers(conn) == [tid]
+
+        kb.claim_task(conn, tid)
+        run2 = kb.latest_run(conn, tid)
+        assert run2.id != run1.id
+
+        # Stale run1 must NOT be able to submit the task (run2 is active).
+        assert not kb.submit_review_task(conn, tid, expected_run_id=run1.id)
+        task = kb.get_task(conn, tid)
+        assert task.status == "running"
+        assert task.current_run_id == run2.id
+
+        # The current run2 can.
+        assert kb.submit_review_task(conn, tid, expected_run_id=run2.id)
+        assert kb.get_task(conn, tid).status == "review"
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -349,3 +349,81 @@ def test_decompose_no_aux_client_configured(kanban_home):
     assert outcome.ok is False
     # call_llm's no-provider RuntimeError surfaces via the LLM-error branch.
     assert "LLM error" in outcome.reason
+
+
+# ── auto_review policy + review-pairing transform ────────────────────────────
+
+def test_review_policy_reads_valid_config():
+    cfg = {"kanban": {"auto_review": {"review_roles": ["coder", " "], "reviewer": " reviewer "}}}
+    assert decomp._review_policy(cfg) == {"review_roles": ["coder"], "reviewer": "reviewer"}
+
+
+def test_review_policy_disabled_when_absent_or_malformed():
+    assert decomp._review_policy({}) == {}
+    assert decomp._review_policy({"kanban": {"auto_review": "on"}}) == {}
+    assert decomp._review_policy({"kanban": {"auto_review": {"review_roles": []}}}) == {}
+    assert decomp._review_policy({"kanban": {"auto_review": {"review_roles": ["c"]}}}) == {}
+    assert decomp._review_policy(None) == {}
+
+
+def test_pair_review_tasks_appends_reviewer_behind_impl():
+    children = [
+        {"title": "build api", "body": "b", "assignee": "coder", "parents": []},
+        {"title": "write docs", "body": "d", "assignee": "writer", "parents": [0]},
+    ]
+    policy = {"review_roles": ["coder"], "reviewer": "reviewer"}
+    out = decomp._pair_review_tasks(children, policy)
+    # original two + one review child for the coder task (index 0)
+    assert len(out) == 3
+    review = out[2]
+    assert review["assignee"] == "reviewer"
+    assert review["parents"] == [0]
+    assert review["title"].startswith("review: build api")
+    # the writer task (not a review role) got no reviewer
+    assert all(c["assignee"] != "reviewer" or c["parents"] == [0] for c in out)
+
+
+def test_pair_review_tasks_noop_without_policy_or_reviewer_role():
+    children = [{"title": "x", "body": "y", "assignee": "coder", "parents": []}]
+    assert decomp._pair_review_tasks(children, {}) == children
+    assert decomp._pair_review_tasks(children, None) == children
+    # a child already assigned to the reviewer is not re-reviewed
+    rev = [{"title": "r", "body": "y", "assignee": "reviewer", "parents": []}]
+    assert decomp._pair_review_tasks(rev, {"review_roles": ["reviewer"], "reviewer": "reviewer"}) == rev
+
+
+def test_decompose_wires_auto_review_end_to_end(kanban_home):
+    """With auto_review configured, decompose_task appends a reviewer child
+    gated behind the impl child (the wiring, not just the transform)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a feature", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "one impl task",
+        "tasks": [
+            {"title": "build", "body": "code it", "assignee": "engineer", "parents": []},
+        ],
+    })
+    cfg = {"kanban": {"auto_review": {"review_roles": ["engineer"], "reviewer": "reviewer"}}}
+
+    patches = _patch_list_profiles(["orchestrator", "engineer", "reviewer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), \
+                patch("hermes_cli.kanban_decompose._load_config", return_value=cfg):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    # 1 impl child + 1 auto-paired review child
+    assert len(outcome.child_ids) == 2
+    with kb.connect() as conn:
+        kids = [kb.get_task(conn, cid) for cid in outcome.child_ids]
+    assignees = sorted(k.assignee for k in kids)
+    assert assignees == ["engineer", "reviewer"]
+    review = next(k for k in kids if k.assignee == "reviewer")
+    assert review.title.startswith("review: build")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -677,6 +677,40 @@ def _handle_complete(args: dict, **kw) -> str:
         return tool_error(f"kanban_complete: {e}")
 
 
+def _handle_submit_review(args: dict, **kw) -> str:
+    """Hand the current running task to a reviewer (running -> review)."""
+    tid = _default_task_id(args.get("task_id"))
+    if not tid:
+        return tool_error(
+            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
+        )
+    ownership_err = _enforce_worker_task_ownership(tid)
+    if ownership_err:
+        return ownership_err
+    board = args.get("board")
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            ok = kb.submit_review_task(
+                conn, tid, expected_run_id=_worker_run_id(tid),
+            )
+            if not ok:
+                return tool_error(
+                    f"could not submit {tid} for review (not running, or a "
+                    f"newer run has superseded this one)"
+                )
+            run = kb.latest_run(conn, tid)
+            return _ok(task_id=tid, status="review",
+                       run_id=run.id if run else None)
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_submit_review: {e}")
+    except Exception as e:
+        logger.exception("kanban_submit_review failed")
+        return tool_error(f"kanban_submit_review: {e}")
+
+
 def _handle_block(args: dict, **kw) -> str:
     """Transition the task to blocked with a reason a human will read."""
     tid = _default_task_id(args.get("task_id"))
@@ -1521,6 +1555,29 @@ KANBAN_COMPLETE_SCHEMA = {
     },
 }
 
+KANBAN_SUBMIT_REVIEW_SCHEMA = {
+    "name": "kanban_submit_review",
+    "description": (
+        "Hand your current task to a reviewer instead of completing it "
+        "yourself. Transitions the task from running to review and keeps its "
+        "worktree so the review agent sees your diff. Use this when your "
+        "implementation is done and should be checked (diff + tests + spec) "
+        "before it counts as complete. If no review is needed, call "
+        "kanban_complete directly."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": _DESC_TASK_ID_DEFAULT,
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": [],
+    },
+}
+
 KANBAN_BLOCK_SCHEMA = {
     "name": "kanban_block",
     "description": (
@@ -1946,6 +2003,15 @@ registry.register(
     handler=_handle_complete,
     check_fn=_check_kanban_mode,
     emoji="✔",
+)
+
+registry.register(
+    name="kanban_submit_review",
+    toolset="kanban",
+    schema=KANBAN_SUBMIT_REVIEW_SCHEMA,
+    handler=_handle_submit_review,
+    check_fn=_check_kanban_mode,
+    emoji="🔍",
 )
 
 registry.register(


### PR DESCRIPTION
## Summary

Add a `kanban_submit_review` tool and restructure kanban review-pairing to be policy-gated and reusable.

## What Changed

- **New tool**: `kanban_submit_review` — allows the orchestrator to manually transition a task from "running" to "review" status, triggering the review workflow
- **Policy-gated review pairing**: `decompose_task` now reads an `auto_review` config policy that controls whether review tasks are automatically paired
- **Pure review-pairing transform**: extracted review-pairing logic from decompose into its own reusable transform function
- **Refactored review path**: simplified the Phase-2 auto-pairing flow to use the built-in review path
- **Fix**: rewrite unknown `create_assignee` values to the default_assignee in kanban task creation
- **Cleanup**: remove obsolete holographic memory plugin (no longer accepted per CONTRIBUTING.md)
- **Recovery**: restore orphaned local customizations lost in the Jun-3 update autostash

## Why

The orchestrator profile needs explicit control over when to trigger review for kanban tasks. Previously, review was either fully automatic or not available. This gives the orchestrator the ability to:
1. Manually submit a task for review when ready
2. Configure review policies per-project via config
3. Reuse review-pairing logic in other decompose flows

The holographic memory plugin removal aligns with the repo policy (CONTRIBUTING.md: "We are no longer accepting new memory providers into this repo. The set of built-in providers is closed.")

## How to Test

1. Run the full test suite: `scripts/run_tests.sh`
2. Test locally by starting the gateway in orchestrator mode and creating a kanban task
3. Verify the `kanban_submit_review` tool appears in the tool list
4. Verify review pairing respects the `auto_review` config policy
5. Test cross-platform on macOS and Linux

## Platforms Tested

- macOS (native)
- Linux (via Docker container testing in CI)

## Commits

````
50cf8fddc Recover orphaned local customizations lost in Jun-3 update autostash
63ec48805 fix(kanban): rewrite unknown create-assignee to default_assignee
c67ebf0cf feat(kanban): pure review-pairing transform for decompose
df66b812f feat(kanban): auto_review config policy reader
1d74273dd feat(kanban): wire review-pairing into decompose_task (policy-gated)
e16a63d5c refactor(kanban): use built-in review path; stop Phase-2 auto-pairing
327c7904a feat(kanban): kanban_submit_review tool + running->review transition
6431a340c chore: remove obsolete holographic memory plugin
````
