### PR TITLE
fix(memory): preserve old_text in memory tool schema (#43412)

### DIFF
--- a/tests/tools/test_memory_tool_schema.py
+++ b/tests/tools/test_memory_tool_schema.py
@@ -39,10 +39,22 @@ def test_memory_schema_has_no_forbidden_top_level_combinators():
 def test_memory_schema_is_well_formed():
     params = MEMORY_SCHEMA["parameters"]
     assert params["type"] == "object"
-    assert params["required"] == ["action", "target"]
+    assert params["required"] == ["action", "target", "old_text"]
     # Nested ``enum`` on property values is fine — only top-level is forbidden.
     assert params["properties"]["action"]["enum"] == ["add", "replace", "remove"]
     assert params["properties"]["target"]["enum"] == ["memory", "user"]
+
+
+def test_memory_schema_old_text_in_required():
+    """old_text MUST be in the required list so schema-aware LLM tool-calling
+    layers do not strip it before invoking the handler. Without it, remove and
+    replace actions fail with 'old_text is required' even when the caller
+    provides it. See #43412."""
+    params = MEMORY_SCHEMA["parameters"]
+    assert "old_text" in params["required"], (
+        "old_text must be in the schema required list. Without it, tool-calling "
+        "layers drop the parameter, breaking remove and replace actions (#43412)."
+    )
 
 
 def test_memory_schema_is_json_serializable():

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -782,7 +782,7 @@ MEMORY_SCHEMA = {
                 "description": "Short unique substring identifying the entry to replace or remove."
             },
         },
-        "required": ["action", "target"],
+        "required": ["action", "target", "old_text"],
     },
 }
 


### PR DESCRIPTION
## Summary

Fixes #43412 by adding `old_text` to the memory tool JSON schema `required` list. Schema-aware tool-calling layers can otherwise omit or strip `old_text` before dispatch, causing `replace` and `remove` to fail with `old_text is required` even when the user supplied a valid substring.

## Why this approach

The runtime handler already correctly requires `old_text` for `replace` and `remove`; the root cause is the schema contract. Making `old_text` required keeps provider/tool-call layers from dropping it. The `add` action ignores `old_text`, so requiring an empty value for add is harmless and matches the issue's suggested low-risk fix.

## Verification

- RED proof on upstream/main captured in `.automation/runs/20260610T081049Z/43412/fail-without-fix.txt`:
  - `test_memory_schema_is_well_formed` failed because `old_text` was absent from `required`.
  - `test_memory_schema_old_text_in_required` failed for the same root cause.
- After fix and rebase onto current upstream/main (`298bb93d3`):
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/tools/test_memory_tool_schema.py tests/tools/test_memory_tool.py -v -o "addopts=" --tb=short`
  - Result: `73 passed in 0.18s`
- Branch shape verified: `git rev-list --left-right --count upstream/main...HEAD` → `0 1`.

## Competitor / duplicate check

- No open PR found referencing `#43412`.
- Same-author duplicate checks for `Tranquil-Flow` by issue number and branch pattern returned no matches.
- Related open PRs were reviewed:
  - #23399 is the closest schema competitor but has failing CI, no regression tests, and uses top-level JSON Schema conditionals that conflict with the existing schema guard against top-level combinators.
  - #29648 and #32577 address different symptoms (`None`/empty-string validation and `old_string` aliasing) and do not fix schema-aware layers dropping `old_text`.
  - #39508 targets external memory provider bridge propagation, not this schema contract.

Auto-published by Moonsong via Path B automated pipeline.
