### PR TITLE
fix(memory): normalize MCP inputSchema to OpenAI format in memory provider

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1220,6 +1220,10 @@ def init_agent(
             _tname = _schema.get("name", "")
             if _tname and _tname in _existing_tool_names:
                 continue  # already registered via plugin path
+            # Normalize MCP-style schemas (inputSchema → parameters) so
+            # providers like LiteLLM that expect the OpenAI key don't 400.
+            if "inputSchema" in _schema and "parameters" not in _schema:
+                _schema["parameters"] = _schema.pop("inputSchema")
             _wrapped = {"type": "function", "function": _schema}
             agent.tools.append(_wrapped)
             if _tname:

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -132,3 +132,71 @@ def test_core_tool_names_rejected_from_memory_routing_table():
     assert "clarify" not in schema_names
     assert "delegate_task" not in schema_names
     assert "honcho_search" in schema_names
+
+
+
+class McpSchemaProvider:
+    """Provider that returns tool schemas in MCP format (inputSchema instead of parameters)."""
+
+    name = "mcp-schema"
+
+    def is_available(self):
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        pass
+
+    def shutdown(self):
+        pass
+
+    def get_tool_schemas(self):
+        return [
+            {
+                "name": "brain_query",
+                "description": "Query the knowledge base",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"q": {"type": "string", "description": "query"}},
+                    "required": ["q"],
+                },
+            }
+        ]
+
+
+def test_mcp_input_schema_normalized_to_parameters():
+    """Memory-provider schemas using MCP inputSchema key must be normalized
+    to OpenAI parameters key before wrapping (#43403)."""
+    provider = McpSchemaProvider()
+    cfg = {"memory": {"provider": "mcp-schema"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+
+    # Find the brain_query tool in agent.tools
+    brain_tool = None
+    for t in agent.tools:
+        if isinstance(t, dict) and t.get("function", {}).get("name") == "brain_query":
+            brain_tool = t
+            break
+    assert brain_tool is not None, "brain_query tool not found in agent.tools"
+    fn = brain_tool["function"]
+    # inputSchema must have been converted to parameters
+    assert "parameters" in fn, f"Expected 'parameters' key, got: {list(fn.keys())}"
+    assert "inputSchema" not in fn, "inputSchema should have been removed after normalization"
+    assert fn["parameters"]["type"] == "object"
+    assert "q" in fn["parameters"]["properties"]


### PR DESCRIPTION
## What does this PR do?

Normalizes MCP-style `inputSchema` keys to OpenAI `parameters` keys when wrapping memory-provider tool schemas in `agent_init.py`. Memory providers that use MCP format (like `open-second-brain`) return schemas with `inputSchema` instead of `parameters`, causing LiteLLM and other OpenAI-compatible providers to reject tool calls with 400 errors.

## Related Issue

Fixes #43403

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py`: Added defensive normalization before wrapping — if a memory-provider schema has `inputSchema` but no `parameters`, convert it before wrapping into the OpenAI function-call format
- `tests/run_agent/test_memory_provider_init.py`: Added `McpSchemaProvider` test fixture and `test_mcp_input_schema_normalized_to_parameters` regression test verifying the normalization

## How to Test

1. Run `pytest tests/run_agent/test_memory_provider_init.py -v` — all 4 tests should pass
2. The new test `test_mcp_input_schema_normalized_to_parameters` creates a mock memory provider that returns MCP-format schemas and verifies they are normalized to OpenAI format after AIAgent init

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/agent_init.py` (memory provider tool wrapping site, line 1215-1223)
- Blast radius: LOW — only affects memory-provider tool schemas with MCP format; existing providers using OpenAI format are unaffected (guard: `if "inputSchema" in _schema and "parameters" not in _schema`)
- Related patterns: MCP → OpenAI schema conversion already exists in `tools/mcp_tool.py:_normalize_mcp_input_schema` and `_build_tool_schema`; this fix applies the same key-renaming at the memory-provider wrapping boundary
