### PR TITLE
fix(cli): respect user choice when declining /v1 suffix (#43408)

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -757,6 +757,7 @@ def _model_flow_custom(config):
         h in _url_lower
         for h in ("localhost", "127.0.0.1", "0.0.0.0", ":11434", ":8080", ":5000")
     )
+    _user_declined_v1 = False
     if _looks_local and not _url_lower.endswith("/v1"):
         print()
         print(f"  Hint: Did you mean to add /v1 at the end?")
@@ -771,19 +772,29 @@ def _model_flow_custom(config):
             if base_url:
                 base_url = effective_url
             print(f"  Updated URL: {effective_url}")
+        else:
+            _user_declined_v1 = True
         print()
 
     from hermes_cli.models import probe_api_models
 
     probe = probe_api_models(effective_key, effective_url)
     if probe.get("used_fallback") and probe.get("resolved_base_url"):
-        print(
-            f"Warning: endpoint verification worked at {probe['resolved_base_url']}/models, "
-            f"not the exact URL you entered. Saving the working base URL instead."
-        )
-        effective_url = probe["resolved_base_url"]
-        if base_url:
-            base_url = effective_url
+        if _user_declined_v1:
+            # User explicitly chose not to add /v1; respect that decision
+            # even if the probe found a working endpoint at /v1.
+            print(
+                f"Note: endpoint verification found a working endpoint at "
+                f"{probe['resolved_base_url']}/models, but keeping your chosen URL."
+            )
+        else:
+            print(
+                f"Warning: endpoint verification worked at {probe['resolved_base_url']}/models, "
+                f"not the exact URL you entered. Saving the working base URL instead."
+            )
+            effective_url = probe["resolved_base_url"]
+            if base_url:
+                base_url = effective_url
     elif probe.get("models") is not None:
         print(
             f"Verified endpoint via {probe.get('probed_url')} "


### PR DESCRIPTION
Fixes #43408. When the user declines adding /v1 to their custom endpoint URL during hermes setup, the setup wizard now respects that choice. Previously, even after answering 'n' to the /v1 prompt, the endpoint verification probe would override the user's URL with the /v1 variant if it worked. This fix tracks when the user explicitly declined /v1 and skips the fallback URL override in that case.