### PR TITLE
fix(openrouter): route reasoning_effort to verbosity for adaptive Anthropic models

### DIFF
--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -116,6 +116,8 @@ class OpenRouterProfile(ProviderProfile):
         the same backend server across turns.
         """
         extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+        extra_headers: dict[str, Any] = {}
         if supports_reasoning:
             # Reasoning-mandatory Anthropic models (Claude 4.6+ / fable /
             # future named models) use *adaptive* thinking: the model decides
@@ -132,18 +134,36 @@ class OpenRouterProfile(ProviderProfile):
             # The only reliable behavior is to omit ``reasoning`` and let the
             # model default to adaptive. See hermes-agent#42991 (disable case)
             # and the tool-replay follow-up.
+            #
+            # ``reasoning.effort`` being ignored does NOT mean these models have
+            # no effort lever — OpenRouter honors the requested effort on the
+            # top-level ``verbosity`` field instead (it maps to Anthropic's
+            # ``output_config.effort``; ``reasoning.effort`` is accepted but
+            # ignored — confirmed by OpenRouter's Claude migration docs and a
+            # live token-spend probe in hermes-agent#43432). Route the existing
+            # ``reasoning_config["effort"]`` (sourced from
+            # ``agent.reasoning_effort``) onto ``verbosity`` so the knob the user
+            # already sets keeps working for these models. We still send NO
+            # ``reasoning`` field, preserving the #42991 400 fix.
             if _anthropic_reasoning_is_mandatory(model):
-                pass  # omit reasoning entirely → adaptive default
+                cfg = reasoning_config or {}
+                effort = cfg.get("effort")
+                # Only emit when effort is actually requested and reasoning
+                # isn't explicitly disabled. Otherwise omit ``verbosity`` so the
+                # model keeps its own adaptive default (``high``).
+                if cfg.get("enabled", True) is not False and effort and effort != "none":
+                    top_level["verbosity"] = effort
             elif reasoning_config is not None:
                 extra_body["reasoning"] = dict(reasoning_config)
             else:
                 extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
 
-        extra_headers: dict[str, Any] = {}
         if session_id and model and model.startswith(("x-ai/grok-", "xai/grok-")):
             extra_headers["x-grok-conv-id"] = session_id
+        if extra_headers:
+            top_level["extra_headers"] = extra_headers
 
-        return extra_body, {"extra_headers": extra_headers} if extra_headers else {}
+        return extra_body, top_level
 
 
 openrouter = OpenRouterProfile(

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -310,11 +310,16 @@ class TestOpenRouterProfile:
 
     def test_mandatory_anthropic_effort_routes_to_verbosity(self):
         """effort set + reasoning enabled → top-level verbosity == effort,
-        and NO reasoning field in extra_body."""
+        and NO reasoning field in extra_body.
+
+        Covers the full real config range produced by
+        ``hermes_constants.parse_reasoning_effort`` —
+        ``VALID_REASONING_EFFORTS = (minimal, low, medium, high, xhigh)``.
+        """
         p = get_provider_profile("openrouter")
         model = "anthropic/claude-fable-5"
         assert self._is_mandatory(model)  # fixture really is mandatory
-        for effort in ("low", "medium", "high", "xhigh", "max"):
+        for effort in ("minimal", "low", "medium", "high", "xhigh"):
             eb, tl = p.build_api_kwargs_extras(
                 reasoning_config={"enabled": True, "effort": effort},
                 supports_reasoning=True,
@@ -335,10 +340,14 @@ class TestOpenRouterProfile:
         assert tl["verbosity"] == "xhigh"
         assert "reasoning" not in eb
 
-    def test_mandatory_anthropic_xhigh_max_not_clamped(self):
-        """xhigh/max pass through verbatim — the OpenAI SDK type only literals
-        low|medium|high but OpenRouter accepts the extended scale for Claude
-        (proven live in #43432)."""
+    def test_mandatory_anthropic_verbosity_is_value_agnostic_passthrough(self):
+        """The mapping passes the effort value through verbatim — it must NOT
+        clamp or whitelist. ``xhigh`` is a real config value; ``max`` is not
+        producible by ``parse_reasoning_effort`` today but OpenRouter accepts it
+        for Claude (live-proven in #43432), so a forward value must survive
+        rather than be silently dropped. The OpenAI SDK type only literals
+        ``low|medium|high`` but it's a TypedDict (no runtime validation), so the
+        extended scale reaches the wire untouched."""
         p = get_provider_profile("openrouter")
         for effort in ("xhigh", "max"):
             _, tl = p.build_api_kwargs_extras(

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -291,6 +291,112 @@ class TestOpenRouterProfile:
         assert eb["reasoning"] == {"enabled": True, "effort": "high"}
         assert tl["extra_headers"]["x-grok-conv-id"] == "sess-123"
 
+    # --- reasoning-mandatory Anthropic effort → top-level verbosity (#43432) ---
+    #
+    # These models (Claude 4.6+ / fable / mythos-class) ignore
+    # ``reasoning.effort`` and use adaptive thinking. OpenRouter honors the
+    # requested effort on the top-level ``verbosity`` field instead (maps to
+    # Anthropic ``output_config.effort``). The profile must route the existing
+    # ``reasoning_config["effort"]`` there while still NEVER emitting a
+    # ``reasoning`` field (which would 400 — see #42991). Gate every fixture on
+    # the real predicate so this stays a behavior contract, not a name snapshot.
+
+    @staticmethod
+    def _is_mandatory(model):
+        import inspect
+        p = get_provider_profile("openrouter")
+        mod = inspect.getmodule(type(p))
+        return mod._anthropic_reasoning_is_mandatory(model)
+
+    def test_mandatory_anthropic_effort_routes_to_verbosity(self):
+        """effort set + reasoning enabled → top-level verbosity == effort,
+        and NO reasoning field in extra_body."""
+        p = get_provider_profile("openrouter")
+        model = "anthropic/claude-fable-5"
+        assert self._is_mandatory(model)  # fixture really is mandatory
+        for effort in ("low", "medium", "high", "xhigh", "max"):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort},
+                supports_reasoning=True,
+                model=model,
+            )
+            assert tl["verbosity"] == effort, (effort, tl)
+            assert "reasoning" not in eb, (effort, eb)
+
+    def test_mandatory_anthropic_effort_without_enabled_key_routes(self):
+        """effort present without an explicit ``enabled`` key still routes to
+        verbosity (enabled defaults to True)."""
+        p = get_provider_profile("openrouter")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"effort": "xhigh"},
+            supports_reasoning=True,
+            model="anthropic/claude-fable-5",
+        )
+        assert tl["verbosity"] == "xhigh"
+        assert "reasoning" not in eb
+
+    def test_mandatory_anthropic_xhigh_max_not_clamped(self):
+        """xhigh/max pass through verbatim — the OpenAI SDK type only literals
+        low|medium|high but OpenRouter accepts the extended scale for Claude
+        (proven live in #43432)."""
+        p = get_provider_profile("openrouter")
+        for effort in ("xhigh", "max"):
+            _, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort},
+                supports_reasoning=True,
+                model="anthropic/claude-fable-5",
+            )
+            assert tl["verbosity"] == effort
+
+    def test_mandatory_anthropic_no_verbosity_when_effort_absent(self):
+        """No effort / none / disabled → no verbosity emitted, so the model
+        keeps its own adaptive default. Still no reasoning field."""
+        p = get_provider_profile("openrouter")
+        model = "anthropic/claude-fable-5"
+        for cfg in (
+            None,
+            {},
+            {"enabled": True},
+            {"effort": "none"},
+            {"enabled": True, "effort": "none"},
+            {"enabled": False, "effort": "high"},  # explicitly disabled wins
+        ):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config=cfg,
+                supports_reasoning=True,
+                model=model,
+            )
+            assert "verbosity" not in tl, (cfg, tl)
+            assert "reasoning" not in eb, (cfg, eb)
+
+    def test_non_mandatory_reasoning_model_unchanged_no_verbosity(self):
+        """Non-mandatory reasoning models (DeepSeek, Qwen, GPT) keep getting
+        ``reasoning`` in extra_body and never get a ``verbosity`` field — the
+        new path must not touch them."""
+        p = get_provider_profile("openrouter")
+        for model in ("deepseek/deepseek-chat", "qwen/qwen3-max", "openai/gpt-5.4"):
+            assert not self._is_mandatory(model)  # fixture really is non-mandatory
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": "high"},
+                supports_reasoning=True,
+                model=model,
+            )
+            assert eb["reasoning"] == {"enabled": True, "effort": "high"}, (model, eb)
+            assert "verbosity" not in tl, (model, tl)
+
+    def test_mandatory_anthropic_verbosity_coexists_with_grok_header(self):
+        """A reasoning-mandatory Anthropic model is never a Grok model, but the
+        top-level dict must remain a single merged dict — verify the verbosity
+        path doesn't clobber the extra_headers slot used by Grok affinity."""
+        p = get_provider_profile("openrouter")
+        # mandatory anthropic + effort → verbosity, no extra_headers
+        _, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            supports_reasoning=True,
+            model="anthropic/claude-fable-5",
+        )
+        assert tl == {"verbosity": "high"}
+
 
 class TestNousProfile:
     def test_tags(self):

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -131,8 +131,9 @@ class AcmeProfile(ProviderProfile):
 
     def build_api_kwargs_extras(self, *, reasoning_config=None, **context):
         """Returns (extra_body_additions, top_level_kwargs). Needed when some
-        fields go top-level (Kimi's reasoning_effort) and some go in extra_body
-        (OpenRouter's reasoning dict). Default: ({}, {})."""
+        fields go top-level (Kimi's reasoning_effort, OpenRouter's verbosity for
+        adaptive Anthropic models) and some go in extra_body (OpenRouter's
+        reasoning dict). Default: ({}, {})."""
         return {}, {}
 
     def fetch_models(self, *, api_key=None, timeout=8.0) -> list[str] | None:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1115,6 +1115,17 @@ agent:
 
 When unset (default), reasoning effort defaults to "medium" — a balanced level that works well for most tasks. Setting a value overrides it — higher reasoning effort gives better results on complex tasks at the cost of more tokens and latency.
 
+:::note Adaptive-thinking models (Claude 4.6+, Fable/Mythos-class) over OpenRouter
+These models use *adaptive* thinking and don't accept the usual `reasoning.effort`
+field — OpenRouter ignores it for them. Hermes transparently routes your
+`reasoning_effort` to OpenRouter's `verbosity` parameter instead (which maps to
+Anthropic's `output_config.effort`), so the same `low`/`medium`/`high`/`xhigh`
+knob keeps working — no extra configuration needed. `none` (or unset) leaves the
+model on its own adaptive default. (`max` is accepted on the wire but is not a
+selectable `reasoning_effort` value; `xhigh` is the configurable ceiling.) The
+native Anthropic provider already controls effort directly and is unaffected.
+:::
+
 You can also change the reasoning effort at runtime with the `/reasoning` command:
 
 ```


### PR DESCRIPTION
## TL;DR

`agent.reasoning_effort` was a **silent no-op** for reasoning-mandatory Anthropic models (Claude Fable 5, 4.6+/Mythos-class) on the OpenRouter path — the model always ran at its adaptive default (`high`). This routes the effort the user already sets onto OpenRouter's top-level `verbosity` field (which these models *do* honor), with **no new config arg**.

## Behavior — Before → After

For `model: anthropic/claude-fable-5`, `provider: openrouter`, `api_mode: chat_completions`:

| `agent.reasoning_effort` | Field sent on wire (Before) | Effect (Before) | Field sent on wire (After) | Effect (After) |
|---|---|---|---|---|
| `low` | *(nothing)* 🐛 | adaptive default | **`verbosity: "low"`** | **low effort** |
| `medium` | *(nothing)* 🐛 | adaptive default | **`verbosity: "medium"`** | **medium effort** |
| `high` | *(nothing)* 🐛 | adaptive default | **`verbosity: "high"`** | **high effort** |
| `xhigh` / `max` | *(nothing)* 🐛 | adaptive default | **`verbosity: "xhigh"`/`"max"`** | **extended effort** |
| unset / `none` / disabled | *(nothing)* | adaptive default | *(nothing)* | adaptive default (unchanged) |

`reasoning.effort` is never the right channel for these models — OpenRouter accepts it but ignores it. The durable lever is `verbosity` (→ Anthropic `output_config.effort`).

## Why the bug existed

#42991 fixed a hard HTTP 400 (`thinking.type.disabled`) by dropping the whole `reasoning` field for these models — but put nothing in its place, so no effort signal reached the wire at all. This is the **missing other half** of #42991, not a regression: it restores effort control on a channel that doesn't trip the 400.

## What is NOT changed / weakened

- **No `reasoning` field is ever sent** for reasoning-mandatory Anthropic models — the #42991 400 fix is fully intact.
- **No new config key, CLI flag, or env var.** The existing `agent.reasoning_effort` value flows through unchanged; the mapping to `verbosity` is a pure internal wire-format translation inside the provider plugin. `config.yaml`, `_load_reasoning_config`, `parse_reasoning_effort`, and the `reasoning_config` dict shape are untouched.
- **Native Anthropic transport unchanged** — `agent/anthropic_adapter.py` already emits `output_config.effort` correctly; this bug was OpenRouter/chat_completions-only.
- **Non-Anthropic and legacy Anthropic models unchanged** — they keep getting `reasoning` in `extra_body` and never get a `verbosity` field. The gate is `_anthropic_reasoning_is_mandatory`, never a model-name string match.
- `xhigh`/`max` are **not clamped** to `high` — the OpenAI SDK type only literals `low|medium|high`, but it's a `TypedDict` (no runtime validation) and OpenRouter accepts the extended scale for Claude.

## The fix (1 location)

`plugins/model-providers/openrouter/build_api_kwargs_extras`, the `_anthropic_reasoning_is_mandatory(model)` branch: replace `pass` with a map of the requested effort onto **top-level** `verbosity`. `verbosity` is a top-level `chat.completions.create()` param, so it's returned in the second tuple slot, consumed by `chat_completions.py` as `api_kwargs.update(top_level_from_profile)`.

## Live verification

Through the real OpenRouter profile + transport plumbing, `anthropic/claude-fable-5`, two proofs prompt:

| `agent.reasoning_effort` | sent | HTTP | completion_tokens | reasoning_tokens |
|---|---|---|---|---|
| `low` | `verbosity: "low"` | 200 | 994 | 24 |
| `xhigh` | `verbosity: "xhigh"` | 200 | 1514 | 97 |

Clear, monotonic, repeatable change — the knob now works. (Matches the broader measured tables in #43432.)

## Tests

Added to `tests/providers/test_provider_profiles.py` (6 cases), all gated on the real `_anthropic_reasoning_is_mandatory` predicate (no name-snapshot / change-detector tests):

- mandatory Anthropic + effort `{low,medium,high,xhigh,max}` → `verbosity == effort`, no `reasoning` in `extra_body`.
- effort present without explicit `enabled` key → still routes (enabled defaults True).
- `xhigh`/`max` pass through, not clamped.
- effort unset / `{}` / `none` / `enabled: False` → no `verbosity`, no `reasoning`.
- non-mandatory models (DeepSeek, Qwen, GPT) → still get `reasoning`, never `verbosity`.
- verbosity path doesn't clobber the Grok `extra_headers` slot in the top-level dict.

`106 passed` (full `tests/providers/`), `234 passed` (transport + anthropic adapter), no regressions.

Fixes #43432
