### PR TITLE
fix(cli): use skin agent_name in resume display instead of hardcoded 'Hermes'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ apps/desktop/demo/
 # PR body is the archive. See the hermes-agent-dev skill's
 # pr-infographic-workflow reference (storage rule + lapse #8 / #COMMIT-1).
 infographic/
+.codegraph/

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -641,11 +641,13 @@ class CLIAgentSetupMixin:
             _session_label_c = _skin.get_color("session_label", "#DAA520")
             _session_border_c = _skin.get_color("session_border", "#8B8682")
             _assistant_label_c = _skin.get_color("ui_ok", "#8FBC8F")
+            _agent_label = _skin.get_branding("agent_name") or "Hermes"
         except Exception:
             _history_text_c = "#FFF8DC"
             _session_label_c = "#DAA520"
             _session_border_c = "#8B8682"
             _assistant_label_c = "#8FBC8F"
+            _agent_label = "Hermes"
 
         lines = Text()
         if skipped:
@@ -664,13 +666,13 @@ class CLIAgentSetupMixin:
                     lines.append(f"         {ml}\n", style="dim")
             elif role == "assistant_last":
                 # Last assistant response shown in full, non-dim
-                lines.append("  ◆ Hermes: ", style=f"bold {_assistant_label_c}")
+                lines.append(f"  ◆ {_agent_label}: ", style=f"bold {_assistant_label_c}")
                 msg_lines = text.splitlines()
                 lines.append(msg_lines[0] + "\n", style="")
                 for ml in msg_lines[1:]:
                     lines.append(f"            {ml}\n", style="")
             else:
-                lines.append("  ◆ Hermes: ", style=f"dim bold {_assistant_label_c}")
+                lines.append(f"  ◆ {_agent_label}: ", style=f"dim bold {_assistant_label_c}")
                 msg_lines = text.splitlines()
                 lines.append(msg_lines[0] + "\n", style="dim")
                 for ml in msg_lines[1:]:

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -132,7 +132,7 @@ class TestDisplayResumedHistory:
         output = self._capture_display(cli)
 
         assert "You:" in output
-        assert "Hermes:" in output
+        assert "◆" in output  # assistant label with skin agent_name
         assert "What is Python?" in output
         assert "Python is a high-level programming language." in output
         assert "How do I install it?" in output
@@ -333,7 +333,7 @@ class TestDisplayResumedHistory:
 
         # The assistant entry should be skipped, only the user message shown
         assert "You:" in output
-        assert "Hermes:" not in output
+        assert "◆" not in output  # no assistant entries to show
 
     def test_only_system_messages_no_output(self):
         cli = _make_cli()

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -129,10 +129,15 @@ class TestDisplayResumedHistory:
     def test_simple_history_shows_user_and_assistant(self):
         cli = _make_cli()
         cli.conversation_history = _simple_history()
-        output = self._capture_display(cli)
+
+        skin = MagicMock()
+        skin.get_branding.return_value = "Test Agent"
+        skin.get_color.side_effect = lambda _name, default: default
+        with patch("hermes_cli.skin_engine.get_active_skin", return_value=skin):
+            output = self._capture_display(cli)
 
         assert "You:" in output
-        assert "◆" in output  # assistant label with skin agent_name
+        assert output.count("◆ Test Agent:") == 2
         assert "What is Python?" in output
         assert "Python is a high-level programming language." in output
         assert "How do I install it?" in output


### PR DESCRIPTION
The resume/replay history view in `_display_resumed_history` showed
`◆ Hermes:` for assistant messages, ignoring the active skin's
`agent_name` branding setting.

## What changed

- Read `agent_name` from the active skin via `get_branding("agent_name")`
- Fall back to `"Hermes"` when skin loading fails
- Update tests to check for the `◆` prefix instead of a hardcoded name

## How to test

1. Create a skin with a custom `agent_name` (or use an existing one)
2. Start a conversation, then exit
3. Resume with `hermes --continue` and verify the assistant label uses
   the skin's agent_name
4. The fallback can be tested by temporarily breaking the skin config

## Platforms tested

- macOS (local)

## Files

- `hermes_cli/cli_agent_setup_mixin.py` — add `_agent_label`, use in labels
- `tests/cli/test_resume_display.py` — decouple assertions from hardcoded name
