### PR TITLE
LINE adapter: add observation mode + mention gating

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -316,6 +316,24 @@ class GatewayAuthorizationMixin:
 
         user_id = source.user_id
 
+        # LINE already applies its effective user/group/room policy at adapter
+        # intake. Reuse that profile-aware live adapter state here so the same
+        # configured chat allowlist also authorizes the shared, user-less source
+        # used by text-only observation mode.
+        if (
+            getattr(source.platform, "value", "") == "line"
+            and source.chat_type in {"group", "room"}
+            and source.chat_id
+        ):
+            adapter = self._authorization_adapter(source.platform, source.profile)
+            if adapter is not None:
+                allowed_attr = (
+                    "allowed_rooms" if source.chat_type == "room" else "allowed_groups"
+                )
+                allowed_chats = getattr(adapter, allowed_attr, set()) or set()
+                if getattr(adapter, "allow_all", False) or source.chat_id in allowed_chats:
+                    return True
+
         # Telegram (and similar) authorize entire group/forum/channel chats
         # by chat ID via TELEGRAM_GROUP_ALLOWED_CHATS / QQ_GROUP_ALLOWED_USERS.
         # That allowlist is chat-scoped, so it must work even when

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1227,6 +1227,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_chats"] = platform_cfg["allowed_chats"]
                 if plat == Platform.TELEGRAM and "group_allowed_chats" in platform_cfg:
                     bridged["group_allowed_chats"] = platform_cfg["group_allowed_chats"]
+                if plat.value == "line":
+                    for key in ("allowed_groups", "allowed_rooms"):
+                        if key in platform_cfg:
+                            bridged[key] = platform_cfg[key]
                 if plat == Platform.TELEGRAM and "allowed_topics" in platform_cfg:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:
@@ -1235,7 +1239,9 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:
                     bridged["exclusive_bot_mentions"] = platform_cfg["exclusive_bot_mentions"]
-                if plat == Platform.TELEGRAM and "observe_unmentioned_group_messages" in platform_cfg:
+                if (
+                    plat == Platform.TELEGRAM or plat.value == "line"
+                ) and "observe_unmentioned_group_messages" in platform_cfg:
                     bridged["observe_unmentioned_group_messages"] = platform_cfg["observe_unmentioned_group_messages"]
                 if "dm_policy" in platform_cfg:
                     bridged["dm_policy"] = platform_cfg["dm_policy"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -800,22 +800,30 @@ def _build_replay_entry(
 
 
 _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER = "observed Telegram group context"
+_LINE_OBSERVED_CONTEXT_PROMPT_MARKER = "observed LINE group context"
+_OBSERVED_CONTEXT_PROMPT_MARKERS = (
+    _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER,
+    _LINE_OBSERVED_CONTEXT_PROMPT_MARKER,
+)
 _OBSERVED_GROUP_CONTEXT_HEADER = "[Observed Telegram group context - context only, not requests]"
 _CURRENT_ADDRESSED_MESSAGE_HEADER = "[Current addressed message - answer only this unless it explicitly asks you to use the observed context]"
 
 
 def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool:
-    """Return True for Telegram group turns that may include observed chatter.
+    """Return True for group turns that may include persisted observed chatter.
 
-    Telegram's observe-unmentioned mode persists skipped group chatter so a
-    later @mention can see it. Those rows must not replay as ordinary user
+    Telegram and LINE observation modes persist skipped group text so a later
+    addressed turn can see it. Those rows must not replay as ordinary user
     turns: a weak wake word like ``@bot cambio`` should not make the model treat
-    old unmentioned chatter as pending work. The Telegram adapter marks these
-    turns with a channel prompt; this helper keeps the run-path check explicit
-    and unit-testable.
+    old unmentioned chatter as pending work. Each adapter marks these turns in
+    its channel prompt; this helper keeps the run-path check explicit and
+    unit-testable.
     """
 
-    return bool(channel_prompt and _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER in channel_prompt)
+    return bool(
+        channel_prompt
+        and any(marker in channel_prompt for marker in _OBSERVED_CONTEXT_PROMPT_MARKERS)
+    )
 
 
 def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -75,6 +75,7 @@ import tempfile
 import time
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import quote as _urlquote
@@ -736,6 +737,8 @@ class LineAdapter(BasePlatformAdapter):
         # button per chat at a time. Postback cache request_id keyed by chat_id.
         self._pending_buttons: Dict[str, str] = {}
 
+        self._mention_patterns = self._compile_mention_patterns()
+
     # ------------------------------------------------------------------
     # Connection lifecycle
     # ------------------------------------------------------------------
@@ -856,6 +859,193 @@ class LineAdapter(BasePlatformAdapter):
             self._lock_key = None
 
     # ------------------------------------------------------------------
+    # Mention gating + text-only observation
+    # ------------------------------------------------------------------
+
+    def _line_bool_setting(self, name: str) -> bool:
+        value = self.config.extra.get(name, False)
+        if isinstance(value, str):
+            return value.strip().lower() in {"true", "1", "yes", "on"}
+        return bool(value)
+
+    def _line_require_mention(self) -> bool:
+        return self._line_bool_setting("require_mention")
+
+    def _line_observe_mode_enabled(self) -> bool:
+        return self._line_require_mention() and self._line_bool_setting(
+            "observe_unmentioned_group_messages"
+        )
+
+    def _line_free_response_channels(self) -> Set[str]:
+        raw = self.config.extra.get("free_response_channels", [])
+        if isinstance(raw, str):
+            return {part.strip() for part in raw.split(",") if part.strip()}
+        if isinstance(raw, (list, tuple, set)):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return set()
+
+    def _compile_mention_patterns(self) -> List[re.Pattern]:
+        raw = self.config.extra.get("mention_patterns", [])
+        patterns = [raw] if isinstance(raw, str) else raw
+        if not isinstance(patterns, (list, tuple)):
+            return []
+        compiled = []
+        for pattern in patterns:
+            if not isinstance(pattern, str) or not pattern.strip():
+                continue
+            try:
+                compiled.append(re.compile(pattern, re.IGNORECASE))
+            except re.error:
+                logger.warning("LINE: ignoring invalid mention pattern %r", pattern)
+        return compiled
+
+    @staticmethod
+    def _is_line_group_chat(source: Dict[str, Any]) -> bool:
+        return source.get("type") in {"group", "room"}
+
+    @staticmethod
+    def _line_message_mentions_bot(event: Dict[str, Any]) -> bool:
+        message = event.get("message") or {}
+        mention = message.get("mention") or {}
+        mentionees = mention.get("mentionees") or []
+        return any(
+            isinstance(item, dict)
+            and (item.get("isSelf") or item.get("type") == "all")
+            for item in mentionees
+        )
+
+    def _line_message_matches_mention_patterns(self, text: str) -> bool:
+        return bool(text) and any(pattern.search(text) for pattern in self._mention_patterns)
+
+    def _line_chat_is_explicitly_allowed(self, source: Dict[str, Any]) -> bool:
+        chat_id, chat_type = _resolve_chat(source)
+        allowed = self.allowed_rooms if chat_type == "room" else self.allowed_groups
+        return bool(chat_id and chat_id in allowed)
+
+    def _should_process_line_message(self, event: Dict[str, Any]) -> bool:
+        source = event.get("source") or {}
+        if not self._is_line_group_chat(source):
+            return True
+        chat_id, _ = _resolve_chat(source)
+        if chat_id in self._line_free_response_channels():
+            return True
+        if not self._line_require_mention():
+            return True
+        if self._line_message_mentions_bot(event):
+            return True
+        message = event.get("message") or {}
+        text = message.get("text", "") if message.get("type") == "text" else ""
+        return self._line_message_matches_mention_patterns(text)
+
+    def _should_clean_line_trigger(self, event: Dict[str, Any]) -> bool:
+        source = event.get("source") or {}
+        if not self._is_line_group_chat(source) or not self._line_require_mention():
+            return False
+        if self._line_message_mentions_bot(event):
+            return False
+        chat_id, _ = _resolve_chat(source)
+        if chat_id in self._line_free_response_channels():
+            return False
+        message = event.get("message") or {}
+        text = message.get("text", "") if message.get("type") == "text" else ""
+        return self._line_message_matches_mention_patterns(text)
+
+    def _should_observe_unmentioned_line_group_message(
+        self, event: Dict[str, Any]
+    ) -> bool:
+        source = event.get("source") or {}
+        message = event.get("message") or {}
+        if not self._line_observe_mode_enabled():
+            return False
+        if not self._is_line_group_chat(source) or message.get("type") != "text":
+            return False
+        chat_id, _ = _resolve_chat(source)
+        if chat_id in self._line_free_response_channels():
+            return False
+        if self._line_message_mentions_bot(event):
+            return False
+        if self._line_message_matches_mention_patterns(message.get("text", "")):
+            return False
+        return self._line_chat_is_explicitly_allowed(source)
+
+    @staticmethod
+    def _line_group_observe_shared_source(source):
+        import dataclasses
+
+        return dataclasses.replace(
+            source, user_id=None, user_name=None, user_id_alt=None
+        )
+
+    @staticmethod
+    def _line_group_observe_attributed_text(event: MessageEvent) -> str:
+        user_id = event.source.user_id or "unknown"
+        sender = event.source.user_name or user_id
+        return f"[{sender}|{user_id}]\n{event.text or ''}"
+
+    @staticmethod
+    def _line_group_observe_channel_prompt() -> str:
+        return (
+            "You are handling a LINE group chat message.\n"
+            "Treat only the current new message as addressed to you. Observed "
+            "group text is context only; do not answer it as separate requests.\n"
+            "(observed LINE group context)"
+        )
+
+    def _apply_line_group_observe_attribution(self, event: MessageEvent) -> MessageEvent:
+        source = event.source
+        raw_source = {
+            "type": source.chat_type,
+            "groupId": source.chat_id if source.chat_type == "group" else None,
+            "roomId": source.chat_id if source.chat_type == "room" else None,
+        }
+        if not self._line_observe_mode_enabled():
+            return event
+        if not self._is_line_group_chat(raw_source):
+            return event
+        if source.chat_id in self._line_free_response_channels():
+            return event
+        if not self._line_chat_is_explicitly_allowed(raw_source):
+            return event
+
+        import dataclasses
+
+        prompt = self._line_group_observe_channel_prompt()
+        channel_prompt = (
+            f"{event.channel_prompt}\n\n{prompt}" if event.channel_prompt else prompt
+        )
+        changes = {
+            "source": self._line_group_observe_shared_source(source),
+            "channel_prompt": channel_prompt,
+        }
+        if not event.is_command():
+            changes["text"] = self._line_group_observe_attributed_text(event)
+        return dataclasses.replace(event, **changes)
+
+    def _clean_line_bot_trigger_text(self, text: str) -> str:
+        for pattern in self._mention_patterns:
+            text = pattern.sub("", text)
+        return text.strip()
+
+    def _observe_unmentioned_line_group_message(self, event: MessageEvent) -> None:
+        store = getattr(self, "_session_store", None)
+        if not store or not event.text:
+            return
+        try:
+            shared_source = self._line_group_observe_shared_source(event.source)
+            session = store.get_or_create_session(shared_source)
+            entry = {
+                "role": "user",
+                "content": self._line_group_observe_attributed_text(event),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "observed": True,
+            }
+            if event.message_id:
+                entry["message_id"] = str(event.message_id)
+            store.append_to_transcript(session.session_id, entry)
+        except Exception as exc:
+            logger.warning("LINE: failed to observe group message: %s", exc)
+
+    # ------------------------------------------------------------------
     # Webhook handlers
     # ------------------------------------------------------------------
 
@@ -938,7 +1128,26 @@ class LineAdapter(BasePlatformAdapter):
         chat_id, chat_type = _resolve_chat(source)
         user_id = source.get("userId", "") or chat_id
 
-        # Stash the reply token for outbound use.
+        if not self._should_process_line_message(event):
+            if self._should_observe_unmentioned_line_group_message(event):
+                source_obj = self.build_source(
+                    chat_id=chat_id,
+                    chat_type=chat_type,
+                    user_id=user_id,
+                    user_name=user_id,
+                    chat_name=chat_id,
+                )
+                self._observe_unmentioned_line_group_message(MessageEvent(
+                    text=msg.get("text", "") or "",
+                    source=source_obj,
+                    raw_message=event,
+                    message_id=message_id,
+                ))
+            return
+
+        # Only addressed messages may provide the reply token for an outbound
+        # response. Ambient observed traffic must not overwrite the token of a
+        # concurrently running addressed turn in the same chat.
         if chat_id and reply_token:
             self._reply_tokens[chat_id] = (
                 reply_token,
@@ -990,6 +1199,10 @@ class LineAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
         )
+
+        if self._should_clean_line_trigger(event):
+            event_obj.text = self._clean_line_bot_trigger_text(event_obj.text)
+        event_obj = self._apply_line_group_observe_attribution(event_obj)
 
         await self.handle_message(event_obj)
 

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -674,3 +674,339 @@ class TestMessageTypeMapping:
     def test_unknown_type_falls_back_to_text(self):
         MessageType = _line.MessageType
         assert _line._LINE_MESSAGE_TYPES.get("flex", MessageType.TEXT) == MessageType.TEXT
+
+
+# ---------------------------------------------------------------------------
+# 10. Mention gating + text-only observation mode
+# ---------------------------------------------------------------------------
+
+_LINE_BEHAVIOR_ENV = (
+    "LINE_ALLOWED_USERS",
+    "LINE_ALLOWED_GROUPS",
+    "LINE_ALLOWED_ROOMS",
+    "LINE_ALLOW_ALL_USERS",
+)
+
+
+def _clear_line_behavior_env(monkeypatch):
+    for name in _LINE_BEHAVIOR_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _message_event(
+    text: str = "ambient context",
+    *,
+    chat_id: str = "C1",
+    user_id: str = "U1",
+    mentioned: bool = False,
+    message_type: str = "text",
+    event_id: str = "evt-1",
+):
+    message = {"id": f"msg-{event_id}", "type": message_type}
+    if message_type == "text":
+        message["text"] = text
+    if mentioned:
+        message["mention"] = {"mentionees": [{"isSelf": True, "type": "user"}]}
+    return {
+        "type": "message",
+        "webhookEventId": event_id,
+        "replyToken": f"reply-{event_id}",
+        "source": {"type": "group", "groupId": chat_id, "userId": user_id},
+        "message": message,
+    }
+
+
+def _observation_store():
+    store = MagicMock()
+    session = MagicMock()
+    session.session_id = "line-shared-session"
+    store.get_or_create_session.return_value = session
+    return store
+
+
+class TestLineObservationIntegration:
+
+    @pytest.mark.asyncio
+    async def test_yaml_group_allowlist_reaches_observation_auth_and_history(
+        self, tmp_path, monkeypatch
+    ):
+        _clear_line_behavior_env(monkeypatch)
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    line:\n"
+            "      enabled: true\n"
+            "      allowed_groups: [\"C1\"]\n"
+            "      require_mention: true\n"
+            "      observe_unmentioned_group_messages: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from gateway.config import Platform, load_gateway_config
+        from gateway.run import (
+            GatewayRunner,
+            _build_gateway_agent_history,
+            _wrap_current_message_with_observed_context,
+        )
+
+        config = load_gateway_config()
+        platform = Platform("line")
+        adapter = LineAdapter(config.platforms[platform])
+        store = _observation_store()
+        adapter.set_session_store(store)
+        dispatched = []
+
+        async def capture(event):
+            dispatched.append(event)
+
+        adapter.handle_message = capture
+        adapter._reply_tokens["C1"] = ("active-token", 9_999_999_999.0)
+
+        await adapter._dispatch_event(_message_event(event_id="ambient"))
+
+        assert adapter.allowed_groups == {"C1"}
+        assert dispatched == []
+        assert adapter._reply_tokens["C1"] == ("active-token", 9_999_999_999.0)
+        store.append_to_transcript.assert_called_once()
+        observed_entry = store.append_to_transcript.call_args.args[1]
+        assert observed_entry["observed"] is True
+        assert "ambient context" in observed_entry["content"]
+        assert "media_urls" not in observed_entry
+        shared_source = store.get_or_create_session.call_args.args[0]
+        assert shared_source.chat_id == "C1"
+        assert shared_source.user_id is None
+        assert shared_source.user_id_alt is None
+
+        await adapter._dispatch_event(
+            _message_event("@bot answer", mentioned=True, event_id="mention")
+        )
+
+        assert len(dispatched) == 1
+        addressed = dispatched[0]
+        assert addressed.source.chat_id == "C1"
+        assert addressed.source.user_id is None
+        assert "observed LINE group context" in addressed.channel_prompt
+
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = {platform: adapter}
+        runner._profile_adapters = {}
+        assert runner._is_user_authorized(addressed.source)
+
+        agent_history, observed_context = _build_gateway_agent_history(
+            [observed_entry], channel_prompt=addressed.channel_prompt
+        )
+        assert agent_history == []
+        assert "ambient context" in observed_context
+        wrapped = _wrap_current_message_with_observed_context(
+            addressed.text, observed_context
+        )
+        assert "ambient context" in wrapped
+        assert "@bot answer" in wrapped
+
+    @pytest.mark.parametrize(
+        ("chat_type", "chat_id", "allowlist_key"),
+        [("group", "C-secondary", "allowed_groups"),
+         ("room", "R-secondary", "allowed_rooms")],
+    )
+    def test_gateway_auth_uses_matching_profile_line_adapter(
+        self, monkeypatch, chat_type, chat_id, allowlist_key
+    ):
+        _clear_line_behavior_env(monkeypatch)
+        from gateway.config import Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        platform = Platform("line")
+        default_adapter = LineAdapter(PlatformConfig(enabled=True, extra={}))
+        secondary_adapter = LineAdapter(PlatformConfig(
+            enabled=True, extra={allowlist_key: [chat_id]}
+        ))
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = {platform: default_adapter}
+        runner._profile_adapters = {"coder": {platform: secondary_adapter}}
+        source = SessionSource(
+            platform=platform,
+            chat_id=chat_id,
+            chat_type=chat_type,
+            user_id=None,
+            profile="coder",
+        )
+
+        assert runner._is_user_authorized(source)
+        source.profile = None
+        assert not runner._is_user_authorized(source)
+
+    @pytest.mark.asyncio
+    async def test_disallowed_group_is_rejected_before_observation(self, monkeypatch):
+        _clear_line_behavior_env(monkeypatch)
+        from gateway.config import PlatformConfig
+
+        adapter = LineAdapter(PlatformConfig(enabled=True, extra={
+            "allowed_groups": ["C1"],
+            "require_mention": True,
+            "observe_unmentioned_group_messages": True,
+        }))
+        store = _observation_store()
+        adapter.set_session_store(store)
+        adapter.handle_message = AsyncMock()
+
+        await adapter._dispatch_event(
+            _message_event(chat_id="C2", event_id="disallowed")
+        )
+
+        store.append_to_transcript.assert_not_called()
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allow_all_does_not_enable_shared_observation(self, monkeypatch):
+        _clear_line_behavior_env(monkeypatch)
+        from gateway.config import PlatformConfig
+
+        adapter = LineAdapter(PlatformConfig(enabled=True, extra={
+            "allow_all_users": True,
+            "require_mention": True,
+            "observe_unmentioned_group_messages": True,
+        }))
+        store = _observation_store()
+        adapter.set_session_store(store)
+        adapter.handle_message = AsyncMock()
+
+        await adapter._dispatch_event(_message_event(event_id="allow-all"))
+
+        store.append_to_transcript.assert_not_called()
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unmentioned_media_is_not_downloaded_or_observed(self, monkeypatch):
+        _clear_line_behavior_env(monkeypatch)
+        from gateway.config import PlatformConfig
+
+        adapter = LineAdapter(PlatformConfig(enabled=True, extra={
+            "allowed_groups": ["C1"],
+            "require_mention": True,
+            "observe_unmentioned_group_messages": True,
+        }))
+        store = _observation_store()
+        adapter.set_session_store(store)
+        adapter._download_media = AsyncMock(return_value="/tmp/observed.jpg")
+        adapter.handle_message = AsyncMock()
+
+        await adapter._dispatch_event(
+            _message_event(message_type="image", event_id="image")
+        )
+
+        adapter._download_media.assert_not_awaited()
+        store.append_to_transcript.assert_not_called()
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dm_behavior_is_unchanged(self, monkeypatch):
+        _clear_line_behavior_env(monkeypatch)
+        from gateway.config import PlatformConfig
+
+        adapter = LineAdapter(PlatformConfig(enabled=True, extra={
+            "allowed_users": ["U1"],
+            "require_mention": True,
+            "observe_unmentioned_group_messages": True,
+        }))
+        adapter._client = MagicMock()
+        adapter._client.loading = AsyncMock()
+        dispatched = []
+
+        async def capture(event):
+            dispatched.append(event)
+
+        adapter.handle_message = capture
+        event = {
+            "type": "message",
+            "webhookEventId": "dm",
+            "source": {"type": "user", "userId": "U1"},
+            "message": {"id": "msg-dm", "type": "text", "text": "hello"},
+        }
+
+        await adapter._dispatch_event(event)
+
+        assert len(dispatched) == 1
+        assert dispatched[0].text == "hello"
+        assert dispatched[0].source.user_id == "U1"
+        assert dispatched[0].source.chat_type == "dm"
+        assert dispatched[0].channel_prompt is None
+
+
+class TestLineMentionCleaning:
+
+    @pytest.mark.parametrize(
+        "mention",
+        [None, {"mentionees": None}, {"mentionees": [None, "invalid"]}],
+    )
+    def test_malformed_mention_metadata_is_not_a_bot_mention(
+        self, monkeypatch, mention
+    ):
+        _clear_line_behavior_env(monkeypatch)
+        from gateway.config import PlatformConfig
+
+        adapter = LineAdapter(PlatformConfig(enabled=True, extra={}))
+        event = {"message": {"type": "text", "text": "hello", "mention": mention}}
+
+        assert not adapter._line_message_mentions_bot(event)
+
+    @pytest.mark.asyncio
+    async def test_native_mention_does_not_apply_regex_cleaning(self, monkeypatch):
+        _clear_line_behavior_env(monkeypatch)
+        from gateway.config import PlatformConfig
+
+        adapter = LineAdapter(PlatformConfig(enabled=True, extra={
+            "allowed_groups": ["C1"],
+            "require_mention": True,
+            "mention_patterns": ["bot"],
+        }))
+        dispatched = []
+
+        async def capture(event):
+            dispatched.append(event)
+
+        adapter.handle_message = capture
+        await adapter._dispatch_event(
+            _message_event("robot help", mentioned=True, event_id="native-mention")
+        )
+
+        assert len(dispatched) == 1
+        assert dispatched[0].text == "robot help"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("extra", "expected"),
+        [
+            ({"require_mention": True}, "please help"),
+            ({"require_mention": False}, "HeyBot please help"),
+            ({"require_mention": True, "free_response_channels": ["C1"]},
+             "HeyBot please help"),
+        ],
+    )
+    async def test_pattern_is_cleaned_only_when_it_wakes_the_bot(
+        self, monkeypatch, extra, expected
+    ):
+        _clear_line_behavior_env(monkeypatch)
+        from gateway.config import PlatformConfig
+
+        config_extra = {
+            "allowed_groups": ["C1"],
+            "mention_patterns": ["HeyBot"],
+            **extra,
+        }
+        adapter = LineAdapter(PlatformConfig(enabled=True, extra=config_extra))
+        dispatched = []
+
+        async def capture(event):
+            dispatched.append(event)
+
+        adapter.handle_message = capture
+        await adapter._dispatch_event(
+            _message_event("HeyBot please help", event_id=str(extra))
+        )
+
+        assert len(dispatched) == 1
+        assert dispatched[0].text == expected


### PR DESCRIPTION
## Summary

Adds mention-gated, text-only observation mode for LINE group and room chats.

When `require_mention` is enabled, unaddressed text from an explicitly allowed chat is stored as context-only history. A later native LINE mention or configured wake pattern can use that context without replaying the observed rows as pending user requests.

## What changed

- Uses the existing LINE chat allowlists as the single source of truth:
  - `allowed_groups` / `LINE_ALLOWED_GROUPS`
  - `allowed_rooms` / `LINE_ALLOWED_ROOMS`
- Applies the same effective allowlist at:
  - LINE webhook intake
  - observation eligibility
  - profile-aware gateway authorization for the shared chat source
- Supports native LINE `isSelf` / `@all` mention metadata and configured `mention_patterns`.
- Cleans a configured wake pattern only when that pattern is what wakes a require-mention chat. Native mentions, free-response chats, and `require_mention: false` keep the original text.
- Stores observation entries as text only. Unaddressed media is not downloaded, cached, stored, or replayed into a later turn.
- Keeps DM and addressed-media handling on their existing paths.
- Prevents ambient observed traffic from replacing the reply token of an addressed turn.
- Hardens malformed LINE mention metadata (`mention: null`, `mentionees: null`, and non-object mentionees).

## Configuration

Credentials remain in `~/.hermes/.env`:

```bash
LINE_CHANNEL_ACCESS_TOKEN=...
LINE_CHANNEL_SECRET=...
```

Example `config.yaml`:

```yaml
gateway:
  platforms:
    line:
      enabled: true
      allowed_groups:
        - Cxxxxxxxx
      require_mention: true
      observe_unmentioned_group_messages: true
      mention_patterns:
        - "(?i)\\bhermes\\b"
```

`allowed_groups` and `allowed_rooms` are chat-scoped: listing a chat authorizes messages from that chat. `allow_all_users` may allow ordinary addressed traffic, but it does **not** enable passive observation; observation still requires an explicit group or room entry.

## Behavior

1. An allowed group sends unmentioned text.
2. The LINE adapter stores it as an `observed=True` text transcript row under the shared chat source and does not invoke the agent.
3. A later native mention or configured wake pattern is dispatched under the same shared source.
4. Gateway authorization resolves the matching live LINE adapter for the current profile and checks its effective group/room allowlist.
5. Observed text is added to the current API turn as context-only material rather than replayed as separate requests.

## Testing

```bash
pytest tests/gateway/test_line_plugin.py -q -o addopts='' --tb=short
# 90 passed

pytest \
  tests/gateway/test_config_driven_access_policy.py \
  tests/gateway/test_multiplex_profile_authz.py \
  tests/gateway/test_telegram_group_gating.py \
  -q -o addopts='' --tb=short
# 128 passed

ruff check \
  gateway/authz_mixin.py \
  gateway/config.py \
  gateway/run.py \
  plugins/platforms/line/adapter.py \
  tests/gateway/test_line_plugin.py
# All checks passed

python -m py_compile \
  gateway/authz_mixin.py \
  gateway/config.py \
  gateway/run.py \
  plugins/platforms/line/adapter.py \
  tests/gateway/test_line_plugin.py

git diff --check upstream/main...HEAD
```

The integration coverage loads a real YAML config and traverses config loading, LINE `_dispatch_event`, text observation, a later addressed event, profile-aware gateway authorization, agent-history extraction, and current-message context wrapping. It also covers denied chats, group/room profile isolation, the `allow_all_users` observation boundary, unaddressed media, DM behavior, reply-token preservation, wake-pattern cleaning, and malformed mention metadata.

## Known limitations

- Observation is intentionally text-only. Unaddressed images, audio, video, files, stickers, and locations are not persisted for later replay.
- LINE mention metadata does not identify whether another mentioned account is a bot, so this does not claim exclusive-other-bot filtering.
- Reply-to-bot detection is not implemented as a wake condition.
- The shared observed-context wrapper currently reuses a legacy Telegram-worded internal header; LINE turns also carry an explicit LINE observation marker and the label has no authorization or routing effect.
