### PR TITLE
feat(browser): add Obscura local browser provider (resolves #15445)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -264,6 +264,16 @@ BROWSERBASE_PROXIES=true
 # Uses custom Chromium build to avoid bot detection altogether
 BROWSERBASE_ADVANCED_STEALTH=false
 
+# -----------------------------------------------------------------------------
+# Obscura, local headless browser provider (https://github.com/h4ckf0r0day/obscura).
+# A Rust CDP engine with no Chrome or Node dependency. Opt in by setting
+# `browser.cloud_provider: obscura` in config.yaml; Hermes spawns `obscura serve`
+# and drives it over CDP. Every setting below is optional.
+# OBSCURA_BIN=obscura          # binary path, or a name on PATH (default: obscura)
+# OBSCURA_STEALTH=false        # pass --stealth (anti-fingerprinting + tracker blocking)
+# OBSCURA_PORT=                # fixed CDP port (default: a free ephemeral port)
+# OBSCURA_STARTUP_TIMEOUT=15   # seconds to wait for the CDP server (default: 15)
+
 # Browser engine for local mode (default: auto = Chrome)
 # "auto"       — use Chrome (don't pass --engine flag)
 # "lightpanda" — use Lightpanda (1.3-5.8x faster navigation, no screenshots)

--- a/plugins/browser/obscura/__init__.py
+++ b/plugins/browser/obscura/__init__.py
@@ -1,0 +1,15 @@
+"""Obscura local browser plugin, bundled, auto-loaded.
+
+Mirrors the other ``plugins/browser/<vendor>/`` plugins: ``provider.py`` holds
+the provider class; ``__init__.py::register`` instantiates and registers it via
+the plugin context.
+"""
+
+from __future__ import annotations
+
+from plugins.browser.obscura.provider import ObscuraBrowserProvider
+
+
+def register(ctx) -> None:
+    """Register the Obscura provider with the plugin context."""
+    ctx.register_browser_provider(ObscuraBrowserProvider())

--- a/plugins/browser/obscura/plugin.yaml
+++ b/plugins/browser/obscura/plugin.yaml
@@ -1,0 +1,7 @@
+name: browser-obscura
+version: 1.0.0
+description: "Obscura (https://github.com/h4ckf0r0day/obscura) local headless browser backend. Spawns `obscura serve` and drives it over CDP, a Rust engine with no Chrome or Node dependency (~70 MB binary, ~30 MB RAM). Opt-in via browser.cloud_provider: obscura; never auto-selected."
+author: h4ckf0r0day
+kind: backend
+provides_browser_providers:
+  - obscura

--- a/plugins/browser/obscura/provider.py
+++ b/plugins/browser/obscura/provider.py
@@ -1,0 +1,254 @@
+"""Obscura local browser provider, plugin form.
+
+Subclasses :class:`agent.browser_provider.BrowserProvider`. Unlike the cloud
+backends (Browserbase, Browser Use, Firecrawl) this provider runs a *local*
+browser: it spawns ``obscura serve`` as a subprocess and hands the agent the
+process's CDP endpoint. Obscura (https://github.com/h4ckf0r0day/obscura) is a
+Rust headless browser that speaks the Chrome DevTools Protocol with no Chrome
+or Node.js dependency, a single ~70 MB binary.
+
+Opt-in only. The registry never auto-selects Obscura; choose it explicitly::
+
+    browser:
+      cloud_provider: "obscura"
+
+Env vars::
+
+    OBSCURA_BIN=obscura          # binary path, or a name on PATH (default "obscura")
+    OBSCURA_STEALTH=false        # pass --stealth (default false)
+    OBSCURA_PORT=                # fixed CDP port (default: an ephemeral free port)
+    OBSCURA_STARTUP_TIMEOUT=15   # seconds to wait for the CDP server (default 15)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import threading
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+import requests
+
+from agent.browser_provider import BrowserProvider
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BIN = "obscura"
+_DEFAULT_STARTUP_TIMEOUT = 15.0
+
+
+class ObscuraBrowserProvider(BrowserProvider):
+    """Local Obscura (https://github.com/h4ckf0r0day/obscura) CDP browser.
+
+    Spawns one ``obscura serve`` process per session and tears it down on
+    close. Lives entirely on localhost; no credentials or network calls.
+    """
+
+    def __init__(self) -> None:
+        # bb_session_id -> the obscura serve process that session owns.
+        self._procs: Dict[str, subprocess.Popen] = {}
+        self._lock = threading.Lock()
+
+    @property
+    def name(self) -> str:
+        return "obscura"
+
+    @property
+    def display_name(self) -> str:
+        return "Obscura"
+
+    # ------------------------------------------------------------------
+    # Availability
+    # ------------------------------------------------------------------
+
+    def _resolve_binary(self) -> Optional[str]:
+        """Resolve the obscura executable, or None if it cannot be found.
+
+        ``shutil.which`` handles a path (absolute or relative) and a bare name
+        on PATH alike, and appends the Windows executable suffix. Cheap and
+        offline: it never spawns anything.
+        """
+        return shutil.which(os.environ.get("OBSCURA_BIN", _DEFAULT_BIN))
+
+    def is_available(self) -> bool:
+        return self._resolve_binary() is not None
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def create_session(self, task_id: str) -> Dict[str, object]:
+        binary = self._resolve_binary()
+        if binary is None:
+            raise ValueError(
+                "Obscura binary not found. Install obscura "
+                "(https://github.com/h4ckf0r0day/obscura), put it on PATH, or set "
+                "OBSCURA_BIN to its path."
+            )
+
+        stealth = os.environ.get("OBSCURA_STEALTH", "false").lower() == "true"
+        port = _resolve_port(os.environ.get("OBSCURA_PORT"))
+        timeout = _resolve_timeout(os.environ.get("OBSCURA_STARTUP_TIMEOUT"))
+
+        cmd = [binary, "serve", "--port", str(port)]
+        if stealth:
+            cmd.append("--stealth")
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError as exc:
+            raise RuntimeError(f"Failed to launch obscura: {exc}") from exc
+
+        cdp_url = _await_cdp(port, proc, timeout)
+        if cdp_url is None:
+            _terminate(proc)
+            raise RuntimeError(
+                f"Obscura CDP server did not become ready on port {port} within "
+                f"{timeout:g}s."
+            )
+
+        session_id = uuid.uuid4().hex
+        with self._lock:
+            self._procs[session_id] = proc
+
+        session_name = f"hermes_{task_id}_{session_id[:8]}"
+        features = {"stealth": stealth, "local": True}
+        logger.info(
+            "Started Obscura session %s (pid %s, port %s, stealth=%s)",
+            session_name,
+            proc.pid,
+            port,
+            stealth,
+        )
+        return {
+            "session_name": session_name,
+            "bb_session_id": session_id,
+            "cdp_url": cdp_url,
+            "features": features,
+        }
+
+    def close_session(self, session_id: str) -> bool:
+        with self._lock:
+            proc = self._procs.pop(session_id, None)
+        if proc is None:
+            logger.debug("No Obscura process tracked for session %s", session_id)
+            return False
+        try:
+            _terminate(proc)
+            logger.debug("Closed Obscura session %s", session_id)
+            return True
+        except Exception as exc:  # never raise out of cleanup
+            logger.error("Failed to close Obscura session %s: %s", session_id, exc)
+            return False
+
+    def emergency_cleanup(self, session_id: str) -> None:
+        with self._lock:
+            proc = self._procs.pop(session_id, None)
+        if proc is None:
+            return
+        try:
+            _terminate(proc)
+        except Exception as exc:
+            logger.debug(
+                "Emergency cleanup failed for Obscura session %s: %s", session_id, exc
+            )
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Obscura",
+            "badge": "local",
+            "tag": "Local Rust headless browser over CDP (no Chrome or Node needed)",
+            "env_vars": [
+                {
+                    "key": "OBSCURA_BIN",
+                    "prompt": "Path to the obscura binary (optional if 'obscura' is on PATH)",
+                    "url": "https://github.com/h4ckf0r0day/obscura",
+                },
+            ],
+            "post_setup": "agent_browser",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Module helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_port(configured: Optional[str]) -> int:
+    """Use OBSCURA_PORT when valid, else ask the OS for a free ephemeral port."""
+    if configured:
+        try:
+            value = int(configured)
+            if 1 <= value <= 65535:
+                return value
+        except ValueError:
+            pass
+        logger.warning(
+            "Invalid OBSCURA_PORT %r; picking a free port instead", configured
+        )
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _resolve_timeout(configured: Optional[str]) -> float:
+    if configured:
+        try:
+            value = float(configured)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+        logger.warning(
+            "Invalid OBSCURA_STARTUP_TIMEOUT %r; using %.0fs",
+            configured,
+            _DEFAULT_STARTUP_TIMEOUT,
+        )
+    return _DEFAULT_STARTUP_TIMEOUT
+
+
+def _await_cdp(port: int, proc: subprocess.Popen, timeout: float) -> Optional[str]:
+    """Poll ``/json/version`` until obscura is ready.
+
+    Returns the ``webSocketDebuggerUrl`` (the CDP endpoint the agent connects
+    to), or None if the process dies or the deadline passes.
+    """
+    deadline = time.monotonic() + timeout
+    version_url = f"http://127.0.0.1:{port}/json/version"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return None  # process exited before serving
+        try:
+            resp = requests.get(version_url, timeout=1.0)
+            if resp.ok:
+                ws_url = resp.json().get("webSocketDebuggerUrl")
+                if ws_url:
+                    return ws_url
+        except requests.RequestException:
+            pass
+        time.sleep(0.1)
+    return None
+
+
+def _terminate(proc: subprocess.Popen) -> None:
+    """Terminate a process, escalating to kill after a short grace period."""
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass

--- a/tests/plugins/browser/test_browser_obscura_provider.py
+++ b/tests/plugins/browser/test_browser_obscura_provider.py
@@ -1,0 +1,213 @@
+"""Tests for the Obscura local browser provider plugin.
+
+Obscura is the only *local* browser backend: ``create_session`` spawns a real
+``obscura serve`` subprocess and returns its CDP endpoint. These tests follow
+the repo rule of using real objects, not mocks: a tiny fake ``obscura`` binary
+(a real Python script that serves ``/json/version`` over HTTP, exactly like the
+real engine) stands in for the Rust binary, so the full spawn / poll / teardown
+path is exercised for real without depending on the binary being installed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import stat
+import time
+
+import pytest
+import requests
+
+from plugins.browser.obscura.provider import ObscuraBrowserProvider
+
+# A real Python program that mimics ``obscura serve --port N``: it serves the
+# ``/json/version`` document the provider polls for, then runs until killed.
+# When FAKE_ARGV_FILE is set it records its argv so a test can assert the CLI
+# shape (e.g. that ``--stealth`` was forwarded).
+_FAKE_OBSCURA = """#!/usr/bin/env python3
+import sys, os, json, http.server, socketserver
+
+args = sys.argv[1:]
+argv_file = os.environ.get("FAKE_ARGV_FILE")
+if argv_file:
+    with open(argv_file, "w") as f:
+        f.write(" ".join(args))
+
+if not args or args[0] != "serve":
+    sys.exit(2)
+port = None
+for i, a in enumerate(args):
+    if a == "--port" and i + 1 < len(args):
+        port = int(args[i + 1])
+if port is None:
+    sys.exit(2)
+
+ws = "ws://127.0.0.1:%d/devtools/browser" % port
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/json/version":
+            body = json.dumps(
+                {"Browser": "Obscura/fake", "webSocketDebuggerUrl": ws}
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *a):
+        pass
+
+
+with socketserver.TCPServer(("127.0.0.1", port), Handler) as srv:
+    srv.serve_forever()
+"""
+
+# A fake that never serves anything: it just sleeps, so the provider's readiness
+# poll times out and create_session raises.
+_FAKE_OBSCURA_NEVER_READY = """#!/usr/bin/env python3
+import time
+time.sleep(60)
+"""
+
+
+def _write_fake(path, body: str) -> str:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return str(path)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for k in (
+        "OBSCURA_BIN",
+        "OBSCURA_STEALTH",
+        "OBSCURA_PORT",
+        "OBSCURA_STARTUP_TIMEOUT",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+@pytest.fixture
+def fake_obscura(tmp_path, monkeypatch: pytest.MonkeyPatch) -> str:
+    path = _write_fake(tmp_path / "obscura", _FAKE_OBSCURA)
+    monkeypatch.setenv("OBSCURA_BIN", path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# is_available
+# ---------------------------------------------------------------------------
+
+
+def test_is_available_false_when_binary_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OBSCURA_BIN", "/nonexistent/path/to/obscura")
+    assert ObscuraBrowserProvider().is_available() is False
+
+
+def test_is_available_true_with_resolvable_binary(fake_obscura: str) -> None:
+    assert ObscuraBrowserProvider().is_available() is True
+
+
+def test_identity() -> None:
+    p = ObscuraBrowserProvider()
+    assert p.name == "obscura"
+    assert p.display_name == "Obscura"
+    schema = p.get_setup_schema()
+    assert schema["post_setup"] == "agent_browser"
+    assert any(v["key"] == "OBSCURA_BIN" for v in schema["env_vars"])
+
+
+# ---------------------------------------------------------------------------
+# create_session / close_session lifecycle (real subprocess)
+# ---------------------------------------------------------------------------
+
+
+def test_create_session_spawns_and_returns_live_cdp_url(fake_obscura: str) -> None:
+    provider = ObscuraBrowserProvider()
+    session = provider.create_session("task-abc")
+    try:
+        assert session["session_name"].startswith("hermes_task-abc_")
+        assert session["bb_session_id"]
+        assert session["features"] == {"stealth": False, "local": True}
+
+        cdp_url = session["cdp_url"]
+        port = int(re.search(r":(\d+)/", cdp_url).group(1))
+        assert cdp_url == f"ws://127.0.0.1:{port}/devtools/browser"
+
+        # The endpoint the provider returned is actually reachable.
+        resp = requests.get(f"http://127.0.0.1:{port}/json/version", timeout=3)
+        assert resp.ok
+        assert resp.json()["webSocketDebuggerUrl"] == cdp_url
+    finally:
+        assert provider.close_session(session["bb_session_id"]) is True
+
+    # After close the process is gone, so the port stops serving.
+    time.sleep(0.5)
+    with pytest.raises(requests.RequestException):
+        requests.get(f"http://127.0.0.1:{port}/json/version", timeout=1)
+
+
+def test_close_unknown_session_returns_false(fake_obscura: str) -> None:
+    assert ObscuraBrowserProvider().close_session("nope") is False
+
+
+def test_create_session_raises_when_binary_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OBSCURA_BIN", "/nonexistent/path/to/obscura")
+    with pytest.raises(ValueError, match="Obscura binary not found"):
+        ObscuraBrowserProvider().create_session("task-1")
+
+
+def test_create_session_raises_when_cdp_never_ready(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _write_fake(tmp_path / "obscura", _FAKE_OBSCURA_NEVER_READY)
+    monkeypatch.setenv("OBSCURA_BIN", path)
+    monkeypatch.setenv("OBSCURA_STARTUP_TIMEOUT", "0.5")
+    with pytest.raises(RuntimeError, match="did not become ready"):
+        ObscuraBrowserProvider().create_session("task-2")
+
+
+def test_stealth_flag_forwarded(
+    fake_obscura: str, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    argv_file = tmp_path / "argv.txt"
+    monkeypatch.setenv("FAKE_ARGV_FILE", str(argv_file))
+    monkeypatch.setenv("OBSCURA_STEALTH", "true")
+    provider = ObscuraBrowserProvider()
+    session = provider.create_session("task-3")
+    try:
+        assert session["features"]["stealth"] is True
+        assert "--stealth" in argv_file.read_text().split()
+    finally:
+        provider.close_session(session["bb_session_id"])
+
+
+def test_port_override_is_honored(
+    fake_obscura: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    port = _free_port()
+    monkeypatch.setenv("OBSCURA_PORT", str(port))
+    provider = ObscuraBrowserProvider()
+    session = provider.create_session("task-4")
+    try:
+        assert session["cdp_url"] == f"ws://127.0.0.1:{port}/devtools/browser"
+    finally:
+        provider.close_session(session["bb_session_id"])

--- a/tests/plugins/browser/test_browser_provider_plugins.py
+++ b/tests/plugins/browser/test_browser_provider_plugins.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-- All three bundled plugins (browserbase, browser-use, firecrawl)
+- All bundled plugins (browserbase, browser-use, firecrawl, obscura)
   instantiate and self-report the expected ABC defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The browser_registry resolves an active provider in the documented
@@ -21,6 +21,7 @@ interface, the registry, and the plugin glue layer simultaneously.
 Mirrors ``tests/plugins/web/test_web_search_provider_plugins.py`` from
 PR #25182.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -44,6 +45,10 @@ def _clear_browser_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "FIRECRAWL_BROWSER_TTL",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
+        "OBSCURA_BIN",
+        "OBSCURA_STEALTH",
+        "OBSCURA_PORT",
+        "OBSCURA_STARTUP_TIMEOUT",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -72,14 +77,14 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All three bundled browser plugins discover and register correctly."""
+    """All bundled browser plugins discover and register correctly."""
 
-    def test_all_three_plugins_present_in_registry(self) -> None:
+    def test_all_bundled_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.browser_registry import list_providers
 
         names = sorted(p.name for p in list_providers())
-        assert names == ["browser-use", "browserbase", "firecrawl"]
+        assert names == ["browser-use", "browserbase", "firecrawl", "obscura"]
 
     @pytest.mark.parametrize(
         "plugin_name,expected_display",
@@ -87,6 +92,7 @@ class TestBundledPluginsRegister:
             ("browserbase", "Browserbase"),
             ("browser-use", "Browser Use"),
             ("firecrawl", "Firecrawl"),
+            ("obscura", "Obscura"),
         ],
     )
     def test_each_plugin_has_name_and_display_name(
@@ -102,7 +108,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["browserbase", "browser-use", "firecrawl"],
+        ["browserbase", "browser-use", "firecrawl", "obscura"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -121,7 +127,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["browserbase", "browser-use", "firecrawl"],
+        ["browserbase", "browser-use", "firecrawl", "obscura"],
     )
     def test_each_plugin_implements_full_lifecycle(self, plugin_name: str) -> None:
         """The ABC's three lifecycle methods are all overridden."""
@@ -135,9 +141,7 @@ class TestBundledPluginsRegister:
         # default — we check by comparing the function reference.
         assert type(provider).create_session is not BrowserProvider.create_session
         assert type(provider).close_session is not BrowserProvider.close_session
-        assert (
-            type(provider).emergency_cleanup is not BrowserProvider.emergency_cleanup
-        )
+        assert type(provider).emergency_cleanup is not BrowserProvider.emergency_cleanup
 
 
 # ---------------------------------------------------------------------------
@@ -313,7 +317,7 @@ class TestLegacyAbcAliases:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["browserbase", "browser-use", "firecrawl"],
+        ["browserbase", "browser-use", "firecrawl", "obscura"],
     )
     def test_is_configured_delegates_to_is_available(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -348,7 +352,7 @@ class TestLegacyAbcAliases:
 
 
 class TestPickerIntegration:
-    """`_plugin_browser_providers()` exposes all three plugins as picker rows."""
+    """`_plugin_browser_providers()` exposes all bundled plugins as picker rows."""
 
     def test_picker_rows_match_registered_plugins(self) -> None:
         _ensure_plugins_loaded()
@@ -356,7 +360,7 @@ class TestPickerIntegration:
 
         rows = _plugin_browser_providers()
         names = sorted(r.get("browser_provider") for r in rows)
-        assert names == ["browser-use", "browserbase", "firecrawl"]
+        assert names == ["browser-use", "browserbase", "firecrawl", "obscura"]
 
     def test_picker_rows_carry_post_setup_hook(self) -> None:
         """Every browser plugin row has post_setup='agent_browser' so


### PR DESCRIPTION
## What does this PR do?
Adds Obscura (https://github.com/h4ckf0r0day/obscura) as a browser provider plugin. Obscura is a Rust headless browser that speaks the Chrome DevTools Protocol with no Chrome or Node dependency (a ~70 MB binary, ~30 MB RAM).
It is the first local browser backend: instead of calling a cloud API, `create_session` spawns `obscura serve` on a free port and hands the agent its CDP endpoint; `close_session` and `emergency_cleanup` tear the process down. It implements the existing `agent.browser_provider.BrowserProvider` ABC and lives entirely in `plugins/browser/obscura/`, with no core files touched. Opt-in via `browser.cloud_provider: obscura`; never auto-selected (same as firecrawl).
This supersedes the abandoned #16609, which targeted the old `tools/browser_providers/` layout (removed in #25214) and predates obscura's CDP maturity.

## Related Issue
Resolves #15445

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `plugins/browser/obscura/provider.py`: the provider. Spawns and owns `obscura serve`, returns its CDP url, and implements the full lifecycle (`create_session`, `close_session`, `emergency_cleanup`).
- `plugins/browser/obscura/plugin.yaml` and `__init__.py`: the plugin manifest and `register()`, mirroring the existing browser plugins.
- `tests/plugins/browser/test_browser_obscura_provider.py`: real-object lifecycle tests using a fake `obscura` binary (no mocks).
- `tests/plugins/browser/test_browser_provider_plugins.py`: extend the bundled-plugin assertions to include obscura.
- `.env.example`: document the optional `OBSCURA_*` env vars.

## How to Test
1. Build obscura (https://github.com/h4ckf0r0day/obscura) and put it on PATH, or set `OBSCURA_BIN` to its path.
2. Run the provider tests (they pass without the binary, using a fake serve): `pytest tests/plugins/browser/test_browser_obscura_provider.py tests/plugins/browser/test_browser_provider_plugins.py -q`
3. Set `browser.cloud_provider: obscura` in config.yaml and run a browser task. Hermes spawns `obscura serve` and drives it over CDP.

## Checklist

### Code
- [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`feat(browser):`)
- [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (this supersedes the abandoned #16609)
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04

### Documentation & Housekeeping
- [x] I've updated relevant documentation (`.env.example`, docstrings)
- [x] `cli-config.yaml.example`: N/A (reuses the existing `browser.cloud_provider` key)
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A (no architecture change; a plugin against the existing ABC)
- [x] I've considered cross-platform impact (subprocess + `shutil.which`, which handles the Windows `.exe` suffix)
- [x] Tool descriptions/schemas: N/A (no tool behavior change)