### PR TITLE
fix(tests): close pid-file read race in test_grandchild_reaped_via_pgroup

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -321,12 +321,19 @@ class TestStdioPgroupReaping:
 
         psutil = pytest.importorskip("psutil")
 
-        # Grandchild: sleep forever, write its pid then wait.
+        # Grandchild: sleep forever, write its pid then wait.  The pid file
+        # is written to a temp path and os.replace()d into place so the
+        # polling reader below can never observe a created-but-empty file
+        # (CI flake: int('') ValueError when the reader won the race between
+        # open('w') creating the file and write() filling it).
         grandchild_pid_file = tmp_path / "grandchild.pid"
         grandchild_script = tmp_path / "grandchild.py"
         grandchild_script.write_text(
             "import os, sys, time\n"
-            f"open({str(grandchild_pid_file)!r}, 'w').write(str(os.getpid()))\n"
+            f"tmp = {str(grandchild_pid_file)!r} + '.tmp'\n"
+            "with open(tmp, 'w') as f:\n"
+            "    f.write(str(os.getpid()))\n"
+            f"os.replace(tmp, {str(grandchild_pid_file)!r})\n"
             "while True:\n"
             "    time.sleep(0.5)\n"
         )


### PR DESCRIPTION
## Summary
Closes the pid-file read race that made `test_grandchild_reaped_via_pgroup` flake in CI (seen red on PR #43442's test (6) shard).

Root cause: the grandchild wrote its pid with `open('w').write(...)`, so the test's polling loop could observe the file after creation but before the write landed, parsing `''` → `ValueError: invalid literal for int()`. The window only loses under CI load — locally it passes every time.

## Changes
- `tests/tools/test_mcp_stability.py`: grandchild writes its pid to a `.tmp` file and `os.replace()`s it into place, so the pid file only ever appears fully written.

## Validation
- 5/5 consecutive local runs of the test pass.

## Infographic

![mcp-stability-pidfile-race-fix](https://v3b.fal.media/files/b/0a9db7d2/3mgZWvDSSzxl7-Uw90Lhs_DwVKXbIU.png)
