### PR TITLE
feat: add custom_instructions config field injected into every session system prompt

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -99,6 +99,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # Fallback to hardcoded identity
         stable_parts.append(DEFAULT_AGENT_IDENTITY)
 
+    # Custom instructions — user-defined rules from config.yaml that are
+    # injected into every session's system prompt after the identity block.
+    # Editable from the desktop Settings → Chat panel.
+    try:
+        from hermes_cli.config import load_config as _load_cfg
+        _cfg_i = _load_cfg() or {}
+    except Exception:
+        _cfg_i = {}
+    _ci = _cfg_i.get("custom_instructions", "") if isinstance(_cfg_i, dict) else ""
+    if _ci and isinstance(_ci, str) and _ci.strip():
+        stable_parts.append(f"## Custom Instructions\n\n{_ci.strip()}")
+
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
 

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -280,6 +280,7 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   fallbackProviders: 'Fallback Models',
   toolsets: 'Enabled Toolsets',
   timezone: 'Timezone',
+  customInstructions: 'Custom Instructions',
   display: {
     personality: 'Personality',
     showReasoning: 'Reasoning Blocks'
@@ -431,6 +432,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   model: 'Used for new chats unless you pick a different model in the composer.',
   modelContextLength: "Leave at 0 to use the selected model's detected context window.",
   fallbackProviders: 'Backup provider:model entries to try if the default model fails.',
+  customInstructions: 'User-defined rules injected into every session system prompt. Use this to set persistent behavior guidelines, e.g. coding conventions or response style.',
   display: {
     personality: 'Default assistant style for new sessions.',
     showReasoning: 'Show reasoning sections when the backend provides them.'
@@ -509,7 +511,7 @@ export const SECTIONS: DesktopConfigSection[] = [
     id: 'chat',
     label: 'Chat',
     icon: MessageCircle,
-    keys: ['display.personality', 'timezone', 'display.show_reasoning', 'agent.image_input_mode']
+    keys: ['display.personality', 'timezone', 'display.show_reasoning', 'agent.image_input_mode', 'custom_instructions']
   },
   {
     id: 'appearance',

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -806,6 +806,11 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    # Custom instructions — user-defined rules injected into every session's
+    # system prompt.  Editable from the desktop Settings → Chat panel or from
+    # the terminal via `hermes config set custom_instructions "..."`.
+    # Empty by default. Combined with SOUL.md (identity) at runtime.
+    "custom_instructions": "",
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -493,6 +493,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         ),
         "options": ["stash", "discard"],
     },
+    "custom_instructions": {
+        "type": "text",
+        "description": "User-defined rules injected into every session's system prompt. Use this to set persistent behavior guidelines — e.g. coding conventions, response style, or safety rules.",
+    },
 }
 
 # Categories with fewer fields get merged into "general" to avoid tab sprawl.


### PR DESCRIPTION
## Summary

Adds a `custom_instructions` configuration field that lets users define persistent behavior guidelines (coding conventions, response style, safety rules) that survive across sessions and git pulls.

## Changes

**`hermes_cli/config.py`** — Added `"custom_instructions": ""` to `DEFAULT_CONFIG` with documentation comment.

**`agent/system_prompt.py`** — In `build_system_prompt_parts()`, reads the config value after the identity block and injects a `## Custom Instructions` section into the system prompt when non-empty.

**`hermes_cli/web_server.py`** — Added `"custom_instructions": {"type": "text"}` to `_SCHEMA_OVERRIDES` so the desktop settings page renders it as a textarea.

**`apps/desktop/src/app/settings/constants.ts`** — Added `custom_instructions` field to the Chat section with label "Custom Instructions" and a descriptive tooltip.

## Usage

- **Desktop**: Settings → Chat → Custom Instructions (textarea)
- **CLI**: `hermes config set custom_instructions "..."`

## Testing

1. Set a value: `hermes config set custom_instructions "Always respond in Chinese"`
2. Start a new session — the instruction appears in the system prompt
3. The setting is persisted in `config.yaml` and survives `git pull`
