### PR TITLE
test: cover openai-codex default oauth auth

### DIFF
--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -369,7 +369,8 @@ def test_auth_add_nous_oauth_honors_custom_label(tmp_path, monkeypatch):
     assert payload["providers"]["nous"]["label"] == "my-nous"
 
 
-def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
+@pytest.mark.parametrize("auth_type", [None, "oauth"])
+def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch, auth_type):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})
     token = _jwt_with_email("codex@example.com")
@@ -389,9 +390,13 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
 
     class _Args:
         provider = "openai-codex"
-        auth_type = "oauth"
         api_key = None
         label = None
+
+    # Regression coverage for #42712: `hermes auth add openai-codex`
+    # without `--type oauth` must choose the Codex device-code OAuth flow,
+    # not the generic API-key prompt.
+    setattr(_Args, "auth_type", auth_type)
 
     auth_add_command(_Args())
 


### PR DESCRIPTION
## Summary
- Add regression coverage that `hermes auth add openai-codex` defaults to the Codex device-code OAuth flow
- Keep existing explicit `--type oauth` coverage for the same provider
- Document the behavior reported in #42712 so future auth changes do not regress back to the generic API-key prompt

## Verification
- `PYTHONPATH=/tmp/hermes-pr-42712 /home/hl-metabase/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_auth_commands.py -k 'codex_oauth_persists_pool_entry or codex_oauth_keeps_distinct_pool_accounts' -q`
- `PYTHONPATH=/tmp/hermes-pr-42712 /home/hl-metabase/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_auth_commands.py -q`
- Fresh `HERMES_HOME` CLI smoke test confirmed `hermes auth add openai-codex` opens the Codex device-code OAuth URL instead of asking for an API key

Refs #42712
