### PR TITLE
fix(whatsapp-bridge): use execFileSync for ffmpeg audio conversion (shell-injection fix)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -614,8 +614,14 @@ app.post('/send-media', async (req, res) => {
         if (needsConversion) {
           tmpPath = path.join(tmpdir(), `hermes_voice_${randomBytes(6).toString('hex')}.ogg`);
           try {
-            execSync(
-              `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus ${JSON.stringify(tmpPath)}`,
+            // execFileSync with an argument array — never spawns a shell, so a
+            // crafted filePath (e.g. containing $(...) or backticks) cannot inject
+            // commands. Double-quoting via JSON.stringify in a shell string does
+            // NOT neutralize command substitution, so the prior execSync form was
+            // a shell-injection vector (#21758 review / CodeRabbit critical).
+            execFileSync(
+              'ffmpeg',
+              ['-y', '-i', filePath, '-ar', '48000', '-ac', '1', '-c:a', 'libopus', tmpPath],
               { timeout: 30000, stdio: 'pipe' }
             );
             audioBuffer = readFileSync(tmpPath);


### PR DESCRIPTION
## Problem

The WhatsApp bridge's `/send-media` endpoint converts non-ogg/opus audio to ogg/opus via ffmpeg so WhatsApp renders a native voice bubble (ptt). The conversion built an ffmpeg command as a **shell string** and ran it through `execSync`:

```js
execSync(
  `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus ${JSON.stringify(tmpPath)}`,
  { timeout: 30000, stdio: 'pipe' }
);
```

`JSON.stringify(filePath)` wraps the path in double quotes, but **double quotes do not neutralize `$(...)` or backtick command substitution in a shell context**. A crafted `filePath` reaching this endpoint (e.g. `/x/$(touch /tmp/pwned).wav`) executes arbitrary commands.

## Fix

Switch to `execFileSync` with an argument array. No shell is spawned, so the path is passed literally to ffmpeg as a single argv element — command substitution is impossible:

```js
execFileSync(
  'ffmpeg',
  ['-y', '-i', filePath, '-ar', '48000', '-ac', '1', '-c:a', 'libopus', tmpPath],
  { timeout: 30000, stdio: 'pipe' }
);
```

Everything else is unchanged: the `readFileSync(tmpPath)` buffer read, fallback-to-original-format on failure, and the `finally` cleanup of the temp `.ogg` all stay as-is.

## Verification

A direct injection probe (filePath containing `$(touch <marker>)`) confirms the marker is **not** created with `execFileSync` — the substitution never reaches a shell:

```
SAFE — injection blocked
```

Scope: one file, one call site. No behavioral change for legitimate audio paths.
