### PR TITLE
feat: add 'provider diagnose' command for connectivity checks #43027

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10379,7 +10379,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate",
-        "model", "pairing", "plugins", "portal", "postinstall", "profile", "proxy",
+        "model", "pairing", "plugins", "portal", "postinstall", "profile","provider", "proxy",
         "prompt-size",
         "send", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11126,9 +11126,15 @@ def main():
     # provider command (parser built in hermes_cli/subcommands/provider.py)
     # =========================================================================
     # 1. Önce fonksiyonu burada tanımla veya main içinde olduğunu garantile
+    # =========================================================================
+    # provider command (parser built in hermes_cli/subcommands/provider.py)
+    # =========================================================================
+    from hermes_cli.provider_diagnose import run_diagnose
+
     def cmd_provider_diagnose(args):
-        from hermes_cli.provider_diagnose import run_diagnose
+        """Bridge to call the provider diagnose function."""
         run_diagnose(args.name)
+
     build_provider_parser(subparsers, cmd_provider_diagnose=cmd_provider_diagnose)
     # =========================================================================
     # debug command  (parser built in hermes_cli/subcommands/debug.py)
@@ -11899,6 +11905,5 @@ def main():
 
 if __name__ == "__main__":
     main()
-def cmd_provider_diagnose(args):
-    from hermes_cli.provider_diagnose import run_diagnose
-    run_diagnose(args.name)
+
+    

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -63,7 +63,8 @@ except ModuleNotFoundError:
 
 import os
 import sys
-
+from typing import Callable
+from hermes_cli.subcommands.provider import build_provider_parser
 
 def _set_process_title() -> None:
     """Set the process title to 'hermes' so tools like 'ps', 'top', and
@@ -11121,7 +11122,14 @@ def main():
     # dump command  (parser built in hermes_cli/subcommands/dump.py)
     # =========================================================================
     build_dump_parser(subparsers, cmd_dump=cmd_dump)
-
+    # =========================================================================
+    # provider command (parser built in hermes_cli/subcommands/provider.py)
+    # =========================================================================
+    # 1. Önce fonksiyonu burada tanımla veya main içinde olduğunu garantile
+    def cmd_provider_diagnose(args):
+        from hermes_cli.provider_diagnose import run_diagnose
+        run_diagnose(args.name)
+    build_provider_parser(subparsers, cmd_provider_diagnose=cmd_provider_diagnose)
     # =========================================================================
     # debug command  (parser built in hermes_cli/subcommands/debug.py)
     # =========================================================================
@@ -11891,3 +11899,6 @@ def main():
 
 if __name__ == "__main__":
     main()
+def cmd_provider_diagnose(args):
+    from hermes_cli.provider_diagnose import run_diagnose
+    run_diagnose(args.name)

--- a/hermes_cli/provider_diagnose.py
+++ b/hermes_cli/provider_diagnose.py
@@ -3,12 +3,17 @@ import os
 import requests
 from hermes_cli.config import load_config
 from hermes_cli.providers import resolve_provider_full
+
 def run_diagnose(provider_name: str):
+    """
+    Performs a diagnostic check on the specified provider's configuration 
+    and network connectivity.
+    """
     config = load_config()
     pdef = resolve_provider_full(provider_name, config.get("providers"), config.get("custom_providers"))
     
     if not pdef:
-        print(f"Error: Provider '{provider_name}' bulunamadı.")
+        print(f"Error: Provider '{provider_name}' not found in configuration.")
         return
 
     print(f"═══ Provider: {provider_name} ═══")
@@ -19,12 +24,15 @@ def run_diagnose(provider_name: str):
     # 2. Env Var Check
     env_vars = getattr(pdef, 'api_key_env_vars', [])
     key_val = next((os.environ.get(v) for v in env_vars if os.environ.get(v)), None)
+    
     if key_val:
-        print(f"✓ API key env var found (len: {len(key_val)} chars)")
+        print(f"✓ API key environment variable found (length: {len(key_val)} chars)")
     else:
-        print("✗ API key env var not set")
+        print("✗ API key environment variable not set")
 
-    # 3. Connectivity Test (Ping)
+    # 3. Connectivity Test
+    # Performs a shallow network reachability check to the provider's base URL.
+    # Does not authenticate or verify model availability.
     if getattr(pdef, 'base_url', None):
         try:
             resp = requests.get(pdef.base_url, timeout=5)
@@ -34,10 +42,13 @@ def run_diagnose(provider_name: str):
     else:
         print("! Base URL not defined (using SDK default)")
 
-# Summary kısmını bu şekilde değiştirelim
+    # 4. Summary
     print("─── Summary ───")
-    # Eğer tüm kontroller geçildiyse "READY", geçilemediyse "ACTION REQUIRED" yazsın
     status = "READY" if key_val else "ACTION REQUIRED"
     print(f"Status: {status}")
+    
     if not key_val:
-        print("Tip: Lütfen GEMINI_API_KEY ortam değişkenini tanımlayın.")
+        # Dynamically suggest the required env var(s)
+        hint = " or ".join(env_vars) if env_vars else f"{provider_name.upper()}_API_KEY"
+        print(f"Tip: Please set one of these environment variables: {hint}")
+        

--- a/hermes_cli/provider_diagnose.py
+++ b/hermes_cli/provider_diagnose.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import os
+import requests
+from hermes_cli.config import load_config
+from hermes_cli.providers import resolve_provider_full
+def run_diagnose(provider_name: str):
+    config = load_config()
+    pdef = resolve_provider_full(provider_name, config.get("providers"), config.get("custom_providers"))
+    
+    if not pdef:
+        print(f"Error: Provider '{provider_name}' bulunamadı.")
+        return
+
+    print(f"═══ Provider: {provider_name} ═══")
+    
+    # 1. Config Check
+    print("✓ Provider definition exists in config.")
+    
+    # 2. Env Var Check
+    env_vars = getattr(pdef, 'api_key_env_vars', [])
+    key_val = next((os.environ.get(v) for v in env_vars if os.environ.get(v)), None)
+    if key_val:
+        print(f"✓ API key env var found (len: {len(key_val)} chars)")
+    else:
+        print("✗ API key env var not set")
+
+    # 3. Connectivity Test (Ping)
+    if getattr(pdef, 'base_url', None):
+        try:
+            resp = requests.get(pdef.base_url, timeout=5)
+            print(f"✓ Base URL reachable: {pdef.base_url} (Status: {resp.status_code})")
+        except Exception as e:
+            print(f"✗ Base URL unreachable: {e}")
+    else:
+        print("! Base URL not defined (using SDK default)")
+
+# Summary kısmını bu şekilde değiştirelim
+    print("─── Summary ───")
+    # Eğer tüm kontroller geçildiyse "READY", geçilemediyse "ACTION REQUIRED" yazsın
+    status = "READY" if key_val else "ACTION REQUIRED"
+    print(f"Status: {status}")
+    if not key_val:
+        print("Tip: Lütfen GEMINI_API_KEY ortam değişkenini tanımlayın.")

--- a/hermes_cli/subcommands/provider.py
+++ b/hermes_cli/subcommands/provider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+from typing import Callable
+
+def build_provider_parser(subparsers, *, cmd_provider_diagnose: Callable) -> None:
+    """provider komut grubunu ve alt komutlarını ekler."""
+    provider_parser = subparsers.add_parser("provider", help="Provider yönetimi ve teşhisi")
+    subparsers_provider = provider_parser.add_subparsers()
+    
+    # diagnose alt komutu
+    diagnose_parser = subparsers_provider.add_parser("diagnose", help="Provider bağlantısını test et")
+    diagnose_parser.add_argument("name", help="Teşhis edilecek provider ismi")
+    diagnose_parser.set_defaults(func=cmd_provider_diagnose)

--- a/hermes_cli/subcommands/provider.py
+++ b/hermes_cli/subcommands/provider.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 from typing import Callable
 
 def build_provider_parser(subparsers, *, cmd_provider_diagnose: Callable) -> None:
-    """provider komut grubunu ve alt komutlarını ekler."""
-    provider_parser = subparsers.add_parser("provider", help="Provider yönetimi ve teşhisi")
+    """Adds the provider command group and its subcommands."""
+    provider_parser = subparsers.add_parser("provider", help="Provider management and diagnostics")
     subparsers_provider = provider_parser.add_subparsers()
     
-    # diagnose alt komutu
-    diagnose_parser = subparsers_provider.add_parser("diagnose", help="Provider bağlantısını test et")
-    diagnose_parser.add_argument("name", help="Teşhis edilecek provider ismi")
+    # diagnose subcommand
+    diagnose_parser = subparsers_provider.add_parser("diagnose", help="Test provider connectivity")
+    diagnose_parser.add_argument("name", help="The name of the provider to diagnose")
     diagnose_parser.set_defaults(func=cmd_provider_diagnose)
+    


### PR DESCRIPTION
## Description
This PR introduces the `hermes provider diagnose <name>` CLI command to streamline provider setup and debugging.

## Why this is needed?
Currently, troubleshooting provider connectivity (like Gemini or Anthropic) is a manual, multi-step process involving env var checks and connection testing. This command automates these checks, reducing onboarding time significantly.

## Key Features
- **Config Validation:** Verifies if the provider exists in `config.yaml`.
- **Env Var Detection:** Checks for required API key environment variables (e.g., `GEMINI_API_KEY`, `GOOGLE_API_KEY`).
- **Connectivity Check:** Performs a health check on the provider's base URL.
- **Actionable Summary:** Provides a clear "READY" or "ACTION REQUIRED" status to guide the user.

## How to test
1. Run: `python -m hermes_cli.main provider diagnose <provider_name>`
2. Observe the output for connectivity and configuration status.

Fixes #43027