### PR TITLE
fix(config): preserve .env file mode in sanitize_env_file too

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5659,19 +5659,34 @@ def sanitize_env_file() -> int:
         fixes += abs(len(sanitized) - len(original_lines))
 
     fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix=".tmp", prefix=".env_")
+    # Preserve original permissions so Docker volume mounts aren't clobbered.
+    original_mode = None
+    try:
+        original_mode = stat.S_IMODE(env_path.stat().st_mode)
+    except OSError:
+        pass
     try:
         with os.fdopen(fd, "w", **write_kw) as f:
             f.writelines(sanitized)
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, env_path)
+        # Preserve the original file mode (e.g. 0640 for Docker volume mounts)
+        # instead of letting _secure_file unconditionally tighten to 0600
+        # (mirrors save_env_value / remove_env_value, #33699 / #43349).
+        if original_mode is not None:
+            try:
+                os.chmod(env_path, original_mode)
+            except OSError:
+                pass
+        else:
+            _secure_file(env_path)
     except BaseException:
         try:
             os.unlink(tmp_path)
         except OSError:
             pass
         raise
-    _secure_file(env_path)
     invalidate_env_cache()
     return fixes
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -560,6 +560,29 @@ class TestSanitizeEnvLines:
             fixes = sanitize_env_file()
             assert fixes == 0
 
+    def test_sanitize_env_file_preserves_existing_file_mode_on_posix(self, tmp_path):
+        """sanitize_env_file rewrites the .env in place, so an operator-set
+        mode (e.g. 0640 for a Docker bind-mount) must survive the rewrite
+        rather than being clobbered to 0600 by _secure_file. Mirrors the
+        save_env_value / remove_env_value preservation (#33699 / #43349).
+        """
+        if os.name == "nt":
+            return
+
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "FAL_KEY=good\n"
+            "OPENROUTER_API_KEY=valFIRECRAWL_API_KEY=val2\n"
+        )
+        os.chmod(env_file, 0o640)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            fixes = sanitize_env_file()
+
+        assert fixes > 0  # a rewrite actually happened
+        env_mode = env_file.stat().st_mode & 0o777
+        assert env_mode == 0o640, f"expected 0o640, got {oct(env_mode)}"
+
 
 class TestOptionalEnvVarsRegistry:
     """Verify that key env vars are registered in OPTIONAL_ENV_VARS."""


### PR DESCRIPTION
## Summary

Completes the `.env`-mode-preservation fix across **all three** `.env`-rewrite paths in `hermes_cli/config.py`:

- **`save_env_value`** — fixed in #33699 (`e4a1b35a3`)
- **`remove_env_value`** — fixed in #43349 (`15813336c`)
- **`sanitize_env_file`** — ⬅ **this PR** (the remaining path)

`sanitize_env_file()` rewrites the `.env` in place when it splits a concatenated line or drops a stale redacted placeholder, then calls `_secure_file()` unconditionally — clobbering an operator-set mode (e.g. `0640` for a Docker bind-mount) back to `0600`. This is the same symptom #33699/#43349 fixed, reached through the auto-sanitize path instead.

> This PR originally also carried the `remove_env_value` fix, but that landed independently via #43349 while this was open — so I rebased onto current `main` and narrowed this PR to the one path still unaddressed.

## Fix

Mirror the other two: capture `original_mode`, and move `_secure_file()` into the `else` branch of the `original_mode is not None` check, so a fresh write still gets `0600` hardening while an existing operator-set mode survives.

## Tests

`test_sanitize_env_file_preserves_existing_file_mode_on_posix` — **fails without the change** (mode comes back `0600`) and passes with it. Full `tests/hermes_cli/test_config.py` runs green (101 passed).