### PR TITLE
fix(telegram): format before chunking in overflow split to preserve MarkdownV2

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2324,34 +2324,51 @@ class TelegramAdapter(BasePlatformAdapter):
         Falls back to ``SendResult(success=False)`` only if even the first-
         chunk edit fails — that's a real adapter problem, not an overflow.
         """
-        chunks = self.truncate_message(
-            content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
-        )
+        if finalize:
+            # Format the entire content first, THEN chunk — mirroring send().
+            # Formatting inflates MarkdownV2 escaping by 4-8 %; chunking
+            # the raw text and formatting per-chunk pushes each chunk past
+            # the 4096 UTF-16 limit, causing Telegram to reject and fall
+            # back to unformatted plain text (issue #43441).
+            formatted_content = self.format_message(content)
+            chunks = self.truncate_message(
+                formatted_content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
+            )
+            if len(chunks) > 1:
+                # Escape MarkdownV2-special parentheses in the "(1/N)"
+                # suffix that truncate_message appends — same as send().
+                chunks = [
+                    re.sub(r" \((\d+)/(\d+)\)$", r" \\(\1/\2\\)", chunk)
+                    for chunk in chunks
+                ]
+        else:
+            chunks = self.truncate_message(
+                content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
+            )
         if len(chunks) <= 1:
             # Defensive: shouldn't happen given the caller's pre-flight, but
             # if truncate_message returned a single chunk just edit normally.
-            chunks = [content]
+            chunks = [content if not finalize else self.format_message(content)]
 
         # Step 1 — edit the existing message with the first chunk.
         first_chunk = chunks[0]
         try:
             if finalize:
-                # Use format_message + parse_mode for the final chunk;
-                # mirror edit_message's main happy-path.
-                formatted = self.format_message(first_chunk)
+                # Chunks are already formatted (see chunking above).
                 try:
                     await self._bot.edit_message_text(
                         chat_id=int(chat_id),
                         message_id=int(message_id),
-                        text=formatted,
+                        text=first_chunk,
                         parse_mode=ParseMode.MARKDOWN_V2,
                     )
                 except Exception as fmt_err:
                     if "not modified" not in str(fmt_err).lower():
+                        # MarkdownV2 rejected — send as plain text.
                         await self._bot.edit_message_text(
                             chat_id=int(chat_id),
                             message_id=int(message_id),
-                            text=first_chunk,
+                            text=_strip_mdv2(first_chunk),
                         )
             else:
                 await self._bot.edit_message_text(
@@ -2392,7 +2409,9 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             for use_markdown in (True, False) if finalize else (False,):
                 try:
-                    text = self.format_message(chunk) if use_markdown else chunk
+                    # Chunks are already formatted when finalize=True (see
+                    # chunking above).  _strip_mdv2 for the plain fallback.
+                    text = chunk if use_markdown else _strip_mdv2(chunk)
                     sent_msg = await self._bot.send_message(
                         chat_id=int(chat_id),
                         text=text,

--- a/tests/gateway/test_telegram_edit_overflow_format.py
+++ b/tests/gateway/test_telegram_edit_overflow_format.py
@@ -1,0 +1,193 @@
+"""Tests for Telegram _edit_overflow_split format-before-chunk fix.
+
+Issue: #43441 — When content exceeds 4096 UTF-16 units, _edit_overflow_split
+was chunking the raw text first, then formatting each chunk with MarkdownV2.
+The formatting inflates escaping by 4-8 %, pushing each chunk past the limit.
+Telegram rejects the oversized formatted chunk and falls back to plain text,
+causing raw Markdown markers (**, `, ```) to appear in the user's chat.
+
+The fix mirrors send(): format the entire content first, then chunk the
+already-formatted text so every chunk is within the 4096 limit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.base import SendResult, utf16_len
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter():
+    """Create a minimal TelegramAdapter for testing overflow split."""
+    from gateway.config import Platform
+    from gateway.platforms.telegram import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter._bot = MagicMock()
+    adapter._metadata_thread_id = MagicMock(return_value=None)
+    adapter._thread_kwargs_for_send = MagicMock(return_value={})
+    adapter._link_preview_kwargs = MagicMock(return_value={})
+    adapter._notification_kwargs = MagicMock(return_value={})
+    return adapter
+
+
+class TestEditOverflowSplitFormatBeforeChunk:
+    """_edit_overflow_split must format-then-chunk when finalize=True."""
+
+    @pytest.mark.asyncio
+    async def test_finalize_formats_entire_content_before_chunking(self):
+        """format_message must be called once on the full content, not per-chunk."""
+        adapter = _make_adapter()
+
+        # Content that is under 4096 raw but will exceed 4096 after MarkdownV2
+        # escaping.  Use **bold** markers that get escaped to \*\*bold\*\*.
+        raw_word = "**bold_text_here** "  # 20 chars raw → ~28 chars MarkdownV2
+        content = raw_word * 200  # 4000 raw chars, ~5600 formatted
+
+        # Mock format_message to simulate MarkdownV2 inflation
+        def fake_format(text):
+            # Simulate escaping: ** → \*\*, etc.  ~40% inflation
+            return text.replace("**", "\\*\\*").replace("_", "\\_")
+
+        adapter.format_message = fake_format
+        adapter.truncate_message = MagicMock(
+            side_effect=lambda text, limit, len_fn=None: (
+                [text] if (len_fn or len)(text) <= limit
+                else [text[:limit], text[limit:]]
+            )
+        )
+        adapter._bot.edit_message_text = AsyncMock(return_value=SimpleNamespace(message_id=200))
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=300))
+
+        result = await adapter._edit_overflow_split(
+            "12345", 100, content, finalize=True,
+        )
+
+        assert result.success
+        # truncate_message must have been called with ALREADY-FORMATTED content
+        call_args = adapter.truncate_message.call_args
+        passed_text = call_args[0][0]
+        # The passed text should contain MarkdownV2 escapes
+        assert "\\*\\*" in passed_text, (
+            "truncate_message received raw content instead of formatted content"
+        )
+
+    @pytest.mark.asyncio
+    async def test_finalize_chunks_stay_within_limit(self):
+        """When finalize=True, each chunk sent to Telegram must be ≤ 4096 UTF-16."""
+        adapter = _make_adapter()
+
+        # Build content that exceeds 4096 after formatting
+        raw_word = "**code** " * 10 + "\n"  # ~100 raw chars per line
+        content = raw_word * 50  # ~5000 raw chars
+
+        def fake_format(text):
+            return text.replace("**", "\\*\\*")
+
+        adapter.format_message = fake_format
+
+        # Use the real truncate_message (it's a staticmethod on the base class)
+        from gateway.platforms.base import BasePlatformAdapter
+        adapter.truncate_message = staticmethod(BasePlatformAdapter.truncate_message)
+
+        sent_texts = []
+        async def capture_edit(**kwargs):
+            sent_texts.append(kwargs.get("text", ""))
+            return SimpleNamespace(message_id=200)
+
+        async def capture_send(**kwargs):
+            sent_texts.append(kwargs.get("text", ""))
+            return SimpleNamespace(message_id=300)
+
+        adapter._bot.edit_message_text = AsyncMock(side_effect=capture_edit)
+        adapter._bot.send_message = AsyncMock(side_effect=capture_send)
+
+        result = await adapter._edit_overflow_split(
+            "12345", 100, content, finalize=True,
+        )
+
+        assert result.success
+        # Every text sent to Telegram must be within the UTF-16 limit
+        for i, text in enumerate(sent_texts):
+            assert utf16_len(text) <= 4096, (
+                f"Chunk {i} exceeds 4096 UTF-16 units: {utf16_len(text)}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_finalize_false_chunks_raw_content(self):
+        """When finalize=False, content is chunked raw (no formatting)."""
+        adapter = _make_adapter()
+
+        content = "x" * 5000  # Exceeds 4096
+
+        format_called = MagicMock()
+        adapter.format_message = lambda text: (format_called(), text)[1]
+        adapter.truncate_message = MagicMock(
+            side_effect=lambda text, limit, len_fn=None: (
+                [text] if (len_fn or len)(text) <= limit
+                else [text[:limit], text[limit:]]
+            )
+        )
+        adapter._bot.edit_message_text = AsyncMock(return_value=SimpleNamespace(message_id=200))
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=300))
+
+        result = await adapter._edit_overflow_split(
+            "12345", 100, content, finalize=False,
+        )
+
+        assert result.success
+        # format_message must NOT have been called for finalize=False
+        assert format_called.call_count == 0, (
+            "format_message was called even though finalize=False"
+        )
+
+    @pytest.mark.asyncio
+    async def test_finalize_first_chunk_fallback_strips_mdv2(self):
+        """When MarkdownV2 edit fails on first chunk, fallback uses _strip_mdv2."""
+        adapter = _make_adapter()
+
+        content = "**bold** " * 300  # ~2700 raw, exceeds after formatting
+
+        def fake_format(text):
+            return text.replace("**", "\\*\\*")
+
+        adapter.format_message = fake_format
+        adapter.truncate_message = MagicMock(
+            side_effect=lambda text, limit, len_fn=None: (
+                [text] if (len_fn or len)(text) <= limit
+                else [text[:limit], text[limit:]]
+            )
+        )
+
+        # First call (MarkdownV2) fails, second call (plain) succeeds
+        call_count = 0
+        async def edit_side_effect(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if kwargs.get("parse_mode"):
+                raise Exception("can't parse entities")
+            return SimpleNamespace(message_id=200)
+
+        adapter._bot.edit_message_text = AsyncMock(side_effect=edit_side_effect)
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=300))
+
+        result = await adapter._edit_overflow_split(
+            "12345", 100, content, finalize=True,
+        )
+
+        assert result.success
+        # The fallback call must NOT contain MarkdownV2 escapes
+        fallback_text = adapter._bot.edit_message_text.call_args_list[-1][1].get("text", "")
+        assert "\\*\\*" not in fallback_text, (
+            "Fallback should use _strip_mdv2 to remove MarkdownV2 escaping"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes `_edit_overflow_split` in the Telegram adapter so that oversized final replies are formatted with MarkdownV2 **before** chunking, not after. This prevents the 4-8% escaping inflation from pushing individual chunks past Telegram's 4096 UTF-16 limit, which caused raw Markdown markers (`**`, backticks, fenced code blocks) to appear literally in forum/bound topic replies.

## Related Issue

Fixes #43441

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: Refactored `_edit_overflow_split` to format the entire content with `format_message` first, then chunk the already-formatted text via `truncate_message` — mirroring the existing `send()` method's pattern. Also escapes `(1/N)` suffixes for MarkdownV2 compatibility and uses `_strip_mdv2()` for plain-text fallback instead of sending raw formatted text.
- `tests/gateway/test_telegram_edit_overflow_format.py`: Added 4 tests covering format-before-chunk ordering, chunk size invariant, finalize=False no-format path, and MarkdownV2 fallback stripping.

## How to Test

1. Bind Hermes to a Telegram forum/bound topic.
2. Ask for a reply containing Markdown formatting (**bold**, `inline code`, fenced code blocks) that exceeds 4096 UTF-16 characters.
3. Verify the final reply renders formatted text instead of raw Markdown markers.
4. Run `pytest tests/gateway/test_telegram_edit_overflow_format.py -v` — all 4 tests should pass.
5. Run `pytest tests/gateway/test_stream_consumer.py tests/gateway/test_telegram_progress_edit_transient.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_telegram_noise_filter.py -v` — all existing tests should pass (126 total).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/telegram.py::_edit_overflow_split` (callers: `edit_message` overflow path, stream consumer finalize)
- Blast radius: LOW — single function change, only affects overflow-split path when `finalize=True`
- Related patterns: `send()` already uses format-first-then-chunk (line 1873-1876); this fix aligns `_edit_overflow_split` with the same pattern
