### PR TITLE
fix: cron env vars wiped after suspend/resume due to stale os.environ snapshot

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1383,8 +1383,45 @@ def _scan_assembled_cron_prompt(
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """Execute a single cron job, applying any per-job profile override."""
     job_id = job["id"]
+    # Prime os.environ from the profile .env BEFORE _job_profile_context takes
+    # its snapshot. Sequential (profile/workdir) jobs block the ticker thread
+    # for their full duration; if the host suspends mid-job, on resume the
+    # inactivity timeout fires, the context's finally restores the now-stale
+    # snapshot, and any vars added after snapshot time would be wiped. Loading
+    # first makes that restore land on a fully-populated env (idempotent).
+    _prime_profile_env(job_id, job.get("profile"))
     with _job_profile_context(job_id, job.get("profile")):
         return _run_job_impl(job)
+
+
+def _prime_profile_env(job_id: str, profile: Optional[str]) -> None:
+    """Load the resolved profile's .env into os.environ.
+
+    Resolves the profile home the same way _job_profile_context does so the
+    snapshot taken there captures a complete environment.
+    """
+    raw_profile = str(profile or "").strip()
+    if not raw_profile:
+        return
+    from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+
+    try:
+        profile_home = Path(
+            resolve_profile_env(normalize_profile_name(raw_profile))
+        ).resolve()
+    except (FileNotFoundError, ValueError) as exc:
+        logger.warning(
+            "Job '%s': cannot pre-load profile %r env (%s)",
+            job_id, raw_profile, exc,
+        )
+        return
+
+    from dotenv import load_dotenv
+
+    try:
+        load_dotenv(str(profile_home / ".env"), override=True, encoding="utf-8")
+    except UnicodeDecodeError:
+        load_dotenv(str(profile_home / ".env"), override=True, encoding="latin-1")
 
 
 def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:


### PR DESCRIPTION
## Problem

`_job_profile_context` (cron/scheduler.py) snapshots `os.environ` before each
profile-scoped job and does a delta-restore in its `finally` block (drop added
keys, revert changed ones). Sequential cron jobs — those with a `profile` or
`workdir` field — block the cron ticker thread for their full duration via
`_ctx.run()`.

If the host **suspends** while such a job is mid-run, the process freezes with
the snapshot still on the stack. On **resume** the inactivity timeout fires
immediately, the `finally` runs, and `os.environ` is force-rewound to the
(now hours-old) pre-suspend snapshot. Any env vars added or changed after the
snapshot was taken — including the profile `.env` values loaded inside the job
via `load_dotenv(...)` — get wiped.

### Asymmetry vs interactive sessions

Interactive hot-reload (`_reload_runtime_env_preserving_config_authority` in
`gateway/run.py`) runs **outside** `_job_profile_context`, so its mutations to
`os.environ` persist. Cron jobs only hold their profile env transiently inside
the context, and the restore at job end removes it — so after suspend/resume
this divergence becomes visible (cron jobs lose env the interactive path keeps).

## Fix

Prime `os.environ` from the resolved profile `.env` **before**
`_job_profile_context` takes its snapshot. The snapshot then captures a
fully-populated environment, so the `finally` restore is idempotent and lands
in a good state instead of rewinding to a partial one.

A small `_prime_profile_env()` helper resolves the profile home exactly the way
`_job_profile_context` does (`normalize_profile_name` + `resolve_profile_env`)
and loads the `.env` with the same `load_dotenv(..., override=True)` pattern
already used inside the job run. No-op for non-profile jobs.

Scope is limited to `cron/scheduler.py`.
