### PR TITLE
fix: prevent electron-builder from auto-discovering unrelated code-signing identity on macOS

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5142,6 +5142,15 @@ def cmd_gui(args: argparse.Namespace):
     if getattr(args, "cwd", None):
         env["HERMES_DESKTOP_CWD"] = str(Path(args.cwd).expanduser().resolve())
 
+    # Prevent electron-builder from auto-discovering a Developer ID cert
+    # for local development builds. If no explicit signing identity is
+    # configured (CSC_LINK / APPLE_SIGNING_IDENTITY), disable auto-discovery
+    # so codesign doesn't pick up an unrelated personal cert that can't
+    # validate its chain (errSecInternalComponent). Ad-hoc signing is
+    # applied post-build by _desktop_macos_relaunchable_fixup.
+    if sys.platform == "darwin" and not env.get("CSC_LINK") and not env.get("APPLE_SIGNING_IDENTITY"):
+        env["CSC_IDENTITY_AUTO_DISCOVERY"] = "false"
+
     source_mode = getattr(args, "source", False)
     skip_build = getattr(args, "skip_build", False)
     force_build = getattr(args, "force_build", False)


### PR DESCRIPTION
Closes #41499

## Bug Description

On macOS, `hermes update` (and `hermes desktop`) fail during the desktop app build step when the user has an Apple Developer ID certificate in their keychain for unrelated projects. electron-builder auto-discovers the cert, tries to sign Hermes.app with it, and `codesign` fails with `errSecInternalComponent` (or "ambiguous identity" when multiple certs share a name).

The update retries 4 times before giving up (normally, after clearing the Electron cache, and via a mirror).

## Root Cause

`cmd_gui()` passes the full environment to `npm run pack` without disabling electron-builder identity auto-discovery. `CSC_IDENTITY_AUTO_DISCOVERY` defaults to `true`, so electron-builder picks up any Developer ID cert in the keychain — even ones meant for the user's own unrelated apps. The cert chain cannot be validated for this project.

## Fix

Set `CSC_IDENTITY_AUTO_DISCOVERY=false` in the build environment when no explicit signing identity (`CSC_LINK` / `APPLE_SIGNING_IDENTITY`) is configured. This matches the existing pattern in `_desktop_macos_relaunchable_fixup`, which already checks for the same env vars before deciding whether to apply ad-hoc signing post-build.

- Only affects macOS (`sys.platform == "darwin"`)
- Only activates when no explicit signing identity is configured
- Users with proper distribution signing setup are unaffected
- Ad-hoc signing is applied after the build as before (via `_desktop_macos_relaunchable_fixup`)

## How to Verify

1. Have any Apple Developer ID cert in your keychain (for an unrelated app)
2. Run `hermes desktop --force-build --build-only`
3. Before: codesign fails with `errSecInternalComponent`
4. After: build succeeds, electron-builder logs "falling back to ad-hoc signature"

## Risk Assessment

Low — narrow scope (macOS-only, gated on no explicit signing identity configured), follows existing project convention, single env var, no behavioral change for any other platform.