### PR TITLE
fix(model): invalidate stale MiniMax-M3 cache entries up to 512K

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1612,13 +1612,16 @@ def get_model_context_length(
                     model, base_url, f"{cached:,}",
                 )
                 _invalidate_cached_context_length(model, base_url)
-            # Invalidate stale ≤204,800 cache entries for MiniMax-M3.  Pre-catalog
+            # Invalidate stale cache entries for MiniMax-M3.  Pre-catalog
             # builds resolved M3 via the generic ``minimax`` catch-all (204,800)
-            # and persisted it before the ``minimax-m3`` (1M) entry existed; that
-            # stale value would otherwise stick forever here at step 1.  M3 is 1M,
-            # so any sub-256K cached value for an M3 slug is a leftover — drop it
-            # and fall through to the hardcoded default.
-            elif cached <= 204_800 and _model_name_suggests_minimax_m3(model):
+            # and persisted it before the ``minimax-m3`` (1M) entry existed;
+            # models.dev also underreports M3 as 512K.  Any cached value below
+            # the catalog entry (1M) is a leftover — drop it and fall through
+            # to the hardcoded default.
+            elif (
+                cached < DEFAULT_CONTEXT_LENGTHS.get("minimax-m3", 1_000_000)
+                and _model_name_suggests_minimax_m3(model)
+            ):
                 logger.info(
                     "Dropping stale MiniMax-M3 cache entry %s@%s -> %s (pre-catalog value); "
                     "re-resolving via hardcoded defaults",


### PR DESCRIPTION
## Fixes #43400

### Problem

MiniMax M3 supports 1M context, but Hermes displays 512K. The root cause is a stale cache entry:

1. `models.dev` reports MiniMax-M3 context as 512K, which gets persisted to the context cache
2. The cache invalidation threshold at `model_metadata.py:1621` was `cached <= 204_800`
3. Since 512K > 204K, the stale cache entry survived invalidation
4. On subsequent lookups, the cached 512K value was returned instead of the correct 1M from the hardcoded catalog

### Fix

Change the cache invalidation threshold from a hardcoded `<= 204_800` to a dynamic comparison against the catalog value (`DEFAULT_CONTEXT_LENGTHS["minimax-m3"]` = 1M). Any cached value below the catalog entry is now invalidated and re-resolved.

### Testing

- Syntax verified: `ast.parse()` passes
- The change is backward-compatible: if the catalog entry changes, the threshold auto-adjusts