### PR TITLE
fix(gateway): format-then-chunk in Telegram overflow split

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2324,26 +2324,41 @@ class TelegramAdapter(BasePlatformAdapter):
         Falls back to ``SendResult(success=False)`` only if even the first-
         chunk edit fails — that's a real adapter problem, not an overflow.
         """
-        chunks = self.truncate_message(
-            content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
-        )
+        if finalize:
+            # Format first, *then* chunk — matching send()'s order.
+            # Chunking raw text and formatting each chunk afterwards
+            # inflates MarkdownV2 escapes past MAX_MESSAGE_LENGTH,
+            # causing Telegram to reject every chunk and fall back to
+            # plain text (issue #43441).
+            formatted = self.format_message(content)
+            chunks = self.truncate_message(
+                formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
+            )
+            if len(chunks) > 1:
+                import re as _re
+                chunks = [
+                    _re.sub(r" \((\d+)/(\d+)\)$", r" \\(\1/2\\)", chunk)
+                    for chunk in chunks
+                ]
+        else:
+            chunks = self.truncate_message(
+                content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
+            )
         if len(chunks) <= 1:
             # Defensive: shouldn't happen given the caller's pre-flight, but
             # if truncate_message returned a single chunk just edit normally.
-            chunks = [content]
+            chunks = [content if not finalize else self.format_message(content)]
 
         # Step 1 — edit the existing message with the first chunk.
         first_chunk = chunks[0]
         try:
             if finalize:
-                # Use format_message + parse_mode for the final chunk;
-                # mirror edit_message's main happy-path.
-                formatted = self.format_message(first_chunk)
+                # First chunk is already formatted — send with MarkdownV2.
                 try:
                     await self._bot.edit_message_text(
                         chat_id=int(chat_id),
                         message_id=int(message_id),
-                        text=formatted,
+                        text=first_chunk,
                         parse_mode=ParseMode.MARKDOWN_V2,
                     )
                 except Exception as fmt_err:
@@ -2351,7 +2366,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._bot.edit_message_text(
                             chat_id=int(chat_id),
                             message_id=int(message_id),
-                            text=first_chunk,
+                            text=_strip_mdv2(first_chunk),
                         )
             else:
                 await self._bot.edit_message_text(
@@ -2392,7 +2407,10 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             for use_markdown in (True, False) if finalize else (False,):
                 try:
-                    text = self.format_message(chunk) if use_markdown else chunk
+                    # Chunks are already formatted when finalize=True
+                    # (format-then-chunk at the top of this method).
+                    # Strip MarkdownV2 escapes for the plain-text fallback.
+                    text = _strip_mdv2(chunk) if finalize and not use_markdown else chunk
                     sent_msg = await self._bot.send_message(
                         chat_id=int(chat_id),
                         text=text,
@@ -2418,7 +2436,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         try:
                             sent_msg = await self._bot.send_message(
                                 chat_id=int(chat_id),
-                                text=chunk,
+                                text=_strip_mdv2(chunk) if finalize else chunk,
                                 **retry_thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),


### PR DESCRIPTION
## Fixes #43441

### Problem

In Telegram bound/forum topics, final replies arrive showing raw Markdown markers literally. The root cause: `_edit_overflow_split()` chunks raw text first, then formats each chunk with MarkdownV2. The escaping inflates each chunk past the 4096 limit, Telegram rejects every formatted attempt, and the fallback delivers raw markers.

### Fix

- When `finalize=True`: format content first, then chunk (matching `send()` order)
- Escape `(1/N)` chunk indicators for MarkdownV2
- Strip MarkdownV2 escapes in all plain-text fallback paths

### Testing

- Syntax verified: `ast.parse()` passes
- `finalize=False` path unchanged