### PR TITLE
fix(agent): include SKILL.md manifest fingerprint in prompt cache key

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1132,6 +1132,15 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names()
+    # Fingerprint of the on-disk SKILL.md manifest (mtime + size per file).
+    # Without this, external edits to skill files (manual edits, git pull,
+    # sync tools, parallel sessions) would be invisible to the in-process
+    # LRU cache — Layer 1 would keep returning stale results and Layer 2
+    # (disk snapshot) would never be consulted.  See #43282.
+    _manifest = _build_skills_manifest(skills_dir)
+    _manifest_fp = hash(tuple(
+        (k, tuple(v)) for k, v in sorted(_manifest.items())
+    ))
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
@@ -1139,6 +1148,7 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        _manifest_fp,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -427,6 +427,45 @@ class TestBuildSkillsSystemPrompt:
         result = build_skills_system_prompt()
         assert "backend-skill" in result
 
+    def test_cache_invalidates_on_skill_file_content_change(
+        self, monkeypatch, tmp_path
+    ):
+        """Cache must miss when a SKILL.md is modified on disk (#43282)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "research" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: Original description\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "Original description" in first
+
+        # Simulate external edit (git pull, sync tool, parallel session)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: Updated description\n---\n"
+        )
+
+        second = build_skills_system_prompt()
+        assert "Updated description" in second
+        assert "Original description" not in second
+
+    def test_cache_hits_when_no_skill_files_changed(
+        self, monkeypatch, tmp_path
+    ):
+        """Cache should hit when no SKILL.md files changed on disk."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "research" / "stable-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: stable-skill\ndescription: Stable\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        second = build_skills_system_prompt()
+        # Same content — cache hit expected (no stale data)
+        assert first == second
+
 
 class TestBuildNousSubscriptionPrompt:
     def test_includes_active_subscription_features(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Adds a manifest fingerprint (mtime/size hash) to the in-process LRU cache key in `build_skills_system_prompt()`, so external edits to SKILL.md files are detected and the cache is invalidated correctly.

## Related Issue

Fixes #43282

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py`: Compute a manifest fingerprint from `_build_skills_manifest()` and include it in the Layer 1 LRU cache key. When any SKILL.md file's mtime or size changes on disk, the fingerprint changes, producing a cache miss that falls through to Layer 2 (disk snapshot validation).
- `tests/agent/test_prompt_builder.py`: Added `test_cache_invalidates_on_skill_file_content_change` (verifies external edits break cache) and `test_cache_hits_when_no_skill_files_changed` (verifies no false misses).

## How to Test

1. Start a gateway session (populates `_SKILLS_PROMPT_CACHE`)
2. In a separate terminal, modify a skill description on disk: `sed -i 's/description: old/description: NEW/' ~/.hermes/skills/research/my-skill/SKILL.md`
3. In the same gateway session, request the `<available_skills>` block again
4. Verify the new description appears (cache miss, rebuild from disk)
5. Run: `pytest tests/agent/test_prompt_builder.py::TestBuildSkillsSystemPrompt -xvs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/prompt_builder.py::build_skills_system_prompt` (cache key construction at L1119-1142)
- Analyzed: `agent/prompt_builder.py::_build_skills_manifest` (manifest builder at L944-954, stat() per SKILL.md)
- Blast radius: LOW — only affects the in-process LRU cache key; Layer 2 (disk snapshot) and full rebuild paths are unchanged
- Related patterns: `_load_skills_snapshot` already validates manifest at L970; this fix brings Layer 1 parity with Layer 2
