### PR TITLE
fix(gemini): preserve terminal stream finish reasons

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -909,7 +909,11 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
 
     finish_reason_raw = str(cand.get("finishReason") or "")
     if finish_reason_raw:
-        mapped = "tool_calls" if tool_call_indices else _map_gemini_finish_reason(finish_reason_raw)
+        mapped = (
+            "tool_calls"
+            if finish_reason_raw == "STOP" and tool_call_indices
+            else _map_gemini_finish_reason(finish_reason_raw)
+        )
         finish_chunk = _make_stream_chunk(model=model, finish_reason=mapped)
         # Attach usage from this event's usageMetadata so the streaming
         # loop in run_agent.py can record token counts (mirrors the

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -778,7 +778,11 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
 
     finish_reason_raw = str(cand.get("finishReason") or "")
     if finish_reason_raw:
-        mapped = "tool_calls" if tool_call_indices else _map_gemini_finish_reason(finish_reason_raw)
+        mapped = (
+            "tool_calls"
+            if finish_reason_raw == "STOP" and tool_call_indices
+            else _map_gemini_finish_reason(finish_reason_raw)
+        )
         finish_chunk = _make_stream_chunk(model=model, finish_reason=mapped)
         # Attach usage from this event's usageMetadata so the streaming
         # loop in run_agent.py can record token counts (mirrors the

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -331,6 +331,52 @@ def test_build_gemini_request_does_not_raise_when_thinking_is_disabled():
     assert request["generationConfig"]["thinkingConfig"]["includeThoughts"] is False
 
 
+@pytest.mark.parametrize(
+    ("gemini_finish_reason", "openai_finish_reason"),
+    [
+        ("STOP", "tool_calls"),
+        ("MAX_TOKENS", "length"),
+        ("SAFETY", "content_filter"),
+    ],
+)
+def test_stream_event_translation_preserves_terminal_finish_reason_after_tool_call(
+    gemini_finish_reason,
+    openai_finish_reason,
+):
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices = {}
+    tool_call_event = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "search", "args": {"q": "abc"}}}
+                    ]
+                }
+            }
+        ]
+    }
+    tool_chunks = translate_stream_event(
+        tool_call_event,
+        model="gemini-2.5-flash",
+        tool_call_indices=tool_call_indices,
+    )
+    terminal_event = {
+        "candidates": [
+            {"content": {"parts": []}, "finishReason": gemini_finish_reason}
+        ]
+    }
+    terminal_chunks = translate_stream_event(
+        terminal_event,
+        model="gemini-2.5-flash",
+        tool_call_indices=tool_call_indices,
+    )
+
+    assert tool_chunks[0].choices[0].delta.tool_calls[0].function.name == "search"
+    assert terminal_chunks[-1].choices[0].finish_reason == openai_finish_reason
+
+
 
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -240,6 +240,44 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
     assert first[-1].choices[0].finish_reason == "tool_calls"
 
 
+@pytest.mark.parametrize(
+    ("gemini_finish_reason", "openai_finish_reason"),
+    [
+        ("STOP", "tool_calls"),
+        ("MAX_TOKENS", "length"),
+        ("SAFETY", "content_filter"),
+    ],
+)
+def test_stream_event_translation_preserves_terminal_finish_reason_after_tool_call(
+    gemini_finish_reason,
+    openai_finish_reason,
+):
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices = {}
+    event = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "search", "args": {"q": "abc"}}}
+                    ]
+                },
+                "finishReason": gemini_finish_reason,
+            }
+        ]
+    }
+
+    chunks = translate_stream_event(
+        event,
+        model="gemini-2.5-flash",
+        tool_call_indices=tool_call_indices,
+    )
+
+    assert chunks[0].choices[0].delta.tool_calls[0].function.name == "search"
+    assert chunks[-1].choices[0].finish_reason == openai_finish_reason
+
+
 
 
 
@@ -251,7 +289,6 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
 # ---------------------------------------------------------------------------
 # X-Goog-Api-Client header tests
 # ---------------------------------------------------------------------------
-
 
 
 


### PR DESCRIPTION
## Summary

- preserve Gemini native streaming terminal `MAX_TOKENS` and `SAFETY` finish reasons after a tool-call event
- keep the existing `STOP` + streamed tool-call behavior that emits OpenAI-compatible `tool_calls`
- refresh the focused regression on current `main` after upstream test refactoring

## Validation

- RED on the refreshed baseline: `2 failed, 9 passed` (`MAX_TOKENS` and `SAFETY`)
- `scripts/run_tests.sh tests/agent/test_gemini_native_adapter.py -q` — 11 passed
- `uv run --extra dev ruff check agent/gemini_native_adapter.py tests/agent/test_gemini_native_adapter.py` — passed
- `git diff --check` — passed
- independent read-only audit: candidate quality PASS; patch quality PASS

`ruff format --check` still reports broad pre-existing formatting drift in both touched files, and `ty check` reports the same two pre-existing `SimpleNamespace` fixture diagnostics found on the baseline; neither was introduced by this patch.

## Duplicate Check

Live searches by PR number, affected symbols, finish-reason behavior, and related commits found no equivalent active PR or fix on `main`. The affected paths did not change between the audited refresh base and the latest upstream head checked immediately before publication.

## Browser / Playwright

Not applicable: this is a provider streaming adapter fix with deterministic CPU unit coverage and no browser-visible surface.
