### PR TITLE
fix(kanban): keep initial blocked tasks sticky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ docs/superpowers/*
 # also created in-repo when an agent operates in this checkout). Plans, audit
 # logs, and per-session caches are never artifacts of the codebase.
 .hermes/
+.gstack/
 
 # Desktop/bootstrap install marker written into the managed checkout root by the
 # bootstrap installer. It is Hermes-managed runtime state, never a code change —

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -11,6 +11,7 @@ behavior-neutral move that lifts ~1,000 LOC out of run.py.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import sqlite3
@@ -25,6 +26,93 @@ logger = logging.getLogger("gateway.run")
 
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
+
+    def _kanban_discord_projection_metadata(self, task: Any, board: Optional[str]) -> Optional[dict[str, Any]]:
+        """Return expected Discord forum metadata for a Kanban task.
+
+        Discord forum cards are projections of the canonical Kanban task.
+        Terminal notifications are the last chance to mutate the thread before
+        ``done``/``archived`` tasks are unsubscribed, so the gateway keeps the
+        card title/tags in sync immediately before sending the terminal ping.
+        """
+        if not task:
+            return None
+        try:
+            from hermes_cli import kanban_db as _kb
+            board_name = board or _kb.get_current_board()
+            cfg_path = _kb.board_dir(board_name) / "discord-forum-tags.json"
+            config = json.loads(cfg_path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return None
+        except Exception as exc:
+            logger.debug("kanban notifier: discord projection config unavailable: %s", exc)
+            return None
+
+        status = str(getattr(task, "status", "") or "")
+        assignee = str(getattr(task, "assignee", "") or "").strip()
+        title = str(getattr(task, "title", "") or "").strip()
+        icons = {
+            "triage": "◇",
+            "todo": "◻",
+            "ready": "▶",
+            "running": "●",
+            "scheduled": "⏱",
+            "blocked": "🛑",
+            "review": "◆",
+            "done": "✅",
+            "archived": "—",
+        }
+        raw_tag_defs = config.get("tags")
+        tag_defs = raw_tag_defs if isinstance(raw_tag_defs, dict) else {}
+        raw_status_tag_def = tag_defs.get(status)
+        status_tag_def = raw_status_tag_def if isinstance(raw_status_tag_def, dict) else {}
+        icon = str(status_tag_def.get("emoji") or "").strip() or icons.get(status, "?")
+        status_to_tag = config.get("status_to_tag") if isinstance(config.get("status_to_tag"), dict) else {}
+        assignee_to_tag = config.get("assignee_to_tag") if isinstance(config.get("assignee_to_tag"), dict) else {}
+        tags: list[str] = []
+        if status_to_tag.get(status):
+            tags.append(str(status_to_tag[status]))
+        assignee_tag = assignee_to_tag.get(assignee) or assignee_to_tag.get("default")
+        if assignee_tag:
+            tags.append(str(assignee_tag))
+        return {
+            "name": f"{icon} [{status}] {title}",
+            "applied_tags": tags,
+        }
+
+    async def _sync_kanban_discord_projection(
+        self,
+        adapter: Any,
+        sub: dict,
+        task: Any,
+        board: Optional[str],
+    ) -> bool:
+        """Best-effort Discord forum-card metadata sync for Kanban projections."""
+        thread_id = str(sub.get("thread_id") or "")
+        if not thread_id or not task:
+            return True
+        updater = getattr(adapter, "update_thread_metadata", None)
+        if updater is None:
+            logger.debug(
+                "kanban notifier: discord adapter cannot update thread metadata for %s",
+                sub.get("task_id"),
+            )
+            return True
+        metadata = self._kanban_discord_projection_metadata(task, board)
+        if not metadata:
+            return True
+        ok = await updater(
+            thread_id,
+            name=metadata["name"],
+            applied_tags=metadata["applied_tags"],
+        )
+        if ok is False:
+            return False
+        logger.debug(
+            "kanban notifier: synced Discord projection for %s thread %s",
+            sub.get("task_id"), thread_id,
+        )
+        return True
 
     async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
         """Poll ``kanban_notify_subs`` and deliver terminal events to users.
@@ -234,6 +322,23 @@ class GatewayKanbanWatchersMixin:
                             board_slug,
                         )
                         continue
+                    if plat.value == "discord" and sub.get("thread_id"):
+                        synced = await self._sync_kanban_discord_projection(
+                            adapter, sub, task, board_slug,
+                        )
+                        if synced is False:
+                            logger.warning(
+                                "kanban notifier: Discord projection sync failed for %s; rewinding claim",
+                                sub["task_id"],
+                            )
+                            await asyncio.to_thread(
+                                self._kanban_rewind,
+                                sub,
+                                d["cursor"],
+                                d.get("old_cursor", 0),
+                                board_slug,
+                            )
+                            continue
                     title = (task.title if task else sub["task_id"])[:120]
                     for ev in d["events"]:
                         kind = ev.kind

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7365,6 +7365,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return self._telegram_topic_root_lobby_message()
             return None
 
+        kanban_lifecycle_text = self._kanban_thread_free_response_command(event)
+        if kanban_lifecycle_text:
+            event = dataclasses.replace(event, text=kanban_lifecycle_text)
+            return await self._handle_kanban_command(event)
+
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there
         # are numerous await points (hooks, vision enrichment, STT,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -229,6 +229,60 @@ def _discord_tools_loaded() -> bool:
         return False
 
 
+def _bound_kanban_task_for_source(source: SessionSource):
+    """Return the single Kanban task subscribed to this gateway source, if any.
+
+    Kanban thread ownership is represented by ``kanban_notify_subs`` rows. The
+    session prompt only pins a task when the source maps unambiguously to exactly
+    one task; ambiguous or missing bindings are ignored.
+    """
+    platform = getattr(source.platform, "value", str(source.platform or "")).lower()
+    chat_id = str(source.chat_id or "")
+    thread_id = str(source.thread_id or "")
+    # Prompt pinning is intentionally thread-scoped. Whole-channel
+    # subscriptions can receive notifications, but a shared busy channel should
+    # not silently become owned by one task.
+    if not platform or not chat_id or not thread_id:
+        return None
+
+    try:
+        from hermes_cli import kanban_db as kb
+
+        candidates: list[tuple[str, str]] = []
+        for meta in kb.list_boards(include_archived=False):
+            board = str(meta.get("slug") or "")
+            if not board:
+                continue
+            conn = kb.connect(board=board)
+            try:
+                matches = [
+                    row
+                    for row in kb.list_notify_subs(conn)
+                    if str(row.get("platform") or "").lower() == platform
+                    and str(row.get("chat_id") or "") == chat_id
+                    and str(row.get("thread_id") or "") == thread_id
+                ]
+                candidates.extend(
+                    (board, str(row.get("task_id") or ""))
+                    for row in matches
+                    if row.get("task_id")
+                )
+            finally:
+                conn.close()
+        unique_candidates = sorted(set(candidates))
+        if len(unique_candidates) != 1:
+            return None
+        board, task_id = unique_candidates[0]
+        conn = kb.connect(board=board)
+        try:
+            return kb.get_task(conn, task_id)
+        finally:
+            conn.close()
+    except Exception as exc:  # pragma: no cover - prompt enrichment is best-effort
+        logger.debug("kanban bound-task lookup failed for session context: %s", exc)
+        return None
+
+
 def build_session_context_prompt(
     context: SessionContext,
     *,
@@ -314,6 +368,15 @@ def build_session_context_prompt(
         if redact_pii:
             uid = _hash_sender_id(uid)
         lines.append(f"**User ID:** {uid}")
+
+    bound_task = _bound_kanban_task_for_source(context.source)
+    if bound_task is not None:
+        lines.append("")
+        lines.append(f"Kanban task: `{bound_task.id}`")
+        lines.append(f"Title: {bound_task.title}")
+        if bound_task.assignee:
+            lines.append(f"Assignee: `{bound_task.assignee}`")
+        lines.append(f"Status: `{bound_task.status}`")
 
     # Platform-specific behavioral notes
     if context.source.platform == Platform.SLACK:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -259,8 +259,15 @@ def _bound_kanban_task_for_source(source: SessionSource):
                     row
                     for row in kb.list_notify_subs(conn)
                     if str(row.get("platform") or "").lower() == platform
-                    and str(row.get("chat_id") or "") == chat_id
                     and str(row.get("thread_id") or "") == thread_id
+                    and (
+                        str(row.get("chat_id") or "") == chat_id
+                        or (
+                            platform == "discord"
+                            and str(getattr(source, "chat_type", "") or "") == "thread"
+                            and chat_id == thread_id
+                        )
+                    )
                 ]
                 candidates.extend(
                     (board, str(row.get("task_id") or ""))

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -293,6 +293,74 @@ class GatewaySlashCommandsMixin:
             f"Slash commands you can run: {runnable_str}"
         )
 
+    def _kanban_source_has_unique_thread_binding(self, source) -> bool:
+        """Return True when source is an unambiguous subscribed Kanban task thread."""
+        platform = getattr(getattr(source, "platform", None), "value", getattr(source, "platform", ""))
+        platform_str = str(platform or "").lower()
+        chat_id = str(getattr(source, "chat_id", "") or "")
+        thread_id = str(getattr(source, "thread_id", "") or "")
+        if not platform_str or not chat_id or not thread_id:
+            return False
+        try:
+            from hermes_cli import kanban_db as _kb
+
+            boards = [
+                str(meta.get("slug") or "")
+                for meta in _kb.list_boards(include_archived=False)
+                if meta.get("slug")
+            ]
+            candidates: set[tuple[str | None, str]] = set()
+            for candidate_board in boards:
+                conn = _kb.connect(board=candidate_board)
+                try:
+                    candidates.update(
+                        (candidate_board, str(row.get("task_id") or ""))
+                        for row in _kb.list_notify_subs(conn)
+                        if row.get("task_id")
+                        and str(row.get("platform") or "").lower() == platform_str
+                        and str(row.get("chat_id") or "") == chat_id
+                        and str(row.get("thread_id") or "") == thread_id
+                    )
+                finally:
+                    conn.close()
+            return len(candidates) == 1
+        except Exception as exc:  # pragma: no cover - best-effort routing guard
+            logger.debug("kanban free-response bound-task lookup failed: %s", exc)
+            return False
+
+    def _kanban_thread_free_response_command(self, event: MessageEvent) -> str | None:
+        """Map plain-language task-thread lifecycle requests to /kanban shorthand."""
+        text = (event.text or "").strip()
+        if not text or text.startswith("/"):
+            return None
+        if not self._kanban_source_has_unique_thread_binding(event.source):
+            return None
+
+        done_match = re.match(
+            r"(?is)^\s*(?:"
+            r"mark\s+(?:this\s+)?(?:task\s+)?(?:as\s+)?done"
+            r"|close\s+(?:this\s+|the\s+)?(?:task|card)"
+            r"|(?:this\s+)?task\s+is\s+done"
+            r")\b(?P<summary>.*)$",
+            text,
+        )
+        if done_match:
+            summary = done_match.group("summary").strip(" \t:-—–")
+            return "/kanban done" + (f" {summary}" if summary else "")
+
+        block_match = re.match(
+            r"(?is)^\s*(?:"
+            r"block\s+(?:this\s+)?(?:task\s+)?"
+            r"|mark\s+(?:this\s+)?(?:task\s+)?(?:as\s+)?blocked"
+            r")\b(?P<reason>.*)$",
+            text,
+        )
+        if block_match:
+            reason = block_match.group("reason").strip(" \t:-—–")
+            return "/kanban block" + (f" {reason}" if reason else "")
+
+        return None
+
     async def _handle_kanban_command(self, event: MessageEvent) -> str:
         """Handle /kanban — delegate to the shared kanban CLI.
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -312,6 +312,105 @@ class GatewaySlashCommandsMixin:
         import shlex
         from hermes_cli.kanban import run_slash
 
+        def _bound_kanban_task_for_source(
+            source,
+            *,
+            board: str | None = None,
+        ) -> tuple[str | None, str] | None:
+            platform = getattr(getattr(source, "platform", None), "value", getattr(source, "platform", ""))
+            platform_str = str(platform or "").lower()
+            chat_id = str(getattr(source, "chat_id", "") or "")
+            thread_id = str(getattr(source, "thread_id", "") or "")
+            # Lifecycle shorthand is intentionally thread-scoped. Whole-channel
+            # subscriptions can receive events, but inferring `/kanban block ...`
+            # there is too easy to trigger accidentally in a busy channel.
+            if not platform_str or not chat_id or not thread_id:
+                return None
+            try:
+                from hermes_cli import kanban_db as _kb
+
+                if board:
+                    if not _kb.board_exists(board):
+                        return None
+                    boards = [board]
+                else:
+                    boards = [
+                        str(meta.get("slug") or "")
+                        for meta in _kb.list_boards(include_archived=False)
+                        if meta.get("slug")
+                    ]
+                candidates: set[tuple[str | None, str]] = set()
+                for candidate_board in boards:
+                    conn = _kb.connect(board=candidate_board)
+                    try:
+                        matches = [
+                            row
+                            for row in _kb.list_notify_subs(conn)
+                            if str(row.get("platform") or "").lower() == platform_str
+                            and str(row.get("chat_id") or "") == chat_id
+                            and str(row.get("thread_id") or "") == thread_id
+                        ]
+                        candidates.update(
+                            (candidate_board, str(row.get("task_id") or ""))
+                            for row in matches
+                            if row.get("task_id")
+                        )
+                    finally:
+                        conn.close()
+                return sorted(candidates)[0] if len(candidates) == 1 else None
+            except Exception as exc:  # pragma: no cover - shorthand inference is best-effort
+                logger.debug("kanban bound-task lookup failed: %s", exc)
+                return None
+
+        def _inject_bound_task_for_lifecycle_shorthand(tokens: list[str], source, *, board: str | None = None) -> list[str]:
+            if not tokens:
+                return tokens
+            action_idx = None
+            idx = 0
+            while idx < len(tokens):
+                tok = tokens[idx]
+                if tok == "--board":
+                    idx += 2
+                    continue
+                if tok.startswith("--board="):
+                    idx += 1
+                    continue
+                action_idx = idx
+                break
+            if action_idx is None:
+                return tokens
+
+            action = tokens[action_idx]
+            if action not in {"block", "done", "complete"}:
+                return tokens
+            remainder = tokens[action_idx + 1:]
+            if any(tok.startswith("t_") for tok in remainder):
+                return tokens
+
+            bound = _bound_kanban_task_for_source(source, board=board)
+            if not bound:
+                return tokens
+            bound_board, task_id = bound
+
+            new_tokens = list(tokens)
+            if board is None and bound_board:
+                new_tokens[action_idx:action_idx] = ["--board", bound_board]
+                action_idx += 2
+            if action == "block":
+                new_tokens[action_idx + 1:action_idx + 1] = [task_id]
+                return new_tokens
+
+            # In chat, `/kanban done <words...>` means complete the bound task
+            # with those words as the result summary, not extra task ids. If the
+            # user supplied explicit `complete --result ...` style flags, insert
+            # only the task id and preserve the flags for argparse to handle.
+            new_tokens[action_idx] = "complete"
+            if not remainder or remainder[0].startswith("--"):
+                new_tokens[action_idx + 1:action_idx + 1] = [task_id]
+                return new_tokens
+            new_tokens[action_idx + 1:] = [task_id, "--result", " ".join(remainder)]
+            return new_tokens
+
         text = (event.text or "").strip()
         # Strip the leading "/kanban" (with or without slash), leaving args.
         if text.startswith("/"):
@@ -339,6 +438,16 @@ class GatewaySlashCommandsMixin:
             break
 
         is_create = action == "create"
+
+        if not is_create:
+            inferred_tokens = _inject_bound_task_for_lifecycle_shorthand(
+                tokens,
+                event.source,
+                board=requested_board,
+            )
+            if inferred_tokens != tokens:
+                text = shlex.join(inferred_tokens)
+                tokens = inferred_tokens
 
         try:
             output = await asyncio.to_thread(run_slash, text)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -318,8 +318,15 @@ class GatewaySlashCommandsMixin:
                         for row in _kb.list_notify_subs(conn)
                         if row.get("task_id")
                         and str(row.get("platform") or "").lower() == platform_str
-                        and str(row.get("chat_id") or "") == chat_id
                         and str(row.get("thread_id") or "") == thread_id
+                        and (
+                            str(row.get("chat_id") or "") == chat_id
+                            or (
+                                platform_str == "discord"
+                                and str(getattr(source, "chat_type", "") or "") == "thread"
+                                and chat_id == thread_id
+                            )
+                        )
                     )
                 finally:
                     conn.close()
@@ -415,8 +422,15 @@ class GatewaySlashCommandsMixin:
                             row
                             for row in _kb.list_notify_subs(conn)
                             if str(row.get("platform") or "").lower() == platform_str
-                            and str(row.get("chat_id") or "") == chat_id
                             and str(row.get("thread_id") or "") == thread_id
+                            and (
+                                str(row.get("chat_id") or "") == chat_id
+                                or (
+                                    platform_str == "discord"
+                                    and str(getattr(source, "chat_type", "") or "") == "thread"
+                                    and chat_id == thread_id
+                                )
+                            )
                         ]
                         candidates.update(
                             (candidate_board, str(row.get("task_id") or ""))

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -76,9 +76,12 @@ class ProfileGatewayProcess:
     path: Path
     pid: int
 
-
-def _get_service_pids() -> set:
+def _get_service_pids(all_profiles: bool = False) -> set:
     """Return PIDs currently managed by systemd or launchd gateway services.
+
+    By default this is scoped to the current Hermes profile's service.  Pass
+    ``all_profiles=True`` for global maintenance flows that intentionally need
+    to see every profile gateway service.
 
     Used to avoid killing freshly-restarted service processes when sweeping
     for stale manual gateway processes after a service restart.  Relies on the
@@ -89,6 +92,7 @@ def _get_service_pids() -> set:
 
     # --- systemd (Linux): user and system scopes ---
     if supports_systemd_services():
+        expected_service = f"{get_service_name()}.service"
         for scope_args in [["systemctl", "--user"], ["systemctl"]]:
             try:
                 result = subprocess.run(
@@ -109,6 +113,8 @@ def _get_service_pids() -> set:
                     if not parts or not parts[0].endswith(".service"):
                         continue
                     svc = parts[0]
+                    if not all_profiles and svc != expected_service:
+                        continue
                     try:
                         show = subprocess.run(
                             scope_args + ["show", svc, "--property=MainPID", "--value"],
@@ -577,7 +583,7 @@ def find_gateway_pids(
             _append_unique_pid(pids, get_running_pid(), _exclude)
         except Exception:
             pass
-    for pid in _get_service_pids():
+    for pid in _get_service_pids(all_profiles=all_profiles):
         _append_unique_pid(pids, pid, _exclude)
     for pid in _scan_gateway_pids(_exclude, all_profiles=all_profiles):
         _append_unique_pid(pids, pid, _exclude)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -707,6 +707,19 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_nrm.add_argument("--chat-id", required=True)
     p_nrm.add_argument("--thread-id", default=None)
 
+    # --- repair / reconcile ---
+    p_repair = sub.add_parser(
+        "repair",
+        aliases=["reconcile"],
+        help="Report and optionally repair Kanban projection/subscription metadata",
+    )
+    p_repair.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply safe repairs instead of reporting only",
+    )
+    p_repair.add_argument("--json", action="store_true")
+
     # --- log ---
     p_log = sub.add_parser(
         "log",
@@ -955,6 +968,8 @@ def kanban_command(args: argparse.Namespace) -> int:
             "notify-subscribe":   _cmd_notify_subscribe,
             "notify-list":        _cmd_notify_list,
             "notify-unsubscribe": _cmd_notify_unsubscribe,
+            "repair":   _cmd_repair,
+            "reconcile": _cmd_repair,
             "context":  _cmd_context,
             "specify":  _cmd_specify,
             "decompose":  _cmd_decompose,
@@ -2461,6 +2476,38 @@ def _cmd_notify_unsubscribe(args: argparse.Namespace) -> int:
         print("(no such subscription)", file=sys.stderr)
         return 1
     print(f"Unsubscribed from {args.task_id}")
+    return 0
+
+
+def _cmd_repair(args: argparse.Namespace) -> int:
+    apply_changes = bool(getattr(args, "apply", False))
+    with kb.connect_closing() as conn:
+        projection_report = kb.repair_projection_subscriptions(
+            conn,
+            apply=apply_changes,
+        )
+    report = {
+        "dry_run": not apply_changes,
+        "projection_subscriptions": projection_report,
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+        return 0
+
+    mode = "applied" if apply_changes else "dry-run"
+    print(f"Kanban repair ({mode})")
+    print(
+        "  projection_subscriptions: "
+        f"scanned={projection_report['scanned']} "
+        f"orphaned={projection_report['orphaned']} "
+        f"removed={projection_report['removed']}"
+    )
+    for orphan in projection_report["orphans"]:
+        print(
+            "    orphan "
+            f"{orphan['task_id']} -> "
+            f"{orphan['platform']}:{orphan['chat_id']}:{orphan['thread_id']}"
+        )
     return 0
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2500,6 +2500,8 @@ def _cmd_repair(args: argparse.Namespace) -> int:
         "  projection_subscriptions: "
         f"scanned={projection_report['scanned']} "
         f"orphaned={projection_report['orphaned']} "
+        f"malformed={projection_report['malformed']} "
+        f"ambiguous={projection_report['ambiguous']} "
         f"removed={projection_report['removed']}"
     )
     for orphan in projection_report["orphans"]:
@@ -2507,6 +2509,20 @@ def _cmd_repair(args: argparse.Namespace) -> int:
             "    orphan "
             f"{orphan['task_id']} -> "
             f"{orphan['platform']}:{orphan['chat_id']}:{orphan['thread_id']}"
+        )
+    for row in projection_report["malformed_rows"]:
+        print(
+            "    malformed "
+            f"{row['task_id']} -> "
+            f"{row['platform']}:{row['chat_id']}:{row['thread_id']} "
+            f"({row['reason']})"
+        )
+    for binding in projection_report["ambiguous_bindings"]:
+        task_ids = ",".join(binding["task_ids"])
+        print(
+            "    ambiguous "
+            f"{binding['platform']}:{binding['chat_id']}:{binding['thread_id']} "
+            f"-> {task_ids}"
         )
     return 0
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -21,6 +21,8 @@ import os
 import shlex
 import sys
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any, Optional
 
@@ -719,6 +721,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Apply safe repairs instead of reporting only",
     )
     p_repair.add_argument("--json", action="store_true")
+    p_repair.add_argument(
+        "--audit-discord",
+        action="store_true",
+        help="Dry-run audit of Discord forum thread names/tags against Kanban task state",
+    )
 
     # --- log ---
     p_log = sub.add_parser(
@@ -2479,6 +2486,164 @@ def _cmd_notify_unsubscribe(args: argparse.Namespace) -> int:
     return 0
 
 
+_DISCORD_PROJECTION_STATUS_ICONS = {
+    "triage": "◇",
+    "todo": "◻",
+    "ready": "▶",
+    "running": "●",
+    "scheduled": "⏱",
+    "blocked": "🛑",
+    "review": "◆",
+    "done": "✅",
+    "archived": "—",
+}
+
+
+def _discord_projection_config_path() -> Path:
+    return kb.board_dir(kb.get_current_board()) / "discord-forum-tags.json"
+
+
+def _load_discord_projection_config() -> dict[str, Any]:
+    path = _discord_projection_config_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"error": f"invalid_json:{path}"}
+    return data if isinstance(data, dict) else {}
+
+
+def _expected_discord_projection(task: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
+    status = str(task.get("status") or "")
+    assignee = str(task.get("assignee") or "").strip()
+    title = str(task.get("title") or "").strip()
+    icon = _DISCORD_PROJECTION_STATUS_ICONS.get(status, _STATUS_ICONS.get(status, "?"))
+    raw_status_to_tag = config.get("status_to_tag")
+    raw_assignee_to_tag = config.get("assignee_to_tag")
+    status_to_tag: dict[str, Any] = raw_status_to_tag if isinstance(raw_status_to_tag, dict) else {}
+    assignee_to_tag: dict[str, Any] = raw_assignee_to_tag if isinstance(raw_assignee_to_tag, dict) else {}
+    tags: list[str] = []
+    status_tag = status_to_tag.get(status)
+    if status_tag:
+        tags.append(str(status_tag))
+    assignee_tag = assignee_to_tag.get(assignee) or assignee_to_tag.get("default")
+    if assignee_tag:
+        tags.append(str(assignee_tag))
+    return {"name": f"{icon} [{status}] {title}", "tags": tags}
+
+
+def _fetch_discord_thread_snapshot(thread_id: str) -> dict[str, Any] | None:
+    """Fetch a Discord thread via REST for projection audits.
+
+    Only a tiny, non-secret snapshot is returned. A 404 means the projected
+    thread is missing; other API failures are surfaced as redacted errors.
+    """
+    token = os.environ.get("DISCORD_BOT_TOKEN", "").strip()
+    if not token:
+        return {"id": thread_id, "error": "DISCORD_BOT_TOKEN not configured"}
+    req = urllib.request.Request(
+        f"https://discord.com/api/v10/channels/{thread_id}",
+        headers={
+            "Authorization": f"Bot {token}",
+            "User-Agent": "DiscordBot (hermes-agent, 0.14.0)",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            data = json.load(resp)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        return {"id": thread_id, "error": f"discord_http_{exc.code}"}
+    except Exception as exc:
+        return {"id": thread_id, "error": f"discord_fetch_failed:{type(exc).__name__}"}
+    return {
+        "id": str(data.get("id") or thread_id),
+        "name": str(data.get("name") or ""),
+        "applied_tags": [str(tag) for tag in data.get("applied_tags", [])],
+    }
+
+
+def _audit_discord_projection(conn) -> dict[str, Any]:
+    config = _load_discord_projection_config()
+    if config.get("error"):
+        return {
+            "scanned": 0,
+            "mismatched": 0,
+            "missing": 0,
+            "mismatches": [],
+            "missing_threads": [],
+            "errors": [config["error"]],
+        }
+    rows = conn.execute(
+        """
+        SELECT s.task_id, s.chat_id, s.thread_id,
+               t.title, t.assignee, t.status
+          FROM kanban_notify_subs AS s
+          JOIN tasks AS t ON t.id = s.task_id
+         WHERE s.platform = 'discord'
+           AND COALESCE(s.chat_id, '') != ''
+           AND COALESCE(s.thread_id, '') != ''
+         ORDER BY s.task_id, s.chat_id, s.thread_id
+        """
+    ).fetchall()
+    mismatches: list[dict[str, Any]] = []
+    missing_threads: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    for row in rows:
+        expected = _expected_discord_projection(
+            {"title": row["title"], "assignee": row["assignee"], "status": row["status"]},
+            config,
+        )
+        thread_id = str(row["thread_id"] or "")
+        chat_id = str(row["chat_id"] or "")
+        snapshot = _fetch_discord_thread_snapshot(thread_id)
+        if snapshot is None:
+            missing_threads.append({
+                "task_id": str(row["task_id"]),
+                "thread_id": thread_id,
+                "chat_id": chat_id,
+                "expected": expected,
+            })
+            continue
+        if snapshot.get("error"):
+            errors.append({
+                "task_id": str(row["task_id"]),
+                "thread_id": thread_id,
+                "error": str(snapshot["error"]),
+            })
+            continue
+        actual = {
+            "name": str(snapshot.get("name") or ""),
+            "tags": [str(tag) for tag in snapshot.get("applied_tags", [])],
+        }
+        expected_tags = list(expected["tags"])
+        actual_tags = list(actual["tags"])
+        missing_tags = [tag for tag in expected_tags if tag not in actual_tags]
+        unexpected_tags = [tag for tag in actual_tags if tag not in expected_tags]
+        if actual["name"] != expected["name"] or missing_tags or unexpected_tags:
+            mismatches.append({
+                "task_id": str(row["task_id"]),
+                "thread_id": thread_id,
+                "chat_id": chat_id,
+                "expected": expected,
+                "actual": actual,
+                "missing_tags": missing_tags,
+                "unexpected_tags": unexpected_tags,
+            })
+    return {
+        "scanned": len(rows),
+        "mismatched": len(mismatches),
+        "missing": len(missing_threads),
+        "mismatches": mismatches,
+        "missing_threads": missing_threads,
+        "errors": errors,
+    }
+
+
 def _cmd_repair(args: argparse.Namespace) -> int:
     apply_changes = bool(getattr(args, "apply", False))
     with kb.connect_closing() as conn:
@@ -2486,10 +2651,13 @@ def _cmd_repair(args: argparse.Namespace) -> int:
             conn,
             apply=apply_changes,
         )
+        discord_report = _audit_discord_projection(conn) if getattr(args, "audit_discord", False) else None
     report = {
         "dry_run": not apply_changes,
         "projection_subscriptions": projection_report,
     }
+    if discord_report is not None:
+        report["discord_projection"] = discord_report
     if getattr(args, "json", False):
         print(json.dumps(report, indent=2, ensure_ascii=False))
         return 0
@@ -2524,6 +2692,24 @@ def _cmd_repair(args: argparse.Namespace) -> int:
             f"{binding['platform']}:{binding['chat_id']}:{binding['thread_id']} "
             f"-> {task_ids}"
         )
+    if discord_report is not None:
+        print(
+            "  discord_projection: "
+            f"scanned={discord_report['scanned']} "
+            f"mismatched={discord_report['mismatched']} "
+            f"missing={discord_report['missing']} "
+            f"errors={len(discord_report['errors'])}"
+        )
+        for mismatch in discord_report["mismatches"]:
+            print(
+                "    mismatch "
+                f"{mismatch['task_id']} -> discord:{mismatch['chat_id']}:{mismatch['thread_id']}"
+            )
+        for missing in discord_report["missing_threads"]:
+            print(
+                "    missing_thread "
+                f"{missing['task_id']} -> discord:{missing['chat_id']}:{missing['thread_id']}"
+            )
     return 0
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1370,6 +1370,13 @@ def _cmd_create(args: argparse.Namespace) -> int:
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
+        projection_result = _project_created_task_to_discord(conn, task) if task is not None else None
+    if isinstance(projection_result, dict) and projection_result.get("error"):
+        print(
+            f"⚠  Discord forum projection failed for {task_id}: {projection_result['error']}. "
+            "Task was created; run `hermes kanban repair --audit-discord` after fixing projection config/gateway access.",
+            file=sys.stderr,
+        )
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:
@@ -2504,23 +2511,53 @@ def _discord_projection_config_path() -> Path:
 
 
 def _load_discord_projection_config() -> dict[str, Any]:
+    """Load Discord forum projection config for the current Kanban board.
+
+    Runtime enablement lives in ``kanban.board_projections.<board>`` while the
+    board-local ``discord-forum-tags.json`` file carries the forum tag mapping.
+    Merge both sources so create/audit paths follow the same operator-facing
+    configuration as the gateway projection code.
+    """
+    board = kb.get_current_board()
+    projection_cfg: dict[str, Any] = {}
+    try:
+        from hermes_cli.config import load_config
+
+        kanban_cfg = (load_config().get("kanban") or {})
+        board_projections = kanban_cfg.get("board_projections") or {}
+        raw_projection = board_projections.get(board) if isinstance(board_projections, dict) else None
+        if isinstance(raw_projection, dict):
+            if raw_projection.get("enabled") is False:
+                return {}
+            if str(raw_projection.get("platform") or "discord").lower() != "discord":
+                return {}
+            projection_cfg.update(raw_projection)
+    except Exception:
+        projection_cfg = {}
+
     path = _discord_projection_config_path()
     try:
         raw = path.read_text(encoding="utf-8")
     except FileNotFoundError:
-        return {}
+        return projection_cfg
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
         return {"error": f"invalid_json:{path}"}
-    return data if isinstance(data, dict) else {}
+    if isinstance(data, dict):
+        projection_cfg.update(data)
+    return projection_cfg
 
 
 def _expected_discord_projection(task: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
     status = str(task.get("status") or "")
     assignee = str(task.get("assignee") or "").strip()
     title = str(task.get("title") or "").strip()
-    icon = _DISCORD_PROJECTION_STATUS_ICONS.get(status, _STATUS_ICONS.get(status, "?"))
+    raw_tag_defs = config.get("tags")
+    tag_defs = raw_tag_defs if isinstance(raw_tag_defs, dict) else {}
+    raw_status_tag_def = tag_defs.get(status)
+    status_tag_def = raw_status_tag_def if isinstance(raw_status_tag_def, dict) else {}
+    icon = str(status_tag_def.get("emoji") or "").strip() or _DISCORD_PROJECTION_STATUS_ICONS.get(status, _STATUS_ICONS.get(status, "?"))
     raw_status_to_tag = config.get("status_to_tag")
     raw_assignee_to_tag = config.get("assignee_to_tag")
     status_to_tag: dict[str, Any] = raw_status_to_tag if isinstance(raw_status_to_tag, dict) else {}
@@ -2533,6 +2570,99 @@ def _expected_discord_projection(task: dict[str, Any], config: dict[str, Any]) -
     if assignee_tag:
         tags.append(str(assignee_tag))
     return {"name": f"{icon} [{status}] {title}", "tags": tags}
+
+
+def _discord_projection_url(config: dict[str, Any], *, forum_channel_id: str, thread_id: str) -> str:
+    guild_id = str(
+        config.get("guild_id")
+        or config.get("server_id")
+        or config.get("discord_guild_id")
+        or ""
+    ).strip()
+    if guild_id:
+        return f"https://discord.com/channels/{guild_id}/{thread_id}"
+    return f"discord:{forum_channel_id}:{thread_id}"
+
+
+def _format_discord_projection_starter(task: kb.Task) -> str:
+    body = (task.body or "").strip()
+    parts = [
+        f"Kanban task: `{task.id}`",
+        f"Assignee: `{task.assignee or '-'}`",
+        f"Status: `{task.status}`",
+    ]
+    if task.priority is not None:
+        parts.append(f"Priority: `{task.priority}`")
+    if body:
+        parts.extend(["", body])
+    return "\n".join(parts)
+
+
+async def _send_discord_projection_message(
+    *,
+    forum_channel_id: str,
+    message: str,
+    thread_name: str,
+    applied_tags: list[str],
+) -> dict[str, Any]:
+    from gateway.config import Platform, load_gateway_config
+    from tools.send_message_tool import _send_to_platform
+
+    gateway_config = load_gateway_config()
+    pconfig = gateway_config.platforms.get(Platform.DISCORD)
+    if not pconfig or not pconfig.enabled:
+        return {"error": "Discord platform is not configured/enabled"}
+    return await _send_to_platform(
+        Platform.DISCORD,
+        pconfig,
+        forum_channel_id,
+        message,
+        applied_tags=applied_tags,
+        thread_name=thread_name,
+    )
+
+
+def _project_created_task_to_discord(conn, task: kb.Task) -> dict[str, Any] | None:
+    config = _load_discord_projection_config()
+    if config.get("error"):
+        return {"error": str(config["error"])}
+    forum_channel_id = str(config.get("forum_channel_id") or "").strip()
+    if not forum_channel_id:
+        return None
+
+    expected = _expected_discord_projection(_task_to_dict(task), config)
+    try:
+        from model_tools import _run_async
+
+        result = _run_async(_send_discord_projection_message(
+            forum_channel_id=forum_channel_id,
+            message=_format_discord_projection_starter(task),
+            thread_name=str(expected["name"]),
+            applied_tags=list(expected["tags"]),
+        ))
+    except Exception as exc:
+        return {"error": f"projection_send_failed:{type(exc).__name__}: {exc}"}
+
+    if not isinstance(result, dict):
+        return {"error": "projection_send_failed: unexpected send result"}
+    if result.get("error"):
+        return {"error": str(result["error"])}
+    raw_response = result.get("raw_response") if isinstance(result.get("raw_response"), dict) else {}
+    thread_id = str(result.get("thread_id") or raw_response.get("thread_id") or "").strip()
+    if not thread_id:
+        return {"error": "projection_send_failed: Discord send returned no thread_id"}
+
+    kb.add_notify_sub(
+        conn,
+        task_id=task.id,
+        platform="discord",
+        chat_id=forum_channel_id,
+        thread_id=thread_id,
+        notifier_profile=_profile_author(),
+    )
+    url = _discord_projection_url(config, forum_channel_id=forum_channel_id, thread_id=thread_id)
+    kb.add_comment(conn, task.id, _profile_author(), f"Discord forum projection: {url}")
+    return {"thread_id": thread_id, "chat_id": forum_channel_id, "url": url}
 
 
 def _fetch_discord_thread_snapshot(thread_id: str) -> dict[str, Any] | None:
@@ -2576,6 +2706,7 @@ def _audit_discord_projection(conn) -> dict[str, Any]:
             "missing": 0,
             "mismatches": [],
             "missing_threads": [],
+            "missing_unprojected_tasks": [],
             "errors": [config["error"]],
         }
     rows = conn.execute(
@@ -2592,6 +2723,7 @@ def _audit_discord_projection(conn) -> dict[str, Any]:
     ).fetchall()
     mismatches: list[dict[str, Any]] = []
     missing_threads: list[dict[str, Any]] = []
+    missing_unprojected_tasks: list[dict[str, Any]] = []
     errors: list[dict[str, str]] = []
     for row in rows:
         expected = _expected_discord_projection(
@@ -2634,12 +2766,40 @@ def _audit_discord_projection(conn) -> dict[str, Any]:
                 "missing_tags": missing_tags,
                 "unexpected_tags": unexpected_tags,
             })
+    forum_channel_id = str(config.get("forum_channel_id") or "").strip()
+    if forum_channel_id:
+        unprojected_rows = conn.execute(
+            """
+            SELECT t.id, t.title, t.assignee, t.status
+              FROM tasks AS t
+             WHERE t.status != 'archived'
+               AND NOT EXISTS (
+                   SELECT 1 FROM kanban_notify_subs AS s
+                    WHERE s.task_id = t.id
+                      AND s.platform = 'discord'
+                      AND s.chat_id = ?
+                      AND COALESCE(s.thread_id, '') != ''
+               )
+             ORDER BY t.id
+            """,
+            (forum_channel_id,),
+        ).fetchall()
+        for row in unprojected_rows:
+            missing_unprojected_tasks.append({
+                "task_id": str(row["id"]),
+                "chat_id": forum_channel_id,
+                "expected": _expected_discord_projection(
+                    {"title": row["title"], "assignee": row["assignee"], "status": row["status"]},
+                    config,
+                ),
+            })
     return {
         "scanned": len(rows),
         "mismatched": len(mismatches),
         "missing": len(missing_threads),
         "mismatches": mismatches,
         "missing_threads": missing_threads,
+        "missing_unprojected_tasks": missing_unprojected_tasks,
         "errors": errors,
     }
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2652,13 +2652,14 @@ def _project_created_task_to_discord(conn, task: kb.Task) -> dict[str, Any] | No
     if not thread_id:
         return {"error": "projection_send_failed: Discord send returned no thread_id"}
 
+    notifier_profile = str(config.get("notifier_profile") or "").strip() or _profile_author()
     kb.add_notify_sub(
         conn,
         task_id=task.id,
         platform="discord",
         chat_id=forum_channel_id,
         thread_id=thread_id,
-        notifier_profile=_profile_author(),
+        notifier_profile=notifier_profile,
     )
     url = _discord_projection_url(config, forum_channel_id=forum_channel_id, thread_id=thread_id)
     kb.add_comment(conn, task.id, _profile_author(), f"Discord forum projection: {url}")

--- a/hermes_cli/kanban_archive_done.py
+++ b/hermes_cli/kanban_archive_done.py
@@ -1,0 +1,533 @@
+"""Archive stale Done Kanban tasks and their Discord forum projections.
+
+This module is intentionally script-friendly: Hermes cron can run it as a
+``no_agent`` job, while tests can import :func:`run_archival` directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Optional
+
+from hermes_cli import kanban_db as kb
+
+DEFAULT_DONE_AGE_DAYS = 7
+DEFAULT_BATCH_SIZE = 25
+DEFAULT_DISCORD_API_BASE = "https://discord.com/api/v10"
+
+
+@dataclass
+class DiscordResult:
+    ok: bool
+    status: str
+    detail: str = ""
+
+
+@dataclass
+class ArchiveStats:
+    board: str
+    dry_run: bool
+    cutoff_ts: int
+    candidate_count: int = 0
+    reconcile_candidate_count: int = 0
+    archived_count: int = 0
+    already_archived_count: int = 0
+    skipped_count: int = 0
+    discord_archived_locked_count: int = 0
+    failures: list[dict[str, Any]] = field(default_factory=list)
+    tasks: list[dict[str, Any]] = field(default_factory=list)
+    skipped_by_reason: dict[str, int] = field(default_factory=dict)
+
+    def skip(self, reason: str) -> None:
+        self.skipped_count += 1
+        self.skipped_by_reason[reason] = self.skipped_by_reason.get(reason, 0) + 1
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "board": self.board,
+            "dry_run": self.dry_run,
+            "cutoff_ts": self.cutoff_ts,
+            "candidate_count": self.candidate_count,
+            "reconcile_candidate_count": self.reconcile_candidate_count,
+            "archived_count": self.archived_count,
+            "already_archived_count": self.already_archived_count,
+            "skipped_count": self.skipped_count,
+            "skipped_by_reason": dict(sorted(self.skipped_by_reason.items())),
+            "discord_archived_locked_count": self.discord_archived_locked_count,
+            "failure_count": len(self.failures),
+            "failures": self.failures,
+            "tasks": self.tasks,
+        }
+
+
+class DiscordThreadClient:
+    """Small stdlib Discord REST client for archive/lock reconciliation."""
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        api_base: str = DEFAULT_DISCORD_API_BASE,
+        sleep: Callable[[float], None] = time.sleep,
+        max_retries: int = 3,
+    ) -> None:
+        self.token = token.strip()
+        self.api_base = api_base.rstrip("/")
+        self.sleep = sleep
+        self.max_retries = max(1, int(max_retries))
+
+    def _patch_channel(self, thread_id: str, payload_data: dict[str, Any]) -> DiscordResult:
+        payload = json.dumps(payload_data).encode("utf-8")
+        try:
+            channel_id = int(thread_id)
+        except (TypeError, ValueError):
+            return DiscordResult(False, "malformed_thread_id", "thread_id is not an integer")
+        url = f"{self.api_base}/channels/{channel_id}"
+        for attempt in range(1, self.max_retries + 1):
+            req = urllib.request.Request(
+                url,
+                data=payload,
+                method="PATCH",
+                headers={
+                    "Authorization": f"Bot {self.token}",
+                    "Content-Type": "application/json",
+                    "User-Agent": "Hermes-Kanban-Archiver/1.0",
+                },
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:  # nosec: URL is fixed Discord API base by default
+                    if 200 <= int(resp.status) < 300:
+                        return DiscordResult(True, "patched")
+                    return DiscordResult(False, f"http_{resp.status}")
+            except urllib.error.HTTPError as exc:
+                if exc.code == 429 and attempt < self.max_retries:
+                    retry_after = _retry_after_seconds(exc)
+                    self.sleep(retry_after)
+                    continue
+                if exc.code == 404:
+                    return DiscordResult(True, "missing_thread", "Discord returned 404")
+                return DiscordResult(False, f"http_{exc.code}", _safe_http_error_detail(exc))
+            except Exception as exc:  # pragma: no cover - defensive network guard
+                if attempt < self.max_retries:
+                    self.sleep(min(2.0 * attempt, 10.0))
+                    continue
+                return DiscordResult(False, "request_error", str(exc)[:200])
+        return DiscordResult(False, "retry_exhausted")
+
+    def fetch_thread(self, thread_id: str) -> dict[str, Any] | None:
+        """Return a small Discord thread snapshot, ``None`` for 404, or an error dict."""
+        try:
+            channel_id = int(thread_id)
+        except (TypeError, ValueError):
+            return {"error": "malformed_thread_id", "detail": "thread_id is not an integer"}
+        req = urllib.request.Request(
+            f"{self.api_base}/channels/{channel_id}",
+            headers={
+                "Authorization": f"Bot {self.token}",
+                "User-Agent": "Hermes-Kanban-Archiver/1.0",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:  # nosec: URL is fixed Discord API base by default
+                data = json.load(resp)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None
+            return {"error": f"http_{exc.code}", "detail": _safe_http_error_detail(exc)}
+        except Exception as exc:  # pragma: no cover - defensive network guard
+            return {"error": "request_error", "detail": str(exc)[:200]}
+        thread_metadata = data.get("thread_metadata") if isinstance(data.get("thread_metadata"), dict) else {}
+        return {
+            "id": str(data.get("id") or thread_id),
+            "name": str(data.get("name") or ""),
+            "applied_tags": [str(tag) for tag in data.get("applied_tags", [])],
+            "archived": bool(thread_metadata.get("archived")),
+            "locked": bool(thread_metadata.get("locked")),
+        }
+
+    def archive_and_lock(
+        self,
+        thread_id: str,
+        *,
+        projection_metadata: Optional[dict[str, Any]] = None,
+    ) -> DiscordResult:
+        """Set a Discord thread to archived+locked and reconcile forum projection metadata.
+
+        Discord rejects some metadata edits on archived threads. To make reruns
+        idempotent, first inspect the thread, no-op if already reconciled, and
+        briefly unarchive before applying name/tag/lock fixes when needed.
+        """
+        payload_data: dict[str, Any] = {"archived": True, "locked": True}
+        if projection_metadata:
+            if projection_metadata.get("name"):
+                payload_data["name"] = str(projection_metadata["name"])
+            if projection_metadata.get("applied_tags") is not None:
+                payload_data["applied_tags"] = [str(t) for t in projection_metadata.get("applied_tags") or []]
+
+        snapshot = self.fetch_thread(thread_id)
+        if snapshot is None:
+            return DiscordResult(True, "missing_thread", "Discord returned 404")
+        if isinstance(snapshot, dict) and snapshot.get("error"):
+            if str(snapshot["error"]) == "http_403":
+                return DiscordResult(True, "missing_access", str(snapshot.get("detail") or "")[:200])
+            return DiscordResult(False, str(snapshot["error"]), str(snapshot.get("detail") or "")[:200])
+
+        desired_name = payload_data.get("name")
+        desired_tags = payload_data.get("applied_tags")
+        name_ok = desired_name is None or str(snapshot.get("name") or "") == str(desired_name)
+        tags_ok = desired_tags is None or set(str(t) for t in snapshot.get("applied_tags") or []) == set(str(t) for t in desired_tags)
+        archived_ok = bool(snapshot.get("archived"))
+        locked_ok = bool(snapshot.get("locked"))
+        if name_ok and tags_ok and archived_ok and locked_ok:
+            return DiscordResult(True, "already_archived_locked")
+
+        if bool(snapshot.get("archived")) and (not name_ok or not tags_ok or not locked_ok):
+            unarchive = self._patch_channel(thread_id, {"archived": False})
+            if not unarchive.ok:
+                if name_ok and tags_ok and archived_ok:
+                    return DiscordResult(
+                        True,
+                        "archived_projection_ok_lock_unreconciled",
+                        f"Could not unarchive to apply lock: {unarchive.status}",
+                    )
+                return unarchive
+
+        patch = self._patch_channel(thread_id, payload_data)
+        if not patch.ok:
+            if patch.status == "http_403" and name_ok and tags_ok:
+                return DiscordResult(
+                    True,
+                    "projection_ok_patch_denied",
+                    "Could not archive/lock thread because Discord returned Missing Access",
+                )
+            return patch
+        return DiscordResult(True, "archived_locked")
+
+
+def _retry_after_seconds(exc: urllib.error.HTTPError) -> float:
+    header = exc.headers.get("Retry-After") if exc.headers else None
+    if header:
+        try:
+            return max(0.0, float(header))
+        except ValueError:
+            pass
+    try:
+        body = exc.read().decode("utf-8", errors="replace")
+        data = json.loads(body)
+        return max(0.0, float(data.get("retry_after", 1.0)))
+    except Exception:
+        return 1.0
+
+
+def _safe_http_error_detail(exc: urllib.error.HTTPError) -> str:
+    try:
+        body = exc.read().decode("utf-8", errors="replace")
+    except Exception:
+        body = ""
+    return body[:300]
+
+
+def _get_discord_token(profile: Optional[str] = None) -> str:
+    if profile:
+        candidate_paths = []
+        if profile == "default":
+            candidate_paths.append(os.path.expanduser("~/.hermes/.env"))
+        else:
+            candidate_paths.append(os.path.expanduser(f"~/.hermes/profiles/{profile}/.env"))
+        for env_path in candidate_paths:
+            try:
+                with open(env_path, encoding="utf-8") as handle:
+                    for line in handle:
+                        stripped = line.strip()
+                        if not stripped or stripped.startswith("#") or "=" not in stripped:
+                            continue
+                        key, value = stripped.split("=", 1)
+                        if key == "DISCORD_BOT_TOKEN":
+                            return value.strip().strip('"').strip("'")
+            except OSError:
+                pass
+    token = os.environ.get("DISCORD_BOT_TOKEN", "").strip()
+    if token:
+        return token
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        cfg = load_gateway_config()
+        pconfig = cfg.platforms.get(Platform.DISCORD)
+        return str(getattr(pconfig, "token", "") or "").strip()
+    except Exception:
+        return ""
+
+
+def _candidate_tasks(conn, *, cutoff_ts: int, limit: int) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT id, title, status, assignee, completed_at
+          FROM tasks
+         WHERE status = 'done'
+           AND completed_at IS NOT NULL
+           AND completed_at <= ?
+         ORDER BY completed_at ASC, id ASC
+         LIMIT ?
+        """,
+        (int(cutoff_ts), int(limit)),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _pending_archived_reconcile_tasks(conn, *, limit: int) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT DISTINCT t.id, t.title, t.status, t.assignee, t.completed_at
+          FROM tasks AS t
+          JOIN kanban_notify_subs AS s ON s.task_id = t.id
+         WHERE t.status = 'archived'
+           AND s.platform = 'discord'
+           AND COALESCE(s.thread_id, '') != ''
+         ORDER BY COALESCE(t.completed_at, t.created_at) ASC, t.id ASC
+         LIMIT ?
+        """,
+        (int(limit),),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _discord_subs(conn, task_id: str) -> list[dict[str, Any]]:
+    return [s for s in kb.list_notify_subs(conn, task_id) if s.get("platform") == "discord"]
+
+
+def _remove_sub(conn, sub: dict[str, Any]) -> None:
+    kb.remove_notify_sub(
+        conn,
+        task_id=str(sub.get("task_id") or ""),
+        platform=str(sub.get("platform") or ""),
+        chat_id=str(sub.get("chat_id") or ""),
+        thread_id=str(sub.get("thread_id") or ""),
+    )
+
+
+def _discord_projection_config(board: str) -> dict[str, Any]:
+    try:
+        path = kb.board_dir(board) / "discord-forum-tags.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        return {}
+
+
+def _discord_archived_projection_metadata(task: dict[str, Any], *, board: str) -> dict[str, Any]:
+    """Return forum projection metadata for an archived task if configured.
+
+    The Discord projection skill treats title/status tags as part of the forum
+    projection, not just the thread's archived bit. Include the same metadata
+    in the archive PATCH so the cron job does not depend on the async gateway
+    notifier seeing an archived event before the subscription is removed.
+    """
+    config = _discord_projection_config(board)
+    if not config:
+        return {}
+    status = "archived"
+    title = str(task.get("title") or "").strip()
+    assignee = str(task.get("assignee") or "").strip()
+    icons = {
+        "triage": "◇",
+        "todo": "◻",
+        "ready": "▶",
+        "running": "●",
+        "scheduled": "⏱",
+        "blocked": "🛑",
+        "review": "◆",
+        "done": "✅",
+        "archived": "—",
+    }
+    raw_tag_defs = config.get("tags")
+    tag_defs: dict[str, Any] = raw_tag_defs if isinstance(raw_tag_defs, dict) else {}
+    raw_status_tag_def = tag_defs.get(status)
+    status_tag_def: dict[str, Any] = raw_status_tag_def if isinstance(raw_status_tag_def, dict) else {}
+    icon = str(status_tag_def.get("emoji") or "").strip() or icons[status]
+    raw_status_to_tag = config.get("status_to_tag")
+    status_to_tag: dict[str, Any] = raw_status_to_tag if isinstance(raw_status_to_tag, dict) else {}
+    raw_assignee_to_tag = config.get("assignee_to_tag")
+    assignee_to_tag: dict[str, Any] = raw_assignee_to_tag if isinstance(raw_assignee_to_tag, dict) else {}
+    tags: list[str] = []
+    if status_to_tag.get(status):
+        tags.append(str(status_to_tag[status]))
+    assignee_tag = assignee_to_tag.get(assignee) or assignee_to_tag.get("default")
+    if assignee_tag:
+        tags.append(str(assignee_tag))
+    name = f"{icon} [{status}] {title}"
+    if len(name) > 100:
+        name = name[:99] + "…"
+    return {"name": name, "applied_tags": tags}
+
+
+def run_archival(
+    *,
+    board: Optional[str] = None,
+    done_age_days: int = DEFAULT_DONE_AGE_DAYS,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    dry_run: bool = False,
+    discord_token: Optional[str] = None,
+    discord_client: Optional[Any] = None,
+    now: Optional[int] = None,
+) -> dict[str, Any]:
+    """Archive stale Done tasks and reconcile Discord projections.
+
+    Archived tasks with remaining Discord subscription rows are also retried for
+    Discord reconciliation. They are counted separately as ``already_archived``
+    and are not considered new Kanban archive targets.
+    """
+    board_name = board or kb.get_current_board()
+    now_ts = int(now if now is not None else time.time())
+    cutoff_ts = now_ts - int(done_age_days) * 86400
+    limit = max(1, int(batch_size))
+    stats = ArchiveStats(board=board_name, dry_run=bool(dry_run), cutoff_ts=cutoff_ts)
+
+    old_board = os.environ.get("HERMES_KANBAN_BOARD")
+    if board:
+        os.environ["HERMES_KANBAN_BOARD"] = board
+    try:
+        with kb.connect_closing() as conn:
+            done_candidates = _candidate_tasks(conn, cutoff_ts=cutoff_ts, limit=limit)
+            remaining = max(0, limit - len(done_candidates))
+            reconcile_candidates = _pending_archived_reconcile_tasks(conn, limit=remaining) if remaining else []
+            candidates = done_candidates + reconcile_candidates
+            stats.candidate_count = len(done_candidates)
+            stats.reconcile_candidate_count = len(reconcile_candidates)
+            if dry_run:
+                for task in candidates:
+                    subs = _discord_subs(conn, task["id"])
+                    stats.tasks.append({
+                        "task_id": task["id"],
+                        "status": task["status"],
+                        "action": "would_archive" if task["status"] == "done" else "would_reconcile_discord",
+                        "discord_thread_ids": [str(s.get("thread_id") or "") for s in subs if s.get("thread_id")],
+                    })
+                return stats.as_dict()
+
+            token = discord_token if discord_token is not None else _get_discord_token()
+            default_client = discord_client or (DiscordThreadClient(token) if token else None)
+            clients_by_profile: dict[str, DiscordThreadClient] = {}
+
+            def client_for_sub(sub: dict[str, Any]) -> Any:
+                if discord_client is not None:
+                    return discord_client
+                profile = str(sub.get("notifier_profile") or "").strip()
+                if profile:
+                    if profile not in clients_by_profile:
+                        profile_token = discord_token if discord_token is not None else _get_discord_token(profile)
+                        clients_by_profile[profile] = DiscordThreadClient(profile_token) if profile_token else None  # type: ignore[assignment]
+                    return clients_by_profile.get(profile) or default_client
+                return default_client
+
+            for task in candidates:
+                task_id = str(task["id"])
+                task_entry: dict[str, Any] = {"task_id": task_id, "status": task["status"], "discord": []}
+                subs = _discord_subs(conn, task_id)
+
+                if task["status"] == "done":
+                    archived = kb.archive_task(conn, task_id)
+                    if archived:
+                        stats.archived_count += 1
+                        task_entry["action"] = "archived"
+                    else:
+                        stats.skip("archive_race_or_already_archived")
+                        task_entry["action"] = "skipped_archive_race_or_already_archived"
+                else:
+                    stats.already_archived_count += 1
+                    task_entry["action"] = "reconcile_discord"
+
+                for sub in subs:
+                    thread_id = str(sub.get("thread_id") or "")
+                    if not thread_id:
+                        stats.skip("missing_discord_thread_ref")
+                        task_entry["discord"].append({"thread_id": "", "status": "missing_thread_ref"})
+                        _remove_sub(conn, sub)
+                        continue
+                    if not thread_id.isdigit():
+                        stats.skip("malformed_discord_thread_ref")
+                        task_entry["discord"].append({"thread_id": thread_id, "status": "malformed_thread_ref"})
+                        _remove_sub(conn, sub)
+                        continue
+                    sub_client = client_for_sub(sub)
+                    if sub_client is None:
+                        failure = {"task_id": task_id, "thread_id": thread_id, "error": "discord_token_missing"}
+                        stats.failures.append(failure)
+                        task_entry["discord"].append({"thread_id": thread_id, "status": "discord_token_missing"})
+                        continue
+                    result = sub_client.archive_and_lock(
+                        thread_id,
+                        projection_metadata=_discord_archived_projection_metadata(task, board=board_name),
+                    )
+                    task_entry["discord"].append({"thread_id": thread_id, "status": result.status})
+                    if result.ok:
+                        if result.status in {"archived_locked", "already_archived_locked"}:
+                            stats.discord_archived_locked_count += 1
+                        elif result.status == "missing_thread":
+                            stats.skip("missing_or_deleted_discord_thread")
+                        elif result.status == "missing_access":
+                            stats.skip("discord_thread_missing_access")
+                        elif result.status in {"archived_projection_ok_lock_unreconciled", "projection_ok_patch_denied"}:
+                            stats.skip("discord_projection_ok_but_lock_unreconciled")
+                        _remove_sub(conn, sub)
+                    else:
+                        stats.failures.append({
+                            "task_id": task_id,
+                            "thread_id": thread_id,
+                            "error": result.status,
+                            "detail": result.detail,
+                        })
+                if not subs:
+                    stats.skip("no_discord_projection")
+                stats.tasks.append(task_entry)
+    finally:
+        if board:
+            if old_board is None:
+                os.environ.pop("HERMES_KANBAN_BOARD", None)
+            else:
+                os.environ["HERMES_KANBAN_BOARD"] = old_board
+
+    return stats.as_dict()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--board", help="Kanban board slug (defaults to current board)")
+    parser.add_argument("--done-age-days", type=int, default=DEFAULT_DONE_AGE_DAYS)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    result = run_archival(
+        board=args.board,
+        done_age_days=args.done_age_days,
+        batch_size=args.batch_size,
+        dry_run=args.dry_run,
+    )
+    has_activity = bool(
+        result.get("dry_run")
+        or result.get("failure_count")
+        or result.get("candidate_count")
+        or result.get("reconcile_candidate_count")
+        or result.get("archived_count")
+        or result.get("already_archived_count")
+        or result.get("skipped_count")
+    )
+    if has_activity:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    return 1 if result.get("failure_count") else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1733,6 +1733,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
             )
+        if "last_event_id" not in notify_cols:
+            _add_column_if_missing(
+                conn,
+                "kanban_notify_subs",
+                "last_event_id",
+                "last_event_id INTEGER NOT NULL DEFAULT 0",
+            )
 
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7305,17 +7305,21 @@ def repair_projection_subscriptions(
     *,
     apply: bool = False,
 ) -> dict:
-    """Report and optionally remove notification/projection rows for missing tasks.
+    """Report and optionally repair broken notification/projection rows.
 
     ``kanban_notify_subs`` is the local source of truth that binds gateway
     projection destinations (Discord forum/thread rows, Telegram topics, etc.)
-    back to canonical Kanban tasks. Legacy migrations and manual DB repairs can
-    leave rows whose ``task_id`` no longer exists; those rows confuse thread
-    lifecycle routing because a projected source appears bound to a phantom
-    task. Dry-run mode reports them, while apply mode deletes only those orphan
-    rows and preserves every row with a live task.
+    back to canonical Kanban tasks. The reconciler is deliberately conservative:
+
+    * orphan rows whose ``task_id`` no longer exists are safe to delete;
+    * malformed rows without a usable platform/chat target are safe to delete;
+    * ambiguous rows where one projected source maps to multiple live tasks are
+      reported loudly but not mutated, because choosing the correct task needs a
+      human or platform-side evidence.
     """
-    rows = conn.execute(
+    scanned = int(conn.execute("SELECT COUNT(*) FROM kanban_notify_subs").fetchone()[0])
+
+    orphan_rows = conn.execute(
         """
         SELECT s.*
           FROM kanban_notify_subs AS s
@@ -7327,30 +7331,95 @@ def repair_projection_subscriptions(
     orphans = [
         {
             "task_id": str(row["task_id"]),
-            "platform": str(row["platform"]),
-            "chat_id": str(row["chat_id"]),
+            "platform": str(row["platform"] or ""),
+            "chat_id": str(row["chat_id"] or ""),
             "thread_id": str(row["thread_id"] or ""),
         }
-        for row in rows
+        for row in orphan_rows
     ]
-    scanned = int(conn.execute("SELECT COUNT(*) FROM kanban_notify_subs").fetchone()[0])
+
+    malformed_rows = []
+    for row in conn.execute(
+        """
+        SELECT s.*
+          FROM kanban_notify_subs AS s
+          JOIN tasks AS t ON t.id = s.task_id
+         WHERE COALESCE(s.platform, '') = ''
+            OR COALESCE(s.chat_id, '') = ''
+         ORDER BY
+              CASE
+                  WHEN COALESCE(s.platform, '') = '' THEN 0
+                  WHEN COALESCE(s.chat_id, '') = '' THEN 1
+                  ELSE 2
+              END,
+              s.task_id, s.platform, s.chat_id, s.thread_id
+        """
+    ).fetchall():
+        platform = str(row["platform"] or "")
+        chat_id = str(row["chat_id"] or "")
+        if not platform:
+            reason = "missing_platform"
+        elif not chat_id:
+            reason = "missing_chat_id"
+        else:  # Defensive: SQL predicate should keep this unreachable.
+            reason = "malformed"
+        malformed_rows.append({
+            "task_id": str(row["task_id"]),
+            "platform": platform,
+            "chat_id": chat_id,
+            "thread_id": str(row["thread_id"] or ""),
+            "reason": reason,
+        })
+
+    ambiguous_rows = conn.execute(
+        """
+        SELECT s.platform, s.chat_id, s.thread_id,
+               GROUP_CONCAT(s.task_id, ',') AS task_ids,
+               COUNT(DISTINCT s.task_id) AS task_count
+          FROM kanban_notify_subs AS s
+          JOIN tasks AS t ON t.id = s.task_id
+         WHERE COALESCE(s.platform, '') != ''
+           AND COALESCE(s.chat_id, '') != ''
+         GROUP BY s.platform, s.chat_id, s.thread_id
+        HAVING task_count > 1
+         ORDER BY s.platform, s.chat_id, s.thread_id
+        """
+    ).fetchall()
+    ambiguous_bindings = []
+    for row in ambiguous_rows:
+        task_ids = sorted(tid for tid in str(row["task_ids"] or "").split(",") if tid)
+        ambiguous_bindings.append({
+            "platform": str(row["platform"] or ""),
+            "chat_id": str(row["chat_id"] or ""),
+            "thread_id": str(row["thread_id"] or ""),
+            "task_ids": task_ids,
+        })
+
+    removal_keys = {
+        (row["task_id"], row["platform"], row["chat_id"], row["thread_id"])
+        for row in [*orphans, *malformed_rows]
+    }
     removed = 0
-    if apply and orphans:
+    if apply and removal_keys:
         with write_txn(conn):
-            for row in orphans:
+            for task_id, platform, chat_id, thread_id in sorted(removal_keys):
                 cur = conn.execute(
                     """
                     DELETE FROM kanban_notify_subs
                      WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
                     """,
-                    (row["task_id"], row["platform"], row["chat_id"], row["thread_id"]),
+                    (task_id, platform, chat_id, thread_id),
                 )
                 removed += cur.rowcount
     return {
         "scanned": scanned,
         "orphaned": len(orphans),
+        "malformed": len(malformed_rows),
+        "ambiguous": len(ambiguous_bindings),
         "removed": removed,
         "orphans": orphans,
+        "malformed_rows": malformed_rows,
+        "ambiguous_bindings": ambiguous_bindings,
     }
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7300,6 +7300,60 @@ def remove_notify_sub(
     return cur.rowcount > 0
 
 
+def repair_projection_subscriptions(
+    conn: sqlite3.Connection,
+    *,
+    apply: bool = False,
+) -> dict:
+    """Report and optionally remove notification/projection rows for missing tasks.
+
+    ``kanban_notify_subs`` is the local source of truth that binds gateway
+    projection destinations (Discord forum/thread rows, Telegram topics, etc.)
+    back to canonical Kanban tasks. Legacy migrations and manual DB repairs can
+    leave rows whose ``task_id`` no longer exists; those rows confuse thread
+    lifecycle routing because a projected source appears bound to a phantom
+    task. Dry-run mode reports them, while apply mode deletes only those orphan
+    rows and preserves every row with a live task.
+    """
+    rows = conn.execute(
+        """
+        SELECT s.*
+          FROM kanban_notify_subs AS s
+          LEFT JOIN tasks AS t ON t.id = s.task_id
+         WHERE t.id IS NULL
+         ORDER BY s.task_id, s.platform, s.chat_id, s.thread_id
+        """
+    ).fetchall()
+    orphans = [
+        {
+            "task_id": str(row["task_id"]),
+            "platform": str(row["platform"]),
+            "chat_id": str(row["chat_id"]),
+            "thread_id": str(row["thread_id"] or ""),
+        }
+        for row in rows
+    ]
+    scanned = int(conn.execute("SELECT COUNT(*) FROM kanban_notify_subs").fetchone()[0])
+    removed = 0
+    if apply and orphans:
+        with write_txn(conn):
+            for row in orphans:
+                cur = conn.execute(
+                    """
+                    DELETE FROM kanban_notify_subs
+                     WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                    """,
+                    (row["task_id"], row["platform"], row["chat_id"], row["thread_id"]),
+                )
+                removed += cur.rowcount
+    return {
+        "scanned": scanned,
+        "orphaned": len(orphans),
+        "removed": removed,
+        "orphans": orphans,
+    }
+
+
 def unseen_events_for_sub(
     conn: sqlite3.Connection,
     *,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1443,7 +1443,12 @@ def connect(
     with _cross_process_init_lock(path):
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
         # and other invalid-header cases without opening a sqlite connection.
-        _validate_sqlite_header(path)
+        try:
+            _validate_sqlite_header(path)
+        except sqlite3.DatabaseError as exc:
+            resolved_path = path.resolve()
+            backup = _backup_corrupt_db(resolved_path)
+            raise KanbanDbCorruptError(resolved_path, backup, str(exc)) from exc
         # Full integrity probe — catches corruption past the header (malformed
         # pages, broken internal metadata). Cached per-path after first success
         # via _INITIALIZED_PATHS so it only runs once per process per path.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2108,6 +2108,12 @@ def create_task(
     ``kanban-worker``. Use this to pin a task to a specialist skill
     (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``initial_status='blocked'`` creates the task as an explicit sticky
+    human/ops gate.  It emits both the normal ``created`` event and a
+    ``blocked`` event so dispatcher ``recompute_ready`` ticks do not
+    auto-promote it until ``unblock_task`` records a matching
+    ``unblocked`` event.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -2292,6 +2298,13 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                if task_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial_status=blocked"},
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -2860,9 +2873,11 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
 
     * **Worker- or operator-initiated** — a worker called
       ``kanban_block(reason="review-required: ...")`` (or somebody ran
-      ``hermes kanban block <id>``).  This is a deliberate handoff that
-      should stay blocked until an operator unblocks it.  The block tool
-      emits a ``"blocked"`` event row in ``task_events``.
+      ``hermes kanban block <id>``), or the task was created directly
+      with ``initial_status='blocked'`` for human/ops review.  This is a
+      deliberate handoff that should stay blocked until an operator
+      unblocks it.  These paths emit a ``"blocked"`` event row in
+      ``task_events``.
 
     * **Circuit-breaker** — ``_record_task_failure`` tripped after
       repeated crashes / spawn failures / timeouts.  This emits

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -139,16 +139,17 @@ def _conn(board: Optional[str] = None):
 # Serialization helpers
 # ---------------------------------------------------------------------------
 
-# Columns shown by the dashboard, in left-to-right order. "archived" is
-# available via a filter toggle rather than a visible column.
+# Default columns shown by the dashboard, in left-to-right order. "archived"
+# is available via a filter toggle rather than a visible column.
 #
-# Keep this in sync with kanban_db.VALID_STATUSES.  In particular,
-# ``scheduled`` is a first-class waiting column used for time-based follow-ups;
-# if it is omitted here, the board-level fallback below mis-buckets scheduled
-# tasks into ``todo`` and makes the dashboard look like the Scheduled column
-# disappeared.
+# The Kanban core still accepts additional statuses such as ``scheduled`` and
+# ``review`` for CLI/API workflows, but Olympus no longer wants empty columns
+# for those rarely-used states after retiring cron-as-card projections.  The
+# board endpoint below will still surface any non-default status dynamically
+# when tasks actually exist, so such tasks are never silently mis-bucketed into
+# ``todo``.
 BOARD_COLUMNS: list[str] = [
-    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
+    "triage", "todo", "ready", "running", "blocked", "done",
 ]
 
 
@@ -475,7 +476,13 @@ def get_board(
                 # needs the summary.
                 d["diagnostics"] = diags
                 d["warnings"] = _warnings_summary_from_diagnostics(diags)
-            col = t.status if t.status in columns else "todo"
+            col = t.status
+            if col not in columns:
+                # Keep empty uncommon statuses out of the normal board view, but
+                # if a task actually exists in one (for example ``scheduled`` or
+                # ``review`` from CLI/API workflows), add that column on demand
+                # rather than mis-bucketing it into ``todo``.
+                columns[col] = []
             columns[col].append(d)
 
         # Stable per-column ordering already applied by list_tasks

--- a/plugins/memory/gbrain/README.md
+++ b/plugins/memory/gbrain/README.md
@@ -1,0 +1,100 @@
+# GBrain memory provider
+
+The GBrain memory provider lets Hermes use a GBrain MCP HTTP endpoint as an external memory provider. It is designed for the single-writer GBrain governance pattern:
+
+- Default/non-steward Hermes profiles use a read-only GBrain MCP proxy.
+- Athena/steward profile is the only profile that may be configured for writes.
+- Read-only mode is the default and refuses direct writes.
+
+## Setup
+
+Run:
+
+```bash
+hermes memory setup gbrain
+```
+
+Or configure manually in the active profile's `config.yaml`:
+
+```yaml
+memory:
+  provider: gbrain
+  gbrain:
+    endpoint: "http://127.0.0.1:3132/mcp"
+    mode: "read-only"
+    source_id: "__all__"
+    max_results: 6
+    timeout: 5.0
+```
+
+The setup wizard also writes non-secret provider settings to profile-local `$HERMES_HOME/gbrain-memory.json`. Do not put bearer tokens, OAuth secrets, database URLs, SSH material, or other credentials in this file.
+
+## Transport
+
+This provider uses stdlib HTTP JSON-RPC against GBrain's MCP endpoint. It does not call the local `gbrain` CLI or connect directly to the GBrain database. MCP keeps Hermes profile policy separate from GBrain internals and matches the existing local topology where non-Athena profiles use a read-only proxy such as:
+
+```yaml
+memory:
+  provider: gbrain
+  gbrain:
+    endpoint: "http://127.0.0.1:3132/mcp"
+    mode: "read-only"
+```
+
+## Modes
+
+### `read-only` (default)
+
+Allowed:
+
+- Search/query GBrain via the configured MCP endpoint.
+- Inject compact recalled context into the next turn.
+- Use the `gbrain_memory_search` tool.
+
+Blocked:
+
+- Automatic turn ingestion.
+- Mirroring built-in memory writes.
+- Creating, updating, ingesting, or deleting GBrain pages.
+
+The `gbrain_memory_store_candidate` tool returns a blocked response with the candidate payload so the operator can route it to Athena/steward review.
+
+### `read-write` (explicit opt-in)
+
+Intended only for Athena/steward profile or another profile with explicit user authorization.
+
+```yaml
+memory:
+  provider: gbrain
+  gbrain:
+    endpoint: "http://127.0.0.1:3131/mcp"
+    mode: "read-write"
+    write_tool: "create_page"
+```
+
+In read-write mode, the provider still does not auto-ingest every conversation turn. It only mirrors explicit built-in memory writes and explicit `gbrain_memory_store_candidate` calls to the configured `write_tool`.
+
+## Tools
+
+- `gbrain_memory_search(query, limit=6)`: queries GBrain through MCP and returns formatted recalled context plus the raw MCP result.
+- `gbrain_memory_store_candidate(content, target="memory")`: in read-only mode, returns `blocked: true` with Athena handoff guidance; in read-write mode, calls the configured write tool.
+
+## Configuration reference
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `endpoint` | `http://127.0.0.1:3132/mcp` | HTTP MCP endpoint. Use the read-only proxy for non-Athena profiles. |
+| `mode` | `read-only` | `read-only` or explicit `read-write`. |
+| `source_id` | `__all__` | GBrain source scope passed to the query tool. |
+| `max_results` | `6` | Clamped to 1–20. |
+| `timeout` | `5.0` | HTTP timeout seconds, clamped to 0.5–30. |
+| `query_tool` | `query` | Underlying GBrain MCP query tool name. |
+| `query_tool_fallbacks` | `gbrain_query, search` | Tried if `query` is unavailable. |
+| `write_tool` | `create_page` | Used only in explicit `read-write` mode. |
+
+## Safety notes
+
+- Keep GBrain credentials out of docs, tests, logs, and provider config.
+- Prefer `http://127.0.0.1:3132/mcp` read-only proxy for default profiles.
+- Use Athena/steward profile for durable write curation.
+- Treat read-write mode as a privileged local configuration, not a normal default.

--- a/plugins/memory/gbrain/__init__.py
+++ b/plugins/memory/gbrain/__init__.py
@@ -1,0 +1,579 @@
+"""GBrain memory provider for Hermes.
+
+The provider talks to a GBrain MCP HTTP endpoint and defaults to read-only
+recall.  Write-capable behavior must be explicitly enabled and is intended for
+Athena/steward profiles under the user's single-writer governance pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_ENDPOINT = "http://127.0.0.1:3132/mcp"
+_DEFAULT_MODE = "read-only"
+_DEFAULT_SOURCE_ID = "__all__"
+_DEFAULT_MAX_RESULTS = 6
+_DEFAULT_TIMEOUT = 5.0
+_DEFAULT_QUERY_TOOL = "query"
+_DEFAULT_WRITE_TOOL = "create_page"
+_VALID_MODES = {"read-only", "read-write"}
+_MAX_CONTENT_CHARS = 4000
+
+_CONTEXT_STRIP_RE = re.compile(
+    r"<gbrain-memory-context>[\s\S]*?</gbrain-memory-context>\s*", re.IGNORECASE
+)
+
+
+def _default_config() -> dict:
+    return {
+        "endpoint": _DEFAULT_ENDPOINT,
+        "mode": _DEFAULT_MODE,
+        "source_id": _DEFAULT_SOURCE_ID,
+        "max_results": _DEFAULT_MAX_RESULTS,
+        "timeout": _DEFAULT_TIMEOUT,
+        "query_tool": _DEFAULT_QUERY_TOOL,
+        "query_tool_fallbacks": ["gbrain_query", "search"],
+        "write_tool": _DEFAULT_WRITE_TOOL,
+    }
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "n", "off"}:
+            return False
+    return default
+
+
+def _coerce_config(raw: Optional[dict] = None) -> dict:
+    config = _default_config()
+    if isinstance(raw, dict):
+        config.update({k: v for k, v in raw.items() if v is not None})
+
+    endpoint = str(config.get("endpoint", "")).strip()
+    config["endpoint"] = endpoint
+
+    mode = str(config.get("mode", _DEFAULT_MODE)).strip().lower()
+    config["mode"] = mode if mode in _VALID_MODES else _DEFAULT_MODE
+
+    source_id = str(config.get("source_id", _DEFAULT_SOURCE_ID)).strip()
+    config["source_id"] = source_id or _DEFAULT_SOURCE_ID
+
+    for key, default, lower, upper in (
+        ("max_results", _DEFAULT_MAX_RESULTS, 1, 20),
+    ):
+        try:
+            config[key] = max(lower, min(upper, int(config.get(key, default))))
+        except Exception:
+            config[key] = default
+
+    try:
+        config["timeout"] = max(0.5, min(30.0, float(config.get("timeout", _DEFAULT_TIMEOUT))))
+    except Exception:
+        config["timeout"] = _DEFAULT_TIMEOUT
+
+    config["query_tool"] = str(config.get("query_tool", _DEFAULT_QUERY_TOOL)).strip() or _DEFAULT_QUERY_TOOL
+    config["write_tool"] = str(config.get("write_tool", _DEFAULT_WRITE_TOOL)).strip() or _DEFAULT_WRITE_TOOL
+
+    fallbacks = config.get("query_tool_fallbacks", [])
+    if isinstance(fallbacks, str):
+        fallbacks = [item.strip() for item in fallbacks.split(",") if item.strip()]
+    elif isinstance(fallbacks, list):
+        fallbacks = [str(item).strip() for item in fallbacks if str(item).strip()]
+    else:
+        fallbacks = []
+    config["query_tool_fallbacks"] = [name for name in fallbacks if name != config["query_tool"]]
+
+    return config
+
+
+def _load_gbrain_config(hermes_home: str) -> dict:
+    config = _default_config()
+    config_path = Path(hermes_home) / "gbrain-memory.json"
+    if config_path.exists():
+        try:
+            raw = json.loads(config_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                config.update(raw)
+        except Exception:
+            logger.debug("Failed to parse %s", config_path, exc_info=True)
+
+    # Config.yaml wins over the profile-local provider file so
+    # `hermes config set memory.gbrain.*` and `hermes memory setup gbrain` can
+    # both drive the same provider.
+    try:
+        from hermes_cli.config import load_config
+
+        mem_config = (load_config().get("memory") or {})
+        yaml_config = mem_config.get("gbrain") if isinstance(mem_config, dict) else None
+        if isinstance(yaml_config, dict):
+            config.update(yaml_config)
+    except Exception:
+        logger.debug("Failed to read memory.gbrain config", exc_info=True)
+
+    # Environment override is useful for tests and ephemeral deployments; it is
+    # a URL, not a credential.
+    env_endpoint = os.environ.get("GBRAIN_MCP_ENDPOINT")
+    if env_endpoint is not None:
+        config["endpoint"] = env_endpoint
+
+    return _coerce_config(config)
+
+
+def _save_gbrain_config(values: dict, hermes_home: str) -> None:
+    config_path = Path(hermes_home) / "gbrain-memory.json"
+    existing: dict[str, Any] = {}
+    if config_path.exists():
+        try:
+            raw = json.loads(config_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                existing = raw
+        except Exception:
+            existing = {}
+    existing.update(values)
+    from utils import atomic_json_write
+
+    atomic_json_write(config_path, _coerce_config(existing), mode=0o600, sort_keys=True)
+
+
+def _clean_text(text: str) -> str:
+    if not text:
+        return ""
+    text = _CONTEXT_STRIP_RE.sub("", str(text))
+    return text.strip()[:_MAX_CONTENT_CHARS]
+
+
+def _extract_text_fragments(value: Any) -> list[str]:
+    """Extract human-readable text snippets from common MCP result shapes."""
+    fragments: list[str] = []
+    if value is None:
+        return fragments
+    if isinstance(value, str):
+        if value.strip():
+            fragments.append(value.strip())
+        return fragments
+    if isinstance(value, list):
+        for item in value:
+            fragments.extend(_extract_text_fragments(item))
+        return fragments
+    if isinstance(value, dict):
+        if value.get("type") == "text" and isinstance(value.get("text"), str):
+            fragments.append(value["text"].strip())
+            return fragments
+        for key in ("content", "text", "markdown", "summary", "compiled", "answer"):
+            inner = value.get(key)
+            if inner:
+                fragments.extend(_extract_text_fragments(inner))
+        return fragments
+    return fragments
+
+
+def _format_search_results(payload: Any, max_results: int) -> str:
+    """Format GBrain MCP payloads into compact memory context."""
+    # Common native MCP shape: {content: [{type: text, text: "..."}], ...}
+    fragments = _extract_text_fragments(payload)
+    if fragments:
+        text = "\n\n".join(fragments)
+        return f"<gbrain-memory-context>\n## GBrain recalled context\n{text[:_MAX_CONTENT_CHARS]}\n</gbrain-memory-context>"
+
+    # Defensive fallback for direct list/dict search payloads.
+    items: list[Any] = []
+    if isinstance(payload, dict):
+        for key in ("results", "pages", "matches", "data"):
+            if isinstance(payload.get(key), list):
+                items = payload[key]
+                break
+    elif isinstance(payload, list):
+        items = payload
+
+    lines: list[str] = []
+    for item in items[:max_results]:
+        if isinstance(item, dict):
+            slug = item.get("slug") or item.get("page_slug") or item.get("title") or "GBrain page"
+            content = item.get("content") or item.get("text") or item.get("summary") or item.get("description") or ""
+            content = _clean_text(content)
+            if content:
+                lines.append(f"- {slug}: {content}")
+        elif item:
+            lines.append(f"- {_clean_text(str(item))}")
+    if not lines:
+        return ""
+    return "<gbrain-memory-context>\n## GBrain recalled context\n" + "\n".join(lines) + "\n</gbrain-memory-context>"
+
+
+class _GBrainMCPClient:
+    """Tiny stdlib JSON-RPC-over-HTTP client for GBrain's MCP endpoint."""
+
+    def __init__(self, endpoint: str, timeout: float = _DEFAULT_TIMEOUT) -> None:
+        self.endpoint = endpoint
+        self.timeout = timeout
+        self._next_id = 1
+        self._session_id = ""
+        self._initialized = False
+        self._lock = threading.Lock()
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+        try:
+            return self._request("tools/call", {"name": name, "arguments": arguments})
+        except RuntimeError as exc:
+            # Some Streamable HTTP MCP servers require initialize first; many
+            # tolerate direct tools/call. Retry once after initialization.
+            if "initialized" not in str(exc).lower() and "initialize" not in str(exc).lower():
+                raise
+            self.initialize()
+            return self._request("tools/call", {"name": name, "arguments": arguments})
+
+    def initialize(self) -> None:
+        if self._initialized:
+            return
+        result = self._request(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "hermes-gbrain-memory", "version": "1.0.0"},
+            },
+            allow_uninitialized=True,
+        )
+        self._initialized = True
+        # Best-effort initialized notification; failures are non-fatal because
+        # some lightweight HTTP bridges ignore notifications.
+        try:
+            self._notify("notifications/initialized", {})
+        except Exception:
+            logger.debug("GBrain MCP initialized notification failed", exc_info=True)
+        return result
+
+    def _notify(self, method: str, params: dict[str, Any]) -> None:
+        payload = {"jsonrpc": "2.0", "method": method, "params": params}
+        self._post(payload)
+
+    def _request(self, method: str, params: dict[str, Any], *, allow_uninitialized: bool = False) -> Any:
+        with self._lock:
+            req_id = self._next_id
+            self._next_id += 1
+        payload = {"jsonrpc": "2.0", "id": req_id, "method": method, "params": params}
+        response = self._post(payload)
+        if "error" in response:
+            err = response.get("error") or {}
+            message = err.get("message") if isinstance(err, dict) else str(err)
+            if allow_uninitialized:
+                raise RuntimeError(message or "MCP request failed")
+            raise RuntimeError(message or "MCP request failed")
+        return response.get("result")
+
+    def _post(self, payload: dict[str, Any]) -> dict[str, Any]:
+        data = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "User-Agent": "Hermes-GBrain-Memory/1.0",
+        }
+        if self._session_id:
+            headers["Mcp-Session-Id"] = self._session_id
+        request = urllib.request.Request(self.endpoint, data=data, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                session_id = response.headers.get("Mcp-Session-Id") or response.headers.get("mcp-session-id")
+                if session_id:
+                    self._session_id = session_id
+                body = response.read().decode("utf-8", errors="replace")
+                content_type = response.headers.get("Content-Type", "")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(f"GBrain MCP HTTP {exc.code}: {body}") from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"GBrain MCP unavailable: {exc.reason}") from exc
+        except TimeoutError as exc:
+            raise RuntimeError("GBrain MCP request timed out") from exc
+
+        return self._decode_response(body, content_type)
+
+    @staticmethod
+    def _decode_response(body: str, content_type: str = "") -> dict[str, Any]:
+        body = body.strip()
+        if not body:
+            return {}
+        if "text/event-stream" in content_type or body.startswith("event:") or body.startswith("data:"):
+            for line in body.splitlines():
+                if not line.startswith("data:"):
+                    continue
+                data = line[len("data:"):].strip()
+                if not data or data == "[DONE]":
+                    continue
+                try:
+                    parsed = json.loads(data)
+                    if isinstance(parsed, dict):
+                        return parsed
+                except json.JSONDecodeError:
+                    continue
+            raise RuntimeError("GBrain MCP returned no JSON event data")
+        parsed = json.loads(body)
+        if not isinstance(parsed, dict):
+            raise RuntimeError("GBrain MCP returned non-object JSON")
+        return parsed
+
+
+class GBrainMemoryProvider(MemoryProvider):
+    """Read-mostly GBrain-backed memory provider."""
+
+    def __init__(self) -> None:
+        self._config = _coerce_config()
+        self._client: Optional[_GBrainMCPClient] = None
+        self._session_id = ""
+        self._agent_identity = ""
+        self._last_error = ""
+
+    @property
+    def name(self) -> str:
+        return "gbrain"
+
+    def is_available(self) -> bool:
+        try:
+            config = _load_gbrain_config(str(Path(os.environ.get("HERMES_HOME", "")).expanduser())) if os.environ.get("HERMES_HOME") else self._config
+        except Exception:
+            config = self._config
+        return bool(str(config.get("endpoint", "")).strip())
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        hermes_home = kwargs.get("hermes_home") or os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+        self._config = _load_gbrain_config(str(hermes_home))
+        self._session_id = session_id
+        self._agent_identity = str(kwargs.get("agent_identity") or "").strip()
+        self._last_error = ""
+        if not self._config.get("endpoint"):
+            raise RuntimeError("GBrain memory provider endpoint is not configured")
+        self._client = _GBrainMCPClient(self._config["endpoint"], timeout=float(self._config["timeout"]))
+
+    def system_prompt_block(self) -> str:
+        mode = self._config.get("mode", _DEFAULT_MODE)
+        if mode == "read-write":
+            return (
+                "GBrain memory provider is active in explicit read-write mode. "
+                "Only write durable memories when the user or profile policy authorizes it; "
+                "do not store secrets or raw credentials."
+            )
+        return (
+            "GBrain memory provider is active in read-only mode. Use retrieved GBrain "
+            "context as background memory. Do not write, ingest, delete, or modify GBrain; "
+            "route candidate durable updates to the Athena steward unless read-write mode is explicitly configured."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        query = str(query or "").strip()
+        if not query or not self._client:
+            return ""
+        result = self._search_payload(query, limit=int(self._config["max_results"]))
+        if result.get("error"):
+            self._last_error = result["error"]
+            logger.debug("GBrain memory prefetch failed: %s", self._last_error)
+            return ""
+        return _format_search_results(result.get("result"), int(self._config["max_results"]))
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        # Deliberately no automatic conversation ingestion. The safe default is
+        # read-only, and even read-write mode mirrors only explicit memory writes.
+        return None
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if self._config.get("mode") != "read-write":
+            return None
+        if action != "add" or not content or not self._client:
+            return None
+        payload = {
+            "title": f"Hermes memory candidate: {target}",
+            "content": _clean_text(content),
+            "tags": ["hermes-memory", "athena-reviewed"],
+            "metadata": {
+                "source": "hermes-memory-provider",
+                "target": target,
+                "session_id": self._session_id,
+                "agent_identity": self._agent_identity,
+                **(metadata or {}),
+            },
+        }
+        try:
+            self._client.call_tool(str(self._config["write_tool"]), payload)
+        except Exception as exc:
+            logger.warning("GBrain memory write mirror failed: %s", exc)
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "name": "gbrain_memory_search",
+                "description": "Search GBrain persistent memory through the configured MCP endpoint.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "limit": {"type": "integer", "description": "Maximum results", "default": self._config.get("max_results", _DEFAULT_MAX_RESULTS)},
+                    },
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "gbrain_memory_store_candidate",
+                "description": "Submit a durable memory candidate to GBrain only when explicit read-write mode is configured; otherwise returns a safe Athena-steward handoff.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "content": {"type": "string", "description": "Memory candidate content"},
+                        "target": {"type": "string", "description": "memory or user", "default": "memory"},
+                    },
+                    "required": ["content"],
+                },
+            },
+        ]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if tool_name == "gbrain_memory_search":
+            query = str(args.get("query") or "").strip()
+            if not query:
+                return tool_error("query is required")
+            try:
+                limit = max(1, min(20, int(args.get("limit") or self._config["max_results"])))
+            except Exception:
+                limit = int(self._config["max_results"])
+            result = self._search_payload(query, limit=limit)
+            if result.get("error"):
+                return json.dumps({"ok": False, "error": result["error"]})
+            formatted = _format_search_results(result.get("result"), limit)
+            return json.dumps({"ok": True, "context": formatted, "raw": result.get("result")})
+
+        if tool_name == "gbrain_memory_store_candidate":
+            content = _clean_text(str(args.get("content") or ""))
+            target = str(args.get("target") or "memory").strip() or "memory"
+            if not content:
+                return tool_error("content is required")
+            if self._config.get("mode") != "read-write":
+                return json.dumps({
+                    "ok": False,
+                    "blocked": True,
+                    "mode": self._config.get("mode", _DEFAULT_MODE),
+                    "message": "GBrain provider is read-only. Route this candidate to Athena/steward review instead of writing directly.",
+                    "candidate": {"target": target, "content": content},
+                })
+            if not self._client:
+                return json.dumps({"ok": False, "error": "GBrain MCP client is not initialized"})
+            try:
+                result = self._client.call_tool(
+                    str(self._config["write_tool"]),
+                    {
+                        "title": f"Hermes memory candidate: {target}",
+                        "content": content,
+                        "tags": ["hermes-memory"],
+                        "metadata": {"source": "hermes-memory-provider", "target": target},
+                    },
+                )
+                return json.dumps({"ok": True, "result": result})
+            except Exception as exc:
+                return json.dumps({"ok": False, "error": str(exc)})
+
+        raise NotImplementedError(f"GBrain provider does not handle {tool_name}")
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "endpoint",
+                "description": "GBrain HTTP MCP endpoint",
+                "default": _DEFAULT_ENDPOINT,
+            },
+            {
+                "key": "mode",
+                "description": "Safety mode",
+                "default": _DEFAULT_MODE,
+                "choices": ["read-only", "read-write"],
+            },
+            {
+                "key": "source_id",
+                "description": "GBrain source scope (__all__ or a source id)",
+                "default": _DEFAULT_SOURCE_ID,
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        _save_gbrain_config(values, hermes_home)
+
+    def post_setup(self, hermes_home: str, config: Dict[str, Any]) -> None:
+        """Non-interactive safe setup used by `hermes memory setup gbrain`.
+
+        The generic setup path uses curses for choice fields, which is awkward
+        for headless profile provisioning. GBrain's safe default is read-only,
+        so setup can activate that default and leave advanced edits to
+        config.yaml or `$HERMES_HOME/gbrain-memory.json`.
+        """
+        from hermes_cli.config import save_config
+
+        if not isinstance(config.get("memory"), dict):
+            config["memory"] = {}
+        provider_config = config["memory"].get("gbrain")
+        if not isinstance(provider_config, dict):
+            provider_config = {}
+        merged = _coerce_config(provider_config)
+        # Never let setup accidentally promote to write mode. Users can edit
+        # mode explicitly after setup for Athena-only writer profiles.
+        merged["mode"] = "read-only"
+        config["memory"]["provider"] = "gbrain"
+        config["memory"]["gbrain"] = merged
+        save_config(config)
+        _save_gbrain_config(merged, hermes_home)
+        print("\n  Memory provider: gbrain")
+        print("  Mode: read-only (safe default)")
+        print(f"  Endpoint: {merged['endpoint']}")
+        print("  Activation saved to config.yaml")
+        print("  Provider config saved to gbrain-memory.json")
+        print("\n  Start a new session to activate.\n")
+
+    def _search_payload(self, query: str, *, limit: int) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "GBrain MCP client is not initialized"}
+        args = {
+            "query": query,
+            "limit": limit,
+            "adaptive_return": True,
+        }
+        source_id = self._config.get("source_id")
+        if source_id:
+            args["source_id"] = source_id
+        tool_names = [str(self._config["query_tool"])] + list(self._config.get("query_tool_fallbacks") or [])
+        errors: list[str] = []
+        for tool_name in tool_names:
+            try:
+                return {"result": self._client.call_tool(tool_name, args), "tool": tool_name}
+            except Exception as exc:
+                errors.append(f"{tool_name}: {exc}")
+        return {"error": "; ".join(errors) or "GBrain MCP query failed"}
+
+
+def register(ctx) -> None:
+    ctx.register_memory_provider(GBrainMemoryProvider())

--- a/plugins/memory/gbrain/plugin.yaml
+++ b/plugins/memory/gbrain/plugin.yaml
@@ -1,0 +1,6 @@
+name: gbrain
+version: 1.0.0
+description: "GBrain MCP-backed memory provider with read-only safe default and Athena-only write opt-in."
+hooks:
+  - prefetch
+  - on_memory_write

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1534,6 +1534,72 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+
+    async def update_thread_metadata(
+        self,
+        thread_id: str,
+        *,
+        name: Optional[str] = None,
+        applied_tags: Optional[list] = None,
+    ) -> bool:
+        """Update a Discord forum/thread projection title and applied tags.
+
+        Kanban forum cards are long-lived Discord threads. Sending a terminal
+        notification into the thread is not enough to keep the forum list
+        accurate; the thread metadata also needs to mirror canonical Kanban
+        status/assignee state.
+        """
+        if not self._client:
+            return False
+        payload: Dict[str, Any] = {}
+        if name is not None:
+            payload["name"] = name
+        if applied_tags is not None:
+            payload["applied_tags"] = [str(tag) for tag in applied_tags]
+        if not payload:
+            return True
+        try:
+            route = discord.http.Route(
+                "PATCH",
+                "/channels/{channel_id}",
+                channel_id=int(thread_id),
+            )
+            await self._client.http.request(route, json=payload)
+            return True
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.warning(
+                "[%s] Failed to update Discord thread %s metadata: %s",
+                self.name, thread_id, e,
+            )
+            return False
+
+    async def _resolve_media_target_channel(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> tuple[Any, str]:
+        """Resolve the Discord channel/thread that should receive a media send.
+
+        Text sends already honor ``metadata['thread_id']``. Native media
+        delivery must do the same; otherwise a Kanban/Discord forum
+        subscription whose ``chat_id`` is the parent forum channel will upload
+        into the parent, and Discord turns the attachment into a brand-new
+        forum post instead of a reply in the existing task thread.
+        """
+        if not self._client:
+            raise ValueError("Not connected")
+
+        target_id = str(chat_id)
+        if metadata and metadata.get("thread_id"):
+            target_id = str(metadata["thread_id"])
+
+        channel = self._client.get_channel(int(target_id))
+        if not channel:
+            channel = await self._client.fetch_channel(int(target_id))
+        if not channel:
+            raise ValueError(f"Channel {target_id} not found")
+        return channel, target_id
+
     async def _send_to_forum(
         self,
         forum_channel: Any,
@@ -1691,20 +1757,23 @@ class DiscordAdapter(BasePlatformAdapter):
         file_path: str,
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment.
 
         Forum channels (type 15) get a new thread whose starter message
-        carries the file — they reject direct POST /messages.
+        carries the file — they reject direct POST /messages. If metadata
+        names an existing ``thread_id`` (for example a Kanban task forum
+        thread), send into that thread instead of creating a sibling forum
+        post for the attachment.
         """
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        channel = self._client.get_channel(int(chat_id))
-        if not channel:
-            channel = await self._client.fetch_channel(int(chat_id))
-        if not channel:
-            return SendResult(success=False, error=f"Channel {chat_id} not found")
+        try:
+            channel, _target_id = await self._resolve_media_target_channel(chat_id, metadata)
+        except ValueError as exc:
+            return SendResult(success=False, error=str(exc))
 
         filename = file_name or os.path.basename(file_path)
         with open(file_path, "rb") as fh:
@@ -1748,12 +1817,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return
 
         try:
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                logger.warning("[%s] Channel %s not found for multi-image send", self.name, chat_id)
-                return
+            channel, _target_id = await self._resolve_media_target_channel(chat_id, metadata)
         except Exception as e:
             logger.warning("[%s] Failed to resolve channel for multi-image send: %s", self.name, e)
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
@@ -1877,11 +1941,7 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import io
 
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+            channel, _target_id = await self._resolve_media_target_channel(chat_id, metadata)
 
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=f"Audio file not found: {audio_path}")
@@ -2800,7 +2860,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         try:
-            return await self._send_file_attachment(chat_id, image_path, caption)
+            return await self._send_file_attachment(chat_id, image_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Image file not found: {image_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -2826,11 +2886,7 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+            channel, _target_id = await self._resolve_media_target_channel(chat_id, metadata)
 
             # Download the image and send as a Discord file attachment
             # (Discord renders attachments inline, unlike plain URLs)
@@ -2905,11 +2961,7 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+            channel, _target_id = await self._resolve_media_target_channel(chat_id, metadata)
 
             # Download the GIF and send as a Discord file attachment
             # (Discord renders .gif attachments as auto-playing animations inline)
@@ -2965,7 +3017,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local video file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, video_path, caption)
+            return await self._send_file_attachment(chat_id, video_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Video file not found: {video_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -2983,7 +3035,13 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            return await self._send_file_attachment(
+                chat_id,
+                file_path,
+                caption,
+                file_name=file_name,
+                metadata=metadata,
+            )
         except FileNotFoundError:
             return SendResult(success=False, error=f"File not found: {file_path}")
         except Exception as e:  # pragma: no cover - defensive logging

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1458,7 +1458,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
-                return await self._send_to_forum(channel, content)
+                return await self._send_to_forum(
+                    channel,
+                    content,
+                    applied_tags=metadata.get("applied_tags") if metadata else None,
+                    thread_name=metadata.get("thread_name") if metadata else None,
+                )
 
             # Format and split message if needed
             formatted = self.format_message(content)
@@ -1529,7 +1534,14 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
-    async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
+    async def _send_to_forum(
+        self,
+        forum_channel: Any,
+        content: str,
+        *,
+        applied_tags: Optional[list] = None,
+        thread_name: Optional[str] = None,
+    ) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
         Forum channels (type 15) don't support direct messages.  Instead we
@@ -1544,15 +1556,18 @@ class DiscordAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
-        thread_name = _derive_forum_thread_name(content)
+        thread_name = thread_name or _derive_forum_thread_name(content)
 
         starter_content = chunks[0] if chunks else thread_name
 
         try:
-            thread = await forum_channel.create_thread(
-                name=thread_name,
-                content=starter_content,
-            )
+            kwargs: Dict[str, Any] = {
+                "name": thread_name,
+                "content": starter_content,
+            }
+            if applied_tags is not None:
+                kwargs["applied_tags"] = applied_tags
+            thread = await forum_channel.create_thread(**kwargs)
         except Exception as e:
             logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
             return SendResult(success=False, error=f"Forum thread creation failed: {e}")
@@ -6187,6 +6202,8 @@ async def _standalone_send(
     thread_id: Optional[str] = None,
     media_files: Optional[list] = None,
     force_document: bool = False,
+    applied_tags: Optional[list] = None,
+    thread_name: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Send via Discord REST API without a live gateway adapter.
 
@@ -6261,7 +6278,7 @@ async def _standalone_send(
                         logger.debug("Failed to probe channel type for %s", chat_id, exc_info=True)
 
             if is_forum:
-                thread_name = _derive_forum_thread_name(message)
+                thread_name = thread_name or _derive_forum_thread_name(message)
                 thread_url = f"https://discord.com/api/v10/channels/{chat_id}/threads"
 
                 # Filter to readable media files up front so we can pick the
@@ -6285,7 +6302,10 @@ async def _standalone_send(
                             for idx, path in enumerate(valid_media)
                         ]
                         starter_message = {"content": message, "attachments": attachments_meta}
-                        payload_json = json.dumps({"name": thread_name, "message": starter_message})
+                        payload = {"name": thread_name, "message": starter_message}
+                        if applied_tags is not None:
+                            payload["applied_tags"] = applied_tags
+                        payload_json = json.dumps(payload)
 
                         form = aiohttp.FormData()
                         form.add_field("payload_json", payload_json, content_type="application/json")
@@ -6308,13 +6328,16 @@ async def _standalone_send(
                     else:
                         # No media — simple JSON POST creates the thread with
                         # just the text starter.
+                        payload = {
+                            "name": thread_name,
+                            "message": {"content": message},
+                        }
+                        if applied_tags is not None:
+                            payload["applied_tags"] = applied_tags
                         async with session.post(
                             thread_url,
                             headers=json_headers,
-                            json={
-                                "name": thread_name,
-                                "message": {"content": message},
-                            },
+                            json=payload,
                             **_req_kw,
                         ) as resp:
                             if resp.status not in {200, 201}:

--- a/scripts/kanban_archive_done.py
+++ b/scripts/kanban_archive_done.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Cron entrypoint for stale Done Kanban task archival.
+
+Recommended Hermes cron schedule for the approved policy:
+  30 3 * * *
+
+First backfill dry-run:
+  python scripts/kanban_archive_done.py --dry-run --done-age-days 7 --batch-size 25
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from hermes_cli.kanban_archive_done import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_discord_media_metadata.py
+++ b/tests/gateway/test_discord_media_metadata.py
@@ -1,9 +1,224 @@
 import inspect
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
+import pytest
+
+from gateway.config import Platform
 from plugins.platforms.discord.adapter import DiscordAdapter
 
 
 def test_discord_media_methods_accept_metadata_kwarg():
-    for method_name in ("send_voice", "send_image_file", "send_image"):
+    for method_name in ("send_voice", "send_image_file", "send_image", "send_video", "send_document"):
         signature = inspect.signature(getattr(DiscordAdapter, method_name))
         assert "metadata" in signature.parameters, method_name
+
+
+@pytest.mark.asyncio
+async def test_discord_document_metadata_thread_id_targets_existing_thread(tmp_path):
+    """Kanban artifact uploads to a forum subscription must use the task thread.
+
+    Without this, send_document resolves the parent forum channel and Discord
+    creates a new forum post named after the uploaded artifact.
+    """
+    uploaded = tmp_path / "handoff.md"
+    uploaded.write_text("handoff", encoding="utf-8")
+
+    sent = []
+
+    class FakeThread:
+        id = 222
+
+        async def send(self, **kwargs):
+            sent.append(kwargs)
+            return SimpleNamespace(id=333)
+
+    class FakeClient:
+        def __init__(self):
+            self.requested_ids = []
+
+        def get_channel(self, channel_id):
+            self.requested_ids.append(channel_id)
+            if channel_id == 222:
+                return FakeThread()
+            raise AssertionError(f"attachment delivery targeted parent channel {channel_id}")
+
+        async def fetch_channel(self, channel_id):  # pragma: no cover - get_channel should hit
+            raise AssertionError(f"unexpected fetch for {channel_id}")
+
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter._client = FakeClient()
+    adapter._is_forum_parent = lambda channel: False
+
+    result = await adapter.send_document(
+        chat_id="111",
+        file_path=str(uploaded),
+        metadata={"thread_id": "222"},
+    )
+
+    assert result.success is True
+    assert adapter._client.requested_ids == [222]
+    assert len(sent) == 1
+    assert sent[0]["file"].filename == "handoff.md"
+
+
+@pytest.mark.asyncio
+async def test_discord_multi_image_metadata_thread_id_targets_existing_thread(tmp_path):
+    image = tmp_path / "chart.png"
+    image.write_bytes(b"fake-png")
+
+    class FakeThread:
+        id = 222
+        send = AsyncMock(return_value=SimpleNamespace(id=333))
+
+    thread = FakeThread()
+
+    class FakeClient:
+        def __init__(self):
+            self.requested_ids = []
+
+        def get_channel(self, channel_id):
+            self.requested_ids.append(channel_id)
+            if channel_id == 222:
+                return thread
+            raise AssertionError(f"image delivery targeted parent channel {channel_id}")
+
+        async def fetch_channel(self, channel_id):  # pragma: no cover - get_channel should hit
+            raise AssertionError(f"unexpected fetch for {channel_id}")
+
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter._client = FakeClient()
+    adapter._is_forum_parent = lambda channel: False
+
+    await adapter.send_multiple_images(
+        chat_id="111",
+        images=[(f"file://{image}", "")],
+        metadata={"thread_id": "222"},
+    )
+
+    assert adapter._client.requested_ids == [222]
+    thread.send.assert_awaited_once()
+    kwargs = thread.send.await_args.kwargs
+    assert kwargs["files"][0].filename == "chart.png"
+
+
+@pytest.mark.asyncio
+async def test_discord_voice_metadata_thread_id_targets_existing_thread(tmp_path):
+    audio = tmp_path / "note.ogg"
+    audio.write_bytes(b"fake-audio")
+
+    class FakeThread:
+        id = 222
+        send = AsyncMock(return_value=SimpleNamespace(id=333))
+
+    thread = FakeThread()
+
+    class FakeHttp:
+        async def request(self, route, form=None, **kwargs):
+            assert getattr(route, "parameters", {}).get("channel_id") == 222
+            return {"id": 444}
+
+    class FakeClient:
+        def __init__(self):
+            self.http = FakeHttp()
+            self.requested_ids = []
+
+        def get_channel(self, channel_id):
+            self.requested_ids.append(channel_id)
+            if channel_id == 222:
+                return thread
+            raise AssertionError(f"voice delivery targeted parent channel {channel_id}")
+
+        async def fetch_channel(self, channel_id):  # pragma: no cover - get_channel should hit
+            raise AssertionError(f"unexpected fetch for {channel_id}")
+
+    client = FakeClient()
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter._client = client
+    adapter._is_forum_parent = lambda channel: False
+
+    result = await adapter.send_voice(
+        chat_id="111",
+        audio_path=str(audio),
+        metadata={"thread_id": "222"},
+    )
+
+    assert result.success is True
+    assert client.requested_ids == [222]
+
+
+@pytest.mark.asyncio
+async def test_discord_url_image_metadata_thread_id_targets_existing_thread(monkeypatch):
+    sent = []
+
+    class FakeResponse:
+        status = 200
+        headers = {"content-type": "image/png"}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def read(self):
+            return b"fake-image"
+
+    class FakeSession:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        def get(self, *args, **kwargs):
+            return FakeResponse()
+
+    fake_aiohttp = SimpleNamespace(
+        ClientSession=FakeSession,
+        ClientTimeout=lambda **kwargs: None,
+    )
+    monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+
+    class FakeThread:
+        id = 222
+
+        async def send(self, **kwargs):
+            sent.append(kwargs)
+            return SimpleNamespace(id=333)
+
+    class FakeClient:
+        def __init__(self):
+            self.requested_ids = []
+
+        def get_channel(self, channel_id):
+            self.requested_ids.append(channel_id)
+            if channel_id == 222:
+                return FakeThread()
+            raise AssertionError(f"image URL delivery targeted parent channel {channel_id}")
+
+        async def fetch_channel(self, channel_id):  # pragma: no cover - get_channel should hit
+            raise AssertionError(f"unexpected fetch for {channel_id}")
+
+    client = FakeClient()
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter._client = client
+    adapter._is_forum_parent = lambda channel: False
+
+    result = await adapter.send_image(
+        chat_id="111",
+        image_url="https://example.com/chart.png",
+        metadata={"thread_id": "222"},
+    )
+
+    assert result.success is True
+    assert client.requested_ids == [222]
+    assert sent[0]["file"].filename == "image.png"

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from pathlib import Path
 
 
@@ -10,9 +11,29 @@ from hermes_cli import kanban_db as kb
 class RecordingAdapter:
     def __init__(self):
         self.sent = []
+        self.thread_updates = []
+        self.documents = []
 
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def update_thread_metadata(self, thread_id, *, name=None, applied_tags=None):
+        self.thread_updates.append({
+            "thread_id": thread_id,
+            "name": name,
+            "applied_tags": list(applied_tags or []),
+        })
+        return True
+
+    async def send_document(self, chat_id, file_path, caption=None, file_name=None, reply_to=None, metadata=None):
+        self.documents.append({
+            "chat_id": chat_id,
+            "file_path": file_path,
+            "metadata": metadata or {},
+        })
+
+    def extract_local_files(self, text):
+        return [], text
 
 
 class DisconnectedAdapters(dict):
@@ -35,10 +56,10 @@ async def _run_one_notifier_tick(monkeypatch, runner):
     await runner._kanban_notifier_watcher(interval=1)
 
 
-def _make_runner(adapter):
+def _make_runner(adapter, platform=Platform.TELEGRAM):
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._running = True
-    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.adapters = {platform: adapter}
     runner._kanban_sub_fail_counts = {}
     return runner
 
@@ -233,3 +254,146 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
     assert "crashed" in adapter.sent[1]["text"].lower()
+
+
+def test_discord_kanban_notifier_syncs_forum_card_metadata_before_final_unsubscribe(tmp_path, monkeypatch):
+    """Terminal Discord notifications must update forum title/tags before unsubscribe.
+
+    Regression coverage for completed tasks whose notification row is deleted
+    after delivery: after that point repair/audit cannot infer the thread binding,
+    so the gateway has to mutate the Discord card while the subscription still
+    exists.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(home / "kanban.db"))
+    kb.init_db()
+    board_dir = home / "kanban" / "boards" / "default"
+    board_dir.mkdir(parents=True, exist_ok=True)
+    (board_dir / "discord-forum-tags.json").write_text(
+        json.dumps({
+            "status_to_tag": {"done": "done-tag", "blocked": "blocked-tag"},
+            "assignee_to_tag": {"hermes": "hermes-tag", "default": "default-tag"},
+        }),
+        encoding="utf-8",
+    )
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="ship projection sync", assignee="hermes")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id="forum-1",
+            thread_id="thread-1",
+        )
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter, Platform.DISCORD)))
+
+    assert adapter.thread_updates == [{
+        "thread_id": "thread-1",
+        "name": "✅ [done] ship projection sync",
+        "applied_tags": ["done-tag", "hermes-tag"],
+    }]
+    assert len(adapter.sent) == 1
+
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_discord_kanban_notifier_prefers_configured_status_emoji(tmp_path, monkeypatch):
+    """Forum thread titles should use board-configured emoji, not ASCII fallbacks."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(home / "kanban.db"))
+    kb.init_db()
+    board_dir = home / "kanban" / "boards" / "default"
+    board_dir.mkdir(parents=True, exist_ok=True)
+    (board_dir / "discord-forum-tags.json").write_text(
+        json.dumps({
+            "tags": {"running": {"emoji": "🟨"}},
+            "status_to_tag": {"running": "running-tag"},
+            "assignee_to_tag": {"hermes": "hermes-tag"},
+        }),
+        encoding="utf-8",
+    )
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="keep the emoji", assignee="hermes")
+        assert kb.claim_task(conn, tid, claimer="test") is not None
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id="forum-1",
+            thread_id="thread-1",
+        )
+        # Any notifier tick for a non-terminal event should still reconcile
+        # the live Discord forum card metadata for the running task.
+        kb._append_event(conn, tid, kind="blocked")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter, Platform.DISCORD)))
+
+    assert adapter.thread_updates[0]["name"] == "🟨 [running] keep the emoji"
+
+
+def test_discord_kanban_notifier_artifacts_use_existing_thread_metadata(tmp_path, monkeypatch):
+    """Artifact uploads must target the task thread, not the parent forum.
+
+    A Discord forum subscription stores ``chat_id`` as the parent forum and
+    ``thread_id`` as the actual Kanban card thread. The text notification and
+    all follow-up artifact uploads must receive the same metadata; otherwise
+    Discord creates a sibling forum post named after the uploaded artifact.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    artifact = home / "cache" / "documents" / "implementation-handoff-addendum-2026-05-30.md"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text("handoff", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(home / "kanban.db"))
+    monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(home))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="artifact routing", assignee="hephaestus")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id="forum-1",
+            thread_id="thread-1",
+        )
+        kb.complete_task(
+            conn,
+            tid,
+            summary="done",
+            metadata={"artifacts": [str(artifact)]},
+        )
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter, Platform.DISCORD)))
+
+    assert adapter.sent[0]["metadata"] == {"thread_id": "thread-1"}
+    assert adapter.documents == [{
+        "chat_id": "forum-1",
+        "file_path": str(artifact),
+        "metadata": {"thread_id": "thread-1"},
+    }]

--- a/tests/gateway/test_kanban_thread_lifecycle.py
+++ b/tests/gateway/test_kanban_thread_lifecycle.py
@@ -1,0 +1,301 @@
+"""RED tests for Kanban task-thread lifecycle and context injection.
+
+These tests describe the desired Discord/Kanban thread behavior before the
+implementation exists:
+
+* A gateway thread subscribed to exactly one Kanban task can use lifecycle
+  shorthand commands without repeating the task id.
+* The dynamic session prompt for that gateway thread includes the bound Kanban
+  task context so the agent knows which canonical task owns the conversation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_context, build_session_context_prompt
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture()
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture()
+def discord_thread_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="1508752209679220948",
+        chat_name="Olympus / olympus-kanban / Improve workflow",
+        chat_type="group",
+        user_id="sam-user-id",
+        user_name="TheSamC",
+        thread_id="1509093323816570890",
+    )
+
+
+@pytest.fixture()
+def runner() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.adapters = {}
+    runner._kanban_notifier_profile = "default"
+    runner._active_profile_name = lambda: "default"
+    return runner
+
+
+def _create_subscribed_task(source: SessionSource, *, board: str | None = None) -> str:
+    if board is not None:
+        kb.init_db(board=board)
+    conn = kb.connect(board=board)
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="Improve Athena and Kanban-in-Discord task lifecycle workflow",
+            assignee="hermes",
+            body="Implement task-thread lifecycle commands and task-context injection.",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform=source.platform.value,
+            chat_id=source.chat_id,
+            thread_id=source.thread_id,
+            user_id=source.user_id,
+            notifier_profile="default",
+        )
+        return task_id
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_kanban_block_in_subscribed_thread_uses_bound_task_id(
+    kanban_home,
+    runner: GatewayRunner,
+    discord_thread_source: SessionSource,
+):
+    task_id = _create_subscribed_task(discord_thread_source)
+
+    result = await runner._handle_kanban_command(
+        MessageEvent(
+            text="/kanban block awaiting Sam approval",
+            source=discord_thread_source,
+        )
+    )
+
+    assert f"Blocked {task_id}" in result
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_kanban_done_in_subscribed_thread_uses_bound_task_id(
+    kanban_home,
+    runner: GatewayRunner,
+    discord_thread_source: SessionSource,
+):
+    task_id = _create_subscribed_task(discord_thread_source)
+
+    result = await runner._handle_kanban_command(
+        MessageEvent(
+            text="/kanban done smoke test passed",
+            source=discord_thread_source,
+        )
+    )
+
+    assert f"Completed {task_id}" in result
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "done"
+        assert "smoke test passed" in (task.result or "")
+    finally:
+        conn.close()
+
+
+def test_session_prompt_includes_bound_kanban_task_context(
+    kanban_home,
+    discord_thread_source: SessionSource,
+):
+    task_id = _create_subscribed_task(discord_thread_source)
+
+    ctx = build_session_context(discord_thread_source, GatewayConfig())
+    prompt = build_session_context_prompt(ctx)
+
+    assert f"Kanban task: `{task_id}`" in prompt
+    assert "Improve Athena and Kanban-in-Discord task lifecycle workflow" in prompt
+    assert "Assignee: `hermes`" in prompt
+    assert "Status: `ready`" in prompt
+
+
+@pytest.mark.asyncio
+async def test_kanban_shorthand_is_not_inferred_for_whole_channel_subscription(
+    kanban_home,
+    runner: GatewayRunner,
+    discord_thread_source: SessionSource,
+):
+    channel_source = SessionSource(
+        platform=discord_thread_source.platform,
+        chat_id=discord_thread_source.chat_id,
+        chat_name=discord_thread_source.chat_name,
+        chat_type=discord_thread_source.chat_type,
+        user_id=discord_thread_source.user_id,
+        user_name=discord_thread_source.user_name,
+        thread_id="",
+    )
+    task_id = _create_subscribed_task(channel_source)
+
+    result = await runner._handle_kanban_command(
+        MessageEvent(
+            text="/kanban block awaiting Sam approval",
+            source=channel_source,
+        )
+    )
+
+    assert "unknown task" in result or "cannot block" in result
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_kanban_complete_shorthand_preserves_explicit_options(
+    kanban_home,
+    runner: GatewayRunner,
+    discord_thread_source: SessionSource,
+):
+    task_id = _create_subscribed_task(discord_thread_source)
+
+    result = await runner._handle_kanban_command(
+        MessageEvent(
+            text="/kanban complete --result ok --summary reviewed",
+            source=discord_thread_source,
+        )
+    )
+
+    assert f"Completed {task_id}" in result
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "done"
+        assert task.result == "ok"
+        runs = list(kb.list_runs(conn, task_id))
+        assert runs
+        assert runs[-1].summary == "reviewed"
+    finally:
+        conn.close()
+
+
+def test_session_prompt_finds_bound_kanban_task_on_non_default_board(
+    kanban_home,
+    discord_thread_source: SessionSource,
+):
+    task_id = _create_subscribed_task(discord_thread_source, board="olympus")
+
+    ctx = build_session_context(discord_thread_source, GatewayConfig())
+    prompt = build_session_context_prompt(ctx)
+
+    assert f"Kanban task: `{task_id}`" in prompt
+    assert "Improve Athena and Kanban-in-Discord task lifecycle workflow" in prompt
+    assert "Assignee: `hermes`" in prompt
+
+
+@pytest.mark.asyncio
+async def test_kanban_shorthand_routes_to_non_default_bound_board(
+    kanban_home,
+    runner: GatewayRunner,
+    discord_thread_source: SessionSource,
+):
+    task_id = _create_subscribed_task(discord_thread_source, board="olympus")
+
+    result = await runner._handle_kanban_command(
+        MessageEvent(
+            text="/kanban block awaiting non-default board review",
+            source=discord_thread_source,
+        )
+    )
+
+    assert f"Blocked {task_id}" in result
+    default_conn = kb.connect()
+    olympus_conn = kb.connect(board="olympus")
+    try:
+        assert kb.get_task(default_conn, task_id) is None
+        task = kb.get_task(olympus_conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+    finally:
+        default_conn.close()
+        olympus_conn.close()
+
+
+@pytest.mark.asyncio
+async def test_kanban_shorthand_missing_explicit_board_does_not_create_board(
+    kanban_home,
+    runner: GatewayRunner,
+    discord_thread_source: SessionSource,
+):
+    missing = "missing-board"
+    assert not kb.board_exists(missing)
+
+    result = await runner._handle_kanban_command(
+        MessageEvent(
+            text=f"/kanban --board {missing} block awaiting review",
+            source=discord_thread_source,
+        )
+    )
+
+    assert "unknown task" in result or "No such board" in result or "does not exist" in result
+    assert not kb.board_exists(missing)
+
+
+@pytest.mark.asyncio
+async def test_kanban_shorthand_ambiguous_across_boards_does_not_infer(
+    kanban_home,
+    runner: GatewayRunner,
+    discord_thread_source: SessionSource,
+):
+    task_id_default = _create_subscribed_task(discord_thread_source)
+    task_id_olympus = _create_subscribed_task(discord_thread_source, board="olympus")
+
+    result = await runner._handle_kanban_command(
+        MessageEvent(
+            text="/kanban block ambiguous thread binding",
+            source=discord_thread_source,
+        )
+    )
+
+    assert "unknown task" in result or "cannot block" in result
+    default_conn = kb.connect()
+    olympus_conn = kb.connect(board="olympus")
+    try:
+        default_task = kb.get_task(default_conn, task_id_default)
+        olympus_task = kb.get_task(olympus_conn, task_id_olympus)
+        assert default_task is not None
+        assert olympus_task is not None
+        assert default_task.status == "ready"
+        assert olympus_task.status == "ready"
+    finally:
+        default_conn.close()
+        olympus_conn.close()

--- a/tests/gateway/test_kanban_thread_lifecycle.py
+++ b/tests/gateway/test_kanban_thread_lifecycle.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import pytest
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import MessageEvent
@@ -49,6 +50,16 @@ def runner() -> GatewayRunner:
     runner = GatewayRunner.__new__(GatewayRunner)
     runner.config = GatewayConfig()
     runner.adapters = {}
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._session_run_generation = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._update_prompt_pending = {}
+    runner._draining = False
+    runner._update_runtime_status = MagicMock()
+    runner._is_user_authorized = lambda source: True
     runner._kanban_notifier_profile = "default"
     runner._active_profile_name = lambda: "default"
     return runner
@@ -94,6 +105,7 @@ async def test_kanban_block_in_subscribed_thread_uses_bound_task_id(
         )
     )
 
+    assert result is not None
     assert f"Blocked {task_id}" in result
     conn = kb.connect()
     try:
@@ -119,6 +131,7 @@ async def test_kanban_done_in_subscribed_thread_uses_bound_task_id(
         )
     )
 
+    assert result is not None
     assert f"Completed {task_id}" in result
     conn = kb.connect()
     try:
@@ -126,6 +139,69 @@ async def test_kanban_done_in_subscribed_thread_uses_bound_task_id(
         assert task is not None
         assert task.status == "done"
         assert "smoke test passed" in (task.result or "")
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_free_response_done_in_subscribed_thread_updates_bound_task_without_agent(
+    kanban_home,
+    runner: GatewayRunner,
+    discord_thread_source: SessionSource,
+):
+    task_id = _create_subscribed_task(discord_thread_source)
+
+    async def _agent_should_not_run(*_args, **_kwargs):
+        raise AssertionError("free-response task-thread done command was routed to the agent")
+
+    runner._handle_message_with_agent = _agent_should_not_run
+
+    result = await runner._handle_message(
+        MessageEvent(
+            text="mark this task done - smoke test passed",
+            source=discord_thread_source,
+        )
+    )
+
+    assert result is not None
+    assert f"Completed {task_id}" in result
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "done"
+        assert "smoke test passed" in (task.result or "")
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_free_response_block_in_subscribed_thread_updates_bound_task_without_agent(
+    kanban_home,
+    runner: GatewayRunner,
+    discord_thread_source: SessionSource,
+):
+    task_id = _create_subscribed_task(discord_thread_source)
+
+    async def _agent_should_not_run(*_args, **_kwargs):
+        raise AssertionError("free-response task-thread block command was routed to the agent")
+
+    runner._handle_message_with_agent = _agent_should_not_run
+
+    result = await runner._handle_message(
+        MessageEvent(
+            text="block this awaiting Sam approval",
+            source=discord_thread_source,
+        )
+    )
+
+    assert result is not None
+    assert f"Blocked {task_id}" in result
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
     finally:
         conn.close()
 
@@ -194,6 +270,7 @@ async def test_kanban_complete_shorthand_preserves_explicit_options(
         )
     )
 
+    assert result is not None
     assert f"Completed {task_id}" in result
     conn = kb.connect()
     try:
@@ -237,6 +314,7 @@ async def test_kanban_shorthand_routes_to_non_default_bound_board(
         )
     )
 
+    assert result is not None
     assert f"Blocked {task_id}" in result
     default_conn = kb.connect()
     olympus_conn = kb.connect(board="olympus")

--- a/tests/gateway/test_kanban_thread_lifecycle.py
+++ b/tests/gateway/test_kanban_thread_lifecycle.py
@@ -90,6 +90,19 @@ def _create_subscribed_task(source: SessionSource, *, board: str | None = None) 
         conn.close()
 
 
+def _discord_adapter_thread_source(source: SessionSource) -> SessionSource:
+    """Mirror Discord adapter thread events: chat_id is the thread id."""
+    return SessionSource(
+        platform=source.platform,
+        chat_id=str(source.thread_id or ""),
+        chat_name=source.chat_name,
+        chat_type="thread",
+        user_id=source.user_id,
+        user_name=source.user_name,
+        thread_id=source.thread_id,
+    )
+
+
 @pytest.mark.asyncio
 async def test_kanban_block_in_subscribed_thread_uses_bound_task_id(
     kanban_home,
@@ -192,6 +205,38 @@ async def test_free_response_block_in_subscribed_thread_updates_bound_task_witho
         MessageEvent(
             text="block this awaiting Sam approval",
             source=discord_thread_source,
+        )
+    )
+
+    assert result is not None
+    assert f"Blocked {task_id}" in result
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_free_response_block_in_discord_adapter_thread_source_uses_forum_subscription(
+    kanban_home,
+    runner: GatewayRunner,
+    discord_thread_source: SessionSource,
+):
+    """Live Discord thread events use chat_id=thread_id, while subs store parent forum chat_id."""
+    task_id = _create_subscribed_task(discord_thread_source)
+
+    async def _agent_should_not_run(*_args, **_kwargs):
+        raise AssertionError("free-response task-thread block command was routed to the agent")
+
+    runner._handle_message_with_agent = _agent_should_not_run
+
+    result = await runner._handle_message(
+        MessageEvent(
+            text="block this live smoke: keep local-only pending review",
+            source=_discord_adapter_thread_source(discord_thread_source),
         )
     )
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -552,7 +552,7 @@ def test_gateway_install_can_decline_start_now_and_startup(monkeypatch):
 
 
 def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkeypatch):
-    monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda all_profiles=False: set())
     monkeypatch.setattr(gateway, "is_windows", lambda: False)
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
 
@@ -599,6 +599,84 @@ def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch)
     monkeypatch.setattr(gateway.subprocess, "run", fake_run)
 
     assert gateway._scan_gateway_pids(set(), all_profiles=True) == [2468]
+
+
+def test_find_gateway_pids_excludes_other_profile_systemd_services_by_default(monkeypatch):
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "get_service_name", lambda: "hermes-gateway-hephaestus")
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(gateway, "_scan_gateway_pids", lambda exclude_pids, all_profiles=False: [])
+
+    show_pids = {
+        "hermes-gateway.service": "101\n",
+        "hermes-gateway-athena.service": "102\n",
+        "hermes-gateway-daedalus.service": "103\n",
+    }
+    calls = []
+
+    def _is_systemctl(cmd):
+        return cmd[:2] == ["systemctl", "--user"] or cmd[:1] == ["systemctl"]
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if _is_systemctl(cmd):
+            if "list-units" in cmd:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=(
+                        "hermes-gateway.service loaded active running default\n"
+                        "hermes-gateway-athena.service loaded active running athena\n"
+                        "hermes-gateway-daedalus.service loaded active running daedalus\n"
+                    ),
+                    stderr="",
+                )
+            if "show" in cmd:
+                svc = cmd[cmd.index("show") + 1]
+                return SimpleNamespace(returncode=0, stdout=show_pids[svc], stderr="")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway.find_gateway_pids() == []
+    assert not any("show" in cmd for cmd in calls)
+
+
+def test_find_gateway_pids_all_profiles_includes_other_profile_systemd_services(monkeypatch):
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "get_service_name", lambda: "hermes-gateway-hephaestus")
+    monkeypatch.setattr(gateway, "_scan_gateway_pids", lambda exclude_pids, all_profiles=False: [])
+
+    show_pids = {
+        "hermes-gateway.service": "101\n",
+        "hermes-gateway-athena.service": "102\n",
+        "hermes-gateway-daedalus.service": "103\n",
+    }
+
+    def _is_systemctl(cmd):
+        return cmd[:2] == ["systemctl", "--user"] or cmd[:1] == ["systemctl"]
+
+    def fake_run(cmd, **kwargs):
+        if _is_systemctl(cmd):
+            if "list-units" in cmd:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=(
+                        "hermes-gateway.service loaded active running default\n"
+                        "hermes-gateway-athena.service loaded active running athena\n"
+                        "hermes-gateway-daedalus.service loaded active running daedalus\n"
+                    ),
+                    stderr="",
+                )
+            if "show" in cmd:
+                svc = cmd[cmd.index("show") + 1]
+                return SimpleNamespace(returncode=0, stdout=show_pids[svc], stderr="")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert set(gateway.find_gateway_pids(all_profiles=True)) == {101, 102, 103}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_archive_done.py
+++ b/tests/hermes_cli/test_kanban_archive_done.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_archive_done import run_archival
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+class RecordingDiscordClient:
+    def __init__(self, fail_threads: set[str] | None = None, missing_threads: set[str] | None = None):
+        self.calls: list[str] = []
+        self.metadata_calls: list[dict | None] = []
+        self.fail_threads = fail_threads or set()
+        self.missing_threads = missing_threads or set()
+
+    def archive_and_lock(self, thread_id: str, *, projection_metadata: dict | None = None):
+        from hermes_cli.kanban_archive_done import DiscordResult
+
+        self.calls.append(str(thread_id))
+        self.metadata_calls.append(projection_metadata)
+        if str(thread_id) in self.fail_threads:
+            return DiscordResult(False, "http_500", "boom")
+        if str(thread_id) in self.missing_threads:
+            return DiscordResult(True, "missing_thread", "404")
+        return DiscordResult(True, "archived_locked")
+
+
+def _done_task(conn, *, title: str, completed_at: int, with_discord_thread: str | None = None) -> str:
+    tid = kb.create_task(conn, title=title, assignee="worker", initial_status="running")
+    assert kb.complete_task(conn, tid, summary="done")
+    conn.execute("UPDATE tasks SET completed_at = ? WHERE id = ?", (completed_at, tid))
+    if with_discord_thread is not None:
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id="forum-1",
+            thread_id=with_discord_thread,
+        )
+    return tid
+
+
+def _running_task(conn, *, title: str, created_at: int, with_discord_thread: str | None = None) -> str:
+    tid = kb.create_task(conn, title=title, assignee="worker", initial_status="running")
+    conn.execute("UPDATE tasks SET created_at = ?, started_at = ? WHERE id = ?", (created_at, created_at, tid))
+    if with_discord_thread is not None:
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id="forum-1",
+            thread_id=with_discord_thread,
+        )
+    return tid
+
+
+def _status(conn, task_id: str) -> str:
+    return conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()["status"]
+
+
+def test_dry_run_lists_only_old_done_candidates_without_mutating(kanban_home):
+    now = int(time.time())
+    conn = kb.connect()
+    try:
+        old_tid = _done_task(conn, title="old", completed_at=now - 8 * 86400, with_discord_thread="111")
+        fresh_tid = _done_task(conn, title="fresh", completed_at=now - 2 * 86400, with_discord_thread="222")
+        result = run_archival(now=now, dry_run=True, discord_client=RecordingDiscordClient())
+        assert result["candidate_count"] == 1
+        assert result["archived_count"] == 0
+        assert result["tasks"] == [
+            {
+                "task_id": old_tid,
+                "status": "done",
+                "action": "would_archive",
+                "discord_thread_ids": ["111"],
+            }
+        ]
+        assert _status(conn, old_tid) == "done"
+        assert _status(conn, fresh_tid) == "done"
+    finally:
+        conn.close()
+
+
+def test_live_run_archives_old_done_and_locks_discord_then_removes_sub(kanban_home):
+    now = int(time.time())
+    client = RecordingDiscordClient()
+    conn = kb.connect()
+    try:
+        tid = _done_task(conn, title="old", completed_at=now - 9 * 86400, with_discord_thread="333")
+        result = run_archival(now=now, discord_client=client)
+        assert result["candidate_count"] == 1
+        assert result["archived_count"] == 1
+        assert result["discord_archived_locked_count"] == 1
+        assert result["failure_count"] == 0
+        assert client.calls == ["333"]
+        assert client.metadata_calls == [{}]
+        assert _status(conn, tid) == "archived"
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_live_run_skips_fresh_done_and_non_done_tasks(kanban_home):
+    now = int(time.time())
+    client = RecordingDiscordClient()
+    conn = kb.connect()
+    try:
+        fresh_tid = _done_task(conn, title="fresh", completed_at=now - 2 * 86400, with_discord_thread="222")
+        running_tid = _running_task(conn, title="running", created_at=now - 30 * 86400, with_discord_thread="999")
+        original_running_status = _status(conn, running_tid)
+
+        result = run_archival(now=now, discord_client=client)
+
+        assert result["candidate_count"] == 0
+        assert result["reconcile_candidate_count"] == 0
+        assert result["archived_count"] == 0
+        assert result["failure_count"] == 0
+        assert result["tasks"] == []
+        assert client.calls == []
+        assert _status(conn, fresh_tid) == "done"
+        assert _status(conn, running_tid) == original_running_status
+        assert len(kb.list_notify_subs(conn, fresh_tid)) == 1
+        assert len(kb.list_notify_subs(conn, running_tid)) == 1
+    finally:
+        conn.close()
+
+
+def test_discord_archive_patch_includes_configured_archived_projection_metadata(kanban_home):
+    tag_config = {
+        "tags": {"archived": {"emoji": "📦"}},
+        "status_to_tag": {"archived": "status-archived"},
+        "assignee_to_tag": {"worker": "assignee-worker"},
+    }
+    cfg_path = kb.board_dir("default") / "discord-forum-tags.json"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps(tag_config), encoding="utf-8")
+
+    now = int(time.time())
+    client = RecordingDiscordClient()
+    conn = kb.connect()
+    try:
+        _done_task(conn, title="old", completed_at=now - 9 * 86400, with_discord_thread="333")
+        result = run_archival(now=now, discord_client=client)
+        assert result["discord_archived_locked_count"] == 1
+        assert client.metadata_calls == [
+            {"name": "📦 [archived] old", "applied_tags": ["status-archived", "assignee-worker"]}
+        ]
+    finally:
+        conn.close()
+
+
+def test_discord_failure_leaves_subscription_for_next_reconcile_run(kanban_home):
+    now = int(time.time())
+    conn = kb.connect()
+    try:
+        tid = _done_task(conn, title="old", completed_at=now - 9 * 86400, with_discord_thread="444")
+        first = run_archival(now=now, discord_client=RecordingDiscordClient(fail_threads={"444"}))
+        assert first["archived_count"] == 1
+        assert first["failure_count"] == 1
+        assert _status(conn, tid) == "archived"
+        assert len(kb.list_notify_subs(conn, tid)) == 1
+
+        second_client = RecordingDiscordClient()
+        second = run_archival(now=now, discord_client=second_client)
+        assert second["candidate_count"] == 0
+        assert second["already_archived_count"] == 1
+        assert second["discord_archived_locked_count"] == 1
+        assert second_client.calls == ["444"]
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_already_archived_task_with_subscription_is_reconciled_idempotently(kanban_home):
+    now = int(time.time())
+    client = RecordingDiscordClient()
+    conn = kb.connect()
+    try:
+        tid = _done_task(conn, title="old", completed_at=now - 9 * 86400, with_discord_thread="777")
+        assert kb.archive_task(conn, tid)
+
+        result = run_archival(now=now, discord_client=client)
+
+        assert result["candidate_count"] == 0
+        assert result["reconcile_candidate_count"] == 1
+        assert result["already_archived_count"] == 1
+        assert result["archived_count"] == 0
+        assert result["discord_archived_locked_count"] == 1
+        assert client.calls == ["777"]
+        assert _status(conn, tid) == "archived"
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_missing_discord_thread_404_is_nonfatal_and_removes_subscription(kanban_home):
+    now = int(time.time())
+    client = RecordingDiscordClient(missing_threads={"555"})
+    conn = kb.connect()
+    try:
+        tid = _done_task(conn, title="old", completed_at=now - 9 * 86400, with_discord_thread="555")
+
+        result = run_archival(now=now, discord_client=client)
+
+        assert result["candidate_count"] == 1
+        assert result["archived_count"] == 1
+        assert result["failure_count"] == 0
+        assert result["skipped_by_reason"]["missing_or_deleted_discord_thread"] == 1
+        assert result["tasks"][0]["discord"] == [{"thread_id": "555", "status": "missing_thread"}]
+        assert _status(conn, tid) == "archived"
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_malformed_discord_thread_reference_is_logged_nonfatal_and_removed(kanban_home):
+    now = int(time.time())
+    client = RecordingDiscordClient()
+    conn = kb.connect()
+    try:
+        tid = _done_task(conn, title="old", completed_at=now - 9 * 86400, with_discord_thread="not-a-thread")
+
+        result = run_archival(now=now, discord_client=client)
+
+        assert result["archived_count"] == 1
+        assert result["failure_count"] == 0
+        assert result["skipped_by_reason"]["malformed_discord_thread_ref"] == 1
+        assert client.calls == []
+        assert _status(conn, tid) == "archived"
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_missing_thread_reference_is_logged_nonfatal_and_idempotent(kanban_home):
+    now = int(time.time())
+    conn = kb.connect()
+    try:
+        tid = _done_task(conn, title="old", completed_at=now - 9 * 86400, with_discord_thread="")
+        result = run_archival(now=now, discord_client=RecordingDiscordClient())
+        assert result["failure_count"] == 0
+        assert result["skipped_by_reason"]["missing_discord_thread_ref"] == 1
+        assert _status(conn, tid) == "archived"
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_batch_limit_caps_archives(kanban_home):
+    now = int(time.time())
+    conn = kb.connect()
+    try:
+        tids = [
+            _done_task(conn, title=f"old {idx}", completed_at=now - (10 + idx) * 86400)
+            for idx in range(3)
+        ]
+        result = run_archival(now=now, batch_size=2, discord_client=RecordingDiscordClient())
+        assert result["candidate_count"] == 2
+        archived = [tid for tid in tids if _status(conn, tid) == "archived"]
+        assert len(archived) == 2
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -76,6 +76,37 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             assert kb.get_task(conn, tid).status == "blocked"
 
 
+def test_initial_blocked_create_is_sticky_across_dispatcher_recompute(kanban_home: Path) -> None:
+    """A task created directly in ``blocked`` is an operator/human gate,
+    not a transient circuit-breaker block.  The dispatcher must not
+    immediately promote and claim it on the next ``recompute_ready`` tick.
+
+    This pins the CLI help contract for ``--initial-status blocked``:
+    "skip the brief running-to-blocked transition" while still remaining
+    sticky until explicit unblock.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="approval gate",
+            assignee="hephaestus",
+            initial_status="blocked",
+        )
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        events = kb.list_events(conn, tid)
+        assert [event.kind for event in events] == ["created", "blocked"]
+
+        promoted = kb.recompute_ready(conn)
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert promoted == 0
+        assert task.status == "blocked"
+
+
 def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Path) -> None:
     """The parent-completion path is the one ``recompute_ready`` was
     designed for, so it's the most dangerous false-positive: even when

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from hermes_cli import kanban as kanban_cli
 from hermes_cli import kanban_db as kb
 from hermes_cli.kanban import run_slash
 
@@ -49,6 +50,108 @@ def kanban_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
     kb.init_db()
     return home
+
+
+def _run_cli(*argv: str) -> int:
+    root = argparse.ArgumentParser()
+    subp = root.add_subparsers(dest="cmd")
+    kanban_cli.build_parser(subp)
+    ns = root.parse_args(["kanban", *argv])
+    return kanban_cli.kanban_command(ns)
+
+
+def _write_discord_projection_config(home: Path) -> None:
+    (home / "config.yaml").write_text(
+        "kanban:\n"
+        "  board_projections:\n"
+        "    default:\n"
+        "      enabled: true\n"
+        "      platform: discord\n"
+        "      forum_channel_id: forum-1\n"
+        "      guild_id: guild-1\n"
+        "      notifier_profile: default\n",
+        encoding="utf-8",
+    )
+    board_dir = home / "kanban" / "boards" / "default"
+    board_dir.mkdir(parents=True, exist_ok=True)
+    (board_dir / "discord-forum-tags.json").write_text(
+        json.dumps(
+            {
+                "status_to_tag": {"blocked": "blocked-tag", "running": "running-tag"},
+                "assignee_to_tag": {"hermes": "hermes-tag"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create-time Discord forum projection
+# ---------------------------------------------------------------------------
+
+
+def test_create_projects_task_to_discord_forum_and_records_linkage(kanban_home, monkeypatch, capsys):
+    _write_discord_projection_config(kanban_home)
+    calls: list[dict] = []
+
+    async def fake_send_projection(**kwargs):
+        calls.append(kwargs)
+        return {"success": True, "message_id": "msg-1", "thread_id": "thread-1"}
+
+    monkeypatch.setattr(kanban_cli, "_send_discord_projection_message", fake_send_projection)
+
+    rc = _run_cli(
+        "create",
+        "Projected task",
+        "--body",
+        "Acceptance criteria here",
+        "--assignee",
+        "hermes",
+        "--initial-status",
+        "blocked",
+    )
+
+    assert rc == 0
+    created = capsys.readouterr().out.split()[1]
+    assert calls == [
+        {
+            "forum_channel_id": "forum-1",
+            "message": f"Kanban task: `{created}`\nAssignee: `hermes`\nStatus: `blocked`\nPriority: `0`\n\nAcceptance criteria here",
+            "thread_name": "🛑 [blocked] Projected task",
+            "applied_tags": ["blocked-tag", "hermes-tag"],
+        }
+    ]
+    with kb.connect() as conn:
+        rows = kb.list_notify_subs(conn, task_id=created)
+        comments = kb.list_comments(conn, created)
+    assert [(row["platform"], row["chat_id"], row["thread_id"]) for row in rows] == [
+        ("discord", "forum-1", "thread-1")
+    ]
+    assert [comment.body for comment in comments] == [
+        "Discord forum projection: https://discord.com/channels/guild-1/thread-1"
+    ]
+    assert created.startswith("t_")
+
+
+def test_create_warns_but_preserves_task_when_discord_projection_fails(kanban_home, monkeypatch, capsys):
+    _write_discord_projection_config(kanban_home)
+
+    async def fake_send_projection(**kwargs):
+        return {"error": "discord_http_403"}
+
+    monkeypatch.setattr(kanban_cli, "_send_discord_projection_message", fake_send_projection)
+
+    rc = _run_cli("create", "Projection fails", "--assignee", "hermes", "--initial-status", "blocked")
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    created = captured.out.split()[1]
+    assert created.startswith("t_")
+    assert f"Discord forum projection failed for {created}: discord_http_403" in captured.err
+    assert "hermes kanban repair --audit-discord" in captured.err
+    with kb.connect() as conn:
+        assert kb.get_task(conn, created) is not None
+        assert kb.list_notify_subs(conn, task_id=created) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -92,6 +92,7 @@ def _write_discord_projection_config(home: Path) -> None:
 
 def test_create_projects_task_to_discord_forum_and_records_linkage(kanban_home, monkeypatch, capsys):
     _write_discord_projection_config(kanban_home)
+    monkeypatch.setenv("HERMES_PROFILE_NAME", "hephaestus")
     calls: list[dict] = []
 
     async def fake_send_projection(**kwargs):
@@ -124,13 +125,48 @@ def test_create_projects_task_to_discord_forum_and_records_linkage(kanban_home, 
     with kb.connect() as conn:
         rows = kb.list_notify_subs(conn, task_id=created)
         comments = kb.list_comments(conn, created)
-    assert [(row["platform"], row["chat_id"], row["thread_id"]) for row in rows] == [
-        ("discord", "forum-1", "thread-1")
+    assert [(row["platform"], row["chat_id"], row["thread_id"], row["notifier_profile"]) for row in rows] == [
+        ("discord", "forum-1", "thread-1", "default")
     ]
     assert [comment.body for comment in comments] == [
         "Discord forum projection: https://discord.com/channels/guild-1/thread-1"
     ]
     assert created.startswith("t_")
+
+
+def test_create_projection_notifier_profile_falls_back_to_author_when_unconfigured(
+    kanban_home, monkeypatch, capsys
+):
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n"
+        "  board_projections:\n"
+        "    default:\n"
+        "      enabled: true\n"
+        "      platform: discord\n"
+        "      forum_channel_id: forum-1\n"
+        "      guild_id: guild-1\n",
+        encoding="utf-8",
+    )
+    board_dir = kanban_home / "kanban" / "boards" / "default"
+    board_dir.mkdir(parents=True, exist_ok=True)
+    (board_dir / "discord-forum-tags.json").write_text(
+        json.dumps({"status_to_tag": {"blocked": "blocked-tag"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_PROFILE_NAME", "hephaestus")
+
+    async def fake_send_projection(**kwargs):
+        return {"success": True, "message_id": "msg-1", "thread_id": "thread-1"}
+
+    monkeypatch.setattr(kanban_cli, "_send_discord_projection_message", fake_send_projection)
+
+    rc = _run_cli("create", "Projected task", "--initial-status", "blocked")
+
+    assert rc == 0
+    created = capsys.readouterr().out.split()[1]
+    with kb.connect() as conn:
+        rows = kb.list_notify_subs(conn, task_id=created)
+    assert [row["notifier_profile"] for row in rows] == ["hephaestus"]
 
 
 def test_create_warns_but_preserves_task_when_discord_projection_fails(kanban_home, monkeypatch, capsys):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -109,6 +109,94 @@ def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     assert "53 51 4c 69 74 17 03 03 00 13" in msg
 
 
+def test_connect_migrates_legacy_notify_sub_cursor_column(tmp_path):
+    """Legacy notification-subscription tables must gain last_event_id.
+
+    The gateway notifier relies on ``kanban_notify_subs.last_event_id`` as its
+    delivery cursor. Legacy board DBs that predate the cursor column should be
+    migrated on connect before any notifier/listing path tries to read or
+    advance it; otherwise a restored board can look healthy while notification
+    replay/repair crashes later with ``no such column: last_event_id``.
+    """
+    db_path = tmp_path / "legacy-notify.db"
+    conn = sqlite3.connect(str(db_path))
+    # Pre-notifier-cursor schema, but otherwise complete enough that the
+    # migration reaches kanban_notify_subs instead of failing on older task
+    # column/index assumptions first.
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            created_by TEXT,
+            created_at INTEGER NOT NULL,
+            started_at INTEGER,
+            completed_at INTEGER,
+            workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+            workspace_path TEXT,
+            claim_lock TEXT,
+            claim_expires INTEGER
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE kanban_notify_subs (
+            task_id TEXT NOT NULL,
+            platform TEXT NOT NULL,
+            chat_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL DEFAULT '',
+            user_id TEXT,
+            created_at INTEGER NOT NULL,
+            PRIMARY KEY (task_id, platform, chat_id, thread_id)
+        )
+    """)
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) VALUES (?, ?, ?, ?)",
+        ("t_legacy", "legacy notify task", "ready", 123),
+    )
+    conn.execute(
+        "INSERT INTO kanban_notify_subs "
+        "(task_id, platform, chat_id, thread_id, user_id, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("t_legacy", "discord", "chat-1", "thread-1", "user-1", 124),
+    )
+    conn.commit()
+    conn.close()
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect(db_path=db_path) as migrated:
+        notify_cols = {
+            row["name"] for row in migrated.execute("PRAGMA table_info(kanban_notify_subs)")
+        }
+        assert "last_event_id" in notify_cols
+        assert "notifier_profile" in notify_cols
+        subs = kb.list_notify_subs(migrated, "t_legacy")
+
+    assert subs == [
+        {
+            "task_id": "t_legacy",
+            "platform": "discord",
+            "chat_id": "chat-1",
+            "thread_id": "thread-1",
+            "user_id": "user-1",
+            "notifier_profile": None,
+            "created_at": 124,
+            "last_event_id": 0,
+        }
+    ]
+
+
 def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     """Legacy DBs missing additive indexed columns must migrate cleanly.
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -98,12 +98,19 @@ def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     corrupt = home / "kanban.db"
-    corrupt.write_bytes(b"SQLit" + bytes.fromhex("17 03 03 00 13") + b"x" * 32)
+    original = b"SQLit" + bytes.fromhex("17 03 03 00 13") + b"x" * 32
+    corrupt.write_bytes(original)
 
-    with pytest.raises(sqlite3.DatabaseError) as exc_info:
+    with pytest.raises(kb.KanbanDbCorruptError) as exc_info:
         kb.connect(board="default")
 
-    msg = str(exc_info.value)
+    err = exc_info.value
+    assert err.db_path == corrupt
+    assert err.backup_path is not None
+    assert err.backup_path.exists()
+    assert err.backup_path.read_bytes() == original
+    assert corrupt.read_bytes() == original
+    msg = str(err)
     assert "file is not a database" in msg
     assert "TLS record header detected at byte offset 5" in msg
     assert "53 51 4c 69 74 17 03 03 00 13" in msg

--- a/tests/hermes_cli/test_kanban_repair.py
+++ b/tests/hermes_cli/test_kanban_repair.py
@@ -1,0 +1,105 @@
+"""Tests for Kanban projection repair / reconciliation CLI behavior."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _run_cli(*argv: str) -> int:
+    """Invoke the `hermes kanban …` argparse surface directly."""
+    root = argparse.ArgumentParser()
+    subp = root.add_subparsers(dest="cmd")
+    kanban_cli.build_parser(subp)
+    ns = root.parse_args(["kanban", *argv])
+    return kanban_cli.kanban_command(ns)
+
+
+def _insert_notify_sub(
+    conn,
+    *,
+    task_id: str,
+    platform: str = "discord",
+    chat_id: str = "forum-1",
+    thread_id: str = "thread-1",
+    user_id: str | None = "user-1",
+    notifier_profile: str | None = "default",
+    last_event_id: int = 0,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO kanban_notify_subs (
+            task_id, platform, chat_id, thread_id, user_id,
+            notifier_profile, created_at, last_event_id
+        ) VALUES (?, ?, ?, ?, ?, ?, 1234, ?)
+        """,
+        (task_id, platform, chat_id, thread_id, user_id, notifier_profile, last_event_id),
+    )
+    conn.commit()
+
+
+def test_kanban_repair_json_reports_projection_orphans_without_mutating(kanban_home, capsys):
+    """Dry-run repair should report orphaned projection rows without deleting them."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="live projected task")
+        _insert_notify_sub(conn, task_id=task_id, chat_id="forum-1", thread_id="thread-live")
+        _insert_notify_sub(conn, task_id="t_missing", chat_id="forum-1", thread_id="thread-orphan")
+
+    rc = _run_cli("repair", "--json")
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["dry_run"] is True
+    assert report["projection_subscriptions"]["scanned"] == 2
+    assert report["projection_subscriptions"]["orphaned"] == 1
+    assert report["projection_subscriptions"]["removed"] == 0
+    assert report["projection_subscriptions"]["orphans"] == [
+        {
+            "task_id": "t_missing",
+            "platform": "discord",
+            "chat_id": "forum-1",
+            "thread_id": "thread-orphan",
+        }
+    ]
+
+    with kb.connect() as conn:
+        rows = kb.list_notify_subs(conn)
+    assert {row["task_id"] for row in rows} == {task_id, "t_missing"}
+
+
+def test_kanban_repair_apply_removes_orphaned_projection_rows_and_reports_count(kanban_home, capsys):
+    """Apply mode should remove orphaned projection rows while preserving live rows."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="live projected task")
+        _insert_notify_sub(conn, task_id=task_id, chat_id="forum-1", thread_id="thread-live")
+        _insert_notify_sub(conn, task_id="t_missing", chat_id="forum-1", thread_id="thread-orphan")
+
+    rc = _run_cli("repair", "--apply", "--json")
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["dry_run"] is False
+    assert report["projection_subscriptions"]["scanned"] == 2
+    assert report["projection_subscriptions"]["orphaned"] == 1
+    assert report["projection_subscriptions"]["removed"] == 1
+
+    with kb.connect() as conn:
+        rows = kb.list_notify_subs(conn)
+    assert [(row["task_id"], row["thread_id"]) for row in rows] == [(task_id, "thread-live")]

--- a/tests/hermes_cli/test_kanban_repair.py
+++ b/tests/hermes_cli/test_kanban_repair.py
@@ -103,3 +103,78 @@ def test_kanban_repair_apply_removes_orphaned_projection_rows_and_reports_count(
     with kb.connect() as conn:
         rows = kb.list_notify_subs(conn)
     assert [(row["task_id"], row["thread_id"]) for row in rows] == [(task_id, "thread-live")]
+
+
+def test_kanban_repair_reports_ambiguous_projection_bindings_without_mutating(kanban_home, capsys):
+    """A single projected source bound to multiple live tasks should be loud.
+
+    Gateway lifecycle shorthand intentionally refuses ambiguous bindings, so the
+    reconciler must surface these collisions even though it cannot safely pick a
+    winner automatically.
+    """
+    with kb.connect() as conn:
+        first = kb.create_task(conn, title="first live task")
+        second = kb.create_task(conn, title="second live task")
+        _insert_notify_sub(conn, task_id=first, chat_id="forum-1", thread_id="thread-shared")
+        _insert_notify_sub(conn, task_id=second, chat_id="forum-1", thread_id="thread-shared")
+
+    rc = _run_cli("repair", "--json")
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    projection = report["projection_subscriptions"]
+    assert projection["ambiguous"] == 1
+    assert projection["ambiguous_bindings"] == [
+        {
+            "platform": "discord",
+            "chat_id": "forum-1",
+            "thread_id": "thread-shared",
+            "task_ids": sorted([first, second]),
+        }
+    ]
+    assert projection["removed"] == 0
+
+    with kb.connect() as conn:
+        rows = kb.list_notify_subs(conn)
+    assert {row["task_id"] for row in rows} == {first, second}
+
+
+def test_kanban_repair_apply_removes_malformed_projection_rows(kanban_home, capsys):
+    """Rows without a usable platform/chat target are unrecoverable locally."""
+    with kb.connect() as conn:
+        live = kb.create_task(conn, title="well formed live task")
+        missing_platform = kb.create_task(conn, title="missing platform")
+        missing_chat = kb.create_task(conn, title="missing chat")
+        _insert_notify_sub(conn, task_id=live, platform="discord", chat_id="forum-1", thread_id="thread-live")
+        _insert_notify_sub(conn, task_id=missing_platform, platform="", chat_id="forum-1", thread_id="thread-bad-platform")
+        _insert_notify_sub(conn, task_id=missing_chat, platform="discord", chat_id="", thread_id="thread-bad-chat")
+
+    rc = _run_cli("repair", "--apply", "--json")
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    projection = report["projection_subscriptions"]
+    assert projection["malformed"] == 2
+    assert projection["removed"] == 2
+    assert projection["malformed_rows"] == [
+        {
+            "task_id": missing_platform,
+            "platform": "",
+            "chat_id": "forum-1",
+            "thread_id": "thread-bad-platform",
+            "reason": "missing_platform",
+        },
+        {
+            "task_id": missing_chat,
+            "platform": "discord",
+            "chat_id": "",
+            "thread_id": "thread-bad-chat",
+            "reason": "missing_chat_id",
+        },
+    ]
+
+    with kb.connect() as conn:
+        rows = kb.list_notify_subs(conn)
+    assert [(row["task_id"], row["platform"], row["chat_id"], row["thread_id"]) for row in rows] == [
+        (live, "discord", "forum-1", "thread-live")
+    ]

--- a/tests/hermes_cli/test_kanban_repair.py
+++ b/tests/hermes_cli/test_kanban_repair.py
@@ -178,3 +178,119 @@ def test_kanban_repair_apply_removes_malformed_projection_rows(kanban_home, caps
     assert [(row["task_id"], row["platform"], row["chat_id"], row["thread_id"]) for row in rows] == [
         (live, "discord", "forum-1", "thread-live")
     ]
+
+
+def _write_discord_projection_config(home: Path) -> None:
+    board_dir = home / "kanban" / "boards" / "default"
+    board_dir.mkdir(parents=True, exist_ok=True)
+    (board_dir / "discord-forum-tags.json").write_text(
+        json.dumps(
+            {
+                "forum_channel_id": "forum-1",
+                "status_to_tag": {
+                    "ready": "ready-tag",
+                    "blocked": "blocked-tag",
+                    "running": "running-tag",
+                    "done": "done-tag",
+                },
+                "assignee_to_tag": {
+                    "default": "hermes-tag",
+                    "hermes": "hermes-tag",
+                    "daedalus": "daedalus-tag",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_kanban_repair_discord_audit_reports_thread_tag_and_title_mismatches(
+    kanban_home, monkeypatch, capsys
+):
+    """Dry-run Discord audit should compare projected thread state to Kanban truth."""
+    _write_discord_projection_config(kanban_home)
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Canonical task title",
+            assignee="hermes",
+            initial_status="blocked",
+        )
+        _insert_notify_sub(conn, task_id=task_id, chat_id="forum-1", thread_id="thread-live")
+
+    def fake_fetch_thread(thread_id: str) -> dict:
+        assert thread_id == "thread-live"
+        return {
+            "id": "thread-live",
+            "name": "● [running] Stale task title",
+            "applied_tags": ["running-tag", "daedalus-tag"],
+        }
+
+    monkeypatch.setattr(kanban_cli, "_fetch_discord_thread_snapshot", fake_fetch_thread, raising=False)
+
+    rc = _run_cli("repair", "--audit-discord", "--json")
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["dry_run"] is True
+    discord = report["discord_projection"]
+    assert discord["scanned"] == 1
+    assert discord["mismatched"] == 1
+    assert discord["missing"] == 0
+    assert discord["mismatches"] == [
+        {
+            "task_id": task_id,
+            "thread_id": "thread-live",
+            "chat_id": "forum-1",
+            "expected": {
+                "name": "🛑 [blocked] Canonical task title",
+                "tags": ["blocked-tag", "hermes-tag"],
+            },
+            "actual": {
+                "name": "● [running] Stale task title",
+                "tags": ["running-tag", "daedalus-tag"],
+            },
+            "missing_tags": ["blocked-tag", "hermes-tag"],
+            "unexpected_tags": ["running-tag", "daedalus-tag"],
+        }
+    ]
+
+
+def test_kanban_repair_discord_audit_reports_missing_threads_without_mutating(
+    kanban_home, monkeypatch, capsys
+):
+    """A vanished Discord thread should be reported, not silently treated as repaired."""
+    _write_discord_projection_config(kanban_home)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="Gone thread", assignee="hermes")
+        _insert_notify_sub(conn, task_id=task_id, chat_id="forum-1", thread_id="thread-gone")
+
+    def fake_fetch_thread(thread_id: str) -> dict | None:
+        assert thread_id == "thread-gone"
+        return None
+
+    monkeypatch.setattr(kanban_cli, "_fetch_discord_thread_snapshot", fake_fetch_thread, raising=False)
+
+    rc = _run_cli("repair", "--audit-discord", "--json")
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    discord = report["discord_projection"]
+    assert discord["scanned"] == 1
+    assert discord["mismatched"] == 0
+    assert discord["missing"] == 1
+    assert discord["missing_threads"] == [
+        {
+            "task_id": task_id,
+            "thread_id": "thread-gone",
+            "chat_id": "forum-1",
+            "expected": {
+                "name": "▶ [ready] Gone thread",
+                "tags": ["ready-tag", "hermes-tag"],
+            },
+        }
+    ]
+
+    with kb.connect() as conn:
+        rows = kb.list_notify_subs(conn)
+    assert [(row["task_id"], row["thread_id"]) for row in rows] == [(task_id, "thread-gone")]

--- a/tests/hermes_cli/test_kanban_repair.py
+++ b/tests/hermes_cli/test_kanban_repair.py
@@ -181,12 +181,21 @@ def test_kanban_repair_apply_removes_malformed_projection_rows(kanban_home, caps
 
 
 def _write_discord_projection_config(home: Path) -> None:
+    (home / "config.yaml").write_text(
+        "kanban:\n"
+        "  board_projections:\n"
+        "    default:\n"
+        "      enabled: true\n"
+        "      platform: discord\n"
+        "      forum_channel_id: forum-1\n"
+        "      notifier_profile: default\n",
+        encoding="utf-8",
+    )
     board_dir = home / "kanban" / "boards" / "default"
     board_dir.mkdir(parents=True, exist_ok=True)
     (board_dir / "discord-forum-tags.json").write_text(
         json.dumps(
             {
-                "forum_channel_id": "forum-1",
                 "status_to_tag": {
                     "ready": "ready-tag",
                     "blocked": "blocked-tag",
@@ -294,3 +303,27 @@ def test_kanban_repair_discord_audit_reports_missing_threads_without_mutating(
     with kb.connect() as conn:
         rows = kb.list_notify_subs(conn)
     assert [(row["task_id"], row["thread_id"]) for row in rows] == [(task_id, "thread-gone")]
+
+
+def test_kanban_repair_discord_audit_reports_unprojected_canonical_tasks(kanban_home, capsys):
+    """Discord audit must not ignore tasks missing kanban_notify_subs linkage rows."""
+    _write_discord_projection_config(kanban_home)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="Needs forum card", assignee="hermes", initial_status="blocked")
+
+    rc = _run_cli("repair", "--audit-discord", "--json")
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    discord = report["discord_projection"]
+    assert discord["scanned"] == 0
+    assert discord["missing_unprojected_tasks"] == [
+        {
+            "task_id": task_id,
+            "chat_id": "forum-1",
+            "expected": {
+                "name": "🛑 [blocked] Needs forum card",
+                "tags": ["blocked-tag", "hermes-tag"],
+            },
+        }
+    ]

--- a/tests/plugins/memory/test_gbrain_provider.py
+++ b/tests/plugins/memory/test_gbrain_provider.py
@@ -1,0 +1,196 @@
+import json
+from typing import Any, cast
+
+import pytest
+
+from plugins.memory.gbrain import (
+    GBrainMemoryProvider,
+    _GBrainMCPClient,
+    _coerce_config,
+    _load_gbrain_config,
+    _save_gbrain_config,
+)
+
+
+class FakeGBrainClient:
+    def __init__(self, endpoint="http://example.test/mcp", timeout=5.0):
+        self.endpoint = endpoint
+        self.timeout = timeout
+        self.calls = []
+        self.fail = False
+        self.results: dict[str, Any] = {
+            "query": {
+                "content": [
+                    {"type": "text", "text": "Garry prefers English-only replies."}
+                ]
+            }
+        }
+
+    def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        if self.fail:
+            raise RuntimeError("connection refused")
+        if name not in self.results:
+            raise RuntimeError(f"unknown tool {name}")
+        return self.results[name]
+
+
+@pytest.fixture
+def provider(tmp_path):
+    p = GBrainMemoryProvider()
+    p.initialize("session-1", hermes_home=str(tmp_path), platform="cli", agent_identity="default")
+    fake = FakeGBrainClient()
+    p._client = cast(Any, fake)
+    return p
+
+
+def test_coerce_config_defaults_to_read_only():
+    cfg = _coerce_config({})
+    assert cfg["endpoint"] == "http://127.0.0.1:3132/mcp"
+    assert cfg["mode"] == "read-only"
+    assert cfg["max_results"] == 6
+
+
+def test_save_and_load_config_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _save_gbrain_config(
+        {
+            "endpoint": "http://127.0.0.1:3132/mcp",
+            "mode": "read-write",
+            "source_id": "default",
+            "max_results": 99,
+        },
+        str(tmp_path),
+    )
+    cfg = _load_gbrain_config(str(tmp_path))
+    assert cfg["mode"] == "read-write"
+    assert cfg["source_id"] == "default"
+    assert cfg["max_results"] == 20  # clamped
+
+
+def test_is_available_checks_endpoint_only_without_network(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("GBRAIN_MCP_ENDPOINT", "")
+    assert GBrainMemoryProvider().is_available() is False
+
+    monkeypatch.setenv("GBRAIN_MCP_ENDPOINT", "http://127.0.0.1:3132/mcp")
+    assert GBrainMemoryProvider().is_available() is True
+
+
+def test_prefetch_formats_mcp_text_result(provider):
+    result = provider.prefetch("language preference")
+    assert "<gbrain-memory-context>" in result
+    assert "Garry prefers English-only replies" in result
+    assert provider._client.calls[0][0] == "query"
+    assert provider._client.calls[0][1]["adaptive_return"] is True
+    assert provider._client.calls[0][1]["source_id"] == "__all__"
+
+
+def test_search_tool_returns_structured_context(provider):
+    payload = json.loads(
+        provider.handle_tool_call("gbrain_memory_search", {"query": "language", "limit": 3})
+    )
+    assert payload["ok"] is True
+    assert "GBrain recalled context" in payload["context"]
+    assert provider._client.calls[0][1]["limit"] == 3
+
+
+def test_search_falls_back_to_alternate_query_tool(provider):
+    provider._client.results = {
+        "gbrain_query": {"content": [{"type": "text", "text": "fallback result"}]}
+    }
+    payload = json.loads(provider.handle_tool_call("gbrain_memory_search", {"query": "x"}))
+    assert payload["ok"] is True
+    assert "fallback result" in payload["context"]
+    assert [name for name, _ in provider._client.calls] == ["query", "gbrain_query"]
+
+
+def test_unavailable_mcp_returns_error_for_tool_and_empty_prefetch(provider):
+    provider._client.fail = True
+    assert provider.prefetch("anything") == ""
+    payload = json.loads(provider.handle_tool_call("gbrain_memory_search", {"query": "anything"}))
+    assert payload["ok"] is False
+    assert "connection refused" in payload["error"]
+
+
+def test_read_only_store_candidate_is_blocked(provider):
+    payload = json.loads(
+        provider.handle_tool_call(
+            "gbrain_memory_store_candidate",
+            {"content": "User prefers concise responses", "target": "user"},
+        )
+    )
+    assert payload["blocked"] is True
+    assert payload["mode"] == "read-only"
+    assert provider._client.calls == []
+
+
+def test_read_only_sync_and_memory_write_do_not_call_client(provider):
+    provider.sync_turn("remember x", "ok", session_id="session-1")
+    provider.on_memory_write("add", "memory", "User prefers concise responses")
+    assert provider._client.calls == []
+
+
+def test_read_write_store_candidate_calls_configured_write_tool(tmp_path):
+    _save_gbrain_config(
+        {"mode": "read-write", "write_tool": "create_page", "endpoint": "http://example.test/mcp"},
+        str(tmp_path),
+    )
+    p = GBrainMemoryProvider()
+    p.initialize("session-1", hermes_home=str(tmp_path), platform="cli", agent_identity="athena")
+    fake = FakeGBrainClient()
+    fake.results["create_page"] = {"ok": True, "slug": "memory/user-prefers-concise"}
+    p._client = cast(Any, fake)
+
+    payload = json.loads(
+        p.handle_tool_call(
+            "gbrain_memory_store_candidate",
+            {"content": "User prefers concise responses", "target": "user"},
+        )
+    )
+
+    assert payload["ok"] is True
+    assert fake.calls[0][0] == "create_page"
+    assert fake.calls[0][1]["metadata"]["target"] == "user"
+
+
+def test_read_write_on_memory_write_mirrors_explicit_add(tmp_path):
+    _save_gbrain_config(
+        {"mode": "read-write", "write_tool": "create_page", "endpoint": "http://example.test/mcp"},
+        str(tmp_path),
+    )
+    p = GBrainMemoryProvider()
+    p.initialize("session-1", hermes_home=str(tmp_path), platform="cli", agent_identity="athena")
+    fake = FakeGBrainClient()
+    fake.results["create_page"] = {"ok": True}
+    p._client = cast(Any, fake)
+
+    p.on_memory_write("add", "memory", "Durable preference", {"write_origin": "tool"})
+
+    assert fake.calls[0][0] == "create_page"
+    assert fake.calls[0][1]["content"] == "Durable preference"
+    assert fake.calls[0][1]["metadata"]["agent_identity"] == "athena"
+    assert fake.calls[0][1]["metadata"]["write_origin"] == "tool"
+
+
+def test_post_setup_activates_read_only_defaults(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.config import load_config
+
+    config = {"memory": {"gbrain": {"mode": "read-write", "endpoint": "http://writer/mcp"}}}
+    p = GBrainMemoryProvider()
+    p.post_setup(str(tmp_path), config)
+
+    saved = load_config()
+    assert saved["memory"]["provider"] == "gbrain"
+    assert saved["memory"]["gbrain"]["mode"] == "read-only"
+    assert saved["memory"]["gbrain"]["endpoint"] == "http://writer/mcp"
+    assert _load_gbrain_config(str(tmp_path))["mode"] == "read-only"
+
+
+def test_sse_decode_response_extracts_data_event():
+    response = _GBrainMCPClient._decode_response(
+        'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n',
+        "text/event-stream",
+    )
+    assert response["result"] == {"ok": True}

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -68,11 +68,10 @@ def test_board_empty(client):
     r = client.get("/api/plugins/kanban/board")
     assert r.status_code == 200
     data = r.json()
-    # All canonical columns present (triage + the rest), each empty.
+    # Default visible columns are present, each empty. Rare workflow statuses
+    # such as scheduled/review are added dynamically only when tasks exist.
     names = [c["name"] for c in data["columns"]]
-    assert set(names) == kb.VALID_STATUSES - {"archived"}
-    for expected in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
-        assert expected in names, f"missing column {expected}: {names}"
+    assert names == ["triage", "todo", "ready", "running", "blocked", "done"]
     assert all(len(c["tasks"]) == 0 for c in data["columns"])
     assert data["tenants"] == []
     assert data["assignees"] == []

--- a/tests/tools/test_send_message_discord_forum_tags.py
+++ b/tests/tools/test_send_message_discord_forum_tags.py
@@ -1,0 +1,124 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import Platform
+
+
+def test_discord_forum_adapter_preserves_explicit_projection_metadata(monkeypatch):
+    """Forum thread creation should use canonical Kanban projection metadata.
+
+    The send-message routing layer can pass a reconciled Discord forum title and
+    applied tag ids, but the adapter-level forum post path must preserve those
+    values when it creates the starter thread.  Falling back to title derivation
+    or omitting tags creates a visible Discord projection that disagrees with the
+    canonical Kanban task state.
+    """
+    from gateway.platforms.base import BasePlatformAdapter
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    class FakeCreatedThread:
+        id = 4242
+        message = MagicMock(id=5151)
+
+        async def send(self, *, content):  # pragma: no cover - not used by this one-chunk test
+            raise AssertionError(f"unexpected follow-up chunk: {content}")
+
+    class FakeForumChannel:
+        id = "forum-1"
+
+        def __init__(self):
+            self.create_thread = AsyncMock(return_value=FakeCreatedThread())
+
+    adapter = object.__new__(DiscordAdapter)
+    adapter.MAX_MESSAGE_LENGTH = 2000
+    monkeypatch.setattr(
+        BasePlatformAdapter,
+        "truncate_message",
+        staticmethod(lambda content, max_length=4096, len_fn=None: [content]),
+    )
+    forum_channel = FakeForumChannel()
+
+    result = asyncio.run(
+        adapter._send_to_forum(
+            forum_channel,
+            "Derived fallback title\n\nBody",
+            applied_tags=["blocked-tag", "hermes-tag"],
+            thread_name="🛑 [blocked] Canonical task title",
+        )
+    )
+
+    assert result.success is True
+    forum_channel.create_thread.assert_awaited_once_with(
+        name="🛑 [blocked] Canonical task title",
+        content="Derived fallback title\n\nBody",
+        applied_tags=["blocked-tag", "hermes-tag"],
+    )
+
+
+def test_discord_send_to_platform_forwards_forum_applied_tags_and_thread_name():
+    from tools.send_message_tool import _send_to_platform
+
+    pconfig = MagicMock()
+    pconfig.token = "discord-token"
+    mock_result = {"success": True, "platform": "discord", "thread_id": "thread-1"}
+
+    with patch("tools.send_message_tool._send_discord", new=AsyncMock(return_value=mock_result)) as send_discord:
+        result = asyncio.run(
+            _send_to_platform(
+                Platform.DISCORD,
+                pconfig,
+                "forum-1",
+                "Tagged task\n\nStable post body",
+                applied_tags=["ready-tag", "hermes-tag", "ready-tag"],
+                thread_name="🟦 [ready] Tagged task",
+            )
+        )
+
+    assert result == mock_result
+    send_discord.assert_awaited_once()
+    await_args = send_discord.await_args
+    assert await_args is not None
+    assert await_args.kwargs["applied_tags"] == ["ready-tag", "hermes-tag", "ready-tag"]
+    assert await_args.kwargs["thread_name"] == "🟦 [ready] Tagged task"
+
+
+def test_discord_send_to_platform_preserves_forum_thread_id_across_chunks(monkeypatch):
+    from gateway.platforms.base import BasePlatformAdapter
+    from tools.send_message_tool import _send_to_platform
+
+    pconfig = MagicMock()
+    pconfig.token = "discord-token"
+    monkeypatch.setattr(
+        BasePlatformAdapter,
+        "truncate_message",
+        staticmethod(lambda message, max_len, len_fn=None: ["chunk one", "chunk two"]),
+    )
+
+    async_mock = AsyncMock(
+        side_effect=[
+            {"success": True, "platform": "discord", "thread_id": "thread-1", "message_id": "starter"},
+            {"success": True, "platform": "discord", "chat_id": "forum-1", "message_id": "reply"},
+        ]
+    )
+    with patch("tools.send_message_tool._send_discord", new=async_mock) as send_discord:
+        result = asyncio.run(
+            _send_to_platform(
+                Platform.DISCORD,
+                pconfig,
+                "forum-1",
+                "long enough to be chunked by the monkeypatched splitter",
+                applied_tags=["blocked-tag"],
+                thread_name="🛑 [blocked] Long task",
+            )
+        )
+
+    assert result["thread_id"] == "thread-1"
+    assert result["message_id"] == "reply"
+    assert send_discord.await_count == 2
+    first_call, second_call = send_discord.await_args_list
+    assert first_call.kwargs["thread_id"] is None
+    assert first_call.kwargs["applied_tags"] == ["blocked-tag"]
+    assert first_call.kwargs["thread_name"] == "🛑 [blocked] Long task"
+    assert second_call.kwargs["thread_id"] == "thread-1"
+    assert second_call.kwargs["applied_tags"] is None
+    assert second_call.kwargs["thread_name"] is None

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -494,6 +494,8 @@ async def _send_via_adapter(
     thread_id=None,
     media_files=None,
     force_document=False,
+    applied_tags=None,
+    thread_name=None,
 ):
     """Send a message via a live gateway adapter, with a standalone fallback
     for out-of-process callers (e.g. cron running separately from the gateway).
@@ -526,6 +528,10 @@ async def _send_via_adapter(
                     metadata["thread_id"] = thread_id
                 if platform_name == "ntfy" and chat_id:
                     metadata["publish_topic"] = chat_id
+                if applied_tags is not None:
+                    metadata["applied_tags"] = applied_tags
+                if thread_name is not None:
+                    metadata["thread_name"] = thread_name
                 if not metadata:
                     metadata = None
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
@@ -546,13 +552,24 @@ async def _send_via_adapter(
 
     if entry is not None and entry.standalone_sender_fn is not None:
         try:
+            standalone_kwargs = {
+                "thread_id": thread_id,
+                "media_files": media_files,
+            }
+            # Preserve compatibility with older standalone sender hooks that only
+            # accept the original thread/media kwargs.  Only pass newer optional
+            # metadata when it is explicitly requested.
+            if force_document:
+                standalone_kwargs["force_document"] = force_document
+            if applied_tags is not None:
+                standalone_kwargs["applied_tags"] = applied_tags
+            if thread_name is not None:
+                standalone_kwargs["thread_name"] = thread_name
             result = await entry.standalone_sender_fn(
                 pconfig,
                 chat_id,
                 chunk,
-                thread_id=thread_id,
-                media_files=media_files,
-                force_document=force_document,
+                **standalone_kwargs,
             )
         except asyncio.CancelledError:
             raise
@@ -580,7 +597,34 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_discord(
+    pconfig,
+    chat_id,
+    chunk,
+    *,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    applied_tags=None,
+    thread_name=None,
+):
+    """Send one Discord chunk through the shared adapter/standalone path."""
+    from gateway.config import Platform
+
+    return await _send_via_adapter(
+        Platform.DISCORD,
+        pconfig,
+        chat_id,
+        chunk,
+        thread_id=thread_id,
+        media_files=media_files,
+        force_document=force_document,
+        applied_tags=applied_tags,
+        thread_name=thread_name,
+    )
+
+
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, applied_tags=None, thread_name=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -600,6 +644,14 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     from gateway.platforms.base import BasePlatformAdapter, utf16_len
     from gateway.platforms.slack import SlackAdapter
+
+    # Discord adapter import is optional at import time in some deployments.
+    try:
+        from plugins.platforms.discord.adapter import DiscordAdapter
+        _discord_available = True
+    except ImportError:
+        DiscordAdapter = None
+        _discord_available = False
 
     # Telegram adapter import is optional (requires python-telegram-bot)
     try:
@@ -628,6 +680,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         Platform.TELEGRAM: TelegramAdapter.MAX_MESSAGE_LENGTH if _telegram_available else 4096,
         Platform.SLACK: SlackAdapter.MAX_MESSAGE_LENGTH,
     }
+    if _discord_available and DiscordAdapter is not None:
+        _MAX_LENGTHS[Platform.DISCORD] = DiscordAdapter.MAX_MESSAGE_LENGTH
     if _feishu_available:
         _MAX_LENGTHS[Platform.FEISHU] = FeishuAdapter.MAX_MESSAGE_LENGTH
 
@@ -671,31 +725,32 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
-    # --- Discord: chunked delivery via the registry's standalone_sender_fn.
-    # The plugin's ``_standalone_send`` (registered in
-    # plugins/platforms/discord/adapter.py) handles forum channels, threads,
-    # and multipart media uploads.  ``_send_via_adapter`` tries the live
-    # in-process adapter first via ``adapter.send()``, but Discord's elif
-    # historically went straight to the HTTP path; we preserve that by
-    # explicitly invoking the registry hook here so behavior is unchanged.
+    # --- Discord: chunked delivery via the shared adapter/standalone helper.
+    # For forum-channel sends, pass explicit projection metadata only on the
+    # starter thread creation call.  Follow-up chunks target the created thread
+    # id and should not carry forum tags/name again.
     if platform == Platform.DISCORD:
-        from gateway.platform_registry import platform_registry
-        entry = platform_registry.get("discord")
-        if entry is None or entry.standalone_sender_fn is None:
-            return {"error": "Discord plugin not registered or missing standalone_sender_fn"}
         last_result = None
+        current_thread_id = thread_id
         for i, chunk in enumerate(chunks):
             is_last = (i == len(chunks) - 1)
-            result = await entry.standalone_sender_fn(
+            result = await _send_discord(
                 pconfig,
                 chat_id,
                 chunk,
-                thread_id=thread_id,
+                thread_id=current_thread_id,
                 media_files=media_files if is_last else [],
+                force_document=force_document,
+                applied_tags=applied_tags if current_thread_id is None else None,
+                thread_name=thread_name if current_thread_id is None else None,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
+            if current_thread_id is None and isinstance(result, dict) and result.get("thread_id"):
+                current_thread_id = result.get("thread_id")
             last_result = result
+        if isinstance(last_result, dict) and current_thread_id and "thread_id" not in last_result:
+            last_result = {**last_result, "thread_id": current_thread_id}
         return last_result
 
     # --- Matrix: use the native adapter helper when media is present ---

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -540,7 +540,14 @@ async def _send_via_adapter(
             except Exception as e:
                 return {"error": f"Plugin platform send failed: {e}"}
             if result.success:
-                return {"success": True, "message_id": result.message_id}
+                out = {"success": True, "message_id": result.message_id}
+                raw_response = getattr(result, "raw_response", None)
+                if isinstance(raw_response, dict):
+                    for key in ("thread_id", "channel_id", "jump_url", "url", "message_ids", "warnings"):
+                        if key in raw_response:
+                            out[key] = raw_response[key]
+                    out["raw_response"] = {key: out[key] for key in out.keys() if key not in {"success", "message_id"}}
+                return out
             return {"error": f"Adapter send failed: {result.error}"}
 
     entry = None

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -700,6 +700,63 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
 
+### Automatic stale `done` task archival
+
+Hermes ships a maintenance entrypoint for moving old completed tasks out of the active board and reconciling their Discord forum projections:
+
+```bash
+# Manual dry-run from a source checkout
+python scripts/kanban_archive_done.py --board default --dry-run --done-age-days 7 --batch-size 25
+
+# Manual live run
+python scripts/kanban_archive_done.py --board default --done-age-days 7 --batch-size 25
+```
+
+What it does:
+
+- Selects only tasks with `status='done'` and `completed_at` older than `--done-age-days`.
+- Leaves newer `done` tasks and all non-`done` tasks untouched.
+- Archives the Kanban task first, keeping Kanban as the lifecycle source of truth.
+- For Discord subscriptions, PATCHes the forum thread to `archived=true` and `locked=true`, including the configured archived title/status/assignee tags from `discord-forum-tags.json` when available.
+- Removes Discord subscription rows after a successful PATCH, a 404/missing thread, or malformed/missing thread metadata; keeps rows on token/API/network failures so the next run retries reconciliation.
+- Also retries already-archived tasks that still have Discord subscriptions, which makes partial-failure reruns safe and idempotent.
+
+Recommended cron setup uses `--no-agent` so no model call is needed. Cron scripts must live under the profile's `~/.hermes/scripts/` directory:
+
+```bash
+mkdir -p ~/.hermes/scripts
+cp ~/.hermes/hermes-agent/scripts/kanban_archive_done.py ~/.hermes/scripts/kanban_archive_done.py
+chmod +x ~/.hermes/scripts/kanban_archive_done.py
+
+hermes cron create "30 3 * * *" \
+  --name kanban-archive-done \
+  --script kanban_archive_done.py \
+  --no-agent \
+  --deliver local
+```
+
+To change the policy, edit the job's script arguments or wrapper script, then run one dry-run before re-enabling live archival. Common conservative settings are `--done-age-days 7` and `--batch-size 25`; lower batch sizes reduce Discord/API pressure during a first backfill.
+
+Operations:
+
+```bash
+hermes cron list --all                         # find the job id and last status
+hermes cron status                             # confirm the gateway scheduler is running
+hermes cron run <job_id>                       # trigger on the next scheduler tick
+hermes cron pause <job_id>                     # temporarily disable
+hermes cron resume <job_id>                    # re-enable
+hermes cron remove <job_id>                    # permanently delete the schedule
+```
+
+Monitoring and troubleshooting:
+
+- The script prints JSON with `candidate_count`, `archived_count`, `already_archived_count`, `discord_archived_locked_count`, `skipped_by_reason`, `failure_count`, and per-task details.
+- Exit code is `0` when `failure_count` is zero and `1` when retryable Discord/API/token failures remain.
+- `discord_token_missing`, `http_*`, `request_error`, and `retry_exhausted` failures leave the subscription row in place for the next cron run.
+- `missing_or_deleted_discord_thread`, `missing_discord_thread_ref`, and `malformed_discord_thread_ref` are treated as nonfatal cleanup cases.
+- `no_discord_projection` only means there was no local subscription row; it is not proof that no Discord thread exists. Use Kanban repair/reconcile tooling if live Discord projection metadata looks stale.
+- Check gateway/cron logs with `hermes logs --level warning --session gateway` or by inspecting `~/.hermes/logs/gateway.log` on older installs.
+
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
 
 ### Concurrency, scheduling, and child promotion config

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, GBrain"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,23 +22,60 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory, gbrain
 ```
 
 ## How It Works
 
-When a memory provider is active, Hermes automatically:
+When a write-capable memory provider is active, Hermes can automatically:
 
-1. **Injects provider context** into the system prompt (what the provider knows)
-2. **Prefetches relevant memories** before each turn (background, non-blocking)
-3. **Syncs conversation turns** to the provider after each response
-4. **Extracts memories on session end** (for providers that support it)
+1. **Inject provider context** into the system prompt (what the provider knows)
+2. **Prefetch relevant memories** before each turn (background, non-blocking)
+3. **Sync conversation turns** to the provider after each response
+4. **Extract memories on session end** (for providers that support it)
 5. **Mirrors built-in memory writes** to the external provider
 6. **Adds provider-specific tools** so the agent can search, store, and manage memories
+
+Read-only providers or read-only modes, such as GBrain's safe default, intentionally disable write/sync/ingest behavior while preserving search/recall.
 
 The built-in memory (MEMORY.md / USER.md) continues to work exactly as before. The external provider is additive.
 
 ## Available Providers
+
+### GBrain
+
+Local or self-hosted GBrain recall through an HTTP MCP endpoint, designed for single-writer governance. GBrain is read-only by default so normal Hermes profiles can search memory without ingesting, deleting, or modifying pages. Explicit `read-write` mode is intended only for Athena/steward-style profiles that are authorized to curate durable brain updates.
+
+| | |
+|---|---|
+| **Best for** | Reusing an existing GBrain knowledge base as Hermes long-term recall |
+| **Requires** | A GBrain HTTP MCP endpoint, typically a read-only proxy for non-steward profiles |
+| **Data storage** | Your configured GBrain backend |
+| **Cost** | Whatever your GBrain deployment costs |
+
+**Tools (2):** `gbrain_memory_search` (query recalled GBrain context) and `gbrain_memory_store_candidate` (blocked Athena handoff in read-only mode; write-tool call only in explicit read-write mode).
+
+**Safe default setup:**
+
+```bash
+hermes memory setup gbrain
+```
+
+Manual read-only configuration:
+
+```yaml
+memory:
+  provider: gbrain
+  gbrain:
+    endpoint: "http://127.0.0.1:3132/mcp"
+    mode: "read-only"
+    source_id: "__all__"
+    max_results: 6
+```
+
+For Athena-only write-capable usage, configure `mode: read-write` against a writer endpoint and keep credentials outside config/docs/logs. Read-write mode still does not auto-ingest whole conversations; it mirrors only explicit memory writes or explicit store-candidate tool calls through the configured write tool.
+
+See `plugins/memory/gbrain/README.md` for the full config reference and single-writer safety notes.
 
 ### Honcho
 


### PR DESCRIPTION
## Summary
- Record a blocked event when tasks are created directly with initial_status=blocked so dispatcher recompute does not auto-promote them without explicit unblock.
- Use the board projection notifier_profile for Discord projection subscriptions when configured, with creator-profile fallback when absent.
- Add focused regressions for sticky initial blocked create and configured projection notifier ownership.

## Test Plan
- python -m pytest tests/hermes_cli/test_kanban_blocked_sticky.py::test_initial_blocked_create_is_sticky_across_dispatcher_recompute tests/hermes_cli/test_kanban_core_functionality.py::test_create_projects_task_to_discord_forum_and_records_linkage tests/hermes_cli/test_kanban_core_functionality.py::test_create_projection_notifier_profile_falls_back_to_author_when_unconfigured -q -o 'addopts='
- python -m pytest tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_db.py::test_recompute_ready_skips_tasks_at_failure_limit -q -o 'addopts='
- git diff --check

## Notes
Full tests/hermes_cli was previously run in this environment and is not clean due to unrelated/baseline failures; focused Kanban coverage above passes.