### PR TITLE
fix(qqbot): fall back to standalone send when reply msg_id expires

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2460,24 +2460,45 @@ class QQAdapter(BasePlatformAdapter):
             reply_to = None
         return last_result
 
+    @staticmethod
+    def _is_msg_id_expired(error: str) -> bool:
+        """Check if an error indicates the reply msg_id has expired.
+
+        QQ Bot returns a 400 with a Chinese message when the msg_id used for
+        threading/reply has expired.  Retrying with the same msg_id will always
+        fail, so callers should fall back to a standalone send.
+        """
+        err = error.lower()
+        return "msg_id" in err and any(
+            k in err for k in ("expired", "expire", "过期")
+        )
+
     async def _send_chunk(
             self,
             chat_id: str,
             content: str,
             reply_to: Optional[str] = None,
     ) -> SendResult:
-        """Send a single chunk with retry + exponential backoff."""
+        """Send a single chunk with retry + exponential backoff.
+
+        If the initial reply fails because the original msg_id has expired
+        (common when the agent takes >5 minutes to respond in group chats),
+        automatically falls back to sending as a standalone message so the
+        response still reaches the chat.  See #43467.
+        """
         last_exc: Optional[Exception] = None
         chat_type = self._guess_chat_type(chat_id)
+        active_reply_to = reply_to
+        msg_id_fallback_done = False
 
         for attempt in range(3):
             try:
                 if chat_type == "c2c":
-                    return await self._send_c2c_text(chat_id, content, reply_to)
+                    return await self._send_c2c_text(chat_id, content, active_reply_to)
                 elif chat_type == "group":
-                    return await self._send_group_text(chat_id, content, reply_to)
+                    return await self._send_group_text(chat_id, content, active_reply_to)
                 elif chat_type == "guild":
-                    return await self._send_guild_text(chat_id, content, reply_to)
+                    return await self._send_guild_text(chat_id, content, active_reply_to)
                 else:
                     return SendResult(
                         success=False, error=f"Unknown chat type for {chat_id}"
@@ -2485,6 +2506,22 @@ class QQAdapter(BasePlatformAdapter):
             except Exception as exc:
                 last_exc = exc
                 err = str(exc).lower()
+
+                # msg_id expired → drop reply_to and retry as standalone
+                if (
+                    active_reply_to
+                    and not msg_id_fallback_done
+                    and self._is_msg_id_expired(err)
+                ):
+                    logger.warning(
+                        "[%s] msg_id %s expired — falling back to standalone send",
+                        self._log_tag,
+                        active_reply_to,
+                    )
+                    active_reply_to = None
+                    msg_id_fallback_done = True
+                    continue
+
                 # Permanent errors — don't retry
                 if any(
                         k in err

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2220,3 +2220,118 @@ class TestReadEventsClosedWsGuard:
         adapter._ws = None
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
+
+
+# ---------------------------------------------------------------------------
+# msg_id expiry fallback (#43467)
+# ---------------------------------------------------------------------------
+
+
+class TestMsgIdExpiryFallback:
+    """When a reply_to msg_id has expired, _send_chunk should fall back to
+    sending as a standalone message instead of retrying the same expired
+    msg_id 3 times and dropping the response."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    def test_is_msg_id_expired_chinese(self):
+        adapter = self._make_adapter()
+        assert adapter._is_msg_id_expired(
+            "QQ Bot API error [400] /v2/groups/g/messages: 回复消息msg_id已过期"
+        )
+
+    def test_is_msg_id_expired_english(self):
+        adapter = self._make_adapter()
+        assert adapter._is_msg_id_expired(
+            "msg_id has expired, please use a valid msg_id"
+        )
+
+    def test_is_msg_id_expired_not_expired(self):
+        adapter = self._make_adapter()
+        assert not adapter._is_msg_id_expired(
+            "QQ Bot API error [400] invalid request body"
+        )
+        assert not adapter._is_msg_id_expired(
+            "QQ Bot API error [403] forbidden"
+        )
+
+    def test_send_chunk_falls_back_to_standalone_on_expired_msg_id(self):
+        adapter = self._make_adapter()
+        adapter._guess_chat_type = mock.MagicMock(return_value="group")
+
+        call_log = []
+
+        async def fake_group_text(chat_id, content, reply_to=None, keyboard=None):
+            call_log.append({"chat_id": chat_id, "reply_to": reply_to})
+            if reply_to:
+                raise RuntimeError(
+                    "QQ Bot API error [400] /v2/groups/g/messages: "
+                    "回复消息msg_id已过期"
+                )
+            from gateway.platforms.base import SendResult
+            return SendResult(success=True, message_id="new_msg")
+
+        adapter._send_group_text = fake_group_text
+        adapter._next_msg_seq = mock.MagicMock(return_value=1)
+
+        result = asyncio.run(
+            adapter._send_chunk("group_123", "hello", reply_to="expired_msg_id")
+        )
+
+        assert result.success is True
+        assert len(call_log) == 2
+        # First attempt: with reply_to → fails
+        assert call_log[0]["reply_to"] == "expired_msg_id"
+        # Second attempt: standalone (no reply_to) → succeeds
+        assert call_log[1]["reply_to"] is None
+
+    def test_send_chunk_no_fallback_without_reply_to(self):
+        """When there's no reply_to, msg_id expiry detection is irrelevant."""
+        adapter = self._make_adapter()
+        adapter._guess_chat_type = mock.MagicMock(return_value="group")
+
+        async def fake_group_text(chat_id, content, reply_to=None, keyboard=None):
+            raise RuntimeError(
+                "QQ Bot API error [400] /v2/groups/g/messages: "
+                "回复消息msg_id已过期"
+            )
+
+        adapter._send_group_text = fake_group_text
+        adapter._next_msg_seq = mock.MagicMock(return_value=1)
+
+        result = asyncio.run(
+            adapter._send_chunk("group_123", "hello", reply_to=None)
+        )
+
+        # Should fail — no fallback possible without reply_to
+        assert result.success is False
+
+    def test_send_chunk_fallback_only_once(self):
+        """The fallback to standalone should only happen once, not loop."""
+        adapter = self._make_adapter()
+        adapter._guess_chat_type = mock.MagicMock(return_value="group")
+
+        attempt_count = 0
+
+        async def fake_group_text(chat_id, content, reply_to=None, keyboard=None):
+            nonlocal attempt_count
+            attempt_count += 1
+            raise RuntimeError(
+                "QQ Bot API error [400] /v2/groups/g/messages: "
+                "回复消息msg_id已过期"
+            )
+
+        adapter._send_group_text = fake_group_text
+        adapter._next_msg_seq = mock.MagicMock(return_value=1)
+
+        result = asyncio.run(
+            adapter._send_chunk("group_123", "hello", reply_to="expired_msg_id")
+        )
+
+        # First attempt with reply_to, second without (both fail),
+        # then the loop continues with remaining retries (also fail)
+        assert result.success is False
+        # Should be 3 total attempts (not infinite loop)
+        assert attempt_count == 3


### PR DESCRIPTION
## What does this PR do?

Falls back to sending as a standalone message when the QQ Bot API rejects a reply because the original `msg_id` has expired. Previously the adapter retried the same expired `msg_id` 3 times and permanently dropped the response.

## Related Issue

Fixes #43467

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/qqbot/adapter.py`: Added `_is_msg_id_expired()` helper that detects both Chinese ("msg_id已过期") and English ("msg_id expired") error messages. Modified `_send_chunk()` to detect msg_id expiry during retries and fall back to sending without `reply_to` (standalone message) instead of retrying the same expired msg_id.
- `tests/gateway/test_qqbot.py`: Added `TestMsgIdExpiryFallback` with 6 tests covering the detection helper and the fallback behavior.

## How to Test

1. Run `pytest tests/gateway/test_qqbot.py::TestMsgIdExpiryFallback -v` — all 6 tests should pass
2. Run `pytest tests/gateway/test_qqbot.py -v` — all 167 tests should pass (no regressions)
3. In a QQ group chat, send a complex request that triggers >5 minutes of tool calls. The response should now arrive as a standalone message instead of being silently dropped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_qqbot.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/qqbot/adapter.py:_send_chunk` (callers: `send`, `send_with_keyboard`)
- Blast radius: LOW — change is scoped to the QQ Bot adapter's retry logic; no other adapters affected
- Related patterns: Similar retry-with-fallback could benefit other platform adapters (Telegram, Discord) if they have message-reply expiry semantics
