### PR TITLE
fix(tools): add old_text to memory tool required schema fields (#43412)

### DIFF
--- a/tests/tools/test_memory_tool_schema.py
+++ b/tests/tools/test_memory_tool_schema.py
@@ -39,7 +39,7 @@ def test_memory_schema_has_no_forbidden_top_level_combinators():
 def test_memory_schema_is_well_formed():
     params = MEMORY_SCHEMA["parameters"]
     assert params["type"] == "object"
-    assert params["required"] == ["action", "target"]
+    assert params["required"] == ["action", "target", "old_text"]
     # Nested ``enum`` on property values is fine — only top-level is forbidden.
     assert params["properties"]["action"]["enum"] == ["add", "replace", "remove"]
     assert params["properties"]["target"]["enum"] == ["memory", "user"]

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -784,7 +784,7 @@ MEMORY_SCHEMA = {
                 "description": "Short unique substring identifying the entry to replace or remove."
             },
         },
-        "required": ["action", "target"],
+        "required": ["action", "target", "old_text"],
     },
 }
 


### PR DESCRIPTION
Fixes #43412. The memory tool schema listed only action and target as required fields, but old_text is required for replace and remove actions. Schema-aware LLMs were dropping the old_text parameter since it wasn't in the required list, causing the handler to reject it as missing.