### PR TITLE
fix(feishu): stop over-escaping Markdown in _escape_markdown_text (#43437)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -454,7 +454,11 @@ def _sender_identity(sender: Any) -> frozenset:
 
 
 def _escape_markdown_text(text: str) -> str:
-    return _MARKDOWN_SPECIAL_CHARS_RE.sub(r"\\\1", text)
+    # Feishu's Markdown renderer expects raw Markdown — pre-escaping special
+    # characters (e.g. \# \* \| \_) breaks rendering by inserting literal
+    # backslashes.  Return text unchanged so Markdown reaches the renderer
+    # intact.  See #43437.
+    return text
 
 
 def _to_boolean(value: Any) -> bool:


### PR DESCRIPTION
Fixes #43437. The _escape_markdown_text function was prepending backslashes to all Markdown special characters, but Feishu's Markdown renderer expects raw Markdown and renders backslash-escaped sequences as literal text. The fix makes the function a no-op passthrough.