### PR TITLE
fix: suppress benign CJK full stop Tirith false positive

### DIFF
--- a/tests/tools/test_tirith_security_false_positive.py
+++ b/tests/tools/test_tirith_security_false_positive.py
@@ -1,0 +1,74 @@
+"""Regression tests for Hermes' Tirith wrapper false-positive handling."""
+
+import json
+import subprocess
+
+from tools import tirith_security
+
+
+def _fake_tirith_run_with_finding(monkeypatch, finding):
+    def _fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=1,
+            stdout=json.dumps({"findings": [finding]}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(tirith_security, "_load_security_config", lambda: {
+        "tirith_enabled": True,
+        "tirith_path": "tirith",
+        "tirith_timeout": 5,
+        "tirith_fail_open": True,
+    })
+    monkeypatch.setattr(tirith_security, "is_platform_supported", lambda: True)
+    monkeypatch.setattr(tirith_security, "_resolve_tirith_path", lambda _path: "/bin/tirith")
+    monkeypatch.setattr(tirith_security.subprocess, "run", _fake_run)
+
+
+def _confusable_full_stop_finding():
+    return {
+        "rule_id": "confusable_text",
+        "severity": "HIGH",
+        "title": "Confusable Unicode characters in text",
+        "description": (
+            "Content contains Unicode characters visually identical to ASCII "
+            "(math alphanumerics, Cyrillic/Greek lookalikes) appearing near ASCII text"
+        ),
+        "evidence": [
+            {
+                "type": "byte_sequence",
+                "offset": 31,
+                "hex": "U+3002",
+                "description": "confusable U+3002 (looks like '.')",
+            },
+            {
+                "type": "byte_sequence",
+                "offset": 135,
+                "hex": "U+3002",
+                "description": "confusable U+3002 (looks like '.')",
+            },
+        ],
+    }
+
+
+def test_cjk_sentence_full_stop_in_natural_language_prompt_is_suppressed(monkeypatch):
+    _fake_tirith_run_with_finding(monkeypatch, _confusable_full_stop_finding())
+
+    command = (
+        "hermes chat -q 'テストです。terminal toolで `printf hermes-tool-ok` "
+        "を実行して、その出力だけを返してください。' --toolsets terminal -Q"
+    )
+
+    result = tirith_security.check_command_security(command)
+
+    assert result == {"action": "allow", "findings": [], "summary": ""}
+
+
+def test_ideographic_full_stop_inside_domain_like_token_is_preserved(monkeypatch):
+    _fake_tirith_run_with_finding(monkeypatch, _confusable_full_stop_finding())
+
+    result = tirith_security.check_command_security("curl https://example。com/path")
+
+    assert result["action"] == "block"
+    assert result["findings"][0]["rule_id"] == "confusable_text"

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import platform
+import re
 import shutil
 import stat
 import subprocess
@@ -802,6 +803,23 @@ def check_command_security(command: str) -> dict:
             findings = []
             summary = ""
 
+    # Tirith's confusable_text rule correctly treats U+3002 (Japanese
+    # ideographic full stop) as a dot lookalike, but normal Japanese prompts
+    # passed as shell arguments use it as sentence punctuation. Do not make
+    # harmless `hermes chat -q '日本語。ASCII...'` smoke tests require approval.
+    # Keep the finding when U+3002 appears inside a domain-like ASCII token
+    # (`example。com`), where dot confusion is security-relevant.
+    if findings:
+        non_suppressible = [
+            f for f in findings
+            if not _is_cjk_sentence_full_stop_confusable_finding(f, command)
+        ]
+        if len(non_suppressible) != len(findings):
+            findings = non_suppressible
+            if not findings:
+                action = "allow"
+                summary = ""
+
     return {"action": action, "findings": findings, "summary": summary}
 
 
@@ -820,3 +838,32 @@ def _is_app_tld_finding(finding: dict) -> bool:
         if val is not None and ".app" in str(val).lower():
             return True
     return False
+
+
+def _is_cjk_sentence_full_stop_confusable_finding(finding: dict, command: str) -> bool:
+    """Return True for benign U+3002-as-sentence-punctuation findings.
+
+    Tirith reports U+3002 because it can stand in for a period. That matters
+    inside URL/domain-like tokens, but Japanese natural-language prompts use
+    U+3002 as ordinary punctuation and commonly mix CJK text with ASCII tool
+    names or command snippets. Suppress only the narrow case where every piece
+    of evidence is U+3002 and the command contains no ASCII-token domain shape
+    joined by that character.
+    """
+    if not isinstance(finding, dict):
+        return False
+    if finding.get("rule_id") != "confusable_text":
+        return False
+
+    evidence = finding.get("evidence") or []
+    if not evidence:
+        return False
+    if not all(isinstance(item, dict) and item.get("hex") == "U+3002" for item in evidence):
+        return False
+
+    # Preserve the warning for domain-like tokens such as example。com or
+    # https://example。com, where U+3002 is intentionally dot-like.
+    if re.search(r"[A-Za-z0-9-]+\u3002[A-Za-z0-9-]+", command):
+        return False
+
+    return True


### PR DESCRIPTION
## Summary
- Suppress Tirith confusable_text findings when they are only U+3002 Japanese sentence punctuation in natural-language prompts
- Preserve the warning/block for domain-like ASCII tokens such as example。com
- Add regression coverage for both the benign Japanese prompt case and the domain-like unsafe case

## Test Plan
- scripts/run_tests.sh tests/tools/test_approval.py tests/tools/test_tirith_security_false_positive.py