### PR TITLE
fix(memory): recall facts when an LLM search query contains FTS5 metasyntax

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -19,6 +19,20 @@ except ImportError:
     import holographic as hrr  # type: ignore[no-redef]
 
 
+def _fts5_safe_query(text: str) -> str:
+    """Quote each whitespace token as an FTS5 literal phrase.
+
+    The memory ``search`` action is driven by the LLM, which routinely emits
+    queries containing FTS5 metasyntax — a stray double-quote, a ``key:value``
+    colon, a bare ``AND``/``OR``/``NEAR``, or a parenthesis. Passing those
+    straight to ``MATCH`` raises ``sqlite3.OperationalError``. Wrapping every
+    token in double quotes (embedded quotes doubled) turns the string into a
+    set of literal phrase matches that FTS5 always accepts, so the search
+    degrades to a usable query instead of returning nothing.
+    """
+    return " ".join('"' + tok.replace('"', '""') + '"' for tok in text.split() if tok)
+
+
 class FactRetriever:
     """Multi-strategy fact retrieval with trust-weighted scoring."""
 
@@ -520,8 +534,18 @@ class FactRetriever:
         try:
             rows = conn.execute(sql, params).fetchall()
         except Exception:
-            # FTS5 MATCH can fail on malformed queries — fall back to empty
-            return []
+            # FTS5 MATCH rejects query syntax the LLM routinely emits (a stray
+            # colon, quote, bare AND/OR/NEAR, or parenthesis). Rather than
+            # silently returning no memories, retry with each token quoted as a
+            # literal phrase so the search still finds matches.
+            safe_query = _fts5_safe_query(query)
+            if not safe_query:
+                return []
+            params[0] = safe_query  # the MATCH bind param is appended first
+            try:
+                rows = conn.execute(sql, params).fetchall()
+            except Exception:
+                return []
 
         if not rows:
             return []

--- a/tests/plugins/memory/test_holographic_retrieval_fts5.py
+++ b/tests/plugins/memory/test_holographic_retrieval_fts5.py
@@ -1,0 +1,78 @@
+"""FactRetriever.search must not silently drop results on FTS5 query syntax.
+
+The memory ``search`` action — the LLM-facing recall path — routes through
+``FactRetriever.search`` → ``_fts_candidates``, which runs the query against an
+FTS5 ``MATCH``. LLM-issued queries frequently contain FTS5 metasyntax: a
+``key:value`` colon, a stray double-quote, a bare ``AND``/``OR``/``NEAR``, or a
+parenthesis. ``MATCH`` raises ``sqlite3.OperationalError`` on those, and the
+candidate fetch used to swallow the error and return ``[]`` — so the agent got
+*no* memories even when relevant facts existed. The fetch now retries with each
+token quoted as a literal phrase so recall degrades gracefully to a match.
+"""
+
+import pytest
+
+from plugins.memory.holographic.store import MemoryStore
+from plugins.memory.holographic.retrieval import FactRetriever, _fts5_safe_query
+
+
+@pytest.fixture
+def retriever():
+    store = MemoryStore(":memory:")
+    store.add_fact("Rust is memory safe and fast", category="tech")
+    store.add_fact("Python is a popular programming language", category="tech")
+    return FactRetriever(store)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "memory:safe",     # colon → FTS5 column-filter syntax
+        '"unterminated',   # stray double-quote
+        "rust AND",        # trailing boolean operator
+        "(python",         # unbalanced parenthesis
+        "NEAR(",           # NEAR with no arguments
+        "fast OR",         # trailing OR
+        "C++ AND rust",    # operator mixed with content
+    ],
+)
+def test_metasyntax_query_does_not_raise_or_silently_empty(retriever, query):
+    # Must never raise sqlite3.OperationalError; always returns a list.
+    results = retriever.search(query, min_trust=0.0)
+    assert isinstance(results, list)
+
+
+def test_colon_query_still_recalls_matching_fact(retriever):
+    # `memory:safe` is invalid FTS5 (column filter). Before the fix the raw
+    # MATCH raised and the fetch returned [], so the agent recalled nothing.
+    # The quoted-phrase retry matches "memory safe" in the Rust fact.
+    results = retriever.search("memory:safe", min_trust=0.0)
+    assert any("memory safe" in r["content"] for r in results), (
+        "colon query should still recall the matching fact, not return empty"
+    )
+
+
+def test_boolean_operator_query_still_recalls(retriever):
+    # "rust AND" is a dangling operator that FTS5 rejects; the retry quotes
+    # both tokens and still finds the Rust fact.
+    results = retriever.search("rust AND", min_trust=0.0)
+    assert any("Rust" in r["content"] for r in results)
+
+
+def test_plain_query_unaffected(retriever):
+    results = retriever.search("rust", min_trust=0.0)
+    assert any("Rust" in r["content"] for r in results)
+
+
+def test_prefix_query_still_works(retriever):
+    # A valid FTS5 prefix query must keep working (raw MATCH is tried first,
+    # before any sanitizing retry).
+    results = retriever.search("pyth*", min_trust=0.0)
+    assert any("Python" in r["content"] for r in results)
+
+
+def test_fts5_safe_query_helper():
+    assert _fts5_safe_query("foo:bar baz") == '"foo:bar" "baz"'
+    # An embedded double-quote is doubled (FTS5 phrase escaping).
+    assert _fts5_safe_query('a"b') == '"a""b"'
+    assert _fts5_safe_query("   ") == ""


### PR DESCRIPTION
## Summary

`FactRetriever.search()` is the path behind the LLM-facing memory `search` action in the holographic memory plugin (`_handle_fact_action` → `retriever.search`). It passes the **raw query** straight to an FTS5 `MATCH` in `_fts_candidates()`:

```python
where_clauses = ["facts_fts MATCH ?"]
params.append(query)          # raw LLM query
...
try:
    rows = conn.execute(sql, params).fetchall()
except Exception:
    return []                 # ← silently drops ALL results
```

LLM-issued search queries routinely contain FTS5 metasyntax — a `key:value` colon (`project:hermes deadline`), a stray double-quote, a bare `AND`/`OR`/`NEAR`, or a parenthesis. FTS5 `MATCH` raises `sqlite3.OperationalError` on those, so the fetch returned `[]` and **the agent recalled no memories even when relevant facts existed** — a silent correctness loss on entirely normal input.

## Fix

Before giving up, retry the `MATCH` with each token quoted as a literal phrase:

```python
except Exception:
    safe_query = _fts5_safe_query(query)   # 'project:hermes deadline' -> '"project:hermes" "deadline"'
    ...
```

The raw query is tried **first**, so valid FTS5 (e.g. `term*` prefix queries) is preserved; only a rejected query falls back to the quoted retry, which degrades to a literal-phrase match instead of returning nothing.

This applies the same try-raw-then-quote approach as #43435 (which fixes the *crash* in `MemoryStore.search_facts`, the direct-API sibling). Here the symptom is silent empty results rather than a crash, because `_fts_candidates` already swallowed the error into `[]`.

> Note: `_fts5_safe_query` is duplicated from #43435's `store.py` helper to keep this PR self-contained. If both land, the two copies can be hoisted into one shared util.

## Tests

New `tests/plugins/memory/test_holographic_retrieval_fts5.py` (12 tests):
- colon / dangling-`AND` / paren / `NEAR(` / stray-quote queries no longer return empty;
- `test_colon_query_still_recalls_matching_fact` and the boolean-operator case **fail without the retry** (they return `[]`) and pass with it;
- plain and `term*` prefix queries are unaffected (raw is tried first);
- `_fts5_safe_query` unit coverage.