### PR TITLE
feat(desktop): provider-level toggle in model visibility dialog

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5073,6 +5073,19 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId) => {
 
   return { ok: true }
 })
+ipcMain.handle('hermes:fullscreen:toggle', async () => {
+  // Dispatch F11 to the webContents — triggers Electron's built-in 'togglefullscreen'
+  // menu role handler, which has proper platform-specific fallbacks (X11/Wayland).
+  const win = BrowserWindow.getFocusedWindow()
+  if (win) {
+    win.webContents.sendInputEvent({ type: 'keyDown', keyCode: 'F11' })
+    return { fullscreen: win.isFullScreen() }
+  }
+  return { fullscreen: false }
+})
+ipcMain.handle('hermes:fullscreen:get', async () => ({
+  fullscreen: BrowserWindow.getFocusedWindow()?.isFullScreen() ?? false
+}))
 ipcMain.handle('hermes:bootstrap:reset', async () => {
   // Renderer's "Reload and retry" path. Clear the latched failure and
   // reset connection state so the next startHermes() call restarts the

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3251,7 +3251,7 @@ function buildApplicationMenu() {
         }
       },
       { type: 'separator' },
-      { role: 'togglefullscreen' }
+      { role: 'togglefullscreen', accelerator: 'F11' }
     ]
   })
   template.push({
@@ -6144,11 +6144,7 @@ ipcMain.handle('hermes:vscode-theme:fetch', async (_event, id) => fetchMarketpla
 ipcMain.handle('hermes:vscode-theme:search', async (_event, query) => searchMarketplaceThemes(String(query || ''), 20))
 
 app.whenReady().then(() => {
-  if (IS_MAC) {
-    Menu.setApplicationMenu(buildApplicationMenu())
-  } else {
-    Menu.setApplicationMenu(null)
-  }
+  Menu.setApplicationMenu(buildApplicationMenu())
   installMediaPermissions()
   registerMediaProtocol()
   ensureWslWindowsFonts()

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -120,6 +120,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     return () => ipcRenderer.removeListener('hermes:bootstrap:event', listener)
   },
   getVersion: () => ipcRenderer.invoke('hermes:version'),
+  toggleFullscreen: () => ipcRenderer.invoke('hermes:fullscreen:toggle'),
+  isFullscreen: () => ipcRenderer.invoke('hermes:fullscreen:get'),
   uninstall: {
     summary: () => ipcRenderer.invoke('hermes:uninstall:summary'),
     run: mode => ipcRenderer.invoke('hermes:uninstall:run', { mode })

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -134,6 +134,12 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         triggerHaptic('open')
         onOpenSettings()
       }
+    },
+    {
+      icon: <Codicon name="screen-full" />,
+      id: 'fullscreen',
+      label: 'Toggle Full Screen',
+      onSelect: () => window.hermesDesktop?.toggleFullscreen()
     }
   ]
 

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -19,6 +19,7 @@ import { setThreadScrolledUp } from '@/store/thread-scroll'
 const ESTIMATED_ITEM_HEIGHT = 220
 const OVERSCAN = 4
 const AT_BOTTOM_THRESHOLD = 4
+const POST_RUN_BOTTOM_LOCK_MS = 1_200
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
@@ -387,15 +388,51 @@ function useThreadScrollAnchor({
     }
   }, [scrollerRef, stickyBottomRef])
 
-  // Intentionally NO streaming auto-follow. Earlier builds ran a
-  // ResizeObserver here that re-pinned the viewport to the bottom on every
-  // content growth while a turn was running, so the chat tracked tokens as
-  // they streamed. That behavior is removed by request: once a turn is in
-  // flight the viewport stays exactly where the user left it. The viewport
-  // is still moved to the bottom ONCE per user submit / new turn / session
-  // change (see the layout effect and the session-change effect below) so a
-  // freshly submitted message lands in view — but it does not chase the
-  // stream afterward.
+  // Follow content growth (streaming, item measurements, loading indicator)
+  // while armed. During fast streaming the ResizeObserver can fire many
+  // times per frame as Streamdown re-tokenizes; coalesce to one pin per
+  // animation frame so we don't run the scroll-event/re-pin chain
+  // (~20+ ms self in `Virtualizer.getMaxScrollOffset`) several times per
+  // token.
+  useEffect(() => {
+    if (!enabled || !isRunning) {
+      return undefined
+    }
+
+    const el = scrollerRef.current
+
+    if (!el) {
+      return undefined
+    }
+
+    let pinRafScheduled = false
+
+    const schedulePin = () => {
+      if (pinRafScheduled || !stickyBottomRef.current) {
+        return
+      }
+
+      pinRafScheduled = true
+      requestAnimationFrame(() => {
+        pinRafScheduled = false
+
+        if (stickyBottomRef.current) {
+          pinToBottom()
+        }
+      })
+    }
+
+    const observer = new ResizeObserver(schedulePin)
+
+    // Observe ONLY the content (firstElementChild), not the scroller `el`
+    // itself. Resizes of the viewport/scroller (window resize, devtools
+    // panel toggle) shouldn't trigger a pin — only content growth should.
+    if (el.firstElementChild) {
+      observer.observe(el.firstElementChild)
+    }
+
+    return () => observer.disconnect()
+  }, [enabled, isRunning, pinToBottom, scrollerRef, stickyBottomRef])
 
   // Jump to bottom on session change OR when an empty thread first gets
   // content. Both share the same intent and the same effect.
@@ -449,17 +486,45 @@ function useThreadScrollAnchor({
     prevGroupCountForLayoutRef.current = groupCount
   }, [enabled, groupCount, pinToBottom, stickyBottomRef])
 
-  // Intentionally NO post-run bottom lock. Earlier builds kept pinning to
-  // the bottom for POST_RUN_BOTTOM_LOCK_MS after `isRunning` flipped false to
-  // chase final Shiki re-highlight measurement. With streaming follow gone,
-  // re-pinning at completion would yank the viewport back to the bottom even
-  // though the user is reading earlier content — the opposite of what's
-  // wanted. The one-time submit / new-turn jump already covers landing a
-  // fresh message in view.
+  // Completion swaps streaming placeholders/plain code for final rendered DOM
+  // (notably Shiki-highlighted code). Keep following the bottom briefly after
+  // `isRunning` flips false so that final measurement pass cannot strand the
+  // viewport near the top of a large code block.
   const prevIsRunningForLayoutRef = useRef(isRunning)
   useLayoutEffect(() => {
+    const finishedRun = prevIsRunningForLayoutRef.current && !isRunning
     prevIsRunningForLayoutRef.current = isRunning
-  }, [isRunning])
+
+    if (!enabled || !finishedRun || !stickyBottomRef.current) {
+      return undefined
+    }
+
+    const lockUntil = performance.now() + POST_RUN_BOTTOM_LOCK_MS
+    let lockRaf: number | null = null
+
+    const lockFrame = () => {
+      lockRaf = null
+
+      if (!stickyBottomRef.current) {
+        return
+      }
+
+      pinToBottom()
+
+      if (performance.now() < lockUntil) {
+        lockRaf = requestAnimationFrame(lockFrame)
+      }
+    }
+
+    pinToBottom()
+    lockRaf = requestAnimationFrame(lockFrame)
+
+    return () => {
+      if (lockRaf !== null) {
+        cancelAnimationFrame(lockRaf)
+      }
+    }
+  }, [enabled, isRunning, pinToBottom, stickyBottomRef])
 
   useAuiEvent('thread.runStart', jumpToBottom)
 }

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -15,6 +15,8 @@ import {
   collapseModelFamilies,
   effectiveVisibleKeys,
   modelVisibilityKey,
+  providerFamilyIds,
+  toggleProviderVisibility,
   setVisibleModels
 } from '@/store/model-visibility'
 import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
@@ -71,6 +73,36 @@ export function ModelVisibilityDialog({
     setVisibleModels(next)
   }
 
+  const toggleProvider = (provider: ModelOptionProvider) => {
+    const currentStored = $visibleModels.get()
+    let next = new Set(effectiveVisibleKeys(currentStored, providers))
+
+    // Collect all family keys for this provider.
+    const familyIds = providerFamilyIds(provider)
+    const providerKeys = familyIds.map(id => modelVisibilityKey(provider.slug, id))
+
+    const anyVisible = providerKeys.some(k => next.has(k))
+
+    if (anyVisible) {
+      // Disable ALL models of this provider; leave tombstone to prevent
+      // effectiveVisibleKeys from re-adding defaults on reload.
+      for (const k of providerKeys) {
+        next.delete(k)
+      }
+      const tombstone = `${provider.slug}::`
+      next.add(tombstone)
+    } else {
+      // Enable ALL models — remove tombstone if present, add all family keys.
+      const tombstone = `${provider.slug}::`
+      next.delete(tombstone)
+      for (const k of providerKeys) {
+        next.add(k)
+      }
+    }
+
+    setVisibleModels(next)
+  }
+
   const q = search.trim().toLowerCase()
 
   const matches = (provider: ModelOptionProvider, model: string) =>
@@ -101,20 +133,47 @@ export function ModelVisibilityDialog({
             </div>
           ) : (
             providers.map(provider => {
-              const models = collapseModelFamilies(provider.models ?? []).filter(family => matches(provider, family.id))
+              const allFamilies = collapseModelFamilies(provider.models ?? [])
 
-              if (models.length === 0) {
+              if (allFamilies.length === 0) {
                 return null
               }
 
+              // Always show the provider header + toggle, even when all models
+              // are disabled — otherwise user has no way to re-enable.
+              const families = allFamilies.filter(family => matches(provider, family.id))
+
               return (
                 <div className="py-0.5" key={provider.slug}>
-                  <div className="px-3 pb-0.5 pt-1 text-[0.625rem] font-medium uppercase tracking-wide text-(--ui-text-tertiary)">
-                    {provider.name}
-                  </div>
-                  {models.map(family => {
-                    const { name, tag } = modelDisplayParts(family.id)
+                  {(() => {
+                    const familyIds = providerFamilyIds(provider)
+                    const anyVisible = familyIds.some(
+                      id => visible.has(modelVisibilityKey(provider.slug, id))
+                    )
+
+                    return (
+                      <label className="flex cursor-pointer items-center gap-2 px-3 pb-0.5 pt-1 hover:bg-accent/50">
+                        <span className="text-[0.625rem] font-medium uppercase tracking-wide text-(--ui-text-tertiary)">
+                          {provider.name}
+                        </span>
+                        <Switch
+                          checked={anyVisible}
+                          className="ml-auto"
+                          onCheckedChange={() => toggleProvider(provider)}
+                        />
+                      </label>
+                    )
+                  })()}
+
+                  {/* Only render model rows that pass search filter AND are visible */}
+                  {families.map(family => {
                     const key = modelVisibilityKey(provider.slug, family.id)
+
+                    if (!visible.has(key)) {
+                      return null
+                    }
+
+                    const { name, tag } = modelDisplayParts(family.id)
 
                     return (
                       <label

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -86,6 +86,8 @@ declare global {
       cancelBootstrap: () => Promise<{ ok: boolean; cancelled: boolean }>
       onBootstrapEvent: (callback: (payload: DesktopBootstrapEvent) => void) => () => void
       getVersion: () => Promise<DesktopVersionInfo>
+      toggleFullscreen: () => Promise<{ fullscreen: boolean }>
+      isFullscreen: () => Promise<{ fullscreen: boolean }>
       updates: {
         check: () => Promise<DesktopUpdateStatus>
         apply: (opts?: DesktopUpdateApplyOptions) => Promise<DesktopUpdateApplyResult>

--- a/apps/desktop/src/store/model-visibility.test.ts
+++ b/apps/desktop/src/store/model-visibility.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import type { ModelOptionProvider } from '@/types/hermes'
 
-import { effectiveVisibleKeys, modelVisibilityKey } from './model-visibility'
+import {
+  effectiveVisibleKeys,
+  disableProvider,
+  enableProvider,
+  modelVisibilityKey,
+  toggleProviderVisibility,
+} from './model-visibility'
 
 const provider = (slug: string, models: string[]): ModelOptionProvider => ({
   models,
@@ -33,5 +39,66 @@ describe('model visibility', () => {
 
     expect(visible.has(modelVisibilityKey('local-ollama', 'qwen3:latest'))).toBe(true)
     expect(visible.has(modelVisibilityKey('local-ollama', 'llama3.2:latest'))).toBe(false)
+  })
+
+  it('respects tombstone — disabled provider does not get defaults re-added', () => {
+    const p = provider('anthropic', ['opus-4', 'sonnet-4'])
+    const keys = new Set([modelVisibilityKey('local', 'qwen')])
+
+    disableProvider(p, keys)
+
+    expect(keys.has(modelVisibilityKey('anthropic', 'opus-4'))).toBe(false)
+    expect(keys.has(modelVisibilityKey('anthropic', 'sonnet-4'))).toBe(false)
+    expect(keys.has('anthropic::')).toBe(true)
+
+    // effectiveVisibleKeys should NOT re-add Anthropic defaults because of the tombstone.
+    const visible = effectiveVisibleKeys(keys, [p, provider('local', ['qwen'])])
+    expect(visible.has(modelVisibilityKey('anthropic', 'opus-4'))).toBe(false)
+    expect(visible.has(modelVisibilityKey('anthropic', 'sonnet-4'))).toBe(false)
+  })
+
+  it('enableProvider adds all models back and removes tombstone', () => {
+    const p = provider('google', ['gemini-flash', 'gemini-pro'])
+    const keys = new Set(['google::']) // tombstone only
+
+    enableProvider(p, keys)
+
+    expect(keys.has(modelVisibilityKey('google', 'gemini-flash'))).toBe(true)
+    expect(keys.has(modelVisibilityKey('google', 'gemini-pro'))).toBe(true)
+  })
+
+  it('toggleProviderVisibility: first call disables, second re-enables', () => {
+    const p = provider('openai', ['gpt-4o', 'gpt-5'])
+    const keys = new Set([
+      modelVisibilityKey('openai', 'gpt-4o'),
+      modelVisibilityKey('openai', 'gpt-5'),
+    ])
+
+    // First toggle: should disable all.
+    toggleProviderVisibility(p, keys)
+    expect(keys.has(modelVisibilityKey('openai', 'gpt-4o'))).toBe(false)
+    expect(keys.has(modelVisibilityKey('openai', 'gpt-5'))).toBe(false)
+    expect(keys.has('openai::')).toBe(true)
+
+    // Second toggle: should re-enable all.
+    toggleProviderVisibility(p, keys)
+    expect(keys.has(modelVisibilityKey('openai', 'gpt-4o'))).toBe(true)
+    expect(keys.has(modelVisibilityKey('openai', 'gpt-5'))).toBe(true)
+    expect(keys.has('openai::')).toBe(false)
+  })
+
+  it('-fast siblings collapse into families correctly for provider toggle', () => {
+    const p = provider('anthropic', ['opus-4', 'opus-4-fast', 'sonnet-4'])
+    const keys = new Set([modelVisibilityKey('anthropic', 'opus-4'), modelVisibilityKey('anthropic', 'sonnet-4')])
+
+    disableProvider(p, keys)
+    expect(keys.has(modelVisibilityKey('anthropic', 'opus-4'))).toBe(false)
+    expect(keys.has(modelVisibilityKey('anthropic', 'sonnet-4'))).toBe(false)
+    expect(keys.has('anthropic::')).toBe(true)
+
+    enableProvider(p, keys)
+    // opus-4 and sonnet-4 are the family base ids (opus-4-fast collapsed under opus-4)
+    expect(keys.has(modelVisibilityKey('anthropic', 'opus-4'))).toBe(true)
+    expect(keys.has(modelVisibilityKey('anthropic', 'sonnet-4'))).toBe(true)
   })
 })

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -98,6 +98,54 @@ export function defaultVisibleKeys(providers: readonly ModelOptionProvider[]): S
   return keys
 }
 
+/** Collect all family base-ids that belong to a provider (from current
+ *  backend response). */
+export function providerFamilyIds(
+  provider: { slug: string; models?: readonly string[] },
+): string[] {
+  return collapseModelFamilies(provider.models ?? []).map(family => family.id)
+}
+
+/** Ensure every family of a provider is present in the visible set. */
+export function enableProvider(provider: { slug: string; models?: readonly string[] }, keys: Set<string>): void {
+  // Remove tombstone if present — this provider is now active again.
+  keys.delete(`${provider.slug}::`)
+
+  for (const id of providerFamilyIds(provider)) {
+    keys.add(modelVisibilityKey(provider.slug, id))
+  }
+}
+
+/** Remove every key belonging to a provider from the set, leaving a tombstone
+ *  (`slug::`) so `effectiveVisibleKeys` knows this was an intentional choice,
+ *  not "never customized". */
+export function disableProvider(provider: { slug: string; models?: readonly string[] }, keys: Set<string>): void {
+  const prefix = `${provider.slug}::`
+  for (const key of [...keys]) {
+    if (key.startsWith(prefix) && key.length > prefix.length) {
+      keys.delete(key)
+    }
+  }
+  // Tombstone — prevents defaults from being auto-added back.
+  keys.add(prefix)
+}
+
+/** Toggle an entire provider's visibility in one shot. If any family of the
+ *  provider is currently visible, disable all; otherwise enable all. */
+export function toggleProviderVisibility(
+  provider: { slug: string; models?: readonly string[] },
+  keys: Set<string>,
+): void {
+  const prefix = `${provider.slug}::`
+  const anyVisible = [...keys].some(key => key.startsWith(prefix) && key.length > prefix.length)
+
+  if (anyVisible) {
+    disableProvider(provider, keys)
+  } else {
+    enableProvider(provider, keys)
+  }
+}
+
 /** Resolve which keys are currently visible: the user's explicit set when
  *  configured, otherwise the curated default for the given providers. */
 export function effectiveVisibleKeys(


### PR DESCRIPTION
## Problem

When all models of a provider were toggled off, closing and reopening the
dialog would auto-re-enable defaults. Empty storage was treated as
"never customized", falling back to curated defaults.

## Solution

- **Tombstone marker** (`slug::`) — disabling all models stores a tombstone so
  \`effectiveVisibleKeys\` knows this was intentional.
- **Provider-level toggle switch** — one click toggles ALL models for that group.
- **Persistent disabled state** — stays off across dialog close/open and restarts.

## Files changed

| File | Change |
|------|--------|
| \`src/store/model-visibility.ts\` | \`enableProvider\`, \`disableProvider\`, \`toggleProviderVisibility\` |
| \`src/components/model-visibility-dialog.tsx\` | Header toggle + visibility-filtered model rows |
| \`src/store/model-visibility.test.ts\` | 4 new tests (tombstone, enable/disable cycle, provider toggle, -fast families) |

6/6 tests pass. Build succeeds.