### PR TITLE
fix(wecom): add media attachment support to send_message tool

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -2846,3 +2846,154 @@ class TestSendTelegramThreadNotFoundRetry:
         finally:
             if media_path and os.path.exists(media_path):
                 os.unlink(media_path)
+
+
+class TestSendWecomMedia:
+    """Tests for WeCom media attachment support in send_message_tool."""
+
+    @staticmethod
+    def _make_mock_adapter():
+        """Create a mock WeComAdapter with connect/send/disconnect/media."""
+        adapter = MagicMock()
+        adapter.connect = AsyncMock(return_value=True)
+        adapter.disconnect = AsyncMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="msg-123",
+        ))
+        adapter._send_media_source = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="media-456",
+        ))
+        adapter.fatal_error_message = None
+        return adapter
+
+    def test_send_wecom_with_media_files(self):
+        """_send_wecom sends media files then text message."""
+        import tempfile
+        adapter = self._make_mock_adapter()
+        media_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tf:
+                tf.write(b"\x89PNG test")
+                media_path = tf.name
+
+            async def run():
+                with patch("gateway.platforms.wecom.WeComAdapter", return_value=adapter), \
+                     patch("gateway.platforms.wecom.check_wecom_requirements", return_value=True):
+                    from tools.send_message_tool import _send_wecom
+                    return await _send_wecom(
+                        {"bot_id": "test", "secret": "test"},
+                        "chat-1",
+                        "hello",
+                        media_files=[(media_path, False)],
+                    )
+
+            result = asyncio.run(run())
+            assert result["success"] is True
+            # Media was sent
+            adapter._send_media_source.assert_called_once()
+            call_kwargs = adapter._send_media_source.call_args
+            assert call_kwargs.kwargs["chat_id"] == "chat-1"
+            assert call_kwargs.kwargs["media_source"] == media_path
+            # Text was sent after media
+            adapter.send.assert_called_once_with("chat-1", "hello")
+        finally:
+            if media_path and os.path.exists(media_path):
+                os.unlink(media_path)
+
+    def test_send_wecom_without_media(self):
+        """_send_wecom without media_files sends text only (backward compat)."""
+        adapter = self._make_mock_adapter()
+
+        async def run():
+            with patch("gateway.platforms.wecom.WeComAdapter", return_value=adapter), \
+                 patch("gateway.platforms.wecom.check_wecom_requirements", return_value=True):
+                from tools.send_message_tool import _send_wecom
+                return await _send_wecom({"bot_id": "t", "secret": "s"}, "chat-1", "hello")
+
+        result = asyncio.run(run())
+        assert result["success"] is True
+        adapter._send_media_source.assert_not_called()
+        adapter.send.assert_called_once_with("chat-1", "hello")
+
+    def test_send_wecom_media_only_no_text(self):
+        """_send_wecom with media but empty text skips text send."""
+        import tempfile
+        adapter = self._make_mock_adapter()
+        media_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tf:
+                tf.write(b"\xff\xd8\xff test")
+                media_path = tf.name
+
+            async def run():
+                with patch("gateway.platforms.wecom.WeComAdapter", return_value=adapter), \
+                     patch("gateway.platforms.wecom.check_wecom_requirements", return_value=True):
+                    from tools.send_message_tool import _send_wecom
+                    return await _send_wecom(
+                        {"bot_id": "t", "secret": "s"},
+                        "chat-1",
+                        "",
+                        media_files=[(media_path, False)],
+                    )
+
+            result = asyncio.run(run())
+            assert result["success"] is True
+            adapter._send_media_source.assert_called_once()
+            adapter.send.assert_not_called()  # empty text → skip
+        finally:
+            if media_path and os.path.exists(media_path):
+                os.unlink(media_path)
+
+    def test_send_wecom_media_file_not_found(self):
+        """_send_wecom skips missing media files gracefully."""
+        adapter = self._make_mock_adapter()
+
+        async def run():
+            with patch("gateway.platforms.wecom.WeComAdapter", return_value=adapter), \
+                 patch("gateway.platforms.wecom.check_wecom_requirements", return_value=True):
+                from tools.send_message_tool import _send_wecom
+                return await _send_wecom(
+                    {"bot_id": "t", "secret": "s"},
+                    "chat-1",
+                    "hello",
+                    media_files=[("/nonexistent/file.png", False)],
+                )
+
+        result = asyncio.run(run())
+        assert result["success"] is True
+        # Media send was skipped (file not found)
+        adapter._send_media_source.assert_not_called()
+        # Text still sent
+        adapter.send.assert_called_once_with("chat-1", "hello")
+
+    def test_send_to_platform_routes_wecom_media(self):
+        """_send_to_platform routes WeCom+media through the media branch."""
+        import tempfile
+        media_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tf:
+                tf.write(b"\x89PNG test")
+                media_path = tf.name
+
+            mock_send_fn = AsyncMock(return_value={"success": True, "platform": "wecom"})
+
+            async def run():
+                pconfig = SimpleNamespace(
+                    extra={"bot_id": "t", "secret": "s"},
+                    token=None, api_key=None,
+                )
+                with patch("tools.send_message_tool._send_wecom", mock_send_fn):
+                    return await _send_to_platform(
+                        Platform.WECOM, pconfig, "chat-1", "hello",
+                        media_files=[(media_path, False)],
+                    )
+
+            result = asyncio.run(run())
+            assert result["success"] is True
+            # _send_wecom was called with media_files
+            mock_send_fn.assert_called_once()
+            call_kwargs = mock_send_fn.call_args
+            assert call_kwargs.kwargs.get("media_files") == [(media_path, False)]
+        finally:
+            if media_path and os.path.exists(media_path):
+                os.unlink(media_path)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -763,11 +763,27 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- WeCom: native media attachment support via adapter ---
+    if platform == Platform.WECOM and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_wecom(
+                pconfig.extra,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else None,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, wecom and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -775,7 +791,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, wecom and feishu"
         )
 
     last_result = None
@@ -1519,8 +1535,13 @@ async def _send_dingtalk(extra, chat_id, message):
         return _error(f"DingTalk send failed: {e}")
 
 
-async def _send_wecom(extra, chat_id, message):
-    """Send via WeCom using the adapter's WebSocket send pipeline."""
+async def _send_wecom(extra, chat_id, message, media_files=None):
+    """Send via WeCom using the adapter's WebSocket send pipeline.
+
+    When *media_files* is provided, each file is uploaded and sent as a media
+    message via the adapter's ``_send_media_source`` pipeline before the text
+    message is delivered.
+    """
     try:
         from gateway.platforms.wecom import WeComAdapter, check_wecom_requirements
         if not check_wecom_requirements():
@@ -1536,10 +1557,26 @@ async def _send_wecom(extra, chat_id, message):
         if not connected:
             return _error(f"WeCom: failed to connect - {adapter.fatal_error_message or 'unknown error'}")
         try:
-            result = await adapter.send(chat_id, message)
-            if not result.success:
-                return _error(f"WeCom send failed: {result.error}")
-            return {"success": True, "platform": "wecom", "chat_id": chat_id, "message_id": result.message_id}
+            # Send media files first (if any)
+            if media_files:
+                for media_path, _is_voice in media_files:
+                    if not os.path.exists(media_path):
+                        logger.warning("WeCom media file not found, skipping: %s", media_path)
+                        continue
+                    media_result = await adapter._send_media_source(
+                        chat_id=chat_id,
+                        media_source=media_path,
+                    )
+                    if not media_result.success:
+                        logger.warning("WeCom media send failed for %s: %s", media_path, media_result.error)
+
+            # Send text message
+            if message.strip():
+                result = await adapter.send(chat_id, message)
+                if not result.success:
+                    return _error(f"WeCom send failed: {result.error}")
+                return {"success": True, "platform": "wecom", "chat_id": chat_id, "message_id": result.message_id}
+            return {"success": True, "platform": "wecom", "chat_id": chat_id}
         finally:
             await adapter.disconnect()
     except Exception as e:


### PR DESCRIPTION
## What does this PR do?

Adds native media attachment support to the WeCom `send_message` tool path. Previously, `MEDIA:<file_path>` directives targeting WeCom were silently dropped — only text was delivered.

## Related Issue

Fixes #37364

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_tool.py`: Added a WeCom media branch in `_send_to_platform()` before the "Non-media platforms" catch-all, routing media files through `adapter._send_media_source()`. Updated `_send_wecom()` to accept optional `media_files` parameter. Updated warning messages to include "wecom" in the supported platform list.
- `tests/tools/test_send_message_tool.py`: Added `TestSendWecomMedia` class with 5 tests covering media+text, text-only, media-only, missing-file, and routing integration.

## How to Test

1. Configure a WeCom bot with valid credentials
2. Run `pytest tests/tools/test_send_message_tool.py::TestSendWecomMedia -xvs` — all 5 tests should pass
3. Run `pytest tests/tools/test_send_message_tool.py -x` — all existing tests should still pass (138 total)
4. In a live session: use `send_message` with `target="wecom"` and a `MEDIA:/path/to/image.png` directive — the image should be uploaded and delivered before the text message

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/send_message_tool.py::_send_to_platform`, `tools/send_message_tool.py::_send_wecom`, `gateway/platforms/wecom.py::_send_media_source`
- Blast radius: LOW — single platform (WeCom) media path, no changes to existing text-only flow
- Related patterns: mirrors the existing Signal/Matrix/Yuanbao/Feishu media branch pattern
