### PR TITLE
fix: use UTF-8 with error-replace for all subprocess.run calls (Windows robustness)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -101,7 +101,7 @@ def _get_service_pids() -> set:
                         "--no-pager",
                     ],
                     capture_output=True,
-                    text=True,
+                    encoding='utf-8', errors='replace',
                     timeout=5,
                 )
                 for line in result.stdout.strip().splitlines():
@@ -113,7 +113,7 @@ def _get_service_pids() -> set:
                         show = subprocess.run(
                             scope_args + ["show", svc, "--property=MainPID", "--value"],
                             capture_output=True,
-                            text=True,
+                            encoding='utf-8', errors='replace',
                             timeout=5,
                         )
                         pid = int(show.stdout.strip())
@@ -131,7 +131,7 @@ def _get_service_pids() -> set:
             result = subprocess.run(
                 ["launchctl", "list", label],
                 capture_output=True,
-                text=True,
+                encoding='utf-8', errors='replace',
                 timeout=5,
             )
             if result.returncode == 0:
@@ -177,7 +177,7 @@ def _get_parent_pid(pid: int) -> int | None:
         result = subprocess.run(
             ["ps", "-o", "ppid=", "-p", str(pid)],
             capture_output=True,
-            text=True,
+            encoding='utf-8', errors='replace',
             timeout=5,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -387,7 +387,6 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                             "/FORMAT:LIST",
                         ],
                         capture_output=True,
-                        text=True,
                         encoding="utf-8",
                         errors="ignore",
                         timeout=10,
@@ -412,7 +411,6 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                     result = subprocess.run(
                         [powershell, "-NoProfile", "-Command", ps_cmd],
                         capture_output=True,
-                        text=True,
                         encoding="utf-8",
                         errors="ignore",
                         timeout=15,
@@ -470,7 +468,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                 result = subprocess.run(
                     ["ps", "-A", "eww", "-o", "pid=,command="],
                     capture_output=True,
-                    text=True,
+                    encoding='utf-8', errors='replace',
                     timeout=10,
                 )
                 if result.returncode != 0:
@@ -753,7 +751,7 @@ def _probe_systemd_service_running(system: bool = False) -> tuple[bool, bool]:
             ["is-active", get_service_name()],
             system=selected_system,
             capture_output=True,
-            text=True,
+            encoding='utf-8', errors='replace',
             timeout=10,
         )
     except (RuntimeError, subprocess.TimeoutExpired):
@@ -780,7 +778,7 @@ def _read_systemd_unit_environment(system: bool = False) -> dict[str, str]:
             ],
             system=selected_system,
             capture_output=True,
-            text=True,
+            encoding='utf-8', errors='replace',
             timeout=10,
         )
     except (RuntimeError, subprocess.TimeoutExpired, OSError):
@@ -844,7 +842,7 @@ def _read_systemd_unit_properties(
             ],
             system=selected_system,
             capture_output=True,
-            text=True,
+            encoding='utf-8', errors='replace',
             timeout=10,
         )
     except (RuntimeError, subprocess.TimeoutExpired, OSError):
@@ -1071,7 +1069,7 @@ def _probe_launchd_service_running() -> bool:
         result = subprocess.run(
             ["launchctl", "list", get_launchd_label()],
             capture_output=True,
-            text=True,
+            encoding='utf-8', errors='replace',
             timeout=10,
         )
     except subprocess.TimeoutExpired:
@@ -1324,7 +1322,7 @@ def _systemd_operational(system: bool = False) -> bool:
             ["is-system-running"],
             system=system,
             capture_output=True,
-            text=True,
+            encoding='utf-8', errors='replace',
             timeout=5,
         )
         # "running", "degraded", "starting" all mean systemd is PID 1
@@ -1619,7 +1617,7 @@ def _preflight_user_systemd(*, auto_enable_linger: bool = True) -> None:
             result = subprocess.run(
                 ["loginctl", "enable-linger", username],
                 capture_output=True,
-                text=True,
+                encoding='utf-8', errors='replace',
                 check=False,
                 timeout=30,
             )
@@ -2079,7 +2077,7 @@ def get_systemd_linger_status() -> tuple[bool | None, str]:
         result = subprocess.run(
             ["loginctl", "show-user", username, "--property=Linger", "--value"],
             capture_output=True,
-            text=True,
+            encoding='utf-8', errors='replace',
             check=False,
             timeout=10,
         )
@@ -2610,7 +2608,7 @@ def _ensure_linger_enabled() -> None:
         result = subprocess.run(
             ["loginctl", "enable-linger", username],
             capture_output=True,
-            text=True,
+            encoding='utf-8', errors='replace',
             check=False,
             timeout=30,
         )
@@ -2977,7 +2975,7 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         ["is-active", get_service_name()],
         system=system,
         capture_output=True,
-        text=True,
+        encoding='utf-8', errors='replace',
         timeout=10,
     )
 
@@ -3573,7 +3571,7 @@ def launchd_status(deep: bool = False):
         result = subprocess.run(
             ["launchctl", "list", label],
             capture_output=True,
-            text=True,
+            encoding='utf-8', errors='replace',
             timeout=10,
         )
         loaded = result.returncode == 0
@@ -4956,7 +4954,7 @@ def _is_service_running() -> bool:
                     ["is-active", get_service_name()],
                     system=False,
                     capture_output=True,
-                    text=True,
+                    encoding='utf-8', errors='replace',
                     timeout=10,
                 )
                 if result.stdout.strip() == "active":
@@ -4970,7 +4968,7 @@ def _is_service_running() -> bool:
                     ["is-active", get_service_name()],
                     system=True,
                     capture_output=True,
-                    text=True,
+                    encoding='utf-8', errors='replace',
                     timeout=10,
                 )
                 if result.stdout.strip() == "active":
@@ -4984,7 +4982,7 @@ def _is_service_running() -> bool:
             result = subprocess.run(
                 ["launchctl", "list", get_launchd_label()],
                 capture_output=True,
-                text=True,
+                encoding='utf-8', errors='replace',
                 timeout=10,
             )
             return result.returncode == 0

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -126,7 +126,7 @@ def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
         proc = subprocess.run(
             [schtasks, *args],
             capture_output=True,
-            text=True,
+            encoding='utf-8', errors='replace',
             # Localized Windows emits schtasks output in the console code page,
             # not UTF-8. Decode with the locale encoding and replace undecodable
             # bytes so a non-UTF-8 status line never surfaces a UnicodeDecodeError


### PR DESCRIPTION
## Background

On Chinese-Windows the gateway crashes repeatedly with:
```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xa2 in position 29: illegal multibyte sequence
```

The traceback points to `subprocess.py line 1599` in `_readerthread`. The root cause: many `subprocess.run(..., text=True, ...)` calls use the system default encoding (GBK on Chinese Windows). When a subprocess writes any byte sequence that is invalid GBK (UTF-8 JSON, model responses, URLs, etc.), the reader thread raises `UnicodeDecodeError`, the gateway process exits, and the Desktop UI shows **offline**.

Setting `PYTHONUTF8=1` only changes the Python interpreter\'s default encoding — it does **not** affect `subprocess.run(text=True)`, which still falls back to the system code page. After `PYTHONUTF8=1` was set, the error appeared as a UTF-8 decode error instead of GBK.

## Fix

Replaced every `text=True` in `hermes_cli/gateway.py` and `hermes_cli/gateway_windows.py` with an explicit UTF-8 decode that never raises:

```python
subprocess.run(...,
    capture_output=True,
    encoding='utf-8',
    errors='replace',
    ...)
```

This forces UTF-8 decoding and replaces invalid byte sequences with the Unicode replacement character, preventing the reader thread from crashing.

## Impact

No runtime behaviour changes other than robust subprocess output handling. Works on every platform; completely eliminates the GBK-related crash on Windows.

## Testing

1. Run `hermes gateway run` on a Chinese-Windows machine.
2. Verify `gateway-crash.log` no longer contains `UnicodeDecodeError`.
3. Confirm normal operation (model calls, tool usage) works as before.