### PR TITLE
feat(memory): Add Hindsight historical session import command

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -130,6 +130,37 @@ Available in `hybrid` and `tools` memory modes:
 | `hindsight_recall` | Multi-strategy search (semantic + entity graph) |
 | `hindsight_reflect` | Cross-memory synthesis (LLM-powered) |
 
+## Import historical Hermes sessions
+
+The Hindsight plugin captures Hermes sessions live once it is enabled. To
+backfill sessions that already existed in `~/.hermes/state.db`, run:
+
+```bash
+hermes hindsight import-sessions --dry-run
+hermes hindsight import-sessions --skip-existing --yes
+```
+
+The `hermes hindsight` command is only registered while `memory.provider` is
+set to `hindsight`. The import targets the same bank as live retention: a
+configured `bank_id_template` is resolved with the active profile, and
+templates containing per-session placeholders (`{platform}`, `{user}`,
+`{session}`) require an explicit `--bank-id`. Local embedded mode starts the
+Hindsight daemon on demand; you do not need to keep `127.0.0.1:9177` running
+manually.
+
+Each historical document uses the Hermes `session_id` as its Hindsight
+`document_id` (live retention appends a start timestamp to its document IDs,
+so backfilled and live documents never collide) and is tagged with
+`session:<session_id>` plus `hermes-backfill`. Use `--doc-id-prefix` to
+namespace backfilled documents for later bulk cleanup. `--skip-existing`
+makes reruns safe: it skips documents whose IDs already exist, and fails with
+a clear error if the client cannot list documents.
+
+Sessions captured live since Hindsight was enabled are not detected by
+`--skip-existing` (live documents use different IDs), so a backfill stores
+their content a second time. Pass `--until <date you enabled Hindsight>` to
+avoid duplicating them.
+
 ## Environment Variables
 
 | Variable | Description |

--- a/plugins/memory/hindsight/cli.py
+++ b/plugins/memory/hindsight/cli.py
@@ -1,0 +1,104 @@
+"""CLI commands for the Hindsight memory plugin.
+
+Discovered by ``plugins.memory.discover_plugin_cli_commands()`` when
+``memory.provider`` is ``hindsight`` and registered as the top-level
+``hermes hindsight`` command.  Keep module-level imports stdlib-only —
+this file is imported during argparse setup, before any provider SDK
+is needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+
+
+def _iso_date(value: str) -> str:
+    """argparse ``type=`` validator for YYYY-MM-DD flags."""
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected YYYY-MM-DD, got {value!r}") from exc
+    return value
+
+
+def _non_negative_int(value: str) -> int:
+    """argparse ``type=`` validator rejecting negatives."""
+    try:
+        number = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}") from exc
+    if number < 0:
+        raise argparse.ArgumentTypeError(f"expected a non-negative integer, got {value!r}")
+    return number
+
+
+def register_cli(subparser) -> None:
+    """Build the ``hermes hindsight`` argparse subcommand tree.
+
+    Called by the plugin CLI registration system during argparse setup.
+    The *subparser* is the parser for ``hermes hindsight``.
+    """
+    subs = subparser.add_subparsers(dest="hindsight_command")
+    parser = subs.add_parser(
+        "import-sessions",
+        help="Backfill historical Hermes sessions from state.db into Hindsight",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Show import candidates without calling Hindsight",
+    )
+    parser.add_argument(
+        "--yes", "-y", action="store_true",
+        help="Skip confirmation prompt",
+    )
+    parser.add_argument(
+        "--skip-existing", action="store_true",
+        help="Skip Hindsight documents whose IDs already exist; recommended for reruns",
+    )
+    parser.add_argument(
+        "--bank-id", default=None,
+        help="Target Hindsight bank (overrides config bank_id/bank_id_template)",
+    )
+    parser.add_argument(
+        "--since", type=_iso_date,
+        help="Only import sessions on or after YYYY-MM-DD",
+    )
+    parser.add_argument(
+        "--until", type=_iso_date,
+        help="Only import sessions on or before YYYY-MM-DD",
+    )
+    parser.add_argument(
+        "--days", type=_non_negative_int,
+        help="Only import sessions from the last N days",
+    )
+    parser.add_argument(
+        "--limit", type=_non_negative_int,
+        help="Limit number of sessions considered",
+    )
+    parser.add_argument(
+        "--retain-timeout", type=_non_negative_int, default=600,
+        help="Per-session retain timeout in seconds (default: 600)",
+    )
+    parser.add_argument(
+        "--doc-id-prefix", default="",
+        help="Prefix to add before each session_id document_id",
+    )
+    parser.add_argument(
+        "--extra-tags", default="hermes-backfill",
+        help="Comma-separated tags to add (default: hermes-backfill)",
+    )
+
+
+def hindsight_command(args: argparse.Namespace) -> None:
+    """Route hindsight subcommands."""
+    sub = getattr(args, "hindsight_command", None)
+    if sub == "import-sessions":
+        from plugins.memory.hindsight.import_sessions import (
+            handle_import_sessions_command,
+        )
+
+        handle_import_sessions_command(args)
+        return
+    print("  Usage: hermes hindsight import-sessions [options]")
+    print("  Available: import-sessions")

--- a/plugins/memory/hindsight/import_sessions.py
+++ b/plugins/memory/hindsight/import_sessions.py
@@ -1,0 +1,526 @@
+"""Historical Hermes session import for the Hindsight memory provider."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+from hermes_constants import get_hermes_home
+
+from . import (
+    _DEFAULT_API_URL,
+    _DEFAULT_IDLE_TIMEOUT,
+    _DEFAULT_LOCAL_URL,
+    _DEFAULT_TIMEOUT,
+    _check_local_runtime,
+    _embedded_profile_name,
+    _load_config,
+    _normalize_retain_tags,
+    _parse_int_setting,
+    _resolve_bank_id_template,
+    _run_sync,
+)
+
+
+_CONTEXT_COMPACTION_RE = re.compile(
+    r"^\s*\[CONTEXT COMPACTION[^\]]*\].*?(?:\n\s*\n|\Z)",
+    re.IGNORECASE | re.DOTALL | re.MULTILINE,
+)
+_SYSTEM_NOTE_RE = re.compile(r"^\s*\[SYSTEM:[^\]]*\]\s*$", re.IGNORECASE | re.MULTILINE)
+_MIN_TRANSCRIPT_CHARS = 20
+_SOURCE = "hermes-backfill"
+# Placeholders that vary per session and therefore cannot be resolved for a
+# whole-history backfill; live retention fills them per gateway session.
+_PER_SESSION_PLACEHOLDERS = ("{platform}", "{user}", "{session}")
+_LIST_DOCUMENTS_PAGE_SIZE = 500
+
+
+class ImportSessionsError(RuntimeError):
+    """User-facing import failure with a clean CLI message."""
+
+
+@dataclass(frozen=True)
+class ImportOptions:
+    dry_run: bool = False
+    yes: bool = False
+    skip_existing: bool = False
+    since: str | None = None
+    until: str | None = None
+    days: int | None = None
+    limit: int | None = None
+    retain_timeout: int = 600
+    doc_id_prefix: str = ""
+    extra_tags: str = "hermes-backfill"
+    bank_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SessionCandidate:
+    session_id: str
+    title: str
+    started_at: float
+    transcript: str
+    turn_count: int
+
+    @property
+    def iso_date(self) -> str:
+        return datetime.fromtimestamp(self.started_at, timezone.utc).isoformat()
+
+
+@dataclass
+class ImportSummary:
+    candidates: int = 0
+    imported: int = 0
+    skipped_short: int = 0
+    skipped_existing: int = 0
+    failed: int = 0
+    bank_id: str = ""
+    failed_session_ids: list[str] | None = None
+    sample_session_ids: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        self.failed_session_ids = self.failed_session_ids or []
+        self.sample_session_ids = self.sample_session_ids or []
+
+
+class HindsightImportClient:
+    """Small sync wrapper around the async Hindsight client methods."""
+
+    def __init__(self, config: dict[str, Any], *, timeout: int) -> None:
+        self.config = config
+        self.timeout = timeout
+        self.mode = config.get("mode", "cloud")
+        if self.mode == "local":
+            self.mode = "local_embedded"
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        if self.mode == "local_embedded":
+            available, reason = _check_local_runtime()
+            if not available:
+                raise RuntimeError(
+                    "Hindsight local runtime is unavailable"
+                    + (f": {reason}" if reason else "")
+                )
+            from hindsight import HindsightEmbedded
+
+            # Mirrors the provider's workaround for HindsightEmbedded.__del__
+            # tearing down the daemon mid-process.
+            HindsightEmbedded.__del__ = lambda self: None
+            llm_provider = self.config.get("llm_provider", "")
+            if llm_provider in {"openai_compatible", "openrouter"}:
+                llm_provider = "openai"
+            kwargs = {
+                "profile": _embedded_profile_name(self.config),
+                "llm_provider": llm_provider,
+                "llm_api_key": (
+                    self.config.get("llmApiKey")
+                    or self.config.get("llm_api_key")
+                    or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
+                ),
+                "llm_model": self.config.get("llm_model", ""),
+                "idle_timeout": _parse_int_setting(
+                    self.config.get("idle_timeout")
+                    if self.config.get("idle_timeout") is not None
+                    else os.environ.get("HINDSIGHT_IDLE_TIMEOUT"),
+                    _DEFAULT_IDLE_TIMEOUT,
+                ),
+            }
+            llm_base_url = self.config.get("llm_base_url", "")
+            if llm_base_url:
+                kwargs["llm_base_url"] = llm_base_url
+            self._client = HindsightEmbedded(**kwargs)
+            return self._client
+
+        from hindsight_client import Hindsight
+
+        default_url = _DEFAULT_LOCAL_URL if self.mode == "local_external" else _DEFAULT_API_URL
+        api_url = self.config.get("api_url") or os.environ.get("HINDSIGHT_API_URL", default_url)
+        api_key = (
+            self.config.get("apiKey")
+            or self.config.get("api_key")
+            or os.environ.get("HINDSIGHT_API_KEY", "")
+        )
+        kwargs: dict[str, Any] = {"base_url": api_url, "timeout": float(self.timeout or _DEFAULT_TIMEOUT)}
+        if api_key:
+            kwargs["api_key"] = api_key
+        self._client = Hindsight(**kwargs)
+        return self._client
+
+    def retain(self, *, bank_id: str, item: dict[str, Any], document_id: str) -> Any:
+        # Same call shape as live retention (one document per call, top-level
+        # document_id) so it works across all supported client versions.
+        client = self._get_client()
+        return _run_sync(
+            client.aretain_batch(
+                bank_id=bank_id,
+                items=[item],
+                document_id=document_id,
+                retain_async=False,
+            ),
+            timeout=self.timeout,
+        )
+
+    def list_document_ids(self, *, bank_id: str, doc_id_prefix: str = "") -> set[str]:
+        client = self._get_client()
+        documents_api = getattr(client, "documents", None)
+        list_documents = getattr(documents_api, "list_documents", None)
+        if not callable(list_documents):
+            raise ImportSessionsError(
+                "This Hindsight client cannot enumerate existing documents; "
+                "rerun without --skip-existing or upgrade hindsight-client."
+            )
+        ids: set[str] = set()
+        offset = 0
+        while True:
+            response = _run_sync(
+                list_documents(
+                    bank_id,
+                    q=doc_id_prefix or None,
+                    limit=_LIST_DOCUMENTS_PAGE_SIZE,
+                    offset=offset,
+                ),
+                timeout=self.timeout,
+            )
+            items = getattr(response, "items", None)
+            if items is None and isinstance(response, dict):
+                items = response.get("items")
+            items = items or []
+            for item in items:
+                doc_id = item.get("id") if isinstance(item, dict) else getattr(item, "id", None)
+                if doc_id:
+                    ids.add(str(doc_id))
+            if len(items) < _LIST_DOCUMENTS_PAGE_SIZE:
+                return ids
+            offset += _LIST_DOCUMENTS_PAGE_SIZE
+
+    def close(self) -> None:
+        client = self._client
+        if client is None:
+            return
+        close = getattr(client, "aclose", None)
+        if close is not None:
+            _run_sync(close(), timeout=10)
+
+
+def resolve_bank_id(config: dict[str, Any], *, override: str | None = None) -> str:
+    """Resolve the target bank the same way live retention does.
+
+    ``override`` (the --bank-id flag) wins.  Otherwise a configured
+    ``bank_id_template`` is resolved with the same profile/workspace values
+    the provider uses; templates with per-session placeholders cannot be
+    resolved for a backfill and require an explicit --bank-id.
+    """
+    if override:
+        return override
+    banks = config.get("banks") if isinstance(config.get("banks"), dict) else {}
+    hermes_bank = banks.get("hermes") if isinstance(banks.get("hermes"), dict) else {}
+    static_bank_id = str(config.get("bank_id") or hermes_bank.get("bankId") or "hermes")
+    template = str(config.get("bank_id_template") or "")
+    if not template:
+        return static_bank_id
+    used = [p for p in _PER_SESSION_PLACEHOLDERS if p in template]
+    if used:
+        raise ImportSessionsError(
+            f"bank_id_template {template!r} uses per-session placeholders "
+            f"({', '.join(used)}) that cannot be resolved for a historical "
+            "import; pass --bank-id explicitly."
+        )
+    from hermes_cli.profiles import get_active_profile_name
+
+    return _resolve_bank_id_template(
+        template,
+        fallback=static_bank_id,
+        profile=get_active_profile_name(),
+        workspace="hermes",
+        platform="",
+        user="",
+        session="",
+    )
+
+
+def _date_bounds(options: ImportOptions) -> tuple[float | None, float | None]:
+    since_ts = _parse_date(options.since, end_of_day=False) if options.since else None
+    until_ts = _parse_date(options.until, end_of_day=True) if options.until else None
+    if options.days is not None:
+        days_since = (datetime.now(timezone.utc) - timedelta(days=options.days)).timestamp()
+        since_ts = max(since_ts, days_since) if since_ts is not None else days_since
+    return since_ts, until_ts
+
+
+def _parse_date(value: str, *, end_of_day: bool) -> float:
+    try:
+        dt = datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise ImportSessionsError(f"Invalid date {value!r}; expected YYYY-MM-DD") from exc
+    if end_of_day:
+        dt = dt + timedelta(days=1) - timedelta(microseconds=1)
+    return dt.timestamp()
+
+
+def load_sessions(
+    db_path: Path,
+    *,
+    config: dict[str, Any],
+    options: ImportOptions,
+) -> tuple[list[SessionCandidate], int]:
+    since_ts, until_ts = _date_bounds(options)
+    clauses = ["COALESCE(archived, 0) = 0"]
+    params: list[Any] = []
+    if since_ts is not None:
+        clauses.append("started_at >= ?")
+        params.append(since_ts)
+    if until_ts is not None:
+        clauses.append("started_at <= ?")
+        params.append(until_ts)
+    order_limit = ""
+    if options.limit is not None:
+        order_limit = " LIMIT ?"
+        params.append(options.limit)
+    sql = (
+        "SELECT id, title, started_at FROM sessions "
+        f"WHERE {' AND '.join(clauses)} ORDER BY started_at ASC{order_limit}"
+    )
+    candidates: list[SessionCandidate] = []
+    skipped_short = 0
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(sql, params).fetchall()
+        for row in rows:
+            messages = conn.execute(
+                "SELECT role, content FROM messages "
+                "WHERE session_id = ? AND COALESCE(active, 1) = 1 "
+                "AND role IN ('user', 'assistant', 'system') "
+                "ORDER BY timestamp ASC, id ASC",
+                (row["id"],),
+            ).fetchall()
+            transcript, turn_count = build_transcript(messages, config=config)
+            if len(transcript) < _MIN_TRANSCRIPT_CHARS:
+                skipped_short += 1
+                continue
+            candidates.append(
+                SessionCandidate(
+                    session_id=str(row["id"]),
+                    title=str(row["title"] or ""),
+                    started_at=float(row["started_at"]),
+                    transcript=transcript,
+                    turn_count=turn_count,
+                )
+            )
+    return candidates, skipped_short
+
+
+def build_transcript(messages: Sequence[Any], *, config: dict[str, Any]) -> tuple[str, int]:
+    prefixes = {
+        "user": str(config.get("retain_user_prefix") or "User").strip() or "User",
+        "assistant": str(config.get("retain_assistant_prefix") or "Assistant").strip() or "Assistant",
+        "system": "System",
+    }
+    lines: list[str] = []
+    turn_count = 0
+    for msg in messages:
+        role = str(_row_get(msg, "role") or "").lower()
+        if role not in prefixes:
+            continue
+        content = _clean_content(_row_get(msg, "content") or "")
+        if not content:
+            continue
+        if role == "user":
+            turn_count += 1
+        lines.append(f"{prefixes[role]}: {content}")
+    return "\n\n".join(lines).strip(), turn_count
+
+
+def _row_get(row: Any, key: str) -> Any:
+    if isinstance(row, dict):
+        return row.get(key)
+    try:
+        return row[key]
+    except Exception:
+        return getattr(row, key, None)
+
+
+def _clean_content(value: Any) -> str:
+    if not isinstance(value, str):
+        value = json.dumps(value, ensure_ascii=False) if value is not None else ""
+    text = _CONTEXT_COMPACTION_RE.sub("", value)
+    text = _SYSTEM_NOTE_RE.sub("", text)
+    text = re.sub(r"[ \t\r\f\v]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def build_retain_item(
+    session: SessionCandidate,
+    *,
+    options: ImportOptions,
+) -> dict[str, Any]:
+    document_id = f"{options.doc_id_prefix}{session.session_id}"
+    tags = [f"session:{session.session_id}", *_normalize_retain_tags(options.extra_tags)]
+    return {
+        "content": session.transcript,
+        "document_id": document_id,
+        "update_mode": "replace",
+        "tags": tags,
+        # Date the memory at the original session time, not import time.
+        "timestamp": session.iso_date,
+        "context": f"historical Hermes session | {session.title} | {session.iso_date}",
+        # Hindsight metadata values must be strings.
+        "metadata": {
+            "session_id": session.session_id,
+            "title": session.title,
+            "session_date": session.iso_date,
+            "turn_count": str(session.turn_count),
+            "source": _SOURCE,
+            "imported_via": "hermes hindsight import-sessions",
+        },
+    }
+
+
+def run_import(
+    options: ImportOptions,
+    *,
+    hermes_home: Path | None = None,
+    client: HindsightImportClient | None = None,
+    config: dict[str, Any] | None = None,
+) -> ImportSummary:
+    home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
+    db_path = home / "state.db"
+    if not db_path.exists():
+        raise ImportSessionsError(f"No Hermes state database found at {db_path}")
+    config = config if config is not None else _load_config()
+    bank_id = resolve_bank_id(config, override=options.bank_id)
+    candidates, skipped_short = load_sessions(db_path, config=config, options=options)
+    summary = ImportSummary(
+        candidates=len(candidates),
+        skipped_short=skipped_short,
+        bank_id=bank_id,
+        sample_session_ids=[s.session_id for s in candidates[:5]],
+    )
+    if options.dry_run or not candidates:
+        return summary
+    owned_client = client is None
+    client = client or HindsightImportClient(config, timeout=options.retain_timeout)
+    try:
+        existing_ids: set[str] = set()
+        if options.skip_existing:
+            existing_ids = client.list_document_ids(
+                bank_id=bank_id, doc_id_prefix=options.doc_id_prefix
+            )
+        sessions = []
+        for session in candidates:
+            document_id = f"{options.doc_id_prefix}{session.session_id}"
+            if document_id in existing_ids:
+                summary.skipped_existing += 1
+                continue
+            sessions.append(session)
+        for index, session in enumerate(sessions, start=1):
+            item = build_retain_item(session, options=options)
+            try:
+                _retry(
+                    lambda: client.retain(
+                        bank_id=bank_id, item=item, document_id=item["document_id"]
+                    )
+                )
+            except Exception:
+                summary.failed += 1
+                summary.failed_session_ids.append(session.session_id)
+            else:
+                summary.imported += 1
+            if index % 10 == 0 or index == len(sessions):
+                print(f"  retained {index}/{len(sessions)} sessions ({summary.failed} failed)")
+    finally:
+        if owned_client and client is not None:
+            client.close()
+    return summary
+
+
+def _retry(fn, *, attempts: int = 3) -> Any:
+    last_exc: Exception | None = None
+    for attempt in range(attempts):
+        try:
+            return fn()
+        except Exception as exc:
+            last_exc = exc
+            if attempt < attempts - 1:
+                time.sleep(0.25 * (2**attempt))
+    assert last_exc is not None
+    raise last_exc
+
+
+def handle_import_sessions_command(args: argparse.Namespace) -> None:
+    options = ImportOptions(
+        dry_run=bool(getattr(args, "dry_run", False)),
+        yes=bool(getattr(args, "yes", False)),
+        skip_existing=bool(getattr(args, "skip_existing", False)),
+        since=getattr(args, "since", None),
+        until=getattr(args, "until", None),
+        days=getattr(args, "days", None),
+        limit=getattr(args, "limit", None),
+        retain_timeout=getattr(args, "retain_timeout", 600),
+        doc_id_prefix=getattr(args, "doc_id_prefix", ""),
+        extra_tags=getattr(args, "extra_tags", "hermes-backfill"),
+        bank_id=getattr(args, "bank_id", None),
+    )
+    try:
+        config = _load_config()
+        bank_id = resolve_bank_id(config, override=options.bank_id)
+        if not options.dry_run and not options.yes:
+            try:
+                answer = input(
+                    "This will import historical Hermes sessions into Hindsight "
+                    f"bank {bank_id!r}. Type 'yes' to confirm: "
+                ).strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print("\nCancelled (no confirmation input; pass --yes for non-interactive use).")
+                sys.exit(1)
+            if answer != "yes":
+                print("Cancelled.")
+                return
+        summary = run_import(options, config=config)
+    except ImportSessionsError as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+    _print_summary(summary, dry_run=options.dry_run)
+
+
+def _print_summary(summary: ImportSummary, *, dry_run: bool) -> None:
+    action = "Dry run" if dry_run else "Import"
+    print(f"\n{action} complete:")
+    print(f"  bank: {summary.bank_id}")
+    print(f"  candidates: {summary.candidates}")
+    print(f"  imported: {summary.imported}")
+    print(f"  skipped short: {summary.skipped_short}")
+    print(f"  skipped existing: {summary.skipped_existing}")
+    print(f"  failed: {summary.failed}")
+    if summary.sample_session_ids:
+        print("  sample sessions: " + ", ".join(summary.sample_session_ids))
+    if summary.failed_session_ids:
+        print("  failed sessions: " + ", ".join(summary.failed_session_ids))
+    print()
+
+
+__all__ = [
+    "HindsightImportClient",
+    "ImportOptions",
+    "ImportSessionsError",
+    "ImportSummary",
+    "SessionCandidate",
+    "build_retain_item",
+    "build_transcript",
+    "handle_import_sessions_command",
+    "load_sessions",
+    "resolve_bank_id",
+    "run_import",
+]

--- a/plugins/memory/hindsight/import_sessions.py
+++ b/plugins/memory/hindsight/import_sessions.py
@@ -276,7 +276,7 @@ def load_sessions(
     options: ImportOptions,
 ) -> tuple[list[SessionCandidate], int]:
     since_ts, until_ts = _date_bounds(options)
-    clauses = ["COALESCE(archived, 0) = 0"]
+    clauses = ["COALESCE(archived, 0) = 0", "ended_at IS NOT NULL"]
     params: list[Any] = []
     if since_ts is not None:
         clauses.append("started_at >= ?")

--- a/tests/plugins/memory/test_hindsight_cli.py
+++ b/tests/plugins/memory/test_hindsight_cli.py
@@ -1,0 +1,103 @@
+"""Tests for the hindsight plugin CLI registration (hermes hindsight ...)."""
+
+import argparse
+
+import pytest
+
+from plugins.memory.hindsight import cli as hindsight_cli
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    hindsight_parser = subparsers.add_parser("hindsight")
+    hindsight_cli.register_cli(hindsight_parser)
+    return parser
+
+
+def test_parses_import_sessions_flags():
+    parser = _build_parser()
+    args = parser.parse_args(
+        [
+            "hindsight", "import-sessions",
+            "--dry-run", "--skip-existing", "-y",
+            "--since", "2026-01-01", "--until", "2026-02-01",
+            "--days", "30", "--limit", "10", "--retain-timeout", "120",
+            "--doc-id-prefix", "hist-", "--extra-tags", "a,b",
+            "--bank-id", "bank",
+        ]
+    )
+
+    assert args.hindsight_command == "import-sessions"
+    assert args.dry_run and args.skip_existing and args.yes
+    assert args.since == "2026-01-01"
+    assert args.until == "2026-02-01"
+    assert args.days == 30
+    assert args.limit == 10
+    assert args.retain_timeout == 120
+    assert args.doc_id_prefix == "hist-"
+    assert args.extra_tags == "a,b"
+    assert args.bank_id == "bank"
+
+
+def test_defaults():
+    args = _build_parser().parse_args(["hindsight", "import-sessions"])
+
+    assert not args.dry_run and not args.yes and not args.skip_existing
+    assert args.since is None and args.until is None
+    assert args.days is None and args.limit is None
+    assert args.retain_timeout == 600
+    assert args.doc_id_prefix == ""
+    assert args.extra_tags == "hermes-backfill"
+    assert args.bank_id is None
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["hindsight", "import-sessions", "--since", "01-01-2026"],
+        ["hindsight", "import-sessions", "--until", "not-a-date"],
+        ["hindsight", "import-sessions", "--days", "-3"],
+        ["hindsight", "import-sessions", "--limit", "ten"],
+    ],
+)
+def test_invalid_values_exit_with_usage_error(argv, capsys):
+    parser = _build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(argv)
+    assert exc.value.code == 2
+    capsys.readouterr()  # swallow argparse usage output
+
+
+def test_dispatch_routes_to_import_sessions_handler(monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        "plugins.memory.hindsight.import_sessions.handle_import_sessions_command",
+        lambda args: called.setdefault("args", args),
+    )
+
+    args = argparse.Namespace(hindsight_command="import-sessions")
+    hindsight_cli.hindsight_command(args)
+
+    assert called["args"] is args
+
+
+def test_no_subcommand_prints_usage(capsys):
+    hindsight_cli.hindsight_command(argparse.Namespace(hindsight_command=None))
+
+    out = capsys.readouterr().out
+    assert "import-sessions" in out
+
+
+def test_discovery_registers_hindsight_cli(monkeypatch):
+    """discover_plugin_cli_commands() picks up the real cli.py when hindsight is active."""
+    import plugins.memory as pm
+
+    monkeypatch.setattr(pm, "_get_active_memory_provider", lambda: "hindsight")
+
+    cmds = pm.discover_plugin_cli_commands()
+
+    assert len(cmds) == 1
+    assert cmds[0]["name"] == "hindsight"
+    assert callable(cmds[0]["setup_fn"])
+    assert cmds[0]["handler_fn"].__name__ == "hindsight_command"

--- a/tests/plugins/memory/test_hindsight_import_sessions.py
+++ b/tests/plugins/memory/test_hindsight_import_sessions.py
@@ -1,0 +1,415 @@
+import argparse
+import asyncio
+import json
+import sqlite3
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from plugins.memory.hindsight import import_sessions as importer
+from plugins.memory.hindsight.import_sessions import (
+    HindsightImportClient,
+    ImportOptions,
+    ImportSessionsError,
+    build_retain_item,
+    build_transcript,
+    load_sessions,
+    run_import,
+)
+
+
+def _ts(date: str) -> float:
+    return datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=timezone.utc).timestamp()
+
+
+def _make_db(tmp_path, sessions):
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                started_at REAL NOT NULL,
+                archived INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp REAL NOT NULL,
+                active INTEGER NOT NULL DEFAULT 1
+            );
+            """
+        )
+        for session in sessions:
+            conn.execute(
+                "INSERT INTO sessions (id, title, started_at, archived) VALUES (?, ?, ?, ?)",
+                (
+                    session["id"],
+                    session.get("title", ""),
+                    _ts(session.get("date", "2026-01-01")),
+                    session.get("archived", 0),
+                ),
+            )
+            for index, message in enumerate(session.get("messages", [])):
+                conn.execute(
+                    "INSERT INTO messages (session_id, role, content, timestamp, active) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (
+                        session["id"],
+                        message["role"],
+                        message.get("content", ""),
+                        _ts(session.get("date", "2026-01-01")) + index,
+                        message.get("active", 1),
+                    ),
+                )
+    return db_path
+
+
+class FakeClient:
+    def __init__(self, existing=None, fail_docs=None):
+        self.existing = set(existing or [])
+        self.fail_docs = set(fail_docs or [])
+        self.calls = []
+        self.closed = False
+
+    def list_document_ids(self, *, bank_id, doc_id_prefix=""):
+        return set(self.existing)
+
+    def retain(self, *, bank_id, item, document_id):
+        self.calls.append((bank_id, item, document_id))
+        if document_id in self.fail_docs:
+            raise RuntimeError("transient failure")
+        return SimpleNamespace(ok=True)
+
+    def close(self):
+        self.closed = True
+
+
+def test_load_sessions_builds_transcript_with_configured_prefixes(tmp_path):
+    _make_db(
+        tmp_path,
+        [
+            {
+                "id": "s1",
+                "title": "Prefix test",
+                "messages": [
+                    {"role": "system", "content": "rules"},
+                    {"role": "user", "content": "hello there"},
+                    {"role": "assistant", "content": "general kenobi"},
+                ],
+            }
+        ],
+    )
+
+    sessions, skipped = load_sessions(
+        tmp_path / "state.db",
+        config={"retain_user_prefix": "Human", "retain_assistant_prefix": "Bot"},
+        options=ImportOptions(),
+    )
+
+    assert skipped == 0
+    assert sessions[0].transcript == "System: rules\n\nHuman: hello there\n\nBot: general kenobi"
+    assert sessions[0].turn_count == 1
+
+
+def test_date_filters_since_until_and_days(tmp_path, monkeypatch):
+    _make_db(
+        tmp_path,
+        [
+            {"id": "old", "date": "2026-01-01", "messages": [{"role": "user", "content": "old enough content"}]},
+            {"id": "mid", "date": "2026-01-10", "messages": [{"role": "user", "content": "middle enough content"}]},
+            {"id": "new", "date": "2026-01-20", "messages": [{"role": "user", "content": "new enough content"}]},
+        ],
+    )
+    sessions, _ = load_sessions(
+        tmp_path / "state.db",
+        config={},
+        options=ImportOptions(since="2026-01-05", until="2026-01-15"),
+    )
+    assert [s.session_id for s in sessions] == ["mid"]
+
+    class FakeDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2026, 1, 21, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(importer, "datetime", FakeDateTime)
+    sessions, _ = load_sessions(
+        tmp_path / "state.db",
+        config={},
+        options=ImportOptions(days=5),
+    )
+    assert [s.session_id for s in sessions] == ["new"]
+
+
+def test_invalid_date_raises_import_sessions_error(tmp_path):
+    _make_db(tmp_path, [])
+    with pytest.raises(ImportSessionsError, match="YYYY-MM-DD"):
+        load_sessions(
+            tmp_path / "state.db",
+            config={},
+            options=ImportOptions(since="01-05-2026"),
+        )
+
+
+def test_skips_short_empty_and_artifact_only_sessions(tmp_path):
+    _make_db(
+        tmp_path,
+        [
+            {"id": "short", "messages": [{"role": "user", "content": "tiny"}]},
+            {"id": "empty", "messages": [{"role": "system", "content": "[SYSTEM: note]"}]},
+            {"id": "ok", "messages": [{"role": "user", "content": "this session has enough useful content"}]},
+        ],
+    )
+
+    sessions, skipped = load_sessions(tmp_path / "state.db", config={}, options=ImportOptions())
+
+    assert [s.session_id for s in sessions] == ["ok"]
+    assert skipped == 2
+
+
+def test_build_transcript_strips_context_compaction_and_system_notes():
+    transcript, _ = build_transcript(
+        [
+            {"role": "user", "content": "[SYSTEM: temporary note]\nkeep this   text"},
+            {
+                "role": "assistant",
+                "content": "before\n[CONTEXT COMPACTION START]\nold context\n\nfinal answer",
+            },
+        ],
+        config={},
+    )
+
+    assert "[SYSTEM:" not in transcript
+    assert "CONTEXT COMPACTION" not in transcript
+    assert "old context" not in transcript
+    assert "keep this text" in transcript
+
+
+def test_retain_item_doc_id_tags_timestamp_and_string_metadata():
+    session = importer.SessionCandidate(
+        session_id="abc123",
+        title="A Session",
+        started_at=_ts("2026-02-03"),
+        transcript="User: useful historical transcript",
+        turn_count=2,
+    )
+
+    item = build_retain_item(session, options=ImportOptions(extra_tags="hermes-backfill,extra"))
+
+    assert item["document_id"] == "abc123"
+    assert item["update_mode"] == "replace"
+    assert item["tags"] == ["session:abc123", "hermes-backfill", "extra"]
+    # Memories are dated at session time, not import time.
+    assert item["timestamp"] == session.iso_date
+    # Hindsight metadata values must all be strings.
+    assert all(isinstance(value, str) for value in item["metadata"].values())
+    assert item["metadata"]["session_id"] == "abc123"
+    assert item["metadata"]["turn_count"] == "2"
+    assert item["metadata"]["source"] == "hermes-backfill"
+    assert item["metadata"]["imported_via"] == "hermes hindsight import-sessions"
+    assert json.dumps(item["metadata"])  # JSON-serializable
+
+
+def test_doc_id_prefix_is_applied():
+    session = importer.SessionCandidate("s1", "", _ts("2026-01-01"), "long enough transcript", 1)
+    item = build_retain_item(session, options=ImportOptions(doc_id_prefix="hist-"))
+    assert item["document_id"] == "hist-s1"
+
+
+def test_dry_run_never_calls_hindsight(tmp_path):
+    _make_db(
+        tmp_path,
+        [{"id": "s1", "messages": [{"role": "user", "content": "long enough session content"}]}],
+    )
+    client = FakeClient()
+
+    summary = run_import(
+        ImportOptions(dry_run=True),
+        hermes_home=tmp_path,
+        client=client,
+        config={"bank_id": "bank"},
+    )
+
+    assert summary.candidates == 1
+    assert summary.bank_id == "bank"
+    assert client.calls == []
+
+
+def test_skip_existing_skips_matching_document_ids(tmp_path):
+    _make_db(
+        tmp_path,
+        [
+            {"id": "s1", "messages": [{"role": "user", "content": "first long enough session"}]},
+            {"id": "s2", "messages": [{"role": "user", "content": "second long enough session"}]},
+        ],
+    )
+    client = FakeClient(existing={"s1"})
+
+    summary = run_import(
+        ImportOptions(skip_existing=True, yes=True),
+        hermes_home=tmp_path,
+        client=client,
+        config={"bank_id": "bank"},
+    )
+
+    assert summary.imported == 1
+    assert summary.skipped_existing == 1
+    assert client.calls[0][2] == "s2"
+
+
+def test_per_session_failure_isolation_imports_unaffected_sessions(tmp_path, monkeypatch):
+    monkeypatch.setattr(importer, "time", SimpleNamespace(sleep=lambda _seconds: None))
+    _make_db(
+        tmp_path,
+        [
+            {"id": "s1", "messages": [{"role": "user", "content": "first long enough session"}]},
+            {"id": "s2", "messages": [{"role": "user", "content": "second long enough session"}]},
+            {"id": "s3", "messages": [{"role": "user", "content": "third long enough session"}]},
+        ],
+    )
+    client = FakeClient(fail_docs={"s2"})
+
+    summary = run_import(
+        ImportOptions(yes=True),
+        hermes_home=tmp_path,
+        client=client,
+        config={"bank_id": "bank"},
+    )
+
+    assert summary.imported == 2
+    assert summary.failed == 1
+    assert summary.failed_session_ids == ["s2"]
+    # s1 and s3 retained once each; s2 retried 3 times before giving up.
+    assert len(client.calls) == 5
+
+
+def test_local_embedded_client_creation_is_mockable(monkeypatch):
+    captured = {}
+
+    class FakeEmbedded:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(importer, "_check_local_runtime", lambda: (True, ""))
+    monkeypatch.setitem(__import__("sys").modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeEmbedded))
+
+    client = HindsightImportClient(
+        {
+            "mode": "local_embedded",
+            "profile": "hermes",
+            "llm_provider": "openrouter",
+            "llmApiKey": "key",
+            "llm_model": "model",
+        },
+        timeout=10,
+    )
+
+    assert isinstance(client._get_client(), FakeEmbedded)
+    assert captured["profile"] == "hermes"
+    assert captured["llm_provider"] == "openai"
+    assert captured["idle_timeout"] > 0
+
+
+def test_list_document_ids_paginates_and_filters_by_prefix(monkeypatch):
+    pages = {
+        0: SimpleNamespace(items=[{"id": f"doc-{i}"} for i in range(500)]),
+        500: SimpleNamespace(items=[{"id": "doc-500"}]),
+    }
+    calls = []
+
+    async def fake_list_documents(bank_id, q=None, limit=None, offset=None):
+        calls.append((bank_id, q, limit, offset))
+        return pages[offset]
+
+    monkeypatch.setattr(importer, "_run_sync", lambda coro, timeout=None: asyncio.run(coro))
+    client = HindsightImportClient({"mode": "cloud"}, timeout=10)
+    client._client = SimpleNamespace(
+        documents=SimpleNamespace(list_documents=fake_list_documents)
+    )
+
+    ids = client.list_document_ids(bank_id="bank", doc_id_prefix="hist-")
+
+    assert len(ids) == 501
+    assert calls[0] == ("bank", "hist-", 500, 0)
+    assert calls[1] == ("bank", "hist-", 500, 500)
+
+
+def test_list_document_ids_errors_when_client_cannot_list():
+    client = HindsightImportClient({"mode": "cloud"}, timeout=10)
+    client._client = SimpleNamespace()  # no documents API
+
+    with pytest.raises(ImportSessionsError, match="--skip-existing"):
+        client.list_document_ids(bank_id="bank")
+
+
+def test_confirmation_eof_cancels_without_importing(monkeypatch):
+    monkeypatch.setattr(importer, "_load_config", lambda: {})
+    monkeypatch.setattr(
+        importer, "run_import", lambda *a, **k: pytest.fail("run_import must not be called")
+    )
+
+    def _raise_eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _raise_eof)
+
+    with pytest.raises(SystemExit) as exc:
+        importer.handle_import_sessions_command(argparse.Namespace(dry_run=False, yes=False))
+
+    assert exc.value.code == 1
+
+
+def test_confirmation_declined_cancels_without_importing(monkeypatch, capsys):
+    monkeypatch.setattr(importer, "_load_config", lambda: {})
+    monkeypatch.setattr(
+        importer, "run_import", lambda *a, **k: pytest.fail("run_import must not be called")
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "no")
+
+    importer.handle_import_sessions_command(argparse.Namespace(dry_run=False, yes=False))
+
+    assert "Cancelled" in capsys.readouterr().out
+
+
+def test_bank_template_error_is_user_facing(monkeypatch, capsys):
+    monkeypatch.setattr(importer, "_load_config", lambda: {"bank_id_template": "x-{session}"})
+
+    with pytest.raises(SystemExit) as exc:
+        importer.handle_import_sessions_command(argparse.Namespace(dry_run=True))
+
+    assert exc.value.code == 1
+    assert "--bank-id" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        ({"bank_id": "direct"}, "direct"),
+        ({"banks": {"hermes": {"bankId": "legacy"}}}, "legacy"),
+        ({}, "hermes"),
+    ],
+)
+def test_resolve_bank_id_static(config, expected):
+    assert importer.resolve_bank_id(config) == expected
+
+
+def test_resolve_bank_id_override_wins():
+    config = {"bank_id": "cfg", "bank_id_template": "x-{session}"}
+    assert importer.resolve_bank_id(config, override="forced") == "forced"
+
+
+def test_resolve_bank_id_profile_template_matches_live_retention(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "Work Profile"
+    )
+    assert importer.resolve_bank_id({"bank_id_template": "hermes-{profile}"}) == "hermes-Work-Profile"
+
+
+def test_resolve_bank_id_per_session_template_requires_override():
+    with pytest.raises(ImportSessionsError, match="--bank-id"):
+        importer.resolve_bank_id({"bank_id_template": "hermes-{platform}-{user}"})

--- a/tests/plugins/memory/test_hindsight_import_sessions.py
+++ b/tests/plugins/memory/test_hindsight_import_sessions.py
@@ -323,6 +323,7 @@ def test_local_embedded_client_creation_is_mockable(monkeypatch):
 
     monkeypatch.setattr(importer, "_check_local_runtime", lambda: (True, ""))
     monkeypatch.setitem(__import__("sys").modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeEmbedded))
+    monkeypatch.delenv("HINDSIGHT_IDLE_TIMEOUT", raising=False)
 
     client = HindsightImportClient(
         {

--- a/tests/plugins/memory/test_hindsight_import_sessions.py
+++ b/tests/plugins/memory/test_hindsight_import_sessions.py
@@ -32,6 +32,7 @@ def _make_db(tmp_path, sessions):
                 id TEXT PRIMARY KEY,
                 title TEXT,
                 started_at REAL NOT NULL,
+                ended_at REAL,
                 archived INTEGER NOT NULL DEFAULT 0
             );
             CREATE TABLE messages (
@@ -45,12 +46,15 @@ def _make_db(tmp_path, sessions):
             """
         )
         for session in sessions:
+            started_at = _ts(session.get("date", "2026-01-01"))
             conn.execute(
-                "INSERT INTO sessions (id, title, started_at, archived) VALUES (?, ?, ?, ?)",
+                "INSERT INTO sessions (id, title, started_at, ended_at, archived) "
+                "VALUES (?, ?, ?, ?, ?)",
                 (
                     session["id"],
                     session.get("title", ""),
-                    _ts(session.get("date", "2026-01-01")),
+                    started_at,
+                    session.get("ended_at", started_at + 60),
                     session.get("archived", 0),
                 ),
             )
@@ -170,6 +174,28 @@ def test_skips_short_empty_and_artifact_only_sessions(tmp_path):
 
     assert [s.session_id for s in sessions] == ["ok"]
     assert skipped == 2
+
+
+def test_excludes_active_sessions_without_ended_at(tmp_path):
+    _make_db(
+        tmp_path,
+        [
+            {
+                "id": "active",
+                "ended_at": None,
+                "messages": [
+                    {"role": "user", "content": "this active session has enough useful content"},
+                    {"role": "assistant", "content": "and a long enough assistant reply too"},
+                ],
+            },
+            {"id": "done", "messages": [{"role": "user", "content": "this session has enough useful content"}]},
+        ],
+    )
+
+    sessions, skipped = load_sessions(tmp_path / "state.db", config={}, options=ImportOptions())
+
+    assert [s.session_id for s in sessions] == ["done"]
+    assert skipped == 0
 
 
 def test_build_transcript_strips_context_compaction_and_system_notes():


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in Hindsight backfill command for users who enable Hindsight after already using Hermes:

```bash
hermes hindsight import-sessions
```

The command imports completed historical sessions from the active Hermes `state.db` into the same Hindsight bank used by live retention. It preserves Hermes session IDs as the default Hindsight `document_id`, dates each memory at the original session time, adds session-scoped tags, supports dry runs and date filters, and can skip documents that already exist for safe reruns.

The CLI surface is delivered entirely through the sanctioned memory-plugin mechanism (`plugins/memory/hindsight/cli.py` with `register_cli()`/`hindsight_command()`, discovered by `discover_plugin_cli_commands()`): **zero changes to core files**, per the plugin rule in `AGENTS.md`. The command is only registered while `memory.provider: hindsight` is active. This extends an existing in-tree provider — no new provider or import framework is added.

Bank targeting matches live retention: a configured `bank_id_template` is resolved with the same profile/workspace values the provider uses; templates with per-session placeholders (`{platform}`, `{user}`, `{session}`) refuse to guess and require an explicit `--bank-id`. Retain calls mirror the provider's proven call shape (one document per `aretain_batch` call with top-level `document_id`), so behavior is consistent across supported `hindsight-client` versions. Local embedded mode uses the same embedded client path as live retention, so the daemon starts on demand.

No memory behavior changes unless the new command is invoked.

## Related Issue

N/A — standalone enhancement to the existing Hindsight provider.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `plugins/memory/hindsight/import_sessions.py` with provider-owned historical session import logic: transcript building with cleanup of Hermes artifacts (context-compaction blocks, `[SYSTEM: ...]` notes), date filters, dry-run, and per-session retain with retry and continue-on-failure isolation.
- Added `plugins/memory/hindsight/cli.py` registering `hermes hindsight import-sessions` via the plugin CLI discovery system (no core-file changes).
- Bank resolution reuses the provider's `_resolve_bank_id_template()` with the same profile/workspace values as live retention; `--bank-id` overrides, and per-session template placeholders require it.
- `--skip-existing` enumerates existing documents through the Hindsight documents API (paginated); it fails with a clear error instead of silently re-importing when the client cannot list documents.
- Retain items date memories at the original session time (`timestamp`) and send string-only metadata, matching the Hindsight API schema.
- Flags: `--dry-run`, `--yes`, `--skip-existing`, `--bank-id`, `--since`/`--until`/`--days` (validated), `--limit`, `--retain-timeout`, `--doc-id-prefix`, `--extra-tags`. Confirmation prompt shows the resolved bank and handles non-interactive stdin cleanly.
- Added focused unit coverage in `tests/plugins/memory/test_hindsight_import_sessions.py` and CLI registration/dispatch coverage in `tests/plugins/memory/test_hindsight_cli.py`.
- Updated `plugins/memory/hindsight/README.md` with usage, bank-template behavior, rerun guidance, and a note that live-retained sessions are duplicated by a backfill unless excluded with `--until`.

## How to Test

1. Run the focused unit and compatibility tests:
   ```bash
   uv run --extra dev python -m pytest tests/plugins/memory/test_hindsight_import_sessions.py tests/plugins/memory/test_hindsight_cli.py tests/hermes_cli/test_plugin_cli_registration.py tests/plugins/memory/test_hindsight_provider.py tests/hermes_cli/test_memory_setup_provider_arg.py
   ```
2. Run lint and syntax checks on touched Python files:
   ```bash
   uv run --extra dev python -m ruff check plugins/memory/hindsight/import_sessions.py plugins/memory/hindsight/cli.py tests/plugins/memory/test_hindsight_import_sessions.py tests/plugins/memory/test_hindsight_cli.py
   uv run --extra dev python -m py_compile plugins/memory/hindsight/import_sessions.py plugins/memory/hindsight/cli.py
   ```
3. Run the cross-platform footgun check on touched Python files:
   ```bash
   python3 scripts/check-windows-footguns.py plugins/memory/hindsight/import_sessions.py plugins/memory/hindsight/cli.py tests/plugins/memory/test_hindsight_import_sessions.py tests/plugins/memory/test_hindsight_cli.py
   ```
4. With `memory.provider: hindsight` active, verify the dry-run CLI path:
   ```bash
   uv run --extra dev python -m hermes_cli.main hindsight import-sessions --dry-run --limit 5
   uv run --extra dev python -m hermes_cli.main hindsight import-sessions --dry-run --skip-existing --limit 5
   ```
5. Confirm no core files are touched:
   ```bash
   git diff main --stat -- hermes_cli/ run_agent.py cli.py gateway/   # empty
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test run:

```text
141 passed in 1.89s
```

Lint / compile / cross-platform checks:

```text
All checks passed!
COMPILE_OK
✓ No Windows footguns found (4 file(s) scanned).
footguns exit: 0
```

Manual dry run:

```text
$ hermes hindsight import-sessions --dry-run --limit 5

Dry run complete:
  bank: hermes
  candidates: 4
  imported: 0
  skipped short: 1
  skipped existing: 0
  failed: 0
  sample sessions: 20260421_100114_bf8e0acc, ...
```