### PR TITLE
fix(docs): fix broken image and video in TUI docs

### DIFF
--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -130,9 +130,9 @@ Open it with any of these:
 - `/sessions new` to create a fresh live session immediately.
 - Click the `N live sessions` count in the status line.
 
-<img alt="Hermes TUI Session Orchestrator with one live session and a +new row" src="/img/docs/tui-session-orchestrator/session-orchestrator.png" />
+<img alt="Hermes TUI Session Orchestrator with one live session and a +new row" src="/docs/img/docs/tui-session-orchestrator/session-orchestrator.png" />
 
-<video controls muted loop playsInline src="/img/docs/tui-session-orchestrator/session-orchestrator-demo.mp4" title="Hermes TUI Session Orchestrator demo"></video>
+<video controls muted loop playsInline src="/docs/img/docs/tui-session-orchestrator/session-orchestrator-demo.mp4" title="Hermes TUI Session Orchestrator demo" style={{maxWidth: '100%'}}></video>
 
 Inside the switcher:
 

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -132,7 +132,7 @@ Open it with any of these:
 
 <img alt="Hermes TUI Session Orchestrator with one live session and a +new row" src="/img/docs/tui-session-orchestrator/session-orchestrator.png" />
 
-<video controls muted loop playsInline src="/img/docs/tui-session-orchestrator/session-orchestrator-demo.mp4" title="Hermes TUI Session Orchestrator demo" />
+<video controls muted loop playsInline src="/img/docs/tui-session-orchestrator/session-orchestrator-demo.mp4" title="Hermes TUI Session Orchestrator demo"></video>
 
 Inside the switcher:
 


### PR DESCRIPTION
## What does this PR do?
Two bugs prevented the image and video from rendering on the [TUI docs page](https://hermes-agent.nousresearch.com/docs/user-guide/tui):

1. **Wrong asset paths** — `<img>` and `<video>` used `/img/...` but with `baseUrl: '/docs/'` the correct path is `/docs/img/...`
2. **Self-closing video tag** — `<video ... />` is invalid HTML5. `<video>` is not a void element and must use `</video>` closing tag.

## Related Issue
Fixes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `website/docs/user-guide/tui.md`:
  - Fixed `<img>` src: `/img/docs/tui-session-orchestrator/session-orchestrator.png` → `/docs/img/docs/tui-session-orchestrator/session-orchestrator.png`
  - Fixed `<video>` src: `/img/docs/tui-session-orchestrator/session-orchestrator-demo.mp4` → `/docs/img/docs/tui-session-orchestrator/session-orchestrator-demo.mp4`
  - Fixed self-closing `<video ... />` → `<video ...></video>`

## How to Test
1. Navigate to `/docs/user-guide/tui`
2. Scroll to the "Live session switcher" section
3. The screenshot image should display correctly
4. The video player should load and be playable

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix

### Testing
- [x] Tested locally — image and video render correctly

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs
before
<img width="1422" height="860" alt="image" src="https://github.com/user-attachments/assets/5c193111-52d7-4a46-a91c-7610cb0219a0" />

after
<img width="1430" height="764" alt="image" src="https://github.com/user-attachments/assets/f0110780-8030-4508-bf31-44f4488a87fc" />
