### PR TITLE
fix(gateway): prevent PID conflicts on restart + cap WeChat session expiry retry loop

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -89,6 +89,7 @@ CONFIG_TIMEOUT_MS = 10_000
 QR_TIMEOUT_MS = 35_000
 
 MAX_CONSECUTIVE_FAILURES = 3
+MAX_SESSION_EXPIRATIONS = 3  # Hard cap on total session expirations before giving up permanently
 RETRY_DELAY_SECONDS = 2
 BACKOFF_DELAY_SECONDS = 30
 SESSION_EXPIRED_ERRCODE = -14
@@ -1225,6 +1226,9 @@ class WeixinAdapter(BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
 
+        # Session expiry hard cap — after MAX_SESSION_EXPIRATIONS, give up permanently.
+        self._session_expiry_count = 0
+
         if self._account_id and not self._token:
             persisted = load_weixin_account(hermes_home, self._account_id)
             if persisted:
@@ -1357,7 +1361,22 @@ class WeixinAdapter(BasePlatformAdapter):
                 if ret not in {0, None} or errcode not in {0, None}:
                     if (ret == SESSION_EXPIRED_ERRCODE or errcode == SESSION_EXPIRED_ERRCODE
                             or _is_stale_session_ret(ret, errcode, response.get("errmsg"))):
-                        logger.error("[%s] Session expired; pausing for 10 minutes", self.name)
+                        self._session_expiry_count += 1
+                        if self._session_expiry_count >= MAX_SESSION_EXPIRATIONS:
+                            logger.error(
+                                "[%s] Session expired %d times (%d max); giving up permanently",
+                                self.name, self._session_expiry_count, MAX_SESSION_EXPIRATIONS,
+                            )
+                            self._set_fatal_error(
+                                "weixin_max_session_expirations",
+                                f"Session expired {self._session_expiry_count} times",
+                                retryable=False,
+                            )
+                            break
+                        logger.error(
+                            "[%s] Session expired (%d/%d); pausing for 10 minutes",
+                            self.name, self._session_expiry_count, MAX_SESSION_EXPIRATIONS,
+                        )
                         await asyncio.sleep(600)
                         consecutive_failures = 0
                         continue

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3661,6 +3661,118 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     _guard_official_docker_root_gateway()
     sys.path.insert(0, str(PROJECT_ROOT))
 
+    # ── Windows: aggressively kill stale gateway processes before starting ──
+    # On Windows, SIGTERM/SIGKILL via os.kill() maps to TerminateProcess which
+    # may not cleanly tear down async I/O. Scheduled Task restarts can overlap
+    # with a draining old instance, producing duplicate PIDs that fight over
+    # the same WeChat/Telegram tokens.  This pre-start sweep uses taskkill /F
+    # to ensure no phantom gateways survive.
+    if replace and sys.platform == "win32":
+        import subprocess as _sp
+        from pathlib import Path as _Path
+
+        pids_to_kill: set = set()
+        hermes_home = str(get_hermes_home())
+
+        # 1. Read PID from gateway_state.json
+        try:
+            state_path = _Path(hermes_home) / "gateway_state.json"
+            if state_path.exists():
+                state = json.loads(state_path.read_text(encoding="utf-8"))
+                state_pid = state.get("pid")
+                if isinstance(state_pid, int) and state_pid > 0 and state_pid != os.getpid():
+                    pids_to_kill.add(state_pid)
+        except Exception:
+            pass
+
+        # 2. Read PIDs from all profile gateway.pid files
+        try:
+            profiles_dir = _Path(hermes_home) / "profiles"
+            if profiles_dir.is_dir():
+                for profile_dir in profiles_dir.iterdir():
+                    pid_file = profile_dir / "gateway.pid"
+                    if pid_file.exists():
+                        try:
+                            pid_text = pid_file.read_text(encoding="utf-8").strip()
+                            pid = int(pid_text)
+                            if pid > 0 and pid != os.getpid():
+                                pids_to_kill.add(pid)
+                        except (ValueError, OSError):
+                            pass
+        except Exception:
+            pass
+
+        # 3. Forcibly terminate all found PIDs
+        for pid in sorted(pids_to_kill):
+            try:
+                print(f"[gateway] Killing stale gateway PID {pid}...", file=sys.stderr)
+                _sp.run(
+                    ["taskkill", "/F", "/PID", str(pid)],
+                    timeout=10,
+                    capture_output=True,
+                )
+            except Exception as exc:
+                print(f"[gateway] Failed to kill PID {pid}: {exc}", file=sys.stderr)
+
+        # 4. Brief wait for processes to actually die
+        if pids_to_kill:
+            import time as _time
+            _time.sleep(1.0)
+
+    elif replace and sys.platform != "win32":
+        # ── Linux / macOS: kill stale gateway processes before starting ──
+        # On Linux systemd restarts or manual restarts can overlap with a
+        # draining old instance, producing duplicate PIDs that fight over
+        # messaging platform tokens (WeChat, Telegram, etc.).
+        import signal as _signal
+        from pathlib import Path as _Path
+
+        pids_to_kill: set = set()
+        hermes_home = str(get_hermes_home())
+
+        # 1. Read PID from gateway_state.json
+        try:
+            state_path = _Path(hermes_home) / "gateway_state.json"
+            if state_path.exists():
+                state = json.loads(state_path.read_text(encoding="utf-8"))
+                state_pid = state.get("pid")
+                if isinstance(state_pid, int) and state_pid > 0 and state_pid != os.getpid():
+                    pids_to_kill.add(state_pid)
+        except Exception:
+            pass
+
+        # 2. Read PIDs from all profile gateway.pid files
+        try:
+            profiles_dir = _Path(hermes_home) / "profiles"
+            if profiles_dir.is_dir():
+                for profile_dir in profiles_dir.iterdir():
+                    pid_file = profile_dir / "gateway.pid"
+                    if pid_file.exists():
+                        try:
+                            pid_text = pid_file.read_text(encoding="utf-8").strip()
+                            pid = int(pid_text)
+                            if pid > 0 and pid != os.getpid():
+                                pids_to_kill.add(pid)
+                        except (ValueError, OSError):
+                            pass
+        except Exception:
+            pass
+
+        # 3. Send SIGKILL to all found PIDs
+        for pid in sorted(pids_to_kill):
+            try:
+                print(f"[gateway] Killing stale gateway PID {pid}...", file=sys.stderr)
+                os.kill(pid, _signal.SIGKILL)
+            except ProcessLookupError:
+                pass  # Already dead
+            except Exception as exc:
+                print(f"[gateway] Failed to kill PID {pid}: {exc}", file=sys.stderr)
+
+        # 4. Brief wait for processes to actually die
+        if pids_to_kill:
+            import time as _time
+            _time.sleep(1.0)
+
     # Detached Windows gateway runs must ignore console-control broadcasts
     # from sibling CLI processes, but foreground `hermes gateway run` still
     # needs to obey the banner's "Press Ctrl+C to stop" contract.


### PR DESCRIPTION
## Summary

Two fixes for gateway stability issues discovered and tested on Windows 11 + WSL2:

### 1. Gateway PID Conflict Prevention (`hermes_cli/gateway.py`)

**Problem**: On restart, old gateway processes sometimes survive `SIGTERM`/`TerminateProcess`, producing duplicate PIDs that fight over WeChat/Telegram tokens → crashes + log spam.

**Fix**: `run_gateway(replace=True)` now has a pre-start PID killer:
- **Windows**: Scans `gateway_state.json` + all profile `gateway.pid` files → `taskkill /F` before starting
- **Linux/macOS**: Same scan → `os.kill(pid, SIGKILL)` before starting
- Waits 1 second after killing for processes to actually die

### 2. WeChat Session Expiry Hard Cap (`gateway/platforms/weixin.py`)

**Problem**: When iLink session expires, WeChat adapter enters an infinite 10-minute retry loop (~800+ errors/day), flooding logs and blocking gateway resources.

**Fix**: `MAX_SESSION_EXPIRATIONS = 3` hard cap:
- After 3 session expirations, `_set_fatal_error(retryable=False)` permanently drops WeChat from the reconnect queue
- Eliminates the 800+/day polling loop

## Testing

- ✅ Windows 11: `hermes gateway restart` cleanly kills old PID before starting new one
- ✅ WeChat: session expiry capped at 3, then permanently disabled
- ✅ No regressions on existing gateway functionality
- ✅ Syntax check passes on both files

## Related

- Discovered via `hermes-crash-recovery` diagnostic flow
- Prevents the "Dual Gateway" issue documented in `windows-hermes-setup` skill