### PR TITLE
fix(cli): don't crash the session on an unbalanced quote in /cron or /curator

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1082,7 +1082,15 @@ class CLICommandsMixin:
                     i += 1
             return opts
 
-        tokens = shlex.split(cmd)
+        try:
+            tokens = shlex.split(cmd)
+        except ValueError:
+            # Unbalanced quote in the typed command (e.g. /cron add "do x).
+            # Fall back to a naive split so the command degrades gracefully
+            # instead of raising ValueError out of process_command — the REPL
+            # dispatch only catches KeyboardInterrupt, so an escaping
+            # ValueError kills the whole session. Mirrors the /tools handler.
+            tokens = cmd.split()
 
         if len(tokens) == 1:
             print()
@@ -1263,7 +1271,12 @@ class CLICommandsMixin:
         """
         import shlex
 
-        tokens = shlex.split(cmd)[1:] if cmd else []
+        try:
+            tokens = shlex.split(cmd)[1:] if cmd else []
+        except ValueError:
+            # Unbalanced quote — degrade to a naive split rather than letting
+            # ValueError escape process_command and kill the REPL session.
+            tokens = cmd.split()[1:] if cmd else []
         if not tokens:
             tokens = ["status"]
 

--- a/tests/cli/test_cli_slash_unbalanced_quote.py
+++ b/tests/cli/test_cli_slash_unbalanced_quote.py
@@ -1,0 +1,55 @@
+"""Slash-command handlers must survive an unbalanced quote in user input.
+
+``/cron`` and ``/curator`` tokenize the typed command with ``shlex.split()``,
+which raises ``ValueError`` on an unbalanced quote (e.g. ``/cron add "do x``).
+The REPL dispatch (``cli.process_command``) is wrapped only in a
+``try/except KeyboardInterrupt``, so an escaping ``ValueError`` unwinds to the
+prompt_toolkit loop and kills the whole session. Both handlers now fall back to
+a naive whitespace split, matching the existing ``/tools`` handler.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli() -> HermesCLI:
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {}
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj.conversation_history = []
+    cli_obj.session_id = "sess-shlex-test"
+    cli_obj._pending_input = MagicMock()
+    cli_obj._app = None
+    return cli_obj
+
+
+def test_curator_command_survives_unbalanced_quote():
+    # shlex.split('/curator "x') raises ValueError; the handler must degrade to
+    # a naive split instead of letting it escape and kill the session.
+    cli_obj = _make_cli()
+    with patch("hermes_cli.curator.cli_main") as mock_main:
+        cli_obj._handle_curator_command('/curator "unterminated')
+    mock_main.assert_called_once()
+    assert mock_main.call_args[0][0] == ['"unterminated']
+
+
+def test_cron_command_survives_unbalanced_quote():
+    # Must not raise ValueError out of the handler. The unknown subcommand
+    # ("unterminated) just prints usage; cronjob is patched defensively so no
+    # real scheduling happens.
+    cli_obj = _make_cli()
+    with patch("tools.cronjob_tools.cronjob", return_value='{"status": "ok"}'):
+        cli_obj._handle_cron_command('/cron "unterminated')
+    # Reaching here without an exception is the assertion.
+
+
+def test_curator_balanced_quote_still_groups_tokens():
+    # The fast path (valid shlex) must keep grouping quoted arguments so the
+    # naive-split fallback never degrades normal usage.
+    cli_obj = _make_cli()
+    with patch("hermes_cli.curator.cli_main") as mock_main:
+        cli_obj._handle_curator_command('/curator run "two words"')
+    mock_main.assert_called_once()
+    assert mock_main.call_args[0][0] == ["run", "two words"]


### PR DESCRIPTION
## Summary

`/cron` and `/curator` tokenize the typed command with `shlex.split()`:

```python
# _handle_cron_command
tokens = shlex.split(cmd)
# _handle_curator_command
tokens = shlex.split(cmd)[1:] if cmd else []
```

`shlex.split()` raises `ValueError: No closing quotation` on an **unbalanced quote** — e.g. `/cron add "do something` (and quoting is exactly how cron prompts are written, so it's an easy slip). The REPL dispatch in `cli.process_command` is wrapped only in `try/except KeyboardInterrupt`:

```python
try:
    if not self.process_command(user_input):
        ...
except KeyboardInterrupt:
    ...
```

so the `ValueError` unwinds past it to the prompt_toolkit loop and **kills the entire interactive session** — the comment right there even notes that an uncaught exception "unwinds to the outer prompt_toolkit loop and the session dies."

The sibling `/tools` handler already guards this exact case:

```python
try:
    parts = shlex.split(cmd)
except ValueError:
    parts = cmd.split()
```

## Fix

Mirror that fallback in both `_handle_cron_command` and `_handle_curator_command`, so an unbalanced quote degrades to a naive whitespace split instead of crashing the session.

## Tests

`tests/cli/test_cli_slash_unbalanced_quote.py`:
- `test_curator_command_survives_unbalanced_quote` and `test_cron_command_survives_unbalanced_quote` — **both raise `ValueError: No closing quotation` without the fix**, pass with it;
- `test_curator_balanced_quote_still_groups_tokens` — confirms the fast path still groups quoted args (`run "two words"` → `["run", "two words"]`), so the fallback never degrades normal usage.