### PR TITLE
fix(gateway): add handoff_state index to prevent heartbeat blocking

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -522,6 +522,8 @@ CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(ex
 DEFERRED_INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_messages_session_active
     ON messages(session_id, active, timestamp);
+CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state
+    ON sessions(handoff_state, started_at);
 """
 
 FTS_SQL = """


### PR DESCRIPTION
## Problem

`_handoff_watcher` polls `sessions` with `WHERE handoff_state = 'pending'` every 2 seconds. Without an index on `handoff_state`, SQLite performs a full index scan via `idx_sessions_started` across all sessions. As `state.db` grows (observed at 1.2GB / 24,740 sessions / 145,983 messages), this synchronous I/O blocks the asyncio event loop, starving Discord heartbeats and preventing message dispatch across all platforms.

### Observed symptoms
- Discord heartbeat blocked for **4,440 seconds** (74 minutes)
- Both Discord and Feishu stop responding to messages
- `gateway_state.json` stops being updated
- No errors in logs — the event loop is simply stuck on SQLite

### Before / After query plan

```
-- Before (no index)
QUERY PLAN
`--SCAN sessions USING INDEX idx_sessions_started

-- After (with index)
QUERY PLAN
`--SEARCH sessions USING INDEX idx_sessions_handoff_state (handoff_state=?)
```

## Fix

Adds a single index:
```sql
CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state 
ON sessions(handoff_state, started_at);
```

Uses `IF NOT EXISTS` for safe idempotent migration on existing databases.

## Related

Closes #40695  
Related to attempted fix PRs: #30067 (thread offload, closed), #30759 (lock approach, partial)