### PR TITLE
fix(cron): resolve per-job provider "custom" to providers.custom instead of codex

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -491,15 +491,27 @@ def _lift_max_output_tokens(entry: Dict[str, Any], result: Dict[str, Any]) -> No
 
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
-    if not requested_norm or requested_norm == "custom":
+    if not requested_norm:
         return None
+
+    # Bare "custom" is normally an incomplete spec — the canonical form is
+    # "custom:<name>" — and is otherwise owned by the model.base_url "bare
+    # custom" trust path. BUT a user may literally name a ``providers:`` (or
+    # legacy ``custom_providers:``) entry "custom" (e.g. ``providers.custom``
+    # pointing at cliproxy). We used to return None here *before* scanning
+    # config, so such an entry was never matched and resolution fell through to
+    # the global default (Codex) — the cause of cron jobs with
+    # ``provider: "custom"`` failing with ``auth_unavailable: providers=codex``.
+    # Fall through to the config scan instead; if no entry is literally named
+    # "custom" it still returns None at the end, preserving the trust path.
 
     # Raw names should only map to custom providers when they are not already
     # valid built-in providers or aliases. Explicit menu keys like
-    # ``custom:local`` always target the saved custom provider.
+    # ``custom:local`` always target the saved custom provider. Bare "custom"
+    # is exempt from the shadow check — it is not a built-in to defer to.
     if requested_norm == "auto":
         return None
-    if not requested_norm.startswith("custom:"):
+    if requested_norm != "custom" and not requested_norm.startswith("custom:"):
         try:
             canonical = auth_mod.resolve_provider(requested_norm)
         except AuthError:
@@ -632,6 +644,20 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         return result
 
     return None
+
+
+def has_named_custom_provider(requested_provider: str) -> bool:
+    """Return True when config defines a custom provider matching the request.
+
+    Thin public wrapper around :func:`_get_named_custom_provider` so other
+    modules (e.g. the cronjob tool) can decide whether a provider name will
+    actually resolve to a configured ``providers:`` / ``custom_providers:``
+    entry — without reaching into a private helper or duplicating the scan.
+    """
+    try:
+        return _get_named_custom_provider(requested_provider) is not None
+    except Exception:
+        return False
 
 
 def _custom_provider_request_overrides(custom_provider: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -712,6 +712,76 @@ def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     assert resolved["source"] == "custom_provider:Local"
 
 
+def test_bare_custom_resolves_providers_dict_entry_named_custom(monkeypatch):
+    """A request for bare ``provider="custom"`` must resolve a literal
+    ``providers.custom`` entry (e.g. a cliproxy endpoint) instead of falling
+    through to the global default. Regression for cron jobs stored with
+    ``provider: "custom"`` failing with ``auth_unavailable: providers=codex``.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "custom": {
+                    "api": "https://cliproxy.example.com/v1",
+                    "api_key": "cliproxy-key",
+                    "default_model": "gpt-5.4",
+                    "name": "CLIProxy",
+                }
+            }
+        },
+    )
+    # Reaching resolve_provider for bare custom with a matching entry means the
+    # named-custom path was bypassed — that is the bug we are fixing.
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider must not be called; providers.custom should match"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://cliproxy.example.com/v1"
+    assert resolved["api_key"] == "cliproxy-key"
+    assert resolved["requested_provider"] == "custom"
+
+
+def test_bare_custom_without_named_entry_still_falls_through(monkeypatch):
+    """No literal providers.custom entry → bare custom keeps the legacy
+    model.base_url trust-path behavior, unchanged by the fix."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "http://127.0.0.1:8082/v1",
+            "default": "my-local-model",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {"providers": {"some-other-proxy": {"api": "https://x.example/v1"}}},
+    )
+    monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "http://127.0.0.1:8082/v1"
+
+
 def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch):
     """After v11→v12 migration deletes custom_providers, resolution should
     still find entries in the providers dict via get_compatible_custom_providers."""

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -452,3 +452,54 @@ class TestUnifiedCronjobTool:
         assert updated["success"] is True
         stored = get_job(created["job_id"])
         assert stored["deliver"] == "telegram"
+
+
+# =========================================================================
+# Per-job model/provider override resolution
+# =========================================================================
+
+from tools.cronjob_tools import _resolve_model_override  # noqa: E402
+
+
+class TestResolveModelOverride:
+    """`_resolve_model_override` must not silently hijack a job that meant to
+    use a configured custom endpoint (e.g. ``providers.custom`` → cliproxy).
+    Regression for cron jobs with ``provider: "custom"`` falling back to codex.
+    """
+
+    def test_keeps_bare_custom_when_a_named_entry_exists(self, monkeypatch):
+        import hermes_cli.runtime_provider as rp_mod
+
+        monkeypatch.setattr(rp_mod, "has_named_custom_provider", lambda name: True)
+        provider, model = _resolve_model_override(
+            {"provider": "custom", "model": "gpt-5.4"}
+        )
+        assert provider == "custom"
+        assert model == "gpt-5.4"
+
+    def test_pins_main_provider_when_bare_custom_unresolvable(self, monkeypatch):
+        import hermes_cli.config as cfg_mod
+        import hermes_cli.runtime_provider as rp_mod
+
+        monkeypatch.setattr(rp_mod, "has_named_custom_provider", lambda name: False)
+        monkeypatch.setattr(
+            cfg_mod, "load_config", lambda: {"model": {"provider": "openai-codex"}}
+        )
+        provider, model = _resolve_model_override(
+            {"provider": "custom", "model": "gpt-5.4"}
+        )
+        # No matching custom entry → fall back to pinning the main provider.
+        assert provider == "openai-codex"
+        assert model == "gpt-5.4"
+
+    def test_keeps_explicit_custom_name_unchanged(self, monkeypatch):
+        import hermes_cli.runtime_provider as rp_mod
+
+        # Even if the resolver claims no entry, the canonical "custom:<name>"
+        # form is never stripped or pinned.
+        monkeypatch.setattr(rp_mod, "has_named_custom_provider", lambda name: False)
+        provider, model = _resolve_model_override(
+            {"provider": "custom:cliproxy", "model": "gpt-5.4"}
+        )
+        assert provider == "custom:cliproxy"
+        assert model == "gpt-5.4"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -326,15 +326,23 @@ def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
         return (None, None)
     model_name = (model_obj.get("model") or "").strip() or None
     provider_name = (model_obj.get("provider") or "").strip() or None
-    # Bare "custom" is an incomplete spec — the canonical form is
-    # "custom:<name>" matching a custom_providers entry. LLMs frequently
+    # Bare "custom" is usually an incomplete spec — the canonical form is
+    # "custom:<name>" matching a custom_providers entry, and LLMs frequently
     # supply the bare type because the schema does not advertise the
-    # ":<name>" suffix, which used to bypass the pinning path below and
-    # leave the job stored with an unresolvable "custom" provider. Treat
-    # the bare value as "no provider supplied" so the current main
-    # provider gets pinned instead.
+    # ":<name>" suffix. It is only a problem when it can't resolve at runtime:
+    # a user may literally name a ``providers.custom`` (or custom_providers
+    # "custom") entry, in which case the job should keep ``provider="custom"``
+    # and run against that endpoint. Only when no such entry exists do we treat
+    # the bare value as "no provider supplied" and pin the current main
+    # provider below — otherwise pinning to ``model.provider`` (e.g. codex)
+    # silently hijacks a job that meant to use the configured custom endpoint.
     if provider_name == "custom":
-        provider_name = None
+        try:
+            from hermes_cli.runtime_provider import has_named_custom_provider
+            if not has_named_custom_provider("custom"):
+                provider_name = None
+        except Exception:
+            provider_name = None
     if model_name and not provider_name:
         # Pin to the current main provider so the job is stable
         try:


### PR DESCRIPTION
## Summary

A cron job stored with `provider: "custom"` (with a working `providers.custom` entry in `config.yaml` pointing at, e.g., cliproxy) fails at execution with:

```
RuntimeError: HTTP 503: auth_unavailable: no auth available (providers=codex, model=gpt-5.4)
```

Normal gateway turns work because they use the profile's `model.provider` / `model.base_url` directly. The cron path **does** read `job["provider"]` and pass it to `resolve_runtime_provider(requested=...)` — the failure is in shared runtime resolution, not the scheduler.

Root cause (two layers):

- **Execution (primary):** `_get_named_custom_provider()` in `hermes_cli/runtime_provider.py` returned `None` for bare `"custom"` *before* scanning config. A user who literally names a `providers.custom` entry (the dict key is `custom`) never matched it, so resolution fell through to the global default (codex auth) → `providers=codex`.
- **Creation (secondary):** `_resolve_model_override()` in `tools/cronjob_tools.py` blindly stripped bare `"custom"` and pinned `model.provider` (often codex) into the stored job, so even newly-created jobs lost the intended custom endpoint.

## Changes

- `_get_named_custom_provider`: bare `"custom"` now falls through to the config scan and matches a literal `providers.custom` / `custom_providers` entry named `custom`. With **no** such entry it still returns `None`, preserving the legacy `model.base_url` "bare custom" trust path (loopback / direct-alias behavior unchanged). Bare `"custom"` is also exempted from the built-in shadow check (it is not a built-in to defer to).
- New public `has_named_custom_provider()` wrapper so the cron tool can ask "will this provider actually resolve?" without reaching into a private helper.
- `_resolve_model_override`: keeps `provider="custom"` when a configured custom endpoint resolves; only strips it and pins the main provider when it is genuinely unresolvable. Canonical `custom:<name>` was already untouched and stays so.

## Test plan

- [x] `tests/hermes_cli/test_runtime_provider_resolution.py` — new `test_bare_custom_resolves_providers_dict_entry_named_custom` (resolves cliproxy, never reaches `resolve_provider`) and `test_bare_custom_without_named_entry_still_falls_through` (no regression to trust path).
- [x] `tests/tools/test_cronjob_tools.py` — new `TestResolveModelOverride`: keeps resolvable `"custom"`, pins main provider when unresolvable, leaves `custom:<name>` untouched.
- [x] `scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py tests/tools/test_cronjob_tools.py` → 191 passed.
- [x] `scripts/run_tests.sh tests/cron/test_scheduler.py tests/hermes_cli/test_regression_16767.py` → 137 passed (no regression to bare-custom + explicit base_url path).


## Infographic

![cron-custom-provider-resolution](https://v3b.fal.media/files/b/0a9dc8f9/CH3Mv9WLdC5WtO9AXb9ga_lwRxDMz2.png)
