### PR TITLE
fix(photon): respect sidecar lockfile during setup

### DIFF
--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -332,13 +332,16 @@ def _install_sidecar() -> int:
             file=sys.stderr,
         )
         return 1
-    # Always pull the newest published spectrum-ts so every setup runs against
-    # the latest SDK. `spectrum-ts@latest` bumps package.json + package-lock.json
-    # to the current release before installing — a plain `npm install` would
-    # stay pinned to whatever the committed lockfile already resolved.
-    print(f"  $ cd {_SIDECAR_DIR} && {npm} install spectrum-ts@latest")
+    # Respect the committed package-lock.json so setup uses the SDK version
+    # Hermes was tested with. Installing `spectrum-ts@latest` here can silently
+    # rewrite package.json/package-lock.json and pull incompatible major SDKs.
+    if (_SIDECAR_DIR / "package-lock.json").exists():
+        command = [npm, "ci"]
+    else:
+        command = [npm, "install"]
+    print(f"  $ cd {_SIDECAR_DIR} && {' '.join(command)}")
     proc = subprocess.run(  # noqa: S603
-        [npm, "install", "spectrum-ts@latest"],
+        command,
         cwd=str(_SIDECAR_DIR),
         check=False,
     )

--- a/tests/plugins/platforms/photon/test_setup_access.py
+++ b/tests/plugins/platforms/photon/test_setup_access.py
@@ -7,6 +7,8 @@ never clobbers a hand-tuned allowlist.
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from hermes_cli.config import get_env_value, save_env_value
@@ -18,10 +20,10 @@ def test_autoconfigure_access_fills_unset(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.delenv("PHOTON_ALLOWED_USERS", raising=False)
     monkeypatch.delenv("PHOTON_HOME_CHANNEL", raising=False)
 
-    cli._autoconfigure_access("+15551234567")
+    cli._autoconfigure_access("+155****4567")
 
-    assert get_env_value("PHOTON_ALLOWED_USERS") == "+15551234567"
-    assert get_env_value("PHOTON_HOME_CHANNEL") == "+15551234567"
+    assert get_env_value("PHOTON_ALLOWED_USERS") == "+155****4567"
+    assert get_env_value("PHOTON_HOME_CHANNEL") == "+155****4567"
 
 
 def test_autoconfigure_access_preserves_existing_allowlist(
@@ -30,26 +32,26 @@ def test_autoconfigure_access_preserves_existing_allowlist(
     monkeypatch.delenv("PHOTON_ALLOWED_USERS", raising=False)
     monkeypatch.delenv("PHOTON_HOME_CHANNEL", raising=False)
     # A hand-tuned allowlist already in place must survive a setup re-run.
-    save_env_value("PHOTON_ALLOWED_USERS", "+19998887777,+15551112222")
+    save_env_value("PHOTON_ALLOWED_USERS", "+199****7777,+155****2222")
 
-    cli._autoconfigure_access("+15551234567")
+    cli._autoconfigure_access("+155****4567")
 
-    assert get_env_value("PHOTON_ALLOWED_USERS") == "+19998887777,+15551112222"
+    assert get_env_value("PHOTON_ALLOWED_USERS") == "+199****7777,+155****2222"
     # The still-unset home channel is filled.
-    assert get_env_value("PHOTON_HOME_CHANNEL") == "+15551234567"
+    assert get_env_value("PHOTON_HOME_CHANNEL") == "+155****4567"
 
 
 def test_env_enablement_seeds_home_channel(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PHOTON_PROJECT_ID", "project_123")
     monkeypatch.setenv("PHOTON_PROJECT_SECRET", "secret_123")
-    monkeypatch.setenv("PHOTON_HOME_CHANNEL", "+15551234567")
+    monkeypatch.setenv("PHOTON_HOME_CHANNEL", "+155****4567")
     monkeypatch.setenv("PHOTON_HOME_CHANNEL_NAME", "Primary DM")
 
     seed = _env_enablement()
 
     assert seed is not None
     assert seed["home_channel"] == {
-        "chat_id": "+15551234567",
+        "chat_id": "+155****4567",
         "name": "Primary DM",
     }
 
@@ -57,13 +59,63 @@ def test_env_enablement_seeds_home_channel(monkeypatch: pytest.MonkeyPatch) -> N
 def test_env_enablement_home_channel_defaults_name(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PHOTON_PROJECT_ID", "project_123")
     monkeypatch.setenv("PHOTON_PROJECT_SECRET", "secret_123")
-    monkeypatch.setenv("PHOTON_HOME_CHANNEL", "+15551234567")
+    monkeypatch.setenv("PHOTON_HOME_CHANNEL", "+155****4567")
     monkeypatch.delenv("PHOTON_HOME_CHANNEL_NAME", raising=False)
 
     seed = _env_enablement()
 
     assert seed is not None
     assert seed["home_channel"] == {
-        "chat_id": "+15551234567",
+        "chat_id": "+155****4567",
         "name": "Home",
     }
+
+
+def test_install_sidecar_respects_committed_lockfile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    sidecar_dir = tmp_path / "sidecar"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "package-lock.json").write_text("{}")
+    calls: list[tuple[list[str], str]] = []
+
+    class _Result:
+        returncode = 0
+
+    def fake_run(command: list[str], *, cwd: str, check: bool) -> _Result:
+        calls.append((command, cwd))
+        assert check is False
+        return _Result()
+
+    monkeypatch.setattr(cli, "_SIDECAR_DIR", sidecar_dir)
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/bin/npm")
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    assert cli._install_sidecar() == 0
+    assert calls == [(["/usr/bin/npm", "ci"], str(sidecar_dir))]
+
+
+def test_install_sidecar_falls_back_to_npm_install_without_lockfile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    sidecar_dir = tmp_path / "sidecar"
+    sidecar_dir.mkdir()
+    calls: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+
+    def fake_run(command: list[str], *, cwd: str, check: bool) -> _Result:
+        calls.append(command)
+        assert cwd == str(sidecar_dir)
+        assert check is False
+        return _Result()
+
+    monkeypatch.setattr(cli, "_SIDECAR_DIR", sidecar_dir)
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/bin/npm")
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    assert cli._install_sidecar() == 0
+    assert calls == [["/usr/bin/npm", "install"]]


### PR DESCRIPTION
## Summary
- Stops `hermes photon setup` from installing `spectrum-ts@latest`
- Uses `npm ci` when the sidecar lockfile is present so setup uses the SDK Hermes was tested with
- Falls back to `npm install` only when no lockfile exists
- Adds regression tests for both install paths

## Why
`package.json` and `package-lock.json` pin the Photon sidecar to `spectrum-ts@1.18.0`, but setup was running `npm install spectrum-ts@latest`. That can silently rewrite the sidecar dependency to a newer incompatible major SDK during onboarding.

## Verification
- `venv/bin/python -m pytest tests/plugins/platforms/photon/test_setup_access.py -q -o 'addopts='` → 6 passed
- `venv/bin/python -m pytest tests/plugins/platforms/photon -q -o 'addopts='` → 68 passed
