### PR TITLE
feat(display): add follow-up question suggestions after each response

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -285,6 +285,31 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             pass
 
+    # Follow-up question suggestions. When display.followup_questions is
+    # enabled, instruct the model to append contextual follow-up questions
+    # at the end of each response. Stable for the lifetime of the agent
+    # (config doesn't change mid-session).
+    try:
+        from hermes_cli.config import load_config
+        _cfg = load_config()
+        _disp = _cfg.get("display", {}) if isinstance(_cfg.get("display"), dict) else {}
+        _fu_enabled = _disp.get("followup_questions", False)
+        _fu_count = max(2, min(5, int(_disp.get("followup_count", 3))))
+    except Exception:
+        _fu_enabled = False
+        _fu_count = 3
+    if _fu_enabled:
+        stable_parts.append(
+            f"After each response, suggest {_fu_count} relevant follow-up "
+            f"questions the user might want to ask next. Present them as a "
+            f"numbered list at the end of your response, separated by a blank "
+            f"line, under a heading like \"**Suggested follow-ups:**\". "
+            f"Questions should be concise, contextual, and help the user "
+            f"explore the topic further. Do not include follow-ups when the "
+            f"response is a simple acknowledgment, greeting, or when the "
+            f"conversation has clearly concluded."
+        )
+
     # ── Context tier (cwd-dependent, may change between sessions) ─
     context_parts: List[str] = []
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1437,6 +1437,12 @@ DEFAULT_CONFIG = {
         # responses and content messages are never touched.  Default 0
         # (disabled) preserves prior behavior.
         "ephemeral_system_ttl": 0,
+        # Follow-up question suggestions. When enabled, the agent appends
+        # 2-N contextual follow-up questions after each response, similar
+        # to Claude.ai's suggestion UI. Gated by config so users who find
+        # it noisy can turn it off.
+        "followup_questions": False,
+        "followup_count": 3,         # number of suggestions (2-5)
         # Per-platform display/streaming overrides. Each key is a gateway
         # platform ("telegram", "discord", "slack", …) mapping to a dict of
         # display settings that override the global value for that platform

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -188,6 +188,7 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("display", "streaming"),
         ("display", "skin"),
         ("display", "show_reasoning"),
+        ("display", "followup_questions"),
         ("privacy", "redact_pii"),
         ("tts", "provider"),
     ]

--- a/tests/agent/test_followup_questions.py
+++ b/tests/agent/test_followup_questions.py
@@ -1,0 +1,162 @@
+"""Tests for the follow-up question suggestions feature.
+
+Verifies that:
+- The config default is False (disabled)
+- The system prompt instruction is NOT injected when followup_questions is False
+- The system prompt instruction IS injected when followup_questions is True
+- The count is clamped to the 2-5 range
+- The instruction content is well-formed
+"""
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Config defaults
+# ---------------------------------------------------------------------------
+
+
+class TestFollowupQuestionsConfig:
+    """Verify DEFAULT_CONFIG has the expected keys and defaults."""
+
+    def test_default_followup_questions_is_false(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        display = DEFAULT_CONFIG.get("display", {})
+        assert display.get("followup_questions") is False
+
+    def test_default_followup_count_is_3(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        display = DEFAULT_CONFIG.get("display", {})
+        assert display.get("followup_count") == 3
+
+
+# ---------------------------------------------------------------------------
+# System prompt injection
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_agent(**overrides):
+    """Create a minimal mock agent for system prompt building."""
+    agent = MagicMock()
+    agent.model = overrides.get("model", "test-model")
+    agent.provider = overrides.get("provider", "test")
+    agent.platform = overrides.get("platform", "")
+    agent.valid_tool_names = overrides.get("valid_tool_names", [])
+    agent.load_soul_identity = True
+    agent.skip_context_files = True
+    agent._task_completion_guidance = False
+    agent._tool_use_enforcement = "false"
+    agent._environment_probe = False
+    agent._memory_store = None
+    agent._memory_manager = None
+    agent._memory_enabled = False
+    agent._user_profile_enabled = False
+    agent._kanban_worker_guidance = None
+    agent.pass_session_id = False
+    agent.session_id = None
+    return agent
+
+
+class TestFollowupQuestionsPromptInjection:
+    """Test that the prompt instruction is conditionally injected."""
+
+    @patch("hermes_cli.config.load_config")
+    def test_not_injected_when_disabled(self, mock_load_config):
+        mock_load_config.return_value = {"display": {"followup_questions": False}}
+        from agent.system_prompt import build_system_prompt
+
+        agent = _make_mock_agent()
+        prompt = build_system_prompt(agent)
+        assert "follow-up" not in prompt.lower()
+        assert "Suggested follow-ups" not in prompt
+
+    @patch("hermes_cli.config.load_config")
+    def test_injected_when_enabled(self, mock_load_config):
+        mock_load_config.return_value = {"display": {"followup_questions": True, "followup_count": 3}}
+        from agent.system_prompt import build_system_prompt
+
+        agent = _make_mock_agent()
+        prompt = build_system_prompt(agent)
+        assert "Suggested follow-ups" in prompt
+        assert "3 relevant follow-up" in prompt
+
+    @patch("hermes_cli.config.load_config")
+    def test_count_reflected_in_prompt(self, mock_load_config):
+        mock_load_config.return_value = {"display": {"followup_questions": True, "followup_count": 5}}
+        from agent.system_prompt import build_system_prompt
+
+        agent = _make_mock_agent()
+        prompt = build_system_prompt(agent)
+        assert "5 relevant follow-up" in prompt
+
+    @patch("hermes_cli.config.load_config")
+    def test_count_clamped_to_min_2(self, mock_load_config):
+        mock_load_config.return_value = {"display": {"followup_questions": True, "followup_count": 1}}
+        from agent.system_prompt import build_system_prompt
+
+        agent = _make_mock_agent()
+        prompt = build_system_prompt(agent)
+        assert "2 relevant follow-up" in prompt
+
+    @patch("hermes_cli.config.load_config")
+    def test_count_clamped_to_max_5(self, mock_load_config):
+        mock_load_config.return_value = {"display": {"followup_questions": True, "followup_count": 10}}
+        from agent.system_prompt import build_system_prompt
+
+        agent = _make_mock_agent()
+        prompt = build_system_prompt(agent)
+        assert "5 relevant follow-up" in prompt
+
+    @patch("hermes_cli.config.load_config")
+    def test_not_injected_on_config_error(self, mock_load_config):
+        mock_load_config.side_effect = Exception("config error")
+        from agent.system_prompt import build_system_prompt
+
+        agent = _make_mock_agent()
+        prompt = build_system_prompt(agent)
+        assert "follow-up" not in prompt.lower()
+
+    @patch("hermes_cli.config.load_config")
+    def test_instruction_mentions_numbered_list(self, mock_load_config):
+        mock_load_config.return_value = {"display": {"followup_questions": True, "followup_count": 3}}
+        from agent.system_prompt import build_system_prompt
+
+        agent = _make_mock_agent()
+        prompt = build_system_prompt(agent)
+        assert "numbered list" in prompt
+
+    @patch("hermes_cli.config.load_config")
+    def test_instruction_mentions_no_followups_for_greetings(self, mock_load_config):
+        mock_load_config.return_value = {"display": {"followup_questions": True, "followup_count": 3}}
+        from agent.system_prompt import build_system_prompt
+
+        agent = _make_mock_agent()
+        prompt = build_system_prompt(agent)
+        assert "simple acknowledgment" in prompt or "greeting" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Dump visibility
+# ---------------------------------------------------------------------------
+
+
+class TestFollowupQuestionsDump:
+    """Verify the key appears in hermes config display when overridden."""
+
+    def test_followup_questions_in_dump_keys(self):
+        from hermes_cli.dump import _config_overrides
+
+        config = {"display": {"followup_questions": True}}
+        with patch("hermes_cli.dump.load_config", return_value=config):
+            overrides = _config_overrides(config)
+        assert "display.followup_questions" in overrides
+
+    def test_followup_questions_not_in_dump_when_default(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        from hermes_cli.dump import _config_overrides
+
+        # Default config — followup_questions is False
+        config = dict(DEFAULT_CONFIG)
+        overrides = _config_overrides(config)
+        assert "display.followup_questions" not in overrides


### PR DESCRIPTION
## Summary

Adds a configurable follow-up question suggestions feature that appends 2–5 contextual follow-up questions at the end of each assistant response, similar to Claude.ai's suggestion UI.

Closes #43413

## Changes

**`hermes_cli/config.py`** — Two new config keys under `display`:
- `followup_questions: false` — enable/disable (default off)
- `followup_count: 3` — number of suggestions (clamped to 2–5)

**`agent/system_prompt.py`** — When `display.followup_questions` is `True`, injects a prompt instruction into the stable system prompt tier telling the model to append a numbered list of follow-up questions under a "**Suggested follow-ups:**" heading. The instruction is suppressed for simple acknowledgments, greetings, and concluded conversations.

**`hermes_cli/dump.py`** — `display.followup_questions` appears in `hermes config display` when overridden from default.

**`tests/agent/test_followup_questions.py`** — 12 tests covering:
- Config defaults (False, count=3)
- Prompt injection when enabled/disabled
- Count clamping (min 2, max 5)
- Graceful fallback on config error
- Instruction content validation
- Dump visibility

## Usage

```yaml
# config.yaml
display:
  followup_questions: true
  followup_count: 3  # 2-5
```

## Design Notes

- **Prompt cache safe**: The instruction is in the stable tier and only depends on config (which doesn't change mid-session), so it doesn't break prefix caching.
- **Zero footprint when off**: Default is `False` — no instruction injected, no tokens consumed.
- **Config-gated**: Users who find it noisy can turn it off without code changes.
