### PR TITLE
fix(config): fall back to provider-level context_length for fill rate calculation

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3969,7 +3969,8 @@ def get_custom_provider_context_length(
 
     Matches any entry whose ``base_url`` equals ``base_url`` (trailing-slash
     insensitive) and returns ``custom_providers[i].models.<model>.context_length``
-    if present and valid.  Returns ``None`` when no override applies.
+    if present and valid.  Falls back to the provider-level ``context_length``
+    if no per-model override is set.  Returns ``None`` when no override applies.
 
     This is the single source of truth for custom-provider context overrides,
     used by:
@@ -4006,21 +4007,30 @@ def get_custom_provider_context_length(
         entry_url = (entry.get("base_url") or "").rstrip("/")
         if not entry_url or entry_url != target_url:
             continue
+        # First check per-model context_length
         models = entry.get("models")
-        if not isinstance(models, dict):
-            continue
-        model_cfg = models.get(model)
-        if not isinstance(model_cfg, dict):
-            continue
-        raw_ctx = model_cfg.get("context_length")
-        if raw_ctx is None:
-            continue
-        try:
-            ctx = int(raw_ctx)
-        except (TypeError, ValueError):
-            continue
-        if ctx > 0:
-            return ctx
+        if isinstance(models, dict):
+            model_cfg = models.get(model)
+            if isinstance(model_cfg, dict):
+                raw_ctx = model_cfg.get("context_length")
+                if raw_ctx is not None:
+                    try:
+                        ctx = int(raw_ctx)
+                    except (TypeError, ValueError):
+                        pass
+                    else:
+                        if ctx > 0:
+                            return ctx
+        # Fallback to provider-level context_length
+        raw_ctx = entry.get("context_length")
+        if raw_ctx is not None:
+            try:
+                ctx = int(raw_ctx)
+            except (TypeError, ValueError):
+                pass
+            else:
+                if ctx > 0:
+                    return ctx
     return None
 
 

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -142,6 +142,70 @@ class TestGetCustomProviderContextLength:
             == 400_000
         )
 
+    def test_falls_back_to_provider_level_context_length(self):
+        """When per-model context_length is absent, provider-level context_length is used."""
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "context_length": 131_072,
+                "models": {"some-model": {}},  # model present but no context_length
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "some-model", "https://example.invalid/v1", custom
+            )
+            == 131_072
+        )
+
+    def test_provider_level_context_length_used_when_no_models_dict(self):
+        """When models dict is absent entirely, provider-level context_length is used."""
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "context_length": 131_072,
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "any-model", "https://example.invalid/v1", custom
+            )
+            == 131_072
+        )
+
+    def test_per_model_overrides_provider_level(self):
+        """Per-model context_length takes precedence over provider-level."""
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "context_length": 131_072,
+                "models": {"m": {"context_length": 500_000}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "m", "https://example.invalid/v1", custom
+            )
+            == 500_000
+        )
+
+    def test_provider_level_invalid_value_is_skipped(self):
+        """Invalid provider-level context_length (string, zero, negative) is skipped."""
+        for bad in ("130K", 0, -100):
+            custom = [
+                {
+                    "base_url": "https://example.invalid/v1",
+                    "context_length": bad,
+                    "models": {"m": {}},
+                }
+            ]
+            assert (
+                get_custom_provider_context_length(
+                    "m", "https://example.invalid/v1", custom
+                )
+                is None
+            ), f"provider-level value {bad!r} should be rejected"
+
 
 class TestGetModelContextLengthHonorsOverride:
     """agent.model_metadata.get_model_context_length must honor the


### PR DESCRIPTION
## Summary
Fixes the context fill rate calculation to use provider-level `context_length` from config.yaml as a fallback when per-model and top-level `context_length` are not set.

## Problem
The context fill rate displayed in the Hermes Agent UI/CLI was calculated using a hardcoded denominator of 256,000 tokens (the default fallback) regardless of the model's actual `context_length` defined in the provider configuration.

When a user configured a provider (e.g., LM Studio with 130k limit) with a provider-level `context_length` in `config.yaml`, the fallback to 256k was still used because the provider-level value wasn't being considered as a fallback.

## Root Cause
The `get_custom_provider_context_length()` function in `hermes_cli/config.py` only checked for per-model `context_length` overrides (`custom_providers[].models.<model>.context_length`) and didn't fall back to the provider-level `context_length` (`custom_providers[].context_length`).

## Solution
Modified `get_custom_provider_context_length()` to:
1. First check per-model `context_length` (existing behavior, highest priority)
2. If not found, fall back to provider-level `context_length` (new behavior)

This ensures that provider-level context windows like LM Studio's 130k limit are properly used for fill rate calculations.

## Testing
- Added 4 new regression tests covering:
  - Provider-level fallback when per-model is absent
  - Provider-level fallback when no models dict exists
  - Per-model takes precedence over provider-level
  - Invalid provider-level values are skipped correctly
- All existing tests continue to pass

## Related Issue
Fixes #43462
