### PR TITLE
docs(memory): clarify that built-in memory does not auto-compact when full

### DIFF
--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -20,7 +20,13 @@ Two files make up the agent's memory:
 Both are stored in `~/.hermes/memories/` and are injected into the system prompt as a frozen snapshot at session start. The agent manages its own memory via the `memory` tool — it can add, replace, or remove entries.
 
 :::info
-Character limits keep memory focused. When memory is full, the agent consolidates or replaces entries to make room for new information.
+Character limits keep memory focused. Memory does **not** auto-compact: when a
+write would exceed the limit, the `memory` tool returns an error instead of
+silently dropping entries. The agent then makes room itself — consolidating or
+removing entries in the same turn before retrying (see [What Happens When Memory
+is Full](#what-happens-when-memory-is-full)). Note that `replace` is also bound
+by the limit: swapping an entry for a longer one can still overflow, so the new
+content must be shortened (or another entry removed) to fit.
 :::
 
 ## How Memory Appears in the System Prompt


### PR DESCRIPTION
## Summary

A user reported confusion (Discord) about built-in `MEMORY.md` behavior when the store is near capacity:

- Memory at `2,189 / 2,200` chars; they tried to `replace` a ~135-char entry with a slightly longer one and got `Replacement would put memory at 2,228/2,200 chars`.
- They confirmed the math is correct, but the docs say *"When memory is full, the agent consolidates or replaces entries to make room"* — which reads as if the store **self-compacts automatically**. In practice the tool just returns an error and asks the agent to consolidate.

This is **not a code bug** — it's intentional design (`fix(memory): instruct in-turn consolidation + retry on overflow`, #41755). The `replace` budget check in `tools/memory_tool.py` correctly computes the *post-replacement* total, and a longer replacement near the cap legitimately overflows. The tool cannot decide which entry to drop — that's the agent's job, prompted by the error.

The only thing genuinely off is the **docs wording**. This PR tightens the `:::info` callout in `website/docs/user-guide/features/memory.md` to make clear that:

- Memory does **not** auto-compact; the tool returns an overflow error rather than silently dropping entries.
- The agent makes room itself (consolidate/remove in-turn, then retry).
- `replace` is bound by the same limit — swapping in a longer entry can still overflow.

No behavior change; docs only.

## Test plan

- [ ] `cd website && npm run build` (Docusaurus build / link check) — verify the new `#what-happens-when-memory-is-full` anchor resolves.


## Infographic

![memory-no-auto-compact](https://v3b.fal.media/files/b/0a9dc90a/_fHbqTokyoBzJ_1Yc_4xP_ijQIIQxE.png)
