### PR TITLE
fix: keep Telegram documents out of native image routing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7489,7 +7489,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             audio_paths = []
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
-                if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
+                # Telegram albums can merge photos and documents into a single
+                # MessageEvent.  In that case the aggregate event may still be
+                # PHOTO, but each attachment's MIME type remains authoritative.
+                # Do not let a PHOTO wrapper promote text/PDF/etc. attachments
+                # into native image routing, or providers reject the turn as
+                # invalid image data.
+                if mtype.startswith("image/") or (not mtype and event.message_type == MessageType.PHOTO):
                     image_paths.append(path)
                 # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a) — never STT
                 # MessageType.VOICE = voice message (Opus/OGG) — always STT

--- a/tests/gateway/test_gateway_inbound_media_routing.py
+++ b/tests/gateway/test_gateway_inbound_media_routing.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from gateway.run import GatewayRunner
+
+
+@pytest.mark.asyncio
+async def test_photo_album_does_not_promote_text_attachment_to_native_image():
+    """Mixed Telegram media groups keep per-attachment MIME boundaries.
+
+    Telegram can deliver an album whose first item is a photo and later items are
+    documents.  The merged MessageEvent may therefore be typed PHOTO while still
+    carrying non-image attachments.  Native image routing must attach only the
+    image MIME entries; otherwise providers reject text bytes as invalid image
+    data.
+    """
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+    runner._pending_native_image_paths_by_session = {}
+    runner._session_key_for_source = lambda source: "telegram:dm:123"
+    runner._decide_image_input_mode = lambda: "native"
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="u1",
+        user_name="Pedro",
+    )
+    event = MessageEvent(
+        text="check these attachments",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/cache/screenshot.png", "/cache/snippet.txt"],
+        media_types=["image/png", "text/plain"],
+    )
+
+    prepared = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert prepared == "check these attachments"
+    assert runner._pending_native_image_paths_by_session["telegram:dm:123"] == [
+        "/cache/screenshot.png"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_photo_without_mime_still_routes_as_native_image():
+    """Keep the legacy fallback for photo updates that lack a MIME type."""
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+    runner._pending_native_image_paths_by_session = {}
+    runner._session_key_for_source = lambda source: "telegram:dm:123"
+    runner._decide_image_input_mode = lambda: "native"
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", chat_type="dm")
+    event = MessageEvent(
+        text="photo",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/cache/photo-without-mime.jpg"],
+        media_types=[""],
+    )
+
+    await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+
+    assert runner._pending_native_image_paths_by_session["telegram:dm:123"] == [
+        "/cache/photo-without-mime.jpg"
+    ]


### PR DESCRIPTION
## Summary

Fixes a Telegram gateway edge case where a mixed media group (photos plus a text/document attachment) can be merged into a single `MessageEvent` whose aggregate `message_type` is `PHOTO`. The previous inbound routing logic used that aggregate type to classify every attachment as an image, so native vision models received text/document bytes as `image_url` data and rejected the turn.

## Reproduction observed in production

A Telegram DM sent one message containing:

- 3 PNG screenshots
- 1 `.txt` snippet document

Gateway cached the files correctly and the `.txt` was valid text, but the merged event was still typed `PHOTO`. The native image routing path then tried to attach the `.txt` as an image. OpenAI/Codex rejected the request with:

```text
HTTP 400: The image data you provided does not represent a valid image.
supported image formats: ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
```

The user turn failed before the agent could answer.

## Fix

Use each attachment's MIME type as the authoritative classifier. Keep the legacy fallback for photo updates with no MIME type, but do not let an aggregate `PHOTO` wrapper promote explicit `text/plain`, PDF, or other document MIME entries into native image routing.

## Tests

Added focused gateway tests for:

- a `PHOTO` event containing `image/png` + `text/plain` only buffers the PNG for native image routing
- a legacy photo attachment without MIME type still routes as an image

Verified locally:

```text
uv run --python /Users/pedro/.local/share/uv/python/cpython-3.11.10-macos-aarch64-none/bin/python3 --extra dev --extra messaging python -m pytest tests/gateway/test_gateway_inbound_media_routing.py tests/gateway/test_telegram_text_batching.py -q

8 passed in 1.97s
```
