### PR TITLE
feat: read Home Assistant todo items

### DIFF
--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -13,10 +13,12 @@ from tools.homeassistant_tool import (
     _check_ha_available,
     _filter_and_summarize,
     _build_service_payload,
+    _build_service_url,
     _parse_service_response,
     _get_headers,
     _handle_get_state,
     _handle_call_service,
+    _handle_get_todo_items,
     _BLOCKED_DOMAINS,
     _ENTITY_ID_RE,
     _SERVICE_NAME_RE,
@@ -36,6 +38,13 @@ SAMPLE_STATES = [
     {"entity_id": "binary_sensor.motion", "state": "off", "attributes": {"friendly_name": "Hallway Motion"}},
     {"entity_id": "sensor.humidity", "state": "55", "attributes": {"friendly_name": "Bedroom Humidity", "area": "bedroom"}},
 ]
+
+
+def _close_mocked_coroutine(mock_run):
+    """Close coroutine created before _run_async is patched to avoid warnings."""
+    coro = mock_run.call_args[0][0]
+    if hasattr(coro, "close"):
+        coro.close()
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +152,18 @@ class TestBuildServicePayload:
         assert payload["entity_id"] == "light.a"
 
 
+class TestBuildServiceUrl:
+    def test_service_url_without_return_response(self):
+        url = _build_service_url("https://ha.example", "light", "turn_on")
+        assert url == "https://ha.example/api/services/light/turn_on"
+
+    def test_service_url_with_return_response(self):
+        url = _build_service_url(
+            "https://ha.example", "todo", "get_items", return_response=True
+        )
+        assert url == "https://ha.example/api/services/todo/get_items?return_response"
+
+
 # ---------------------------------------------------------------------------
 # Service response parsing
 # ---------------------------------------------------------------------------
@@ -179,6 +200,31 @@ class TestParseServiceResponse:
     def test_service_name_format(self):
         result = _parse_service_response("climate", "set_temperature", [])
         assert result["service"] == "climate.set_temperature"
+
+    def test_return_response_preserves_dict_response(self):
+        ha_response = {
+            "todo.tawnberry": {
+                "items": [
+                    {"summary": "Milk", "status": "needs_action"},
+                    {"summary": "Eggs", "status": "needs_action"},
+                ]
+            }
+        }
+        result = _parse_service_response(
+            "todo", "get_items", ha_response, return_response=True
+        )
+        assert result["success"] is True
+        assert result["service"] == "todo.get_items"
+        assert result["affected_entities"] == []
+        assert result["response"] == ha_response
+
+    def test_non_return_response_keeps_existing_dict_behavior(self):
+        result = _parse_service_response(
+            "script", "run", {"result": "ok"}, return_response=False
+        )
+        assert result["success"] is True
+        assert result["affected_entities"] == []
+        assert "response" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -322,8 +368,9 @@ class TestCallServiceStringData:
             "entity_id": "climate.living_room",
             "data": '{"hvac_mode": "heat"}',
         })
-        call_args = mock_run.call_args[0][0]  # the coroutine arg
         # _run_async was called, meaning we got past validation
+        mock_run.assert_called_once()
+        _close_mocked_coroutine(mock_run)
 
     @patch("tools.homeassistant_tool._run_async", return_value={"success": True})
     def test_dict_data_passthrough(self, mock_run):
@@ -335,6 +382,7 @@ class TestCallServiceStringData:
             "data": {"brightness": 255},
         })
         mock_run.assert_called_once()
+        _close_mocked_coroutine(mock_run)
 
     def test_invalid_json_string_returns_error(self):
         """Malformed JSON string in data returns a clear error."""
@@ -357,6 +405,84 @@ class TestCallServiceStringData:
             "data": "   ",
         })
         mock_run.assert_called_once()
+        _close_mocked_coroutine(mock_run)
+
+    @patch("tools.homeassistant_tool._run_async", return_value={"success": True})
+    def test_return_response_boolean_passthrough(self, mock_run):
+        """return_response can be supplied as a top-level boolean."""
+        result = json.loads(_handle_call_service({
+            "domain": "todo",
+            "service": "get_items",
+            "entity_id": "todo.tawnberry",
+            "data": '{"status": "needs_action"}',
+            "return_response": True,
+        }))
+        assert result["result"]["success"] is True
+        mock_run.assert_called_once()
+        _close_mocked_coroutine(mock_run)
+
+    @patch("tools.homeassistant_tool._run_async", return_value={"success": True})
+    def test_return_response_string_true_passthrough(self, mock_run):
+        """return_response may arrive as a string in XML tool-calling mode."""
+        result = json.loads(_handle_call_service({
+            "domain": "todo",
+            "service": "get_items",
+            "entity_id": "todo.tawnberry",
+            "data": '{"status": "needs_action"}',
+            "return_response": "true",
+        }))
+        assert result["result"]["success"] is True
+        mock_run.assert_called_once()
+        _close_mocked_coroutine(mock_run)
+
+
+class TestGetTodoItemsHandler:
+    def test_missing_entity_id(self):
+        result = json.loads(_handle_get_todo_items({}))
+        assert "error" in result
+        assert "entity_id" in result["error"]
+
+    def test_rejects_invalid_entity_id(self):
+        result = json.loads(_handle_get_todo_items({"entity_id": "../../config"}))
+        assert "error" in result
+        assert "Invalid entity_id" in result["error"]
+
+    def test_rejects_non_todo_entity(self):
+        result = json.loads(_handle_get_todo_items({"entity_id": "sensor.temperature"}))
+        assert "error" in result
+        assert "todo" in result["error"].lower()
+
+    def test_rejects_invalid_status(self):
+        result = json.loads(_handle_get_todo_items({
+            "entity_id": "todo.tawnberry",
+            "status": "unknown",
+        }))
+        assert "error" in result
+        assert "status" in result["error"].lower()
+
+    @patch("tools.homeassistant_tool._run_async", return_value={
+        "success": True,
+        "service": "todo.get_items",
+        "affected_entities": [],
+        "response": {
+            "todo.tawnberry": {
+                "items": [
+                    {"summary": "Milk", "status": "needs_action"},
+                    {"summary": "Hermes test item", "status": "needs_action"},
+                ]
+            }
+        },
+    })
+    def test_get_todo_items_returns_items(self, mock_run):
+        result = json.loads(_handle_get_todo_items({
+            "entity_id": "todo.tawnberry",
+            "status": "needs_action",
+        }))
+        assert result["result"]["entity_id"] == "todo.tawnberry"
+        assert result["result"]["count"] == 2
+        assert result["result"]["items"][0]["summary"] == "Milk"
+        mock_run.assert_called_once()
+        _close_mocked_coroutine(mock_run)
 
 
 # ---------------------------------------------------------------------------
@@ -490,13 +616,21 @@ class TestRegistration:
         names = registry.get_all_tool_names()
         assert "ha_list_entities" in names
         assert "ha_get_state" in names
+        assert "ha_list_services" in names
         assert "ha_call_service" in names
+        assert "ha_get_todo_items" in names
 
     def test_tools_in_homeassistant_toolset(self):
         from tools.registry import registry
 
         toolset_map = registry.get_tool_to_toolset_map()
-        for tool in ("ha_list_entities", "ha_get_state", "ha_call_service"):
+        for tool in (
+            "ha_list_entities",
+            "ha_get_state",
+            "ha_list_services",
+            "ha_call_service",
+            "ha_get_todo_items",
+        ):
             assert toolset_map[tool] == "homeassistant"
 
     def test_check_fn_gates_availability(self, monkeypatch):
@@ -505,7 +639,13 @@ class TestRegistration:
 
         monkeypatch.delenv("HASS_TOKEN", raising=False)
         invalidate_check_fn_cache()
-        defs = registry.get_definitions({"ha_list_entities", "ha_get_state", "ha_call_service"})
+        defs = registry.get_definitions({
+            "ha_list_entities",
+            "ha_get_state",
+            "ha_list_services",
+            "ha_call_service",
+            "ha_get_todo_items",
+        })
         assert len(defs) == 0
 
     def test_check_fn_includes_when_token_set(self, monkeypatch):
@@ -514,5 +654,11 @@ class TestRegistration:
 
         monkeypatch.setenv("HASS_TOKEN", "test-token")
         invalidate_check_fn_cache()
-        defs = registry.get_definitions({"ha_list_entities", "ha_get_state", "ha_call_service"})
-        assert len(defs) == 3
+        defs = registry.get_definitions({
+            "ha_list_entities",
+            "ha_get_state",
+            "ha_list_services",
+            "ha_call_service",
+            "ha_get_todo_items",
+        })
+        assert len(defs) == 5

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -153,10 +153,24 @@ def _build_service_payload(
     return payload
 
 
+def _build_service_url(
+    hass_url: str,
+    domain: str,
+    service: str,
+    return_response: bool = False,
+) -> str:
+    """Build the HA service URL, optionally requesting response data."""
+    url = f"{hass_url}/api/services/{domain}/{service}"
+    if return_response:
+        url += "?return_response"
+    return url
+
+
 def _parse_service_response(
     domain: str,
     service: str,
     result: Any,
+    return_response: bool = False,
 ) -> Dict[str, Any]:
     """Parse HA service call response into a structured result."""
     affected = []
@@ -167,10 +181,30 @@ def _parse_service_response(
                 "state": s.get("state", ""),
             })
 
-    return {
+    parsed = {
         "success": True,
         "service": f"{domain}.{service}",
         "affected_entities": affected,
+    }
+    if return_response:
+        parsed["response"] = result
+    return parsed
+
+
+def _extract_todo_items_response(
+    entity_id: str,
+    service_result: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Extract todo items from a HA todo.get_items service response."""
+    response = service_result.get("response", {}) if isinstance(service_result, dict) else {}
+    entity_payload = response.get(entity_id, {}) if isinstance(response, dict) else {}
+    items = entity_payload.get("items", []) if isinstance(entity_payload, dict) else []
+    if not isinstance(items, list):
+        items = []
+    return {
+        "entity_id": entity_id,
+        "count": len(items),
+        "items": items,
     }
 
 
@@ -179,12 +213,13 @@ async def _async_call_service(
     service: str,
     entity_id: Optional[str] = None,
     data: Optional[Dict[str, Any]] = None,
+    return_response: bool = False,
 ) -> Dict[str, Any]:
     """Call a Home Assistant service."""
     import aiohttp
 
     hass_url, hass_token = _get_config()
-    url = f"{hass_url}/api/services/{domain}/{service}"
+    url = _build_service_url(hass_url, domain, service, return_response)
     payload = _build_service_payload(entity_id, data)
 
     async with aiohttp.ClientSession() as session:
@@ -197,7 +232,7 @@ async def _async_call_service(
             resp.raise_for_status()
             result = await resp.json()
 
-    return _parse_service_response(domain, service, result)
+    return _parse_service_response(domain, service, result, return_response=return_response)
 
 
 # ---------------------------------------------------------------------------
@@ -280,12 +315,54 @@ def _handle_call_service(args: dict, **kw) -> str:
         except json.JSONDecodeError as e:
             return tool_error(f"Invalid JSON string in 'data' parameter: {e}")
 
+    return_response = args.get("return_response", False)
+    if isinstance(return_response, str):
+        return_response = return_response.strip().lower() in {"1", "true", "yes", "on"}
+    else:
+        return_response = bool(return_response)
+
     try:
-        result = _run_async(_async_call_service(domain, service, entity_id, data))
+        result = _run_async(
+            _async_call_service(
+                domain,
+                service,
+                entity_id,
+                data,
+                return_response=return_response,
+            )
+        )
         return json.dumps({"result": result})
     except Exception as e:
         logger.error("ha_call_service error: %s", e)
         return tool_error(f"Failed to call {domain}.{service}: {e}")
+
+
+def _handle_get_todo_items(args: dict, **kw) -> str:
+    """Handler for ha_get_todo_items tool."""
+    entity_id = args.get("entity_id", "")
+    if not entity_id:
+        return tool_error("Missing required parameter: entity_id")
+    if not _ENTITY_ID_RE.match(entity_id):
+        return tool_error(f"Invalid entity_id format: {entity_id}")
+    if not entity_id.startswith("todo."):
+        return tool_error(f"ha_get_todo_items only supports todo entities, got: {entity_id}")
+
+    status = args.get("status", "needs_action") or "needs_action"
+    if status not in {"needs_action", "completed"}:
+        return tool_error("Invalid status: expected 'needs_action' or 'completed'")
+
+    try:
+        result = _run_async(_async_call_service(
+            "todo",
+            "get_items",
+            entity_id=entity_id,
+            data={"status": status},
+            return_response=True,
+        ))
+        return json.dumps({"result": _extract_todo_items_response(entity_id, result)})
+    except Exception as e:
+        logger.error("ha_get_todo_items error: %s", e)
+        return tool_error(f"Failed to get todo items for {entity_id}: {e}")
 
 
 # ---------------------------------------------------------------------------
@@ -464,8 +541,42 @@ HA_CALL_SERVICE_SCHEMA = {
                     '{"volume_level": 0.5} for media players.'
                 ),
             },
+            "return_response": {
+                "type": "boolean",
+                "description": (
+                    "Set true for Home Assistant services that return response data, "
+                    "such as todo.get_items. This appends ?return_response to the REST call."
+                ),
+            },
         },
         "required": ["domain", "service"],
+    },
+}
+
+
+HA_GET_TODO_ITEMS_SCHEMA = {
+    "name": "ha_get_todo_items",
+    "description": (
+        "Get items from a Home Assistant todo list entity, such as a Bring grocery list. "
+        "Use this to read shopping-list contents."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "entity_id": {
+                "type": "string",
+                "description": "Todo entity ID, e.g. 'todo.tawnberry' or 'todo.costco'.",
+            },
+            "status": {
+                "type": "string",
+                "description": (
+                    "Item status to fetch: 'needs_action' for active items or 'completed'. "
+                    "Defaults to 'needs_action'."
+                ),
+                "enum": ["needs_action", "completed"],
+            },
+        },
+        "required": ["entity_id"],
     },
 }
 
@@ -510,4 +621,13 @@ registry.register(
     handler=_handle_call_service,
     check_fn=_check_ha_available,
     emoji="🏠",
+)
+
+registry.register(
+    name="ha_get_todo_items",
+    toolset="homeassistant",
+    schema=HA_GET_TODO_ITEMS_SCHEMA,
+    handler=_handle_get_todo_items,
+    check_fn=_check_ha_available,
+    emoji="🛒",
 )

--- a/website/docs/user-guide/messaging/homeassistant.md
+++ b/website/docs/user-guide/messaging/homeassistant.md
@@ -48,7 +48,7 @@ Home Assistant will appear as a connected platform alongside any other messaging
 
 ## Available Tools
 
-Hermes Agent registers four tools for smart home control:
+Hermes Agent registers Home Assistant tools for smart-home control and todo/shopping-list access:
 
 ### `ha_list_entities`
 
@@ -91,6 +91,20 @@ List available services (actions) for device control. Shows what actions can be 
 What services are available for climate devices?
 ```
 
+### `ha_get_todo_items`
+
+Get active or completed items from a Home Assistant `todo` entity, including Bring! shopping lists.
+
+**Parameters:**
+- `entity_id` *(required)* — Todo entity ID, e.g. `todo.shopping_list`, `todo.groceries`
+- `status` *(optional)* — `needs_action` for active items, or `completed`. Defaults to `needs_action`.
+
+**Example:**
+```
+What's on my grocery list?
+→ ha_get_todo_items(entity_id="todo.shopping_list")
+```
+
 ### `ha_call_service`
 
 Call a Home Assistant service to control a device.
@@ -100,6 +114,7 @@ Call a Home Assistant service to control a device.
 - `service` *(required)* — Service name: `turn_on`, `turn_off`, `toggle`, `set_temperature`, `set_hvac_mode`, `open_cover`, `close_cover`, `set_volume_level`
 - `entity_id` *(optional)* — Target entity, e.g., `light.living_room`
 - `data` *(optional)* — Additional parameters as a JSON object
+- `return_response` *(optional)* — Set to `true` for services that return data, such as `todo.get_items`.
 
 **Examples:**
 


### PR DESCRIPTION
## Summary
- add optional `return_response` support to `ha_call_service`
- add `ha_get_todo_items` for Home Assistant todo/Bring shopping-list reads
- document todo list access and response-returning service calls

## Test Plan
- `python -m py_compile tools/homeassistant_tool.py tests/tools/test_homeassistant_tool.py`
- `python -m pytest tests/tools/test_homeassistant_tool.py -q -o 'addopts='`
- live local verification against Home Assistant todo entities returned structured counts for `todo.tawnberry` and `todo.costco`
