### PR TITLE
fix(memory): use exact match instead of LIKE in _resolve_entity to prevent wildcard bugs

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -435,20 +435,24 @@ class MemoryStore:
 
         Returns the entity_id.
         """
-        # Exact name match
+        # Exact name match (case-insensitive; use = with LOWER to avoid
+        # LIKE wildcard pitfalls — _ is single-char wildcard, % is multi-char)
         row = self._conn.execute(
-            "SELECT entity_id FROM entities WHERE name LIKE ?", (name,)
+            "SELECT entity_id FROM entities WHERE LOWER(name) = LOWER(?)",
+            (name,),
         ).fetchone()
         if row is not None:
             return int(row["entity_id"])
 
-        # Search aliases — aliases stored as comma-separated; use LIKE with % boundaries
+        # Search aliases — aliases stored as comma-separated; use LIKE with
+        # % boundaries, but escape wildcard chars in the search term.
+        escaped = name.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         alias_row = self._conn.execute(
             """
             SELECT entity_id FROM entities
-            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%'
+            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%' ESCAPE '\\'
             """,
-            (name,),
+            (escaped,),
         ).fetchone()
         if alias_row is not None:
             return int(alias_row["entity_id"])

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -1,0 +1,149 @@
+"""Tests for _resolve_entity LIKE-wildcard and case-sensitivity fixes (issue #43394)."""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.memory.holographic.store import MemoryStore as FactStore
+
+
+class TestResolveEntityNameMatch:
+    """_resolve_entity name lookup must be exact (no LIKE wildcards)."""
+
+    def test_underscore_not_wildcard(self):
+        """Underscore in entity name must NOT match arbitrary single chars."""
+        store = FactStore(":memory:")
+        try:
+            store.add_fact("test_entity is a framework", category="tech")
+            # "testXentity" should NOT resolve to "test_entity"
+            id_different = store._resolve_entity("testXentity")
+            id_original = store._resolve_entity("test_entity")
+            assert id_different != id_original
+        finally:
+            store.close()
+
+    def test_percent_not_wildcard(self):
+        """Percent in entity name must NOT match arbitrary substrings."""
+        store = FactStore(":memory:")
+        try:
+            store.add_fact("100% complete", category="general")
+            # "100X complete" should NOT resolve to "100% complete"
+            id_different = store._resolve_entity("100X complete")
+            id_original = store._resolve_entity("100% complete")
+            assert id_different != id_original
+        finally:
+            store.close()
+
+    def test_case_insensitive_match(self):
+        """Entity lookup must be case-insensitive (docstring contract)."""
+        store = FactStore(":memory:")
+        try:
+            store.add_fact("Apple released iOS 19", category="tech")
+            # Different casing should resolve to the SAME entity
+            id_upper = store._resolve_entity("APPLE")
+            id_original = store._resolve_entity("Apple")
+            assert id_upper == id_original
+        finally:
+            store.close()
+
+    def test_exact_match_no_false_positive(self):
+        """Similar but distinct names must resolve to different entities."""
+        store = FactStore(":memory:")
+        try:
+            store.add_fact("OpenAI is an AI company", category="tech")
+            store.add_fact("OpenAI_API is a library", category="tech")
+            id1 = store._resolve_entity("OpenAI")
+            id2 = store._resolve_entity("OpenAI_API")
+            assert id1 != id2
+        finally:
+            store.close()
+
+
+class TestResolveEntityAliasMatch:
+    """Alias lookup must escape LIKE wildcards in search term."""
+
+    def test_alias_underscore_not_wildcard(self):
+        """Underscore in alias search must NOT match arbitrary chars."""
+        store = FactStore(":memory:")
+        try:
+            # Manually insert entity with alias containing underscore
+            store._conn.execute(
+                "INSERT INTO entities (name, aliases) VALUES (?, ?)",
+                ("Test Entity", "test_alias,other"),
+            )
+            store._conn.commit()
+            # "test_alias" should match, "testXalias" should NOT
+            id_match = store._resolve_entity("test_alias")
+            assert id_match is not None
+            # Now search for a name that doesn't exist as name or alias
+            id_no_match = store._resolve_entity("testXalias")
+            # Should be a NEW entity (different ID)
+            assert id_no_match != id_match
+        finally:
+            store.close()
+
+    def test_alias_percent_not_wildcard(self):
+        """Percent in alias search must NOT match arbitrary substrings."""
+        store = FactStore(":memory:")
+        try:
+            store._conn.execute(
+                "INSERT INTO entities (name, aliases) VALUES (?, ?)",
+                ("Revenue Corp", "100%"),
+            )
+            store._conn.commit()
+            # "100%" should match via alias
+            id_match = store._resolve_entity("100%")
+            assert id_match is not None
+            # "100X" should NOT match via alias
+            id_no_match = store._resolve_entity("100X")
+            assert id_no_match != id_match
+        finally:
+            store.close()
+
+    def test_alias_exact_match_still_works(self):
+        """Normal alias matching (no wildcards) must still work."""
+        store = FactStore(":memory:")
+        try:
+            store._conn.execute(
+                "INSERT INTO entities (name, aliases) VALUES (?, ?)",
+                ("Robert", "Bob,Bobby"),
+            )
+            store._conn.commit()
+            id_bob = store._resolve_entity("Bob")
+            id_robert = store._resolve_entity("Robert")
+            assert id_bob == id_robert
+        finally:
+            store.close()
+
+
+class TestResolveEntityRegression:
+    """Ensure the fix doesn't break normal entity resolution."""
+
+    def test_new_entity_created_when_no_match(self):
+        """A truly new name must create a new entity."""
+        store = FactStore(":memory:")
+        try:
+            id1 = store._resolve_entity("UniqueEntity")
+            id2 = store._resolve_entity("UniqueEntity")
+            assert id1 == id2  # same entity on repeated lookup
+            # Different name → different entity
+            id3 = store._resolve_entity("DifferentEntity")
+            assert id3 != id1
+        finally:
+            store.close()
+
+    def test_add_fact_links_to_existing_entity(self):
+        """add_fact must reuse existing entities (no duplicates)."""
+        store = FactStore(":memory:")
+        try:
+            # Use a multi-word capitalized phrase (the regex extracts those)
+            store.add_fact("John Doe released a new framework", category="tech")
+            store.add_fact("John Doe improved the framework", category="tech")
+            # Should have exactly 1 entity for "John Doe"
+            rows = store._conn.execute(
+                "SELECT COUNT(*) FROM entities WHERE LOWER(name) = LOWER(?)",
+                ("John Doe",),
+            ).fetchone()
+            assert rows[0] == 1
+        finally:
+            store.close()


### PR DESCRIPTION
## What does this PR do?

Fixes `_resolve_entity()` in the holographic memory store to use exact matching instead of `LIKE`, preventing wildcard-related entity duplication and incorrect entity linking.

## Related Issue

Fixes #43394

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/holographic/store.py`: Replace `LIKE` with `LOWER() = LOWER()` for case-insensitive exact name match; escape `_` and `%` wildcards in alias LIKE search with `ESCAPE` clause
- `tests/plugins/memory/test_holographic_store.py`: Add 9 tests covering underscore/percent wildcard prevention, case-insensitive matching, alias escaping, and regression scenarios

## How to Test

1. Run `pytest tests/plugins/memory/test_holographic_store.py -v` — all 9 tests should pass
2. Verify that entity names containing `_` (e.g., `test_entity`) no longer match unrelated names like `testXentity`
3. Verify that entity names containing `%` (e.g., `100%`) no longer match unrelated names like `100X`
4. Verify that case-insensitive matching still works (e.g., `Apple` and `APPLE` resolve to the same entity)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `_resolve_entity` in `plugins/memory/holographic/store.py` (3 call sites: L182, L291, L433)
- Blast radius: LOW — `_resolve_entity` is internal to `MemoryStore`, called only by `add_fact` and `_link_fact_entity`
- Related patterns: SQL `LIKE` wildcard escaping; `LOWER()` for case-insensitive comparison
