### PR TITLE
fix(memory): add old_text to schema required list (#43412)

### DIFF
--- a/tests/tools/test_memory_tool_schema.py
+++ b/tests/tools/test_memory_tool_schema.py
@@ -39,7 +39,7 @@ def test_memory_schema_has_no_forbidden_top_level_combinators():
 def test_memory_schema_is_well_formed():
     params = MEMORY_SCHEMA["parameters"]
     assert params["type"] == "object"
-    assert params["required"] == ["action", "target"]
+    assert params["required"] == ["action", "target", "old_text"]
     # Nested ``enum`` on property values is fine — only top-level is forbidden.
     assert params["properties"]["action"]["enum"] == ["add", "replace", "remove"]
     assert params["properties"]["target"]["enum"] == ["memory", "user"]

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -784,7 +784,7 @@ MEMORY_SCHEMA = {
                 "description": "Short unique substring identifying the entry to replace or remove."
             },
         },
-        "required": ["action", "target"],
+        "required": ["action", "target", "old_text"],
     },
 }
 


### PR DESCRIPTION
Fixes #43412. The memory tool's remove action was failing with 'old_text is required' even when old_text was provided, because old_text was not in the schema's required list. Some LLM tool-calling implementations drop arguments not marked as required, so the handler received an empty string. Adding old_text to the required list ensures it is always passed through.