### PR TITLE
fix(skills/github): resolve .env via HERMES_HOME instead of hardcoded ~/.hermes

### DIFF
--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -220,8 +220,8 @@ if command -v gh &>/dev/null && gh auth status &>/dev/null; then
   echo "AUTH_METHOD=gh"
 elif [ -n "$GITHUB_TOKEN" ]; then
   echo "AUTH_METHOD=curl"
-elif [ -f ~/.hermes/.env ] && grep -q "^GITHUB_TOKEN=" ~/.hermes/.env; then
-  export GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" ~/.hermes/.env | head -1 | cut -d= -f2 | tr -d '\n\r')
+elif _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
+  export GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
   echo "AUTH_METHOD=curl"
 elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
   export GITHUB_TOKEN=$(grep "github.com" ~/.git-credentials | head -1 | sed 's|https://[^:]*:\([^@]*\)@.*|\1|')

--- a/skills/github/github-auth/scripts/gh-env.sh
+++ b/skills/github/github-auth/scripts/gh-env.sh
@@ -23,8 +23,8 @@ if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
     GH_USER=$(gh api user --jq '.login' 2>/dev/null)
 elif [ -n "$GITHUB_TOKEN" ]; then
     GH_AUTH_METHOD="curl"
-elif [ -f "$HOME/.hermes/.env" ] && grep -q "^GITHUB_TOKEN=" "$HOME/.hermes/.env" 2>/dev/null; then
-    GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$HOME/.hermes/.env" | head -1 | cut -d= -f2 | tr -d '\n\r')
+elif _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env" 2>/dev/null; then
+    GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     if [ -n "$GITHUB_TOKEN" ]; then
         GH_AUTH_METHOD="curl"
     fi

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -28,8 +28,8 @@ if command -v gh &>/dev/null && gh auth status &>/dev/null; then
 else
   AUTH="git"
   if [ -z "$GITHUB_TOKEN" ]; then
-    if [ -f ~/.hermes/.env ] && grep -q "^GITHUB_TOKEN=" ~/.hermes/.env; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" ~/.hermes/.env | head -1 | cut -d= -f2 | tr -d '\n\r')
+    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
+      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
       GITHUB_TOKEN=$(grep "github.com" ~/.git-credentials 2>/dev/null | head -1 | sed 's|https://[^:]*:\([^@]*\)@.*|\1|')
     fi

--- a/skills/github/github-issues/SKILL.md
+++ b/skills/github/github-issues/SKILL.md
@@ -28,8 +28,8 @@ if command -v gh &>/dev/null && gh auth status &>/dev/null; then
 else
   AUTH="git"
   if [ -z "$GITHUB_TOKEN" ]; then
-    if [ -f ~/.hermes/.env ] && grep -q "^GITHUB_TOKEN=" ~/.hermes/.env; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" ~/.hermes/.env | head -1 | cut -d= -f2 | tr -d '\n\r')
+    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
+      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
       GITHUB_TOKEN=$(grep "github.com" ~/.git-credentials 2>/dev/null | head -1 | sed 's|https://[^:]*:\([^@]*\)@.*|\1|')
     fi

--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -30,8 +30,8 @@ else
   AUTH="git"
   # Ensure we have a token for API calls
   if [ -z "$GITHUB_TOKEN" ]; then
-    if [ -f ~/.hermes/.env ] && grep -q "^GITHUB_TOKEN=" ~/.hermes/.env; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" ~/.hermes/.env | head -1 | cut -d= -f2 | tr -d '\n\r')
+    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
+      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
       GITHUB_TOKEN=$(grep "github.com" ~/.git-credentials 2>/dev/null | head -1 | sed 's|https://[^:]*:\([^@]*\)@.*|\1|')
     fi

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -27,8 +27,8 @@ if command -v gh &>/dev/null && gh auth status &>/dev/null; then
 else
   AUTH="git"
   if [ -z "$GITHUB_TOKEN" ]; then
-    if [ -f ~/.hermes/.env ] && grep -q "^GITHUB_TOKEN=" ~/.hermes/.env; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" ~/.hermes/.env | head -1 | cut -d= -f2 | tr -d '\n\r')
+    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
+      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
       GITHUB_TOKEN=$(grep "github.com" ~/.git-credentials 2>/dev/null | head -1 | sed 's|https://[^:]*:\([^@]*\)@.*|\1|')
     fi


### PR DESCRIPTION
## Summary

A user running Hermes via docker-compose reported that the official `github-auth` skill (and siblings) kept claiming `GITHUB_TOKEN` was "not set" even though it was present in `.env` and the dashboard Keys page showed it. Their key clue: *"HERMES_HOME=/opt/data but hermes always mentions ~/.hermes/.env which is wrong?"*

### Root cause

The GitHub skills' auth-detection blocks fall back to reading the token from a **hardcoded** `~/.hermes/.env`:

```bash
elif [ -f ~/.hermes/.env ] && grep -q "^GITHUB_TOKEN=" ~/.hermes/.env; then
  export GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" ~/.hermes/.env | ...)
```

In the official Docker layout, `HERMES_HOME=/opt/data`, but Hermes tool subprocesses run with `HOME=/opt/data/home` (set by `get_subprocess_home()` for per-profile HOME isolation — the same pitfall already documented in the `xurl` skill). So `~/.hermes/.env` expands to `/opt/data/home/.hermes/.env`, which doesn't exist, while the real secrets file is `/opt/data/.env`. The token is never found.

This is the `AGENTS.md` "do not hardcode `~/.hermes` paths — it breaks profiles / `HERMES_HOME`" pitfall, in skill scripts.

### Fix

Resolve the env file as `${HERMES_HOME:-$HOME/.hermes}/.env`. `HERMES_HOME` is bridged into the tool subprocess environment (`_inject_context_hermes_home` in `tools/environments/local.py`, and it also passes through from the container env since it isn't in the secret blocklist), so this resolves to `/opt/data/.env` in Docker and falls back to `~/.hermes/.env` everywhere else.

Applied to all six auth-detection sites (the whole bug class):

- `github-auth/SKILL.md` + `github-auth/scripts/gh-env.sh`
- `github-issues/SKILL.md`
- `github-repo-management/SKILL.md`
- `github-pr-workflow/SKILL.md`
- `github-code-review/SKILL.md`

No behavior change on non-Docker/default setups (`HERMES_HOME` unset → `$HOME/.hermes/.env`, identical to before).

## Test plan

- [ ] `bash -n skills/github/github-auth/scripts/gh-env.sh` (done — syntax OK; compound `if VAR=...; [ -f ] && grep; then` validated).
- [ ] In a Docker deployment with `HERMES_HOME=/opt/data` and `GITHUB_TOKEN` in `/opt/data/.env`, source `gh-env.sh` and confirm `GH_AUTH_METHOD=curl` with the token resolved (previously `none`).
- [ ] Default local setup (`HERMES_HOME` unset): token still read from `~/.hermes/.env`.