### PR TITLE
fix(tui): use live agent model for image routing after /model switch

### DIFF
--- a/tests/tui_gateway/test_image_routing_stale_model.py
+++ b/tests/tui_gateway/test_image_routing_stale_model.py
@@ -1,0 +1,93 @@
+"""Test that TUI gateway image routing uses live agent model, not stale runtime value.
+
+Regression test for #43516 — after switching models via /model mid-session,
+image routing should use the updated agent.provider and agent.model instead of
+the stale _RUNTIME_MAIN_MODEL set by the previous turn.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _make_agent(provider="", model=""):
+    """Create a mock agent with provider/model attributes."""
+    agent = SimpleNamespace()
+    agent.provider = provider
+    agent.model = model
+    agent.api_mode = ""
+    return agent
+
+
+class TestImageRoutingModelPreference:
+    """Verify the provider/model preference logic used in tui_gateway/server.py.
+
+    The fix (line ~5036) uses:
+        getattr(agent, "provider", "") or _read_main_provider()
+        getattr(agent, "model", "") or _read_main_model()
+
+    These tests verify the getattr + fallback expression produces the correct
+    value for all edge cases.
+    """
+
+    def test_prefers_agent_provider_and_model(self):
+        """After /model switch, agent attributes take priority."""
+        agent = _make_agent(provider="alibaba", model="qwen3.7-plus")
+        _stale_provider = "alibaba"
+        _stale_model = "qwen3.7-max"
+
+        effective_provider = getattr(agent, "provider", "") or _stale_provider
+        effective_model = getattr(agent, "model", "") or _stale_model
+
+        assert effective_provider == "alibaba"
+        assert effective_model == "qwen3.7-plus"
+
+    def test_falls_back_to_stale_when_agent_empty(self):
+        """Empty string on agent → falls back to stale runtime values."""
+        agent = _make_agent(provider="", model="")
+        _stale_provider = "openai"
+        _stale_model = "gpt-4o"
+
+        effective_provider = getattr(agent, "provider", "") or _stale_provider
+        effective_model = getattr(agent, "model", "") or _stale_model
+
+        assert effective_provider == "openai"
+        assert effective_model == "gpt-4o"
+
+    def test_falls_back_to_stale_when_agent_none(self):
+        """None on agent → getattr default "" → falsy → falls back."""
+        agent = SimpleNamespace(provider=None, model=None)
+        _stale_provider = "openai"
+        _stale_model = "gpt-4o"
+
+        effective_provider = getattr(agent, "provider", "") or _stale_provider
+        effective_model = getattr(agent, "model", "") or _stale_model
+
+        assert effective_provider == "openai"
+        assert effective_model == "gpt-4o"
+
+    def test_no_agent_uses_fallback(self):
+        """No agent at all → pure fallback."""
+        _stale_provider = "anthropic"
+        _stale_model = "claude-sonnet-4"
+
+        effective_provider = getattr(None, "provider", "") or _stale_provider
+        effective_model = getattr(None, "model", "") or _stale_model
+
+        assert effective_provider == "anthropic"
+        assert effective_model == "claude-sonnet-4"
+
+    def test_provider_and_model_differ_after_switch(self):
+        """Simulate the exact scenario from #43516."""
+        # User switched from qwen3.7-max → qwen3.7-plus via /model
+        agent = _make_agent(provider="alibaba", model="qwen3.7-plus")
+
+        # Runtime still has stale value from previous turn
+        _read_main_provider = lambda: "alibaba"
+        _read_main_model = lambda: "qwen3.7-max"
+
+        # The fix: prefer agent's live values
+        effective_provider = getattr(agent, "provider", "") or _read_main_provider()
+        effective_model = getattr(agent, "model", "") or _read_main_model()
+
+        assert effective_model == "qwen3.7-plus"  # NOT "qwen3.7-max"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5034,8 +5034,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
 
                     _cfg = _tui_load_config()
                     _mode = decide_image_input_mode(
-                        _read_main_provider(),
-                        _read_main_model(),
+                        getattr(agent, "provider", "") or _read_main_provider(),
+                        getattr(agent, "model", "") or _read_main_model(),
                         _cfg,
                     )
                     if getattr(agent, "api_mode", "") == "codex_app_server":


### PR DESCRIPTION
## Problem

When switching models via `/model` mid-session (e.g., from a non-vision model to a vision-capable one), image attachments still fail with `[The user attached an image but analysis failed.]` even though the new model supports vision.

The image routing decision in `tui_gateway/server.py` uses `_read_main_model()` which reads from `_RUNTIME_MAIN_MODEL` (set by the **previous turn's** `build_turn_context`). It does **not** reflect the current `agent.model` value that was just updated by `/model`.

## Root Cause

```python
# Before (line 5036-5040):
_mode = decide_image_input_mode(
    _read_main_provider(),   # stale — from previous turn
    _read_main_model(),      # stale — from previous turn
    _cfg,
)
```

The CLI path (`cli.py` lines 9787-9788) already uses `self.provider` and `self.model` directly — it doesn't have this bug. Only `tui_gateway/server.py` was affected.

## Fix

Prefer `agent.provider`/`agent.model` (live values) over `_read_main_provider()`/`_read_main_model()` (stale runtime values), with getattr + fallback for the no-agent edge case:

```python
_mode = decide_image_input_mode(
    getattr(agent, "provider", "") or _read_main_provider(),
    getattr(agent, "model", "") or _read_main_model(),
    _cfg,
)
```

This matches the existing pattern in `cli.py` and gracefully falls back when agent attributes are empty/None.

## Testing

- 5 new tests in `tests/tui_gateway/test_image_routing_stale_model.py`:
  - Agent with live provider/model → uses agent values (not stale)
  - Agent with empty strings → falls back to stale
  - Agent with None → falls back to stale
  - No agent at all → pure fallback
  - Exact #43516 scenario (qwen3.7-max → qwen3.7-plus switch)

## Files Changed

- `tui_gateway/server.py` — 2 lines changed (prefer agent.provider/model)
- `tests/tui_gateway/test_image_routing_stale_model.py` — new file, 93 lines

Closes #43516
