### PR TITLE
fix: notify home channel after launchd gateway restarts

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -12,6 +12,7 @@ import signal
 import subprocess
 import sys
 import textwrap
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -75,6 +76,30 @@ class ProfileGatewayProcess:
     profile: str
     path: Path
     pid: int
+
+
+def _write_planned_restart_notification_marker(*, via_service: bool, detached: bool) -> None:
+    """Tell the next gateway startup to notify home channels after restart.
+
+    The in-gateway SIGUSR1 restart path writes this marker during graceful
+    shutdown.  CLI-managed launchd restarts can fall back to SIGTERM/kickstart,
+    which bypasses the gateway's restart state; write the same marker here so
+    macOS restart behavior matches systemd/manual planned restarts.
+    """
+    try:
+        from utils import atomic_json_write
+
+        atomic_json_write(
+            get_hermes_home() / ".restart_pending.json",
+            {
+                "requested_at": time.time(),
+                "via_service": bool(via_service),
+                "detached": bool(detached),
+            },
+            indent=None,
+        )
+    except Exception as exc:
+        logger.debug("Failed to write planned restart notification marker: %s", exc)
 
 
 def _get_service_pids() -> set:
@@ -3526,6 +3551,7 @@ def launchd_restart():
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
             return
+        _write_planned_restart_notification_marker(via_service=True, detached=False)
         if pid is not None:
             try:
                 terminate_pid(pid, force=False)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,5 +1,6 @@
 """Tests for gateway service management helpers."""
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -555,13 +556,14 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
-    def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
+    def test_launchd_restart_drains_running_gateway_before_kickstart(self, tmp_path, monkeypatch):
         calls = []
-        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
 
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
         monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
@@ -580,10 +582,17 @@ class TestLaunchdServiceRecovery:
             ("term", 321, False),
             ["launchctl", "kickstart", "-k", target],
         ]
+        marker = tmp_path / ".restart_pending.json"
+        assert marker.exists()
+        payload = json.loads(marker.read_text())
+        assert payload["via_service"] is True
+        assert payload["detached"] is False
+        assert isinstance(payload["requested_at"], float)
 
-    def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
+    def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, tmp_path, monkeypatch, capsys):
         calls = []
 
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path)
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 321,
@@ -602,6 +611,7 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_restart()
 
         assert calls == [("self", 321)]
+        assert not (tmp_path / ".restart_pending.json").exists()
         assert "restart requested" in capsys.readouterr().out.lower()
 
     def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):


### PR DESCRIPTION
## Summary
- write the planned restart marker before CLI-managed macOS launchd restarts that fall back to SIGTERM/kickstart
- preserve the in-gateway SIGUSR1 path so it still owns its own marker write
- cover both launchd restart paths in service tests

## Tests
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `python -m pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery::test_launchd_restart_drains_running_gateway_before_kickstart tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery::test_launchd_restart_self_requests_graceful_restart_without_kickstart tests/gateway/test_restart_notification.py -o 'addopts=' -q`

Note: I also ran a broader macOS local slice (`tests/hermes_cli/test_gateway_service.py tests/gateway/test_restart_notification.py tests/gateway/test_gateway_shutdown.py`) and hit pre-existing platform-specific systemd expectations on macOS; the targeted launchd and restart-notification tests pass.