### PR TITLE
feat(skills): add model-task-router — automatic task-to-model routing backed by DeepSWE data

### DIFF
--- a/optional-skills/software-development/model-task-router/SKILL.md
+++ b/optional-skills/software-development/model-task-router/SKILL.md
@@ -7,9 +7,8 @@ license: MIT
 metadata:
   hermes:
     tags: [model-routing, task-classification, cost-optimization, delegation, multi-model]
-    related_issues:
-      - https://github.com/NousResearch/hermes-agent/issues/30652
-      - https://github.com/NousResearch/hermes-agent/issues/16525
+    related_skills: [model-selection]
+    requires_toolsets: [terminal]
 ---
 
 # Model Task Router

--- a/optional-skills/software-development/model-task-router/SKILL.md
+++ b/optional-skills/software-development/model-task-router/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: model-task-router
-description: Classify tasks and route to the best-fit model. Coding-heavy → delegate_task with a coding model, orchestration → current model directly, mechanical → delegate_task with default subagent model. Configure your preferred coding and architecture models below.
+description: Classify tasks and route to the best-fit model. Coding-heavy → terminal-spawned agent, orchestration → current model directly, mechanical → delegate_task. Configure your preferred coding and architecture models below.
 version: 2.0.0
 author: Sugumaran Balasubramaniyan (https://github.com/Sugumaran-Balasubramaniyan)
 license: MIT
@@ -60,8 +60,8 @@ Source: [DeepSWE leaderboard](https://deepswe.datacurve.ai/), [explainx.ai DeepS
 
 | Task Category | How | Why |
 |--------------|-----|-----|
-| **Code Generation** (implement, fix, refactor, PR, tests) | `delegate_task` with coding model | Coding models have proven DeepSWE results |
-| **Hard Architecture** (system design, complex debugging, security) | `delegate_task` with architecture model | Highest reasoning capability |
+| **Code Generation** (implement, fix, refactor, PR, tests) | terminal-spawn `hermes chat` with coding model | Coding models have proven DeepSWE results |
+| **Hard Architecture** (system design, complex debugging, security) | terminal-spawn `hermes chat` with architecture model | Highest reasoning capability |
 | **Orchestration** (tools, shell, file ops, diagnostics) | Current model directly | Tool-calling efficiency |
 | **Research** (web search, docs, analysis, planning) | Current model directly | Reasoning + web tools inline |
 | **Mechanical** (grep, find, run tests, simple edits) | `delegate_task` (default subagent model) | Fast, cheap, delegated |
@@ -101,12 +101,12 @@ User says: "..."
 ├─ Keywords: "implement", "build", "create", "write code", "fix bug",
 │           "refactor", "add feature", "PR", "patch"
 │  AND task modifies or creates source files
-│  → ROUTE: Coding → delegate_task(model=coding_model, toolsets=[terminal, file, web])
+│  → ROUTE: Coding → terminal-spawn hermes chat --model coding_model
 │
 ├─ Keywords: "architecture", "design system", "how would you structure",
 │           "security review", "complex debugging"
 │  AND task is high-stakes, multi-system, or multi-file
-│  → ROUTE: Architecture → delegate_task(model=architecture_model, toolsets=[terminal, file, web])
+│  → ROUTE: Architecture → terminal-spawn hermes chat --model architecture_model
 │
 ├─ Keywords: "search for", "find all", "grep", "list files",
 │           "run tests", "check if", "what's the content of"
@@ -131,29 +131,35 @@ This forces direct handling even though "fix" would normally trigger a coding di
 
 ## Dispatch Mechanism
 
-### For Coding Tasks → delegate_task
+**Important:** `delegate_task` does not currently support per-task model override ([issue #18591](https://github.com/NousResearch/hermes-agent/issues/18591)). To dispatch a task to a specific model, use `terminal` to spawn a fresh agent with `hermes chat`. For mechanical tasks, `delegate_task` with the default subagent model is correct.
 
-```python
-delegate_task(
-    goal="<full task description>",
-    context="""<file paths, error messages, constraints, existing code, project context>""",
-    model="openrouter/openai/gpt-5.4",   # your coding_model
-    toolsets=["terminal", "file", "web"]
-)
+### For Coding Tasks → terminal-spawned agent
+
+```bash
+# Spawn a fresh agent with the coding model
+hermes chat -q "<full task description with file paths and context>" \
+  --model openrouter/openai/gpt-5.4 \
+  --provider openrouter \
+  --toolsets terminal,file,web
 ```
 
-### For Architecture Tasks → delegate_task
+**IMPORTANT:** When dispatching a coding task:
+1. Include ALL relevant context in the `-q` string: file paths, error messages, constraints, existing code snippets
+2. Set a generous timeout: coding tasks can take 5-15 minutes
+3. If the task is large, spawn in background and poll: `terminal(background=true, notify_on_complete=true)`
+4. Verify the spawned agent's results before reporting to the user — agents can hallucinate completion
+5. If the spawned agent fails, try once more with more specific instructions, then report the blocker
 
-```python
-delegate_task(
-    goal="<architecture question with full context>",
-    context="""<system description, constraints, trade-offs to evaluate>""",
-    model="openrouter/openai/gpt-5.5",   # your architecture_model
-    toolsets=["terminal", "file", "web"]
-)
+### For Architecture Tasks → terminal-spawned agent
+
+```bash
+hermes chat -q "<full architecture question with context>" \
+  --model openrouter/openai/gpt-5.5 \
+  --provider openrouter \
+  --toolsets terminal,file,web
 ```
 
-### For Mechanical Tasks → delegate_task (default model)
+### For Mechanical Tasks → delegate_task (default subagent model)
 
 ```python
 delegate_task(
@@ -163,6 +169,8 @@ delegate_task(
 )
 ```
 
+Good for: searching codebase for patterns, running test suites, simple file modifications, finding and listing files.
+
 ### For Orchestration/Research → Handle Directly
 
 Use your current model inline. Do NOT delegate or spawn. Handle tool calls directly.
@@ -171,26 +179,28 @@ See also: `subagent-driven-development` skill for the full delegation workflow (
 
 ## Dispatch Checklist
 
-When delegating a coding or architecture task:
+When spawning a coding or architecture task via `hermes chat`:
 
-1. **Pack all context**: The subagent has no memory of your conversation. Include file paths, error messages, constraints, and relevant code.
-2. **Verify results**: Subagents self-report "completed" when they haven't. Always read the modified file or run the test before reporting to the user.
-3. **Retry once if needed**: If the subagent fails, try once more with more specific instructions, then report the blocker.
+1. **Pack all context**: The spawned agent has no memory of your conversation. Include file paths, error messages, constraints, and relevant code.
+2. **Verify results**: Agents self-report "completed" when they haven't. Always read the modified file or run the test before reporting to the user.
+3. **Retry once if needed**: If the spawned agent fails, try once more with more specific instructions, then report the blocker.
 4. **Announce the routing**: Short message like "Routing to GPT-5.4 for implementation..." keeps the user informed.
 
 ## Anti-Patterns
 
 - **Do NOT delegate orchestration.** The current model handles tool-calling; delegation adds overhead for no benefit.
-- **Do NOT delegate one-liner fixes.** Use `[route: direct]` for trivial edits.
-- **Do NOT skip verification.** Subagents can hallucinate completion. Read files, run tests, confirm.
-- **Do NOT delegate without context.** Pack every relevant detail into the `context` field.
+- **Do NOT spawn agents for one-liner fixes.** Use `[route: direct]` for trivial edits.
+- **Do NOT skip verification.** Spawned agents can hallucinate completion. Read files, run tests, confirm.
+- **Do NOT spawn without context.** Pack every relevant detail into the `-q` string.
 - **Do NOT use the architecture model for routine coding.** It's overkill; save it for hard problems.
 
 ## Pitfalls
 
-- **`delegate_task` model parameter**: Only supported for agents with the delegation toolset. If your deployment doesn't support per-task model overrides, coding and architecture tasks will use your default subagent model — still useful, but won't get the specialized model benefit.
-- **Rate limits**: Multiple models share provider-level rate limits. If one dispatch fails, try the other or fall back to the current model.
-- **Context budget**: Each `delegate_task` summary adds tokens. Don't delegate trivial tasks; use `[route: direct]` instead.
+- **`delegate_task` has no model parameter**: Per-task model override on `delegate_task` is not yet implemented ([issue #18591](https://github.com/NousResearch/hermes-agent/issues/18591)). Use `hermes chat -q --model ...` via `terminal()` for model-specific dispatch.
+- **Spawned agents have no session memory**: When using `hermes chat`, the spawned process starts fresh. Pack ALL context into the `-q` string — file paths, error messages, constraints, relevant code.
+- **Background processes need monitoring**: For long tasks, use `terminal(background=true, notify_on_complete=true)` and verify results with `process(action='wait')` or `process(action='poll')`.
+- **Rate limits**: GPT-5.4 and GPT-5.5 share OpenAI rate limits via OpenRouter. If one dispatch fails, try the other or fall back to the current model.
+- **Context budget**: Each spawned agent session adds cost and latency. Don't dispatch trivial tasks; use `[route: direct]` instead.
 
 ## Related Hermes Issues
 

--- a/optional-skills/software-development/model-task-router/SKILL.md
+++ b/optional-skills/software-development/model-task-router/SKILL.md
@@ -43,7 +43,7 @@ DeepSWE (real-world coding, contamination-free) and Terminal-Bench (agentic CLI)
 | Gemini 3.5 Flash | — | 28% | Budget-aware option |
 | GPT-5.4-Mini | — | 24% | Fast, cheap, delegated |
 | Kimi K2.6 | — | 24% | Budget option |
-| DeepSeek V4-Pro | 55.4% | ~8%* | See caveats below |
+| DeepSeek V4-Pro | 55.4% | ~8%* | See caveats above |
 
 *\*V4-Pro was run at default effort (no tuning) and may have been affected by OpenRouter guardrail 404s. Score directionally suggests lower coding throughput, but magnitude is uncertain. Community replications report 5–8%. Awaiting re-run with proper effort tuning.*
 
@@ -90,7 +90,7 @@ architecture_model: openrouter/openai/gpt-5.5
 ## Decision Tree
 
 Priority order: Coding > Architecture > Mechanical > Research > Orchestration.
-First match wins. User can override by prefixing their message with `[route: <category>]`.
+First match wins; ties broken left-to-right by priority order. User can override by prefixing their message with `[route: <category>]`.
 
 ```
 User says: "..."

--- a/optional-skills/software-development/model-task-router/SKILL.md
+++ b/optional-skills/software-development/model-task-router/SKILL.md
@@ -30,9 +30,11 @@ DeepSWE ([deepswe.datacurve.ai](https://deepswe.datacurve.ai)) — the only cont
 | DeepSeek V4-Pro | 55.4% | **8%** | **−47** |
 | MiniMax M3 | 59.0% | 20% | −39 |
 
-Models that look identical on public benchmarks (55-60% Pro) diverge by **47 points** on real engineering tasks. V4-Pro costs **$52.75 per solved task** vs GPT-5.4 at **$7.82** — despite being 17× cheaper per token — because it solves almost nothing.
+Models that look identical on public benchmarks (55-60% Pro) diverge by **47 points** on real engineering tasks. V4-Pro requires **12.5 attempts per success** vs GPT-5.4 at **1.8 attempts** — it fails 92% of coding tasks on the first try.
 
 But V4-Pro is excellent at tool orchestration (Terminal-Bench 67.9%, $0.87/M). The optimal strategy is **task-based routing**: orchestration on V4-Pro, coding on GPT-5.4+.
+
+> **Note:** Cost figures are cache-adjusted per [DeepSWE issue #21](https://github.com/datacurve-ai/deep-swe/issues/21). V4-Pro's real cost is $0.30/task ($3.75/solve), not the previously reported $4.22/task. The routing recommendation stands — the issue is reliability, not cost.
 
 Full data: `references/deepswe-routing-data.md`
 
@@ -44,11 +46,11 @@ Load this skill at session start for any session involving mixed task types (cod
 
 | Task Category | Model | DeepSWE | Why |
 |--------------|-------|:-----:|-----|
-| **Code Generation** (implement, fix, refactor, write tests, PR) | `openrouter/openai/gpt-5.4` | 56% | 7× V4-Pro on real coding |
-| **Hard Architecture** (system design, complex debugging, security audit) | `openrouter/openai/gpt-5.5` | 70% | Best-in-class reasoning + coding |
-| **Orchestration** (tools, shell, file ops, navigation, diagnostics) | Current (V4-Pro) | 8% | Terminal-Bench 67.9%, $0.87/M |
+| **Code Generation** (implement, fix, refactor, write tests, PR) | `openrouter/openai/gpt-5.4` | 56% | 7× V4-Pro success rate, 1.8 attempts/solve |
+| **Hard Architecture** (system design, complex debugging, security audit) | `openrouter/openai/gpt-5.5` | 70% | Best-in-class, 1.4 attempts/solve |
+| **Orchestration** (tools, shell, file ops, navigation, diagnostics) | Current (V4-Pro) | 8% | Terminal-Bench 67.9%, $0.87/M — V4-Pro's strength |
 | **Research** (web search, documentation, analysis, planning) | Current (V4-Pro) | — | Good reasoning, cheap |
-| **Mechanical** (grep, find, list files, run tests, simple edits) | Subagent auto (GPT-5.4-Mini) | 24% | delegate_task default |
+| **Mechanical** (grep, find, list files, run tests, simple edits) | Subagent auto (GPT-5.4-Mini) | 24% | 4.2 attempts/solve, delegated |
 
 ## Decision Tree
 

--- a/optional-skills/software-development/model-task-router/SKILL.md
+++ b/optional-skills/software-development/model-task-router/SKILL.md
@@ -1,189 +1,203 @@
 ---
 name: model-task-router
-description: Automatically route tasks to the optimal model based on task type. Coding → GPT-5.4, architecture → GPT-5.5, orchestration → V4-Pro, search → V4-Pro. Use when you need to classify a user request and dispatch it to the right model without the user manually switching.
-version: 1.0.0
+description: Classify tasks and route to the best-fit model. Coding-heavy → delegate_task with a coding model, orchestration → current model directly, mechanical → delegate_task with default subagent model. Configure your preferred coding and architecture models below.
+version: 2.0.0
 author: Sugumaran Balasubramaniyan (https://github.com/Sugumaran-Balasubramaniyan)
 license: MIT
 metadata:
   hermes:
-    tags: [model-routing, task-classification, cost-optimization, delegation, multi-model]
-    related_skills: [model-selection]
-    requires_toolsets: [terminal]
+    tags: [model-routing, task-classification, delegation, multi-model]
+    related_skills: [subagent-driven-development]
 ---
 
 # Model Task Router
 
-Automatic task-to-model routing for Hermes Agent. Classifies incoming user requests and dispatches them to the optimal model — no manual `/model` switches required.
+Classify incoming user requests by task type and route to the appropriate model. No manual `/model` switches required.
 
-**By [Sugumaran Balasubramaniyan](https://github.com/Sugumaran-Balasubramaniyan)** — AI/ML Engineer | MLOps | LLM Systems  
-Portfolio: [sugumaran-balasubramaniyan.com](https://www.sugumaran-balasubramaniyan.com) | LinkedIn: [@sugumaranbalasubramaniyan](https://www.linkedin.com/in/sugumaranbalasubramaniyan/)  
-HuggingFace: [sugumaran](https://huggingface.co/sugumaran) | Email: bsugumaran@hotmail.com
+## Why Task-Based Routing
 
-## Why This Skill Exists
+Different models have different strengths. Benchmarks like DeepSWE and Terminal-Bench show meaningful divergence across task types — a model strong at tool orchestration may not be the best choice for multi-file code generation, and vice versa. Rather than switching models manually, this skill classifies tasks and dispatches automatically.
 
-DeepSWE ([deepswe.datacurve.ai](https://deepswe.datacurve.ai)) — the only contamination-free, real-complexity coding benchmark — reveals a brutal truth:
+### Data Caveats
 
-| Model | SWE-bench Pro | DeepSWE | Collapse |
-|-------|:------------:|:-------:|:--------:|
-| GPT-5.5 | 58.6% | **70%** | +11 |
-| GPT-5.4 | 57.7% | **56%** | −2 |
-| DeepSeek V4-Pro | 55.4% | **8%** | **−47** |
-| MiniMax M3 | 59.0% | 20% | −39 |
+The benchmark data behind this skill has known limitations:
 
-Models that look identical on public benchmarks (55-60% Pro) diverge by **47 points** on real engineering tasks. V4-Pro requires **12.5 attempts per success** vs GPT-5.4 at **1.8 attempts** — it fails 92% of coding tasks on the first try.
+- **Effort tuning inconsistency**: Some models were benchmarked without the effort-level optimization applied to competitors. Scores for those models may understate capability.
+- **Provider-level quirks**: OpenRouter privacy guardrails (data-training concerns) can block certain providers, causing benchmark failures unrelated to model capability.
+- **Limited community replication**: Independent replications have produced varying results. The published numbers are directional, not definitive.
 
-But V4-Pro is excellent at tool orchestration (Terminal-Bench 67.9%, $0.87/M). The optimal strategy is **task-based routing**: orchestration on V4-Pro, coding on GPT-5.4+.
+**Treat published scores as a starting point, not gospel.** If your experience with a model differs from the data, adjust the routing table below.
 
-> **Note:** Cost figures are cache-adjusted per [DeepSWE issue #21](https://github.com/datacurve-ai/deep-swe/issues/21). V4-Pro's real cost is $0.30/task ($3.75/solve), not the previously reported $4.22/task. The routing recommendation stands — the issue is reliability, not cost.
+## Published Model Performance
 
-Full data: `references/deepswe-routing-data.md`
+DeepSWE (real-world coding, contamination-free) and Terminal-Bench (agentic CLI) scores as of June 2026:
 
-## When to Use
+### DeepSWE — Real-World Coding
 
-Load this skill at session start for any session involving mixed task types (coding + orchestration + research). All subsequent turns use automatic routing.
+| Model | SWE-bench Pro | DeepSWE | Notes |
+|-------|:------------:|:-------:|-------|
+| GPT-5.5 (xhigh) | 58.6% | 70% | Best-in-class |
+| GPT-5.4 (xhigh) | 57.7% | 56% | Strong general coding |
+| Claude Opus 4.7 | 64.3% | 54% | Competitive coding |
+| Claude Sonnet 4.6 | — | 32% | Mid-tier |
+| Gemini 3.5 Flash | — | 28% | Budget-aware option |
+| GPT-5.4-Mini | — | 24% | Fast, cheap, delegated |
+| Kimi K2.6 | — | 24% | Budget option |
+| DeepSeek V4-Pro | 55.4% | ~8%* | See caveats below |
 
-## Routing Table (Backed by DeepSWE + Terminal-Bench Data)
+*\*V4-Pro was run at default effort (no tuning) and may have been affected by OpenRouter guardrail 404s. Score directionally suggests lower coding throughput, but magnitude is uncertain. Community replications report 5–8%. Awaiting re-run with proper effort tuning.*
 
-| Task Category | Model | DeepSWE | Why |
-|--------------|-------|:-----:|-----|
-| **Code Generation** (implement, fix, refactor, write tests, PR) | `openrouter/openai/gpt-5.4` | 56% | 7× V4-Pro success rate, 1.8 attempts/solve |
-| **Hard Architecture** (system design, complex debugging, security audit) | `openrouter/openai/gpt-5.5` | 70% | Best-in-class, 1.4 attempts/solve |
-| **Orchestration** (tools, shell, file ops, navigation, diagnostics) | Current (V4-Pro) | 8% | Terminal-Bench 67.9%, $0.87/M — V4-Pro's strength |
-| **Research** (web search, documentation, analysis, planning) | Current (V4-Pro) | — | Good reasoning, cheap |
-| **Mechanical** (grep, find, list files, run tests, simple edits) | Subagent auto (GPT-5.4-Mini) | 24% | 4.2 attempts/solve, delegated |
+### Terminal-Bench — Agentic CLI / Tool Orchestration
+
+| Model | Score | $/1M Output |
+|-------|:-----:|:-----------:|
+| GPT-5.5 | 82.7% | $30.00 |
+| DeepSeek V4-Pro | 67.9% | $0.87 |
+
+Source: [DeepSWE leaderboard](https://deepswe.datacurve.ai/), [explainx.ai DeepSWE writeup](https://explainx.ai/blog/deepswe), [Terminal-Bench](https://kilo.ai/leaderboard)
+
+## Routing Table
+
+| Task Category | How | Why |
+|--------------|-----|-----|
+| **Code Generation** (implement, fix, refactor, PR, tests) | `delegate_task` with coding model | Coding models have proven DeepSWE results |
+| **Hard Architecture** (system design, complex debugging, security) | `delegate_task` with architecture model | Highest reasoning capability |
+| **Orchestration** (tools, shell, file ops, diagnostics) | Current model directly | Tool-calling efficiency |
+| **Research** (web search, docs, analysis, planning) | Current model directly | Reasoning + web tools inline |
+| **Mechanical** (grep, find, run tests, simple edits) | `delegate_task` (default subagent model) | Fast, cheap, delegated |
+
+### Configuring Your Models
+
+Set these in your `~/.hermes/config.yaml` or adapt based on what's available:
+
+```yaml
+# Coding model — used for implement/fix/refactor/PR tasks
+coding_model: openrouter/openai/gpt-5.4
+
+# Architecture model — used for system design, hard debugging, security
+architecture_model: openrouter/openai/gpt-5.5
+
+# Your current (orchestrator) model — handles tool calls, research, planning
+# The skill uses whatever model is active; no override needed.
+```
+
+**If you don't configure these, the skill defaults to:**
+- Coding: `openrouter/openai/gpt-5.4` (56% DeepSWE)
+- Architecture: `openrouter/openai/gpt-5.5` (70% DeepSWE)
+- Orchestration/Research: your current model (whatever is active)
+- Mechanical: your configured `delegation.model` (or system default)
 
 ## Decision Tree
+
+Priority order: Coding > Architecture > Mechanical > Research > Orchestration.
+First match wins. User can override by prefixing their message with `[route: <category>]`.
 
 ```
 User says: "..."
 │
-├─ Contains: "implement", "build", "create", "write code", "fix bug",
-│           "refactor", "add feature", "PR", "patch", "debug" with code
-│  AND task requires writing >20 lines of new code or modifying multiple files
-│  → ROUTE: Coding task → dispatch to GPT-5.4
+├─ [route: code] or [route: architecture] or [route: mechanical] or [route: direct]
+│  → User override — use the specified route, skip keyword classification
 │
-├─ Contains: "architecture", "design system", "how would you structure",
-│           "hard problem", "complex reasoning", "security review"
-│  AND task is high-stakes, multi-system, or requires deep expertise
-│  → ROUTE: Architecture task → dispatch to GPT-5.5
+├─ Keywords: "implement", "build", "create", "write code", "fix bug",
+│           "refactor", "add feature", "PR", "patch"
+│  AND task modifies or creates source files
+│  → ROUTE: Coding → delegate_task(model=coding_model, toolsets=[terminal, file, web])
 │
-├─ Contains: "search for", "find all", "grep", "list files",
+├─ Keywords: "architecture", "design system", "how would you structure",
+│           "security review", "complex debugging"
+│  AND task is high-stakes, multi-system, or multi-file
+│  → ROUTE: Architecture → delegate_task(model=architecture_model, toolsets=[terminal, file, web])
+│
+├─ Keywords: "search for", "find all", "grep", "list files",
 │           "run tests", "check if", "what's the content of"
-│  AND task is purely mechanical
-│  → ROUTE: Mechanical → use delegate_task (auto GPT-5.4-Mini)
+│  AND task is purely mechanical (read-only or single command)
+│  → ROUTE: Mechanical → delegate_task with default subagent model
 │
-├─ Contains: "research", "summarize", "what is", "explain", "how does",
-│           "find documentation", "look up", "search the web for"
-│  → HANDLE: Research → use web_search/web_extract with current model
+├─ Keywords: "research", "summarize", "what is", "explain",
+│           "look up", "search the web for"
+│  → ROUTE: Research → handle directly with current model
 │
-└─ Everything else: tool calls, shell commands, file navigation,
-   diagnostics, configuration, planning
-   → HANDLE: Orchestration → use current model (V4-Pro)
+└─ Everything else: tool calls, shell, navigation, diagnostics, config, planning
+   → ROUTE: Orchestration → handle directly with current model
 ```
+
+### User Override
+
+Prefix any message with `[route: code]`, `[route: architecture]`, `[route: mechanical]`, or `[route: direct]` to override automatic classification. Example:
+
+> [route: direct] Fix this typo in README.md
+
+This forces direct handling even though "fix" would normally trigger a coding dispatch. Use for small one-liner fixes.
 
 ## Dispatch Mechanism
 
-### For Coding Tasks → terminal spawn GPT-5.4
+### For Coding Tasks → delegate_task
 
-```bash
-# Dispatch pattern — use terminal with background=true for long tasks
-hermes chat -q "<full task description with file paths and context>" \
-  --model openrouter/openai/gpt-5.4 \
-  --provider openrouter \
-  --toolsets terminal,file,web
+```python
+delegate_task(
+    goal="<full task description>",
+    context="""<file paths, error messages, constraints, existing code, project context>""",
+    model="openrouter/openai/gpt-5.4",   # your coding_model
+    toolsets=["terminal", "file", "web"]
+)
 ```
 
-**IMPORTANT:** When dispatching a coding task:
-1. Include ALL relevant context in the -q string: file paths, error messages, constraints, existing code snippets
-2. Set a generous timeout: coding tasks can take 5-15 minutes
-3. If the task is large, spawn in background and poll
-4. Verify the subagent's results before reporting to user — subagents can hallucinate completion
-5. If the subagent fails, try once more with more specific instructions, then report the blocker
+### For Architecture Tasks → delegate_task
 
-### For Architecture Tasks → terminal spawn GPT-5.5
-
-```bash
-hermes chat -q "<full architecture question with context>" \
-  --model openrouter/openai/gpt-5.5 \
-  --provider openrouter \
-  --toolsets terminal,file,web
+```python
+delegate_task(
+    goal="<architecture question with full context>",
+    context="""<system description, constraints, trade-offs to evaluate>""",
+    model="openrouter/openai/gpt-5.5",   # your architecture_model
+    toolsets=["terminal", "file", "web"]
+)
 ```
 
-### For Mechanical Tasks → delegate_task
+### For Mechanical Tasks → delegate_task (default model)
 
-Use `delegate_task` — automatically uses GPT-5.4-Mini (24% DeepSWE). Good for:
-- Searching codebase for patterns
-- Running test suites
-- Simple file modifications
-- Finding and listing files
+```python
+delegate_task(
+    goal="<mechanical task>",
+    context="""<what to search, where, what to report back>""",
+    toolsets=["terminal", "file"]
+)
+```
 
 ### For Orchestration/Research → Handle Directly
 
-Use the current model (V4-Pro). Do NOT delegate or spawn. Handle tool calls inline.
+Use your current model inline. Do NOT delegate or spawn. Handle tool calls directly.
+
+See also: `subagent-driven-development` skill for the full delegation workflow (spec review → quality review → verify).
+
+## Dispatch Checklist
+
+When delegating a coding or architecture task:
+
+1. **Pack all context**: The subagent has no memory of your conversation. Include file paths, error messages, constraints, and relevant code.
+2. **Verify results**: Subagents self-report "completed" when they haven't. Always read the modified file or run the test before reporting to the user.
+3. **Retry once if needed**: If the subagent fails, try once more with more specific instructions, then report the blocker.
+4. **Announce the routing**: Short message like "Routing to GPT-5.4 for implementation..." keeps the user informed.
 
 ## Anti-Patterns
 
-- **Do NOT delegate orchestration.** V4-Pro is better at tool-calling than GPT-5.4-Mini. Only delegate actual code generation.
-- **Do NOT code inline with V4-Pro.** It scores 8% on DeepSWE. Any non-trivial code change MUST be dispatched to GPT-5.4+.
-- **Do NOT use GPT-5.5 for routine coding.** GPT-5.4 is 80% as good at 50% the cost. Reserve GPT-5.5 for architecture and hard reasoning.
-- **Do NOT spawn a subagent without context.** The spawned process has no memory of the conversation. Pack ALL relevant info into the -q string.
-- **Do NOT trust subagent self-reports.** Subagents say "completed" when they haven't. Always verify: read the file, run the test, check the output.
+- **Do NOT delegate orchestration.** The current model handles tool-calling; delegation adds overhead for no benefit.
+- **Do NOT delegate one-liner fixes.** Use `[route: direct]` for trivial edits.
+- **Do NOT skip verification.** Subagents can hallucinate completion. Read files, run tests, confirm.
+- **Do NOT delegate without context.** Pack every relevant detail into the `context` field.
+- **Do NOT use the architecture model for routine coding.** It's overkill; save it for hard problems.
 
-## Verification Checklist
+## Pitfalls
 
-After any dispatched coding task:
-1. Read the modified file(s) to verify changes exist
-2. Run relevant tests if available
-3. Check for syntax errors
-4. Report actual results (not subagent's self-report) to the user
-
-## Cost Awareness
-
-- Orchestration turn (V4-Pro): ~$0.09 per 100K output
-- Coding dispatch (GPT-5.4): ~$1.50 per task
-- Architecture dispatch (GPT-5.5): ~$3.00 per task
-- Mechanical subagent (GPT-5.4-Mini): ~$0.45 per task
-
-Announce the routing decision briefly so the user knows what's happening:
-"Routing to GPT-5.4 for implementation..." or "Handling with V4-Pro."
-
-## Hermes Config for This Skill
-
-```yaml
-# ~/.hermes/config.yaml
-model:
-  default: deepseek-v4-pro
-  provider: deepseek
-
-fallback_providers:
-  - openrouter/openai/gpt-5.4
-  - openrouter/qwen/qwen3.7-max
-  - openrouter/google/gemini-2.0-flash-001
-
-delegation:
-  model: openrouter/openai/gpt-5.4-mini
-  provider: openrouter
-  reasoning_effort: medium
-  max_concurrent_children: 8
-  child_timeout_seconds: 900
-
-agent:
-  reasoning_effort: high
-
-# All auxiliary models → deepseek-v4-flash + provider: deepseek
-```
+- **`delegate_task` model parameter**: Only supported for agents with the delegation toolset. If your deployment doesn't support per-task model overrides, coding and architecture tasks will use your default subagent model — still useful, but won't get the specialized model benefit.
+- **Rate limits**: Multiple models share provider-level rate limits. If one dispatch fails, try the other or fall back to the current model.
+- **Context budget**: Each `delegate_task` summary adds tokens. Don't delegate trivial tasks; use `[route: direct]` instead.
 
 ## Related Hermes Issues
 
 - [#30652](https://github.com/NousResearch/hermes-agent/issues/30652) — Dynamic model routing based on task complexity (open, P3)
 - [#16525](https://github.com/NousResearch/hermes-agent/issues/16525) — Expose model_switch as agent-callable tool (open, P3)
-- [#32704](https://github.com/NousResearch/hermes-agent/issues/32704) — Capability-Based Multi-Model Routing (closed, duplicate)
 - [#18591](https://github.com/NousResearch/hermes-agent/issues/18591) — Per-task model override for delegate_task (open)
 
-## Pitfalls
+## References
 
-- **delegate_task model is fixed** — cannot override per-task. Use terminal-spawned hermes for model-specific dispatching.
-- **Spawned hermes has no session memory** — pack all context. Be thorough.
-- **Background processes need monitoring** — use process(action='poll') or process(action='wait') to track completion.
-- **Rate limits** — GPT-5.4 and GPT-5.5 share OpenAI rate limits via OpenRouter. If one fails, try the other or fall back to V4-Pro.
-- **V4-Pro for coding is a known failure mode** — 8% DeepSWE means 92% of real coding tasks fail. Never inline code with V4-Pro.
+- `references/deepswe-routing-data.md` — Full benchmark data, cost analysis, and caveats

--- a/optional-skills/software-development/model-task-router/SKILL.md
+++ b/optional-skills/software-development/model-task-router/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: model-task-router
+description: Automatically route tasks to the optimal model based on task type. Coding → GPT-5.4, architecture → GPT-5.5, orchestration → V4-Pro, search → V4-Pro. Use when you need to classify a user request and dispatch it to the right model without the user manually switching.
+version: 1.0.0
+author: Sugumaran Balasubramaniyan (https://github.com/Sugumaran-Balasubramaniyan)
+license: MIT
+metadata:
+  hermes:
+    tags: [model-routing, task-classification, cost-optimization, delegation, multi-model]
+    related_issues:
+      - https://github.com/NousResearch/hermes-agent/issues/30652
+      - https://github.com/NousResearch/hermes-agent/issues/16525
+---
+
+# Model Task Router
+
+Automatic task-to-model routing for Hermes Agent. Classifies incoming user requests and dispatches them to the optimal model — no manual `/model` switches required.
+
+**By [Sugumaran Balasubramaniyan](https://github.com/Sugumaran-Balasubramaniyan)** — AI/ML Engineer | MLOps | LLM Systems  
+Portfolio: [sugumaran-balasubramaniyan.com](https://www.sugumaran-balasubramaniyan.com) | LinkedIn: [@sugumaranbalasubramaniyan](https://www.linkedin.com/in/sugumaranbalasubramaniyan/)  
+HuggingFace: [sugumaran](https://huggingface.co/sugumaran) | Email: bsugumaran@hotmail.com
+
+## Why This Skill Exists
+
+DeepSWE ([deepswe.datacurve.ai](https://deepswe.datacurve.ai)) — the only contamination-free, real-complexity coding benchmark — reveals a brutal truth:
+
+| Model | SWE-bench Pro | DeepSWE | Collapse |
+|-------|:------------:|:-------:|:--------:|
+| GPT-5.5 | 58.6% | **70%** | +11 |
+| GPT-5.4 | 57.7% | **56%** | −2 |
+| DeepSeek V4-Pro | 55.4% | **8%** | **−47** |
+| MiniMax M3 | 59.0% | 20% | −39 |
+
+Models that look identical on public benchmarks (55-60% Pro) diverge by **47 points** on real engineering tasks. V4-Pro costs **$52.75 per solved task** vs GPT-5.4 at **$7.82** — despite being 17× cheaper per token — because it solves almost nothing.
+
+But V4-Pro is excellent at tool orchestration (Terminal-Bench 67.9%, $0.87/M). The optimal strategy is **task-based routing**: orchestration on V4-Pro, coding on GPT-5.4+.
+
+Full data: `references/deepswe-routing-data.md`
+
+## When to Use
+
+Load this skill at session start for any session involving mixed task types (coding + orchestration + research). All subsequent turns use automatic routing.
+
+## Routing Table (Backed by DeepSWE + Terminal-Bench Data)
+
+| Task Category | Model | DeepSWE | Why |
+|--------------|-------|:-----:|-----|
+| **Code Generation** (implement, fix, refactor, write tests, PR) | `openrouter/openai/gpt-5.4` | 56% | 7× V4-Pro on real coding |
+| **Hard Architecture** (system design, complex debugging, security audit) | `openrouter/openai/gpt-5.5` | 70% | Best-in-class reasoning + coding |
+| **Orchestration** (tools, shell, file ops, navigation, diagnostics) | Current (V4-Pro) | 8% | Terminal-Bench 67.9%, $0.87/M |
+| **Research** (web search, documentation, analysis, planning) | Current (V4-Pro) | — | Good reasoning, cheap |
+| **Mechanical** (grep, find, list files, run tests, simple edits) | Subagent auto (GPT-5.4-Mini) | 24% | delegate_task default |
+
+## Decision Tree
+
+```
+User says: "..."
+│
+├─ Contains: "implement", "build", "create", "write code", "fix bug",
+│           "refactor", "add feature", "PR", "patch", "debug" with code
+│  AND task requires writing >20 lines of new code or modifying multiple files
+│  → ROUTE: Coding task → dispatch to GPT-5.4
+│
+├─ Contains: "architecture", "design system", "how would you structure",
+│           "hard problem", "complex reasoning", "security review"
+│  AND task is high-stakes, multi-system, or requires deep expertise
+│  → ROUTE: Architecture task → dispatch to GPT-5.5
+│
+├─ Contains: "search for", "find all", "grep", "list files",
+│           "run tests", "check if", "what's the content of"
+│  AND task is purely mechanical
+│  → ROUTE: Mechanical → use delegate_task (auto GPT-5.4-Mini)
+│
+├─ Contains: "research", "summarize", "what is", "explain", "how does",
+│           "find documentation", "look up", "search the web for"
+│  → HANDLE: Research → use web_search/web_extract with current model
+│
+└─ Everything else: tool calls, shell commands, file navigation,
+   diagnostics, configuration, planning
+   → HANDLE: Orchestration → use current model (V4-Pro)
+```
+
+## Dispatch Mechanism
+
+### For Coding Tasks → terminal spawn GPT-5.4
+
+```bash
+# Dispatch pattern — use terminal with background=true for long tasks
+hermes chat -q "<full task description with file paths and context>" \
+  --model openrouter/openai/gpt-5.4 \
+  --provider openrouter \
+  --toolsets terminal,file,web
+```
+
+**IMPORTANT:** When dispatching a coding task:
+1. Include ALL relevant context in the -q string: file paths, error messages, constraints, existing code snippets
+2. Set a generous timeout: coding tasks can take 5-15 minutes
+3. If the task is large, spawn in background and poll
+4. Verify the subagent's results before reporting to user — subagents can hallucinate completion
+5. If the subagent fails, try once more with more specific instructions, then report the blocker
+
+### For Architecture Tasks → terminal spawn GPT-5.5
+
+```bash
+hermes chat -q "<full architecture question with context>" \
+  --model openrouter/openai/gpt-5.5 \
+  --provider openrouter \
+  --toolsets terminal,file,web
+```
+
+### For Mechanical Tasks → delegate_task
+
+Use `delegate_task` — automatically uses GPT-5.4-Mini (24% DeepSWE). Good for:
+- Searching codebase for patterns
+- Running test suites
+- Simple file modifications
+- Finding and listing files
+
+### For Orchestration/Research → Handle Directly
+
+Use the current model (V4-Pro). Do NOT delegate or spawn. Handle tool calls inline.
+
+## Anti-Patterns
+
+- **Do NOT delegate orchestration.** V4-Pro is better at tool-calling than GPT-5.4-Mini. Only delegate actual code generation.
+- **Do NOT code inline with V4-Pro.** It scores 8% on DeepSWE. Any non-trivial code change MUST be dispatched to GPT-5.4+.
+- **Do NOT use GPT-5.5 for routine coding.** GPT-5.4 is 80% as good at 50% the cost. Reserve GPT-5.5 for architecture and hard reasoning.
+- **Do NOT spawn a subagent without context.** The spawned process has no memory of the conversation. Pack ALL relevant info into the -q string.
+- **Do NOT trust subagent self-reports.** Subagents say "completed" when they haven't. Always verify: read the file, run the test, check the output.
+
+## Verification Checklist
+
+After any dispatched coding task:
+1. Read the modified file(s) to verify changes exist
+2. Run relevant tests if available
+3. Check for syntax errors
+4. Report actual results (not subagent's self-report) to the user
+
+## Cost Awareness
+
+- Orchestration turn (V4-Pro): ~$0.09 per 100K output
+- Coding dispatch (GPT-5.4): ~$1.50 per task
+- Architecture dispatch (GPT-5.5): ~$3.00 per task
+- Mechanical subagent (GPT-5.4-Mini): ~$0.45 per task
+
+Announce the routing decision briefly so the user knows what's happening:
+"Routing to GPT-5.4 for implementation..." or "Handling with V4-Pro."
+
+## Hermes Config for This Skill
+
+```yaml
+# ~/.hermes/config.yaml
+model:
+  default: deepseek-v4-pro
+  provider: deepseek
+
+fallback_providers:
+  - openrouter/openai/gpt-5.4
+  - openrouter/qwen/qwen3.7-max
+  - openrouter/google/gemini-2.0-flash-001
+
+delegation:
+  model: openrouter/openai/gpt-5.4-mini
+  provider: openrouter
+  reasoning_effort: medium
+  max_concurrent_children: 8
+  child_timeout_seconds: 900
+
+agent:
+  reasoning_effort: high
+
+# All auxiliary models → deepseek-v4-flash + provider: deepseek
+```
+
+## Related Hermes Issues
+
+- [#30652](https://github.com/NousResearch/hermes-agent/issues/30652) — Dynamic model routing based on task complexity (open, P3)
+- [#16525](https://github.com/NousResearch/hermes-agent/issues/16525) — Expose model_switch as agent-callable tool (open, P3)
+- [#32704](https://github.com/NousResearch/hermes-agent/issues/32704) — Capability-Based Multi-Model Routing (closed, duplicate)
+- [#18591](https://github.com/NousResearch/hermes-agent/issues/18591) — Per-task model override for delegate_task (open)
+
+## Pitfalls
+
+- **delegate_task model is fixed** — cannot override per-task. Use terminal-spawned hermes for model-specific dispatching.
+- **Spawned hermes has no session memory** — pack all context. Be thorough.
+- **Background processes need monitoring** — use process(action='poll') or process(action='wait') to track completion.
+- **Rate limits** — GPT-5.4 and GPT-5.5 share OpenAI rate limits via OpenRouter. If one fails, try the other or fall back to V4-Pro.
+- **V4-Pro for coding is a known failure mode** — 8% DeepSWE means 92% of real coding tasks fail. Never inline code with V4-Pro.

--- a/optional-skills/software-development/model-task-router/references/deepswe-routing-data.md
+++ b/optional-skills/software-development/model-task-router/references/deepswe-routing-data.md
@@ -1,8 +1,10 @@
 # DeepSWE Routing Data — Why Model Routing Matters
 
+> **Updated 2026-06-10**: Cost figures corrected based on [DeepSWE issue #21](https://github.com/datacurve-ai/deep-swe/issues/21) — DeepSeek's cache-hit pricing was not applied, inflating costs 4-14×. The solve-rate data (8%) is unaffected. The routing recommendation stands, but the justification shifts from cost to reliability.
+
 ## The Evidence
 
-DeepSWE (deepswe.datacurve.ai) is the only contamination-free, real-complexity coding benchmark. Tasks are written from scratch, require 5.5× more code than SWE-bench Pro, and span 91 repositories across 5 languages.
+DeepSWE ([deepswe.datacurve.ai](https://deepswe.datacurve.ai)) is the only contamination-free, real-complexity coding benchmark. Tasks are written from scratch, require 5.5× more code than SWE-bench Pro, and span 91 repositories across 5 languages.
 
 ## Key Finding: Models Collapse on Real Engineering Tasks
 
@@ -14,20 +16,23 @@ DeepSWE (deepswe.datacurve.ai) is the only contamination-free, real-complexity c
 | MiniMax M3 | 59.0% | 20% | **−39** |
 | DeepSeek V4-Pro | 55.4% | **8%** | **−47** |
 
-**Budget models that look competitive on SWE-bench Pro collapse on real tasks.** V4-Pro drops from 55% to 8%. M3 drops from 59% to 20%. The gap between "good enough" and "actually works" is invisible on contaminated benchmarks.
+## Cost Analysis (Cache-Adjusted, June 2026)
 
-## Cost per Solved Task (DeepSWE)
+DeepSeek V4-Pro's actual pricing includes cache-hit rates at $0.0036/M (99.2% off cache-miss). DeepSWE's reported costs billed all tokens at the miss rate. Corrected:
 
-| Model | Pass@1 | Avg Cost/Task | Cost per Solve |
-|-------|:------:|:------------:|:--------------:|
-| GPT-5.4 | 56% | $4.38 | **$7.82** |
-| GPT-5.5 | 70% | $6.61 | $9.44 |
-| GPT-5.4-Mini | 24% | $2.08 | $8.67 |
-| Claude Opus 4.7 | 54% | $18.19 | $33.69 |
-| MiniMax M3 | 20% | $5.57 | $27.85 |
-| DeepSeek V4-Pro | 8% | $4.22 | **$52.75** |
+| Model | DeepSWE | Cost/Task | Cost/Solve | Attempts/Solve |
+|-------|:-------:|:---------:|:----------:|:--------------:|
+| GPT-5.5 | **70%** | $6.61 | $9.44 | 1.4 |
+| GPT-5.4 | **56%** | $4.38 | **$7.82** | 1.8 |
+| GPT-5.4-Mini | 24% | $2.08 | $8.67 | 4.2 |
+| DeepSeek V4-Pro | **8%** | **$0.30** | **$3.75** | 12.5 |
 
-V4-Pro is 6.7× more expensive per solved task than GPT-5.4 despite being 17× cheaper per token — because it barely solves anything.
+**Key insight:** V4-Pro costs the least per eventual solve ($3.75), but requires **12.5× more attempts** than GPT-5.4 (1.8). The routing decision isn't about cost — it's about reliability. A task routed to V4-Pro fails 92% of the time on first attempt.
+
+### Additional Concerns (from DeepSWE Issue #21)
+
+- **No effort tuning**: V4-Pro was run with `reasoning_effort: null` while all other models had tuned effort levels (xhigh, max, medium). Its 8% score may improve with proper tuning.
+- **OpenRouter privacy guardrail**: OpenRouter blocks DeepSeek by default (data-training concern). Benchmark tests may have failed from 404 errors, not model capability.
 
 ## Terminal-Bench (Agentic CLI)
 
@@ -36,14 +41,21 @@ V4-Pro is 6.7× more expensive per solved task than GPT-5.4 despite being 17× c
 | GPT-5.5 | 82.7% | $30.00 |
 | DeepSeek V4-Pro | 67.9% | $0.87 |
 
-V4-Pro is competitive at tool orchestration. The routing strategy preserves V4-Pro for CLI/tool work while dispatching coding to GPT-5.4+.
+## The Routing Decision
+
+| Task Type | Route to | Why |
+|-----------|----------|-----|
+| Code Generation | GPT-5.4 | 56% success, 1.8 attempts — gets it done |
+| Architecture | GPT-5.5 | 70% success, 1.4 attempts — best-in-class |
+| Orchestration | V4-Pro | 67.9% Terminal-Bench, cheap, reliable at tools |
+| Mechanical | GPT-5.4-Mini | 24% success, delegated, fast |
+
+V4-Pro should not code because it fails 92% of real coding tasks — not because it costs more per solve.
 
 ## Sources
 
 - DeepSWE Leaderboard: https://deepswe.datacurve.ai/
+- DeepSWE Issue #21 (cost correction): https://github.com/datacurve-ai/deep-swe/issues/21
 - DeepSWE Blog: https://deepswe.datacurve.ai/blog
-- SWE-bench Pro Leaderboard: https://codingfleet.com/blog/swe-bench-pro-leaderboard-2026/
-- DeepSeek V4 Technical Report: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/DeepSeek_V4.pdf
-- DeepSeek V4 Blog: https://huggingface.co/blog/deepseekv4
+- DeepSeek V4 Technical Report: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
 - Kilo Leaderboard: https://kilo.ai/leaderboard
-- Vellum LLM Leaderboard: https://www.vellum.ai/llm-leaderboard

--- a/optional-skills/software-development/model-task-router/references/deepswe-routing-data.md
+++ b/optional-skills/software-development/model-task-router/references/deepswe-routing-data.md
@@ -1,0 +1,49 @@
+# DeepSWE Routing Data — Why Model Routing Matters
+
+## The Evidence
+
+DeepSWE (deepswe.datacurve.ai) is the only contamination-free, real-complexity coding benchmark. Tasks are written from scratch, require 5.5× more code than SWE-bench Pro, and span 91 repositories across 5 languages.
+
+## Key Finding: Models Collapse on Real Engineering Tasks
+
+| Model | SWE-bench Pro | DeepSWE | Collapse |
+|-------|:------------:|:-------:|:--------:|
+| GPT-5.5 (xhigh) | 58.6% | **70%** | +11 — improves |
+| GPT-5.4 (xhigh) | 57.7% | **56%** | −2 — holds |
+| Claude Opus 4.7 | 64.3% | 54% | −10 |
+| MiniMax M3 | 59.0% | 20% | **−39** |
+| DeepSeek V4-Pro | 55.4% | **8%** | **−47** |
+
+**Budget models that look competitive on SWE-bench Pro collapse on real tasks.** V4-Pro drops from 55% to 8%. M3 drops from 59% to 20%. The gap between "good enough" and "actually works" is invisible on contaminated benchmarks.
+
+## Cost per Solved Task (DeepSWE)
+
+| Model | Pass@1 | Avg Cost/Task | Cost per Solve |
+|-------|:------:|:------------:|:--------------:|
+| GPT-5.4 | 56% | $4.38 | **$7.82** |
+| GPT-5.5 | 70% | $6.61 | $9.44 |
+| GPT-5.4-Mini | 24% | $2.08 | $8.67 |
+| Claude Opus 4.7 | 54% | $18.19 | $33.69 |
+| MiniMax M3 | 20% | $5.57 | $27.85 |
+| DeepSeek V4-Pro | 8% | $4.22 | **$52.75** |
+
+V4-Pro is 6.7× more expensive per solved task than GPT-5.4 despite being 17× cheaper per token — because it barely solves anything.
+
+## Terminal-Bench (Agentic CLI)
+
+| Model | Score | $/1M Output |
+|-------|:-----:|:-----------:|
+| GPT-5.5 | 82.7% | $30.00 |
+| DeepSeek V4-Pro | 67.9% | $0.87 |
+
+V4-Pro is competitive at tool orchestration. The routing strategy preserves V4-Pro for CLI/tool work while dispatching coding to GPT-5.4+.
+
+## Sources
+
+- DeepSWE Leaderboard: https://deepswe.datacurve.ai/
+- DeepSWE Blog: https://deepswe.datacurve.ai/blog
+- SWE-bench Pro Leaderboard: https://codingfleet.com/blog/swe-bench-pro-leaderboard-2026/
+- DeepSeek V4 Technical Report: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/DeepSeek_V4.pdf
+- DeepSeek V4 Blog: https://huggingface.co/blog/deepseekv4
+- Kilo Leaderboard: https://kilo.ai/leaderboard
+- Vellum LLM Leaderboard: https://www.vellum.ai/llm-leaderboard

--- a/optional-skills/software-development/model-task-router/references/deepswe-routing-data.md
+++ b/optional-skills/software-development/model-task-router/references/deepswe-routing-data.md
@@ -1,38 +1,57 @@
-# DeepSWE Routing Data — Why Model Routing Matters
+# DeepSWE Routing Data — Reference
 
-> **Updated 2026-06-10**: Cost figures corrected based on [DeepSWE issue #21](https://github.com/datacurve-ai/deep-swe/issues/21) — DeepSeek's cache-hit pricing was not applied, inflating costs 4-14×. The solve-rate data (8%) is unaffected. The routing recommendation stands, but the justification shifts from cost to reliability.
+> **Updated 2026-06-11**: Full model table with published and community-verified data. All solve-rate claims from DeepSWE issue #21 were retracted by the issue author (2026-06-08) after discovering a test-setup error. The cost-correction analysis in that issue remains valid and is included below. Treat DeepSWE scores as directional — effort tuning, provider routing, and limited replication all introduce uncertainty.
 
 ## The Evidence
 
-DeepSWE ([deepswe.datacurve.ai](https://deepswe.datacurve.ai)) is the only contamination-free, real-complexity coding benchmark. Tasks are written from scratch, require 5.5× more code than SWE-bench Pro, and span 91 repositories across 5 languages.
+DeepSWE ([deepswe.datacurve.ai](https://deepswe.datacurve.ai)) is a contamination-free, real-complexity coding benchmark. Tasks are written from scratch, require ~5.5x more code than SWE-bench Pro, and span 91 repositories across 5 languages.
 
-## Key Finding: Models Collapse on Real Engineering Tasks
+## Full DeepSWE Results (Published + Community)
 
-| Model | SWE-bench Pro | DeepSWE | Collapse |
-|-------|:------------:|:-------:|:--------:|
-| GPT-5.5 (xhigh) | 58.6% | **70%** | +11 — improves |
-| GPT-5.4 (xhigh) | 57.7% | **56%** | −2 — holds |
-| Claude Opus 4.7 | 64.3% | 54% | −10 |
-| MiniMax M3 | 59.0% | 20% | **−39** |
-| DeepSeek V4-Pro | 55.4% | **8%** | **−47** |
+| Model | SWE-bench Pro | DeepSWE | Delta | Notes |
+|-------|:------------:|:-------:|:-----:|-------|
+| GPT-5.5 (xhigh) | 58.6% | **70%** | +11 | Best-in-class |
+| GPT-5.4 (xhigh) | 57.7% | **56%** | −2 | Strong general coding |
+| Claude Opus 4.7 | 64.3% | **54%** | −10 | Competitive coding |
+| Claude Sonnet 4.6 | — | 32% | — | Mid-tier |
+| Gemini 3.5 Flash | — | 28% | — | Budget-aware |
+| GPT-5.4-Mini | — | 24% | — | Fast, cheap, delegated |
+| Kimi K2.6 | — | 24% | — | Budget option |
+| DeepSeek V4-Pro | 55.4% | ~8%* | −47 | See caveats below |
 
-## Cost Analysis (Cache-Adjusted, June 2026)
+### V4-Pro Caveats
 
-DeepSeek V4-Pro's actual pricing includes cache-hit rates at $0.0036/M (99.2% off cache-miss). DeepSWE's reported costs billed all tokens at the miss rate. Corrected:
+The ~8% DeepSWE score for V4-Pro comes with significant methodological concerns documented in [DeepSWE issue #21](https://github.com/datacurve-ai/deep-swe/issues/21):
 
-| Model | DeepSWE | Cost/Task | Cost/Solve | Attempts/Solve |
-|-------|:-------:|:---------:|:----------:|:--------------:|
-| GPT-5.5 | **70%** | $6.61 | $9.44 | 1.4 |
-| GPT-5.4 | **56%** | $4.38 | **$7.82** | 1.8 |
-| GPT-5.4-Mini | 24% | $2.08 | $8.67 | 4.2 |
-| DeepSeek V4-Pro | **8%** | **$0.30** | **$3.75** | 12.5 |
+1. **No effort tuning**: V4-Pro was run at `reasoning_effort: null` while all other models had tuned effort levels (xhigh, max, medium). Thinking mode was left on but unoptimized.
+2. **OpenRouter guardrail 404s**: OpenRouter blocks DeepSeek by default (data-training privacy concern). API calls may have returned 404 errors rather than model failures.
+3. **Limited replication**: Community member `ivanfioravanti` ran an independent test via direct DeepSeek API and got ~5.3% (similar direction). No independent confirmation with proper effort tuning exists yet.
+4. **Solve-rate claims from issue #21 retracted**: The issue author retracted their own solve-rate analysis after discovering a test-setup error.
 
-**Key insight:** V4-Pro costs the least per eventual solve ($3.75), but requires **12.5× more attempts** than GPT-5.4 (1.8). The routing decision isn't about cost — it's about reliability. A task routed to V4-Pro fails 92% of the time on first attempt.
+**Bottom line**: V4-Pro likely underperforms GPT-5.4/5.5 on coding tasks, but the magnitude of the gap is uncertain pending a re-run with proper effort tuning. Configure your routing accordingly.
 
-### Additional Concerns (from DeepSWE Issue #21)
+## Cost Analysis (from DeepSWE Issue #21 — Valid)
 
-- **No effort tuning**: V4-Pro was run with `reasoning_effort: null` while all other models had tuned effort levels (xhigh, max, medium). Its 8% score may improve with proper tuning.
-- **OpenRouter privacy guardrail**: OpenRouter blocks DeepSeek by default (data-training concern). Benchmark tests may have failed from 404 errors, not model capability.
+DeepSeek V4-Pro pricing includes cache-hit rates at $0.0036/M (99.2% off cache-miss). DeepSWE's reported costs billed all tokens at the miss rate ($0.435/M). In real-world agent runs, ~78% of tokens are cache hits.
+
+### Corrected Cost per Task (Cache-Adjusted)
+
+| Model | DeepSWE | Reported Cost | Corrected Cost | Factor |
+|-------|:-------:|:------------:|:--------------:|:------:|
+| GPT-5.5 | 70% | $6.61/task | — | — |
+| GPT-5.4 | 56% | $4.38/task | — | — |
+| GPT-5.4-Mini | 24% | $2.08/task | — | — |
+| DeepSeek V4-Pro | 8% | $4.22/task | ~$0.30/task | ~14× inflation |
+
+Source: Reproducible analysis script in issue #21 by `agentecobuilder`. Verified independently.
+
+**Key finding**: V4-Pro's per-task cost was inflated ~14× by ignoring cache-hit pricing. The real cost is very low (~$0.30/task). However, cost-per-task ignores solve rate — if a model requires many retries, the effective cost-per-solve may be higher despite low per-token pricing. Since the solve rate is uncertain (see caveats), cost-per-solve calculations are withheld pending a proper re-benchmark.
+
+### Additional Cost Considerations
+
+- **OpenRouter 5% fee** for high-usage accounts adds to all OpenRouter-routed models
+- **Reasoning tokens**: Thinking-mode models generate hidden reasoning tokens that are billed but not shown in output token counts
+- **Provider pricing volatility**: DeepSeek and other providers adjust pricing frequently; verify current rates
 
 ## Terminal-Bench (Agentic CLI)
 
@@ -41,21 +60,18 @@ DeepSeek V4-Pro's actual pricing includes cache-hit rates at $0.0036/M (99.2% of
 | GPT-5.5 | 82.7% | $30.00 |
 | DeepSeek V4-Pro | 67.9% | $0.87 |
 
-## The Routing Decision
+V4-Pro is competitive at tool orchestration and CLI tasks — a different skill set from code generation. This supports the routing strategy: coding → specialized coding models, orchestration → efficient orchestrator.
 
-| Task Type | Route to | Why |
-|-----------|----------|-----|
-| Code Generation | GPT-5.4 | 56% success, 1.8 attempts — gets it done |
-| Architecture | GPT-5.5 | 70% success, 1.4 attempts — best-in-class |
-| Orchestration | V4-Pro | 67.9% Terminal-Bench, cheap, reliable at tools |
-| Mechanical | GPT-5.4-Mini | 24% success, delegated, fast |
+## Routing Principles
 
-V4-Pro should not code because it fails 92% of real coding tasks — not because it costs more per solve.
+1. **Route based on task type, not model brand loyalty.** Different models excel at different things.
+2. **Treat published benchmarks as directional.** Real-world experience with your actual tasks is the best calibration.
+3. **Configure coding/architecture models explicitly.** Don't rely on the orchestrator model for code generation if there's a stronger option.
+4. **Verify subagent results.** No benchmark score guarantees a correct implementation. Always read the output.
 
 ## Sources
 
 - DeepSWE Leaderboard: https://deepswe.datacurve.ai/
-- DeepSWE Issue #21 (cost correction): https://github.com/datacurve-ai/deep-swe/issues/21
-- DeepSWE Blog: https://deepswe.datacurve.ai/blog
-- DeepSeek V4 Technical Report: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
-- Kilo Leaderboard: https://kilo.ai/leaderboard
+- DeepSWE Issue #21 (cost correction, caveats): https://github.com/datacurve-ai/deep-swe/issues/21
+- explainx.ai DeepSWE analysis: https://explainx.ai/blog/deepswe
+- Terminal-Bench / Kilo Leaderboard: https://kilo.ai/leaderboard


### PR DESCRIPTION
## Summary

Adds `model-task-router`, a skill that automatically classifies incoming Hermes Agent tasks and routes them to the optimal model — no manual `/model` switches required.

> **Correction (2026-06-10):** Cost figures updated per [DeepSWE issue #21](https://github.com/datacurve-ai/deep-swe/issues/21). DeepSeek cache-hit pricing ($0.0036/M) was not applied in original benchmark, inflating costs. The corrected argument shifts from cost to **reliability**: V4-Pro fails 92% of real coding tasks on first attempt vs GPT-5.4 at 44%.

## The Problem (Backed by DeepSWE)

| Model | SWE-bench Pro | DeepSWE | Collapse | Attempts/Solve |
|-------|:------------:|:-------:|:--------:|:--------------:|
| GPT-5.5 (xhigh) | 58.6% | **70%** | +11 | 1.4 |
| GPT-5.4 (xhigh) | 57.7% | **56%** | −2 | **1.8** |
| DeepSeek V4-Pro | 55.4% | **8%** | **−47** | 12.5 |
| MiniMax M3 | 59.0% | 20% | −39 | 5.0 |

## The Solution

Task-based automatic routing:

| Task Type | Model | Why |
|-----------|-------|-----|
| Code Generation | GPT-5.4 (56% DeepSWE) | 7× V4-Pro success rate, 1.8 attempts/solve |
| Hard Architecture | GPT-5.5 (70% DeepSWE) | Best-in-class, 1.4 attempts/solve |
| Orchestration | V4-Pro | Terminal-Bench 67.9%, V4-Pro strength |
| Research | V4-Pro | Good reasoning, cheap |
| Mechanical | GPT-5.4-Mini (24% DeepSWE) | delegated, 4.2 attempts/solve |

Full cost analysis with cache-adjustment: `references/deepswe-routing-data.md`

## Related Issues

- Closes (partially): [#30652](https://github.com/NousResearch/hermes-agent/issues/30652)
- Related: [#16525](https://github.com/NousResearch/hermes-agent/issues/16525), [#18591](https://github.com/NousResearch/hermes-agent/issues/18591)
- Data correction: [datacurve-ai/deep-swe#21](https://github.com/datacurve-ai/deep-swe/issues/21)

Authored-by: Sugumaran Balasubramaniyan <bsugumaran@hotmail.com>