### PR TITLE
fix(profiles): use unique tmp file in set_active_profile to prevent p…

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -27,6 +27,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -1823,10 +1824,24 @@ def set_active_profile(name: str) -> None:
         # Remove the file to indicate default
         path.unlink(missing_ok=True)
     else:
-        # Atomic write
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(canon + "\n")
-        tmp.replace(path)
+        # Atomic write via unique tmp to avoid parallel-writer clobber
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(path.parent),
+            suffix=".tmp",
+            prefix=".active_profile_",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(canon + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, str(path))
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
 
 def get_active_profile_name() -> str:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -15,6 +15,7 @@ import types
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import concurrent.futures
 import pytest
 import yaml
 
@@ -739,6 +740,52 @@ class TestActiveProfile:
     def test_set_nonexistent_raises(self, profile_env):
         with pytest.raises(FileNotFoundError):
             set_active_profile("nonexistent")
+
+    def test_write_leaves_no_orphan_tmp(self, profile_env):
+        """Successful write must not leave .tmp siblings in the profile dir."""
+        create_profile("coder", no_alias=True)
+        set_active_profile("coder")
+
+        active_dir = profile_env / ".hermes"
+        assert (active_dir / "active_profile").exists()
+        assert not [
+            p for p in active_dir.iterdir()
+            if p.name.endswith(".tmp")
+        ], "orphan .tmp file(s) found after set_active_profile"
+
+    def test_parallel_writes_produce_valid_active_profile(self, profile_env):
+        """Concurrent callers must not corrupt active_profile or leak tmp files."""
+        create_profile("alpha", no_alias=True)
+        create_profile("beta", no_alias=True)
+
+        active_path = profile_env / ".hermes" / "active_profile"
+        errors = []
+
+        def _writer(name: str) -> None:
+            try:
+                set_active_profile(name)
+            except Exception as exc:
+                errors.append(exc)
+
+        workers = 6
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [
+                pool.submit(_writer, n)
+                for n in ("alpha", "beta") * (workers // 2)
+            ]
+            concurrent.futures.wait(futures)
+            for fut in futures:
+                fut.result()
+
+        assert not errors, f"set_active_profile raised during parallel write: {errors}"
+        final = active_path.read_text().strip()
+        assert final in {"alpha", "beta"}, (
+            f"active_profile contains unexpected value {final!r}"
+        )
+        assert not [
+            p for p in active_path.parent.iterdir()
+            if p.name.endswith(".tmp")
+        ], "orphan .tmp file(s) after parallel writes"
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Replaces the predictable `.tmp` file name in `set_active_profile()` with
a unique temporary file via `tempfile.mkstemp`. When two processes write
to `active_profile` concurrently, the old implementation caused silent
last-writer-wins corruption through a shared `active_profile.tmp` name.

---

## Root cause

`set_active_profile()` in `hermes_cli/profiles.py` used
`path.with_suffix(".tmp")` to create a temporary file before renaming it
to `active_profile`. This produces a constant name (`active_profile.tmp`)
shared by all writers. When two processes call `set_active_profile()`
simultaneously (e.g. the web dashboard and the CLI on the same host),
both write to the same `.tmp` file, overwriting each other. The final
`os.replace` call is atomic but whichever process wins the race
determines the outcome — the other write is silently lost with no error.

Practical scenario: a user switches profile in the browser dashboard
while simultaneously running `hermes profile switch` in the terminal.
The active profile ends up as whichever write completed last, which may
not match the user's intent.

---

## Behavioral change

Before: `set_active_profile()` used a fixed `active_profile.tmp` name,
allowing parallel writers to clobber each other silently.

After: `tempfile.mkstemp(dir=..., prefix=".active_profile_", suffix=".tmp")`
creates a unique temporary file per caller. Each caller now writes to its
own unique tmp file, eliminating the clobber window. On success the tmp
is atomically renamed to `active_profile` via `os.replace`. On any
failure the tmp is cleaned up in the `except BaseException` handler,
leaving no orphan files.

---

## What changed

**`hermes_cli/profiles.py`**
- Replaced `path.with_suffix(".tmp")` + `tmp.write_text()` + `tmp.replace()`
  with `tempfile.mkstemp()` + `os.fdopen()` + `os.fsync()` + `os.replace()`
  in `set_active_profile()`
- Added `import tempfile` to module imports
- Pattern matches the atomic write style used in `hermes_cli/config.py`
  (lines 5661-5673)

**`tests/hermes_cli/test_profiles.py`**
- Added `test_write_leaves_no_orphan_tmp`: verifies no `.tmp` files remain
  after a successful `set_active_profile()` call
- Added `test_parallel_writes_produce_valid_active_profile`: runs 6
  concurrent writers and verifies the final value is valid and no orphan
  tmp files remain

---

## What is NOT changed

- `get_active_profile_name()` unchanged
- `set_active_profile("default")` branch unchanged
- No behavior change when called from a single process
- Each caller now writes to its own unique tmp file; the final
  `os.replace` remains atomic
- No changes to profile directory structure or file naming conventions
