### PR TITLE
fix(cli): merge user-configured models into built-in provider picker entries

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1399,6 +1399,20 @@ def list_authenticated_providers(
             model_ids = curated.get(hermes_id, [])
             if hermes_id in _MODELS_DEV_PREFERRED:
                 model_ids = _merge_with_models_dev(hermes_id, model_ids)
+        # Merge user-configured models from providers.<id>.models so they
+        # appear alongside curated entries (Section 3 skips slugs already in
+        # seen_slugs, so user models for built-in providers would be lost).
+        if user_providers and isinstance(user_providers, dict):
+            _ucfg = user_providers.get(hermes_id) or user_providers.get(hermes_id.lower())
+            if isinstance(_ucfg, dict):
+                _extra = []
+                _cfg_models = _ucfg.get("models", [])
+                if isinstance(_cfg_models, dict):
+                    _extra = [m for m in _cfg_models if m]
+                elif isinstance(_cfg_models, list):
+                    _extra = [m for m in _cfg_models if m]
+                if _extra:
+                    model_ids = list(model_ids) + [m for m in _extra if m not in model_ids]
         total = len(model_ids)
         top = model_ids[:max_models]
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -719,3 +719,49 @@ def test_custom_providers_discover_models_false_string_is_normalised(monkeypatch
     assert gateway_prov is not None
     assert calls == [], "string 'false' must disable live discovery"
     assert gateway_prov["models"] == ["only-model"]
+
+def test_builtin_provider_merges_user_configured_models(monkeypatch):
+    """User-configured models for a built-in provider must appear in the
+    picker alongside curated models, not be silently skipped because the
+    slug is already in seen_slugs (Section 3 skip)."""
+    import hermes_cli.models as models_mod
+    import hermes_cli.providers as providers_mod
+
+    # Simulate a built-in provider with curated models (deepseek is not an
+    # alias so it won't be skipped by the aggregator-alias guard).
+    fake_curated = {"deepseek": ["deepseek-chat", "deepseek-reasoner"]}
+    monkeypatch.setattr(models_mod, "_PROVIDER_MODELS", fake_curated)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {
+        "deepseek": {"env": ["DEEPSEEK_API_KEY"], "name": "DeepSeek"},
+    })
+    # Prevent cached_provider_model_ids from hitting real APIs
+    monkeypatch.setattr(models_mod, "cached_provider_model_ids", lambda *a, **kw: [])
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    # User has added custom models under providers.deepseek.models
+    user_providers = {
+        "deepseek": {
+            "models": {
+                "deepseek-v4-pro": {"label": "DeepSeek V4 Pro"},
+                "deepseek-v4-flash": {"label": "DeepSeek V4 Flash"},
+            },
+        },
+    }
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+
+    providers = list_authenticated_providers(
+        current_provider="deepseek",
+        user_providers=user_providers,
+        max_models=50,
+    )
+
+    ds = [p for p in providers if p["slug"] == "deepseek"]
+    assert len(ds) == 1, "deepseek should appear exactly once"
+    models = ds[0]["models"]
+    # Curated models must be present
+    assert "deepseek-chat" in models
+    assert "deepseek-reasoner" in models
+    # User-configured models must also be present
+    assert "deepseek-v4-pro" in models, "user-configured model missing from picker"
+    assert "deepseek-v4-flash" in models, "user-configured model missing from picker"


### PR DESCRIPTION
## What does this PR do?

Merges user-configured models from `providers.<id>.models` into built-in provider picker entries. Previously, when a user added custom models to a built-in provider (e.g. `providers.alibaba.models`), those models were silently discarded because Section 1 of `list_authenticated_providers()` added the slug to `seen_slugs` before Section 3 could process user-configured models.

## Related Issue

Fixes #43528

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`: After computing `model_ids` from the curated list in Section 1, merge in any user-configured models from `user_providers[hermes_id]`. User models are appended after curated ones (no duplicates).
- `tests/hermes_cli/test_model_switch_custom_providers.py`: Added `test_builtin_provider_merges_user_configured_models` — verifies that user-configured models appear alongside curated models in the picker for a built-in provider.

## How to Test

1. Add custom models to a built-in provider in config.yaml:
   ```yaml
   providers:
     deepseek:
       models:
         deepseek-v4-pro:
           label: DeepSeek V4 Pro
         deepseek-v4-flash:
           label: DeepSeek V4 Flash
   ```
2. Run `hermes model` or open the Desktop model picker
3. Verify that both curated models (deepseek-chat, deepseek-reasoner) and user-configured models (deepseek-v4-pro, deepseek-v4-flash) appear
4. Run: `pytest tests/hermes_cli/test_model_switch_custom_providers.py::test_builtin_provider_merges_user_configured_models -xvs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_model_switch_custom_providers.py -x` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/model_switch.py::list_authenticated_providers()` (Section 1 + Section 3 interaction)
- Blast radius: LOW — only affects model picker display, no change to model resolution or API calls
- Related patterns: Section 3 `seen_slugs` skip logic at line ~1669; user_providers dict structure
