### PR TITLE
fix(desktop): preserve empty model visibility providers

### DIFF
--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -15,7 +15,8 @@ import {
   collapseModelFamilies,
   effectiveVisibleKeys,
   modelVisibilityKey,
-  setVisibleModels
+  setVisibleModels,
+  toggleVisibleModelKey
 } from '@/store/model-visibility'
 import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
 
@@ -59,16 +60,7 @@ export function ModelVisibilityDialog({
   const visible = effectiveVisibleKeys(stored, providers)
 
   const toggle = (provider: ModelOptionProvider, model: string) => {
-    const next = new Set(effectiveVisibleKeys($visibleModels.get(), providers))
-    const key = modelVisibilityKey(provider.slug, model)
-
-    if (next.has(key)) {
-      next.delete(key)
-    } else {
-      next.add(key)
-    }
-
-    setVisibleModels(next)
+    setVisibleModels(toggleVisibleModelKey($visibleModels.get(), providers, provider, model))
   }
 
   const q = search.trim().toLowerCase()

--- a/apps/desktop/src/store/model-visibility.test.ts
+++ b/apps/desktop/src/store/model-visibility.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import type { ModelOptionProvider } from '@/types/hermes'
 
-import { effectiveVisibleKeys, modelVisibilityKey } from './model-visibility'
+import {
+  effectiveVisibleKeys,
+  modelVisibilityKey,
+  providerHiddenVisibilityKey,
+  toggleVisibleModelKey
+} from './model-visibility'
 
 const provider = (slug: string, models: string[]): ModelOptionProvider => ({
   models,
@@ -33,5 +38,34 @@ describe('model visibility', () => {
 
     expect(visible.has(modelVisibilityKey('local-ollama', 'qwen3:latest'))).toBe(true)
     expect(visible.has(modelVisibilityKey('local-ollama', 'llama3.2:latest'))).toBe(false)
+  })
+
+  it('keeps a provider hidden when its last visible model is toggled off', () => {
+    const providers = [
+      provider('copilot', ['claude-sonnet-4.6']),
+      provider('local-ollama', ['qwen3:latest'])
+    ]
+
+    const stored = new Set([
+      modelVisibilityKey('copilot', 'claude-sonnet-4.6'),
+      modelVisibilityKey('local-ollama', 'qwen3:latest')
+    ])
+
+    const next = toggleVisibleModelKey(stored, providers, providers[1], 'qwen3:latest')
+    const visible = effectiveVisibleKeys(next, providers)
+
+    expect(next.has(providerHiddenVisibilityKey('local-ollama'))).toBe(true)
+    expect(visible.has(modelVisibilityKey('copilot', 'claude-sonnet-4.6'))).toBe(true)
+    expect(visible.has(modelVisibilityKey('local-ollama', 'qwen3:latest'))).toBe(false)
+  })
+
+  it('removes the hidden-provider marker when a model is toggled back on', () => {
+    const providers = [provider('local-ollama', ['qwen3:latest'])]
+    const stored = new Set([providerHiddenVisibilityKey('local-ollama')])
+
+    const next = toggleVisibleModelKey(stored, providers, providers[0], 'qwen3:latest')
+
+    expect(next.has(providerHiddenVisibilityKey('local-ollama'))).toBe(false)
+    expect(next.has(modelVisibilityKey('local-ollama', 'qwen3:latest'))).toBe(true)
   })
 })

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -9,9 +9,17 @@ const STORAGE_KEY = 'hermes.desktop.visible-models'
  *  customized the list. Backend `models` are already relevance-ordered. */
 export const DEFAULT_VISIBLE_PER_PROVIDER = 50
 
+const PROVIDER_HIDDEN_MARKER = '__hermes_provider_hidden__'
+
 /** Stable key for a provider/model pair (`::` avoids colliding with model ids
  *  that contain a single colon, e.g. `model:tag`). */
 export const modelVisibilityKey = (provider: string, model: string): string => `${provider}::${model}`
+
+/** Marker stored when a provider has been explicitly customized down to zero
+ *  visible models. Without this, an empty provider is indistinguishable from a
+ *  newly configured provider and `effectiveVisibleKeys()` re-adds defaults. */
+export const providerHiddenVisibilityKey = (provider: string): string =>
+  modelVisibilityKey(provider, PROVIDER_HIDDEN_MARKER)
 
 /** A model and its optional `…-fast` sibling, collapsed into one logical row.
  *  `id` is the canonical (base) model; `fastId` is the fast variant if present. */
@@ -80,6 +88,34 @@ export function setVisibleModels(keys: Set<string>): void {
 
 export function setModelVisibilityOpen(open: boolean): void {
   $modelVisibilityOpen.set(open)
+}
+
+export function toggleVisibleModelKey(
+  stored: Set<string> | null,
+  providers: readonly ModelOptionProvider[],
+  provider: ModelOptionProvider,
+  model: string
+): Set<string> {
+  const next = new Set(effectiveVisibleKeys(stored, providers))
+  const key = modelVisibilityKey(provider.slug, model)
+  const hiddenKey = providerHiddenVisibilityKey(provider.slug)
+
+  if (next.has(key)) {
+    next.delete(key)
+
+    const hasVisibleProviderModel = collapseModelFamilies(provider.models ?? []).some(family =>
+      next.has(modelVisibilityKey(provider.slug, family.id))
+    )
+
+    if (!hasVisibleProviderModel) {
+      next.add(hiddenKey)
+    }
+  } else {
+    next.delete(hiddenKey)
+    next.add(key)
+  }
+
+  return next
 }
 
 /** The default-visible key set: the curated top-N per provider. Used both as


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop model visibility dialog bug where toggling off the last visible model for a provider immediately re-enables that provider's default models.

The model visibility store previously represented customization only as a set of visible `provider::model` keys. When the last key for a provider was removed, `effectiveVisibleKeys()` could no longer tell the difference between "the user intentionally hid this provider" and "this provider has never been customized", so it re-added the default-visible models.

This PR stores an explicit hidden-provider marker when a provider is customized down to zero visible models. That keeps the default-fallback path for genuinely new providers while preserving the user's intentional hide-all choice.

## Related Issue

Fixes #43485

Related PR: #43496 appears to address the same bug. This PR is kept as a draft for maintainer/user comparison; it can be closed if #43496 is preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/model-visibility.ts`
  - Add `providerHiddenVisibilityKey()` marker for providers intentionally hidden to zero visible models.
  - Add `toggleVisibleModelKey()` so the toggle behavior is centralized and testable.
  - Keep `effectiveVisibleKeys()` default behavior for truly uncustomized/new providers.
- `apps/desktop/src/components/model-visibility-dialog.tsx`
  - Use `toggleVisibleModelKey()` from the store instead of duplicating visibility-set mutation in the component.
- `apps/desktop/src/store/model-visibility.test.ts`
  - Add regression coverage for hiding the last model in a provider without re-adding defaults.
  - Add coverage for removing the hidden-provider marker when a model is toggled back on.

## How to Test

1. Open Hermes Desktop.
2. Open the status-bar model picker and choose **Edit models**.
3. For a provider with visible models, toggle every model off.
4. Verify the final toggle stays off and the provider's models do not snap back to enabled.
5. Toggle one model from that provider back on and verify it becomes visible again.

Automated checks run locally:

```bash
npx eslint src/store/model-visibility.ts src/store/model-visibility.test.ts src/components/model-visibility-dialog.tsx
npm run test:ui -- src/store/model-visibility.test.ts
npm run type-check
npm run build
python scripts/check-windows-footguns.py --diff main...HEAD
```

Full-suite check attempted with the repository-preferred runner:

```bash
scripts/run_tests.sh
```

Result: `30318` tests passed, `1` failed. The failing test is `tests/hermes_cli/test_web_server.py::TestNewEndpoints::test_profiles_create_creates_wrapper_alias_when_safe`; it fails the same way on current `main`, so this appears to be pre-existing and unrelated to this Desktop change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - Note: a related open PR was found after draft creation: #43496.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Note: `scripts/run_tests.sh` was run instead, per `CONTRIBUTING.md`; it has one pre-existing failure also reproducible on `main`.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux, Linux 7.0.11-1-cachyos x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A: user-facing behavior is unchanged except for fixing the bug.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A: no config keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no architecture/workflow change.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - No OS-specific code; `python scripts/check-windows-footguns.py --diff main...HEAD` passed.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no tool behavior or schema changed.

## For New Skills

N/A — this PR does not add or modify skills.

## Screenshots / Logs

Targeted verification logs:

```text
✓ src/store/model-visibility.test.ts (4 tests)
Test Files  1 passed (1)
Tests       4 passed (4)

npm run type-check → tsc -b passed
npm run build → vite build + assert-dist-built passed
python scripts/check-windows-footguns.py --diff main...HEAD → ✓ No Windows footguns found
```
