### PR TITLE
Support adapter channel directory enumeration

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -69,6 +69,12 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
 
     for platform, adapter in adapters.items():
         try:
+            list_channels = getattr(adapter, "list_channels", None)
+            if callable(list_channels):
+                platform_channels = await list_channels()
+                if platform_channels is not None:
+                    platforms[platform.value] = _normalize_adapter_channels(platform_channels)
+                    continue
             if platform == Platform.DISCORD:
                 platforms["discord"] = _build_discord(adapter)
             elif platform == Platform.SLACK:
@@ -143,6 +149,32 @@ def _build_discord(adapter) -> List[Dict[str, str]]:
 
     # Merge any DMs from session history
     channels.extend(_build_from_sessions("discord"))
+    return channels
+
+
+def _normalize_adapter_channels(raw_channels: Any) -> List[Dict[str, Any]]:
+    channels: List[Dict[str, Any]] = []
+    seen_ids = set()
+    if not isinstance(raw_channels, list):
+        return channels
+    for raw in raw_channels:
+        if not isinstance(raw, dict):
+            continue
+        channel_id = str(raw.get("id") or "").strip()
+        name = str(raw.get("name") or channel_id).strip()
+        if not channel_id or not name or channel_id in seen_ids:
+            continue
+        entry: Dict[str, Any] = {
+            "id": channel_id,
+            "name": name,
+            "type": str(raw.get("type") or "dm"),
+        }
+        if raw.get("thread_id"):
+            entry["thread_id"] = str(raw.get("thread_id"))
+        if raw.get("guild"):
+            entry["guild"] = str(raw.get("guild"))
+        channels.append(entry)
+        seen_ids.add(channel_id)
     return channels
 
 

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -6,6 +6,7 @@ import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from gateway.config import Platform
 from gateway.channel_directory import (
     build_channel_directory,
     lookup_channel_type,
@@ -67,6 +68,25 @@ class TestBuildChannelDirectoryWrites:
             result = load_directory()
 
         assert result == previous
+
+    def test_uses_adapter_list_channels_when_available(self, tmp_path):
+        class AdapterWithChannels:
+            async def list_channels(self):
+                return [
+                    {"id": "default", "name": "主对话", "type": "dm"},
+                    {"id": "family_1", "name": "达拉崩吧", "type": "group"},
+                    {"id": "", "name": "ignored", "type": "dm"},
+                    {"id": "family_1", "name": "duplicate", "type": "group"},
+                ]
+
+        cache_file = tmp_path / "channel_directory.json"
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            directory = asyncio.run(build_channel_directory({Platform.TELEGRAM: AdapterWithChannels()}))
+
+        assert directory["platforms"]["telegram"] == [
+            {"id": "default", "name": "主对话", "type": "dm"},
+            {"id": "family_1", "name": "达拉崩吧", "type": "group"},
+        ]
 
 
 class TestResolveChannelName:


### PR DESCRIPTION
## Summary
- let gateway channel directory use adapter-provided list_channels() before falling back to platform-specific/session discovery
- normalize adapter-provided channel entries and dedupe invalid/duplicate ids
- add coverage for adapter-driven channel enumeration

## Why
Plugin platforms such as Xiaoduiyou can enumerate current delivery targets directly. Without this hook, send_message(action=list) only sees stale session-history entries and cannot reliably target renamed/current channels.

## Test
- python -m pytest -q tests/gateway/test_channel_directory.py