### PR TITLE
fix(cron): restore HERMES_CRON_SESSION after jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1575,9 +1575,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
     agent = None
 
-    # Mark this as a cron session so the approval system can apply cron_mode.
-    # This env var is process-wide and persists for the lifetime of the
-    # scheduler process — every job this process runs is a cron job.
+    # Mark this run as a cron session so the approval system can apply
+    # cron_mode.  os.environ is process-wide, and gateway runs the scheduler
+    # in-process; restore the previous value in finally so one cron tick does
+    # not poison later interactive gateway sessions.
+    _prior_cron_session = os.environ.get("HERMES_CRON_SESSION", "_UNSET_")
     os.environ["HERMES_CRON_SESSION"] = "1"
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
@@ -2007,6 +2009,10 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 os.environ.pop("TERMINAL_CWD", None)
             else:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
+        if _prior_cron_session == "_UNSET_":
+            os.environ.pop("HERMES_CRON_SESSION", None)
+        else:
+            os.environ["HERMES_CRON_SESSION"] = _prior_cron_session
         # Clean up ContextVar session/delivery state for this job.
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1021,6 +1021,48 @@ class TestRunJobSessionPersistence:
         assert success is True
         cleanup_mock.assert_called_once()
 
+    def test_run_job_clears_cron_session_env_after_tick(self, tmp_path, monkeypatch):
+        # Regression: the gateway runs cron in-process. Leaving
+        # HERMES_CRON_SESSION=1 in os.environ after a job makes later
+        # interactive gateway sessions look like cron sessions, so
+        # execute_code can be blocked by cron approval policy.
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        job = {
+            "id": "env-clean-job",
+            "name": "env-clean",
+            "prompt": "hello",
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, _final_response, _error = run_job(job)
+
+        assert success is True
+        assert "HERMES_CRON_SESSION" not in os.environ
+
+    def test_run_job_restores_existing_cron_session_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "external")
+        job = {
+            "id": "env-restore-job",
+            "name": "env-restore",
+            "prompt": "hello",
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, _final_response, _error = run_job(job)
+
+        assert success is True
+        assert os.environ["HERMES_CRON_SESSION"] == "external"
+
     def _make_run_job_patches(self, tmp_path):
         """Common patches for run_job tests."""
         fake_db = MagicMock()


### PR DESCRIPTION
## What does this PR do?

The cron scheduler runs in-process inside the gateway. Setting `HERMES_CRON_SESSION=1` process-wide without restoring the prior value leaks cron approval context into later interactive gateway sessions, which can incorrectly block tools such as `execute_code`.

This PR saves the prior value before each job and restores it in `finally`:
- unsets `HERMES_CRON_SESSION` if it was not previously set
- restores the previous value if it was

## Related Issue

Fixes #37968

Related: #35515 #43370

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py`: save and restore `HERMES_CRON_SESSION` around each cron job
- `tests/cron/test_scheduler.py`: add regression tests for unset and pre-existing env values

## How to Test

1. `uv run --extra dev pytest tests/cron/test_scheduler.py::TestRunJobSessionPersistence -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [ ] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
