### PR TITLE
feat: add gateway usage-report command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7076,6 +7076,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
+        if canonical == "usage-report":
+            return await self._handle_usage_report_command(event)
+
         if canonical == "insights":
             return await self._handle_insights_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2851,6 +2851,62 @@ class GatewaySlashCommandsMixin:
             return "\n".join(parts)
         return t("gateway.usage.no_data")
 
+    async def _handle_usage_report_command(self, event: MessageEvent) -> str:
+        """Handle /usage-report — summarize skill usage telemetry.
+
+        The command is gateway-only, so keep the response compact and mobile
+        friendly: total catalog size, provenance counts, and the most active
+        skills from the current telemetry snapshot. Run the filesystem scan off
+        the event loop because usage_report() walks the whole skills tree.
+        """
+        from tools.skill_usage import usage_report
+
+        rows = await asyncio.to_thread(usage_report)
+        if not rows:
+            return "📈 **Skill Usage Report**\nNo skills found in the current profile."
+
+        counts = {"agent": 0, "bundled": 0, "hub": 0}
+        active_rows = []
+        for row in rows:
+            prov = str(row.get("provenance") or "agent")
+            counts[prov] = counts.get(prov, 0) + 1
+            if int(row.get("activity_count") or 0) > 0:
+                active_rows.append(row)
+
+        ranked = sorted(
+            active_rows,
+            key=lambda row: (-int(row.get("activity_count") or 0), str(row.get("name") or "")),
+        )[:5]
+
+        lines = [
+            "📈 **Skill Usage Report**",
+            f"Skills tracked: {len(rows)} total · {len(active_rows)} active",
+            (
+                "Sources: "
+                f"local {counts.get('agent', 0)} · "
+                f"bundled {counts.get('bundled', 0)} · "
+                f"hub {counts.get('hub', 0)}"
+            ),
+        ]
+
+        if ranked:
+            lines.append("")
+            lines.append("Top active skills:")
+            for idx, row in enumerate(ranked, start=1):
+                name = str(row.get("name") or "(unnamed)")
+                uses = int(row.get("use_count") or 0)
+                views = int(row.get("view_count") or 0)
+                activity = int(row.get("activity_count") or 0)
+                prov = str(row.get("provenance") or "agent")
+                lines.append(
+                    f"{idx}. {name} — {activity} touches ({uses} uses, {views} views) [{prov}]"
+                )
+        else:
+            lines.append("")
+            lines.append("No recorded skill activity yet.")
+
+        return "\n".join(lines)
+
     async def _handle_insights_command(self, event: MessageEvent) -> str:
         """Handle /insights command -- show usage insights and analytics."""
         args = event.get_command_args().strip()

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -203,6 +203,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
     CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
+    CommandDef("usage-report", "Generate a fresh usage report and send the summary", "Info",
+               gateway_only=True),
     CommandDef("insights", "Show usage insights and analytics", "Info",
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -66,6 +66,40 @@ class TestSlashCommands:
         assert "/" in response_text
 
     @pytest.mark.asyncio
+    async def test_usage_report_command_dispatches_to_gateway_handler(self, adapter, platform, monkeypatch):
+        import tools.skill_usage as skill_usage
+
+        monkeypatch.setattr(
+            skill_usage,
+            "usage_report",
+            lambda: [
+                {
+                    "name": "opportunity-radar",
+                    "provenance": "agent",
+                    "activity_count": 4,
+                    "use_count": 3,
+                    "view_count": 1,
+                },
+                {
+                    "name": "hermes-agent",
+                    "provenance": "bundled",
+                    "activity_count": 0,
+                    "use_count": 0,
+                    "view_count": 0,
+                },
+            ],
+        )
+
+        send = await send_and_capture(adapter, "/usage-report", platform)
+
+        send.assert_called_once()
+        response_text = send.call_args[1].get("content") or send.call_args[0][1]
+        assert "skill usage report" in response_text.lower()
+        assert "skills tracked: 2 total" in response_text.lower()
+        assert "top active skills" in response_text.lower()
+        assert "1. opportunity-radar" in response_text.lower()
+
+    @pytest.mark.asyncio
     async def test_sequential_commands_share_session(self, adapter, platform):
         """Two commands from the same chat_id should both succeed."""
         send_help = await send_and_capture(adapter, "/help", platform)


### PR DESCRIPTION
## Summary
- add a gateway-only `/usage-report` command that summarizes skill-usage telemetry
- wire the command into gateway slash-command dispatch and help text
- cover the new command with end-to-end gateway tests

## Verification
- python3 -m pytest tests/e2e/test_platform_commands.py -q -k usage_report