### PR TITLE
fix(context): parse vLLM's token-based output-cap error format

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1027,6 +1027,23 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         if _available >= 1:
             return _available
 
+    # vLLM style: both the window and the prompt are reported in TOKENS, e.g.
+    #   "This model's maximum context length is 131072 tokens. However, you
+    #    requested 65536 output tokens and your prompt contains at least 65537
+    #    input tokens, for a total of at least 131073 tokens. Please reduce
+    #    the length of the input prompt or the number of requested output
+    #    tokens."
+    # Available output = window - input. When the input alone is at or over
+    # the window this stays None, so the caller correctly falls through to
+    # compression instead of futilely shrinking the output cap.
+    _m_vllm_input = re.search(
+        r'prompt contains (?:at least )?(\d+)\s*input tokens', error_lower
+    )
+    if _m_ctx_tok and _m_vllm_input:
+        _available = int(_m_ctx_tok.group(1)) - int(_m_vllm_input.group(1))
+        if _available >= 1:
+            return _available
+
     return None
 
 

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -62,3 +62,49 @@ class TestParseCharBasedOutputCap:
         msg = ("maximum context length is 1000 tokens. However, you requested "
                "1000 output tokens and your prompt contains 9000 characters.")
         assert parse_available_output_tokens_from_error(msg) is None
+
+
+class TestParseVllmTokenBasedOutputCap:
+    """vLLM reports both the window and the prompt in TOKENS.
+
+    Until this format was parsed, the recovery path misclassified it as
+    prompt-too-long and looped through compression (which frees little) while
+    retrying with the same oversized max_tokens — terminating in "cannot
+    compress further" even though simply lowering the output cap would have
+    succeeded.
+    """
+
+    # Verbatim vLLM 0.22 / OpenAI-compatible server response (max_tokens set).
+    _VLLM_MSG = (
+        "This model's maximum context length is 131072 tokens. However, you "
+        "requested 65536 output tokens and your prompt contains at least "
+        "65537 input tokens, for a total of at least 131073 tokens. Please "
+        "reduce the length of the input prompt or the number of requested "
+        "output tokens."
+    )
+
+    def test_vllm_token_based_format(self):
+        # available output = 131072 - 65537 = 65535
+        assert parse_available_output_tokens_from_error(self._VLLM_MSG) == 65535
+
+    def test_vllm_without_at_least_qualifier(self):
+        # Some versions omit the "at least" hedge.
+        msg = ("This model's maximum context length is 131072 tokens. However, "
+               "you requested 4096 output tokens and your prompt contains "
+               "100000 input tokens, for a total of 104096 tokens.")
+        assert parse_available_output_tokens_from_error(msg) == 31072
+
+    def test_vllm_retry_fits_inside_window(self):
+        # The retried cap plus the reported input must fit in the window.
+        available = parse_available_output_tokens_from_error(self._VLLM_MSG)
+        assert available is not None
+        assert available + 65537 <= 131072
+
+    def test_vllm_input_alone_exceeds_window_returns_none(self):
+        # Input >= window -> lowering the output cap cannot help; the caller
+        # must fall through to the compression path.
+        msg = ("This model's maximum context length is 131072 tokens. However, "
+               "you requested 1024 output tokens and your prompt contains at "
+               "least 140000 input tokens, for a total of at least 141024 "
+               "tokens.")
+        assert parse_available_output_tokens_from_error(msg) is None


### PR DESCRIPTION
## What does this PR do?

Teaches `parse_available_output_tokens_from_error()` to extract the available output budget from vLLM's token-based context-overflow phrasing:

> This model's maximum context length is **131072 tokens**. However, you requested **65536 output tokens** and your prompt contains at least **65537 input tokens**, for a total of at least 131073 tokens. Please reduce the length of the input prompt or the number of requested output tokens.

The function's `is_output_cap_error` gate already matched this message (the `"requested" + "output tokens"` clause), but every extraction pattern missed it — Anthropic's `available_tokens:`, OpenRouter's `(A of text input, ...)` breakdown, and the LM Studio/llama.cpp *characters*-based variant all use different phrasings. The result was `None`, which sent the recovery path down the wrong branch: it misclassified the failure as prompt-too-long and looped through compression — which frees little, while each retry kept requesting the same oversized `max_tokens` — terminating in *"Context length exceeded and cannot compress further"* even though simply lowering the output cap for the retry would have succeeded.

Observed live against vLLM 0.22 (custom provider, no `model.max_tokens` set, so the profile default of 65536 reserved half a 131072 window):

```
⚠️  Context length exceeded, but provider did not report a max context length; keeping context_length at 131,072 tokens and compressing.
🗜️ Context too large (~43,089 tokens) — compressing (1/3)...
🗜️ Compressed 27 → 20 messages, retrying...
   [same 400 — retry still requests 65536 output tokens]
❌ Context length exceeded and cannot compress further.
```

With this fix the existing repair path (`available_out` → `_ephemeral_max_output_tokens` in `conversation_loop.py`) engages: available output = window − reported input, retry fits, no compression needed. When the input alone is at or over the window, extraction still returns `None` so the caller correctly falls through to compression.

Not covered here (happy to follow up): the OpenAI-classic phrasing `"you requested N tokens (X in the messages, Y in the completion)"` is similarly unparsed.

## Related Issue

Relates to #43547 (this PR fixes the recovery-path half of that incident; the issue proposes making the compaction trigger reservation-aware, which is a design question first).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` — new extraction branch in `parse_available_output_tokens_from_error()` for `"prompt contains [at least] N input tokens"`; reuses the already-parsed window figure.
- `tests/test_output_cap_parsing.py` — new `TestParseVllmTokenBasedOutputCap` class (4 cases): verbatim vLLM 0.22 message, the no-`"at least"` variant, retry-fits-inside-window invariant, and input-exceeds-window → `None`.

## How to Test

1. `pytest tests/test_output_cap_parsing.py` — 11 passed (7 pre-existing + 4 new).
2. Live repro: serve any model via vLLM with `--max-model-len N`, configure it as a `custom` provider without `model.max_tokens`, and grow a session past `N − 65536` input tokens. Before: compression loop → "cannot compress further". After: one retry with a reduced output cap succeeds.

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests that prove my fix/feature works
- [x] All tests pass locally
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring comment added inline; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python regex, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

---

I had Claude Fable 5 do this work - it diagnosed the failure live on my own Hermes deployment (custom vLLM endpoint on local hardware), traced it through the recovery path, and wrote the fix and tests; the error message in the test fixture is verbatim from my logs. Same goal as my previous PRs: pushing Fable to be a useful open-source contributor with minimal hand-holding - acceptance is the signal I'm looking for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
