### PR TITLE
feat(skills): add hermes skills lint structure validator

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -122,6 +122,42 @@ def parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     return frontmatter, body
 
 
+def parse_frontmatter_strict(content: str) -> Tuple[Dict[str, Any], str, Optional[str]]:
+    """Parse YAML frontmatter without the lenient key:value fallback.
+
+    Unlike parse_frontmatter(), a YAML failure is surfaced instead of being
+    papered over — callers that validate skills (e.g. the linter) need to know
+    when the runtime would silently degrade to naive parsing.
+
+    Returns:
+        (frontmatter_dict, remaining_body, yaml_error_or_None)
+    """
+    frontmatter: Dict[str, Any] = {}
+    body = content
+
+    if not content.startswith("---"):
+        return frontmatter, body, None
+
+    end_match = re.search(r"\n---\s*\n", content[3:])
+    if not end_match:
+        return frontmatter, body, None
+
+    yaml_content = content[3 : end_match.start() + 3]
+    body = content[end_match.end() + 3 :]
+
+    try:
+        parsed = yaml_load(yaml_content)
+    except Exception as exc:
+        return frontmatter, body, str(exc)
+
+    if isinstance(parsed, dict):
+        frontmatter = parsed
+    elif parsed is not None:
+        return frontmatter, body, f"frontmatter is {type(parsed).__name__}, expected a mapping"
+
+    return frontmatter, body, None
+
+
 # ── Platform matching ─────────────────────────────────────────────────────
 
 

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1028,6 +1028,80 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
         c.print()
 
 
+def do_lint(targets: Optional[List[str]] = None, all_skills: bool = False,
+            as_json: bool = False, fail_on: str = "error",
+            console: Optional[Console] = None) -> int:
+    """Validate skill structure. Returns an exit code (0/1/2) for CI use."""
+    from tools.skills_lint import (
+        collect_installed_skill_names,
+        find_installed_skill_paths,
+        format_lint_report,
+        lint_skill,
+    )
+
+    c = console or _console
+    targets = targets or []
+
+    if all_skills and targets:
+        c.print("[bold red]Error:[/] --all cannot be combined with explicit targets.\n")
+        return 2
+
+    # Resolve targets to skill directories
+    skill_dirs: List[Path] = []
+    if all_skills:
+        skill_dirs = sorted(set(find_installed_skill_paths().values()),
+                            key=lambda p: str(p))
+        if not skill_dirs:
+            c.print("[dim]No installed skills found.[/]\n")
+            return 0
+    elif targets:
+        installed = None
+        for target in targets:
+            candidate = Path(target)
+            if candidate.is_dir() or ("/" in target or "\\" in target):
+                if not (candidate / "SKILL.md").exists() and candidate.name != "SKILL.md":
+                    c.print(f"[bold red]Error:[/] no SKILL.md found at '{target}'.\n")
+                    return 2
+                skill_dirs.append(candidate)
+                continue
+            if installed is None:
+                installed = find_installed_skill_paths()
+            if target in installed:
+                skill_dirs.append(installed[target])
+            else:
+                c.print(f"[bold red]Error:[/] '{target}' is not a path or an installed skill.\n")
+                return 2
+    else:
+        if Path("SKILL.md").exists():
+            skill_dirs.append(Path("."))
+        else:
+            c.print("Usage: hermes skills lint [targets ...] | --all  "
+                    "(or run from a directory containing SKILL.md)\n")
+            return 2
+
+    known_names = collect_installed_skill_names()
+    results = [lint_skill(d, known_skill_names=known_names) for d in skill_dirs]
+
+    if as_json:
+        print(json.dumps([r.to_dict() for r in results], indent=2))
+    else:
+        for result in results:
+            c.print(format_lint_report(result))
+            c.print()
+        total_errors = sum(len(r.errors) for r in results)
+        total_warnings = sum(len(r.warnings) for r in results)
+        summary = (f"{len(results)} skill(s) linted: "
+                   f"{total_errors} error(s), {total_warnings} warning(s)")
+        if total_errors:
+            c.print(f"[bold red]{summary}[/]\n")
+        elif total_warnings:
+            c.print(f"[yellow]{summary}[/]\n")
+        else:
+            c.print(f"[bold green]{summary}[/]\n")
+
+    return 1 if any(r.exit_relevant(fail_on) for r in results) else 0
+
+
 def do_uninstall(name: str, console: Optional[Console] = None,
                  skip_confirm: bool = False,
                  invalidate_cache: bool = True) -> None:
@@ -1310,24 +1384,18 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
         c.print(f"[bold red]Error:[/] No SKILL.md found at {path}\n")
         return
 
-    # Validate the skill
-    import yaml
-    skill_md = (path / "SKILL.md").read_text(encoding="utf-8")
-    fm = {}
-    if skill_md.startswith("---"):
-        import re
-        match = re.search(r'\n---\s*\n', skill_md[3:])
-        if match:
-            try:
-                fm = yaml.safe_load(skill_md[3:match.start() + 3]) or {}
-            except yaml.YAMLError:
-                pass
+    # Lint the skill structure before the security scan — lint errors block,
+    # warnings are informational.
+    from tools.skills_lint import format_lint_report, lint_skill
 
-    name = fm.get("name", path.name)
-    description = fm.get("description", "")
-    if not description:
-        c.print("[bold red]Error:[/] SKILL.md must have a 'description' in frontmatter.\n")
+    lint_result = lint_skill(path)
+    if lint_result.findings:
+        c.print(format_lint_report(lint_result))
+    if lint_result.errors:
+        c.print("[bold red]Cannot publish: fix the lint error(s) above first.[/]\n")
         return
+
+    name = lint_result.skill_name
 
     # Self-scan before publishing
     c.print(f"[bold]Scanning '{name}' before publish...[/]")
@@ -1578,6 +1646,15 @@ def skills_command(args) -> None:
     elif action == "audit":
         do_audit(name=getattr(args, "name", None),
                  deep=getattr(args, "deep", False))
+    elif action == "lint":
+        # do_lint returns an exit code for CI; skills_command's caller does not
+        # propagate return values, so raise SystemExit here (cf. cmd_security).
+        raise SystemExit(do_lint(
+            targets=getattr(args, "targets", None),
+            all_skills=getattr(args, "all_skills", False),
+            as_json=getattr(args, "json", False),
+            fail_on=getattr(args, "fail_on", "error"),
+        ))
     elif action == "uninstall":
         do_uninstall(args.name)
     elif action == "reset":
@@ -1613,7 +1690,7 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|lint|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -135,6 +135,34 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Run AST-level analysis on Python files (opt-in diagnostic)",
     )
 
+    skills_lint = skills_subparsers.add_parser(
+        "lint",
+        help="Validate skill structure (frontmatter, fields, requirements)",
+        description=(
+            "Validate SKILL.md structure: frontmatter syntax, required fields, "
+            "field constraints, and requirement declarations. Targets can be "
+            "paths to skill directories or installed skill names. With no "
+            "target, lints the current directory if it contains a SKILL.md. "
+            "Exit codes: 0 clean, 1 findings at/above --fail-on, 2 usage error."
+        ),
+    )
+    skills_lint.add_argument(
+        "targets",
+        nargs="*",
+        help="Skill directories or installed skill names (default: ./SKILL.md)",
+    )
+    skills_lint.add_argument(
+        "--all", action="store_true", dest="all_skills",
+        help="Lint every installed skill",
+    )
+    skills_lint.add_argument(
+        "--json", action="store_true", help="Output results as JSON"
+    )
+    skills_lint.add_argument(
+        "--fail-on", default="error", choices=["error", "warning"],
+        help="Severity threshold for exit code 1 (default: error)",
+    )
+
     skills_uninstall = skills_subparsers.add_parser(
         "uninstall", help="Remove a hub-installed skill"
     )

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -781,3 +781,162 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
 
+
+
+# ---------------------------------------------------------------------------
+# do_lint
+# ---------------------------------------------------------------------------
+
+_CLEAN_SKILL_MD = """---
+name: {name}
+description: A perfectly fine skill for testing.
+version: 1.0.0
+---
+# Usage
+"""
+
+_NO_DESCRIPTION_SKILL_MD = """---
+name: {name}
+---
+# Usage
+"""
+
+_LEGACY_PREREQ_SKILL_MD = """---
+name: {name}
+description: fine
+prerequisites:
+  env_vars: [MY_TOKEN]
+---
+# Usage
+"""
+
+
+def _write_skill(tmp_path, dirname, template=_CLEAN_SKILL_MD):
+    skill_dir = tmp_path / dirname
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        template.format(name=dirname), encoding="utf-8"
+    )
+    return skill_dir
+
+
+@pytest.fixture()
+def lint_env(monkeypatch):
+    """Isolate do_lint from the real installed-skills enumeration."""
+    import tools.skills_lint as skills_lint
+
+    monkeypatch.setattr(
+        skills_lint, "collect_installed_skill_names", lambda: frozenset()
+    )
+    installed = {}
+    monkeypatch.setattr(
+        skills_lint, "find_installed_skill_paths", lambda: dict(installed)
+    )
+    return installed
+
+
+def _run_lint(**kwargs):
+    from hermes_cli.skills_hub import do_lint
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=200)
+    code = do_lint(console=console, **kwargs)
+    return sink.getvalue(), code
+
+
+def test_do_lint_clean_path_target_exits_zero(tmp_path, lint_env):
+    skill = _write_skill(tmp_path, "clean-skill")
+    out, code = _run_lint(targets=[str(skill)])
+    assert code == 0
+    assert "OK" in out
+    assert "0 error(s), 0 warning(s)" in out
+
+
+def test_do_lint_error_exits_one(tmp_path, lint_env):
+    skill = _write_skill(tmp_path, "broken-skill", _NO_DESCRIPTION_SKILL_MD)
+    out, code = _run_lint(targets=[str(skill)])
+    assert code == 1
+    assert "HSL015" in out
+
+
+def test_do_lint_fail_on_warning_flips_exit_code(tmp_path, lint_env):
+    skill = _write_skill(tmp_path, "legacy-skill", _LEGACY_PREREQ_SKILL_MD)
+    out, code = _run_lint(targets=[str(skill)])
+    assert code == 0
+    assert "HSL032" in out
+    _, code = _run_lint(targets=[str(skill)], fail_on="warning")
+    assert code == 1
+
+
+def test_do_lint_all_with_targets_is_usage_error(tmp_path, lint_env):
+    out, code = _run_lint(targets=["x"], all_skills=True)
+    assert code == 2
+    assert "--all" in out
+
+
+def test_do_lint_unknown_name_is_usage_error(lint_env):
+    out, code = _run_lint(targets=["no-such-skill"])
+    assert code == 2
+    assert "no-such-skill" in out
+
+
+def test_do_lint_resolves_installed_name(tmp_path, lint_env):
+    skill = _write_skill(tmp_path, "my-skill")
+    lint_env["my-skill"] = skill
+    out, code = _run_lint(targets=["my-skill"])
+    assert code == 0
+    assert "my-skill" in out
+
+
+def test_do_lint_all_lints_every_installed_skill(tmp_path, lint_env):
+    lint_env["a-skill"] = _write_skill(tmp_path, "a-skill")
+    lint_env["b-skill"] = _write_skill(tmp_path, "b-skill", _NO_DESCRIPTION_SKILL_MD)
+    out, code = _run_lint(all_skills=True)
+    assert code == 1
+    assert "2 skill(s) linted" in out
+    assert "a-skill" in out and "b-skill" in out
+
+
+def test_do_lint_no_target_no_skill_md_is_usage_error(tmp_path, monkeypatch, lint_env):
+    monkeypatch.chdir(tmp_path)
+    out, code = _run_lint()
+    assert code == 2
+    assert "Usage" in out
+
+
+def test_do_lint_no_target_lints_cwd(tmp_path, monkeypatch, lint_env):
+    skill = _write_skill(tmp_path, "cwd-skill")
+    monkeypatch.chdir(skill)
+    out, code = _run_lint()
+    assert code == 0
+    assert "cwd-skill" in out
+
+
+def test_do_lint_json_output(tmp_path, lint_env, capsys):
+    skill = _write_skill(tmp_path, "legacy-skill", _LEGACY_PREREQ_SKILL_MD)
+    sink_out, code = _run_lint(targets=[str(skill)], as_json=True)
+    import json as _json
+    payload = _json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert isinstance(payload, list) and len(payload) == 1
+    assert payload[0]["skill_name"] == "legacy-skill"
+    assert payload[0]["findings"][0]["rule_id"] == "HSL032"
+    # Human report must be suppressed in JSON mode.
+    assert "HSL032" not in sink_out
+
+
+def test_do_publish_blocks_on_lint_error(tmp_path, lint_env):
+    """Publish must abort on lint errors before the security scan runs."""
+    from hermes_cli.skills_hub import do_publish
+
+    skill = _write_skill(tmp_path, "broken-skill", _NO_DESCRIPTION_SKILL_MD)
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=200)
+
+    with patch("tools.skills_guard.scan_skill",
+               side_effect=AssertionError("scan_skill must not run")):
+        do_publish(str(skill), target="github", repo="o/r", console=console)
+
+    out = sink.getvalue()
+    assert "HSL015" in out
+    assert "Cannot publish" in out

--- a/tests/hermes_cli/test_skills_subparser.py
+++ b/tests/hermes_cli/test_skills_subparser.py
@@ -32,3 +32,28 @@ def test_no_duplicate_skills_subparser():
                 "See issue #898 for details."
             ) from e
         raise
+
+
+def test_skills_lint_parses_with_defaults():
+    """`hermes skills lint` argparse wiring: defaults and flags round-trip."""
+    import argparse as _argparse
+
+    from hermes_cli.subcommands.skills import build_skills_parser
+
+    parser = _argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_skills_parser(subparsers, cmd_skills=lambda args: None)
+
+    args = parser.parse_args(["skills", "lint"])
+    assert args.skills_action == "lint"
+    assert args.targets == []
+    assert args.all_skills is False
+    assert args.json is False
+    assert args.fail_on == "error"
+
+    args = parser.parse_args(
+        ["skills", "lint", "my-skill", "--json", "--fail-on", "warning"]
+    )
+    assert args.targets == ["my-skill"]
+    assert args.json is True
+    assert args.fail_on == "warning"

--- a/tests/tools/test_skills_lint.py
+++ b/tests/tools/test_skills_lint.py
@@ -1,0 +1,333 @@
+"""Tests for tools/skills_lint.py — per-rule positive and negative cases."""
+
+import re
+
+import pytest
+
+from agent.skill_utils import parse_frontmatter, parse_frontmatter_strict
+from tools.skills_lint import (
+    RULES,
+    SEVERITY_ERROR,
+    SEVERITY_WARNING,
+    format_lint_report,
+    lint_skill,
+)
+
+
+CLEAN_FRONTMATTER = """\
+---
+name: {name}
+description: A perfectly fine skill for testing.
+version: 1.0.0
+author: tests
+license: MIT
+platforms: [linux, macos, windows]
+---
+"""
+
+
+def make_skill(tmp_path, *, dirname="clean-skill", frontmatter=None, body="# Usage\n"):
+    """Write a SKILL.md into tmp_path/<dirname> and return the skill dir."""
+    skill_dir = tmp_path / dirname
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    content = (
+        frontmatter
+        if frontmatter is not None
+        else CLEAN_FRONTMATTER.format(name=dirname)
+    ) + body
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+def rule_ids(result):
+    return sorted({f.rule_id for f in result.findings})
+
+
+# ---------------------------------------------------------------------------
+# Registry meta-test
+# ---------------------------------------------------------------------------
+
+def test_rule_registry_is_well_formed():
+    ids = [rule_id for rule_id, _, _ in RULES]
+    assert len(ids) == len(set(ids)), "duplicate rule IDs"
+    for rule_id, severity, fn in RULES:
+        assert re.fullmatch(r"HSL\d{3}", rule_id), rule_id
+        assert severity in (SEVERITY_ERROR, SEVERITY_WARNING), rule_id
+        assert callable(fn)
+
+
+# ---------------------------------------------------------------------------
+# Clean skill / structural rules
+# ---------------------------------------------------------------------------
+
+def test_clean_skill_has_no_findings(tmp_path):
+    result = lint_skill(make_skill(tmp_path))
+    assert result.findings == []
+    assert result.skill_name == "clean-skill"
+    assert "OK" in format_lint_report(result)
+
+
+def test_missing_skill_md_is_hsl001(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    result = lint_skill(empty)
+    assert rule_ids(result) == ["HSL001"]
+
+
+def test_no_frontmatter_is_hsl001(tmp_path):
+    result = lint_skill(make_skill(tmp_path, frontmatter="", body="# Just markdown\n"))
+    assert "HSL001" in rule_ids(result)
+
+
+def test_unterminated_fence_is_hsl001(tmp_path):
+    result = lint_skill(
+        make_skill(tmp_path, frontmatter="---\nname: x\ndescription: y\n", body="")
+    )
+    assert rule_ids(result) == ["HSL001"]
+
+
+def test_broken_yaml_is_hsl002_and_runtime_would_not_error(tmp_path):
+    broken = "---\nname: [unclosed\ndescription: \"also: broken\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=broken, body="body\n"))
+    assert rule_ids(result) == ["HSL002"]
+
+    # Pin the gap this rule exists for: the lenient runtime parser swallows
+    # the same content without raising, silently degrading to naive parsing.
+    fm, _ = parse_frontmatter(broken + "body\n")
+    assert isinstance(fm, dict)
+    _, _, yaml_error = parse_frontmatter_strict(broken + "body\n")
+    assert yaml_error is not None
+
+
+def test_non_mapping_frontmatter_is_hsl003(tmp_path):
+    result = lint_skill(
+        make_skill(tmp_path, frontmatter="---\n- just\n- a\n- list\n---\n")
+    )
+    assert rule_ids(result) == ["HSL003"]
+
+
+def test_structural_failure_suppresses_field_rules(tmp_path):
+    broken = "---\nname: [unclosed\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=broken))
+    # No misleading "name/description missing" cascade on top of HSL002.
+    assert rule_ids(result) == ["HSL002"]
+
+
+# ---------------------------------------------------------------------------
+# name / version / description
+# ---------------------------------------------------------------------------
+
+def test_missing_name_is_hsl010(tmp_path):
+    fm = "---\ndescription: fine\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL010" in rule_ids(result)
+
+
+def test_long_name_is_hsl011(tmp_path):
+    fm = f"---\nname: {'x' * 70}\ndescription: fine\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL011" in rule_ids(result)
+
+
+def test_unsafe_name_is_hsl012(tmp_path):
+    fm = "---\nname: ../escape\ndescription: fine\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL012" in rule_ids(result)
+
+
+def test_name_dir_mismatch_is_hsl013(tmp_path):
+    fm = "---\nname: other-name\ndescription: fine\n---\n"
+    result = lint_skill(make_skill(tmp_path, dirname="this-dir", frontmatter=fm))
+    assert "HSL013" in rule_ids(result)
+    assert result.skill_name == "other-name"
+
+
+def test_lint_cwd_dot_resolves_real_dirname(tmp_path, monkeypatch):
+    """Path('.') must compare against the resolved directory name, not ''."""
+    from pathlib import Path
+
+    skill = make_skill(tmp_path)  # name matches dirname "clean-skill"
+    monkeypatch.chdir(skill)
+    result = lint_skill(Path("."))
+    assert "HSL013" not in rule_ids(result)
+    assert result.findings == []
+
+
+def test_bad_version_is_hsl014(tmp_path):
+    fm = "---\nname: clean-skill\ndescription: fine\nversion: not.a.version!\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL014" in rule_ids(result)
+
+
+def test_missing_description_is_hsl015(tmp_path):
+    fm = "---\nname: clean-skill\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL015" in rule_ids(result)
+
+
+def test_long_description_is_hsl016(tmp_path):
+    fm = f"---\nname: clean-skill\ndescription: {'d' * 1100}\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL016" in rule_ids(result)
+
+
+# ---------------------------------------------------------------------------
+# platforms / unknown keys
+# ---------------------------------------------------------------------------
+
+def test_unknown_platform_is_hsl020(tmp_path):
+    fm = "---\nname: clean-skill\ndescription: fine\nplatforms: [linux, solaris]\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL020" in rule_ids(result)
+
+
+def test_platforms_wrong_type_is_hsl020(tmp_path):
+    fm = "---\nname: clean-skill\ndescription: fine\nplatforms:\n  os: linux\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL020" in rule_ids(result)
+
+
+def test_single_platform_string_is_valid(tmp_path):
+    fm = "---\nname: clean-skill\ndescription: fine\nplatforms: macos\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL020" not in rule_ids(result)
+
+
+def test_unknown_key_is_hsl021(tmp_path):
+    fm = "---\nname: clean-skill\ndescription: fine\ncolour: red\n---\n"
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL021" in rule_ids(result)
+
+
+# ---------------------------------------------------------------------------
+# requirement declarations
+# ---------------------------------------------------------------------------
+
+def test_env_entry_without_name_is_hsl030(tmp_path):
+    fm = (
+        "---\nname: clean-skill\ndescription: fine\n"
+        "required_environment_variables:\n  - prompt: enter the token\n---\n"
+    )
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL030" in rule_ids(result)
+
+
+def test_env_block_wrong_type_is_hsl030(tmp_path):
+    fm = (
+        "---\nname: clean-skill\ndescription: fine\n"
+        "required_environment_variables: API_KEY\n---\n"
+    )
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL030" in rule_ids(result)
+
+
+def test_valid_env_entries_pass(tmp_path):
+    fm = (
+        "---\nname: clean-skill\ndescription: fine\n"
+        "required_environment_variables:\n"
+        "  - name: API_KEY\n    prompt: enter key\n"
+        "  - SECOND_VAR\n---\n"
+    )
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL030" not in rule_ids(result)
+    assert "HSL031" not in rule_ids(result)
+
+
+def test_invalid_env_var_name_is_hsl031(tmp_path):
+    fm = (
+        "---\nname: clean-skill\ndescription: fine\n"
+        "required_environment_variables:\n  - name: 1BAD-NAME\n---\n"
+    )
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL031" in rule_ids(result)
+
+
+def test_legacy_prerequisites_is_hsl032(tmp_path):
+    fm = (
+        "---\nname: clean-skill\ndescription: fine\n"
+        "prerequisites:\n  env_vars: [MY_TOKEN]\n  commands: [curl]\n---\n"
+    )
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    assert "HSL032" in rule_ids(result)
+    assert all(f.severity == SEVERITY_WARNING for f in result.findings)
+
+
+def test_invalid_dependency_spec_is_hsl040(tmp_path):
+    fm = (
+        "---\nname: clean-skill\ndescription: fine\n"
+        "dependencies: ['requests>=2.0', 'not a valid spec!!']\n---\n"
+    )
+    result = lint_skill(make_skill(tmp_path, frontmatter=fm))
+    findings = [f for f in result.findings if f.rule_id == "HSL040"]
+    assert len(findings) == 1
+    assert "not a valid spec!!" in findings[0].message
+
+
+# ---------------------------------------------------------------------------
+# cross-references
+# ---------------------------------------------------------------------------
+
+def _related_fm(related):
+    return (
+        "---\nname: clean-skill\ndescription: fine\n"
+        "metadata:\n  hermes:\n    related_skills: [" + ", ".join(related) + "]\n---\n"
+    )
+
+
+def test_unknown_related_skill_is_hsl050(tmp_path):
+    skill = make_skill(tmp_path, frontmatter=_related_fm(["exists", "ghost"]))
+    result = lint_skill(skill, known_skill_names=frozenset({"exists"}))
+    findings = [f for f in result.findings if f.rule_id == "HSL050"]
+    assert len(findings) == 1
+    assert "ghost" in findings[0].message
+
+
+def test_related_skills_skipped_without_known_names(tmp_path):
+    skill = make_skill(tmp_path, frontmatter=_related_fm(["ghost"]))
+    result = lint_skill(skill, known_skill_names=None)
+    assert "HSL050" not in rule_ids(result)
+
+
+def test_missing_script_reference_is_hsl060(tmp_path):
+    skill = make_skill(tmp_path, body="Run `python scripts/run.py` to start.\n")
+    (skill / "scripts").mkdir()
+    result = lint_skill(skill)
+    findings = [f for f in result.findings if f.rule_id == "HSL060"]
+    assert len(findings) == 1
+    assert "scripts/run.py" in findings[0].field
+
+
+def test_existing_script_reference_passes(tmp_path):
+    skill = make_skill(tmp_path, body="Run `python scripts/run.py` to start.\n")
+    (skill / "scripts").mkdir()
+    (skill / "scripts" / "run.py").write_text("print('hi')\n", encoding="utf-8")
+    result = lint_skill(skill)
+    assert "HSL060" not in rule_ids(result)
+
+
+def test_unanchored_path_reference_is_ignored(tmp_path):
+    # docs/ is neither a resource dir nor an existing directory — too likely
+    # to be prose, so HSL060 stays quiet.
+    skill = make_skill(tmp_path, body="See docs/guide.md upstream.\n")
+    result = lint_skill(skill)
+    assert "HSL060" not in rule_ids(result)
+
+
+# ---------------------------------------------------------------------------
+# parse_frontmatter_strict
+# ---------------------------------------------------------------------------
+
+def test_parse_frontmatter_strict_valid():
+    fm, body, err = parse_frontmatter_strict("---\nname: x\n---\nbody\n")
+    assert fm == {"name": "x"}
+    assert body == "body\n"
+    assert err is None
+
+
+def test_parse_frontmatter_strict_matches_lenient_on_valid_input():
+    content = CLEAN_FRONTMATTER.format(name="x") + "body\n"
+    strict_fm, strict_body, err = parse_frontmatter_strict(content)
+    lenient_fm, lenient_body = parse_frontmatter(content)
+    assert err is None
+    assert strict_fm == lenient_fm
+    assert strict_body == lenient_body

--- a/tools/skills_lint.py
+++ b/tools/skills_lint.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""
+Skills Lint — Structure validator for SKILL.md files.
+
+Complements skills_guard (security) and the hub update checker: this module
+validates the *shape* of a skill — frontmatter syntax, required fields, field
+constraints, and requirement declarations — surfacing problems the runtime
+otherwise hides (lenient YAML fallback, silently dropped env-var entries,
+silent name/description truncation).
+
+Rule IDs are stable (HSLxxx) so JSON output can be consumed by CI and so
+individual rules can be suppressed in the future.
+
+Usage:
+    from tools.skills_lint import lint_skill, format_lint_report
+
+    result = lint_skill(Path("skills/category/my-skill"))
+    if result.errors:
+        print(format_lint_report(result))
+"""
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
+
+
+SEVERITY_ERROR = "error"
+SEVERITY_WARNING = "warning"
+
+# Top-level frontmatter keys actually read somewhere in the codebase.
+KNOWN_FRONTMATTER_KEYS = frozenset(
+    {
+        "name",
+        "description",
+        "version",
+        "author",
+        "license",
+        "platforms",
+        "environments",
+        "compatibility",
+        "dependencies",
+        "prerequisites",
+        "required_environment_variables",
+        "required_credential_files",
+        "setup",
+        "metadata",
+        "tags",
+        "triggers",
+    }
+)
+
+VALID_PLATFORMS = frozenset({"linux", "macos", "windows"})
+
+_BODY_PATH_RE = re.compile(
+    r"(?<![\w/.])((?:\./)?[A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*"
+    r"/[A-Za-z0-9_.-]+\.(?:py|sh|bash|js|ts|rb|ps1|json|ya?ml|toml|csv|md|txt))\b"
+)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LintFinding:
+    rule_id: str        # "HSL0xx"
+    severity: str       # "error" | "warning"
+    field: str          # frontmatter key or relative file path
+    message: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "rule_id": self.rule_id,
+            "severity": self.severity,
+            "field": self.field,
+            "message": self.message,
+        }
+
+
+@dataclass
+class LintResult:
+    skill_path: Path
+    skill_name: str
+    findings: List[LintFinding] = field(default_factory=list)
+
+    @property
+    def errors(self) -> List[LintFinding]:
+        return [f for f in self.findings if f.severity == SEVERITY_ERROR]
+
+    @property
+    def warnings(self) -> List[LintFinding]:
+        return [f for f in self.findings if f.severity == SEVERITY_WARNING]
+
+    def exit_relevant(self, fail_on: str) -> bool:
+        """True when findings meet/exceed the --fail-on threshold."""
+        if fail_on == SEVERITY_WARNING:
+            return bool(self.findings)
+        return bool(self.errors)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "skill_path": str(self.skill_path),
+            "skill_name": self.skill_name,
+            "errors": len(self.errors),
+            "warnings": len(self.warnings),
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+
+@dataclass
+class LintContext:
+    skill_dir: Path
+    raw: str
+    frontmatter: Dict[str, Any]
+    body: str
+    yaml_error: Optional[str]
+    known_skill_names: Optional[FrozenSet[str]] = None
+
+
+# ---------------------------------------------------------------------------
+# Rule registry
+# ---------------------------------------------------------------------------
+
+# Each rule yields (field, message) pairs; severity lives in the registration.
+RuleFn = Callable[[LintContext], Iterable[Tuple[str, str]]]
+RULES: List[Tuple[str, str, RuleFn]] = []
+
+# Structural rules run first; when any of them fires the field rules are
+# skipped, because an empty/garbage frontmatter dict would cascade into
+# misleading "name missing"/"description missing" noise.
+_STRUCTURAL_RULE_IDS = frozenset({"HSL001", "HSL002", "HSL003"})
+
+
+def rule(rule_id: str, severity: str) -> Callable[[RuleFn], RuleFn]:
+    def register(fn: RuleFn) -> RuleFn:
+        RULES.append((rule_id, severity, fn))
+        return fn
+
+    return register
+
+
+# ── Structural rules ───────────────────────────────────────────────────────
+
+@rule("HSL001", SEVERITY_ERROR)
+def _check_fence(ctx: LintContext):
+    if not ctx.raw.startswith("---"):
+        yield "frontmatter", "SKILL.md has no YAML frontmatter block (must start with '---')"
+    elif not re.search(r"\n---\s*\n", ctx.raw[3:]):
+        yield "frontmatter", "frontmatter fence is unterminated (no closing '---' line)"
+
+
+@rule("HSL002", SEVERITY_ERROR)
+def _check_yaml(ctx: LintContext):
+    if ctx.yaml_error and "expected a mapping" not in ctx.yaml_error:
+        yield (
+            "frontmatter",
+            f"YAML parse failure: {ctx.yaml_error.splitlines()[0]} — at runtime this "
+            "silently falls back to naive key:value parsing, dropping nested fields",
+        )
+
+
+@rule("HSL003", SEVERITY_ERROR)
+def _check_mapping(ctx: LintContext):
+    if ctx.yaml_error and "expected a mapping" in ctx.yaml_error:
+        yield "frontmatter", f"frontmatter must be a YAML mapping: {ctx.yaml_error}"
+
+
+# ── name / version / description ───────────────────────────────────────────
+
+@rule("HSL010", SEVERITY_ERROR)
+def _check_name_present(ctx: LintContext):
+    name = ctx.frontmatter.get("name")
+    if not isinstance(name, str) or not name.strip():
+        yield "name", "'name' is missing or empty"
+
+
+@rule("HSL011", SEVERITY_ERROR)
+def _check_name_length(ctx: LintContext):
+    from tools.skills_tool import MAX_NAME_LENGTH
+
+    name = ctx.frontmatter.get("name")
+    if isinstance(name, str) and len(name) > MAX_NAME_LENGTH:
+        yield (
+            "name",
+            f"'name' is {len(name)} chars (max {MAX_NAME_LENGTH}); "
+            "the runtime truncates it silently",
+        )
+
+
+@rule("HSL012", SEVERITY_ERROR)
+def _check_name_safe(ctx: LintContext):
+    from tools.skills_hub import _validate_skill_name
+
+    name = ctx.frontmatter.get("name")
+    if isinstance(name, str) and name.strip():
+        try:
+            _validate_skill_name(name.strip())
+        except ValueError as exc:
+            yield "name", f"'name' would be rejected at install time: {exc}"
+
+
+@rule("HSL013", SEVERITY_WARNING)
+def _check_name_matches_dir(ctx: LintContext):
+    name = ctx.frontmatter.get("name")
+    if isinstance(name, str) and name.strip() and name.strip() != ctx.skill_dir.name:
+        yield (
+            "name",
+            f"'name' ({name.strip()!r}) differs from directory name "
+            f"({ctx.skill_dir.name!r}); list/uninstall key on the frontmatter name",
+        )
+
+
+@rule("HSL014", SEVERITY_WARNING)
+def _check_version(ctx: LintContext):
+    from packaging.version import InvalidVersion, Version
+
+    version = ctx.frontmatter.get("version")
+    if version is None:
+        return
+    try:
+        Version(str(version))
+    except InvalidVersion:
+        yield "version", f"'version' ({version!r}) is not a valid version string"
+
+
+@rule("HSL015", SEVERITY_ERROR)
+def _check_description_present(ctx: LintContext):
+    desc = ctx.frontmatter.get("description")
+    if not isinstance(desc, str) or not desc.strip():
+        yield "description", "'description' is missing or empty"
+
+
+@rule("HSL016", SEVERITY_ERROR)
+def _check_description_length(ctx: LintContext):
+    from tools.skills_tool import MAX_DESCRIPTION_LENGTH
+
+    desc = ctx.frontmatter.get("description")
+    if isinstance(desc, str) and len(desc) > MAX_DESCRIPTION_LENGTH:
+        yield (
+            "description",
+            f"'description' is {len(desc)} chars (max {MAX_DESCRIPTION_LENGTH}); "
+            "the runtime truncates it silently",
+        )
+
+
+# ── platforms / unknown keys ───────────────────────────────────────────────
+
+@rule("HSL020", SEVERITY_ERROR)
+def _check_platforms(ctx: LintContext):
+    platforms = ctx.frontmatter.get("platforms")
+    if platforms is None:
+        return
+    if isinstance(platforms, str):
+        platforms = [platforms]
+    if not isinstance(platforms, list):
+        yield "platforms", f"'platforms' must be a list or string, got {type(platforms).__name__}"
+        return
+    for entry in platforms:
+        normalized = str(entry).strip().lower()
+        if normalized not in VALID_PLATFORMS:
+            yield (
+                "platforms",
+                f"unknown platform {entry!r} (valid: {', '.join(sorted(VALID_PLATFORMS))})",
+            )
+
+
+@rule("HSL021", SEVERITY_WARNING)
+def _check_unknown_keys(ctx: LintContext):
+    for key in ctx.frontmatter:
+        if str(key) not in KNOWN_FRONTMATTER_KEYS:
+            yield str(key), f"unknown frontmatter key {key!r} is ignored by the runtime"
+
+
+# ── requirement declarations ───────────────────────────────────────────────
+
+def _iter_declared_env_names(ctx: LintContext):
+    """Yield (source_field, raw_name) for every declared env var, all formats."""
+    raw = ctx.frontmatter.get("required_environment_variables")
+    if isinstance(raw, dict):
+        raw = [raw]
+    if isinstance(raw, list):
+        for entry in raw:
+            if isinstance(entry, str):
+                yield "required_environment_variables", entry
+            elif isinstance(entry, dict):
+                name = entry.get("name") or entry.get("env_var")
+                if name:
+                    yield "required_environment_variables", str(name)
+
+    setup = ctx.frontmatter.get("setup")
+    if isinstance(setup, dict):
+        secrets = setup.get("collect_secrets")
+        if isinstance(secrets, list):
+            for entry in secrets:
+                if isinstance(entry, dict) and entry.get("env_var"):
+                    yield "setup.collect_secrets", str(entry["env_var"])
+
+    prereq = ctx.frontmatter.get("prerequisites")
+    if isinstance(prereq, dict):
+        env_vars = prereq.get("env_vars")
+        if isinstance(env_vars, list):
+            for entry in env_vars:
+                yield "prerequisites.env_vars", str(entry)
+
+
+@rule("HSL030", SEVERITY_ERROR)
+def _check_env_var_entries(ctx: LintContext):
+    raw = ctx.frontmatter.get("required_environment_variables")
+    if raw is None:
+        return
+    if isinstance(raw, dict):
+        raw = [raw]
+    if not isinstance(raw, list):
+        yield (
+            "required_environment_variables",
+            f"must be a list, got {type(raw).__name__}; the runtime ignores it entirely",
+        )
+        return
+    for i, entry in enumerate(raw):
+        if isinstance(entry, str):
+            continue
+        if not isinstance(entry, dict):
+            yield (
+                f"required_environment_variables[{i}]",
+                f"entry must be a string or mapping, got {type(entry).__name__}; "
+                "the runtime drops it silently",
+            )
+        elif not str(entry.get("name") or entry.get("env_var") or "").strip():
+            yield (
+                f"required_environment_variables[{i}]",
+                "entry has no 'name' (or 'env_var'); the runtime drops it silently",
+            )
+
+
+@rule("HSL031", SEVERITY_ERROR)
+def _check_env_var_names(ctx: LintContext):
+    from tools.skills_tool import _ENV_VAR_NAME_RE
+
+    for source_field, name in _iter_declared_env_names(ctx):
+        candidate = name.strip()
+        if candidate and not _ENV_VAR_NAME_RE.match(candidate):
+            yield (
+                source_field,
+                f"invalid environment variable name {candidate!r}; "
+                "the runtime drops it silently",
+            )
+
+
+@rule("HSL032", SEVERITY_WARNING)
+def _check_legacy_prerequisites(ctx: LintContext):
+    if "prerequisites" in ctx.frontmatter:
+        yield (
+            "prerequisites",
+            "legacy 'prerequisites' block; migrate env_vars to "
+            "'required_environment_variables' entries with prompt/help text",
+        )
+
+
+@rule("HSL040", SEVERITY_WARNING)
+def _check_dependencies(ctx: LintContext):
+    from packaging.requirements import InvalidRequirement, Requirement
+
+    deps = ctx.frontmatter.get("dependencies")
+    if deps is None:
+        return
+    if not isinstance(deps, list):
+        yield "dependencies", f"'dependencies' must be a list, got {type(deps).__name__}"
+        return
+    for entry in deps:
+        try:
+            Requirement(str(entry))
+        except InvalidRequirement:
+            yield "dependencies", f"invalid pip requirement spec {entry!r}"
+
+
+# ── cross-references ───────────────────────────────────────────────────────
+
+@rule("HSL050", SEVERITY_WARNING)
+def _check_related_skills(ctx: LintContext):
+    if ctx.known_skill_names is None:
+        return
+    metadata = ctx.frontmatter.get("metadata")
+    if not isinstance(metadata, dict):
+        return
+    hermes_meta = metadata.get("hermes")
+    if not isinstance(hermes_meta, dict):
+        return
+    related = hermes_meta.get("related_skills")
+    if not isinstance(related, list):
+        return
+    for entry in related:
+        name = str(entry).strip()
+        if name and name not in ctx.known_skill_names:
+            yield (
+                "metadata.hermes.related_skills",
+                f"related skill {name!r} not found among installed skills",
+            )
+
+
+@rule("HSL060", SEVERITY_WARNING)
+def _check_body_file_refs(ctx: LintContext):
+    seen: set = set()
+    for match in _BODY_PATH_RE.finditer(ctx.body):
+        candidate = match.group(1)
+        if candidate in seen or "://" in candidate:
+            continue
+        seen.add(candidate)
+        # Anchor heuristic: only flag paths that are clearly skill-relative —
+        # either explicitly "./"-prefixed, or rooted at a directory the skill
+        # actually ships. Bare paths like "src/auth.py" in prose are usually
+        # examples about the *user's* project, not skill resources.
+        relative = candidate[2:] if candidate.startswith("./") else candidate
+        first_segment = relative.split("/", 1)[0]
+        anchored = (
+            candidate.startswith("./")
+            or (ctx.skill_dir / first_segment).is_dir()
+        )
+        if anchored and not (ctx.skill_dir / relative).exists():
+            yield candidate, f"referenced file {candidate!r} does not exist in the skill directory"
+
+
+# ---------------------------------------------------------------------------
+# Entry points
+# ---------------------------------------------------------------------------
+
+def lint_skill(
+    skill_path: Path,
+    *,
+    known_skill_names: Optional[FrozenSet[str]] = None,
+) -> LintResult:
+    """Lint one skill directory (or a SKILL.md path) and return all findings."""
+    skill_path = Path(skill_path)
+    skill_dir = skill_path.parent if skill_path.name == "SKILL.md" else skill_path
+    # Resolve so Path(".") and trailing-separator inputs get a real directory
+    # name — HSL013 compares against it and the report displays it.
+    skill_dir = skill_dir.resolve()
+    skill_md = skill_dir / "SKILL.md"
+
+    result = LintResult(skill_path=skill_dir, skill_name=skill_dir.name)
+
+    try:
+        raw = skill_md.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        result.findings.append(
+            LintFinding("HSL001", SEVERITY_ERROR, "SKILL.md", "SKILL.md not found")
+        )
+        return result
+    except (UnicodeDecodeError, PermissionError) as exc:
+        result.findings.append(
+            LintFinding("HSL001", SEVERITY_ERROR, "SKILL.md", f"cannot read SKILL.md: {exc}")
+        )
+        return result
+
+    from agent.skill_utils import parse_frontmatter_strict
+
+    frontmatter, body, yaml_error = parse_frontmatter_strict(raw)
+    ctx = LintContext(
+        skill_dir=skill_dir,
+        raw=raw,
+        frontmatter=frontmatter,
+        body=body,
+        yaml_error=yaml_error,
+        known_skill_names=known_skill_names,
+    )
+
+    name = frontmatter.get("name")
+    if isinstance(name, str) and name.strip():
+        result.skill_name = name.strip()
+
+    structural = [r for r in RULES if r[0] in _STRUCTURAL_RULE_IDS]
+    field_rules = [r for r in RULES if r[0] not in _STRUCTURAL_RULE_IDS]
+
+    for rule_id, severity, fn in structural:
+        for finding_field, message in fn(ctx):
+            result.findings.append(LintFinding(rule_id, severity, finding_field, message))
+
+    if result.findings:
+        return result
+
+    for rule_id, severity, fn in field_rules:
+        for finding_field, message in fn(ctx):
+            result.findings.append(LintFinding(rule_id, severity, finding_field, message))
+
+    return result
+
+
+def collect_installed_skill_names() -> FrozenSet[str]:
+    """Names of all installed skills (including disabled), for HSL050."""
+    from tools.skills_tool import _find_all_skills
+
+    return frozenset(s["name"] for s in _find_all_skills(skip_disabled=True))
+
+
+def find_installed_skill_paths() -> Dict[str, Path]:
+    """Map installed skill names (frontmatter name, dirname fallback) to dirs.
+
+    Mirrors the enumeration order of skills_tool._find_all_skills: the local
+    skills dir wins over external dirs, first occurrence of a name wins.
+    """
+    from agent.skill_utils import (
+        get_external_skills_dirs,
+        is_excluded_skill_path,
+        iter_skill_index_files,
+        parse_frontmatter,
+    )
+    from tools.skills_tool import SKILLS_DIR
+
+    paths: Dict[str, Path] = {}
+    dirs_to_scan = []
+    if SKILLS_DIR.exists():
+        dirs_to_scan.append(SKILLS_DIR)
+    dirs_to_scan.extend(get_external_skills_dirs())
+
+    for scan_dir in dirs_to_scan:
+        for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
+            if is_excluded_skill_path(skill_md):
+                continue
+            try:
+                frontmatter, _ = parse_frontmatter(
+                    skill_md.read_text(encoding="utf-8")[:4000]
+                )
+            except Exception:
+                frontmatter = {}
+            name = str(frontmatter.get("name") or skill_md.parent.name).strip()
+            paths.setdefault(name, skill_md.parent)
+            paths.setdefault(skill_md.parent.name, skill_md.parent)
+
+    return paths
+
+
+def format_lint_report(result: LintResult) -> str:
+    """Compact multi-line report for one skill, suitable for CLI display."""
+    if not result.findings:
+        status = "OK"
+    elif result.errors:
+        status = f"{len(result.errors)} error(s), {len(result.warnings)} warning(s)"
+    else:
+        status = f"{len(result.warnings)} warning(s)"
+
+    lines = [f"Lint: {result.skill_name} ({result.skill_path})  {status}"]
+    severity_order = {SEVERITY_ERROR: 0, SEVERITY_WARNING: 1}
+    for f in sorted(result.findings, key=lambda f: (severity_order.get(f.severity, 2), f.rule_id)):
+        sev = f.severity.upper().ljust(8)
+        lines.append(f"  {f.rule_id}  {sev} {f.field}: {f.message}")
+    return "\n".join(lines)

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -424,6 +424,8 @@ hermes skills list --source hub                   # List hub-installed skills
 hermes skills check                               # Check installed hub skills for upstream updates
 hermes skills update                              # Reinstall hub skills with upstream changes when needed
 hermes skills audit                               # Re-scan all hub skills for security
+hermes skills lint my-skill                       # Validate skill structure (frontmatter, fields, requirements)
+hermes skills lint --all --fail-on warning        # Lint every installed skill; exit 1 on any finding (CI-friendly)
 hermes skills uninstall k8s                       # Remove a hub skill
 hermes skills reset google-workspace              # Un-stick a bundled skill from "user-modified" (see below)
 hermes skills reset google-workspace --restore    # Also restore the bundled version, deleting your local edits
@@ -641,6 +643,81 @@ hermes skills update react   # Update one specific installed hub skill
 ```
 
 This uses the stored source identifier plus the current upstream bundle content hash to detect drift.
+
+### Linting skills
+
+`hermes skills lint` validates a skill's **structure** — the shape of its `SKILL.md` ID-card. It complements `hermes skills audit`, which scans for *security* threats: `audit` asks "is this skill dangerous?", `lint` asks "is this skill well-formed?".
+
+The need is concrete. Hermes is deliberately forgiving at runtime — when a skill's frontmatter is malformed, it degrades quietly rather than crashing: broken YAML silently falls back to naive `key:value` parsing (dropping nested fields), malformed `required_environment_variables` entries are silently discarded, and over-length `name`/`description` values are silently truncated. That resilience is good for end users but bad for skill *authors*, who never learn their skill is subtly broken. `lint` surfaces exactly those hidden problems.
+
+#### Usage
+
+```bash
+hermes skills lint                          # Lint the skill in the current directory (./SKILL.md)
+hermes skills lint skills/my-skill          # Lint by path — works on uninstalled skills too
+hermes skills lint my-skill other-skill     # Lint one or more installed skills by name
+hermes skills lint --all                    # Lint every installed skill
+hermes skills lint --all --json             # Machine-readable output (for scripts/CI)
+hermes skills lint --all --fail-on warning  # Treat warnings as failures
+```
+
+A target is resolved as a **path** if it exists as a directory or contains a path separator; otherwise it's looked up as an **installed skill name**. With no target, the current directory is linted when it contains a `SKILL.md`.
+
+#### Severity and exit codes
+
+Every finding has a stable rule ID (e.g. `HSL015`) and one of two severities:
+
+- **error** — the skill will silently misbehave or lose data at runtime or install time. Fix these.
+- **warning** — style, migration, or heuristic issues. Worth addressing, but not breaking.
+
+Exit codes make `lint` safe to drop into CI:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | No findings at or above the `--fail-on` threshold |
+| `1` | Findings at or above the threshold (default threshold: `error`) |
+| `2` | Usage error (unknown target, `--all` combined with explicit targets, etc.) |
+
+`--fail-on warning` lowers the bar so that *any* finding fails the run — useful for a strict gate on skills you author.
+
+#### Rule reference
+
+| Rule | Severity | What it catches |
+|------|----------|-----------------|
+| `HSL001` | error | Missing or unterminated frontmatter fence (`---`) |
+| `HSL002` | error | YAML parse failure — the runtime would silently fall back to naive parsing |
+| `HSL003` | error | Frontmatter is valid YAML but not a mapping (e.g. a list) |
+| `HSL010` | error | `name` is missing or empty |
+| `HSL011` | error | `name` exceeds 64 chars (runtime truncates it silently) |
+| `HSL012` | error | `name` would be rejected at install time (path separators, `..`, drive letters) |
+| `HSL013` | warning | `name` differs from the skill's directory name |
+| `HSL014` | warning | `version` is present but not a valid version string |
+| `HSL015` | error | `description` is missing or empty |
+| `HSL016` | error | `description` exceeds 1024 chars (runtime truncates it silently) |
+| `HSL020` | error | `platforms` contains a value outside `linux`/`macos`/`windows`, or has the wrong type |
+| `HSL021` | warning | Unknown top-level frontmatter key (ignored by the runtime — often a typo) |
+| `HSL030` | error | A `required_environment_variables` entry is malformed (no `name`/`env_var`) — silently dropped at runtime |
+| `HSL031` | error | An env-var name is invalid (must match `^[A-Za-z_][A-Za-z0-9_]*$`) — silently dropped at runtime |
+| `HSL032` | warning | Legacy `prerequisites` block in use — migrate to `required_environment_variables` |
+| `HSL040` | warning | A `dependencies` entry is not a valid pip requirement spec |
+| `HSL050` | warning | `metadata.hermes.related_skills` references a skill that isn't installed |
+| `HSL060` | warning | A skill-relative file referenced in the body (e.g. `scripts/run.py`) doesn't exist |
+
+#### Use in publishing and CI
+
+`hermes skills publish` runs `lint` automatically **before** its security scan — lint **errors block publishing**, warnings are shown but don't. This guarantees a published skill is well-formed and that `publish` and `lint` can never disagree.
+
+For continuous integration, lint your skills and let the exit code gate the build:
+
+```bash
+# Fail the build on any structural error in any skill under this repo
+hermes skills lint --all || exit 1
+
+# Strict mode: fail on warnings too
+hermes skills lint --all --fail-on warning
+```
+
+For programmatic use, `--json` emits one object per linted skill with `skill_name`, `errors`, `warnings`, and the full `findings` array (each with `rule_id`, `severity`, `field`, `message`).
 
 :::tip GitHub rate limits
 Skills hub operations use the GitHub API, which has a rate limit of 60 requests/hour for unauthenticated users. If you see rate-limit errors during install or search, set `GITHUB_TOKEN` in your `.env` file to increase the limit to 5,000 requests/hour. The error message includes an actionable hint when this happens.


### PR DESCRIPTION
## What

Adds `hermes skills lint`, a **structural** validator for `SKILL.md` files. It complements the existing `hermes skills audit` (security scanning) and the hub update checker: `audit` asks *"is this skill dangerous?"*, `lint` asks *"is this skill well-formed?"*.

## Why

Hermes is deliberately forgiving at runtime — when a skill's frontmatter is malformed, it degrades quietly rather than crashing. That is good for end users but bad for skill **authors**, who never learn their skill is subtly broken. Today:

- `parse_frontmatter()` silently falls back to naive `key:value` parsing on broken YAML, dropping nested fields.
- `_get_required_environment_variables()` silently drops malformed env-var entries.
- Over-length `name`/`description` values are silently truncated.
- `skills publish` only checked that a `description` exists and that the security scan passes.

`lint` surfaces exactly those hidden problems, with stable rule IDs and CI-friendly exit codes.

## What changed

- **`tools/skills_lint.py`** (new) — data-driven rule registry (18 rules, `HSL001`–`HSL060`), `lint_skill()`, `format_lint_report()`, and installed-skill enumeration helpers. Structural failures (e.g. broken YAML) suppress the field rules so authors do not get a misleading "name missing" cascade on top of the real error.
- **`agent/skill_utils.py`** — adds `parse_frontmatter_strict()`, which surfaces YAML errors instead of papering over them. The existing lenient `parse_frontmatter()` is untouched.
- **`hermes_cli/`** — new subcommand `hermes skills lint [targets ...] [--all] [--json] [--fail-on error|warning]` with exit codes `0` (clean) / `1` (findings at/above threshold) / `2` (usage error). `do_publish()` now runs lint **before** the security scan; lint errors block publishing, warnings do not.
- **Docs** — `website/docs/user-guide/features/skills.md` gains a full rule reference, severity/exit-code semantics, and CI guidance.

## Severity model

- **error** — the skill will silently misbehave or lose data at runtime/install. Fix these.
- **warning** — style, migration, or heuristic issues.

## Testing

- 74 tests pass: per-rule unit tests in `tests/tools/test_skills_lint.py` (including a test that pins the gap — the same broken YAML `HSL002` flags is swallowed without error by the lenient runtime parser), plus CLI tests for exit codes, `--json`, `--fail-on`, and publish-blocks-on-lint-error in `tests/hermes_cli/`.
- Swept all 78 locally installed skills: **0 errors, 51 warnings** — no false-positive errors, and warnings map to genuine issues (legacy `prerequisites` blocks, name/dir mismatches, missing referenced files).

## Example

```console
$ hermes skills lint --all --fail-on warning
Lint: apple-notes (.../skills/apple/apple-notes)  1 warning(s)
  HSL032  WARNING  prerequisites: legacy 'prerequisites' block; migrate env_vars to
                   'required_environment_variables' entries with prompt/help text
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
