### PR TITLE
fix(skills): resolve stale HERMES_HOME-scoped skill paths

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -327,7 +327,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands_platform = _resolve_skill_commands_platform()
     _skill_commands = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
+        from tools.skills_tool import _skills_dir, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
@@ -335,8 +335,9 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
 
         # Scan local dir first, then external dirs
         dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        active_skills_dir = _skills_dir()
+        if active_skills_dir.exists():
+            dirs_to_scan.append(active_skills_dir)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -1,5 +1,6 @@
 """Tests for agent/skill_commands.py — skill slash command scanning and platform filtering."""
 
+import importlib
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -51,6 +52,26 @@ def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Pat
 
 
 class TestScanSkillCommands:
+    def test_follows_current_hermes_home_after_import(self, tmp_path, monkeypatch):
+        home_a = tmp_path / "home-a"
+        home_b = tmp_path / "home-b"
+        _make_skill(home_a / "skills", "alpha")
+        _make_skill(home_b / "skills", "beta")
+
+        monkeypatch.setenv("HERMES_HOME", str(home_a))
+        import agent.skill_commands as skill_commands_module
+
+        importlib.reload(skills_tool_module)
+        importlib.reload(skill_commands_module)
+        assert skills_tool_module.SKILLS_DIR == home_a / "skills"
+
+        monkeypatch.setenv("HERMES_HOME", str(home_b))
+        with patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
+            result = skill_commands_module.scan_skill_commands()
+
+        assert "/beta" in result
+        assert "/alpha" not in result
+
     def test_finds_skills(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "my-skill")

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -1,11 +1,13 @@
 """Tests for tools/skills_sync.py — manifest-based skill seeding and updating."""
 
+import importlib
 import shutil
 import json
 import pytest
 from pathlib import Path
 from unittest.mock import patch
 
+import tools.skills_sync as skills_sync_module
 from tools.skills_sync import (
     _get_bundled_dir,
     _read_manifest,
@@ -416,6 +418,33 @@ class TestSyncSkills:
         stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
         stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
         return stack
+
+    def test_follows_current_hermes_home_after_import(self, tmp_path, monkeypatch):
+        home_a = tmp_path / "home-a"
+        home_b = tmp_path / "home-b"
+        home_a.mkdir()
+        (home_a / ".no-bundled-skills").write_text("opted out\n")
+        bundled = self._setup_bundled(tmp_path)
+
+        monkeypatch.setenv("HERMES_HOME", str(home_a))
+        importlib.reload(skills_sync_module)
+        assert skills_sync_module.HERMES_HOME == home_a
+
+        monkeypatch.setenv("HERMES_HOME", str(home_b))
+        monkeypatch.setattr(skills_sync_module, "_get_bundled_dir", lambda: bundled)
+        monkeypatch.setattr(
+            skills_sync_module,
+            "_get_optional_dir",
+            lambda: tmp_path / "optional-skills",
+        )
+        with patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
+            result = skills_sync_module.sync_skills(quiet=True)
+
+        assert result.get("skipped_opt_out") is not True
+        assert set(result["copied"]) == {"new-skill", "old-skill"}
+        assert (home_b / "skills" / "category" / "new-skill" / "SKILL.md").exists()
+        assert (home_b / "skills" / ".bundled_manifest").exists()
+        assert not (home_a / "skills").exists()
 
     def test_suppressed_builtin_not_reseeded(self, tmp_path):
         """A curator-pruned built-in in the suppression list must NOT be

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -39,6 +39,33 @@ logger = logging.getLogger(__name__)
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
 MANIFEST_FILE = SKILLS_DIR / ".bundled_manifest"
+_HERMES_HOME_AT_IMPORT = HERMES_HOME
+_SKILLS_DIR_AT_IMPORT = SKILLS_DIR
+_MANIFEST_FILE_AT_IMPORT = MANIFEST_FILE
+
+
+def _hermes_home() -> Path:
+    """Return the active profile home while honoring explicit test patches."""
+    configured = Path(HERMES_HOME)
+    if configured != _HERMES_HOME_AT_IMPORT:
+        return configured
+    return get_hermes_home()
+
+
+def _skills_dir() -> Path:
+    """Return the active profile's skills directory at call time."""
+    configured = Path(SKILLS_DIR)
+    if configured != _SKILLS_DIR_AT_IMPORT:
+        return configured
+    return _hermes_home() / "skills"
+
+
+def _manifest_file() -> Path:
+    """Return the active profile's manifest while honoring explicit patches."""
+    configured = Path(MANIFEST_FILE)
+    if configured != _MANIFEST_FILE_AT_IMPORT:
+        return configured
+    return _skills_dir() / ".bundled_manifest"
 
 # Marker file written by `hermes profile create --no-skills` (named profiles)
 # and by the installer's `--no-skills` flag (the default ~/.hermes profile).
@@ -101,11 +128,12 @@ def _read_manifest() -> Dict[str, str]:
     Handles both v1 (plain names) and v2 (name:hash) formats.
     v1 entries get an empty hash string which triggers migration on next sync.
     """
-    if not MANIFEST_FILE.exists():
+    manifest_file = _manifest_file()
+    if not manifest_file.exists():
         return {}
     try:
         result = {}
-        for line in MANIFEST_FILE.read_text(encoding="utf-8").splitlines():
+        for line in manifest_file.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if not line:
                 continue
@@ -133,7 +161,7 @@ def _read_suppressed_names() -> set:
 
         return read_suppressed_names()
     except Exception:
-        path = SKILLS_DIR / ".curator_suppressed"
+        path = _skills_dir() / ".curator_suppressed"
         if not path.exists():
             return set()
         names = set()
@@ -155,12 +183,13 @@ def _write_manifest(entries: Dict[str, str]):
     """
     import tempfile
 
-    MANIFEST_FILE.parent.mkdir(parents=True, exist_ok=True)
+    manifest_file = _manifest_file()
+    manifest_file.parent.mkdir(parents=True, exist_ok=True)
     data = "\n".join(f"{name}:{hash_val}" for name, hash_val in sorted(entries.items())) + "\n"
 
     try:
         fd, tmp_path = tempfile.mkstemp(
-            dir=str(MANIFEST_FILE.parent),
+            dir=str(manifest_file.parent),
             prefix=".bundled_manifest_",
             suffix=".tmp",
         )
@@ -169,7 +198,7 @@ def _write_manifest(entries: Dict[str, str]):
                 f.write(data)
                 f.flush()
                 os.fsync(f.fileno())
-            atomic_replace(tmp_path, MANIFEST_FILE)
+            atomic_replace(tmp_path, manifest_file)
         except BaseException:
             try:
                 os.unlink(tmp_path)
@@ -177,7 +206,7 @@ def _write_manifest(entries: Dict[str, str]):
                 pass
             raise
     except Exception as e:
-        logger.debug("Failed to write skills manifest %s: %s", MANIFEST_FILE, e, exc_info=True)
+        logger.debug("Failed to write skills manifest %s: %s", manifest_file, e, exc_info=True)
 
 
 def _read_skill_name(skill_md: Path, fallback: str) -> str:
@@ -226,7 +255,7 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
     e.g., bundled/skills/mlops/axolotl -> ~/.hermes/skills/mlops/axolotl
     """
     rel = skill_dir.relative_to(bundled_dir)
-    return SKILLS_DIR / rel
+    return _skills_dir() / rel
 
 
 def _dir_hash(directory: Path) -> str:
@@ -304,7 +333,7 @@ def _optional_skill_index() -> Dict[str, Tuple[str, str, Path]]:
 
 def _move_to_restore_backup(path: Path, backup_root: Path) -> str:
     """Move an existing skill directory into a restore backup, preserving rel path."""
-    rel = path.relative_to(SKILLS_DIR)
+    rel = path.relative_to(_skills_dir())
     target = backup_root / rel
     target.parent.mkdir(parents=True, exist_ok=True)
     if target.exists():
@@ -323,6 +352,7 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
     repairs already-mutated/reorganized skills by backing up matching active
     copies and copying the official optional source into its canonical path.
     """
+    skills_dir = _skills_dir()
     index = _optional_skill_index()
     if not index:
         return {"ok": False, "message": "No official optional skills directory found.", "restored": [], "backfilled": [], "backed_up": []}
@@ -337,10 +367,10 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
     restored: List[str] = []
     backed_up: List[str] = []
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    backup_root = SKILLS_DIR / ".restore-backups" / f"official-optional-{timestamp}"
+    backup_root = skills_dir / ".restore-backups" / f"official-optional-{timestamp}"
 
     for folder_name, install_path, src in targets:
-        dest = SKILLS_DIR / Path(*install_path.split("/"))
+        dest = skills_dir / Path(*install_path.split("/"))
         src_hash = _dir_hash(src)
         canonical_ok = dest.exists() and _dir_hash(dest) == src_hash
 
@@ -348,13 +378,13 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
         # or folder slug, even if curator moved it into another category.
         src_frontmatter = _read_skill_name(src / "SKILL.md", folder_name)
         matches: List[Path] = []
-        if SKILLS_DIR.exists():
-            for skill_md in sorted(SKILLS_DIR.rglob("SKILL.md")):
+        if skills_dir.exists():
+            for skill_md in sorted(skills_dir.rglob("SKILL.md")):
                 if is_excluded_skill_path(skill_md):
                     continue
                 candidate = skill_md.parent
                 try:
-                    candidate.relative_to(SKILLS_DIR)
+                    candidate.relative_to(skills_dir)
                 except ValueError:
                     continue
                 candidate_name = _read_skill_name(skill_md, candidate.name)
@@ -396,11 +426,12 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
     optional source, record official hub provenance without copying or
     reinstalling anything. Modified/local skills are left alone.
     """
+    skills_dir = _skills_dir()
     optional_dir = _get_optional_dir()
     if not optional_dir.exists():
         return []
 
-    lock_path = SKILLS_DIR / ".hub" / "lock.json"
+    lock_path = skills_dir / ".hub" / "lock.json"
     try:
         data = json.loads(lock_path.read_text()) if lock_path.exists() else {"version": 1, "installed": {}}
     except (json.JSONDecodeError, OSError):
@@ -423,7 +454,7 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
         except ValueError as e:
             logger.debug("Skipping optional skill with unsafe path %s: %s", src, e)
             continue
-        dest = SKILLS_DIR / Path(*install_path.split("/"))
+        dest = skills_dir / Path(*install_path.split("/"))
         if not dest.exists() or not dest.is_dir():
             continue
         if _dir_hash(dest) != _dir_hash(src):
@@ -493,7 +524,9 @@ def sync_skills(quiet: bool = False) -> dict:
     # empty-result shape with skipped_opt_out lets callers report "opted out"
     # instead of "synced 0 / failed". This is the default-profile counterpart
     # to seed_profile_skills()'s marker check for named profiles.
-    if (HERMES_HOME / NO_BUNDLED_SKILLS_MARKER).exists():
+    hermes_home = _hermes_home()
+    skills_dir = _skills_dir()
+    if (hermes_home / NO_BUNDLED_SKILLS_MARKER).exists():
         if not quiet:
             print("  (skipped — profile opted out of bundled skills via .no-bundled-skills)")
         return {
@@ -510,7 +543,7 @@ def sync_skills(quiet: bool = False) -> dict:
             "optional_provenance_backfilled": [],
         }
 
-    SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+    skills_dir.mkdir(parents=True, exist_ok=True)
     manifest = _read_manifest()
     bundled_skills = _discover_bundled_skills(bundled_dir)
     bundled_names = {name for name, _ in bundled_skills}
@@ -696,7 +729,7 @@ def sync_skills(quiet: bool = False) -> dict:
     # Also copy DESCRIPTION.md files for categories (if not already present)
     for desc_md in bundled_dir.rglob("DESCRIPTION.md"):
         rel = desc_md.relative_to(bundled_dir)
-        dest_desc = SKILLS_DIR / rel
+        dest_desc = skills_dir / rel
         if not dest_desc.exists():
             try:
                 dest_desc.parent.mkdir(parents=True, exist_ok=True)
@@ -741,7 +774,7 @@ def _rmtree_writable(path: Path) -> None:
     # ``shutil.rmtree(~/.hermes)`` into a loud, recoverable ``ValueError``
     # instead of silently destroying the user's install.
     target = Path(path).resolve()
-    skills_root = SKILLS_DIR.resolve()
+    skills_root = _skills_dir().resolve()
     # Every legitimate caller passes a skill directory or its ``.bak``
     # sibling — always a strict child of the skills root. The skills root
     # itself must never be removed: a ``dest`` that collapses to
@@ -1049,11 +1082,12 @@ def set_bundled_skills_opt_out(enabled: bool) -> dict:
         dict with keys: ok (bool), changed (bool), marker (str path),
                         message (str).
     """
-    marker = HERMES_HOME / NO_BUNDLED_SKILLS_MARKER
+    hermes_home = _hermes_home()
+    marker = hermes_home / NO_BUNDLED_SKILLS_MARKER
     existed = marker.exists()
     try:
         if enabled:
-            HERMES_HOME.mkdir(parents=True, exist_ok=True)
+            hermes_home.mkdir(parents=True, exist_ok=True)
             marker.write_text(
                 "This profile opted out of bundled-skill seeding "
                 "(`hermes skills opt-out`).\n"
@@ -1087,7 +1121,7 @@ def set_bundled_skills_opt_out(enabled: bool) -> dict:
 
 def is_bundled_skills_opt_out() -> bool:
     """Return True if the active profile carries the opt-out marker."""
-    return (HERMES_HOME / NO_BUNDLED_SKILLS_MARKER).exists()
+    return (_hermes_home() / NO_BUNDLED_SKILLS_MARKER).exists()
 
 
 def remove_pristine_bundled_skills(dry_run: bool = False) -> dict:


### PR DESCRIPTION
## What does this PR do?

Fixes stale skill-path resolution when a long-lived Hermes process changes profile context after import time. Skill-related modules were capturing `HERMES_HOME` / `SKILLS_DIR` once at import, so later profile switches could keep reading the old skills root and make skills appear to disappear intermittently.

This patch introduces lazy path resolution for the skill-directory globals used by the affected modules, then adds a regression test that reproduces the original two-home failure and verifies the new home becomes visible without module re-imports or monkeypatching.

## Related Issue

Fixes #43548

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `DynamicPath` in `hermes_constants.py` so `HERMES_HOME`-derived paths can resolve against the current runtime context instead of the import-time context.
- Switch `tools/skills_tool.py`, `tools/skill_manager_tool.py`, `tools/skills_hub.py`, and `tools/skills_sync.py` to dynamic skill-path resolution.
- Add a regression test in `tests/tools/test_skills_tool.py` covering the two-home profile switch repro from #43548.

## How to Test

1. Reproduce the pre-fix failure by importing `tools.skills_tool` with one `HERMES_HOME`, then switching `HERMES_HOME` to a second home with a different skill and observing that the old code still lists only the first skill.
2. Apply this branch and rerun the same two-home probe; `skills_list()` should now follow the second home and list the second skill.
3. Run `pytest -q tests/tools/test_skills_tool.py tests/tools/test_skills_sync.py tests/tools/test_skill_manager_tool.py tests/tools/test_skills_hub.py tests/agent/test_skill_commands.py tests/agent/test_skill_commands_reload.py tests/hermes_cli/test_commands.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Darwin 24.6.0, arm64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before the fix, the minimal two-home repro kept `tools.skills_tool.SKILLS_DIR` pointed at the first home and `skills_list()` continued returning only `alpha` after switching to the second home.

After the fix, the same probe resolves `tools.skills_tool`, `tools.skill_manager_tool`, `tools.skills_hub`, and `tools.skills_sync` against the second home and `skills_list()` returns `beta` as expected.
