### PR TITLE
fix(gateway): normalize user-visible response output

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -91,6 +91,7 @@ from gateway.platforms.base import (
 )
 from agent.redact import redact_sensitive_text
 from gateway.readiness import collect_runtime_readiness
+from gateway.response_normalization import extract_visible_response_text
 
 logger = logging.getLogger(__name__)
 
@@ -685,13 +686,16 @@ _MEDIA_MIME = {
 _MEDIA_DATA_URL_MAX_BYTES = 5 * 1024 * 1024  # skip images larger than 5MB
 
 
-def _resolve_media_to_data_urls(text: str) -> str:
-    """Replace ``MEDIA:<path>`` image tags with inline base64 data URLs.
+def _resolve_media_to_data_urls(content: Any) -> str:
+    """Extract visible text, then inline safe ``MEDIA:<path>`` image tags.
 
     Remote OpenAI-compatible frontends can't read local file paths, so
     ``MEDIA:`` tags referencing images on the server are useless to them.
     Inline small local images as markdown data URLs; non-image or unreadable
     paths are left untouched.
+
+    Visible-text extraction is intentionally outbound-only. The separate
+    request-content normalizers above retain their existing inbound behavior.
 
     Uses the same anchored ``MEDIA_TAG_CLEANUP_RE`` matcher and
     ``validate_media_delivery_path`` safety check every other platform
@@ -704,6 +708,7 @@ def _resolve_media_to_data_urls(text: str) -> str:
     process could see was base64-exfiltrated to the API caller if its path
     merely appeared in the model's own final reply text.
     """
+    text = extract_visible_response_text(content)
     if not text or "MEDIA:" not in text:
         return text
     import base64
@@ -3677,7 +3682,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 # deltas were streamed (e.g. some providers only emit
                 # the full response at the end), emit a single fallback
                 # delta so Responses clients still receive a live text part.
-                agent_final = result.get("final_response", "") if isinstance(result, dict) else ""
+                agent_final = _resolve_media_to_data_urls(
+                    result.get("final_response", "") if isinstance(result, dict) else ""
+                )
                 if agent_final and not final_text_parts:
                     await _emit_text_delta(agent_final)
                 if agent_final and not final_response_text:
@@ -4650,8 +4657,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     "output": msg.get("content", ""),
                 })
 
-        # Final assistant message
-        final = result.get("final_response", "")
+        # Final assistant message. This is an outbound delivery boundary: keep
+        # literal strings exact, but unwrap positively recognized provider/Hermes
+        # content blocks before placing them in the Responses API envelope.
+        final = _resolve_media_to_data_urls(result.get("final_response", ""))
         if not final:
             final = _redact_api_error_text(result.get("error", "(No response generated)"))
 
@@ -5160,7 +5169,9 @@ class APIServerAdapter(BasePlatformAdapter):
                         last_event="run.failed",
                     )
                 else:
-                    final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    final_response = _resolve_media_to_data_urls(
+                        result.get("final_response", "") if isinstance(result, dict) else ""
+                    )
                     _put_event_if_active({
                         "event": "run.completed",
                         "run_id": run_id,

--- a/gateway/response_normalization.py
+++ b/gateway/response_normalization.py
@@ -1,0 +1,91 @@
+"""Outbound-only extraction of user-visible text from recognized response shapes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Optional, Tuple
+
+
+_VISIBLE_TEXT_TYPES = frozenset({"text", "input_text", "output_text", "summary_text"})
+_MESSAGE_ROLES = frozenset({"assistant"})
+_MAX_DEPTH = 10
+_MISSING = object()
+
+
+def _safe_string(value: Any) -> str:
+    try:
+        return str(value)
+    except Exception:
+        return f"[Unsupported response content: {type(value).__name__}]"
+
+
+def _try_extract(response: Any, *, depth: int = 0) -> Tuple[bool, str]:
+    """Return ``(recognized, text)`` without guessing from generic fields."""
+    if depth > _MAX_DEPTH:
+        return False, ""
+    if response is None:
+        return True, ""
+    if isinstance(response, str):
+        return True, response
+
+    if isinstance(response, (list, tuple)):
+        if not response:
+            return False, ""
+        parts = []
+        for item in response:
+            # A bare list of strings/None is not a positively recognized
+            # provider shape. Keep the whole unknown structure visible.
+            if item is None or isinstance(item, str):
+                return False, ""
+            recognized, text = _try_extract(item, depth=depth + 1)
+            if not recognized:
+                return False, ""
+            if text:
+                parts.append(text)
+        return True, "\n".join(parts)
+
+    if isinstance(response, Mapping):
+        item_type = _safe_string(response.get("type") or "").strip().lower()
+        if item_type in _VISIBLE_TEXT_TYPES:
+            text = response.get("text", _MISSING)
+            if text is _MISSING or text is None:
+                return False, ""
+            return True, _safe_string(text)
+        if item_type == "message" and "content" in response:
+            return _try_extract(response["content"], depth=depth + 1)
+        role = _safe_string(response.get("role") or "").strip().lower()
+        if role in _MESSAGE_ROLES and "content" in response:
+            return _try_extract(response["content"], depth=depth + 1)
+        return False, ""
+
+    try:
+        item_type_value: Optional[Any] = getattr(response, "type", None)
+        item_type = _safe_string(item_type_value or "").strip().lower()
+        if item_type in _VISIBLE_TEXT_TYPES:
+            text = getattr(response, "text", _MISSING)
+            if text is _MISSING or text is None:
+                return False, ""
+            return True, _safe_string(text)
+        if item_type == "message" and hasattr(response, "content"):
+            return _try_extract(getattr(response, "content"), depth=depth + 1)
+        role = _safe_string(getattr(response, "role", "") or "").strip().lower()
+        if role in _MESSAGE_ROLES and hasattr(response, "content"):
+            return _try_extract(getattr(response, "content"), depth=depth + 1)
+    except Exception:
+        return False, ""
+
+    return False, ""
+
+
+def extract_visible_response_text(response: Any) -> str:
+    """Return outbound visible text without interpreting string contents.
+
+    Strings pass through byte-for-byte. Structured values are unwrapped only
+    when they match positively recognized provider/Hermes text blocks or
+    assistant-message wrappers. Unknown structures remain visible via a safe
+    string fallback instead of being silently converted to an empty response.
+    """
+    recognized, text = _try_extract(response)
+    if recognized:
+        return text
+    return _safe_string(response)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -56,6 +56,7 @@ from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
+from gateway.response_normalization import extract_visible_response_text
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -13343,7 +13344,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _stale_adapter._post_delivery_callbacks.pop(_quick_key, None)
                 return None
 
-            response = agent_result.get("final_response") or ""
+            response = extract_visible_response_text(
+                agent_result.get("final_response") or ""
+            )
             # Hidden-reasoning-only retry exhaustion: the loop's sentinel text
             # ("Codex response remained incomplete after 3 continuation
             # attempts") doubles as final_response, so it would be delivered
@@ -15196,7 +15199,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             result = await self._run_in_executor_with_context(run_sync)
 
-            response = result.get("final_response", "") if result else ""
+            response = extract_visible_response_text(
+                result.get("final_response", "") if isinstance(result, dict) else ""
+            )
             if not response and result and result.get("error"):
                 response = f"Error: {result['error']}"
 
@@ -21429,8 +21434,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _stream_consumer is not None:
                 _stream_consumer.finish()
             
-            # Return final response, or a message if something went wrong
-            final_response = result.get("final_response")
+            # Normalize only the outbound assistant value. Request-content
+            # normalization above remains separate and unchanged.
+            final_response = extract_visible_response_text(
+                result.get("final_response")
+            )
 
             # Extract actual token counts from the agent instance used for this run
             _last_prompt_toks = 0
@@ -22328,7 +22336,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # _run_agent_task; sending the raw copy bypasses those steps.
                     _delivery_result = response if isinstance(response, dict) else (result or {})
                     _previewed = bool(_delivery_result.get("response_previewed"))
-                    first_response = _delivery_result.get("final_response", "")
+                    first_response = extract_visible_response_text(
+                        _delivery_result.get("final_response", "")
+                    )
                     _already_streamed = _stream_confirmed_final_delivery(
                         _sc,
                         first_response,
@@ -22550,7 +22560,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # at silence.  (#10xxx — "agent stops after web search")
         _sc = stream_consumer_holder[0]
         if isinstance(response, dict) and not response.get("failed"):
-            _final = response.get("final_response") or ""
+            _final = extract_visible_response_text(
+                response.get("final_response") or ""
+            )
             _is_empty_sentinel = not _final or _final == "(empty)"
             # response_previewed means the interim_assistant_callback already
             # saw the final text, but only suppress the normal send if that
@@ -22593,7 +22605,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await _sc.adapter.edit_message(
                             chat_id=source.chat_id,
                             message_id=_sc_msg_id,
-                            content=response["final_response"],
+                            content=_final,
                             finalize=True,
                         )
                         response["already_sent"] = True

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2675,6 +2675,39 @@ class TestResponsesStreaming:
                 assert " world" in body
 
     @pytest.mark.asyncio
+    async def test_stream_extracts_structured_final_when_provider_emits_no_deltas(
+        self, adapter
+    ):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                return (
+                    {
+                        "final_response": {
+                            "type": "message",
+                            "content": [
+                                {"type": "output_text", "text": "structured fallback"}
+                            ],
+                        },
+                        "messages": [],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        assert "structured fallback" in body
+        assert "'type': 'message'" not in body
+        assert "response.completed" in body
+
+    @pytest.mark.asyncio
     async def test_stream_string_false_returns_json_response(self, adapter):
         """Quoted false must not route Responses API requests into SSE mode."""
         mock_result = {

--- a/tests/gateway/test_api_server_media_data_urls.py
+++ b/tests/gateway/test_api_server_media_data_urls.py
@@ -54,6 +54,32 @@ class TestResolveMediaToDataUrls(unittest.TestCase):
         self.assertEqual(_resolve_media_to_data_urls("plain text"), "plain text")
         self.assertEqual(_resolve_media_to_data_urls(""), "")
 
+    def test_structured_visible_text_is_extracted_before_media_inlining(self):
+        p = self._write_png()
+        out = _resolve_media_to_data_urls({
+            "type": "output_text",
+            "text": f"Here: MEDIA:{p}",
+        })
+        self.assertIn("Here:", out)
+        self.assertIn("data:image/png;base64,", out)
+        self.assertNotIn("MEDIA:", out)
+
+    def test_responses_output_item_keeps_structured_media_inlining(self):
+        from gateway.platforms.api_server import APIServerAdapter
+
+        p = self._write_png()
+        items = APIServerAdapter._extract_output_items({
+            "messages": [],
+            "final_response": {
+                "type": "output_text",
+                "text": f"Here: MEDIA:{p}",
+            },
+        })
+        text = items[-1]["content"][0]["text"]
+        self.assertIn("Here:", text)
+        self.assertIn("data:image/png;base64,", text)
+        self.assertNotIn("MEDIA:", text)
+
     def test_oversized_image_skipped(self):
         from gateway.platforms import api_server as mod
 

--- a/tests/gateway/test_api_server_normalize.py
+++ b/tests/gateway/test_api_server_normalize.py
@@ -13,6 +13,10 @@ class TestNormalizeChatContent:
     def test_plain_string_returned_as_is(self):
         assert _normalize_chat_content("hello world") == "hello world"
 
+    def test_json_looking_request_string_is_unchanged(self):
+        content = '{"status":"ok","summary":"user supplied"}'
+        assert _normalize_chat_content(content) == content
+
     def test_empty_string_returned_as_is(self):
         assert _normalize_chat_content("") == ""
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -247,6 +247,38 @@ class TestRunStatus:
                 assert status["last_event"] == "run.completed"
 
     @pytest.mark.asyncio
+    async def test_status_and_events_extract_structured_visible_output(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": {
+                        "type": "message",
+                        "content": [
+                            {"type": "output_text", "text": "visible run output"}
+                        ],
+                    }
+                }
+                mock_agent.session_prompt_tokens = 1
+                mock_agent.session_completion_tokens = 1
+                mock_agent.session_total_tokens = 2
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                events_body = await events_resp.text()
+                status_resp = await cli.get(f"/v1/runs/{run_id}")
+                status = await status_resp.json()
+
+        assert status["status"] == "completed"
+        assert status["output"] == "visible run output"
+        assert "visible run output" in events_body
+        assert "'type': 'message'" not in events_body
+
+    @pytest.mark.asyncio
     async def test_status_reflects_explicit_session_id(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:

--- a/tests/gateway/test_response_normalization.py
+++ b/tests/gateway/test_response_normalization.py
@@ -1,0 +1,88 @@
+"""Contracts for outbound user-visible response extraction."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.response_normalization import extract_visible_response_text
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "ordinary prose",
+        '{"status":"ok"}',
+        '```json\n{"status":"ok","summary":"example"}\n```',
+        "[SimpleNamespace(type='output_text', text='code example')]",
+        "  whitespace is part of the answer  ",
+    ],
+)
+def test_visible_response_strings_pass_through_exactly(response):
+    assert extract_visible_response_text(response) == response
+
+
+def test_recognized_typed_blocks_and_message_wrappers_extract_visible_prose():
+    response = {
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "first"},
+            SimpleNamespace(type="input_text", text="second"),
+            {"type": "output_text", "text": "third"},
+            SimpleNamespace(type="summary_text", text="fourth"),
+        ],
+    }
+
+    assert extract_visible_response_text(response) == "first\nsecond\nthird\nfourth"
+
+    object_wrapper = SimpleNamespace(
+        type="message",
+        role="assistant",
+        content=[SimpleNamespace(type="output_text", text="object wrapper")],
+    )
+    assert extract_visible_response_text(object_wrapper) == "object wrapper"
+
+
+def test_unknown_structures_are_not_suppressed_or_inferred_from_generic_keys():
+    response = {
+        "status": "ok",
+        "summary": "not a typed block",
+        "metadata": {"created_at": "tomorrow"},
+    }
+
+    assert extract_visible_response_text(response) == str(response)
+    assert extract_visible_response_text([]) == "[]"
+    assert extract_visible_response_text(["one", "two"]) == "['one', 'two']"
+    assert extract_visible_response_text({"type": "output_text"}) == (
+        "{'type': 'output_text'}"
+    )
+    assert extract_visible_response_text({"type": "output_text", "text": None}) == (
+        "{'type': 'output_text', 'text': None}"
+    )
+    assert extract_visible_response_text({
+        "type": "custom",
+        "text": "do not infer",
+    }) == ("{'type': 'custom', 'text': 'do not infer'}")
+
+
+def test_unprintable_unknown_structure_returns_an_explicit_fallback():
+    class Unprintable:
+        def __str__(self):
+            raise RuntimeError("cannot render")
+
+    assert extract_visible_response_text(Unprintable()) == (
+        "[Unsupported response content: Unprintable]"
+    )
+
+
+def test_responses_api_output_item_uses_visible_text_extraction():
+    items = APIServerAdapter._extract_output_items({
+        "messages": [],
+        "final_response": {
+            "type": "message",
+            "content": [{"type": "output_text", "text": "visible answer"}],
+        },
+    })
+
+    assert items[-1]["content"] == [{"type": "output_text", "text": "visible answer"}]

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1081,6 +1081,114 @@ class TransformedStreamAgent:
         }
 
 
+class StructuredMediaAgent:
+    """Returns structured prose plus current-turn tool media."""
+
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        return {
+            "final_response": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "visible answer"}],
+            },
+            "messages": [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_tts",
+                            "function": {"name": "text_to_speech", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_tts",
+                    "content": (
+                        '{"success": true, "media_tag": '
+                        '"[[audio_as_voice]]\\nMEDIA:/tmp/voice.ogg"}'
+                    ),
+                },
+            ],
+            "api_calls": 1,
+        }
+
+
+@pytest.mark.asyncio
+async def test_structured_response_is_extracted_before_tool_media_auto_append(
+    monkeypatch, tmp_path
+):
+    _adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StructuredMediaAgent,
+        session_id="sess-structured-media",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": False},
+        },
+    )
+
+    assert result["final_response"] == (
+        "visible answer\n[[audio_as_voice]]\nMEDIA:/tmp/voice.ogg"
+    )
+
+
+class StructuredTransformedStreamAgent:
+    """Returns a recognized structured final response after streaming text."""
+
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.stream_delta_callback:
+            self.stream_delta_callback("original answer")
+        return {
+            "final_response": {
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": "visible transformed answer"}
+                ],
+            },
+            "response_previewed": True,
+            "response_transformed": True,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+@pytest.mark.asyncio
+async def test_structured_transformed_response_edits_visible_text_in_place(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StructuredTransformedStreamAgent,
+        session_id="sess-structured-transformed",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.MATRIX,
+        chat_id="!structured:matrix.example.org",
+        chat_type="group",
+        thread_id="$thread",
+        adapter_cls=MetadataEditProgressCaptureAdapter,
+    )
+
+    assert result.get("already_sent") is True
+    assert any(
+        edit["content"] == "visible transformed answer" for edit in adapter.edits
+    )
+
+
 @pytest.mark.asyncio
 async def test_transformed_response_edits_streamed_message_in_place(monkeypatch, tmp_path):
     """When a transform_llm_output hook modifies the response after streaming,


### PR DESCRIPTION
## Summary

This PR was rebuilt from current upstream `main` rather than rebasing the stale implementation.

- add a narrowly scoped outbound visible-text extractor
- keep inbound request-content normalization separate and unchanged
- normalize current API and native gateway response-delivery boundaries
- preserve existing media and API data-URL conversion behavior

## Behavior

Ordinary strings pass through exactly, including JSON-looking answers, code examples, repr-looking strings, and leading/trailing whitespace.

Structured values are unwrapped only when they match positively recognized Hermes/provider shapes:

- `text`
- `input_text`
- `output_text`
- `summary_text`
- recognized message/assistant wrappers
- equivalent object attributes

Generic fields such as `status`, `summary`, `metadata`, `events`, or `created_at` are not treated as leak indicators. Unknown structured values remain visible through a safe fallback instead of being silently converted into an empty answer.

The lower shared gateway path also normalizes structured output before tool-result `MEDIA:` tags are auto-appended.

## Regression coverage

Tests cover:

- exact preservation of ordinary, JSON-looking, code, and repr-looking strings
- recognized typed content blocks and object/message wrappers
- safe handling of generic-key, malformed, empty, and unknown structures
- Responses API output, streaming fallback, run status, and run events
- native gateway delivery and transformed streamed-message edits
- structured output combined with tool-result media auto-append
- existing media/data-URL conversion behavior
- unchanged inbound request normalization

## Verification

- refreshed onto upstream `main` at `7d96e602a9d231f63f0a6977084d627c7c9c63be`
- 462 focused/relevant tests passed
- full gateway suite: 10,394 passed, 0 failed
- Ruff lint passed
- scoped Ruff format checks passed
- Python compilation passed
- `git diff --check` passed
- independent review passed with no blocking logic or security findings
