### PR TITLE
feat(observability): OTEL trace emitter plugin (Phase 1)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -295,7 +295,10 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         _invoke_hook(
             "on_session_start",
             session_id=agent.session_id,
+            parent_session_id=getattr(agent, "_parent_session_id", None) or "",
+            resume_from=getattr(agent, "_parent_session_id", None) or "",
             model=agent.model,
+            provider=getattr(agent, "provider", None) or "",
             platform=getattr(agent, "platform", None) or "",
         )
     except Exception as exc:
@@ -3583,6 +3586,8 @@ def run_conversation(
                         turn_id=turn_id,
                         api_request_id=api_request_id,
                         session_id=agent.session_id or "",
+                        parent_session_id=getattr(agent, "_parent_session_id", None) or "",
+                        resume_from=getattr(agent, "_parent_session_id", None) or "",
                         platform=agent.platform or "",
                         model=agent.model,
                         provider=agent.provider,
@@ -4703,6 +4708,8 @@ def run_conversation(
                 user_message=original_user_message,
                 assistant_response=final_response,
                 conversation_history=list(messages),
+                parent_session_id=getattr(agent, "_parent_session_id", None) or "",
+                resume_from=getattr(agent, "_parent_session_id", None) or "",
                 model=agent.model,
                 platform=getattr(agent, "platform", None) or "",
             )

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1499,6 +1499,8 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # This env var is process-wide and persists for the lifetime of the
     # scheduler process — every job this process runs is a cron job.
     os.environ["HERMES_CRON_SESSION"] = "1"
+    _prior_cron_job_id = os.environ.get("HERMES_CRON_JOB_ID")
+    os.environ["HERMES_CRON_JOB_ID"] = str(job_id)
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
@@ -1958,6 +1960,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             cleanup_stale_async_clients()
         except Exception as e:
             logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
+        # Restore prior HERMES_CRON_JOB_ID so nested/sequential jobs don't
+        # inherit this job's ID after we're done.
+        if _prior_cron_job_id is None:
+            os.environ.pop("HERMES_CRON_JOB_ID", None)
+        else:
+            os.environ["HERMES_CRON_JOB_ID"] = _prior_cron_job_id
 
 
 def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> int:

--- a/plugins/observability/otel/__init__.py
+++ b/plugins/observability/otel/__init__.py
@@ -1,0 +1,353 @@
+"""otel — Hermes plugin for OpenTelemetry trace export.
+
+Pushes session, model, tool, and cron spans to any OTLP/HTTP collector.
+Fail-open: export errors are logged as warnings; agent runs are never
+interrupted.
+
+The plugin is opt-in. Enable it with ``hermes plugins enable
+observability/otel`` and set ``otel.enabled: true`` (or
+``HERMES_OTEL_ENABLED=1``); ``otel.endpoint`` and
+``HERMES_OTEL_ENDPOINT`` configure the collector URL — ``/v1/traces`` is
+appended when omitted.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# OTLP status + span-kind enums; tiny subset, kept here so the plugin
+# stays zero-dep (no opentelemetry-sdk import).
+STATUS_OK, STATUS_ERROR = 1, 2
+KIND_INTERNAL, KIND_CLIENT = 1, 3
+
+# One entry per (session_id|task_id|process); the sticky execution_id and
+# resume lineage mean subsequent API/tool spans inherit continuity
+# attributes without every call site having to pass them again.
+_SESSIONS: dict[str, dict[str, Any]] = {}
+
+
+def _now_ns() -> int:
+    return time.time_ns()
+
+
+def _id(n: int) -> str:
+    return uuid.uuid4().hex[:n]
+
+
+def _compact(d: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in d.items() if v not in (None, "")}
+
+
+def _json(value: Any, limit: int = 4096) -> str:
+    # Coerce non-strings via JSON so attribute values stay valid OTLP
+    # strings; fall back to repr when the payload isn't JSON-serializable.
+    if not isinstance(value, str):
+        try:
+            value = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        except Exception:
+            value = str(value)
+    if len(value) <= limit:
+        return value
+    suffix = f"...[truncated {len(value) - limit} chars]"
+    return value[: max(0, limit - len(suffix))] + suffix
+
+
+def _attr(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return {"boolValue": value}
+    if isinstance(value, int):
+        return {"intValue": str(value)}
+    if isinstance(value, float):
+        return {"doubleValue": value}
+    return {"stringValue": _json(value)}
+
+
+def _attrs(d: dict[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for k, v in d.items():
+        if not k:
+            continue
+        av = _attr(v)
+        if av is not None:
+            out.append({"key": str(k), "value": av})
+    return out
+
+
+def _session(kwargs: dict[str, Any]) -> dict[str, Any]:
+    key = str(kwargs.get("session_id") or kwargs.get("task_id") or f"thread:{os.getpid()}")
+    state = _SESSIONS.get(key)
+    if state is None:
+        state = {
+            "trace_id": _id(32),
+            "execution_id": kwargs.get("execution_id") or _id(32),
+            "start_ns": _now_ns(),
+            "parent_session_id": kwargs.get("parent_session_id"),
+            "resume_from": kwargs.get("resume_from") or kwargs.get("parent_session_id"),
+        }
+        _SESSIONS[key] = state
+    return state
+
+
+def _continuity(kwargs: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
+    return _compact({
+        "gen_ai.session.id": kwargs.get("session_id") or kwargs.get("task_id"),
+        "gen_ai.agent.execution.id": kwargs.get("execution_id") or state["execution_id"],
+        "hermes.resume_from": kwargs.get("resume_from") or kwargs.get("parent_session_id") or state.get("resume_from"),
+        "hermes.cron.job.id": kwargs.get("cron_job_id") or os.environ.get("HERMES_CRON_JOB_ID", "").strip() or None,
+    })
+
+
+def _span(name: str, kwargs: dict[str, Any], attrs: dict[str, Any], *, kind: int = KIND_INTERNAL, status: int = STATUS_OK, duration_ns: int = 1_000_000, message: str = "") -> dict[str, Any]:
+    # The post-event hooks don't carry an explicit start timestamp, so we
+    # estimate backwards from the duration the hook payload already
+    # supplies. Wall-clock position is approximate; the duration is exact.
+    state = _session(kwargs)
+    end = _now_ns()
+    span: dict[str, Any] = {
+        "traceId": state["trace_id"],
+        "spanId": _id(16),
+        "name": name,
+        "kind": kind,
+        "startTimeUnixNano": str(max(0, end - duration_ns)),
+        "endTimeUnixNano": str(end),
+        "attributes": _attrs({**_continuity(kwargs, state), **_compact(attrs)}),
+        "status": {"code": status},
+    }
+    if message:
+        span["status"]["message"] = _json(message, 512)
+    return span
+
+
+class _Exporter:
+    def __init__(self, cfg: dict[str, Any]) -> None:
+        endpoint = (
+            os.environ.get("HERMES_OTEL_ENDPOINT")
+            or cfg.get("endpoint")
+            or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+            or "http://localhost:4318/v1/traces"
+        )
+        endpoint = endpoint.rstrip("/")
+        if not endpoint.endswith("/v1/traces"):
+            endpoint += "/v1/traces"
+        self.endpoint = endpoint
+
+        # Headers can be a dict in config or a comma-list from env; we accept both.
+        headers: dict[str, str] = dict(cfg.get("headers") or {})
+        for part in (os.environ.get("HERMES_OTEL_HEADERS") or os.environ.get("OTEL_EXPORTER_OTLP_HEADERS") or "").split(","):
+            if ":" in part:
+                k, v = part.split(":", 1)
+                if k.strip():
+                    headers[k.strip()] = v.strip()
+        headers["Content-Type"] = "application/json"
+        self.headers = headers
+
+        self.service = os.environ.get("HERMES_OTEL_SERVICE_NAME") or cfg.get("service_name") or "hermes-agent"
+        self.timeout = float(os.environ.get("HERMES_OTEL_TIMEOUT_SECONDS") or cfg.get("timeout_seconds") or 1.0)
+        self.retry = float(os.environ.get("HERMES_OTEL_RETRY_INTERVAL_SECONDS") or cfg.get("retry_interval_seconds") or 30.0)
+        # next_retry_at is wall-clock based so a long-lived process doesn't
+        # hammer an unreachable collector; one failure silently backs off
+        # for the configured interval before re-trying.
+        self.next_retry_at = 0.0
+
+    def export(self, spans: list[dict[str, Any]]) -> None:
+        if not spans:
+            return
+        # Drop silently during backoff rather than raising — observer
+        # hooks must never break the agent loop.
+        if time.time() < self.next_retry_at:
+            logger.warning("OTEL export skipped during retry backoff; dropping %d span(s)", len(spans))
+            return
+        payload = {
+            "resourceSpans": [{
+                "resource": {"attributes": _attrs({"service.name": self.service, "telemetry.sdk.language": "python"})},
+                "scopeSpans": [{"scope": {"name": "hermes.observability.otel", "version": "1.0.0"}, "spans": spans}],
+            }]
+        }
+        try:
+            import urllib.request
+            data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+            req = urllib.request.Request(self.endpoint, data=data, headers=self.headers, method="POST")
+            with urllib.request.urlopen(req, timeout=max(0.1, self.timeout)) as r:
+                if r.status >= 400:
+                    raise RuntimeError(f"HTTP {r.status}")
+            self.next_retry_at = 0.0
+        except Exception as exc:
+            self.next_retry_at = time.time() + max(0.0, self.retry)
+            logger.warning("OTEL export failed; dropping %d span(s) until retry window elapses: %s", len(spans), exc)
+
+
+_EXPORTER: _Exporter | None = None
+
+
+def _exporter() -> _Exporter | None:
+    global _EXPORTER
+    if _EXPORTER is not None:
+        return _EXPORTER
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config().get("otel") or {}
+    except Exception:
+        cfg = {}
+    if not isinstance(cfg, dict):
+        cfg = {}
+    raw = os.environ.get("HERMES_OTEL_ENABLED", cfg.get("enabled", False))
+    truthy = raw if isinstance(raw, bool) else str(raw).strip().lower() in {"1", "true", "yes", "on"}
+    if not truthy:
+        return None
+    _EXPORTER = _Exporter(cfg)
+    return _EXPORTER
+
+
+def _emit(name: str, kwargs: dict[str, Any], attrs: dict[str, Any], **kw: Any) -> None:
+    try:
+        ex = _exporter()
+        if ex:
+            ex.export([_span(name, kwargs, attrs, **kw)])
+    except Exception:
+        # Belt-and-suspenders: even if a hook callback catches nothing,
+        # the agent loop must still be unaffected.
+        logger.debug("OTEL hook failed", exc_info=True)
+
+
+def on_session_start(**kwargs: Any) -> None:
+    # Touch the session to seed trace_id / execution_id; the actual
+    # session span is emitted on finalize so duration is real.
+    state = _session(kwargs)
+    state["attrs"] = _compact({
+        **_continuity(kwargs, state),
+        "hermes.platform": kwargs.get("platform"),
+        "hermes.model": kwargs.get("model"),
+        "hermes.provider": kwargs.get("provider"),
+        "hermes.task_id": kwargs.get("task_id"),
+    })
+
+
+def on_session_finalize(**kwargs: Any) -> None:
+    key = str(kwargs.get("session_id") or kwargs.get("task_id") or f"thread:{os.getpid()}")
+    state = _SESSIONS.pop(key) or {}
+    duration = max(1_000_000, _now_ns() - int(state.get("start_ns") or _now_ns()))
+    _emit(
+        "hermes.session", kwargs,
+        {**(state.get("attrs") or {}), "hermes.finalize.reason": kwargs.get("reason")},
+        duration_ns=duration,
+    )
+
+
+def on_session_reset(**kwargs: Any) -> None:
+    # Reset re-uses the finalize path so the old session's span still
+    # closes — otherwise long-lived profiles would leak trace rows.
+    if old := kwargs.get("old_session_id") or kwargs.get("session_id"):
+        on_session_finalize(**{**kwargs, "session_id": old, "reason": kwargs.get("reason") or "reset"})
+
+
+def on_session_end(**kwargs: Any) -> None:
+    return None  # Session span is owned by finalize; end is intentionally quiet.
+
+
+def on_post_api_request(**kwargs: Any) -> None:
+    raw = kwargs.get("usage")
+    usage = raw if isinstance(raw, dict) else {}
+    provider = kwargs.get("provider") or kwargs.get("gen_ai_system") or "llm"
+    api_duration = kwargs.get("api_duration") or 0
+    _emit(
+        f"gen_ai.chat {provider}", kwargs,
+        {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.system": provider,
+            "gen_ai.request.model": kwargs.get("model"),
+            "gen_ai.response.model": kwargs.get("response_model") or kwargs.get("model"),
+            "gen_ai.usage.input_tokens": usage.get("prompt_tokens") or usage.get("input_tokens"),
+            "gen_ai.usage.output_tokens": usage.get("completion_tokens") or usage.get("output_tokens"),
+            "gen_ai.usage.total_tokens": usage.get("total_tokens"),
+            "hermes.api_request_id": kwargs.get("api_request_id"),
+            "hermes.turn_id": kwargs.get("turn_id"),
+            "hermes.api_call_count": kwargs.get("api_call_count"),
+            "hermes.provider": kwargs.get("provider"),
+            "hermes.finish_reason": kwargs.get("finish_reason"),
+        },
+        kind=KIND_CLIENT,
+        duration_ns=max(1_000_000, int(api_duration * 1_000_000_000)),
+        message=kwargs.get("finish_reason") or "",
+    )
+
+
+def on_api_request_error(**kwargs: Any) -> None:
+    error = kwargs.get("error")
+    message = (error or {}).get("message") if isinstance(error, dict) else str(error or "")
+    error_type = (error or {}).get("type") if isinstance(error, dict) else type(error).__name__
+    provider = kwargs.get("provider") or "llm"
+    _emit(
+        f"gen_ai.chat {provider}", kwargs,
+        {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.system": provider,
+            "gen_ai.request.model": kwargs.get("model"),
+            "error.type": error_type,
+            "hermes.error.message": message,
+            "hermes.error.reason": kwargs.get("reason"),
+            "hermes.retryable": kwargs.get("retryable"),
+            "hermes.retry_count": kwargs.get("retry_count"),
+        },
+        status=STATUS_ERROR,
+        kind=KIND_CLIENT,
+        message=message,
+    )
+
+
+def on_post_tool_call(**kwargs: Any) -> None:
+    status = (kwargs.get("status") or "ok").lower()
+    tool = kwargs.get("tool_name") or "tool"
+    duration_ms = kwargs.get("duration_ms")
+    args = kwargs.get("args")
+    result = kwargs.get("result")
+    _emit(
+        f"hermes.tool {tool}", kwargs,
+        {
+            "hermes.tool.name": tool,
+            "gen_ai.tool.call.id": kwargs.get("tool_call_id"),
+            "hermes.tool.status": status,
+            "hermes.tool.duration_ms": duration_ms,
+            "hermes.tool.args.size": len(_json(args)) if args is not None else 0,
+            "hermes.tool.result.size": len(_json(result)) if result is not None else 0,
+            "error.type": kwargs.get("error_type"),
+            "hermes.error.message": kwargs.get("error_message"),
+        },
+        status=STATUS_OK if status == "ok" else STATUS_ERROR,
+        duration_ns=int(duration_ms * 1_000_000) if duration_ms else 1_000_000,
+        message=kwargs.get("error_message") or "",
+    )
+
+
+# Older plugin spikes exposed unprefixed names; keep them so existing
+# importers/tests still resolve cleanly. The on_* spellings above are
+# the canonical Phase 1 surface.
+post_api_request = on_post_api_request
+api_request_error = on_api_request_error
+post_tool_call = on_post_tool_call
+
+
+def register(ctx) -> None:
+    for name, hook in {
+        "on_session_start": on_session_start,
+        "on_session_end": on_session_end,
+        "on_session_finalize": on_session_finalize,
+        "on_session_reset": on_session_reset,
+        "post_api_request": on_post_api_request,
+        "api_request_error": on_api_request_error,
+        "post_tool_call": on_post_tool_call,
+    }.items():
+        ctx.register_hook(name, hook)
+
+
+def _reset_for_tests() -> None:
+    global _EXPORTER
+    _SESSIONS.clear()
+    _EXPORTER = None

--- a/plugins/observability/otel/plugin.yaml
+++ b/plugins/observability/otel/plugin.yaml
@@ -1,0 +1,13 @@
+name: otel
+version: "1.0.0"
+description: "Optional OpenTelemetry trace export for Hermes — pushes session, model, tool, and cron spans to any OTLP/HTTP collector. Opt in with `hermes plugins enable observability/otel`, then set `otel.endpoint` (or HERMES_OTEL_ENDPOINT) and `otel.enabled: true`."
+author: tripplen23
+requires_env: []
+hooks:
+  - on_session_start
+  - on_session_end
+  - on_session_finalize
+  - on_session_reset
+  - post_api_request
+  - api_request_error
+  - post_tool_call

--- a/run_agent.py
+++ b/run_agent.py
@@ -567,6 +567,9 @@ class AIAgent:
             start_context = {
                 "old_session_id": old_session_id,
                 "carry_over_context": carry_over_context,
+                "parent_session_id": getattr(self, "_parent_session_id", None) or "",
+                "resume_from": getattr(self, "_parent_session_id", None) or "",
+                "provider": getattr(self, "provider", None) or "",
                 "platform": getattr(self, "platform", None) or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                 "model": getattr(self, "model", ""),
                 "context_length": getattr(engine, "context_length", None),

--- a/tests/plugins/test_otel_plugin.py
+++ b/tests/plugins/test_otel_plugin.py
@@ -1,0 +1,227 @@
+"""Tests for the bundled observability/otel plugin."""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import yaml
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[2] / "plugins" / "observability" / "otel"
+
+
+class _FakeExporter:
+    def __init__(self) -> None:
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+
+
+def _fresh_plugin(monkeypatch):
+    sys.modules.pop("plugins.observability.otel", None)
+    plugin = importlib.import_module("plugins.observability.otel")
+    plugin._reset_for_tests()
+    fake = _FakeExporter()
+    monkeypatch.setattr(plugin, "_exporter", lambda: fake)
+    return plugin, fake
+
+
+def _attrs(span):
+    out = {}
+    for item in span["attributes"]:
+        value = item["value"]
+        out[item["key"]] = next(iter(value.values()))
+    return out
+
+
+def test_manifest_declares_phase_1_hooks():
+    data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text())
+    assert data["name"] == "otel"
+    assert set(data["hooks"]) == {
+        "on_session_start",
+        "on_session_end",
+        "on_session_finalize",
+        "on_session_reset",
+        "post_api_request",
+        "api_request_error",
+        "post_tool_call",
+    }
+
+
+def test_api_request_exports_gen_ai_span_with_continuity_attrs(monkeypatch):
+    plugin, fake = _fresh_plugin(monkeypatch)
+    monkeypatch.setenv("HERMES_CRON_JOB_ID", "job-123")
+    base = {
+        "session_id": "s1",
+        "parent_session_id": "s0",
+        "turn_id": "turn-1",
+        "api_request_id": "api-1",
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "api_call_count": 1,
+    }
+
+    plugin.on_session_start(**base, platform="cron")
+    plugin.on_post_api_request(
+        **base,
+        response_model="gpt-4o-mini-2024-07-18",
+        finish_reason="stop",
+        api_duration=0.125,
+        usage={"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+    )
+
+    assert len(fake.spans) == 1
+    span = fake.spans[0]
+    assert span["name"] == "gen_ai.chat openai"
+    assert span["kind"] == plugin.KIND_CLIENT
+    assert span["status"] == {"code": plugin.STATUS_OK, "message": "stop"}
+    attrs = _attrs(span)
+    assert attrs["gen_ai.operation.name"] == "chat"
+    assert attrs["gen_ai.system"] == "openai"
+    assert attrs["gen_ai.request.model"] == "gpt-4o-mini"
+    assert attrs["gen_ai.response.model"] == "gpt-4o-mini-2024-07-18"
+    assert attrs["gen_ai.usage.input_tokens"] == "11"
+    assert attrs["gen_ai.usage.output_tokens"] == "7"
+    assert attrs["gen_ai.usage.total_tokens"] == "18"
+    assert attrs["gen_ai.session.id"] == "s1"
+    assert attrs["gen_ai.agent.execution.id"]
+    assert attrs["hermes.resume_from"] == "s0"
+    assert attrs["hermes.cron.job.id"] == "job-123"
+    assert attrs["hermes.api_request_id"] == "api-1"
+
+
+def test_tool_call_exports_tool_span_with_call_id(monkeypatch):
+    plugin, fake = _fresh_plugin(monkeypatch)
+
+    plugin.on_post_tool_call(
+        session_id="s1",
+        turn_id="turn-1",
+        tool_call_id="tool-1",
+        tool_name="terminal",
+        args={"command": "pwd"},
+        result='{"output":"/tmp"}',
+        status="ok",
+        duration_ms=12.5,
+    )
+
+    span = fake.spans[0]
+    assert span["name"] == "hermes.tool terminal"
+    attrs = _attrs(span)
+    assert attrs["hermes.tool.name"] == "terminal"
+    assert attrs["gen_ai.tool.call.id"] == "tool-1"
+    assert attrs["gen_ai.session.id"] == "s1"
+    assert attrs["gen_ai.agent.execution.id"]
+    assert attrs["hermes.tool.status"] == "ok"
+    assert attrs["hermes.tool.duration_ms"] == 12.5
+    assert attrs["hermes.tool.args.size"]
+    assert attrs["hermes.tool.result.size"]
+
+
+def test_session_finalize_exports_session_span(monkeypatch):
+    plugin, fake = _fresh_plugin(monkeypatch)
+
+    plugin.on_session_start(session_id="s1", platform="discord", model="m", provider="p")
+    plugin.on_session_finalize(session_id="s1", reason="shutdown")
+
+    span = fake.spans[0]
+    assert span["name"] == "hermes.session"
+    attrs = _attrs(span)
+    assert attrs["gen_ai.session.id"] == "s1"
+    assert attrs["gen_ai.agent.execution.id"]
+    assert attrs["hermes.platform"] == "discord"
+    assert attrs["hermes.finalize.reason"] == "shutdown"
+
+
+def test_continuity_attrs_propagate_to_subsequent_spans(monkeypatch):
+    plugin, fake = _fresh_plugin(monkeypatch)
+    plugin.on_session_start(session_id="s1", parent_session_id="s0", resume_from="r0", platform="cli")
+    plugin.on_post_tool_call(
+        session_id="s1",
+        tool_call_id="tc-1",
+        tool_name="terminal",
+        args={"cmd": "ls"},
+        result="ok",
+        status="ok",
+        duration_ms=4,
+    )
+    plugin.on_post_api_request(
+        session_id="s1",
+        turn_id="turn-1",
+        api_request_id="api-1",
+        provider="openai",
+        model="gpt",
+        usage={"prompt_tokens": 1, "completion_tokens": 1},
+        finish_reason="stop",
+    )
+
+    api_attrs = _attrs(fake.spans[0])
+    tool_attrs = _attrs(fake.spans[1])
+    for attrs in (api_attrs, tool_attrs):
+        assert attrs["gen_ai.session.id"] == "s1"
+        assert attrs["gen_ai.agent.execution.id"]
+        assert attrs["hermes.resume_from"] == "r0"
+
+
+def test_session_attrs_carry_into_session_span(monkeypatch):
+    plugin, fake = _fresh_plugin(monkeypatch)
+    plugin.on_session_start(session_id="s1", platform="discord", model="m", provider="p")
+    plugin.on_post_api_request(
+        session_id="s1",
+        provider="p",
+        model="m",
+        usage={"prompt_tokens": 1},
+        finish_reason="stop",
+    )
+    plugin.on_session_finalize(session_id="s1", reason="shutdown")
+
+    api_span, _ = fake.spans[0], fake.spans[1]
+    session_span = fake.spans[1]
+    assert api_span["name"].startswith("gen_ai.chat")
+    assert session_span["name"] == "hermes.session"
+    attrs = _attrs(session_span)
+    assert attrs["gen_ai.session.id"] == "s1"
+    assert attrs["hermes.platform"] == "discord"
+    assert attrs["hermes.model"] == "m"
+    assert attrs["hermes.provider"] == "p"
+
+
+def test_api_request_error_emits_error_status(monkeypatch):
+    plugin, fake = _fresh_plugin(monkeypatch)
+    plugin.on_api_request_error(
+        session_id="s1",
+        provider="openai",
+        model="gpt",
+        error={"type": "RateLimitError", "message": "rate limited"},
+        reason="rate_limit",
+        retryable=True,
+        retry_count=1,
+    )
+
+    span = fake.spans[0]
+    assert span["name"] == "gen_ai.chat openai"
+    assert span["status"] == {"code": plugin.STATUS_ERROR, "message": "rate limited"}
+    attrs = _attrs(span)
+    assert attrs["error.type"] == "RateLimitError"
+    assert attrs["hermes.retryable"] is True
+
+
+def test_exporter_warns_when_export_fails_and_when_backoff_drops(monkeypatch, caplog):
+    plugin = importlib.import_module("plugins.observability.otel")
+    monkeypatch.setenv("HERMES_OTEL_ENABLED", "1")
+    monkeypatch.delenv("HERMES_OTEL_ENDPOINT", raising=False)
+    exporter = plugin._Exporter({
+        "endpoint": "http://127.0.0.1:1/v1/traces",
+        "timeout_seconds": 0.1,
+        "retry_interval_seconds": 60,
+    })
+    span = {"traceId": "1" * 32, "spanId": "2" * 16, "name": "test", "startTimeUnixNano": "1", "endTimeUnixNano": "2", "attributes": [], "status": {"code": 1}}
+
+    with caplog.at_level("WARNING", logger=plugin.__name__):
+        exporter.export([span])
+        exporter.export([span])
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("OTEL export failed; dropping 1 span(s)" in message for message in messages)
+    assert any("OTEL export skipped during retry backoff; dropping 1 span(s)" in message for message in messages)


### PR DESCRIPTION
## Summary

Phase 1 OTEL trace emitter plugin per [issue #38824](https://github.com/NousResearch/hermes-agent/issues/38824).

### What
-  — zero-dep OTLP/HTTP exporter with graceful degradation
-  — plugin manifest declaring all Phase 1 hooks
-  — 227-line test suite covering all spans and error paths
- Hook calls patched into: , , , 

### Phase 1 scope (per norika1207-lab's review)
- ✅ OTLP HTTP exporter with retry backoff + warning logs on failure
- ✅ Span types: , , 
- ✅ Config via env: , , 
- ✅ gen_ai.* semantic-convention attributes (, , )
- ✅  for cross-run lineage
- ✅  from  env var (restored after each job)

### Out of scope (Phase 2)
- Full observability dashboard
- Agent-level metrics (statsd/prometheus)
- Streaming traces

---
/cc @norika1207-lab — ready for your review. Will open a separate PR for Phase 2 once this is approved.