### PR TITLE
feat(skills): add port skill collection optional skill

### DIFF
--- a/optional-skills/migration/port-skill-collection/LICENSE
+++ b/optional-skills/migration/port-skill-collection/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 port-skill-collection contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/optional-skills/migration/port-skill-collection/SKILL.md
+++ b/optional-skills/migration/port-skill-collection/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: port-skill-collection
+description: Port a Claude Code plugin or external skill collection (a GitHub repo of SKILL.md directories) into Hermes Agent. Use when installing, importing, adapting, refreshing, or auditing existing skills from Claude Code, Codex, Cursor, OpenCode, or agentskills-style repos — e.g. "port this skill repo into Hermes", "add the skills from github.com/x/y", "refresh the ported skills from upstream", or "audit this skill collection before install". For authoring new skills from scratch, use skill-creator instead; this skill is only for migrating existing ones.
+version: 2.2.5
+author: vcolombo + Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [skills, migration, claude-code, setup]
+    category: migration
+---
+
+# Port a Skill Collection into Hermes
+
+Adapt an external skill repository for use in Hermes. Skills can port; plugin infrastructure such as hooks, slash commands, and named agents usually needs Hermes-native replacement.
+
+## First-time port workflow
+
+### 1. Locate and pin the source
+- Get the source repository URL from the user.
+- Clone or update a persistent external checkout such as `$HERMES_HOME/external-skill-repos/<repo-name>` or another user-approved persistent path. Do not put the only checkout in a temporary directory.
+- Record the source identity before copying anything:
+  ```bash
+  git -C <repo> remote get-url origin
+  git -C <repo> rev-parse HEAD
+  git -C <repo> status --short
+  ```
+- Pin provenance to that commit SHA. Future upstream updates must use refresh mode, not reinstall-overwrite.
+- Find skills by searching for `SKILL.md` files. Do not assume a fixed repository layout.
+
+### 2. Resolve the active Hermes skill destination
+- Do **not** assume shell `~/.hermes/skills`. Resolve the active profile/Hermes home first.
+- Prefer Hermes-native writes when creating local/runtime skills: `skill_manage(action='create')`, `skill_manage(action='patch')`, and `skill_manage(action='write_file')` target the active profile and reduce wrong-profile writes.
+- If you must copy files manually, derive the destination from the active runtime:
+  ```bash
+  hermes profile show default  # or the explicit target profile
+  hermes skills list
+  ```
+- Verify the installed path with `skill_view(<name>)` or a fresh Hermes process.
+
+### 3. Inventory and prune (hard gate before installing)
+- List every discovered skill: name + one-line description.
+- Estimate rough per-session index cost before installation. Every installed skill contributes its `name` + `description` to the new-session `<available_skills>` index.
+- **Hard gate:** if the source contains more than 3 skills, present the full inventory with one-line descriptions and rough index cost, then wait for the user to choose the subset before installing anything.
+- A broad request such as "install the repo" or "add the skills" is not consent to index a large collection. Treat it as a request to inventory and recommend a subset unless the user explicitly confirms after seeing the inventory/cost.
+
+### 4. Install the chosen subset
+Pick one method and tell the user the tradeoff:
+- **Copy (default):** copy each chosen skill directory into the resolved active skills directory, e.g. `<active-skills-dir>/<category>/<skill-name>/`. Pro: owned, prunable, stable. Con: no automatic updates; use refresh mode later.
+- **Symlink (small whole collection only):** symlink a deliberately chosen small collection into the resolved active skills directory only after confirming Hermes indexes symlinked directories in this deployment. Pro: external checkout updates can flow through. Con: all linked skills get indexed every session.
+
+Standard preservation steps for each copied skill:
+- Preserve upstream license files (`LICENSE`, `LICENSE.txt`, `NOTICE`, or equivalent) inside the installed skill directory when the source provides them.
+- Preserve the unmodified upstream `SKILL.md` as `references/original-SKILL.md` before rewriting for Hermes.
+- Add provenance to the adapted `SKILL.md` frontmatter or body: source repo URL, source relative path, pinned commit SHA, port date, and a note that the installed body was adapted for Hermes.
+- Copy support files deliberately into Hermes-supported support directories (`references/`, `templates/`, `scripts/`, `assets/`) and document any files omitted.
+
+### 5. Record the port ledger
+Maintain a `ports.yaml` ledger at the resolved active skills root, alongside skill category directories:
+
+```text
+<active-skills-dir>/ports.yaml
+```
+
+The ledger answers "what have I ported and what is stale?" for manual-copy installs that do not participate in hub `skills check/update`.
+
+Record at least:
+- source repo URL;
+- pinned upstream SHA;
+- installed skills and destination paths;
+- source relative path for each skill;
+- port date;
+- install method (`copy` or `symlink`);
+- whether Hermes adaptations exist;
+- paths to upstream baselines such as `references/original-SKILL.md`.
+
+See `references/ports-ledger.md` for the schema and update rules. Use `templates/ports.yaml` as a starter when creating a new ledger.
+
+### 6. Compatibility pass
+For every installed skill:
+- Frontmatter must have `name` and `description`; repair minimal valid frontmatter if missing or malformed.
+- Flag external-agent-specific references the agent should mentally translate: tool names, project memory files, home-directory config paths, and agent dispatch concepts. Do not rewrite bodies unless the user asks; summarize the Hermes equivalents instead.
+- Note missing CLIs, credentials, MCP servers, OS-specific scripts, or paid external APIs so the user can decide.
+- Quote YAML metadata values that look like dates or typed scalars, especially generated fields such as `ported_at: "YYYY-MM-DD"`.
+
+### 7. Bootstrap / discipline wiring (if applicable)
+If the source plugin used a session-start hook to inject a meta-skill, Hermes has no hook equivalent. Offer one of:
+- **Topic/platform binding:** create a trimmed bootstrap skill containing only the load-bearing rules, then bind it to the intended Hermes platform/topic/profile after backing up config and showing a focused diff.
+- **Global persona note:** add a concise instruction to the agent persona asking it to check relevant installed skills before acting.
+- **Neither:** skills still trigger from their descriptions, just not mandatorily.
+
+### 8. Activate and verify
+- Installed skills take effect in new sessions. Tell the user to start a new session or otherwise invalidate prompt caching after installation.
+- Verify with `skill_view(<name>)` on representative installed skills, including one with multiline YAML frontmatter.
+- Verify the ledger entry exists and maps each installed skill back to repo + source path + pinned SHA.
+- Give the user one natural test phrase per installed skill that should trigger it.
+
+## Refresh mode
+
+Refresh is a separate mode for existing ports, not a mid-pipeline step for first-time installs.
+
+Use refresh mode when the source repository has moved and the user wants to pull upstream changes into already-adapted Hermes skills. The mode relies on `ports.yaml`: read the ledger, diff pinned SHA to new SHA, identify only installed skills whose source paths changed, then reconcile upstream edits into local Hermes adaptations without overwriting them.
+
+Read `references/refresh-mode.md` before doing refresh work.
+
+## Publishing this skill or a ported skill to GitHub
+
+- Prefer a real skill directory layout when a skill has support files:
+  ```text
+  skills/<skill-name>/SKILL.md
+  skills/<skill-name>/references/...
+  ```
+- Install full-directory skills with a GitHub identifier such as:
+  ```bash
+  hermes skills install owner/repo/skills/<skill-name>
+  ```
+- Raw `SKILL.md` URLs install only that one file and cannot bring support files. Do not split critical instructions into `references/` while advertising only a raw-file install path.
+- For public skill repositories, add CI safety gates before relying on the repo as an install source: repository-specific structure/frontmatter validation, Hermes `tools.skills_guard` scanning, secret scanning such as Gitleaks, GitHub CodeQL when scripts are present, and Dependabot for GitHub Actions updates. GitHub has useful code/secret/dependency scanners, but no Hermes-skill-specific native scanner; use Hermes' scanner in Actions for that layer.
+- Add a `SKILL.md` version-bump gate for public releases: with full tag history (`fetch-depth: 0`), compare the working-tree `SKILL.md` to the same file at the semver-highest release tag, and if content changed require the current `version:` to be greater than the tagged version. See `references/public-skill-release-gates.md`.
+- Keep public-facing repositories generic: remove deployment-specific paths, personal names, hostnames, private project names, chat-thread details, and private operational notes.
+- Before making a repo public, scan the working tree and reachable Git history for internal strings or credential patterns.
+- For public-repo privacy scrub CI, keep private denylist terms out of the repo, source them from CI secrets, print `Private scrub patterns loaded: N`, and redact private-match details. See `references/public-repo-privacy-scrub.md`.
+
+## Pitfalls
+
+- Do not trim the example trigger phrases or the skill-creator disambiguation from this skill's own description; they exist because this skill previously lost trigger matches to neighboring authoring skills.
+- Do not skip commit pinning because the source repo is "latest" or small. Without a SHA, refresh mode cannot distinguish upstream drift from local adaptation.
+- Do not refresh by copying upstream over the adapted Hermes skill. Diff pinned SHA to new SHA and reconcile changes into local adaptations.
+- Do not drop license/NOTICE files or original upstream `SKILL.md`; provenance is part of the install.
+- Do not let `ports.yaml` become optional paperwork. Manual-copy ports need it because hub update metadata is unavailable.
+- Do not use shell `~` as a proxy for Hermes home. `HOME`, `HERMES_HOME`, active profile home, and persisted volume paths may differ.
+- In containerized runtimes, confirm the resolved active-profile skills directory is on persistent storage before installing. A persistent source checkout does not protect copied skills if the install destination lives on an ephemeral image layer.
+- GitHub API rate limits and web `tree/` pages can break source acquisition. Authenticate repeated GitHub requests and clone/fetch repositories instead of scraping `tree/` URLs.
+- Do not enable optional shell-execution features just because a ported skill contains shell snippets; surface that to the user as a trust decision.
+- Never embed private scrub terms in a public validator; the denylist is itself a disclosure. Source them from CI secrets, print a loaded-pattern count so empty secrets are visible, and make failure output say only that a private pattern matched. See `references/public-repo-privacy-scrub.md`.
+- Do not allow public `SKILL.md` content to drift without a release bump. Compare against the semver-highest tag (not graph-nearest `git describe`), and if content changed require `current_version > tagged_version`; same-version edits and downgrades must fail. See `references/public-skill-release-gates.md`.
+- Do not split this skill's future critical workflow docs into support files unless the documented install path fetches a full skill directory.
+
+## Done means
+
+The user has: chosen skills installed under the resolved active-profile skills directory, source repo/relative path/pinned commit SHA recorded in each adapted skill and in `ports.yaml`, upstream license/NOTICE files preserved when present, unmodified upstream `SKILL.md` saved as `references/original-SKILL.md`, compatibility summary delivered, any bootstrap wiring applied with a config backup, and verified test triggers. For refresh work, done also means the ledger was used, only changed installed skills were reconciled, local Hermes adaptations were preserved, baselines were backed up, and pinned SHAs were updated only after verification.

--- a/optional-skills/migration/port-skill-collection/references/ports-ledger.md
+++ b/optional-skills/migration/port-skill-collection/references/ports-ledger.md
@@ -1,0 +1,68 @@
+# Port ledger (`ports.yaml`)
+
+Manual-copy ports do not get Hermes hub metadata, so maintain a `ports.yaml` ledger at the resolved active skills root:
+
+```text
+<active-skills-dir>/ports.yaml
+```
+
+The ledger is the single answer to: what was ported, from where, at which upstream SHA, which local skills are adapted, and what needs refresh review.
+
+## Minimal schema
+
+```yaml
+version: 1
+updated_at: "2026-06-10"
+ports:
+  - source_repo: "https://github.com/example/skills"
+    checkout_path: "$HERMES_HOME/external-skill-repos/example-skills"
+    pinned_sha: "0123456789abcdef0123456789abcdef01234567"
+    pinned_short_sha: "0123456"
+    installed_at: "2026-06-10"
+    install_method: copy
+    adaptations: true
+    skills:
+      - name: example-skill
+        category: productivity
+        source_path: "skills/example-skill"
+        installed_path: "productivity/example-skill"
+        original_skill_path: "productivity/example-skill/references/original-SKILL.md"
+        support_files:
+          - "productivity/example-skill/templates/example.txt"
+        notes: "Hermes frontmatter and tool-name adaptations applied."
+```
+
+## Field rules
+
+- `source_repo`: canonical upstream URL. Prefer the Git remote URL, not a web page copy if they differ.
+- `checkout_path`: persistent local checkout used for diffing. This may be omitted for a portable public example, but in an operational install it should exist.
+- `pinned_sha`: full upstream SHA used for provenance and exact diffs.
+- `pinned_short_sha`: short SHA for readable backup filenames.
+- `installed_at`: quoted date string; quote date-like YAML scalars.
+- `install_method`: `copy` or `symlink`.
+- `adaptations`: `true` when local Hermes changes exist and refresh must reconcile, not overwrite.
+- `skills[].source_path`: source-relative directory containing the upstream `SKILL.md`.
+- `skills[].installed_path`: path relative to the active skills root.
+- `skills[].original_skill_path`: path relative to the active skills root for the saved upstream baseline.
+- `skills[].support_files`: copied support files relative to the active skills root.
+
+## Update rules
+
+1. Create or update the ledger immediately after first install, before reporting done.
+2. Keep one `ports[]` entry per source repo + pinned SHA group. If the same repo is ported twice for separate subsets, merge entries when practical.
+3. On refresh, read the ledger first. The ledger controls which source paths are relevant.
+4. After successful refresh, update `pinned_sha`, `pinned_short_sha`, `updated_at`, and any touched skill notes.
+5. If refresh is incomplete or conflicts remain, leave the old pinned SHA in place and add a `refresh_blocked` note rather than pretending the port is current.
+
+## Staleness check pattern
+
+For each ledger entry:
+
+```bash
+git -C <checkout_path> fetch --all --prune
+old=<pinned_sha>
+new=$(git -C <checkout_path> rev-parse HEAD)
+git -C <checkout_path> diff --name-status "$old..$new" -- <source_path_1> <source_path_2>
+```
+
+If no recorded source paths changed, the installed port is current even if unrelated upstream skills moved.

--- a/optional-skills/migration/port-skill-collection/references/public-repo-privacy-scrub.md
+++ b/optional-skills/migration/port-skill-collection/references/public-repo-privacy-scrub.md
@@ -1,0 +1,66 @@
+# Public repository privacy scrub pattern
+
+Use this when publishing or maintaining a public skill repository with CI hygiene checks.
+
+## Problem
+
+A scrub validator can become the disclosure if it hardcodes private denylist terms directly in the public repo. Private names, deployment paths, project names, hosting providers, profile names, and platform identifiers are often exactly the strings the scan exists to suppress.
+
+## Pattern
+
+1. Keep only generic credential regexes in the public repository, such as token/key shapes.
+2. Load private scrub patterns from CI secrets, for example `PRIVATE_SCRUB_PATTERNS` as newline-separated regexes.
+3. Print the count of private patterns loaded so unset or fork-missing secrets are visible in CI logs:
+   ```text
+   Private scrub patterns loaded: N
+   ```
+4. Never print the private regex value on failure. Report only a redacted marker:
+   ```text
+   path/to/file matched private scrub pattern [redacted]
+   ```
+5. Once private patterns are externalized, scan all tracked files (`git ls-files`) rather than only README/license/skill directories. Include `scripts/` and `.github/` so validators and workflows are covered too.
+6. For public repos where private terms already reached history, use `git filter-repo` or BFG to rewrite reachable refs and retag affected releases. Treat this as harm reduction, not guaranteed erasure from platform caches.
+7. Verify after rewrite by cloning/fetching the remote and scanning all heads/tags for the private terms.
+
+## GitHub Actions shape
+
+```yaml
+- name: Run package validator and Hermes skill scanner
+  env:
+    HERMES_AGENT_SOURCE: ${{ github.workspace }}/.ci/hermes-agent
+    PRIVATE_SCRUB_PATTERNS: ${{ secrets.PRIVATE_SCRUB_PATTERNS }}
+  run: python scripts/validate_skill_repo.py
+```
+
+## Validator sketch
+
+```python
+GENERIC_FORBIDDEN_PUBLIC_PATTERNS = [
+    r"ghp_[A-Za-z0-9_]+",
+    r"sk-[A-Za-z0-9_-]{12,}",
+    r"AKIA[0-9A-Z]{16}",
+]
+
+PRIVATE_SCRUB_PATTERNS_ENV = "PRIVATE_SCRUB_PATTERNS"
+
+
+def load_private_scrub_patterns(env: Mapping[str, str]) -> list[str]:
+    raw = env.get(PRIVATE_SCRUB_PATTERNS_ENV, "")
+    return [line.strip() for line in raw.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+
+
+def scan_public_strings() -> None:
+    private_patterns = load_private_scrub_patterns()
+    print(f"Private scrub patterns loaded: {len(private_patterns)}")
+    pattern_sources = [(p, "generic") for p in GENERIC_FORBIDDEN_PUBLIC_PATTERNS]
+    pattern_sources.extend((p, "private") for p in private_patterns)
+    # scan tracked files from `git ls-files`
+    # for private matches, print only: private scrub pattern [redacted]
+```
+
+## Done means
+
+- CI shows a nonzero private-pattern count for the canonical repo when expected.
+- Empty-secret/fork behavior is visible as `Private scrub patterns loaded: 0`, not silent.
+- Private match failures do not echo private terms.
+- The public working tree and reachable remote heads/tags are scanned after any rewrite.

--- a/optional-skills/migration/port-skill-collection/references/public-skill-release-gates.md
+++ b/optional-skills/migration/port-skill-collection/references/public-skill-release-gates.md
@@ -1,0 +1,63 @@
+# Public skill release gates
+
+Use this when maintaining a public skill repository, especially one with a directory-based skill package and tagged releases.
+
+## Clean install gate
+
+Before tagging a release, run the exact advertised install command against a clean Hermes home and verify support files load through `skill_view`.
+
+Expected checks:
+
+- the install command uses the full skill directory identifier, not a raw `SKILL.md` URL;
+- installed files include `LICENSE`, `SKILL.md`, and required `references/`, `templates/`, `scripts/`, or `assets/` files;
+- `skill_view(<name>)` loads the main skill;
+- `skill_view(<name>, file_path=...)` loads every required support file;
+- the parsed frontmatter has populated `name`, `description`, tags/category, and the intended `version`.
+
+## SKILL.md version-bump gate
+
+A public skill repo should make unversioned `SKILL.md` drift unrepresentable in CI.
+
+Validator pattern:
+
+1. Ensure the validator checkout has full tag history:
+   ```yaml
+   - uses: actions/checkout@v6
+     with:
+       fetch-depth: 0
+   ```
+2. Select the semver-highest release tag, not the graph-nearest tag. `git describe --tags --abbrev=0` is graph-nearest and can compare against a stale baseline on release branches.
+3. Load the tagged baseline with:
+   ```bash
+   git show <tag>:skills/<skill-name>/SKILL.md
+   ```
+4. If working-tree `SKILL.md` content is unchanged from that tag, pass.
+5. If content changed, parse both `version:` values as semver tuples and require `current > tagged`.
+6. If `current <= tagged`, fail with exactly:
+   ```text
+   SKILL.md changed without a version bump.
+   ```
+
+This catches both same-version edits and typo downgrades such as `2.2.4 -> 2.2.3`.
+
+## Synthetic validator tests
+
+Before committing the gate, verify all three cases locally:
+
+- unchanged `SKILL.md`: pass;
+- changed content with the same version: fail with `SKILL.md changed without a version bump.`;
+- changed content with a lower version: fail with the same message;
+- changed content with a higher version: pass and report the version transition.
+
+## Tagging policy
+
+After release-worthy changes:
+
+1. validate locally;
+2. commit;
+3. tag the exact commit with the new version;
+4. push `main` and the tag;
+5. wait for CI;
+6. inspect CI logs for the version-bump gate and any privacy-scrub visibility counts.
+
+Do not claim release readiness from git cleanliness or a previous CI run; use fresh CI evidence on the release commit.

--- a/optional-skills/migration/port-skill-collection/references/refresh-mode.md
+++ b/optional-skills/migration/port-skill-collection/references/refresh-mode.md
@@ -1,0 +1,111 @@
+# Refresh mode
+
+Refresh mode updates existing manually ported skills from upstream without destroying local Hermes adaptations.
+
+Use this only after a first-time port exists and `ports.yaml` has entries for the installed skills.
+
+## Workflow
+
+### 1. Read the ledger first
+
+Open `<active-skills-dir>/ports.yaml` and identify:
+
+- source repo;
+- persistent checkout path;
+- pinned SHA;
+- installed skills;
+- source path for each installed skill;
+- whether adaptations are present;
+- saved upstream baseline path for each skill.
+
+If the ledger is missing, stop and reconstruct it from installed skill provenance, saved upstream baselines, Git history, or user input before changing files.
+
+### 2. Fetch and diff SHA-to-SHA
+
+Keep the source checkout clean, then fetch and compare the ledger's pinned SHA to the requested new SHA or current HEAD:
+
+```bash
+git -C <repo> status --short
+git -C <repo> fetch --all --prune
+old=<pinned-sha>
+new=$(git -C <repo> rev-parse HEAD)
+git -C <repo> diff --name-status "$old..$new"
+```
+
+Then narrow the diff to only source paths recorded in the ledger:
+
+```bash
+git -C <repo> diff --name-status "$old..$new" -- <source-relative-path-1> <source-relative-path-2>
+```
+
+### 3. Identify touched installed skills
+
+Only refresh installed skills whose recorded source path changed, or whose copied support files changed upstream.
+
+Report unrelated upstream changes as out of scope. Do not run compatibility work on skills that are not installed.
+
+### 4. Three-way reconcile, never clobber
+
+For each touched installed skill, compare three versions:
+
+1. previous upstream baseline: `references/original-SKILL.md` or file content at the pinned SHA;
+2. new upstream file at the new SHA;
+3. current adapted Hermes `SKILL.md`.
+
+Apply upstream content changes into the adapted Hermes file. Do not replace the adapted file wholesale with upstream. Preserve Hermes frontmatter, trigger wording, local compatibility notes, support-file paths, and any user-specific adaptations that belong in the local install.
+
+### 5. Preserve baselines with short SHA filenames
+
+Before updating `references/original-SKILL.md`, back up the old baseline using a short SHA filename:
+
+```bash
+short=$(git -C <repo> rev-parse --short <pinned-sha>)
+cp references/original-SKILL.md "references/original-SKILL.${short}.md"
+```
+
+Then write the new unmodified upstream `SKILL.md` to `references/original-SKILL.md` for the next refresh cycle.
+
+### 6. Refresh support files deliberately
+
+For scripts, templates, references, and assets copied from upstream:
+
+- diff each changed file;
+- update files that are still upstream-owned;
+- preserve local-only files;
+- leave conflict notes for locally modified support files;
+- do not delete local files just because upstream removed or rearranged them without telling the user.
+
+### 7. Run compatibility only on touched skills
+
+For changed installed skills, re-check:
+
+- frontmatter parseability;
+- required `name` and `description`;
+- quoted YAML date/timestamp-like scalars;
+- external-agent-specific wording that needs Hermes translation;
+- missing CLIs, credentials, MCP servers, OS-specific scripts, or paid external APIs;
+- support-file links and paths.
+
+### 8. Update ledger only after verification
+
+After the adapted skill parses and verification passes:
+
+- update `pinned_sha` and `pinned_short_sha` in `ports.yaml`;
+- update `updated_at`;
+- update notes for touched skills;
+- record conflicts or skipped files if any.
+
+If reconciliation is incomplete, leave the old pinned SHA in place and add a `refresh_blocked` note.
+
+## Refresh done means
+
+- ledger read first;
+- upstream diff reviewed from pinned SHA to new SHA;
+- changed installed skills identified;
+- unrelated source changes ignored;
+- local Hermes adaptations preserved;
+- old upstream baseline backed up using a short SHA filename;
+- new upstream baseline saved;
+- compatibility pass rerun only for touched skills;
+- `ports.yaml` updated only after successful verification;
+- concise change/conflict summary delivered.

--- a/optional-skills/migration/port-skill-collection/templates/ports.yaml
+++ b/optional-skills/migration/port-skill-collection/templates/ports.yaml
@@ -1,0 +1,18 @@
+version: 1
+updated_at: "YYYY-MM-DD"
+ports:
+  - source_repo: "https://github.com/example/skills"
+    checkout_path: "$HERMES_HOME/external-skill-repos/example-skills"
+    pinned_sha: "0123456789abcdef0123456789abcdef01234567"
+    pinned_short_sha: "0123456"
+    installed_at: "YYYY-MM-DD"
+    install_method: copy
+    adaptations: true
+    skills:
+      - name: example-skill
+        category: productivity
+        source_path: "skills/example-skill"
+        installed_path: "productivity/example-skill"
+        original_skill_path: "productivity/example-skill/references/original-SKILL.md"
+        support_files: []
+        notes: "Describe Hermes adaptations or leave empty."


### PR DESCRIPTION
## Summary
- Adds `port-skill-collection` as an optional migration skill under `optional-skills/migration/`.
- Includes support references for port ledgers, refresh mode, public repo privacy scrub, and public skill release gates.
- Includes the MIT license and `templates/ports.yaml` starter ledger.

## Validation
- Parsed SKILL.md frontmatter and verified version `2.2.5` plus required support files.
- Ran Hermes `tools.skills_guard` against the optional skill: SAFE / allowed.
- Scanned the submitted skill directory for internal deployment terms: no matches.
- Source distribution repo validation passed at v2.2.5; Skill Safety and CodeQL are green on `vcolombo/port-skill-collection`.
