### PR TITLE
feat(gateway): per-channel working directories (channel_cwds)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -503,6 +503,7 @@ def init_agent(
     chat_type: str = None,
     thread_id: str = None,
     gateway_session_key: str = None,
+    session_cwd: str = None,
     skip_context_files: bool = False,
     load_soul_identity: bool = False,
     skip_memory: bool = False,
@@ -588,6 +589,9 @@ def init_agent(
     agent._chat_type = chat_type
     agent._thread_id = thread_id
     agent._gateway_session_key = gateway_session_key  # Stable per-chat key (e.g. agent:main:telegram:dm:123)
+    # Explicit logical working directory for the session row (e.g. a
+    # per-channel channel_cwds entry).  None = use the launch-dir heuristic.
+    agent._session_cwd = (session_cwd or "").strip() or None
     # Pluggable print function — CLI replaces this with _cprint so that
     # raw ANSI status lines are routed through prompt_toolkit's renderer
     # instead of going directly to stdout where patch_stdout's StdoutProxy

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1590,6 +1590,12 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "channel_cwds" in platform_cfg:
+                    channel_cwds = platform_cfg["channel_cwds"]
+                    if isinstance(channel_cwds, dict):
+                        bridged["channel_cwds"] = {str(k): v for k, v in channel_cwds.items()}
+                    else:
+                        bridged["channel_cwds"] = channel_cwds
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 if "typing_indicator" in platform_cfg:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2104,6 +2104,12 @@ class MessageEvent:
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
 
+    # Per-channel working directory (e.g. Discord channel_cwds).  Pins the
+    # session's logical cwd so context files (AGENTS.md / HERMES.md /
+    # .cursorrules) and the terminal sandbox resolve against the channel's
+    # project folder instead of the gateway launch directory.
+    channel_cwd: Optional[str] = None
+
     # Channel context recovered by history backfill (e.g. messages between
     # bot turns that were missed due to require_mention).  Kept separate
     # from ``text`` so the sender-prefix logic in run.py can operate on the
@@ -2549,6 +2555,45 @@ def resolve_channel_prompt(
         prompt = str(prompt).strip()
         if prompt:
             return prompt
+    return None
+
+
+def resolve_channel_cwd(
+    config_extra: dict,
+    channel_id: str,
+    parent_id: str | None = None,
+) -> str | None:
+    """Resolve a per-channel working directory from platform config.
+
+    Looks up ``channel_cwds`` in the adapter's ``config.extra`` dict.
+    Prefers an exact match on *channel_id*; falls back to *parent_id*
+    (useful for forum threads / child channels inheriting a parent cwd).
+
+    Returns the expanded absolute path, or None if no match is found.
+    A configured path that is not an existing directory is ignored with a
+    warning so a typo in config.yaml is visible instead of silently skipped.
+    """
+    cwds = config_extra.get("channel_cwds") or {}
+    if not isinstance(cwds, dict):
+        return None
+
+    for key in (channel_id, parent_id):
+        if not key:
+            continue
+        raw = cwds.get(key)
+        if raw is None:
+            continue
+        raw = str(raw).strip()
+        if not raw:
+            continue
+        resolved = os.path.abspath(os.path.expanduser(raw))
+        if not os.path.isdir(resolved):
+            logger.warning(
+                "channel_cwds: working directory configured for channel %s "
+                "does not exist, ignoring: %s", key, raw,
+            )
+            continue
+        return resolved
     return None
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4237,6 +4237,20 @@ class TurnRunner:
 
         turn_route = self._runner._resolve_turn_agent_config(ctx.message, model, runtime_kwargs)
 
+        # Per-channel working directory: start this session's terminal
+        # sandbox in the configured folder.  The _SESSION_CWD contextvar
+        # (set in _set_session_env) already covers context files and the
+        # system prompt; this covers the shell.  Registering again on a
+        # later turn is a no-op unless the config changed, in which case
+        # the live env is updated in place (same as the ACP/dashboard
+        # surfaces — see register_task_env_overrides).
+        if ctx.channel_cwd and ctx.session_id:
+            try:
+                from tools.terminal_tool import register_task_env_overrides
+                register_task_env_overrides(ctx.session_id, {"cwd": ctx.channel_cwd})
+            except Exception:
+                logger.debug("Failed to register channel cwd override", exc_info=True)
+
         # Check agent cache — reuse the AIAgent from the previous message
         # in this session to preserve the frozen system prompt and tool
         # schemas for prompt cache hits.
@@ -4483,7 +4497,8 @@ class TurnRunner:
                 session_db=getattr(self._runner._session_db, "_db", self._runner._session_db),
                 # Reload from disk — do not reuse the startup snapshot (#60955).
                 fallback_model=self._runner._refresh_fallback_model(),
-            )
+                session_cwd=ctx.channel_cwd,
+                )
             if _cache_lock and _cache is not None:
                 with _cache_lock:
                     # Record the session_id the snapshot was taken for
@@ -15640,7 +15655,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # Set session context variables for tools (task-local, concurrency-safe)
         _session_env_tokens = self._set_session_env(context)
-        
+
+        # Pin the per-channel working directory (channel_cwds) for this
+        # message's context so context files (AGENTS.md / HERMES.md) and the
+        # system prompt resolve against the channel's project folder.
+        # set_session_vars above already initialised the cwd contextvar to "";
+        # this override is cleared with the rest in _clear_session_env.
+        _event_channel_cwd = getattr(event, "channel_cwd", None)
+        if _event_channel_cwd:
+            try:
+                from agent.runtime_cwd import set_session_cwd
+                set_session_cwd(_event_channel_cwd)
+            except Exception:
+                logger.debug("Failed to pin channel cwd contextvar", exc_info=True)
+
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
         persist_user_message = None
@@ -16664,6 +16692,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
+                channel_cwd=getattr(event, "channel_cwd", None),
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
@@ -22973,6 +23002,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        channel_cwd: Optional[str] = None,
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
@@ -22992,7 +23022,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message, context_prompt, history, source, session_id,
                 session_key=session_key, run_generation=run_generation,
                 _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
-                channel_prompt=channel_prompt, moa_config=moa_config,
+                channel_prompt=channel_prompt, channel_cwd=channel_cwd,
+                moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=message_type,
@@ -23004,7 +23035,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message, context_prompt, history, source, session_id,
                 session_key=session_key, run_generation=run_generation,
                 _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
-                channel_prompt=channel_prompt, moa_config=moa_config,
+                channel_prompt=channel_prompt, channel_cwd=channel_cwd,
+                moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=message_type,
@@ -23126,6 +23158,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        channel_cwd: Optional[str] = None,
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
@@ -23406,6 +23439,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             history=history,
             context_prompt=context_prompt,
             channel_prompt=channel_prompt,
+            channel_cwd=channel_cwd,
             session_id=session_id,
             session_key=session_key,
             run_generation=run_generation,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2587,6 +2587,7 @@ class GatewaySlashCommandsMixin:
             source=source,
             raw_message=event.raw_message,
             channel_prompt=event.channel_prompt,
+            channel_cwd=event.channel_cwd,
         )
         
         # Let the normal message handler process it

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -81,6 +81,7 @@ class TurnContext:
     history: Any = None
     context_prompt: Optional[str] = None
     channel_prompt: Optional[str] = None
+    channel_cwd: Optional[str] = None
     session_id: Optional[str] = None
     session_key: Optional[str] = None
     run_generation: Optional[int] = None

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1794,6 +1794,7 @@ DEFAULT_CONFIG = {
         # If True, require @mention in Slack thread replies too.
         "thread_require_mention": False,
         "channel_prompts": {},         # Per-channel ephemeral system prompts
+        "channel_cwds": {},            # Per-channel working directories
     },
 
     # Discord platform settings (gateway mode)
@@ -1823,6 +1824,7 @@ DEFAULT_CONFIG = {
         "websocket_heartbeat_ack_max_age_seconds": 60,
         "websocket_max_latency_seconds": 30,
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
+        "channel_cwds": {},            # Per-channel working directories (forum parents apply to child threads)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES
         # authorizes only guild messages in the role's own guild — DMs require
         # DISCORD_ALLOWED_USERS. Set dm_role_auth_guild to a guild ID to also
@@ -1896,6 +1898,7 @@ DEFAULT_CONFIG = {
     "telegram": {
         "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
+        "channel_cwds": {},            # Per-chat/topic working directories (topics inherit from parent group)
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
         "extra": {
             "rich_messages": False,     # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
@@ -1909,6 +1912,7 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "channel_prompts": {},         # Per-channel ephemeral system prompts
+        "channel_cwds": {},            # Per-channel working directories
     },
 
     # Matrix platform settings (gateway mode)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5854,6 +5854,7 @@ class DiscordAdapter(BasePlatformAdapter):
             source=source,
             raw_message=interaction,
             channel_prompt=self._resolve_channel_prompt(channel_id, parent_id or None),
+            channel_cwd=self._resolve_channel_cwd(channel_id, parent_id or None),
         )
 
     # ------------------------------------------------------------------
@@ -5943,6 +5944,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _parent_id = str(getattr(_parent_channel, "id", "") or "")
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(thread_id, _parent_id or None)
+        _channel_cwd = self._resolve_channel_cwd(thread_id, _parent_id or None)
         event = MessageEvent(
             text=text,
             message_type=MessageType.TEXT,
@@ -5950,6 +5952,7 @@ class DiscordAdapter(BasePlatformAdapter):
             raw_message=interaction,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            channel_cwd=_channel_cwd,
         )
         await self.handle_message(event)
 
@@ -5969,6 +5972,11 @@ class DiscordAdapter(BasePlatformAdapter):
         """Resolve a Discord per-channel prompt, preferring the exact channel over its parent."""
         from gateway.platforms.base import resolve_channel_prompt
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
+
+    def _resolve_channel_cwd(self, channel_id: str, parent_id: str | None = None) -> str | None:
+        """Resolve a Discord per-channel working directory, preferring the exact channel over its parent."""
+        from gateway.platforms.base import resolve_channel_cwd
+        return resolve_channel_cwd(self.config.extra, channel_id, parent_id)
 
     def _discord_require_mention(self) -> bool:
         """Return whether Discord channel messages require a bot mention."""
@@ -7846,6 +7854,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _chan_id = str(getattr(_chan, "id", ""))
         _skills = self._resolve_channel_skills(_chan_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(_chan_id, _parent_id or None)
+        _channel_cwd = self._resolve_channel_cwd(_chan_id, _parent_id or None)
 
         reply_to_id = None
         reply_to_text = None
@@ -7867,6 +7876,7 @@ class DiscordAdapter(BasePlatformAdapter):
             timestamp=message.created_at,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            channel_cwd=_channel_cwd,
             channel_context=_channel_context,
         )
 

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -958,9 +958,12 @@ class MattermostAdapter(BasePlatformAdapter):
             message_id=post_id,
         )
 
-        # Per-channel ephemeral prompt
-        from gateway.platforms.base import resolve_channel_prompt
+        # Per-channel ephemeral prompt + working directory
+        from gateway.platforms.base import resolve_channel_cwd, resolve_channel_prompt
         _channel_prompt = resolve_channel_prompt(
+            self.config.extra, channel_id, None,
+        )
+        _channel_cwd = resolve_channel_cwd(
             self.config.extra, channel_id, None,
         )
 
@@ -973,6 +976,7 @@ class MattermostAdapter(BasePlatformAdapter):
             media_urls=media_urls if media_urls else None,
             media_types=media_types if media_types else None,
             channel_prompt=_channel_prompt,
+            channel_cwd=_channel_cwd,
         )
 
         await self.handle_message(msg_event)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6215,6 +6215,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         # Per-channel ephemeral prompt
         from gateway.platforms.base import (
+            resolve_channel_cwd,
             resolve_channel_prompt,
             resolve_channel_skills,
         )
@@ -6235,6 +6236,11 @@ class SlackAdapter(BasePlatformAdapter):
                 if _channel_prompt
                 else _identity_prompt
             )
+        _channel_cwd = resolve_channel_cwd(
+            self.config.extra,
+            channel_id,
+            None,
+        )
         _auto_skill = resolve_channel_skills(
             self.config.extra,
             channel_id,
@@ -6286,6 +6292,7 @@ class SlackAdapter(BasePlatformAdapter):
             reply_to_message_id=thread_ts if thread_ts != ts else None,
             channel_prompt=_channel_prompt,
             channel_context=channel_context,
+            channel_cwd=_channel_cwd,
             reply_to_text=reply_to_text,
             auto_skill=_auto_skill,
             metadata={

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9680,10 +9680,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     except Exception:
                         reply_to_text = None
 
-        # Per-channel/topic ephemeral prompt
-        from gateway.platforms.base import resolve_channel_prompt
+        # Per-channel/topic ephemeral prompt + working directory
+        from gateway.platforms.base import resolve_channel_cwd, resolve_channel_prompt
         _chat_id_str = str(chat.id)
         _channel_prompt = resolve_channel_prompt(
+            self.config.extra,
+            thread_id_str or _chat_id_str,
+            _chat_id_str if thread_id_str else None,
+        )
+        _channel_cwd = resolve_channel_cwd(
             self.config.extra,
             thread_id_str or _chat_id_str,
             _chat_id_str if thread_id_str else None,
@@ -9700,6 +9705,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
+            channel_cwd=_channel_cwd,
             timestamp=message.date,
         )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -489,6 +489,7 @@ class AIAgent:
         chat_type: str = None,
         thread_id: str = None,
         gateway_session_key: str = None,
+        session_cwd: str = None,
         skip_context_files: bool = False,
         load_soul_identity: bool = False,
         skip_memory: bool = False,
@@ -573,6 +574,7 @@ class AIAgent:
             chat_type=chat_type,
             thread_id=thread_id,
             gateway_session_key=gateway_session_key,
+            session_cwd=session_cwd,
             skip_context_files=skip_context_files,
             load_soul_identity=load_soul_identity,
             skip_memory=skip_memory,
@@ -636,7 +638,10 @@ class AIAgent:
                 system_prompt=self._cached_system_prompt,
                 user_id=None,
                 parent_session_id=self._parent_session_id,
-                cwd=_launch_cwd_for_session(source),
+                # An explicit session cwd (e.g. a per-channel channel_cwds
+                # entry resolved by the gateway) wins over the launch-dir
+                # heuristic, which records nothing for gateway sessions.
+                cwd=getattr(self, "_session_cwd", None) or _launch_cwd_for_session(source),
                 profile_name=_profile_for_session,
             )
             self._session_db_created = True

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -7,11 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from agent.secret_scope import (
-    reset_secret_scope,
-    set_multiplex_active,
-    set_secret_scope,
-)
+from agent.secret_scope import reset_secret_scope, set_secret_scope
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from gateway.config import (
     ChannelOverride,
@@ -23,27 +19,18 @@ from gateway.config import (
     StreamingConfig,
     _apply_env_overrides,
     load_gateway_config,
-    persist_home_channel,
 )
 
 
 class TestHomeChannelRoundtrip:
     def test_to_dict_from_dict(self):
-        hc = HomeChannel(
-            platform=Platform.DISCORD,
-            chat_id="999",
-            name="general",
-            user_id="user-123",
-            scope_id="guild-456",
-        )
+        hc = HomeChannel(platform=Platform.DISCORD, chat_id="999", name="general")
         d = hc.to_dict()
         restored = HomeChannel.from_dict(d)
 
         assert restored.platform == Platform.DISCORD
         assert restored.chat_id == "999"
         assert restored.name == "general"
-        assert restored.user_id == "user-123"
-        assert restored.scope_id == "guild-456"
 
 
 class TestPlatformConfigRoundtrip:
@@ -77,12 +64,46 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"enabled": "false"})
         assert restored.enabled is False
 
+    def test_gateway_restart_notification_defaults_true(self):
+        assert PlatformConfig().gateway_restart_notification is True
+        assert PlatformConfig.from_dict({}).gateway_restart_notification is True
 
     def test_gateway_restart_notification_roundtrip_false(self):
         pc = PlatformConfig(enabled=True, gateway_restart_notification=False)
         restored = PlatformConfig.from_dict(pc.to_dict())
         assert restored.gateway_restart_notification is False
 
+    def test_gateway_restart_notification_coerces_quoted_false(self):
+        restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
+        assert restored.gateway_restart_notification is False
+
+    def test_typing_indicator_defaults_true(self):
+        assert PlatformConfig().typing_indicator is True
+        assert PlatformConfig.from_dict({}).typing_indicator is True
+
+    def test_typing_indicator_roundtrip_false(self):
+        pc = PlatformConfig(enabled=True, typing_indicator=False)
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.typing_indicator is False
+
+    def test_typing_indicator_coerces_quoted_false(self):
+        restored = PlatformConfig.from_dict({"typing_indicator": "false"})
+        assert restored.typing_indicator is False
+
+    def test_typing_indicator_resolved_from_extra(self):
+        # The shared-key loop in load_gateway_config bridges the flag into
+        # extra; from_dict must honor it there too (mirrors _grn fallback).
+        restored = PlatformConfig.from_dict({"extra": {"typing_indicator": False}})
+        assert restored.typing_indicator is False
+
+    def test_typing_status_text_defaults_none(self):
+        assert PlatformConfig().typing_status_text is None
+        assert PlatformConfig.from_dict({}).typing_status_text is None
+
+    def test_typing_status_text_roundtrip(self):
+        pc = PlatformConfig(enabled=True, typing_status_text="is pouncing… 🐾")
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.typing_status_text == "is pouncing… 🐾"
 
     def test_typing_status_text_resolved_from_extra(self):
         # Same bridge route as typing_indicator: the shared-key loop copies a
@@ -92,6 +113,9 @@ class TestPlatformConfigRoundtrip:
         )
         assert restored.typing_status_text == "chasing yarn…"
 
+    def test_typing_status_text_omitted_from_to_dict_when_unset(self):
+        # None must not serialize — keeps existing config files byte-stable.
+        assert "typing_status_text" not in PlatformConfig().to_dict()
 
     def test_channel_overrides_roundtrip(self):
         pc = PlatformConfig(
@@ -117,11 +141,30 @@ class TestPlatformConfigRoundtrip:
         assert restored.channel_overrides["1234567890"].model == "openrouter/healer-alpha"
         assert restored.channel_overrides["9876543210"].provider == "anthropic"
 
+    def test_channel_overrides_from_dict_normalizes_channel_id_to_str(self):
+        """YAML may have numeric channel IDs; we store as str."""
+        data = {
+            "enabled": True,
+            "channel_overrides": {
+                1234567890: {"model": "openrouter/healer-alpha"},
+            },
+        }
+        pc = PlatformConfig.from_dict(data)
+        assert "1234567890" in pc.channel_overrides
+        assert pc.channel_overrides["1234567890"].model == "openrouter/healer-alpha"
+
 
 class TestChannelOverride:
     def test_from_dict_empty(self):
         assert ChannelOverride.from_dict({}).model is None
         assert ChannelOverride.from_dict(None).model is None
+
+    def test_to_dict_omits_none(self):
+        ov = ChannelOverride(model="gpt-4", provider=None, system_prompt="Hi")
+        d = ov.to_dict()
+        assert d["model"] == "gpt-4"
+        assert "provider" not in d
+        assert d["system_prompt"] == "Hi"
 
 
 class TestPlatformConfigMalformedSections:
@@ -153,6 +196,20 @@ class TestGetConnectedPlatforms:
         assert Platform.DISCORD not in connected
         assert Platform.SLACK not in connected
 
+    def test_empty_platforms(self):
+        config = GatewayConfig()
+        assert config.get_connected_platforms() == []
+
+    def test_dingtalk_recognised_via_extras(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DINGTALK: PlatformConfig(
+                    enabled=True,
+                    extra={"client_id": "cid", "client_secret": "sec"},
+                ),
+            },
+        )
+        assert Platform.DINGTALK in config.get_connected_platforms()
 
     def test_dingtalk_recognised_via_env_vars(self, monkeypatch):
         """DingTalk configured via env vars (no extras) should still be
@@ -167,6 +224,27 @@ class TestGetConnectedPlatforms:
         )
         assert Platform.DINGTALK in config.get_connected_platforms()
 
+    def test_dingtalk_missing_creds_not_connected(self, monkeypatch):
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+        config = GatewayConfig(
+            platforms={
+                Platform.DINGTALK: PlatformConfig(enabled=True, extra={}),
+            },
+        )
+        assert Platform.DINGTALK not in config.get_connected_platforms()
+
+    def test_dingtalk_disabled_not_connected(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DINGTALK: PlatformConfig(
+                    enabled=False,
+                    extra={"client_id": "cid", "client_secret": "sec"},
+                ),
+            },
+        )
+        assert Platform.DINGTALK not in config.get_connected_platforms()
+
 
 class TestSessionResetPolicy:
     def test_roundtrip(self):
@@ -179,6 +257,12 @@ class TestSessionResetPolicy:
         assert restored.idle_minutes == 120
         assert restored.bg_process_max_age_hours == 48
 
+    def test_defaults(self):
+        policy = SessionResetPolicy()
+        assert policy.mode == "none"
+        assert policy.at_hour == 4
+        assert policy.idle_minutes == 1440
+        assert policy.bg_process_max_age_hours == 24
 
     def test_from_dict_treats_null_values_as_defaults(self):
         restored = SessionResetPolicy.from_dict(
@@ -190,9 +274,28 @@ class TestSessionResetPolicy:
         assert restored.idle_minutes == 1440
         assert restored.bg_process_max_age_hours == 24
 
+    def test_from_dict_coerces_quoted_false_notify(self):
+        restored = SessionResetPolicy.from_dict({"notify": "false"})
+        assert restored.notify is False
+
+    def test_from_dict_malformed_section_falls_back_to_defaults(self):
+        restored = SessionResetPolicy.from_dict("oops")
+        assert restored.mode == SessionResetPolicy().mode
+        assert restored.at_hour == 4
+        assert restored.idle_minutes == 1440
+
 
 class TestStreamingConfig:
+    def test_defaults_to_auto_transport(self):
+        # "auto" prefers native draft streaming where the platform supports
+        # it (Telegram DMs) and falls back to edit-based everywhere else, so
+        # it is safe as the global out-of-the-box default.
+        restored = StreamingConfig.from_dict({"enabled": "true"})
+        assert restored.transport == "auto"
 
+    def test_from_dict_coerces_quoted_false_enabled(self):
+        restored = StreamingConfig.from_dict({"enabled": "false"})
+        assert restored.enabled is False
 
     def test_from_dict_malformed_numeric_values_fall_back_to_defaults(self):
         restored = StreamingConfig.from_dict(
@@ -206,8 +309,38 @@ class TestStreamingConfig:
         assert restored.buffer_threshold == 24
         assert restored.fresh_final_after_seconds == 0.0
 
+    def test_from_dict_malformed_section_falls_back_to_defaults(self):
+        restored = StreamingConfig.from_dict("enabled")
+        assert restored.enabled is False
+        assert restored.transport == "auto"
+
 
 class TestGatewayConfigRoundtrip:
+    def test_full_roundtrip(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    token="tok_123",
+                    home_channel=HomeChannel(Platform.TELEGRAM, "123", "Home"),
+                ),
+            },
+            reset_triggers=["/new"],
+            quick_commands={"limits": {"type": "exec", "command": "echo ok"}},
+            group_sessions_per_user=False,
+            thread_sessions_per_user=True,
+            systemd_watchdog_seconds=120,
+        )
+        d = config.to_dict()
+        restored = GatewayConfig.from_dict(d)
+
+        assert Platform.TELEGRAM in restored.platforms
+        assert restored.platforms[Platform.TELEGRAM].token == "tok_123"
+        assert restored.reset_triggers == ["/new"]
+        assert restored.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
+        assert restored.group_sessions_per_user is False
+        assert restored.thread_sessions_per_user is True
+        assert restored.systemd_watchdog_seconds == 120
 
     def test_systemd_watchdog_from_dict_disables_invalid_values(self):
         invalid_values = [
@@ -228,6 +361,23 @@ class TestGatewayConfigRoundtrip:
             config = GatewayConfig.from_dict({"systemd_watchdog_seconds": raw})
             assert config.systemd_watchdog_seconds == 0
 
+    def test_systemd_watchdog_from_dict_accepts_nested_positive_integer(self):
+        config = GatewayConfig.from_dict(
+            {"gateway": {"systemd_watchdog_seconds": "45"}}
+        )
+
+        assert config.systemd_watchdog_seconds == 45
+
+    def test_max_concurrent_sessions_from_dict_normalizes_disabled_values(self):
+        assert GatewayConfig.from_dict({}).max_concurrent_sessions is None
+        assert GatewayConfig.from_dict({"max_concurrent_sessions": None}).max_concurrent_sessions is None
+        assert GatewayConfig.from_dict({"max_concurrent_sessions": 0}).max_concurrent_sessions is None
+        assert GatewayConfig.from_dict({"max_concurrent_sessions": -1}).max_concurrent_sessions is None
+
+    def test_max_concurrent_sessions_from_dict_accepts_positive_integer(self):
+        config = GatewayConfig.from_dict({"max_concurrent_sessions": "3"})
+
+        assert config.max_concurrent_sessions == 3
 
     def test_max_concurrent_sessions_from_dict_ignores_invalid_values(self, caplog):
         caplog.set_level(logging.WARNING, logger="gateway.config")
@@ -240,6 +390,20 @@ class TestGatewayConfigRoundtrip:
             for record in caplog.records
         )
 
+    def test_max_concurrent_sessions_from_dict_accepts_nested_fallback(self):
+        config = GatewayConfig.from_dict({"gateway": {"max_concurrent_sessions": 4}})
+
+        assert config.max_concurrent_sessions == 4
+
+    def test_max_concurrent_sessions_top_level_overrides_nested(self):
+        config = GatewayConfig.from_dict(
+            {
+                "gateway": {"max_concurrent_sessions": 4},
+                "max_concurrent_sessions": 2,
+            }
+        )
+
+        assert config.max_concurrent_sessions == 2
 
     def test_roundtrip_preserves_unauthorized_dm_behavior(self):
         config = GatewayConfig(
@@ -275,6 +439,51 @@ class TestGatewayConfigRoundtrip:
         )
 
         assert config.get_unauthorized_dm_behavior(Platform.EMAIL) == "pair"
+
+    def test_from_dict_coerces_quoted_false_always_log_local(self):
+        restored = GatewayConfig.from_dict({"always_log_local": "false"})
+        assert restored.always_log_local is False
+
+    def test_from_dict_ignores_malformed_nested_sections(self):
+        restored = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "telegram": "enabled",
+                    "discord": {"enabled": True, "token": "tok"},
+                },
+                "default_reset_policy": "daily",
+                "reset_by_type": ["oops"],
+                "reset_by_platform": "oops",
+                "streaming": "enabled",
+            }
+        )
+
+        assert Platform.TELEGRAM not in restored.platforms
+        assert restored.platforms[Platform.DISCORD].enabled is True
+        assert restored.default_reset_policy.mode == SessionResetPolicy().mode
+        assert restored.reset_by_type == {}
+        assert restored.reset_by_platform == {}
+        assert restored.streaming.transport == "auto"
+
+    def test_get_notice_delivery_defaults_to_public(self):
+        config = GatewayConfig(
+            platforms={Platform.SLACK: PlatformConfig(enabled=True, token="***")}
+        )
+
+        assert config.get_notice_delivery(Platform.SLACK) == "public"
+
+    def test_get_notice_delivery_honors_platform_override(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.SLACK: PlatformConfig(
+                    enabled=True,
+                    token="***",
+                    extra={"notice_delivery": "private"},
+                ),
+            }
+        )
+
+        assert config.get_notice_delivery(Platform.SLACK) == "private"
 
 
 class TestLoadGatewayConfig:
@@ -315,6 +524,19 @@ class TestLoadGatewayConfig:
 
         assert config.default_reset_policy.mode == "none"
 
+    def test_session_reset_without_mode_means_no_auto_reset(self, tmp_path, monkeypatch):
+        """A session_reset block that tunes knobs but omits mode stays off."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "session_reset:\n  idle_minutes: 60\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.default_reset_policy.mode == "none"
+        assert config.default_reset_policy.idle_minutes == 60
 
     def test_explicit_session_reset_opt_in_is_honored(self, tmp_path, monkeypatch):
         """Users who explicitly opt in to auto-reset keep their policy."""
@@ -331,25 +553,42 @@ class TestLoadGatewayConfig:
         assert config.default_reset_policy.mode == "idle"
         assert config.default_reset_policy.idle_minutes == 30
 
-
-    def test_slack_ignored_channels_config_sets_env_bridge(self, tmp_path, monkeypatch):
+    def test_bridges_quick_commands_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
-        (hermes_home / "config.yaml").write_text(
-            "slack:\n"
-            "  ignored_channels:\n"
-            "    - C0123456789\n"
-            "    - C0987654321\n",
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "quick_commands:\n"
+            "  limits:\n"
+            "    type: exec\n"
+            "    command: echo ok\n",
             encoding="utf-8",
         )
 
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.delenv("SLACK_IGNORED_CHANNELS", raising=False)
 
-        load_gateway_config()
+        config = load_gateway_config()
 
-        assert os.getenv("SLACK_IGNORED_CHANNELS") == "C0123456789,C0987654321"
+        assert config.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
 
+    def test_typing_status_text_from_toplevel_platform_block(self, tmp_path, monkeypatch):
+        """A top-level ``slack:`` block reaches PlatformConfig via the
+        shared-key bridge (bridged into extra, then the from_dict extra
+        fallback) — the route a bare ``hermes config set``-style YAML uses."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            'slack:\n  typing_status_text: "is pouncing… 🐾"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert (
+            config.platforms[Platform.SLACK].typing_status_text
+            == "is pouncing… 🐾"
+        )
 
     def test_typing_status_text_from_nested_platforms_block(self, tmp_path, monkeypatch):
         """``platforms.slack.typing_status_text`` reaches PlatformConfig via
@@ -471,98 +710,19 @@ class TestLoadGatewayConfig:
 
         assert config.stt_enabled is False
 
-
-    @staticmethod
-    def _clear_api_server_env(monkeypatch):
-        """Keep _apply_env_overrides from masking the YAML path under test."""
-        for key in (
-            "API_SERVER_ENABLED",
-            "API_SERVER_KEY",
-            "API_SERVER_PORT",
-            "API_SERVER_HOST",
-            "API_SERVER_CORS_ORIGINS",
-            "API_SERVER_MODEL_NAME",
-        ):
-            monkeypatch.delenv(key, raising=False)
-
-    def test_api_server_from_nested_gateway_section(self, tmp_path, monkeypatch):
-        """``gateway.api_server:`` (nested YAML form) must be discovered and
-        enable the platform.
-
-        Regression for #66630: load_gateway_config handled gateway.streaming
-        and gateway.platforms.* but silently dropped nested gateway.<platform>
-        blocks, so ``gateway.api_server.enabled: true`` never started the API
-        server unless API_SERVER_* env vars were also set.
-        """
-        self._clear_api_server_env(monkeypatch)
+    def test_stt_echo_transcripts_from_nested_gateway_section(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
-        (hermes_home / "config.yaml").write_text(
-            "gateway:\n  api_server:\n    enabled: true\n",
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n  stt_echo_transcripts: false\n",
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         config = load_gateway_config()
 
-        assert Platform.API_SERVER in config.platforms
-        assert config.platforms[Platform.API_SERVER].enabled is True
-
-    def test_api_server_port_bridged_into_extra(self, tmp_path, monkeypatch):
-        """``gateway.api_server.port`` must land in PlatformConfig.extra —
-        the adapter reads port/key/host/cors_origins/model_name from extra
-        (gateway/platforms/api_server.py), and from_dict discards unknown
-        top-level keys, so without the bridge the port is silently lost."""
-        self._clear_api_server_env(monkeypatch)
-        hermes_home = tmp_path / ".hermes"
-        hermes_home.mkdir()
-        (hermes_home / "config.yaml").write_text(
-            "gateway:\n"
-            "  api_server:\n"
-            "    enabled: true\n"
-            "    port: 8642\n"
-            "    host: 0.0.0.0\n"
-            "    key: sekrit\n"
-            "    model_name: my-hermes\n",
-            encoding="utf-8",
-        )
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-
-        config = load_gateway_config()
-
-        extra = config.platforms[Platform.API_SERVER].extra
-        assert extra["port"] == 8642
-        assert extra["host"] == "0.0.0.0"
-        assert extra["key"] == "sekrit"
-        assert extra["model_name"] == "my-hermes"
-
-
-    def test_non_platform_gateway_keys_not_misparsed_as_platforms(self, tmp_path, monkeypatch):
-        """Nested-platform discovery must only pick up keys matching the
-        Platform enum: ``gateway.streaming`` / ``gateway.timeout`` must not
-        be turned into phantom platform entries or break loading."""
-        self._clear_api_server_env(monkeypatch)
-        hermes_home = tmp_path / ".hermes"
-        hermes_home.mkdir()
-        (hermes_home / "config.yaml").write_text(
-            "gateway:\n"
-            "  streaming:\n"
-            "    enabled: false\n"
-            "  timeout: 120\n"
-            "  api_server:\n"
-            "    enabled: true\n",
-            encoding="utf-8",
-        )
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-
-        config = load_gateway_config()
-
-        # streaming still parsed as the streaming subsection, not a platform
-        assert config.streaming.enabled is False
-        # only real platforms present; nothing named streaming/timeout leaked in
-        assert all(isinstance(p, Platform) for p in config.platforms)
-        assert config.platforms[Platform.API_SERVER].enabled is True
-
+        assert config.stt_echo_transcripts is False
 
     def test_group_sessions_per_user_from_nested_gateway_section(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
@@ -578,6 +738,19 @@ class TestLoadGatewayConfig:
 
         assert config.group_sessions_per_user is False
 
+    def test_thread_sessions_per_user_from_nested_gateway_section(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n  thread_sessions_per_user: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.thread_sessions_per_user is True
 
     def test_reset_triggers_from_nested_gateway_section(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
@@ -607,6 +780,19 @@ class TestLoadGatewayConfig:
 
         assert config.always_log_local is False
 
+    def test_filter_silence_narration_from_nested_gateway_section(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n  filter_silence_narration: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.filter_silence_narration is False
 
     def test_unauthorized_dm_behavior_from_nested_gateway_section(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
@@ -622,6 +808,24 @@ class TestLoadGatewayConfig:
 
         assert config.unauthorized_dm_behavior == "ignore"
 
+    def test_top_level_still_wins_over_nested_gateway_section(self, tmp_path, monkeypatch):
+        """Top-level keys keep precedence over the nested gateway.* fallback
+        for every key this fix touches (matches the existing
+        gateway.streaming/write_sessions_json precedence contract)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "always_log_local: true\n"
+            "gateway:\n"
+            "  always_log_local: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.always_log_local is True
 
     def test_present_empty_top_level_session_reset_blocks_nested_fallback(self, tmp_path, monkeypatch):
         """Key-presence precedence: a present (even empty) top-level
@@ -645,6 +849,25 @@ class TestLoadGatewayConfig:
         # The nested value must not leak through the present top-level key.
         assert config.default_reset_policy.mode != "idle"
 
+    def test_present_top_level_stt_blocks_nested_fallback(self, tmp_path, monkeypatch):
+        """Key-presence precedence for stt: a present top-level stt (even
+        mistyped/non-dict) must not be replaced by gateway.stt."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "stt: {}\n"
+            "gateway:\n"
+            "  stt:\n"
+            "    enabled: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        # gateway.stt.enabled=false must NOT win over the present top-level stt.
+        assert config.stt_enabled is True
 
     def test_relay_platform_enabled_from_env_url(self, tmp_path, monkeypatch):
         """GATEWAY_RELAY_URL must enable Platform.RELAY in config.platforms so
@@ -666,6 +889,145 @@ class TestLoadGatewayConfig:
         assert relay.extra.get("relay_url") == "https://connector.example/relay"
         assert Platform.RELAY in config.get_connected_platforms()
 
+    def test_relay_platform_absent_when_url_unset(self, tmp_path, monkeypatch):
+        """No relay URL -> no RELAY platform, so direct/single-tenant gateways
+        are unaffected."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("GATEWAY_RELAY_URL", raising=False)
+
+        config = load_gateway_config()
+
+        assert Platform.RELAY not in config.platforms
+
+    def test_relay_platform_enabled_from_config_yaml(self, tmp_path, monkeypatch):
+        """gateway.relay_url in config.yaml also enables RELAY (env-less path)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n  platforms:\n    relay:\n      extra:\n        relay_url: https://connector.example/relay\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("GATEWAY_RELAY_URL", raising=False)
+
+        config = load_gateway_config()
+
+        assert Platform.RELAY in config.platforms
+        assert config.platforms[Platform.RELAY].enabled is True
+
+    def test_bridges_group_sessions_per_user_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("group_sessions_per_user: false\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.group_sessions_per_user is False
+
+    def test_bridges_thread_sessions_per_user_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("thread_sessions_per_user: true\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.thread_sessions_per_user is True
+
+    def test_thread_sessions_per_user_defaults_to_false(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("{}\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.thread_sessions_per_user is False
+
+    def test_bridges_top_level_max_concurrent_sessions_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("max_concurrent_sessions: 2\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.max_concurrent_sessions == 2
+
+    def test_bridges_nested_max_concurrent_sessions_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  max_concurrent_sessions: 3\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.max_concurrent_sessions == 3
+
+    def test_top_level_max_concurrent_sessions_overrides_nested_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "max_concurrent_sessions: 2\n"
+            "gateway:\n"
+            "  max_concurrent_sessions: 3\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.max_concurrent_sessions == 2
+
+    def test_scalar_gateway_section_does_not_crash_streaming_fallback(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("gateway: disabled\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.streaming.transport == "auto"
+
+    def test_bridges_discord_thread_require_mention_from_config_yaml(self, tmp_path, monkeypatch):
+        """discord.thread_require_mention in config.yaml should reach the runtime env var."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  thread_require_mention: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_THREAD_REQUIRE_MENTION") == "true"
 
     def test_thread_require_mention_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
         """Explicit env var should win over config.yaml (env > yaml precedence)."""
@@ -686,6 +1048,91 @@ class TestLoadGatewayConfig:
         # Env value preserved, not clobbered by yaml.
         assert os.environ.get("DISCORD_THREAD_REQUIRE_MENTION") == "true"
 
+    def test_bridges_discord_bots_require_inline_mention_from_config_yaml(self, tmp_path, monkeypatch):
+        """discord.bots_require_inline_mention should reach the runtime env var."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  bots_require_inline_mention: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_BOTS_REQUIRE_INLINE_MENTION") == "true"
+
+    def test_bots_require_inline_mention_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
+        """Explicit env var should win over config.yaml for inline bot mention gating."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  bots_require_inline_mention: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", "true")
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_BOTS_REQUIRE_INLINE_MENTION") == "true"
+
+    def test_bridges_discord_allow_from_from_config_yaml(self, tmp_path, monkeypatch):
+        """discord.allow_from should populate DISCORD_ALLOWED_USERS for auth."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  allow_from:\n"
+            "    - \"123456789012345678\"\n"
+            "    - \"999888777666555444\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_ALLOWED_USERS", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["allow_from"] == [
+            "123456789012345678",
+            "999888777666555444",
+        ]
+        assert os.environ.get("DISCORD_ALLOWED_USERS") == (
+            "123456789012345678,999888777666555444"
+        )
+
+    def test_bridges_discord_platform_extra_allow_from_to_env(self, tmp_path, monkeypatch):
+        """platforms.discord.extra.allow_from should reach DISCORD_ALLOWED_USERS too."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  discord:\n"
+            "    extra:\n"
+            "      allow_from:\n"
+            "        - \"123456789012345678\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_ALLOWED_USERS", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["allow_from"] == [
+            "123456789012345678",
+        ]
+        assert os.environ.get("DISCORD_ALLOWED_USERS") == "123456789012345678"
 
     def test_bridges_nested_gateway_platforms_dingtalk_allowed_users_to_env(self, tmp_path, monkeypatch):
         """gateway.platforms.dingtalk.extra.allowed_users must reach
@@ -720,6 +1167,181 @@ class TestLoadGatewayConfig:
         ]
         assert os.environ.get("DINGTALK_ALLOWED_USERS") == "user-id-1,user-id-2"
 
+    def test_bridges_platforms_dingtalk_extra_allowed_users_to_env(self, tmp_path, monkeypatch):
+        """platforms.dingtalk.extra.allowed_users should reach DINGTALK_ALLOWED_USERS too."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  dingtalk:\n"
+            "    extra:\n"
+            "      allowed_users:\n"
+            "        - manager1234\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DINGTALK_ALLOWED_USERS", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DINGTALK].extra["allowed_users"] == [
+            "manager1234",
+        ]
+        assert os.environ.get("DINGTALK_ALLOWED_USERS") == "manager1234"
+
+    def test_dingtalk_allowed_users_env_takes_precedence_over_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    dingtalk:\n"
+            "      extra:\n"
+            "        allowed_users:\n"
+            "          - config-user\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DINGTALK_ALLOWED_USERS", "env-user")
+
+        load_gateway_config()
+
+        assert os.environ.get("DINGTALK_ALLOWED_USERS") == "env-user"
+
+    def test_top_level_dingtalk_allowed_users_wins_over_nested_extra(self, tmp_path, monkeypatch):
+        """The legacy top-level dingtalk: block keeps precedence over the
+        nested platform extra when both define an allowlist."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "dingtalk:\n"
+            "  allowed_users:\n"
+            "    - top-level-user\n"
+            "gateway:\n"
+            "  platforms:\n"
+            "    dingtalk:\n"
+            "      extra:\n"
+            "        allowed_users:\n"
+            "          - nested-user\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DINGTALK_ALLOWED_USERS", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DINGTALK_ALLOWED_USERS") == "top-level-user"
+
+    def test_nested_dingtalk_allowlist_authorizes_listed_user_only(self, tmp_path, monkeypatch):
+        """E2E for the documented setup: a nested-only allowlist must
+        authorize the listed user at the gateway and still deny others.
+
+        Before the bridge existed, the listed user passed the adapter's
+        _is_user_allowed() but _is_user_authorized() fell through to
+        default-deny because DINGTALK_ALLOWED_USERS was never populated.
+        """
+        from types import SimpleNamespace
+
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    dingtalk:\n"
+            "      enabled: true\n"
+            "      extra:\n"
+            "        allowed_users:\n"
+            "          - user-id-1\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        for var in (
+            "DINGTALK_ALLOWED_USERS",
+            "DINGTALK_ALLOW_ALL_USERS",
+            "GATEWAY_ALLOWED_USERS",
+            "GATEWAY_ALLOW_ALL_USERS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        config = load_gateway_config()
+
+        runner = object.__new__(GatewayRunner)
+        runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+        runner.config = config
+
+        def _dm_source(user_id):
+            return SessionSource(
+                platform=Platform.DINGTALK,
+                chat_id="dm-1",
+                chat_type="dm",
+                user_id=user_id,
+                user_name="someone",
+            )
+
+        assert runner._is_user_authorized(_dm_source("user-id-1")) is True
+        assert runner._is_user_authorized(_dm_source("intruder")) is False
+
+    def test_bridges_quoted_false_platform_enabled_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  api_server:\n"
+            "    enabled: \"false\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.API_SERVER].enabled is False
+        assert Platform.API_SERVER not in config.get_connected_platforms()
+
+    def test_bridges_nested_gateway_platforms_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      enabled: true\n"
+            "      token: nested-token\n"
+            "      home_channel:\n"
+            "        platform: telegram\n"
+            "        chat_id: \"123\"\n"
+            "        name: Nested Home\n"
+            "      extra:\n"
+            "        reply_prefix: nested\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        telegram = config.platforms[Platform.TELEGRAM]
+        assert telegram.enabled is True
+        assert telegram.token == "nested-token"
+        assert telegram.home_channel == HomeChannel(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            name="Nested Home",
+        )
+        assert telegram.extra["reply_prefix"] == "nested"
 
     def test_top_level_platforms_override_nested_gateway_platforms(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
@@ -788,6 +1410,306 @@ class TestLoadGatewayConfig:
             "bridged into PlatformConfig.extra by the shared-key loop"
         )
 
+    def test_shared_key_loop_bridges_allow_from_from_nested_gateway_platforms(self, tmp_path, monkeypatch):
+        """Same regression check for ``gateway.platforms:`` path."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      allow_from:\n"
+            "        - \"777888999\"\n"
+            "      require_mention: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        telegram = config.platforms[Platform.TELEGRAM]
+        assert telegram.extra.get("allow_from") == ["777888999"], (
+            "allow_from configured under plugins.platforms.telegram.adapter must be "
+            "bridged into PlatformConfig.extra by the shared-key loop"
+        )
+        assert telegram.extra.get("require_mention") is False
+
+    def test_bridges_quoted_false_session_notify_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "session_reset:\n"
+            "  notify: \"false\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.default_reset_policy.notify is False
+
+    def test_bridges_quoted_false_always_log_local_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "always_log_local: \"false\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.always_log_local is False
+
+    def test_bridges_discord_channel_overrides_from_top_level_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  channel_overrides:\n"
+            '    "1234567890":\n'
+            "      model: openrouter/healer-alpha\n"
+            "      provider: openrouter\n"
+            "      system_prompt: Daily news summarizer\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        discord = config.platforms[Platform.DISCORD]
+        assert "1234567890" in discord.channel_overrides
+        ov = discord.channel_overrides["1234567890"]
+        assert ov.model == "openrouter/healer-alpha"
+        assert ov.provider == "openrouter"
+        assert ov.system_prompt == "Daily news summarizer"
+
+    def test_bridges_discord_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  channel_prompts:\n"
+            "    \"123\": Research mode\n"
+            "    456: Therapist mode\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["channel_prompts"] == {
+            "123": "Research mode",
+            "456": "Therapist mode",
+        }
+
+    def test_bridges_discord_channel_cwds_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  channel_cwds:\n"
+            "    \"123\": /tmp/research\n"
+            "    456: /tmp/docs\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["channel_cwds"] == {
+            "123": "/tmp/research",
+            "456": "/tmp/docs",
+        }
+
+    def test_bridges_telegram_channel_cwds_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  channel_cwds:\n"
+            '    "-1001234567": /tmp/research\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["channel_cwds"] == {
+            "-1001234567": "/tmp/research",
+        }
+
+    def test_channel_cwds_coexist_with_channel_prompts(self, tmp_path, monkeypatch):
+        """Existing channel_prompts configs keep working unchanged next to channel_cwds."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  channel_prompts:\n"
+            "    \"123\": Research mode\n"
+            "  channel_cwds:\n"
+            "    \"123\": /tmp/research\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        extra = config.platforms[Platform.DISCORD].extra
+        assert extra["channel_prompts"] == {"123": "Research mode"}
+        assert extra["channel_cwds"] == {"123": "/tmp/research"}
+
+    def test_bridges_discord_history_backfill_settings_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  history_backfill: true\n"
+            "  history_backfill_limit: 17\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_HISTORY_BACKFILL", raising=False)
+        monkeypatch.delenv("DISCORD_HISTORY_BACKFILL_LIMIT", raising=False)
+
+        load_gateway_config()
+
+        assert os.getenv("DISCORD_HISTORY_BACKFILL") == "true"
+        assert os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT") == "17"
+
+    def test_bridges_telegram_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  channel_prompts:\n"
+            '    "-1001234567": Research assistant\n'
+            "    789: Creative writing\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["channel_prompts"] == {
+            "-1001234567": "Research assistant",
+            "789": "Creative writing",
+        }
+
+    def test_bridges_slack_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "slack:\n"
+            "  channel_prompts:\n"
+            '    "C01ABC": Code review mode\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].extra["channel_prompts"] == {
+            "C01ABC": "Code review mode",
+        }
+
+    def test_bridges_feishu_allow_bots_from_config_yaml_to_env(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "feishu:\n  allow_bots: mentions\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("FEISHU_ALLOW_BOTS", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("FEISHU_ALLOW_BOTS") == "mentions"
+
+    def test_feishu_allow_bots_env_takes_precedence_over_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "feishu:\n  allow_bots: all\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("FEISHU_ALLOW_BOTS", "none")
+
+        load_gateway_config()
+
+        assert os.environ.get("FEISHU_ALLOW_BOTS") == "none"
+
+    def test_bridges_telegram_allow_bots_from_config_yaml_to_env(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n  allow_bots: mentions\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("TELEGRAM_ALLOW_BOTS", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("TELEGRAM_ALLOW_BOTS") == "mentions"
+
+    def test_telegram_allow_bots_env_takes_precedence_over_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n  allow_bots: all\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "none")
+
+        load_gateway_config()
+
+        assert os.environ.get("TELEGRAM_ALLOW_BOTS") == "none"
+
+    def test_invalid_quick_commands_in_config_yaml_are_ignored(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("quick_commands: not-a-mapping\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.quick_commands == {}
 
     def test_bridges_unauthorized_dm_behavior_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
@@ -807,6 +1729,21 @@ class TestLoadGatewayConfig:
         assert config.unauthorized_dm_behavior == "ignore"
         assert config.platforms[Platform.WHATSAPP].extra["unauthorized_dm_behavior"] == "pair"
 
+    def test_bridges_telegram_disable_link_previews_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  disable_link_previews: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["disable_link_previews"] is True
 
     def test_loads_telegram_rich_messages_from_gateway_platform_extra(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
@@ -827,6 +1764,91 @@ class TestLoadGatewayConfig:
 
         assert config.platforms[Platform.TELEGRAM].extra["rich_messages"] is False
 
+    def test_loads_telegram_rich_drafts_from_gateway_platform_extra(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      extra:\n"
+            "        rich_drafts: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["rich_drafts"] is True
+
+    def test_load_config_default_keeps_telegram_rich_messages_opt_in(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from hermes_cli.config import load_config
+
+        config = load_config()
+
+        assert config["telegram"]["extra"]["rich_messages"] is False
+        assert config["telegram"]["extra"]["rich_drafts"] is False
+
+    def test_bridges_telegram_extra_base_url_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  extra:\n"
+            "    base_url: https://custom-proxy.example.com/bot\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert (
+            config.platforms[Platform.TELEGRAM].extra["base_url"]
+            == "https://custom-proxy.example.com/bot"
+        )
+
+    def test_bridges_notice_delivery_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "slack:\n"
+            "  notice_delivery: private\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.get_notice_delivery(Platform.SLACK) == "private"
+
+    def test_bridges_telegram_proxy_url_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  proxy_url: socks5://127.0.0.1:1080\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("TELEGRAM_PROXY", raising=False)
+
+        load_gateway_config()
+
+        import os
+        assert os.environ.get("TELEGRAM_PROXY") == "socks5://127.0.0.1:1080"
 
     def test_telegram_proxy_env_takes_precedence_over_config(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
@@ -871,12 +1893,6 @@ class TestLoadGatewayConfig:
         monkeypatch.setenv("API_SERVER_ENABLED", "true")
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "default-token")
 
-        # Model the real multiplexed gateway: run.py flips the runtime flag at
-        # startup (set_multiplex_active) BEFORE any secondary-profile config
-        # loads.  Without the flag, a scope miss legitimately falls through to
-        # os.environ (single-profile overlay semantics, #67827) and this test
-        # would no longer exercise the cross-profile isolation it's about.
-        set_multiplex_active(True)
         home_token = set_hermes_home_override(str(secondary_home))
         secret_token = set_secret_scope({"DISCORD_BOT_TOKEN": "worker-token"})
         try:
@@ -884,88 +1900,10 @@ class TestLoadGatewayConfig:
         finally:
             reset_secret_scope(secret_token)
             reset_hermes_home_override(home_token)
-            set_multiplex_active(False)
 
         assert config.multiplex_profiles is True
         assert config.platforms[Platform.DISCORD].token == "worker-token"
         assert Platform.API_SERVER not in config.platforms
-
-
-class TestWebhookPortBridging:
-    """Top-level port/host in the YAML platform section must be bridged into
-    PlatformConfig.extra so the webhook/api_server adapters can read them.
-
-    The adapters (WebhookAdapter, ApiServerAdapter) read port/host from
-    ``config.extra``, but users naturally write them at the top level of the
-    platform section in config.yaml:
-
-        platforms:
-          webhook:
-            enabled: true
-            host: 0.0.0.0
-            port: 8649
-
-    Without bridging, the port silently falls back to DEFAULT_PORT (8644),
-    causing port conflicts between profiles that configure different ports."""
-
-    def test_webhook_port_bridged_from_toplevel(self, tmp_path, monkeypatch):
-        hermes_home = tmp_path / ".hermes"
-        hermes_home.mkdir()
-        config_path = hermes_home / "config.yaml"
-        config_path.write_text(
-            "platforms:\n"
-            "  webhook:\n"
-            "    enabled: true\n"
-            "    host: 0.0.0.0\n"
-            "    port: 8649\n",
-            encoding="utf-8",
-        )
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.delenv("WEBHOOK_ENABLED", raising=False)
-        monkeypatch.delenv("WEBHOOK_PORT", raising=False)
-
-        config = load_gateway_config()
-
-        assert Platform.WEBHOOK in config.platforms
-        wh = config.platforms[Platform.WEBHOOK]
-        assert wh.enabled is True
-        assert wh.extra.get("port") == 8649
-        assert wh.extra.get("host") == "0.0.0.0"
-
-
-    def test_msgraph_webhook_port_host_secret_bridged_from_toplevel(self, tmp_path, monkeypatch):
-        """msgraph_webhook top-level port/host/secret must be bridged into extra,
-        with an explicit extra: value still winning over the top-level one."""
-        hermes_home = tmp_path / ".hermes"
-        hermes_home.mkdir()
-        config_path = hermes_home / "config.yaml"
-        config_path.write_text(
-            "platforms:\n"
-            "  msgraph_webhook:\n"
-            "    enabled: true\n"
-            "    host: 0.0.0.0\n"
-            "    port: 8651\n"
-            "    secret: toplevel-secret\n"
-            "    extra:\n"
-            "      client_state: my-client-state\n"
-            "      secret: extra-secret\n",
-            encoding="utf-8",
-        )
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.delenv("MSGRAPH_WEBHOOK_ENABLED", raising=False)
-        monkeypatch.delenv("MSGRAPH_WEBHOOK_PORT", raising=False)
-        monkeypatch.delenv("MSGRAPH_WEBHOOK_CLIENT_STATE", raising=False)
-
-        config = load_gateway_config()
-
-        assert Platform.MSGRAPH_WEBHOOK in config.platforms
-        ms = config.platforms[Platform.MSGRAPH_WEBHOOK]
-        assert ms.enabled is True
-        assert ms.extra.get("port") == 8651
-        assert ms.extra.get("host") == "0.0.0.0"
-        # explicit extra: wins over top-level
-        assert ms.extra.get("secret") == "extra-secret"
-        assert ms.extra.get("client_state") == "my-client-state"
 
 
 class TestHomeChannelEnvOverrides:
@@ -1067,6 +2005,10 @@ class TestMultiplexProfilesEnvOverride:
         return load_gateway_config()
 
     # ── Tier 1: env wins ──────────────────────────────────────────────────
+    def test_env_true_forces_on_with_no_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "true")
+        config = self._load(tmp_path, monkeypatch, config_text=None)
+        assert config.multiplex_profiles is True
 
     def test_env_true_overrides_config_false(self, tmp_path, monkeypatch):
         # THE discriminating test: env-set wins over an explicit config value.
@@ -1076,6 +2018,12 @@ class TestMultiplexProfilesEnvOverride:
         )
         assert config.multiplex_profiles is True
 
+    def test_env_false_overrides_config_true(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "off")
+        config = self._load(
+            tmp_path, monkeypatch, config_text="multiplex_profiles: true\n"
+        )
+        assert config.multiplex_profiles is False
 
     # ── Tier 2: config.yaml when env unset ────────────────────────────────
     def test_config_true_when_env_unset(self, tmp_path, monkeypatch):
@@ -1095,15 +2043,59 @@ class TestMultiplexProfilesEnvOverride:
         )
         assert config.multiplex_profiles is True
 
+    def test_whitespace_env_does_not_shadow_config_true(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "   ")
+        config = self._load(
+            tmp_path, monkeypatch, config_text="multiplex_profiles: true\n"
+        )
+        assert config.multiplex_profiles is True
+
+    def test_unrecognized_env_falls_through_to_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "maybe")
+        config = self._load(
+            tmp_path, monkeypatch, config_text="multiplex_profiles: true\n"
+        )
+        assert config.multiplex_profiles is True
 
     # ── Tier 3: default False ─────────────────────────────────────────────
+    def test_default_false_when_neither_set(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+        config = self._load(tmp_path, monkeypatch, config_text=None)
+        assert config.multiplex_profiles is False
 
     # ── The resolver in isolation ─────────────────────────────────────────
+    def test_resolver_tristate(self, monkeypatch):
+        from gateway.config import _env_multiplex_profiles_override
+
+        monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+        assert _env_multiplex_profiles_override() is None
+        for truthy in ("1", "true", "TRUE", "yes", "on"):
+            monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", truthy)
+            assert _env_multiplex_profiles_override() is True, truthy
+        for falsy in ("0", "false", "FALSE", "no", "off"):
+            monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", falsy)
+            assert _env_multiplex_profiles_override() is False, falsy
+        for noise in ("", "   ", "maybe", "2"):
+            monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", noise)
+            assert _env_multiplex_profiles_override() is None, repr(noise)
 
 
 class TestMultiplexProfilesConfig:
     """Tests for parsing multiplex_profiles (top-level and nested forms)."""
 
+    def test_multiplex_profiles_top_level(self, tmp_path, monkeypatch):
+        """Top-level multiplex_profiles is honored."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "multiplex_profiles: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.multiplex_profiles is True
 
     def test_multiplex_profiles_nested_under_gateway(self, tmp_path, monkeypatch):
         """gateway.multiplex_profiles (the form written by `hermes config set
@@ -1126,6 +2118,32 @@ class TestMultiplexProfilesConfig:
             "loader only forwarded the top-level form"
         )
 
+    def test_multiplex_profiles_default_false(self, tmp_path, monkeypatch):
+        """Default is False when neither form is present."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.multiplex_profiles is False
+
+    def test_multiplex_profiles_top_level_overrides_nested(self, tmp_path, monkeypatch):
+        """When both forms are present, top-level wins (matches profile_routes
+        and other parity bridges in load_gateway_config)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "multiplex_profiles: true\n"
+            "gateway:\n  multiplex_profiles: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.multiplex_profiles is True
 
     def test_multiplex_profiles_explicit_top_level_false_not_consulting_nested(
         self, tmp_path, monkeypatch
@@ -1150,37 +2168,3 @@ class TestMultiplexProfilesConfig:
             "Explicit top-level false was overridden by nested true — "
             "loader must respect top-level precedence when key is present"
         )
-
-
-class TestApiServerEnvOverride:
-    def test_env_key_does_not_reenable_explicitly_disabled_api_server(self):
-        """An explicit ``platforms.api_server.enabled: false`` must survive
-        _apply_env_overrides() even when API_SERVER_KEY is present in the env.
-
-        Regression: _apply_env_overrides() force-set api_server.enabled = True
-        whenever API_SERVER_KEY (or API_SERVER_ENABLED) was set. In multiplex
-        mode a secondary profile pins ``api_server.enabled: false`` so it shares
-        the default profile's listener instead of binding its own port, but it
-        still inherits the process-level API_SERVER_KEY. The unconditional
-        re-enable flipped it back on and tripped the MultiplexConfigError check.
-
-        The fix honors the explicit disable, flagged by ``_enabled_explicit`` in
-        the platform's extra (set when the config.yaml pins enabled).
-        """
-        config = GatewayConfig(
-            platforms={
-                Platform.API_SERVER: PlatformConfig(
-                    enabled=False,
-                    extra={"_enabled_explicit": True},
-                ),
-            },
-        )
-
-        api_server_key = "secret-key-at-least-16"
-        with patch.dict(os.environ, {"API_SERVER_KEY": api_server_key}, clear=True):
-            _apply_env_overrides(config)
-
-        # Explicit disable wins over the env-var presence.
-        assert config.platforms[Platform.API_SERVER].enabled is False
-        # The key is still wired through for the shared listener.
-        assert config.platforms[Platform.API_SERVER].extra.get("key") == api_server_key

--- a/tests/gateway/test_discord_channel_cwd.py
+++ b/tests/gateway/test_discord_channel_cwd.py
@@ -1,0 +1,380 @@
+"""Tests for Discord channel_cwds resolution and session wiring."""
+
+import sys
+import threading
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_discord_mock():
+    """Stub ``discord`` only when the real package is genuinely absent.
+
+    Checking ``sys.modules`` alone is not enough: when discord is installed
+    but simply not imported yet, the stub wins the ``setdefault`` race and
+    every later test module that imports the real package silently skips.
+    """
+    try:
+        import discord  # noqa: F401
+        return
+    except ImportError:
+        pass
+    discord_mod = types.ModuleType("discord")
+    discord_mod.Intents = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.Interaction = object
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType, resolve_channel_cwd
+from gateway.session import SessionSource
+
+
+class _CapturingAgent:
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+
+    def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+
+def _install_fake_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_adapter():
+    _ensure_discord_mock()
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    adapter = object.__new__(DiscordAdapter)
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    return adapter
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = "Global prompt"
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._pending_model_notes = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(streaming=None)
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda source: SimpleNamespace(session_id="session-1"),
+        load_transcript=lambda session_id: [],
+    )
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._enrich_message_with_vision = AsyncMock(return_value="ENRICHED")
+    return runner
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="12345",
+        chat_type="thread",
+        user_id="user-1",
+    )
+
+
+class TestResolveChannelCwd:
+    def test_no_cwd_returns_none(self):
+        assert resolve_channel_cwd({}, "123") is None
+
+    def test_match_by_channel_id(self, tmp_path):
+        extra = {"channel_cwds": {"100": str(tmp_path)}}
+        assert resolve_channel_cwd(extra, "100") == str(tmp_path)
+
+    def test_match_by_parent_id(self, tmp_path):
+        extra = {"channel_cwds": {"200": str(tmp_path)}}
+        assert resolve_channel_cwd(extra, "999", parent_id="200") == str(tmp_path)
+
+    def test_exact_channel_overrides_parent(self, tmp_path):
+        thread_dir = tmp_path / "thread"
+        forum_dir = tmp_path / "forum"
+        thread_dir.mkdir()
+        forum_dir.mkdir()
+        extra = {
+            "channel_cwds": {
+                "999": str(thread_dir),
+                "200": str(forum_dir),
+            }
+        }
+        assert resolve_channel_cwd(extra, "999", parent_id="200") == str(thread_dir)
+
+    def test_tilde_is_expanded(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / "project").mkdir()
+        extra = {"channel_cwds": {"100": "~/project"}}
+        assert resolve_channel_cwd(extra, "100") == str(tmp_path / "project")
+
+    def test_missing_directory_is_ignored(self, tmp_path):
+        extra = {"channel_cwds": {"100": str(tmp_path / "does-not-exist")}}
+        assert resolve_channel_cwd(extra, "100") is None
+
+    def test_invalid_child_falls_back_to_valid_parent(self, tmp_path):
+        """A stale child override must not block inheriting a valid parent cwd."""
+        parent_dir = tmp_path / "forum"
+        parent_dir.mkdir()
+        extra = {
+            "channel_cwds": {
+                "999": str(tmp_path / "missing-thread"),  # invalid child
+                "200": str(parent_dir),  # valid parent
+            }
+        }
+        assert resolve_channel_cwd(extra, "999", parent_id="200") == str(parent_dir)
+
+    def test_blank_values_are_ignored(self):
+        extra = {"channel_cwds": {"100": "   "}}
+        assert resolve_channel_cwd(extra, "100") is None
+
+    def test_non_dict_config_is_ignored(self):
+        extra = {"channel_cwds": ["not", "a", "dict"]}
+        assert resolve_channel_cwd(extra, "100") is None
+
+
+class TestDiscordAdapterChannelCwd:
+    def test_build_slash_event_sets_channel_cwd(self, tmp_path):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_cwds": {"321": str(tmp_path)}}
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+
+        interaction = SimpleNamespace(
+            channel_id=321,
+            channel=SimpleNamespace(name="general", guild=None, parent_id=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+        adapter._get_effective_topic = MagicMock(return_value=None)
+
+        event = adapter._build_slash_event(interaction, "/retry")
+
+        assert event.channel_cwd == str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_dispatch_thread_session_inherits_parent_channel_cwd(self, tmp_path):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_cwds": {"200": str(tmp_path)}}
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+        adapter._get_effective_topic = MagicMock(return_value=None)
+        adapter.handle_message = AsyncMock()
+
+        interaction = SimpleNamespace(
+            guild=SimpleNamespace(name="Wetlands"),
+            channel=SimpleNamespace(id=200, parent=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+
+        await adapter._dispatch_thread_session(interaction, "999", "new-thread", "hello")
+
+        dispatched_event = adapter.handle_message.await_args.args[0]
+        assert dispatched_event.channel_cwd == str(tmp_path)
+
+    def test_channel_cwd_coexists_with_channel_prompt(self, tmp_path):
+        """A channel may carry both a prompt and a cwd — neither affects the other."""
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_prompts": {"321": "Research mode"},
+            "channel_cwds": {"321": str(tmp_path)},
+        }
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+
+        interaction = SimpleNamespace(
+            channel_id=321,
+            channel=SimpleNamespace(name="general", guild=None, parent_id=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+        adapter._get_effective_topic = MagicMock(return_value=None)
+
+        event = adapter._build_slash_event(interaction, "/retry")
+
+        assert event.channel_prompt == "Research mode"
+        assert event.channel_cwd == str(tmp_path)
+
+    def test_event_without_config_has_no_channel_cwd(self):
+        adapter = _make_adapter()
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+
+        interaction = SimpleNamespace(
+            channel_id=321,
+            channel=SimpleNamespace(name="general", guild=None, parent_id=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+        adapter._get_effective_topic = MagicMock(return_value=None)
+
+        event = adapter._build_slash_event(interaction, "/retry")
+
+        assert event.channel_cwd is None
+
+
+@pytest.mark.asyncio
+async def test_run_agent_wires_channel_cwd_to_session_and_terminal(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    (tmp_path / "config.yaml").write_text("agent:\n  system_prompt: Global prompt\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    import tools.terminal_tool as terminal_tool
+
+    registered = {}
+
+    def _capture_override(task_id, overrides):
+        registered[task_id] = overrides
+
+    monkeypatch.setattr(terminal_tool, "register_task_env_overrides", _capture_override)
+
+    _CapturingAgent.last_init = None
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:discord:thread:12345",
+        channel_cwd=str(project_dir),
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init["session_cwd"] == str(project_dir)
+    assert registered == {"session-1": {"cwd": str(project_dir)}}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_without_channel_cwd_registers_nothing(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    (tmp_path / "config.yaml").write_text("agent:\n  system_prompt: Global prompt\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    import tools.terminal_tool as terminal_tool
+
+    registered = {}
+
+    def _capture_override(task_id, overrides):
+        registered[task_id] = overrides
+
+    monkeypatch.setattr(terminal_tool, "register_task_env_overrides", _capture_override)
+
+    _CapturingAgent.last_init = None
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:discord:thread:12345",
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init["session_cwd"] is None
+    assert registered == {}
+
+
+@pytest.mark.asyncio
+async def test_retry_preserves_channel_cwd(tmp_path):
+    """/retry must carry channel_cwd onto the rebuilt event, not just the prompt."""
+    from gateway.slash_commands import GatewaySlashCommandsMixin
+
+    handler = object.__new__(GatewaySlashCommandsMixin)
+    session_entry = SimpleNamespace(session_id="s1", last_prompt_tokens=5)
+    handler.async_session_store = SimpleNamespace(
+        get_or_create_session=AsyncMock(return_value=session_entry),
+        load_transcript=AsyncMock(return_value=[{"role": "user", "content": "hello"}]),
+        rewrite_transcript=AsyncMock(),
+    )
+
+    captured = {}
+
+    async def _capture(evt):
+        captured["event"] = evt
+        return "ok"
+
+    handler._handle_message = _capture
+
+    event = MessageEvent(
+        text="/retry",
+        message_type=MessageType.TEXT,
+        source=_make_source(),
+        channel_prompt="Research mode",
+        channel_cwd=str(tmp_path),
+    )
+
+    result = await handler._handle_retry_command(event)
+
+    assert result == "ok"
+    assert captured["event"].channel_cwd == str(tmp_path)
+    assert captured["event"].channel_prompt == "Research mode"
+    assert captured["event"].text == "hello"

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -348,6 +348,7 @@ discord:
     limit: 100                    # Global scan cap per reconnect
     max_dispatches: 10            # Recovery dispatch cap per reconnect
   channel_prompts: {}             # Per-channel ephemeral system prompts
+  channel_cwds: {}                # Per-channel working directories
   voice_channel_inactivity_timeout_seconds: 300  # Set 0 to stay in VC until explicit /voice leave
   voice_playback_timeout_seconds: 120             # Minimum playback watchdog; long clips get duration+padding
   allow_mentions:                 # What the bot is allowed to ping (safe defaults)
@@ -476,6 +477,26 @@ Behavior:
 - Exact thread/channel ID matches win.
 - If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
 - Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
+
+#### `discord.channel_cwds`
+
+**Type:** mapping — **Default:** `{}`
+
+Per-channel working directories. Sessions started from a messaging channel otherwise have no project folder: context files are not picked up and the terminal sandbox starts wherever the gateway was launched. Mapping a channel to a folder gives that channel its own project.
+
+```yaml
+discord:
+  channel_cwds:
+    "1234567890": /Users/me/projects/hermes
+    "9876543210": /Users/me/projects/website
+```
+
+Behavior:
+- Exact thread/channel ID matches win; threads and forum posts fall back to the parent channel/forum ID, same as `channel_prompts`.
+- The folder becomes the session's working directory, so `AGENTS.md` / `HERMES.md` in it are loaded as context files and the terminal tool starts there.
+- The directory is stamped on the session row at creation, so messaging sessions group by workspace in Hermes Desktop.
+- Configured paths that do not exist are ignored with a warning, and resolution continues — a stale thread entry still inherits a valid parent channel's folder.
+- Independent of `channel_prompts`; both keys can be set on the same channel.
 
 #### `discord.history_backfill`
 

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -325,6 +325,19 @@ mattermost:
 
 Keys are Mattermost channel IDs (find them in the channel URL or via the API). All messages in the matching channel get the prompt injected as an ephemeral system instruction.
 
+## Per-Channel Working Directories
+
+Give a channel its own project folder. Without this, a session started from Mattermost has no working directory — project context files are not picked up and the terminal sandbox starts in the gateway's launch directory.
+
+```yaml
+mattermost:
+  channel_cwds:
+    "channel_id_abc123": /Users/me/projects/research
+    "channel_id_def456": /Users/me/projects/hermes
+```
+
+Keys are Mattermost channel IDs, same as `channel_prompts`. The folder becomes the session's working directory, so `AGENTS.md` / `HERMES.md` in it load as context files, the terminal tool starts there, and the session groups by workspace in Hermes Desktop. Paths that do not exist are ignored with a warning. `channel_prompts` and `channel_cwds` are independent — set either or both on the same channel.
+
 ## Security
 
 :::warning

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -903,6 +903,19 @@ slack:
 
 Keys are Slack channel IDs (find them via channel details → "About" → scroll to bottom). All messages in the matching channel get the prompt injected as an ephemeral system instruction.
 
+## Per-Channel Working Directories
+
+Give a channel its own project folder. Without this, a session started from Slack has no working directory — project context files are not picked up and the terminal sandbox starts in the gateway's launch directory.
+
+```yaml
+slack:
+  channel_cwds:
+    "C01RESEARCH": /Users/me/projects/research
+    "C02ENGINEERING": /Users/me/projects/hermes
+```
+
+Keys are Slack channel IDs, same as `channel_prompts`. The folder becomes the session's working directory, so `AGENTS.md` / `HERMES.md` in it load as context files, the terminal tool starts there, and the session groups by workspace in Hermes Desktop. Paths that do not exist are ignored with a warning. `channel_prompts` and `channel_cwds` are independent — set either or both on the same channel.
+
 ## Per-Channel Skill Bindings
 
 Auto-load a skill whenever a new session starts in a specific channel or DM. Unlike per-channel prompts (which are injected on every turn), skill bindings inject the skill content as a user message at **session start** — it becomes part of the conversation history and does not need to be reloaded on subsequent turns.

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1246,6 +1246,19 @@ Keys are chat IDs (groups/supergroups) or forum topic IDs. For forum groups, top
 
 Numeric YAML keys are automatically normalized to strings.
 
+## Per-Channel Working Directories
+
+Give a group or forum topic its own project folder. Without this, a session started from Telegram has no working directory — project context files are not picked up and the terminal sandbox starts in the gateway's launch directory.
+
+```yaml
+telegram:
+  channel_cwds:
+    "-1001234567890": /Users/me/projects/research
+    "42": /Users/me/projects/hermes
+```
+
+Keys are chat IDs or forum topic IDs, resolved exactly like `channel_prompts` — a topic-level entry wins, and a topic with no entry falls back to its group. The folder becomes the session's working directory, so `AGENTS.md` / `HERMES.md` in it load as context files, the terminal tool starts there, and the session groups by workspace in Hermes Desktop. Paths that do not exist are ignored with a warning, and resolution continues, so a stale topic entry still inherits a valid group folder. Numeric YAML keys are normalized to strings.
+
 ## Troubleshooting
 
 | Problem | Solution |


### PR DESCRIPTION
**What & why**

I run Hermes with one Discord channel per project. `channel_prompts` already gives each channel its own instructions, but the sessions created there never get a working directory — the `AGENTS.md` sitting in the project folder is never picked up, and the terminal starts in whatever directory the gateway was launched from.

This adds `channel_cwds`, a direct sibling of `channel_prompts`:

```yaml
discord:
  channel_prompts:
    "123456789": Research mode
  channel_cwds:
    "123456789": ~/projects/research
```

When a message in a configured channel comes in:
- the session row gets the cwd at creation, so these sessions group into the right workspace in the desktop app
- context-file discovery (AGENTS.md / HERMES.md / .cursorrules) and the system prompt cwd resolve against the project folder, via the existing `_SESSION_CWD` contextvar
- the terminal sandbox starts in the folder — same `register_task_env_overrides` path the dashboard and ACP surfaces already use, so in-session `cd` tracking behaves as expected

Resolution mirrors `channel_prompts`: exact channel/thread id wins, threads and forum posts inherit from the parent channel, Telegram topics inherit from the group. Wired for Discord, Slack, Telegram and Mattermost. A configured path that doesn't exist is ignored with a warning rather than breaking the session.

**Backward compatibility:** `channel_prompts` is untouched — both keys coexist on the same channel (covered by tests).

**How to test**
1. Add a `channel_cwds` entry for a channel id, restart the gateway
2. Message the bot in that channel — the system prompt shows the configured cwd, an `AGENTS.md` in the folder is injected, and `terminal` commands run in the folder
3. New sessions from that channel appear under the folder's workspace in the desktop app

**Tests:** new suite `tests/gateway/test_discord_channel_cwd.py` (resolver, adapter wiring, `_run_agent` session/terminal wiring), config bridging tests for Discord/Telegram plus a prompts+cwds coexistence test. Full `tests/gateway/` suite passes (the handful of failures on my machine also fail on clean main — env-specific). Tested on macOS.
