### PR TITLE
fix(config): only call _secure_file when original permissions were not preserved

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5702,13 +5702,14 @@ def save_env_value(key: str, value: str):
                 os.chmod(env_path, original_mode)
             except OSError:
                 pass
+        else:
+            _secure_file(env_path)
     except BaseException:
         try:
             os.unlink(tmp_path)
         except OSError:
             pass
         raise
-    _secure_file(env_path)
 
     os.environ[key] = value
     invalidate_env_cache()
@@ -5758,13 +5759,14 @@ def remove_env_value(key: str) -> bool:
                     os.chmod(env_path, original_mode)
                 except OSError:
                     pass
+            else:
+                _secure_file(env_path)
         except BaseException:
             try:
                 os.unlink(tmp_path)
             except OSError:
                 pass
             raise
-        _secure_file(env_path)
 
     os.environ.pop(key, None)
     invalidate_env_cache()


### PR DESCRIPTION
## Problem

In `save_env_value()` and `remove_env_value()`, the code restores original file permissions via `os.chmod(env_path, original_mode)` to preserve non-standard modes (e.g., for Docker volume mounts). However, `_secure_file(env_path)` is then called unconditionally after the restore, which re-tightens permissions to `0600` — completely undoing the intended permission preservation.

This is the same bug class documented in `references/secure-file-perm-undo-pattern.md`.

## Fix

Move `_secure_file()` into the `else` branch so it only tightens permissions on new files (when `original_mode` is None), not when the original mode was successfully restored.

## Changes

- `hermes_cli/config.py`: `save_env_value()` — moved `_secure_file()` into `else` branch
- `hermes_cli/config.py`: `remove_env_value()` — same fix

## Tests

All existing tests pass (95 in test_config.py, 6 in test_env_load_cache.py).