### PR TITLE
fix(cli): bound temp-file creation so one-shot commands cannot busy-spin

### DIFF
--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -15,10 +15,9 @@ from __future__ import annotations
 import json
 import logging
 import os
-import tempfile
 import time
 from typing import Any, Mapping, Optional
-from utils import atomic_replace
+from utils import atomic_replace, bounded_mkstemp
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +114,7 @@ def record_nous_rate_limit(
         }
 
         # Atomic write: write to temp file + rename
-        fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
+        fd, tmp_path = bounded_mkstemp(dir=state_dir, suffix=".tmp")
         try:
             with os.fdopen(fd, "w") as f:
                 json.dump(state, f)

--- a/agent/secret_sources/_cache.py
+++ b/agent/secret_sources/_cache.py
@@ -22,11 +22,12 @@ from __future__ import annotations
 
 import json
 import os
-import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Generic, Optional, TypeVar
+
+from utils import bounded_mkstemp
 
 __all__ = [
     "FetchResult",
@@ -188,7 +189,7 @@ class DiskCache(Generic[K]):
             }
             # Write to a sibling temp file and atomic-rename.  tempfile honours
             # os.umask, so we explicitly chmod 0600 before the rename.
-            fd, tmp = tempfile.mkstemp(
+            fd, tmp = bounded_mkstemp(
                 prefix=self._tmp_prefix, suffix=".tmp", dir=str(cache_dir)
             )
             try:

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -45,6 +45,8 @@ import zipfile
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from utils import bounded_mkstemp
+
 from agent.secret_sources._cache import (
     CachedFetch as _CachedFetch,
     DiskCache,
@@ -245,7 +247,7 @@ def install_bws(*, force: bool = False) -> Path:
 
         # Move into place atomically.  We write to a sibling tempfile in
         # the final directory so the rename can't cross filesystems.
-        fd, staged = tempfile.mkstemp(dir=str(bin_dir), prefix=".bws_")
+        fd, staged = bounded_mkstemp(dir=str(bin_dir), prefix=".bws_", suffix="")
         os.close(fd)
         shutil.copy2(extracted, staged)
         os.chmod(

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -113,7 +113,6 @@ import re
 import shlex
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 from contextlib import contextmanager
@@ -130,7 +129,7 @@ except ImportError:  # pragma: no cover
     fcntl = None  # type: ignore[assignment]
 
 from hermes_constants import get_hermes_home
-from utils import atomic_replace
+from utils import atomic_replace, bounded_mkstemp
 
 logger = logging.getLogger(__name__)
 
@@ -652,7 +651,7 @@ def save_allowlist(data: Dict[str, Any]) -> None:
     p = allowlist_path()
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(
+        fd, tmp_path = bounded_mkstemp(
             prefix=f"{p.name}.", suffix=".tmp", dir=str(p.parent),
         )
         try:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 import json
 import logging
 import shutil
-import tempfile
 import threading
 import time
 import os
@@ -39,7 +38,7 @@ from typing import Optional, Dict, List, Any, Set, Tuple, Union
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
-from utils import atomic_replace
+from utils import atomic_replace, bounded_mkstemp
 
 try:
     from croniter import croniter
@@ -755,7 +754,7 @@ def _atomic_write_epoch(path: Path) -> None:
     torn/truncated file. Best-effort: failures are swallowed by callers.
     """
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".hb_")
+    fd, tmp_path = bounded_mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".hb_")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(str(time.time()))
@@ -872,7 +871,7 @@ def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
     """Save all jobs to storage. Caller must hold _jobs_lock()."""
     jobs_file = _current_cron_store().jobs_file
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(jobs_file.parent), suffix='.tmp', prefix='.jobs_')
+    fd, tmp_path = bounded_mkstemp(dir=str(jobs_file.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
             json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
@@ -2168,7 +2167,7 @@ def save_job_output(job_id: str, output: str):
     timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S")
     output_file = job_output_dir / f"{timestamp}.md"
 
-    fd, tmp_path = tempfile.mkstemp(dir=str(job_output_dir), suffix='.tmp', prefix='.output_')
+    fd, tmp_path = bounded_mkstemp(dir=str(job_output_dir), suffix='.tmp', prefix='.output_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
             f.write(output)

--- a/cron/suggestions.py
+++ b/cron/suggestions.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import tempfile
 import threading
 import uuid
 from pathlib import Path
@@ -38,7 +37,7 @@ from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
-from utils import atomic_replace
+from utils import atomic_replace, bounded_mkstemp
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +91,7 @@ def _load_raw() -> Dict[str, Any]:
 
 def _save_raw(suggestions: List[Dict[str, Any]]) -> None:
     _ensure_dir()
-    fd, tmp_path = tempfile.mkstemp(dir=str(SUGGESTIONS_FILE.parent), suffix=".tmp", prefix=".sugg_")
+    fd, tmp_path = bounded_mkstemp(dir=str(SUGGESTIONS_FILE.parent), suffix=".tmp", prefix=".sugg_")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -23,7 +23,6 @@ import json
 import logging
 import os
 import secrets
-import tempfile
 import threading
 import time
 from pathlib import Path
@@ -34,7 +33,7 @@ from gateway.whatsapp_identity import (
     normalize_whatsapp_identifier,
 )
 from hermes_constants import get_hermes_dir, get_hermes_home
-from utils import atomic_replace
+from utils import atomic_replace, bounded_mkstemp
 
 logger = logging.getLogger(__name__)
 
@@ -213,7 +212,7 @@ def _secure_write(path: Path, data: str) -> None:
     complete file or the new one — never a partial write.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    fd, tmp_path = bounded_mkstemp(dir=str(path.parent), suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(data)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -94,7 +94,7 @@ from .whatsapp_identity import (
     canonical_whatsapp_identifier,
     normalize_whatsapp_identifier,  # noqa: F401 - re-exported for gateway.session callers
 )
-from utils import atomic_replace
+from utils import atomic_replace, bounded_mkstemp
 
 # Session keys/ids flow into filesystem paths downstream (e.g.
 # ``sessions_dir / f"{session_id}.json"`` in hermes_state, request-dump
@@ -1254,7 +1254,6 @@ class SessionStore:
 
     def _save_sessions_json(self, data: Dict[str, Any]) -> None:
         """Write the legacy sessions.json mirror of the routing index."""
-        import tempfile
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
         sessions_file = self.sessions_dir / "sessions.json"
 
@@ -1276,7 +1275,7 @@ class SessionStore:
             ),
             **data,
         }
-        fd, tmp_path = tempfile.mkstemp(
+        fd, tmp_path = bounded_mkstemp(
             dir=str(self.sessions_dir), suffix=".tmp", prefix=".sessions_"
         )
         try:

--- a/gateway/sticker_cache.py
+++ b/gateway/sticker_cache.py
@@ -10,9 +10,10 @@ Cache location: ~/.hermes/sticker_cache.json
 
 import json
 import os
-import tempfile
 import time
 from typing import Optional
+
+from utils import bounded_mkstemp
 
 from hermes_cli.config import get_hermes_home
 
@@ -39,7 +40,7 @@ def _load_cache() -> dict:
 def _save_cache(cache: dict) -> None:
     """Save the sticker cache to disk atomically."""
     CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(
+    fd, tmp_path = bounded_mkstemp(
         dir=str(CACHE_PATH.parent), suffix=".tmp"
     )
     try:

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -734,9 +734,9 @@ def migrate(
         # rename. Same-directory rename is atomic on POSIX and ReplaceFile
         # on Windows. Avoids leaving a half-written config.toml that
         # codex would refuse to load if we crash mid-write.
-        import tempfile
-        tmp_fd, tmp_path_str = tempfile.mkstemp(
-            prefix=".config.toml.", dir=str(codex_home)
+        from utils import bounded_mkstemp
+        tmp_fd, tmp_path_str = bounded_mkstemp(
+            prefix=".config.toml.", dir=str(codex_home), suffix=""
         )
         tmp_path = Path(tmp_path_str)
         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -22,7 +22,6 @@ import shutil
 import stat
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 from dataclasses import dataclass
@@ -742,7 +741,7 @@ def get_container_exec_info() -> Optional[dict]:
 
 # Re-export from hermes_constants — canonical definition lives there.
 from hermes_constants import get_hermes_home  # noqa: F811,E402
-from utils import atomic_replace, fast_safe_load
+from utils import atomic_replace, bounded_mkstemp, fast_safe_load
 
 def get_config_path() -> Path:
     """Get the main config file path."""
@@ -7472,7 +7471,7 @@ def sanitize_env_file() -> int:
         fixes = sum(1 for a, b in zip(original_lines, sanitized) if a != b)
         fixes += abs(len(sanitized) - len(original_lines))
 
-    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix=".tmp", prefix=".env_")
+    fd, tmp_path = bounded_mkstemp(dir=str(env_path.parent), suffix=".tmp", prefix=".env_")
     try:
         with os.fdopen(fd, "w", **write_kw) as f:
             f.writelines(sanitized)
@@ -7601,7 +7600,7 @@ def save_env_value(key: str, value: str):
             lines[-1] += "\n"
         lines.append(f"{key}={serialized_value}\n")
     
-    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+    fd, tmp_path = bounded_mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
     # Preserve original permissions so Docker volume mounts aren't clobbered.
     original_mode = None
     if env_path.exists():
@@ -7673,7 +7672,7 @@ def remove_env_value(key: str) -> bool:
     found = len(new_lines) < len(lines)
 
     if found:
-        fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+        fd, tmp_path = bounded_mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
         # Preserve original permissions so Docker volume mounts aren't clobbered.
         original_mode = None
         try:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
-from utils import atomic_replace, fast_safe_load
+from utils import atomic_replace, bounded_mkstemp, fast_safe_load
 
 
 # Env var name suffixes that indicate credential values.  These are the
@@ -197,8 +197,7 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         stripped = [line.replace("\x00", "") for line in original]
         sanitized = _sanitize_env_lines(stripped)
         if sanitized != original:
-            import tempfile
-            fd, tmp = tempfile.mkstemp(
+            fd, tmp = bounded_mkstemp(
                 dir=str(path.parent), suffix=".tmp", prefix=".env_"
             )
             try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -89,7 +89,7 @@ from hermes_cli.memory_providers import (
     ProviderField as DeclaredProviderField,
     get_memory_provider as get_declared_memory_provider,
 )
-from utils import env_var_enabled
+from utils import bounded_mkstemp, env_var_enabled
 
 try:
     from fastapi import (
@@ -2067,7 +2067,7 @@ async def upload_managed_file_stream(
 
     # Write to a sibling temp file first so a partial/aborted upload never
     # clobbers an existing file, then atomically rename into place.
-    tmp_fd, tmp_name = tempfile.mkstemp(
+    tmp_fd, tmp_name = bounded_mkstemp(
         prefix=f".{target.name}.", suffix=".upload", dir=str(target.parent)
     )
     tmp_path = Path(tmp_name)
@@ -12018,7 +12018,7 @@ async def run_import_upload(
     safe_name = _safe_backup_upload_name(file.filename)
     stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
     target = staging_dir / f"dashboard-import-{stamp}-{secrets.token_hex(4)}-{safe_name}"
-    tmp_fd, tmp_name = tempfile.mkstemp(
+    tmp_fd, tmp_name = bounded_mkstemp(
         prefix=f".{target.name}.",
         suffix=".upload",
         dir=str(staging_dir),

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -14,13 +14,12 @@ import json
 import os
 import re
 import secrets
-import tempfile
 import time
 from pathlib import Path
 from typing import Dict
 
 from hermes_constants import display_hermes_home
-from utils import atomic_replace
+from utils import atomic_replace, bounded_mkstemp
 from hermes_cli.config import cfg_get
 
 
@@ -55,11 +54,10 @@ def _save_subscriptions(subs: Dict[str, dict]) -> None:
     # via tempfile + chmod 0o600 before the atomic rename so a permissive
     # umask cannot leave the secrets readable to other local users in the
     # window between create and rename.
-    fd, tmp_name = tempfile.mkstemp(
+    fd, tmp_name = bounded_mkstemp(
         prefix=f".{path.name}.",
         suffix=".tmp",
         dir=path.parent,
-        text=True,
     )
     tmp_path = Path(tmp_name)
     try:

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -666,7 +666,7 @@ class TestAllowlistConcurrency:
         import logging
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
         monkeypatch.setattr(
-            shell_hooks.tempfile, "mkstemp",
+            shell_hooks, "bounded_mkstemp",
             lambda *a, **kw: (_ for _ in ()).throw(OSError(28, "No space")),
         )
         with caplog.at_level(logging.WARNING, logger=shell_hooks.logger.name):
@@ -739,14 +739,14 @@ class TestAllowlistConcurrency:
         p.parent.mkdir(parents=True, exist_ok=True)
 
         tmp_paths_seen: list = []
-        real_mkstemp = shell_hooks.tempfile.mkstemp
+        real_mkstemp = shell_hooks.bounded_mkstemp
 
         def spying_mkstemp(*args, **kwargs):
             fd, path = real_mkstemp(*args, **kwargs)
             tmp_paths_seen.append(path)
             return fd, path
 
-        monkeypatch.setattr(shell_hooks.tempfile, "mkstemp", spying_mkstemp)
+        monkeypatch.setattr(shell_hooks, "bounded_mkstemp", spying_mkstemp)
 
         shell_hooks.save_allowlist({"approvals": [{"event": "a", "command": "x"}]})
         shell_hooks.save_allowlist({"approvals": [{"event": "b", "command": "y"}]})

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1692,6 +1692,17 @@ class TestSaveJobOutput:
         assert output_file.read_text() == "# Results\nEverything ok."
         assert "test123" in str(output_file)
 
+    def test_write_denied_raises_promptly(self, tmp_cron_dir):
+        """Regression for the one-shot CLI busy-spin: a write-denied cron
+        store must surface PermissionError immediately instead of retrying
+        TMP_MAX candidate names inside tempfile."""
+        from unittest.mock import patch as mock_patch
+
+        denial = PermissionError(13, "Access is denied", str(tmp_cron_dir))
+        with mock_patch("cron.jobs.bounded_mkstemp", side_effect=denial):
+            with pytest.raises(PermissionError):
+                save_jobs([])
+
     @pytest.mark.parametrize("bad_job_id", ["../escape", "nested/escape", ".", "..", ""])
     def test_rejects_unsafe_job_id(self, tmp_cron_dir, bad_job_id):
         """Path-escape attempts must fail closed and never create dirs."""

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -91,6 +91,17 @@ class TestSecureWrite:
         mode = oct(target.stat().st_mode & 0o777)
         assert mode == "0o600"
 
+    def test_write_denied_raises_promptly(self, tmp_path):
+        """Regression for the one-shot CLI busy-spin: an ACL-denied pairing
+        dir must surface PermissionError immediately instead of retrying
+        TMP_MAX candidate names inside tempfile."""
+        target = tmp_path / "approved.json"
+        denial = PermissionError(13, "Access is denied", str(target))
+        with patch("gateway.pairing.bounded_mkstemp", side_effect=denial):
+            with pytest.raises(PermissionError):
+                _secure_write(target, "data")
+        assert not target.exists()
+
 
 # ---------------------------------------------------------------------------
 # Code generation

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -530,6 +530,17 @@ class TestSaveEnvValueSecure:
             save_env_value("TENOR_API_KEY", "sk-test-secret")
             assert os.environ["TENOR_API_KEY"] == "sk-test-secret"
 
+    def test_save_env_value_unwritable_home_raises_promptly(self, tmp_path):
+        """Regression for the one-shot CLI busy-spin: a write-denied
+        HERMES_HOME must surface PermissionError to the caller immediately
+        instead of retrying TMP_MAX candidate names inside tempfile."""
+        denial = PermissionError(13, "Access is denied", str(tmp_path / ".env"))
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with patch("hermes_cli.config.bounded_mkstemp", side_effect=denial):
+                with pytest.raises(PermissionError):
+                    save_env_value("TENOR_API_KEY", "sk-test-secret")
+        assert not (tmp_path / ".env").exists()
+
     def test_save_env_value_hardens_file_permissions_on_posix(self, tmp_path):
         if os.name == "nt":
             return
@@ -726,7 +737,7 @@ class TestSaveConfigAtomicity:
 
             # Read raw YAML to verify it's valid and correct
             config_path = tmp_path / "config.yaml"
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 raw = yaml.safe_load(f)
             assert raw["model"] == "test/atomic-model"
             assert raw["agent"]["max_turns"] == 77

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -86,6 +86,26 @@ def test_null_bytes_in_user_env_are_stripped(tmp_path, monkeypatch):
     assert os.getenv("OPENAI_API_KEY") == "sk-123"
 
 
+def test_sanitize_write_denied_degrades_quietly(tmp_path, monkeypatch):
+    """Regression for the one-shot CLI busy-spin: when the sanitized .env
+    cannot be written back (ACL-denied HERMES_HOME), sanitization must
+    neither hang nor raise - it is best-effort by contract."""
+    from unittest.mock import patch
+
+    from hermes_cli.env_loader import _sanitize_env_file_if_needed
+
+    env_file = tmp_path / ".env"
+    corrupted = "GLM_API_KEY=abc\x00\x00\n"
+    env_file.write_text(corrupted, encoding="utf-8")
+
+    denial = PermissionError(13, "Access is denied", str(env_file))
+    with patch("hermes_cli.env_loader.bounded_mkstemp", side_effect=denial):
+        _sanitize_env_file_if_needed(env_file)  # must return, not raise
+
+    # The corrupted file is left as-is for the next successful run.
+    assert env_file.read_text(encoding="utf-8") == corrupted
+
+
 def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
     home = tmp_path / "hermes"
     home.mkdir()

--- a/tests/test_bounded_mkstemp_call_sites.py
+++ b/tests/test_bounded_mkstemp_call_sites.py
@@ -1,0 +1,51 @@
+"""Persistent-dir temp files must go through ``utils.bounded_mkstemp``.
+
+``tempfile.mkstemp`` retries candidate names up to ``TMP_MAX`` times
+(2**31-1 on Windows) and its bpo-22107 workaround treats every
+``PermissionError`` as a name collision whenever ``os.access(dir, os.W_OK)``
+claims the directory is writable.  ``os.access`` cannot see ACL denials on
+Windows, so ``mkstemp`` aimed at a directory the process may not write to
+(HERMES_HOME under a sandboxed agent shell, a hardened service account)
+busy-spins one CPU core for hours instead of raising.
+
+System-temp usage (no ``dir=``) is out of scope: tempfile falls back
+across several candidate directories for those, and an unwritable system
+temp dir breaks the interpreter long before it breaks Hermes.  Anything
+that passes ``dir=`` targets a persistent location and must use the
+bounded helper instead.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Product code reachable from a running `hermes` process.  Skills under
+# optional-skills/ run as standalone scripts and cannot import utils.
+PRODUCT_DIRS = ("agent", "cron", "gateway", "hermes_cli", "tools", "plugins")
+
+# Matches mkstemp calls that pass dir= (via `tempfile` or any alias ending
+# in "tempfile", e.g. `_tempfile`), across line breaks.
+_MKSTEMP_WITH_DIR = re.compile(
+    r"tempfile\.mkstemp\((?:[^()]|\([^()]*\))*\bdir\s*=", re.S
+)
+
+
+def test_no_unbounded_mkstemp_into_persistent_dirs():
+    files = [REPO_ROOT / "utils.py"]
+    for d in PRODUCT_DIRS:
+        files.extend(sorted((REPO_ROOT / d).rglob("*.py")))
+
+    violations = [
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in files
+        if _MKSTEMP_WITH_DIR.search(
+            path.read_text(encoding="utf-8", errors="replace")
+        )
+    ]
+
+    assert not violations, (
+        "tempfile.mkstemp(dir=...) targets a persistent directory and "
+        "busy-spins for hours on an ACL-denied dir on Windows (bpo-22107); "
+        f"use utils.bounded_mkstemp instead: {violations}"
+    )

--- a/tests/test_utils_bounded_mkstemp.py
+++ b/tests/test_utils_bounded_mkstemp.py
@@ -1,0 +1,138 @@
+"""Tests for utils.bounded_mkstemp — the bounded tempfile.mkstemp replacement.
+
+Regression coverage for the one-shot CLI busy-spin: ``tempfile.mkstemp``
+treats PermissionError as a name collision on Windows (bpo-22107) and
+retries up to TMP_MAX times — 2**31-1 on Windows — so commands writing
+into an ACL-denied ``~/.hermes`` (sandboxed agent shells, hardened
+service accounts) burned a full CPU core for hours instead of exiting.
+``bounded_mkstemp`` must fail within ``_BOUNDED_MKSTEMP_ATTEMPTS`` opens.
+"""
+
+import os
+import time
+
+import pytest
+
+import utils
+from utils import _BOUNDED_MKSTEMP_ATTEMPTS, bounded_mkstemp
+
+
+class TestHappyPath:
+    def test_creates_file_and_returns_open_fd(self, tmp_path):
+        fd, path = bounded_mkstemp(
+            dir=str(tmp_path), prefix=".manifest_", suffix=".tmp"
+        )
+        try:
+            assert os.path.dirname(path) == str(tmp_path)
+            name = os.path.basename(path)
+            assert name.startswith(".manifest_")
+            assert name.endswith(".tmp")
+            os.write(fd, b"payload")
+        finally:
+            os.close(fd)
+        assert (tmp_path / name).read_bytes() == b"payload"
+
+    def test_distinct_names_across_calls(self, tmp_path):
+        paths = set()
+        for _ in range(16):
+            fd, path = bounded_mkstemp(dir=str(tmp_path))
+            os.close(fd)
+            paths.add(path)
+        assert len(paths) == 16
+
+    def test_owner_only_mode_on_posix(self, tmp_path):
+        if os.name == "nt":
+            pytest.skip("POSIX permission bits")
+        fd, path = bounded_mkstemp(dir=str(tmp_path))
+        os.close(fd)
+        assert os.stat(path).st_mode & 0o777 == 0o600
+
+
+class TestCollisionRetry:
+    def test_collision_moves_to_fresh_name(self, tmp_path, monkeypatch):
+        tokens = iter([b"\x00" * 8, b"\x11" * 8])
+        monkeypatch.setattr(os, "urandom", lambda n: next(tokens))
+        (tmp_path / ("tmp" + (b"\x00" * 8).hex() + ".tmp")).touch()
+
+        fd, path = bounded_mkstemp(dir=str(tmp_path))
+        os.close(fd)
+        assert path == str(tmp_path / ("tmp" + (b"\x11" * 8).hex() + ".tmp"))
+
+    def test_persistent_collision_is_bounded(self, tmp_path, monkeypatch):
+        calls = {"n": 0}
+
+        def constant_urandom(n):
+            calls["n"] += 1
+            return b"\x00" * n
+
+        monkeypatch.setattr(os, "urandom", constant_urandom)
+        (tmp_path / ("tmp" + ("00" * 8) + ".tmp")).touch()
+
+        with pytest.raises(FileExistsError):
+            bounded_mkstemp(dir=str(tmp_path))
+        assert calls["n"] == _BOUNDED_MKSTEMP_ATTEMPTS
+
+
+class TestPermissionErrorBounded:
+    def test_windows_semantics_fail_fast_not_tmp_max(self, tmp_path, monkeypatch):
+        """The incident regression: a denied directory must raise within
+        ``_BOUNDED_MKSTEMP_ATTEMPTS`` open attempts — not retry TMP_MAX
+        (2**31-1 on Windows) candidate names at 100% CPU.
+        """
+        monkeypatch.setattr(utils, "_MKSTEMP_RETRY_PERMISSION_ERROR", True)
+        calls = {"n": 0}
+
+        def denying_open(path, flags, mode=0o777):
+            calls["n"] += 1
+            raise PermissionError(13, "Access is denied", path)
+
+        monkeypatch.setattr(os, "open", denying_open)
+        with pytest.raises(PermissionError):
+            bounded_mkstemp(dir=str(tmp_path))
+        assert calls["n"] == _BOUNDED_MKSTEMP_ATTEMPTS
+
+    def test_posix_semantics_raise_on_first_denial(self, tmp_path, monkeypatch):
+        """On POSIX PermissionError is unambiguous — no retry can help."""
+        monkeypatch.setattr(utils, "_MKSTEMP_RETRY_PERMISSION_ERROR", False)
+        calls = {"n": 0}
+
+        def denying_open(path, flags, mode=0o777):
+            calls["n"] += 1
+            raise PermissionError(13, "Permission denied", path)
+
+        monkeypatch.setattr(os, "open", denying_open)
+        with pytest.raises(PermissionError):
+            bounded_mkstemp(dir=str(tmp_path))
+        assert calls["n"] == 1
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows ACL deny semantics")
+class TestWindowsAclDeny:
+    def test_acl_denied_dir_raises_promptly(self, tmp_path):
+        """End-to-end on a real ACL-denied directory: PermissionError in
+        milliseconds, where ``tempfile.mkstemp`` spins for hours.
+        """
+        import getpass
+        import subprocess
+
+        denied = tmp_path / "denied"
+        denied.mkdir()
+        user = getpass.getuser()
+        set_deny = subprocess.run(
+            ["icacls", str(denied), "/deny", f"{user}:(OI)(CI)(W,AD,WD,DC)"],
+            capture_output=True,
+            text=True,
+        )
+        if set_deny.returncode != 0:
+            pytest.skip(f"cannot set a deny ACL here: {set_deny.stderr.strip()}")
+        try:
+            start = time.monotonic()
+            with pytest.raises(PermissionError):
+                bounded_mkstemp(dir=str(denied))
+            assert time.monotonic() - start < 5.0
+        finally:
+            subprocess.run(
+                ["icacls", str(denied), "/remove:d", user],
+                capture_output=True,
+                text=True,
+            )

--- a/tests/test_utils_bounded_mkstemp.py
+++ b/tests/test_utils_bounded_mkstemp.py
@@ -111,28 +111,51 @@ class TestWindowsAclDeny:
     def test_acl_denied_dir_raises_promptly(self, tmp_path):
         """End-to-end on a real ACL-denied directory: PermissionError in
         milliseconds, where ``tempfile.mkstemp`` spins for hours.
+
+        The deny ACE is placed by SID, not account name: on machines with
+        several similar local principals (sandbox pseudo-users, a machine
+        name equal to the user name) icacls can resolve a bare name to the
+        wrong principal and silently produce an ineffective deny.  A probe
+        write then confirms the deny actually bites before asserting.
         """
-        import getpass
         import subprocess
 
         denied = tmp_path / "denied"
         denied.mkdir()
-        user = getpass.getuser()
+        whoami = os.path.join(
+            os.environ.get("SystemRoot", r"C:\Windows"), "System32", "whoami.exe"
+        )
+        got_sid = subprocess.run(
+            [whoami, "/user", "/fo", "csv", "/nh"], capture_output=True, text=True
+        )
+        if got_sid.returncode != 0:
+            pytest.skip(f"cannot resolve own SID: {got_sid.stderr.strip()}")
+        sid = got_sid.stdout.strip().rsplit(",", 1)[-1].strip().strip('"')
         set_deny = subprocess.run(
-            ["icacls", str(denied), "/deny", f"{user}:(OI)(CI)(W,AD,WD,DC)"],
+            ["icacls", str(denied), "/deny", f"*{sid}:(OI)(CI)(W,AD,WD,DC)"],
             capture_output=True,
             text=True,
         )
         if set_deny.returncode != 0:
             pytest.skip(f"cannot set a deny ACL here: {set_deny.stderr.strip()}")
         try:
+            try:
+                probe_fd = os.open(
+                    str(denied / "probe.bin"), os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600
+                )
+            except PermissionError:
+                pass  # the deny is effective — proceed to the real assertion
+            else:
+                os.close(probe_fd)
+                pytest.skip("deny ACL not effective in this environment")
+
             start = time.monotonic()
             with pytest.raises(PermissionError):
                 bounded_mkstemp(dir=str(denied))
             assert time.monotonic() - start < 5.0
         finally:
             subprocess.run(
-                ["icacls", str(denied), "/remove:d", user],
+                ["icacls", str(denied), "/remove:d", f"*{sid}"],
                 capture_output=True,
                 text=True,
             )

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -69,6 +69,19 @@ class TestReadWriteManifest:
 
         assert result == {"skill-a": "hash1", "skill-b": "hash2"}
 
+    def test_write_manifest_unwritable_dir_degrades_quietly(self, tmp_path):
+        """Regression for the one-shot CLI busy-spin: an unwritable skills
+        dir must neither hang nor raise — sync logs at DEBUG and moves on,
+        and the manifest is rebuilt on the next successful sync."""
+        manifest_file = tmp_path / ".bundled_manifest"
+        denial = PermissionError(13, "Access is denied", str(manifest_file))
+
+        with patch("tools.skills_sync.MANIFEST_FILE", manifest_file):
+            with patch("tools.skills_sync.bounded_mkstemp", side_effect=denial):
+                _write_manifest({"skill-a": "abc123"})  # must return, not raise
+
+        assert not manifest_file.exists()
+
     def test_read_manifest_mixed_v1_v2(self, tmp_path):
         """Manifest with both v1 and v2 lines (shouldn't happen but handle gracefully)."""
         manifest_file = tmp_path / ".bundled_manifest"

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -26,14 +26,13 @@ Design:
 import json
 import logging
 import os
-import tempfile
 import time
 from contextlib import contextmanager
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, Any, List, Optional
 
-from utils import atomic_replace
+from utils import atomic_replace, bounded_mkstemp
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 msvcrt = None
@@ -768,7 +767,7 @@ class MemoryStore:
         content = ENTRY_DELIMITER.join(entries) if entries else ""
         try:
             # Write to temp file in same directory (same filesystem for atomic rename)
-            fd, tmp_path = tempfile.mkstemp(
+            fd, tmp_path = bounded_mkstemp(
                 dir=str(path.parent), suffix=".tmp", prefix=".mem_"
             )
             try:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -37,13 +37,12 @@ import logging
 import os
 import re
 import shutil
-import tempfile
 import contextvars as _ctxvars
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import get_hermes_home, display_hermes_home
-from utils import atomic_replace, is_truthy_value
+from utils import atomic_replace, bounded_mkstemp, is_truthy_value
 from hermes_cli.config import cfg_get
 
 logger = logging.getLogger(__name__)
@@ -768,7 +767,7 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
         encoding: Text encoding (default: utf-8)
     """
     file_path.parent.mkdir(parents=True, exist_ok=True)
-    fd, temp_path = tempfile.mkstemp(
+    fd, temp_path = bounded_mkstemp(
         dir=str(file_path.parent),
         prefix=f".{file_path.name}.tmp.",
         suffix="",

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import tempfile
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -35,6 +34,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
 from agent.skill_utils import is_excluded_skill_path, is_external_skill_path
+from utils import bounded_mkstemp
 
 logger = logging.getLogger(__name__)
 
@@ -290,7 +290,7 @@ def _write_suppressed_names(names: Set[str]) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         data = "\n".join(sorted(names)) + ("\n" if names else "")
-        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".curator_suppressed_", suffix=".tmp")
+        fd, tmp = bounded_mkstemp(dir=str(path.parent), prefix=".curator_suppressed_", suffix=".tmp")
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(data)
@@ -522,7 +522,7 @@ def save_usage(data: Dict[str, Dict[str, Any]]) -> None:
     path = _usage_file()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(
+        fd, tmp_path = bounded_mkstemp(
             dir=str(path.parent), prefix=".usage_", suffix=".tmp"
         )
         try:

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -31,7 +31,7 @@ from pathlib import Path, PurePosixPath
 from hermes_constants import get_bundled_skills_dir, get_hermes_home, get_optional_skills_dir
 from agent.skill_utils import is_excluded_skill_path
 from typing import Dict, List, Optional, Set, Tuple
-from utils import atomic_replace
+from utils import atomic_replace, bounded_mkstemp
 
 logger = logging.getLogger(__name__)
 
@@ -153,13 +153,11 @@ def _write_manifest(entries: Dict[str, str]):
     Uses a temp file + os.replace() to avoid corruption if the process
     crashes or is interrupted mid-write.
     """
-    import tempfile
-
     MANIFEST_FILE.parent.mkdir(parents=True, exist_ok=True)
     data = "\n".join(f"{name}:{hash_val}" for name, hash_val in sorted(entries.items())) + "\n"
 
     try:
-        fd, tmp_path = tempfile.mkstemp(
+        fd, tmp_path = bounded_mkstemp(
             dir=str(MANIFEST_FILE.parent),
             prefix=".bundled_manifest_",
             suffix=".tmp",
@@ -457,10 +455,8 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
         # Atomic write so a crash mid-write can't silently wipe all provenance
         # via the JSONDecodeError fallback above (which resets `installed` to
         # an empty dict).
-        import tempfile
-
         payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
-        fd, tmp_path = tempfile.mkstemp(
+        fd, tmp_path = bounded_mkstemp(
             dir=str(lock_path.parent),
             prefix=".lock_",
             suffix=".tmp",

--- a/utils.py
+++ b/utils.py
@@ -6,7 +6,6 @@ import logging
 import os
 import shutil
 import stat
-import tempfile
 from pathlib import Path
 from typing import Any, Union
 from urllib.parse import urlparse
@@ -88,6 +87,64 @@ def _restore_file_mode(path: Path, mode: "int | None") -> None:
         pass
 
 
+# Maximum distinct names bounded_mkstemp() tries before giving up.
+# Deliberately tiny: names carry 64 bits of randomness, so a genuine
+# collision is implausible, and the point is to fail fast on persistent
+# errors instead of inheriting tempfile's TMP_MAX retry budget.
+_BOUNDED_MKSTEMP_ATTEMPTS = 8
+
+# Windows reports "a directory with this name already exists" as EACCES
+# (bpo-22107), so a PermissionError there is ambiguous and worth one more
+# try under a different name.  On POSIX it is a real permission failure
+# and retrying cannot help.
+_MKSTEMP_RETRY_PERMISSION_ERROR = os.name == "nt"
+
+# Mirror tempfile's open flags so the created file behaves identically:
+# 0o600, exclusive create, no symlink following, binary mode on Windows.
+_MKSTEMP_FLAGS = os.O_RDWR | os.O_CREAT | os.O_EXCL
+if hasattr(os, "O_NOFOLLOW"):
+    _MKSTEMP_FLAGS |= os.O_NOFOLLOW
+if hasattr(os, "O_BINARY"):
+    _MKSTEMP_FLAGS |= os.O_BINARY
+
+
+def bounded_mkstemp(
+    dir: Union[str, Path], prefix: str = "tmp", suffix: str = ".tmp"
+) -> "tuple[int, str]":
+    """``tempfile.mkstemp`` with a small, bounded retry budget.
+
+    ``tempfile.mkstemp`` retries candidate names up to ``TMP_MAX`` times —
+    2**31-1 on Windows — and its bpo-22107 workaround treats every
+    ``PermissionError`` as a name collision whenever ``os.access(dir,
+    os.W_OK)`` claims the directory is writable.  ``os.access`` cannot see
+    ACL denials on Windows, so calling ``mkstemp`` in a directory the
+    process may not write to (sandboxed agent shells, hardened service
+    accounts) busy-spins one CPU core for hours instead of raising.
+    One-shot CLI commands hit this through the atomic-write helpers and
+    never exit.
+
+    This helper generates 64-bit random names itself and tries at most
+    ``_BOUNDED_MKSTEMP_ATTEMPTS`` of them: a real name collision moves on
+    to a fresh name, while an error that persists across every attempt is
+    a real filesystem problem and is re-raised within milliseconds.
+
+    Returns ``(fd, path)`` exactly like ``tempfile.mkstemp``.
+    """
+    last_error: "OSError | None" = None
+    for _ in range(_BOUNDED_MKSTEMP_ATTEMPTS):
+        path = os.path.join(str(dir), f"{prefix}{os.urandom(8).hex()}{suffix}")
+        try:
+            return os.open(path, _MKSTEMP_FLAGS, 0o600), path
+        except FileExistsError as exc:
+            last_error = exc
+        except PermissionError as exc:
+            if not _MKSTEMP_RETRY_PERMISSION_ERROR:
+                raise
+            last_error = exc
+    assert last_error is not None  # attempts >= 1, so the loop set or raised
+    raise last_error
+
+
 def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     """Atomically move *tmp_path* onto *target*, preserving symlinks.
 
@@ -166,7 +223,7 @@ def atomic_json_write(
     original_mode = None if mode is not None else _preserve_file_mode(path)
     original_owner = _preserve_file_owner(path)
 
-    fd, tmp_path = tempfile.mkstemp(
+    fd, tmp_path = bounded_mkstemp(
         dir=str(path.parent),
         prefix=f".{path.stem}_",
         suffix=".tmp",
@@ -252,7 +309,7 @@ def atomic_yaml_write(
     original_mode = _preserve_file_mode(path)
     original_owner = _preserve_file_owner(path)
 
-    fd, tmp_path = tempfile.mkstemp(
+    fd, tmp_path = bounded_mkstemp(
         dir=str(path.parent),
         prefix=f".{path.stem}_",
         suffix=".tmp",
@@ -338,7 +395,7 @@ def atomic_roundtrip_yaml_update(
 
     original_mode = _preserve_file_mode(path)
     original_owner = _preserve_file_owner(path)
-    fd, tmp_path = tempfile.mkstemp(
+    fd, tmp_path = bounded_mkstemp(
         dir=str(path.parent),
         prefix=f".{path.stem}_",
         suffix=".tmp",


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows busy-spin where any one-shot `hermes` CLI command can pin a full CPU core for **hours** instead of exiting, whenever `~/.hermes` denies writes at the ACL level (sandboxed agent shells such as Codex's `workspace-write` mode, hardened service accounts, locked-down corporate profiles).

**Root cause (verified in code + live stack dump):** CPython's `tempfile.mkstemp` retries candidate names up to `TMP_MAX` times — **2,147,483,647 on Windows** — and its bpo-22107 workaround treats *every* `PermissionError` as a name collision when `os.access(dir, os.W_OK)` claims the directory is writable. `os.access` cannot see ACL denials on Windows, so `mkstemp` in an ACL-denied directory becomes a ~30-hour hot loop instead of an immediate error.

Hermes calls `mkstemp(dir=<hermes home>...)` on hot paths: the bundled-skills manifest sync runs at startup for gateway commands (`tools/skills_sync.py::_write_manifest`), and `hermes_cli/config.py::save_env_value` persists credentials. Observed in production (Windows 11): three `hermes gateway status` runs and one `hermes photon webhook register` launched from a sandboxed agent shell were orphaned at the agent's timeout and burned 0.5–1.0 cores each for 7–9 hours (~22 CPU-hours) until manually killed. py-spy on a live reproduction shows the exact stack:

```
Thread 19724 (active): "MainThread"
    _mkstemp_inner (tempfile.py:256)
    mkstemp (tempfile.py:357)
    _write_manifest (tools\skills_sync.py:133)
    sync_skills (tools\skills_sync.py:615)
    _sync_bundled_skills_quietly (hermes_cli\main.py:2001)
    cmd_gateway (hermes_cli\main.py:2218)
    main (hermes_cli\main.py:11567)
```

**The fix** mirrors the repo's existing pattern of small dependency-free helpers in `utils.py` (next to `atomic_replace` / `atomic_json_write`, which this directly serves): a new `bounded_mkstemp()` with the same `(fd, path)` contract and open flags as `tempfile.mkstemp`, but it generates 64-bit random names itself and tries **at most 8** of them. A real name collision moves to a fresh name; an error that persists across every attempt is a real filesystem problem and is re-raised within milliseconds. Callers keep their existing degradation paths: skills sync logs at DEBUG and moves on; `save_env_value` propagates `PermissionError` to the command's error handling.

## Related Issue

No existing issue found for this (searched for `mkstemp` / CPU-spin reports). Full root-cause analysis is inline above; happy to file a companion issue if maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `utils.py` — new `bounded_mkstemp(dir, prefix, suffix)` helper (bounded retry budget, stdlib-only, side-effect-free, unit-testable without launching the app); the three atomic-write helpers (`atomic_json_write`, `atomic_yaml_write`, `atomic_roundtrip_yaml_update`) now use it; dropped the now-unused `import tempfile`.
- `tools/skills_sync.py` — `_write_manifest` and `_backfill_optional_provenance` use `bounded_mkstemp` (this is the CLI-startup path every gateway command hits).
- `tools/skill_usage.py` — `_write_suppressed_names` and `save_usage` use `bounded_mkstemp`.
- `hermes_cli/config.py` — `sanitize_env_file`, `save_env_value`, `remove_env_value` use `bounded_mkstemp` (the `photon webhook register` persistence path).
- `tests/test_utils_bounded_mkstemp.py` — new, dependency-free: happy path, fresh-name-on-collision, bounded persistent collision, bounded PermissionError under Windows semantics (the incident regression — asserts exactly `_BOUNDED_MKSTEMP_ATTEMPTS` open attempts, not TMP_MAX), immediate raise under POSIX semantics, and a real ACL-deny end-to-end test (Windows-only, self-skipping where ACLs can't be set).
- `tests/tools/test_skills_sync.py` — `_write_manifest` against an unwritable dir returns quietly instead of hanging/raising.
- `tests/hermes_cli/test_config.py` — `save_env_value` against a write-denied home raises `PermissionError` promptly; also fixed a pre-existing `open()` without `encoding=` in this file flagged by `scripts/check-windows-footguns.py` (CI runs it on changed files).

## How to Test

1. Unit tests: `pytest tests/test_utils_bounded_mkstemp.py tests/tools/test_skills_sync.py tests/hermes_cli/test_config.py -q`
2. Reproduce the bug on Windows against the **unfixed** code: create a scratch dir, deny writes (`icacls <dir> /deny <you>:(OI)(CI)(W,AD,WD,DC)`), then `set HERMES_HOME=<dir>` and run `hermes gateway status`. Stock code never exits and pins a core (py-spy shows `_mkstemp_inner`); attach from another shell to confirm.
3. Same scenario on this branch: the command **exits in ~1.6s with correct status output** (the manifest write degrades to a DEBUG log), and `hermes photon webhook register` surfaces `PermissionError` through its existing error path instead of spinning.
4. Cleanup: `icacls <dir> /remove:d <you>`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — full relevant suites on Windows (`tests/tools/`, all five `tests/hermes_cli/test_config*.py`, `tests/test_utils*`): **155 passed**; the only failures are two pre-existing POSIX-assumption tests (`~/.hermes` default-path and `/`-separator asserts) verified failing identically on an unmodified checkout on Windows, and one pre-existing Windows collection error (`tests/tools/test_search_hidden_dirs.py` shells out to POSIX `which` at import). Output in Screenshots/Logs.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro 10.0.26200, Python 3.12.10
- [x] `scripts/check-windows-footguns.py --diff <base>`: ✓ No Windows footguns found (7 files scanned)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new helper and changed call sites) — README/`docs/` N/A (no user-facing behavior change on healthy systems)
- [x] N/A — no config keys added/changed (`cli-config.yaml.example` untouched)
- [x] N/A — no architecture/workflow change (`CONTRIBUTING.md` / `AGENTS.md` untouched)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the helper preserves `tempfile.mkstemp` flags (`O_NOFOLLOW`/`O_BINARY` where available, mode `0o600`); POSIX behavior is unchanged except that `PermissionError` now raises on the first attempt (which is what raw `mkstemp` does on POSIX anyway); Windows keeps one bounded retry round for the bpo-22107 EACCES-means-directory-collision ambiguity
- [x] N/A — no tool behavior/schema change

## Screenshots / Logs

**Dedicated tests (Windows 11, includes the real ACL-deny end-to-end test):**

```
tests/test_utils_bounded_mkstemp.py::TestHappyPath::test_creates_file_and_returns_open_fd PASSED [ 12%]
tests/test_utils_bounded_mkstemp.py::TestHappyPath::test_distinct_names_across_calls PASSED [ 25%]
tests/test_utils_bounded_mkstemp.py::TestHappyPath::test_owner_only_mode_on_posix SKIPPED [ 37%]
tests/test_utils_bounded_mkstemp.py::TestCollisionRetry::test_collision_moves_to_fresh_name PASSED [ 50%]
tests/test_utils_bounded_mkstemp.py::TestCollisionRetry::test_persistent_collision_is_bounded PASSED [ 62%]
tests/test_utils_bounded_mkstemp.py::TestPermissionErrorBounded::test_windows_semantics_fail_fast_not_tmp_max PASSED [ 75%]
tests/test_utils_bounded_mkstemp.py::TestPermissionErrorBounded::test_posix_semantics_raise_on_first_denial PASSED [ 87%]
tests/test_utils_bounded_mkstemp.py::TestWindowsAclDeny::test_acl_denied_dir_raises_promptly PASSED [100%]

======================== 7 passed, 1 skipped in 0.43s =========================
```

**Relevant suites (Windows 11):** `tests/tools/test_skills_sync.py` + all five `tests/hermes_cli/test_config*.py` + `tests/test_utils*`:

```
2 failed, 155 passed, 1 skipped in 4.46s
(both failures are pre-existing POSIX-assumption tests; verified failing
identically on an unmodified checkout on Windows — they pass in Linux CI)
```

**Before → after on a real ACL-denied `HERMES_HOME` (the production incident shape):**

Before (unfixed code, orphaned by the launching agent at its 10s timeout — CPU column is cumulative seconds, sampled 15s apart):

```
ORPHANS SURVIVING:
  python PID=24192 CPU=12.8s
after 15 more seconds:
  python PID=24192 CPU=27.8s ALIVE   <- 100% of a core, indefinitely
```

py-spy stack of that process: see "What does this PR do?" above.

After (this branch, identical denied dir):

```
EXITED code=0 in 1.6s
✓ Scheduled Task registered: Hermes_Gateway
  Status: Running
✓ Gateway process running (PID: 3648)
no orphans left behind
```

**Footgun scan:**

```
✓ No Windows footguns found (7 file(s) scanned).
```

## Review follow-up (2026-07-14)

Per the sweeper review, the fix now covers the **entire** persistent-dir `mkstemp` class, not just the incident paths: 16 call sites across 15 files route through `bounded_mkstemp` (the original four files plus `cron/jobs.py`, `cron/suggestions.py`, `gateway/session.py`, `gateway/pairing.py`, `gateway/sticker_cache.py`, `agent/nous_rate_guard.py`, `agent/secret_sources/_cache.py`, `agent/secret_sources/bitwarden.py`, `agent/shell_hooks.py`, `tools/memory_tool.py`, `tools/skill_manager_tool.py`, `hermes_cli/webhook.py`, `hermes_cli/web_server.py`, `hermes_cli/env_loader.py`, `hermes_cli/codex_runtime_plugin_migration.py`). System-temp callers (no `dir=`) deliberately keep plain `tempfile.mkstemp`. A new source-scan test (`tests/test_bounded_mkstemp_call_sites.py`) fails the suite if any future `tempfile.mkstemp(dir=...)` lands in product code, plus focused denial-path regressions for the cron store, pairing writes, and `.env` sanitize. The Windows ACL end-to-end test now sets its deny ACE by SID and probes it before asserting (bare account names can resolve to the wrong principal on machines with sandbox pseudo-users). Details in the review reply below.
