### PR TITLE
fix(agent): pass memory-provider on_pre_compress() insights to compression summary

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1234,6 +1234,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         self,
         turns_to_summarize: List[Dict[str, Any]],
         focus_topic: Optional[str] = None,
+        provider_insights: str = "",
     ) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
@@ -1262,6 +1263,16 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
         content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+
+        # Memory-provider insights captured before compression.  These are
+        # provider-extracted key facts from messages about to be discarded.
+        _insights = provider_insights.strip()
+        _insights_section = ""
+        if _insights:
+            _insights_section = (
+                "\n\nMEMORY PROVIDER INSIGHTS (extracted from messages about to "
+                "be compacted — preserve these in the summary):\n" + _insights
+            )
 
         # Current date for temporal anchoring (see ## Temporal Anchoring below).
         # Date-only granularity matches system_prompt.py:337 (PR #20451) and the
@@ -1397,7 +1408,7 @@ PREVIOUS SUMMARY:
 {self._previous_summary}
 
 NEW TURNS TO INCORPORATE:
-{content_to_summarize}
+{content_to_summarize}{_insights_section}
 
 Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
 
@@ -1409,7 +1420,7 @@ Update the summary using this exact structure. PRESERVE all existing information
 Create a structured checkpoint summary for the conversation after earlier turns are compacted. The summary should preserve enough detail for continuity without re-reading the original turns.
 
 TURNS TO SUMMARIZE:
-{content_to_summarize}
+{content_to_summarize}{_insights_section}
 
 Use this exact structure:
 
@@ -1525,7 +1536,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 else:
                     _reason = "timed out"
                 self._fallback_to_main_for_compression(e, _reason)
-                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)  # retry immediately
+                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic, provider_insights=provider_insights)  # retry immediately
 
             # Unknown-error best-effort retry on main model.  Losing N turns of
             # context is almost always worse than one extra summary attempt, so
@@ -1542,7 +1553,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 and not getattr(self, "_summary_model_fallen_back", False)
             ):
                 self._fallback_to_main_for_compression(e, "failed")
-                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic, provider_insights=provider_insights)
 
             # Transient errors (timeout, rate limit, network, JSON decode,
             # streaming premature-close) — shorter cooldown for JSON decode and
@@ -1942,6 +1953,12 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         # this, /compress would silently no-op for 30-60s after a failure.
         if force and self._summary_failure_cooldown_until > 0.0:
             self._summary_failure_cooldown_until = 0.0
+
+        # Capture and clear provider insights — they are consumed exactly
+        # once per compress() call to avoid stale data on re-entry.
+        _insights = getattr(self, "_pre_compress_insights", "").strip()
+        self._pre_compress_insights = ""
+
         n_messages = len(messages)
         # Only need head + 3 tail messages minimum (token budget decides the real tail size)
         _min_for_compress = self._protect_head_size(messages) + 3 + 1
@@ -2037,7 +2054,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             )
 
         # Phase 3: Generate structured summary
-        summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+        summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic, provider_insights=_insights)
 
         # If summary generation failed, behavior splits on
         # ``abort_on_summary_failure`` (config: compression.abort_on_summary_failure):

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -425,12 +425,17 @@ def compress_context(
             except Exception as _rel_err:
                 logger.debug("compression lock release failed: %s", _rel_err)
 
-    # Notify external memory provider before compression discards context
+    # Notify external memory provider before compression discards context.
+    # The return value contains provider-extracted insights that the
+    # compressor should include in the summary prompt so they survive
+    # compaction.  Stored on the compressor instance; cleared after use.
+    _pre_compress_insights: str = ""
     if agent._memory_manager:
         try:
-            agent._memory_manager.on_pre_compress(messages)
+            _pre_compress_insights = agent._memory_manager.on_pre_compress(messages) or ""
         except Exception:
             pass
+    agent.context_compressor._pre_compress_insights = _pre_compress_insights
 
     try:
         compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2183,3 +2183,164 @@ class TestPreflightSentinelGuard:
         compressor.last_prompt_tokens = 50_000
         result = self._seed(compressor.last_prompt_tokens, 10_000)
         assert result == 50_000
+
+
+class TestProviderInsightsInCompression:
+    """Verify that memory-provider on_pre_compress() return values are
+    included in the compression summary prompt (#43558)."""
+
+    @pytest.fixture()
+    def compressor(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=2,
+                protect_last_n=2,
+                quiet_mode=True,
+            )
+            return c
+
+    @staticmethod
+    def _make_messages(n=10):
+        """Generate enough messages to exceed the compression threshold."""
+        msgs = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(n):
+            msgs.append({"role": "user", "content": f"question {i} " + "x" * 80})
+            msgs.append({"role": "assistant", "content": f"answer {i} " + "y" * 80})
+        return msgs
+
+    def test_insights_injected_into_prompt(self, compressor):
+        """Provider insights should appear in the summarizer prompt."""
+        captured_prompts = []
+
+        def fake_call_llm(**kwargs):
+            captured_prompts.append(kwargs["messages"][0]["content"])
+            return '{"summary": "## Summary\nTest summary content."}'
+
+        compressor._previous_summary = None
+        compressor._summary_failure_cooldown_until = 0.0
+
+        messages = self._make_messages(6)
+
+        with patch("agent.context_compressor.call_llm", side_effect=fake_call_llm):
+            compressor._generate_summary(
+                messages,
+                provider_insights="User prefers Python over JavaScript.",
+            )
+        assert captured_prompts, "Expected call_llm to be called"
+        assert "MEMORY PROVIDER INSIGHTS" in captured_prompts[0]
+        assert "User prefers Python over JavaScript." in captured_prompts[0]
+
+    def test_no_insights_section_when_empty(self, compressor):
+        """When provider_insights is empty, no insights section in prompt."""
+        captured_prompts = []
+
+        def fake_call_llm(**kwargs):
+            captured_prompts.append(kwargs["messages"][0]["content"])
+            return '{"summary": "## Summary\nTest summary content."}'
+
+        compressor._previous_summary = None
+        compressor._summary_failure_cooldown_until = 0.0
+
+        messages = self._make_messages(6)
+
+        with patch("agent.context_compressor.call_llm", side_effect=fake_call_llm):
+            compressor._generate_summary(messages, provider_insights="")
+        assert captured_prompts
+        assert "MEMORY PROVIDER INSIGHTS" not in captured_prompts[0]
+
+    def test_insights_in_iterative_update(self, compressor):
+        """Provider insights should appear in iterative update prompts too."""
+        captured_prompts = []
+
+        def fake_call_llm(**kwargs):
+            captured_prompts.append(kwargs["messages"][0]["content"])
+            return '{"summary": "## Summary\nUpdated summary content."}'
+
+        compressor._previous_summary = "Previous summary here."
+        compressor._summary_failure_cooldown_until = 0.0
+
+        messages = self._make_messages(6)
+
+        with patch("agent.context_compressor.call_llm", side_effect=fake_call_llm):
+            compressor._generate_summary(
+                messages,
+                provider_insights="Key insight from memory provider.",
+            )
+        assert captured_prompts
+        assert "MEMORY PROVIDER INSIGHTS" in captured_prompts[0]
+        assert "Key insight from memory provider." in captured_prompts[0]
+
+    def test_insights_cleared_after_compress(self, compressor):
+        """_pre_compress_insights should be cleared after compress() returns."""
+        compressor._pre_compress_insights = "stale insights from prior call"
+
+        with patch.object(compressor, "_generate_summary", return_value="## Summary\n" + "x" * 200):
+            messages = self._make_messages(6)
+            compressor.compress(messages, current_tokens=50000)
+
+        assert compressor._pre_compress_insights == ""
+
+    def test_insights_passed_to_generate_summary(self, compressor):
+        """compress() should pass captured insights to _generate_summary."""
+        compressor._pre_compress_insights = "Important fact from memory."
+
+        captured_kwargs = {}
+
+        def spy_generate(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return "## Summary\n" + "x" * 200
+
+        with patch.object(compressor, "_generate_summary", side_effect=spy_generate):
+            messages = self._make_messages(6)
+            compressor.compress(messages, current_tokens=50000)
+
+        assert captured_kwargs.get("provider_insights") == "Important fact from memory."
+
+    def test_whitespace_only_insights_ignored(self, compressor):
+        """Whitespace-only insights should not produce an insights section."""
+        captured_prompts = []
+
+        def fake_call_llm(**kwargs):
+            captured_prompts.append(kwargs["messages"][0]["content"])
+            return '{"summary": "## Summary\nTest summary content."}'
+
+        compressor._previous_summary = None
+        compressor._summary_failure_cooldown_until = 0.0
+
+        messages = self._make_messages(6)
+
+        with patch("agent.context_compressor.call_llm", side_effect=fake_call_llm):
+            compressor._generate_summary(messages, provider_insights="   \n  ")
+        assert captured_prompts
+        assert "MEMORY PROVIDER INSIGHTS" not in captured_prompts[0]
+
+    def test_insights_survive_retry(self, compressor):
+        """Insights should be passed through on retry after provider fallback."""
+        call_count = [0]
+        captured_prompts = []
+
+        def fake_call_llm(**kwargs):
+            call_count[0] += 1
+            captured_prompts.append(kwargs["messages"][0]["content"])
+            if call_count[0] == 1:
+                raise Exception("provider error")
+            return '{"summary": "## Summary\nRecovered summary."}'
+
+        compressor._previous_summary = None
+        compressor._summary_failure_cooldown_until = 0.0
+        # Configure a summary model so fallback path is exercised
+        compressor.summary_model = "aux/model"
+        compressor.provider = "test-provider"
+        compressor._summary_model_fallen_back = False
+
+        messages = self._make_messages(6)
+
+        with patch("agent.context_compressor.call_llm", side_effect=fake_call_llm):
+            compressor._generate_summary(
+                messages,
+                provider_insights="Insight that must survive retry.",
+            )
+        # At least one prompt should contain the insights
+        assert any("Insight that must survive retry." in p for p in captured_prompts)

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -75,7 +75,7 @@ def test_handoff_in_protected_head_populates_previous_summary_before_update():
     old_summary = "PROTECTED-HEAD-SUMMARY durable facts from before restart"
     seen_turns = []
 
-    def fake_generate_summary(turns_to_summarize, focus_topic=None):
+    def fake_generate_summary(turns_to_summarize, focus_topic=None, provider_insights=""):
         seen_turns.extend(turns_to_summarize)
         return "new summary from resumed turns"
 


### PR DESCRIPTION
## What does this PR do?

Fixes `MemoryProvider.on_pre_compress()` return value being silently discarded in `conversation_compression.py`. Memory providers' pre-compression insights are now passed to the summarizer prompt so they survive context compaction.

## Related Issue

Fixes #43558

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py`: Capture return value of `on_pre_compress()` and store on compressor instance instead of discarding it
- `agent/context_compressor.py`: Add `provider_insights` parameter to `_generate_summary()`, inject as "MEMORY PROVIDER INSIGHTS" section in the summarizer prompt; capture and clear insights at the start of `compress()` to prevent stale data on re-entry; propagate insights through retry paths
- `tests/agent/test_context_compressor.py`: 7 new tests covering insights injection, empty/whitespace handling, iterative update, cleanup after compress, parameter forwarding, and retry survival

## How to Test

1. Configure a memory provider that returns non-empty text from `on_pre_compress()`
2. Trigger context compression on a long conversation
3. Verify the compression summary includes content from the provider insights section
4. Run `pytest tests/agent/test_context_compressor.py::TestProviderInsightsInCompression -v` — all 7 tests should pass
5. Run `pytest tests/agent/test_context_compressor.py -v` — all 101 tests should pass (no regressions)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_context_compressor.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/conversation_compression.py:compress_context()` (caller), `agent/context_compressor.py:_generate_summary()` (receiver), `agent/memory_manager.py:on_pre_compress()` (interface)
- Blast radius: LOW — only affects the compression summary prompt construction; no behavioral change when no memory provider is configured
- Related patterns: `focus_topic` parameter follows the same injection pattern into the summarizer prompt
