### PR TITLE
feat(gateway): add message:received decision hook before agent processing

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -11,6 +11,9 @@ Events:
   - session:start       -- New session created (first message of a new session)
   - session:end         -- Session ends (user ran /new or /reset)
   - session:reset       -- Session reset completed (new session entry created)
+  - message:received    -- Decision hook before agent processing; handlers
+                           may deny (swallow + optional reply) or rewrite
+                           (mutate message / append context prompt)
   - agent:start         -- Agent begins processing a message
   - agent:step          -- Each turn in the tool-calling loop
   - agent:end           -- Agent finishes processing

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9364,6 +9364,51 @@ class GatewayRunner:
                 "session_id": session_entry.session_id,
                 "message": message_text[:500],
             }
+            # Decision-style pre-agent hook. Handlers registered for
+            # message:received may return:
+            #   {"decision": "deny", "reply": "..."}    swallow the message
+            #       (optional reply is delivered as a platform notice);
+            #   {"decision": "rewrite", "message": "...",
+            #    "context_prompt_append": "..."}        mutate the message
+            #       and/or append to the context prompt before the agent runs.
+            # Handlers that return None behave exactly like telemetry hooks,
+            # mirroring the command:* decision hooks' back-compat contract.
+            # The decision context carries the full message text (the
+            # agent:start context keeps its 500-char preview).
+            _decision_ctx = dict(hook_ctx)
+            _decision_ctx["message"] = message_text
+            try:
+                _message_decisions = await self.hooks.emit_collect(
+                    "message:received", _decision_ctx
+                )
+            except Exception as _decision_err:
+                logger.debug(
+                    "message:received hook dispatch failed (non-fatal): %s",
+                    _decision_err,
+                )
+                _message_decisions = []
+            for _decision_result in _message_decisions:
+                if not isinstance(_decision_result, dict):
+                    continue
+                _decision = str(_decision_result.get("decision", "")).strip().lower()
+                if _decision == "deny":
+                    _deny_reply = str(_decision_result.get("reply") or "")
+                    if _deny_reply:
+                        await self._deliver_platform_notice(source, _deny_reply)
+                    return None
+                if _decision == "rewrite":
+                    _new_message = str(_decision_result.get("message") or "")
+                    if _new_message:
+                        message_text = _new_message
+                    _context_append = str(
+                        _decision_result.get("context_prompt_append") or ""
+                    )
+                    if _context_append:
+                        context_prompt = (
+                            f"{context_prompt}\n\n{_context_append}"
+                            if context_prompt
+                            else _context_append
+                        )
             await self.hooks.emit("agent:start", hook_ctx)
 
             # Run the agent

--- a/tests/test_message_received_hook.py
+++ b/tests/test_message_received_hook.py
@@ -1,0 +1,101 @@
+"""Tests for the ``message:received`` decision hook.
+
+The hook fires in the gateway just before ``agent:start``. Driving the full
+gateway message pipeline from a unit test would be prohibitively heavy, so
+these tests exercise the discovery and emit_collect dispatch semantics that
+the wiring in ``gateway/run.py`` depends on:
+
+    for _decision_result in _message_decisions:
+        if not isinstance(_decision_result, dict):
+            continue
+        _decision = str(_decision_result.get("decision", "")).strip().lower()
+        if _decision == "deny":
+            ...  # swallow, optional platform-notice reply
+        if _decision == "rewrite":
+            ...  # mutate message_text / append context_prompt
+
+Mirrors ``test_transform_llm_output_hook.py`` which tests the equivalent
+contract for the LLM-output seam.
+"""
+
+import asyncio
+from pathlib import Path
+
+import yaml
+
+import gateway.hooks as hooks_mod
+from gateway.hooks import HookRegistry
+
+
+def _make_hook(hooks_dir: Path, name: str, handler_body: str) -> None:
+    hook_dir = hooks_dir / name
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text(
+        yaml.safe_dump({"name": name, "description": "t", "events": ["message:received"]}),
+        encoding="utf-8",
+    )
+    (hook_dir / "handler.py").write_text(
+        "async def handle(event_type, context):\n" + handler_body,
+        encoding="utf-8",
+    )
+
+
+def _registry_for(tmp_path: Path, monkeypatch) -> HookRegistry:
+    monkeypatch.setattr(hooks_mod, "HOOKS_DIR", tmp_path)
+    registry = HookRegistry()
+    registry.discover_and_load()
+    return registry
+
+
+def test_deny_decision_is_collected(tmp_path, monkeypatch):
+    _make_hook(
+        tmp_path,
+        "denier",
+        "    if context.get('message') == 'block me':\n"
+        "        return {'decision': 'deny', 'reply': 'not allowed'}\n"
+        "    return None\n",
+    )
+    registry = _registry_for(tmp_path, monkeypatch)
+
+    results = asyncio.run(registry.emit_collect("message:received", {"message": "block me"}))
+    assert results == [{"decision": "deny", "reply": "not allowed"}]
+
+    passthrough = asyncio.run(registry.emit_collect("message:received", {"message": "hello"}))
+    assert passthrough == []  # None-returning handlers keep telemetry semantics
+
+
+def test_rewrite_decision_carries_message_and_context(tmp_path, monkeypatch):
+    _make_hook(
+        tmp_path,
+        "rewriter",
+        "    return {'decision': 'rewrite', 'message': 'rewritten',\n"
+        "            'context_prompt_append': 'extra context'}\n",
+    )
+    registry = _registry_for(tmp_path, monkeypatch)
+    results = asyncio.run(registry.emit_collect("message:received", {"message": "original"}))
+    assert results == [
+        {"decision": "rewrite", "message": "rewritten", "context_prompt_append": "extra context"}
+    ]
+
+
+def test_handler_errors_do_not_abort_other_handlers(tmp_path, monkeypatch):
+    _make_hook(tmp_path, "a-broken", "    raise RuntimeError('boom')\n")
+    _make_hook(tmp_path, "b-decider", "    return {'decision': 'deny'}\n")
+    registry = _registry_for(tmp_path, monkeypatch)
+    results = asyncio.run(registry.emit_collect("message:received", {"message": "x"}))
+    assert results == [{"decision": "deny"}]
+
+
+def test_full_message_text_documented_in_context(tmp_path, monkeypatch):
+    # the wiring passes the full message text in the decision context while
+    # agent:start keeps its 500-char preview; handlers can rely on it.
+    captured = {}
+    _make_hook(
+        tmp_path,
+        "capturer",
+        "    return {'decision': '', 'seen': context.get('message')}\n",
+    )
+    registry = _registry_for(tmp_path, monkeypatch)
+    long_text = "long " * 200
+    results = asyncio.run(registry.emit_collect("message:received", {"message": long_text}))
+    assert results[0]["seen"] == long_text


### PR DESCRIPTION
## What

Adds a decision-style `message:received` hook that fires in the gateway just before `agent:start`, letting hooks make deterministic routing decisions before a message reaches the agent:

- `{"decision": "deny", "reply": "..."}` — swallow the message; the optional reply is delivered via `_deliver_platform_notice` (privacy rules respected). Returns before typing starts.
- `{"decision": "rewrite", "message": "...", "context_prompt_append": "..."}` — mutate the message text and/or append to the context prompt before the agent runs.
- `None` — exactly the previous telemetry semantics; existing hooks are unaffected.

This mirrors the back-compat contract the `command:*` hooks adopted when they moved from fire-and-forget `emit()` to `emit_collect()` ("return values are now honored, but handlers that return nothing behave exactly as before"). The decision context carries the full message text; the `agent:start` context keeps its 500-char preview. Hook dispatch failures are logged and never block the pipeline.

## Why

Today the hook surface offers lifecycle observation (`agent:start/step/end`, `session:*`) and command decisions (`command:*`), but no way for a hook to intercept a plain message before agent processing. Concrete use case we run in production: an admin sends a short natural-language confirmation ("approve", "恢复") in a DM that should bind to a pending operational decision deterministically — the binding/validation runs in an external CLI, and the agent should either be skipped (clarification needed) or receive structured context (decision applied, follow-up instructions). Without a pre-agent decision hook this requires patching the gateway; with it, the integration is a normal `~/.hermes/hooks/` package.

Other natural fits: per-route rate limiting, content policy gates, deterministic FAQ short-circuits.

## Testing

- `tests/test_message_received_hook.py` exercises the discovery + `emit_collect` decision semantics the wiring depends on (deny collected, rewrite payload carried, handler errors don't abort other handlers, full message text available), mirroring `test_transform_llm_output_hook.py`'s approach of testing the dispatch contract rather than driving the full gateway pipeline.
- 4 passed locally; no behavior change when no hook subscribes to the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
