### PR TITLE
fix(send-message): route plugin media through standalone senders

### DIFF
--- a/tests/tools/test_send_message_plugin_media.py
+++ b/tests/tools/test_send_message_plugin_media.py
@@ -1,0 +1,113 @@
+"""Regression tests for plugin media delivery in send_message_tool."""
+
+import asyncio
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.platform_registry import PlatformEntry, platform_registry
+from tools.send_message_tool import _send_via_adapter
+
+
+PHOTON = Platform("photon")
+
+
+class _LiveAdapter:
+    async def send(self, *, chat_id, content, metadata=None):  # pragma: no cover
+        raise AssertionError("media delivery must not use generic adapter.send")
+
+
+class _Runner:
+    def __init__(self) -> None:
+        self.adapters = {PHOTON: _LiveAdapter()}
+
+
+def test_plugin_media_prefers_standalone_sender(monkeypatch):
+    """Plugin MEDIA sends should use the plugin media-capable sender.
+
+    The live adapter's generic ``send`` method only carries text and metadata;
+    for Photon it can omit attachments or fail on event-loop-owned state.
+    """
+    calls = []
+
+    async def standalone_sender(pconfig, chat_id, message, *, thread_id=None, media_files=None, force_document=False):
+        calls.append(
+            {
+                "pconfig": pconfig,
+                "chat_id": chat_id,
+                "message": message,
+                "thread_id": thread_id,
+                "media_files": media_files,
+                "force_document": force_document,
+            }
+        )
+        return {"success": True, "message_id": "media-1"}
+
+    entry = PlatformEntry(
+        name="photon",
+        label="Photon",
+        adapter_factory=lambda cfg: _LiveAdapter(),
+        check_fn=lambda: True,
+        standalone_sender_fn=standalone_sender,
+    )
+    monkeypatch.setattr(platform_registry, "get", lambda name: entry if name == "photon" else None)
+    monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: _Runner())
+
+    pconfig = SimpleNamespace(extra={})
+    result = asyncio.run(
+        _send_via_adapter(
+            PHOTON,
+            pconfig,
+            "+15555550123",
+            "caption",
+            thread_id="thread-1",
+            media_files=[("/tmp/test.png", False)],
+            force_document=True,
+        )
+    )
+
+    assert result == {"success": True, "message_id": "media-1"}
+    assert calls == [
+        {
+            "pconfig": pconfig,
+            "chat_id": "+15555550123",
+            "message": "caption",
+            "thread_id": "thread-1",
+            "media_files": [("/tmp/test.png", False)],
+            "force_document": True,
+        }
+    ]
+
+
+def test_plugin_text_without_media_still_uses_live_adapter(monkeypatch):
+    """Do not change the existing fast path for plugin text-only sends."""
+
+    class _TextAdapter:
+        async def send(self, *, chat_id, content, metadata=None):
+            return SimpleNamespace(success=True, message_id="text-1", error=None)
+
+    class _TextRunner:
+        adapters = {PHOTON: _TextAdapter()}
+
+    async def standalone_sender(*args, **kwargs):  # pragma: no cover
+        raise AssertionError("text-only send should prefer live adapter")
+
+    entry = PlatformEntry(
+        name="photon",
+        label="Photon",
+        adapter_factory=lambda cfg: _TextAdapter(),
+        check_fn=lambda: True,
+        standalone_sender_fn=standalone_sender,
+    )
+    monkeypatch.setattr(platform_registry, "get", lambda name: entry if name == "photon" else None)
+    monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: _TextRunner())
+
+    result = asyncio.run(
+        _send_via_adapter(
+            PHOTON,
+            SimpleNamespace(extra={}),
+            "+15555550123",
+            "hello",
+        )
+    )
+
+    assert result == {"success": True, "message_id": "text-1"}

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -514,6 +514,43 @@ async def _send_via_adapter(
     except Exception:
         runner = None
 
+    entry = None
+    try:
+        from gateway.platform_registry import platform_registry
+        entry = platform_registry.get(platform_name)
+    except Exception:
+        entry = None
+
+    # Plugin media delivery may need a platform-specific standalone sender
+    # even when a live gateway adapter exists. The generic adapter.send(...)
+    # interface only carries text/metadata, so routing MEDIA through it can
+    # either omit attachments or trip adapter event-loop ownership bugs when
+    # the tool is invoked from a different loop than the live gateway adapter.
+    if media_files and entry is not None and entry.standalone_sender_fn is not None:
+        try:
+            result = await entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+                media_files=media_files,
+                force_document=force_document,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.debug("Plugin standalone media send for %s raised", platform_name, exc_info=True)
+            return {"error": f"Plugin standalone send failed: {e}"}
+        if isinstance(result, dict) and (result.get("success") or result.get("error")):
+            return result
+        return {
+            "error": (
+                f"Plugin standalone send for '{platform_name}' returned an "
+                f"invalid result: expected a dict with 'success' or 'error' "
+                f"keys, got {type(result).__name__}"
+            )
+        }
+
     if runner is not None:
         try:
             adapter = runner.adapters.get(platform)
@@ -536,13 +573,6 @@ async def _send_via_adapter(
             if result.success:
                 return {"success": True, "message_id": result.message_id}
             return {"error": f"Adapter send failed: {result.error}"}
-
-    entry = None
-    try:
-        from gateway.platform_registry import platform_registry
-        entry = platform_registry.get(platform_name)
-    except Exception:
-        entry = None
 
     if entry is not None and entry.standalone_sender_fn is not None:
         try:
@@ -767,7 +797,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and plugin platforms with media senders; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -775,7 +805,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and plugin platforms with media senders"
         )
 
     last_result = None


### PR DESCRIPTION
## Summary
- Routes plugin `send_message` MEDIA delivery through the plugin's `standalone_sender_fn` when one exists
- Avoids the generic live adapter `send(...)` path for plugin media, because that interface only carries text/metadata
- Keeps existing text-only plugin sends on the live adapter fast path
- Updates MEDIA support wording to include plugin platforms with media senders
- Adds regression tests covering media and text-only plugin send routing

## Why
Photon registers a media-capable standalone sender that posts to the sidecar `/send-attachment` endpoint, but `send_message` could still try the live adapter's generic text send path first. In live testing, this either omitted Photon media attachments or hit an event-loop ownership error from the live adapter.

## Verification
- `venv/bin/python -m pytest tests/tools/test_send_message_plugin_media.py -q -o 'addopts='` → 2 passed
- `venv/bin/python -m pytest tests/tools/test_send_message_plugin_media.py tests/tools/test_signal_media.py tests/plugins/platforms/photon/test_outbound_media.py -q -o 'addopts='` → 15 passed, 3 skipped
