### PR TITLE
fix(cli): keep repo-root agent-browser during update refresh

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7417,8 +7417,16 @@ def _update_node_dependencies() -> None:
         return
 
     # Step 2: install only the workspaces update needs (ui-tui, web).
-    # --workspace selects specific workspaces; the rest (desktop) are skipped.
-    ws_args = [*extra_args, "--workspace", "ui-tui", "--workspace", "web"]
+    # Keep the workspace root included so repo-root-only dependencies like
+    # agent-browser are not pruned by the scoped refresh.
+    ws_args = [
+        *extra_args,
+        "--workspace",
+        "ui-tui",
+        "--workspace",
+        "web",
+        "--include-workspace-root",
+    ]
     ws_result = _run_npm_install_deterministic(
         npm,
         PROJECT_ROOT,

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -263,6 +263,7 @@ class TestCmdUpdateBranchFallback:
             "ui-tui",
             "--workspace",
             "web",
+            "--include-workspace-root",
         ]
         assert npm_calls[:2] == [
             (root_flags, PROJECT_ROOT),


### PR DESCRIPTION
## What does this PR do?

Fixes a `hermes update` regression where the workspace-scoped npm refresh can prune repo-root-only dependencies after the update reports success. In practice this leaves `node_modules/agent-browser` and `node_modules/.bin/agent-browser` missing, so `hermes doctor` starts reporting browser tooling as broken until the user manually reruns a root-only npm install.

The fix keeps the workspace root included during the `ui-tui`/`web` refresh step, which preserves repo-root dependencies like `agent-browser` while still skipping `apps/desktop`.

## Related Issue

Fixes #43564

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `--include-workspace-root` to the workspace-scoped npm refresh in `hermes_cli/main.py` so repo-root dependencies are not pruned during `hermes update`.
- Update `tests/hermes_cli/test_cmd_update.py` to require the new flag in the update flow.

## How to Test

1. On `upstream/main`, run the same npm sequence used by `hermes update`:
   - `npm ci --no-fund --no-audit --progress=false --workspaces=false`
   - `npm ci --no-fund --no-audit --progress=false --workspace ui-tui --workspace web`
2. Observe that `node_modules/agent-browser` is present after the root-only install and missing after the workspace-scoped refresh.
3. Apply this branch and rerun the sequence, but with the updated workspace refresh (`--include-workspace-root`); `node_modules/agent-browser` should remain present after both steps.
4. Run `pytest -q tests/hermes_cli/test_cmd_update.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Darwin 24.6.0 arm64, Python 3.11.15, Node v22.22.3, npm 10.9.8

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Manual repro on clean `upstream/main` (`a72bb03757c0c925c686f9774eefc8dc5a77b329`):

- After `npm ci --no-fund --no-audit --progress=false --workspaces=false`: `after_root_ci=present`
- After `npm ci --no-fund --no-audit --progress=false --workspace ui-tui --workspace web`: `after_workspace_ci=missing`

Manual verification after the fix:

- After `npm ci --no-fund --no-audit --progress=false --workspaces=false`: `after_root_ci=present`
- After `npm ci --no-fund --no-audit --progress=false --workspace ui-tui --workspace web --include-workspace-root`: `after_workspace_ci=present`

Targeted test validation:

- `pytest -q tests/hermes_cli/test_cmd_update.py`
- Result: `25 passed in 39.01s`
