### PR TITLE
fix(desktop): handle prefill dispatch type in command.dispatch for /undo

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -28,6 +28,7 @@ import {
   clearComposerAttachments,
   type ComposerAttachment,
   setComposerAttachmentUploadState,
+  setComposerDraft,
   terminalContextBlocksFromDraft,
   updateComposerAttachment
 } from '@/store/composer'
@@ -964,6 +965,17 @@ export function usePromptActions({
 
           if (dispatch.type === 'alias') {
             await runSlash(`/${dispatch.target}${arg ? ` ${arg}` : ''}`, sessionId, false)
+
+            return
+          }
+
+          if (dispatch.type === 'prefill') {
+            if (dispatch.notice?.trim()) {
+              renderSlashOutput(dispatch.notice)
+            }
+            if (dispatch.message) {
+              setComposerDraft(dispatch.message)
+            }
 
             return
           }

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -82,11 +82,18 @@ export interface SendCommandDispatchResponse {
   message: string
 }
 
+export interface PrefillCommandDispatchResponse {
+  type: 'prefill'
+  message?: string
+  notice?: string
+}
+
 export type CommandDispatchResponse =
   | ExecCommandDispatchResponse
   | AliasCommandDispatchResponse
   | SkillCommandDispatchResponse
   | SendCommandDispatchResponse
+  | PrefillCommandDispatchResponse
 
 export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
 

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
 
-import { coerceThinkingText, optimisticAttachmentRef } from './chat-runtime'
+import { coerceThinkingText, optimisticAttachmentRef, parseCommandDispatch } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
 
@@ -50,5 +50,88 @@ describe('coerceThinkingText', () => {
         "◉_◉ processing... I don't see any current rewritten thinking or next thinking to process. Could you provide the thinking content you'd like me to rewrite?"
       )
     ).toBe('')
+  })
+})
+
+describe('parseCommandDispatch', () => {
+  it('returns null for non-object input', () => {
+    expect(parseCommandDispatch(null)).toBeNull()
+    expect(parseCommandDispatch(undefined)).toBeNull()
+    expect(parseCommandDispatch('string')).toBeNull()
+    expect(parseCommandDispatch(42)).toBeNull()
+  })
+
+  it('parses exec dispatch', () => {
+    expect(parseCommandDispatch({ type: 'exec', output: 'hello' })).toEqual({
+      type: 'exec',
+      output: 'hello'
+    })
+  })
+
+  it('parses plugin dispatch', () => {
+    expect(parseCommandDispatch({ type: 'plugin', output: 'ok' })).toEqual({
+      type: 'plugin',
+      output: 'ok'
+    })
+  })
+
+  it('parses alias dispatch', () => {
+    expect(parseCommandDispatch({ type: 'alias', target: 'help' })).toEqual({
+      type: 'alias',
+      target: 'help'
+    })
+  })
+
+  it('returns null for alias without target', () => {
+    expect(parseCommandDispatch({ type: 'alias' })).toBeNull()
+  })
+
+  it('parses skill dispatch', () => {
+    expect(
+      parseCommandDispatch({ type: 'skill', name: 'test', message: 'do it' })
+    ).toEqual({ type: 'skill', name: 'test', message: 'do it' })
+  })
+
+  it('returns null for skill without name', () => {
+    expect(parseCommandDispatch({ type: 'skill' })).toBeNull()
+  })
+
+  it('parses send dispatch', () => {
+    expect(parseCommandDispatch({ type: 'send', message: 'hello' })).toEqual({
+      type: 'send',
+      message: 'hello'
+    })
+  })
+
+  it('returns null for send without message', () => {
+    expect(parseCommandDispatch({ type: 'send' })).toBeNull()
+  })
+
+  it('parses prefill dispatch with message and notice', () => {
+    expect(
+      parseCommandDispatch({
+        type: 'prefill',
+        message: 'edit me',
+        notice: '↶ Undid 1 turn'
+      })
+    ).toEqual({ type: 'prefill', message: 'edit me', notice: '↶ Undid 1 turn' })
+  })
+
+  it('parses prefill dispatch with only message', () => {
+    expect(
+      parseCommandDispatch({ type: 'prefill', message: 'edit me' })
+    ).toEqual({ type: 'prefill', message: 'edit me', notice: undefined })
+  })
+
+  it('parses prefill dispatch with no message (empty undo)', () => {
+    expect(parseCommandDispatch({ type: 'prefill' })).toEqual({
+      type: 'prefill',
+      message: undefined,
+      notice: undefined
+    })
+  })
+
+  it('returns null for unknown type', () => {
+    expect(parseCommandDispatch({ type: 'unknown' })).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -233,6 +233,9 @@ export function parseCommandDispatch(raw: unknown): CommandDispatchResponse | nu
     case 'send':
       return typeof row.message === 'string' ? { type: 'send', message: row.message } : null
 
+    case 'prefill':
+      return { type: 'prefill', message: str(row.message), notice: str(row.notice) }
+
     default:
       return null
   }

--- a/web/src/lib/slashExec.ts
+++ b/web/src/lib/slashExec.ts
@@ -28,13 +28,16 @@ export type CommandDispatchResponse =
   | { type: "exec" | "plugin"; output?: string }
   | { type: "alias"; target: string }
   | { type: "skill"; name: string; message?: string }
-  | { type: "send"; message: string };
+  | { type: "send"; message: string }
+  | { type: "prefill"; message?: string; notice?: string };
 
 export interface SlashExecCallbacks {
   /** Render a transcript system message. */
   sys(text: string): void;
   /** Submit a user message to the agent (prompt.submit). */
   send(message: string): Promise<void> | void;
+  /** Prefill the composer with text without submitting. */
+  prefill?(text: string): void;
 }
 
 export interface SlashExecOptions {
@@ -56,7 +59,7 @@ export async function executeSlash({
   command,
   sessionId,
   gw,
-  callbacks: { sys, send },
+  callbacks: { sys, send, prefill },
 }: SlashExecOptions): Promise<SlashExecResult> {
   const { name, arg } = parseSlash(command);
 
@@ -119,6 +122,12 @@ export async function executeSlash({
         await send(msg);
         return "sent";
       }
+
+      case "prefill": {
+        if (d.notice?.trim()) sys(d.notice);
+        if (d.message) prefill?.(d.message);
+        return "done";
+      }
     }
   } catch (err) {
     sys(`error: ${err instanceof Error ? err.message : String(err)}`);
@@ -156,6 +165,9 @@ function parseCommandDispatch(raw: unknown): CommandDispatchResponse | null {
       return typeof r.message === "string"
         ? { type: "send", message: r.message }
         : null;
+
+    case "prefill":
+      return { type: "prefill", message: str(r.message), notice: str(r.notice) };
 
     default:
       return null;


### PR DESCRIPTION
## What does this PR do?

Adds `prefill` dispatch type handling to the Desktop and web `parseCommandDispatch()` functions, fixing `/undo` (and any future prefill-based commands) in both clients.

## Related Issue

Fixes #43560

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/types.ts`: Added `PrefillCommandDispatchResponse` interface and included it in the `CommandDispatchResponse` union type
- `apps/desktop/src/lib/chat-runtime.ts`: Added `prefill` case to `parseCommandDispatch()` — returns `{type: 'prefill', message?, notice?}` without strict validation (message is optional for empty undo scenarios)
- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`: Added `prefill` handler after the `alias` handler — renders `notice` as a system message via `renderSlashOutput()` and sets the composer draft via `setComposerDraft()`
- `web/src/lib/slashExec.ts`: Added `prefill` to `CommandDispatchResponse` union, added optional `prefill` callback to `SlashExecCallbacks`, added `prefill` case to both `parseCommandDispatch()` and `executeSlash()`
- `apps/desktop/src/lib/chat-runtime.test.ts`: Added 6 test cases for `parseCommandDispatch` covering all dispatch types including `prefill` (with message+notice, message-only, empty, and unknown type)

## How to Test

1. Start Hermes Desktop
2. Open a session with conversation history
3. Type `/undo` and press Enter
4. Observe: "↶ Undid 1 turn..." appears as a system message, and the undone message text is prefilled in the composer for editing
5. Verify TUI `/undo` still works as before (no regression)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `parseCommandDispatch` (callers: 3 — Desktop `use-prompt-actions.ts`, web `slashExec.ts`, recursive alias call)
- Analyzed: `CommandDispatchResponse` type union (consumers: Desktop type checker, web type checker)
- Blast radius: LOW — adds a new dispatch type branch; existing branches unchanged
- Related patterns: TUI already handles `prefill` in `createSlashHandler.ts:123-134` — this PR mirrors that behavior in Desktop and web clients
