### PR TITLE
fix(browser): reap orphaned Chrome processes after daemon exit on Windows

### DIFF
--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -405,3 +405,82 @@ class TestEmergencyCleanupRunsReaper:
         assert reaper_called, (
             "Reaper must run on exit even with no active sessions"
         )
+
+
+class TestReapOrphanedChromeProcesses:
+    """Tests for _reap_orphaned_chrome_processes() — Windows orphan Chrome killer."""
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only test")
+    def test_no_chrome_processes_is_noop(self, monkeypatch):
+        """When wmic finds no chrome.exe, return 0."""
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_active_sessions", {})
+
+        fake_result = type("R", (), {"stdout": b"Node,CommandLine,ParentProcessId,ProcessId\n"})()
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: fake_result)
+        assert bt._reap_orphaned_chrome_processes() == 0
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only test")
+    def test_skips_when_active_sessions_exist(self, monkeypatch):
+        """Must not kill anything when this process has active browser sessions."""
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_active_sessions", {"some_task": {"session_name": "h_abc"}})
+        assert bt._reap_orphaned_chrome_processes() == 0
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only test")
+    def test_kills_orphaned_headless_chrome(self, monkeypatch):
+        """Kill main headless Chrome processes using agent-browser-chrome user-data-dir."""
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_active_sessions", {})
+
+        csv_lines = (
+            "Node,CommandLine,ParentProcessId,ProcessId\n"
+            'SKYNET,"C:\\\\chrome.exe --headless=new --user-data-dir=C:\\\\Temp\\\\agent-browser-chrome-abc123",100,200\n'
+            'SKYNET,"C:\\\\chrome.exe --type=renderer --user-data-dir=C:\\\\Temp\\\\agent-browser-chrome-abc123",200,201\n'
+            'SKYNET,"C:\\\\chrome.exe --headless=new --user-data-dir=C:\\\\Users\\\\chuckie\\\\Chrome\\\\User Data",300,301\n'
+        )
+        fake_result = type("R", (), {"stdout": csv_lines.encode()})()
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: fake_result)
+
+        killed_pids = []
+        monkeypatch.setattr(
+            "tools.process_registry.ProcessRegistry._terminate_host_pid",
+            lambda pid: killed_pids.append(pid),
+        )
+
+        assert bt._reap_orphaned_chrome_processes() == 1
+        assert killed_pids == [200]
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only test")
+    def test_ignores_non_agent_browser_chrome(self, monkeypatch):
+        """Chrome with normal user-data-dir must not be touched."""
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_active_sessions", {})
+
+        csv_lines = (
+            "Node,CommandLine,ParentProcessId,ProcessId\n"
+            'SKYNET,"C:\\\\chrome.exe --headless=new --user-data-dir=C:\\\\Users\\\\chuckie\\\\Chrome\\\\User Data",300,301\n'
+        )
+        fake_result = type("R", (), {"stdout": csv_lines.encode()})()
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: fake_result)
+
+        killed_pids = []
+        monkeypatch.setattr(
+            "tools.process_registry.ProcessRegistry._terminate_host_pid",
+            lambda pid: killed_pids.append(pid),
+        )
+
+        assert bt._reap_orphaned_chrome_processes() == 0
+        assert killed_pids == []
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX-only test")
+    def test_noop_on_posix(self, monkeypatch):
+        """On non-Windows, the function should be a no-op."""
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_active_sessions", {})
+        assert bt._reap_orphaned_chrome_processes() == 0

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -410,6 +410,34 @@ class TestEmergencyCleanupRunsReaper:
 class TestReapOrphanedChromeProcesses:
     """Tests for _reap_orphaned_chrome_processes() — Windows orphan Chrome killer."""
 
+    def test_csv_command_line_with_comma_is_parsed(self):
+        """Quoted commas in CommandLine must not shift the PID columns."""
+        import tools.browser_tool as bt
+
+        csv_lines = (
+            "Node,CommandLine,ParentProcessId,ProcessId\n"
+            'SKYNET,"C:\\\\chrome.exe --headless=new --flag=a,b '
+            '--user-data-dir=C:\\\\Temp\\\\agent-browser-chrome-abc123",100,200\n'
+        )
+
+        assert bt._select_orphaned_chrome_pids(
+            csv_lines, lambda _pid: False
+        ) == [200]
+
+    def test_live_parent_from_concurrent_session_is_not_selected(self):
+        """A live agent-browser parent may belong to another Hermes process."""
+        import tools.browser_tool as bt
+
+        csv_lines = (
+            "Node,CommandLine,ParentProcessId,ProcessId\n"
+            'SKYNET,"C:\\\\chrome.exe --headless=new '
+            '--user-data-dir=C:\\\\Temp\\\\agent-browser-chrome-live",100,200\n'
+        )
+
+        assert bt._select_orphaned_chrome_pids(
+            csv_lines, lambda pid: pid == 100
+        ) == []
+
     @pytest.mark.skipif(os.name != "nt", reason="Windows-only test")
     def test_no_chrome_processes_is_noop(self, monkeypatch):
         """When wmic finds no chrome.exe, return 0."""
@@ -444,6 +472,7 @@ class TestReapOrphanedChromeProcesses:
         )
         fake_result = type("R", (), {"stdout": csv_lines.encode()})()
         monkeypatch.setattr("subprocess.run", lambda *a, **kw: fake_result)
+        monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: False)
 
         killed_pids = []
         monkeypatch.setattr(

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1290,6 +1290,94 @@ def _write_owner_pid(socket_dir: str, session_name: str) -> None:
                      session_name, exc)
 
 
+def _reap_orphaned_chrome_processes() -> int:
+    """Kill orphaned headless Chrome processes from dead agent-browser daemons.
+
+    On Windows, when an agent-browser daemon exits (gateway restart, crash),
+    its Chromium child processes get reparented to Explorer.exe.  The main
+    reaper ``_reap_orphaned_browser_sessions`` handles daemons that are
+    *still alive*, but cannot reach Chrome children whose daemon already
+    exited.  This function catches those orphans by scanning for Chrome
+    processes whose ``--user-data-dir`` points at a stale
+    ``agent-browser-chrome-*`` temp directory.
+
+    Safe to call from the cleanup thread or on startup.
+    """
+    if os.name != "nt":
+        # On POSIX, process-tree SIGTERM cascades reliably; this is a
+        # Windows-specific reparenting problem.
+        return 0
+
+    try:
+        import subprocess, tempfile, re
+        from gateway.status import _pid_exists
+
+        # Only reap when there are NO active browser sessions in this
+        # process.  If sessions exist, Chrome processes likely belong to
+        # them and should not be touched.
+        with _cleanup_lock:
+            if _active_sessions:
+                return 0
+
+        tmpdir = tempfile.gettempdir()
+        result = subprocess.run(
+            [
+                "wmic", "process",
+                "where", "name='chrome.exe'",
+                "get", "processid,parentprocessid,commandline",
+                "/format:csv",
+            ],
+            capture_output=True, timeout=15,
+            creationflags=0x08000000,  # CREATE_NO_WINDOW
+        )
+        stdout = result.stdout.decode("utf-8", errors="replace")
+
+        # Collect PIDs of main (non-child-type) Chrome processes that use
+        # an agent-browser-chrome user-data-dir.
+        udd_re = re.compile(
+            r'--user-data-dir="?([^"]*agent-browser-chrome-[^" ]+)')
+        main_pids: list[int] = []
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line or line.startswith("Node"):
+                continue
+            parts = line.split(",", 3)
+            if len(parts) < 4:
+                continue
+            try:
+                pid = int(parts[3])
+                cmdline = parts[1]
+            except (ValueError, IndexError):
+                continue
+            m = udd_re.search(cmdline)
+            if not m:
+                continue
+            # Only match main browser processes (have --headless, no --type)
+            if "--headless" in cmdline and "--type=" not in cmdline:
+                main_pids.append(pid)
+
+        if not main_pids:
+            return 0
+
+        reaped = 0
+        from tools.process_registry import ProcessRegistry
+        for pid in main_pids:
+            try:
+                ProcessRegistry._terminate_host_pid(pid)
+                reaped += 1
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+
+        if reaped:
+            logger.info(
+                "Reaped %d orphaned Chrome process tree(s) whose daemon "
+                "already exited (Windows reparenting workaround)", reaped)
+        return reaped
+    except Exception as exc:
+        logger.debug("Orphan Chrome reap skipped: %s", exc)
+        return 0
+
+
 def _reap_orphaned_browser_sessions():
     """Scan for orphaned agent-browser daemon processes from previous runs.
 
@@ -1417,6 +1505,13 @@ def _browser_cleanup_thread_worker():
         _reap_orphaned_browser_sessions()
     except Exception as e:
         logger.warning("Orphan reap error: %s", e)
+
+    # Second pass: kill orphaned Chrome processes whose daemon already
+    # exited (Windows reparenting workaround — see _reap_orphaned_chrome_processes).
+    try:
+        _reap_orphaned_chrome_processes()
+    except Exception as e:
+        logger.warning("Orphan Chrome reap error: %s", e)
 
     while _cleanup_running:
         try:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -50,6 +50,7 @@ Usage:
 """
 
 import atexit
+import csv
 import functools
 import json
 import logging
@@ -62,7 +63,7 @@ import tempfile
 import threading
 import time
 import requests
-from typing import Dict, Any, Optional, List, Tuple, Union
+from typing import Dict, Any, Optional, List, Tuple, Union, Callable
 from pathlib import Path
 from agent.auxiliary_client import call_llm
 from hermes_constants import get_hermes_home
@@ -1290,6 +1291,58 @@ def _write_owner_pid(socket_dir: str, session_name: str) -> None:
                      session_name, exc)
 
 
+def _select_orphaned_chrome_pids(
+    wmic_output: str,
+    pid_exists: Callable[[int], bool],
+) -> List[int]:
+    """Return agent-browser Chrome PIDs whose recorded parent is dead.
+
+    WMIC emits quoted CSV and Chrome command lines can contain commas, so this
+    parser deliberately uses :mod:`csv`.  Parent liveness is checked
+    fail-closed: an unreadable, invalid, or live parent prevents selection.
+    """
+    rows = csv.reader(wmic_output.splitlines())
+    try:
+        header = next(row for row in rows if row)
+    except StopIteration:
+        return []
+
+    columns = {
+        name.lstrip("\ufeff").strip().lower(): index
+        for index, name in enumerate(header)
+    }
+    required = ("commandline", "parentprocessid", "processid")
+    if any(name not in columns for name in required):
+        return []
+
+    udd_re = re.compile(
+        r'--user-data-dir="?([^"]*agent-browser-chrome-[^" ]+)')
+    orphaned_pids: List[int] = []
+    for row in rows:
+        try:
+            cmdline = row[columns["commandline"]]
+            parent_pid = int(row[columns["parentprocessid"]])
+            pid = int(row[columns["processid"]])
+        except (IndexError, TypeError, ValueError):
+            continue
+
+        if parent_pid <= 0 or pid <= 0:
+            continue
+        if not udd_re.search(cmdline):
+            continue
+        if "--headless" not in cmdline or "--type=" in cmdline:
+            continue
+
+        try:
+            if pid_exists(parent_pid):
+                continue
+        except (OSError, ValueError):
+            continue
+        orphaned_pids.append(pid)
+
+    return orphaned_pids
+
+
 def _reap_orphaned_chrome_processes() -> int:
     """Kill orphaned headless Chrome processes from dead agent-browser daemons.
 
@@ -1309,7 +1362,6 @@ def _reap_orphaned_chrome_processes() -> int:
         return 0
 
     try:
-        import subprocess, tempfile, re
         from gateway.status import _pid_exists
 
         # Only reap when there are NO active browser sessions in this
@@ -1319,7 +1371,6 @@ def _reap_orphaned_chrome_processes() -> int:
             if _active_sessions:
                 return 0
 
-        tmpdir = tempfile.gettempdir()
         result = subprocess.run(
             [
                 "wmic", "process",
@@ -1332,29 +1383,10 @@ def _reap_orphaned_chrome_processes() -> int:
         )
         stdout = result.stdout.decode("utf-8", errors="replace")
 
-        # Collect PIDs of main (non-child-type) Chrome processes that use
-        # an agent-browser-chrome user-data-dir.
-        udd_re = re.compile(
-            r'--user-data-dir="?([^"]*agent-browser-chrome-[^" ]+)')
-        main_pids: list[int] = []
-        for line in stdout.splitlines():
-            line = line.strip()
-            if not line or line.startswith("Node"):
-                continue
-            parts = line.split(",", 3)
-            if len(parts) < 4:
-                continue
-            try:
-                pid = int(parts[3])
-                cmdline = parts[1]
-            except (ValueError, IndexError):
-                continue
-            m = udd_re.search(cmdline)
-            if not m:
-                continue
-            # Only match main browser processes (have --headless, no --type)
-            if "--headless" in cmdline and "--type=" not in cmdline:
-                main_pids.append(pid)
+        # A live parent can be another Hermes process's agent-browser daemon.
+        # Only a matching main Chrome process whose recorded parent is gone is
+        # safe to treat as orphaned.
+        main_pids = _select_orphaned_chrome_pids(stdout, _pid_exists)
 
         if not main_pids:
             return 0


### PR DESCRIPTION
## Problem

On Windows, when an agent-browser daemon exits (gateway restart, crash, SIGKILL), its Chromium child processes get **reparented to Explorer.exe** and live forever. The existing reaper (`_reap_orphaned_browser_sessions`) handles daemons that are *still alive* via `taskkill /T /F`, but cannot reach Chrome children whose daemon already exited — the tree-kill target is gone.

**Evidence:** Issue #32047 — 200+ orphaned Chrome processes after a few browser tasks. In the reporter's instance, 6 headless Chrome instances (each with crashpad/gpu/network/storage/renderer children = ~48 processes) had ParentProcessId = Explorer.exe, not the original agent-browser daemon.

PR #31231 added `taskkill /T /F` tree-kill for the daemon reaper, which works when the daemon is still alive. But the reparenting race means the daemon can exit *before* the reaper runs, leaving Chrome orphans.

## Fix

Add `_reap_orphaned_chrome_processes()` as a **second-pass reaper** that runs after the existing daemon reaper on startup:

1. **Scans** running `chrome.exe` processes via `wmic`
2. **Matches** those with `--user-data-dir` containing `agent-browser-chrome-*` (the temp profile pattern agent-browser creates)
3. **Only targets** main headless instances (`--headless` in cmdline, no `--type=`) — child processes (renderer, GPU, etc.) are killed by `taskkill /T /F` cascade
4. **Skips** when `_active_sessions` is non-empty — if this process has live browser sessions, those Chrome instances belong to it and must not be touched
5. **Kills** via `ProcessRegistry._terminate_host_pid` (same `taskkill /T /F` as the daemon reaper)
6. **Windows-only** — on POSIX, process-tree SIGTERM cascades reliably through init reparenting; this is a Windows-specific problem

### Why `wmic` instead of scanning temp dirs?

The `agent-browser-chrome-*` user-data-dirs don't contain PID files — they're created by Playwright internally. We can't match them to socket dirs by UUID (different naming). Scanning running processes via `wmic` and matching the command-line `--user-data-dir` is the only reliable way to identify which Chrome instances are orphaned.

## Files Changed

- `tools/browser_tool.py` — added `_reap_orphaned_chrome_processes()` and call site in `_browser_cleanup_thread_worker`
- `tests/tools/test_browser_orphan_reaper.py` — 5 new tests (Windows-only + POSIX no-op)

## Testing

```
pytest tests/tools/test_browser_orphan_reaper.py -v -k "TestReapOrphanedChromeProcesses"
```

## Related

- Fixes #32047
- Extends #31231 (daemon tree-kill) with a second pass for already-exited daemons
- Related: #17388 (original orphan issue), #7931 (startup reap)