### PR TITLE
fix(bluebubbles): use timezone-aware UTC for tempGuid timestamps

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -15,7 +15,7 @@ import os
 import re
 import uuid
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -475,7 +475,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -531,7 +531,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:


### PR DESCRIPTION
## Bug

`gateway/platforms/bluebubbles.py` builds `tempGuid` values with
`datetime.utcnow().timestamp()` (two sites):

```python
"tempGuid": f"temp-{datetime.utcnow().timestamp()}",
```

`datetime.utcnow()` returns a **naive** datetime (no `tzinfo`). Calling
`.timestamp()` on a naive datetime makes Python interpret it as **local** time,
not UTC - so on any host not set to UTC the resulting epoch value is wrong by
the machine''s UTC offset. (It''s also deprecated as of Python 3.12 and
scheduled for removal.)

## Fix

Use a timezone-aware UTC datetime so `.timestamp()` is correct on every host:

```python
"tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
```

`timezone` is added to the existing `from datetime import datetime` import.

## Impact

`tempGuid` only needs to be unique-ish, so the practical fallout is limited,
but the value was simply incorrect (and emitting a DeprecationWarning). This
makes it correct and 3.12+-clean. Two occurrences fixed.