### PR TITLE
fix(hermes_time): drop redundant KeyError in except tuple

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -67,7 +67,7 @@ def _get_zoneinfo(name: str) -> Optional[ZoneInfo]:
         return None
     try:
         return ZoneInfo(name)
-    except (KeyError, Exception) as exc:
+    except Exception as exc:
         logger.warning(
             "Invalid timezone '%s': %s. Falling back to server local time.",
             name, exc,


### PR DESCRIPTION
## Bug

`hermes_time._get_zoneinfo` catches:

```python
except (KeyError, Exception) as exc:
```

`KeyError` is a subclass of `Exception`, so `(KeyError, Exception)` is exactly
equivalent to `except Exception` - the `KeyError` entry is dead and misleads
readers into thinking it is handled specially (e.g. that `ZoneInfoNotFoundError`,
which subclasses `KeyError`, gets distinct treatment - it does not).

## Fix

```python
except Exception as exc:
```

Behavior is unchanged (still a safe fail-open to server-local time for any
invalid timezone); the redundant, misleading entry is removed.