### PR TITLE
fix(hyperliquid): replace deprecated datetime.utcfromtimestamp

### DIFF
--- a/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
+++ b/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
@@ -171,7 +171,7 @@ def _format_timestamp_ms(value: Any) -> str:
         ts_ms = int(value)
     except (TypeError, ValueError):
         return "-"
-    return dt.datetime.utcfromtimestamp(ts_ms / 1000).strftime("%Y-%m-%d %H:%M:%S UTC")
+    return dt.datetime.fromtimestamp(ts_ms / 1000, tz=dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
 def _compact_number(value: Any, decimals: int = 2) -> str:


### PR DESCRIPTION
## Bug

The Hyperliquid skill client (`optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py`)
formats display timestamps with:

```python
return dt.datetime.utcfromtimestamp(ts_ms / 1000).strftime("%Y-%m-%d %H:%M:%S UTC")
```

`datetime.utcfromtimestamp()` is **deprecated as of Python 3.12** (scheduled for
removal) and returns a naive datetime. The script runs under the same
interpreter as Hermes (3.12+), so it emits a `DeprecationWarning`.

## Fix

```python
return dt.datetime.fromtimestamp(ts_ms / 1000, tz=dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
```

The displayed UTC string is identical; the deprecation is gone.