### PR TITLE
feat(gateway): add display.terminal_code_blocks toggle for compact terminal previews

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -46,6 +46,11 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # live, just cleaned up after success so the chat doesn't fill up with
     # stale breadcrumbs. Failed runs leave bubbles in place as breadcrumbs.
     "cleanup_progress": False,
+    # When true, terminal commands render as a fenced code block on
+    # markdown-capable platforms (Discord, Telegram, Slack, …). Set false to
+    # keep the compact one-line `terminal: "cmd…"` preview instead — same info,
+    # far less vertical space. Default on (current behavior).
+    "terminal_code_blocks": True,
 }
 
 # ---------------------------------------------------------------------------
@@ -224,6 +229,7 @@ def _normalise(setting: str, value: Any) -> Any:
         "interim_assistant_messages",
         "long_running_notifications",
         "busy_ack_detail",
+        "terminal_code_blocks",
     }:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12926,6 +12926,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             )
         )
+        # Whether terminal commands render as a fenced code block on
+        # markdown-capable platforms. Default on (current behavior); set
+        # display.terminal_code_blocks: false (or per-platform) to fall back to
+        # the compact one-line `terminal: "cmd…"` preview.
+        terminal_code_blocks_enabled = bool(
+            resolve_display_setting(
+                user_config,
+                platform_key,
+                "terminal_code_blocks",
+                True,
+            )
+        )
         
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if tool_progress_enabled else None
@@ -13073,6 +13085,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # at ``tool_preview_length`` (default 40) so a long or multi-line
             # command doesn't render as a huge block — matching the budget the
             # non-terminal preview path already applies (#42634).
+            #
+            # Gated on ``display.terminal_code_blocks`` (default true): set it
+            # false (globally or per-platform) to skip the fence entirely and
+            # keep the compact one-line ``terminal: "cmd…"`` preview, which is
+            # the same info in far less vertical space.
             _code_block_full = None
             _code_block_short = None
             try:
@@ -13080,7 +13097,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 _progress_adapter = None
             if (
-                getattr(_progress_adapter, "supports_code_blocks", False)
+                terminal_code_blocks_enabled
+                and getattr(_progress_adapter, "supports_code_blocks", False)
                 and tool_name == "terminal"
                 and isinstance(args, dict)
                 and isinstance(args.get("command"), str)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1429,6 +1429,11 @@ DEFAULT_CONFIG = {
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+        # Gateway: render terminal commands as fenced code blocks on
+        # markdown-capable platforms (Discord, Telegram, Slack, …). Set false
+        # (globally or per-platform via display.platforms.<p>) to keep the
+        # compact one-line `terminal: "cmd…"` preview instead.
+        "terminal_code_blocks": True,
         # Auto-delete system-notice replies (e.g. "✨ New session started!",
         # "♻ Restarting gateway…", "⚡ Stopped…") after N seconds on platforms
         # that support message deletion (currently Telegram; other platforms

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1488,3 +1488,107 @@ async def test_terminal_progress_no_bash_block_in_verbose_mode(monkeypatch, tmp_
     all_content = " ".join(call["content"] for call in adapter.sent)
     all_content += " ".join(call["content"] for call in adapter.edits)
     assert "```bash" not in all_content
+
+
+@pytest.mark.asyncio
+async def test_terminal_code_blocks_disabled_uses_compact_preview(monkeypatch, tmp_path):
+    """display.terminal_code_blocks=false opts out of the fenced block on a
+    markdown-capable platform: the terminal command falls back to the compact
+    one-line `terminal: "cmd…"` preview (same info, far less vertical space)."""
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"terminal_code_blocks": False}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TerminalCommandAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji
+
+    adapter = CodeBlockProgressAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-terminal-no-code-block",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    all_content = " ".join(call["content"] for call in adapter.sent)
+    all_content += " ".join(call["content"] for call in adapter.edits)
+    # No fenced block at all — the compact quoted preview is used instead.
+    assert "```" not in all_content
+    assert 'terminal: "' in all_content
+
+
+@pytest.mark.asyncio
+async def test_terminal_code_blocks_disabled_per_platform(monkeypatch, tmp_path):
+    """The opt-out also works as a per-platform override
+    (display.platforms.<platform>.terminal_code_blocks=false)."""
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump(
+            {"display": {"platforms": {"telegram": {"terminal_code_blocks": False}}}}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TerminalCommandAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji
+
+    adapter = CodeBlockProgressAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-terminal-no-code-block-perplatform",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    all_content = " ".join(call["content"] for call in adapter.sent)
+    all_content += " ".join(call["content"] for call in adapter.edits)
+    assert "```" not in all_content
+    assert 'terminal: "' in all_content

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1246,6 +1246,7 @@ display:
   show_cost: false        # Show estimated $ cost in the CLI status bar
   timestamps: false       # When true, prefixes user and assistant labels with [HH:MM] timestamps in the CLI / TUI transcript
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+  terminal_code_blocks: true  # Gateway: render terminal commands as fenced code blocks on markdown platforms (set false for the compact one-line preview)
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
     fields: ["model", "context_pct", "cwd"]
@@ -1334,6 +1335,8 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
+
+`terminal_code_blocks` (gateway-only, default `true`) controls how `terminal` tool calls render on markdown-capable platforms (Discord, Telegram, Slack, …). When `true`, the command is shown in a fenced code block; in verbose mode the full command is shown, while `all`/`new` modes show a single capped line inside the block. Set it to `false` — globally or per platform via `display.platforms.<platform>.terminal_code_blocks` — to fall back to the compact one-line `terminal: "cmd…"` preview, which conveys the same (truncated) info in far less vertical space.
 
 ## Privacy
 


### PR DESCRIPTION
## Summary

On markdown-capable messaging platforms (Discord, Telegram, Slack, …), `terminal` tool calls render as a fenced code block (`#41215`, `#42576`, capped in non-verbose by `#42729`). A user reported that this takes much more vertical space than the old compact line, and noted the key issue: **in non-verbose mode the command is truncated to one capped line anyway (`#42729`), so the block delivers no extra info — just ~4× the vertical space** of the compact `terminal: "cmd…"` preview. Today there's no way to opt out short of disabling *all* tool progress (`tool_progress: off`).

This adds a per-platform-overrideable `display.terminal_code_blocks` setting (default `true`, so existing behavior is unchanged) that lets users opt back into the compact one-liner.

## Behavior

- `display.terminal_code_blocks: true` (default) — unchanged: fenced block on markdown platforms; verbose shows the full command, `all`/`new` show a single capped line in the block.
- `display.terminal_code_blocks: false` — terminal falls back to the compact `{emoji} terminal: "cmd…"` one-liner (same truncation budget as other tools), no fence.
- Works globally (`display.terminal_code_blocks`) or per-platform (`display.platforms.<platform>.terminal_code_blocks`), via the existing `resolve_display_setting()` precedence.

## Changes

- `gateway/display_config.py` — new overrideable key in `_GLOBAL_DEFAULTS` + bool normalization (so it flows through `resolve_display_setting` and per-platform overrides).
- `gateway/run.py` — resolve `terminal_code_blocks_enabled` and gate the fenced-block path on it; when off, the existing compact-preview fallthrough handles terminal.
- `hermes_cli/config.py` — document the key in `DEFAULT_CONFIG` (additive; no `_config_version` bump needed).
- `website/docs/user-guide/configuration.md` — document the setting (global + per-platform).

## Test plan

- [x] New `tests/gateway/test_run_progress_topics.py::test_terminal_code_blocks_disabled_uses_compact_preview` and `::test_terminal_code_blocks_disabled_per_platform` — assert no fence + compact `terminal: "` line when the toggle is off (global and per-platform).
- [x] Existing terminal-progress tests (fenced block on/cap/verbose) still pass unchanged (default true).
- [x] `scripts/run_tests.sh tests/gateway/test_run_progress_topics.py` → 34 passed; `test_display_config.py` + `test_config_validation.py` → 55 passed.