### PR TITLE
feat(optional-skills): add gym-workout-programmer

### DIFF
--- a/optional-skills/health/gym-workout-programmer/SKILL.md
+++ b/optional-skills/health/gym-workout-programmer/SKILL.md
@@ -1,0 +1,468 @@
+---
+name: gym-workout-programmer
+description: >-
+  Generate structured gym workout programs tailored to the user's training
+  level, goals, available equipment, schedule, and injuries. Covers full-body,
+  upper/lower, and push/pull/legs splits; rep-range, double progression, and
+  weekly progression rules; a free-weight to machine exercise substitution
+  matrix; and machine-first adaptations for beginners. Use when the user asks
+  for a workout plan, training program, exercise routine, a specific session
+  for today, exercise substitutions when equipment is busy or unavailable, or
+  guidance on when/how to add weight. Pairs with the related `fitness-nutrition`
+  skill for exercise search and macro/calorie tracking.
+platforms: [linux, macos, windows]
+version: 1.0.0
+authors:
+  - hegin
+license: MIT
+metadata:
+  hermes:
+    tags: [fitness, gym, workout, strength-training, hypertrophy, exercise, programming, periodization, progression]
+    category: health
+    related_skills: [fitness-nutrition]
+---
+
+# Gym Workout Programmer
+
+Generate structured, level-appropriate gym workout programs. This skill carries
+the programming rules — split selection, rep ranges, progression method, and
+substitution logic — so the agent does not have to reinvent them every time
+the user asks for a plan.
+
+For exercise search (specific movement by muscle/equipment) and nutrition
+lookup (calories, macros), use the related **`fitness-nutrition`** skill. This
+skill is the *programming* and *coaching* layer on top.
+
+---
+
+## When This Skill Activates
+
+Use when the user:
+
+- Asks for a workout program, training plan, or exercise routine
+- Needs a specific session plan for today ("what should I do at the gym")
+- Wants to know what exercises to do, how many sets/reps, or what weight to use
+- Asks about exercise substitutions ("the squat rack is taken, what else?")
+- Wants progression guidance ("when do I add weight?", "am I ready to progress?")
+- Mentions gym, weights, strength training, hypertrophy, muscle groups, split, periodization, or deload
+
+**Do not use this skill** for: exercise lookup by muscle (use `fitness-nutrition`),
+general nutrition questions (use `fitness-nutrition`), running/cycling/swimming
+programming (use sport-specific sources), rehab/clinical physical therapy
+(refer to a professional), or medical advice.
+
+---
+
+## Core Principles
+
+1. **Technique first** — never sacrifice form for weight. A clean rep at a
+   lighter load builds more muscle and joints you can still use next month.
+2. **Progressive overload** — increase stimulus over time. Add weight, reps, or
+   sets. Without progression, the adaptation stops.
+3. **Individualization** — adapt to the user's level, injuries, available
+   equipment, time budget, and what they actually enjoy. A program the user
+   will not do is worse than a slightly less optimal one they will.
+4. **Recovery is part of the program** — muscles grow between sessions, not
+   during. Sleep, nutrition, and rest days are not optional.
+5. **Simplicity for beginners** — beginners need basic compound movements and
+   progressive overload, not fancy exercises. 3–4 working exercises per session
+   is plenty at low training age.
+6. **Consistency beats novelty** — "muscle confusion" is a marketing term.
+   Stick to a split for 8–12 weeks before changing it.
+
+---
+
+## Warm-Up Protocol (General)
+
+Always include or assume a warm-up. The standard protocol:
+
+- **Cardio (optional, 5 min)**: light treadmill, rower, or bike to raise core
+  temperature. Skip on a tight time budget — mobility covers the rest.
+- **Dynamic mobility (3–5 min)**: arm circles, leg swings, hip circles, torso
+  twists — 10 reps each direction.
+- **Movement prep (per first compound)**: 1–2 ramp-up sets with empty bar or
+  light weight before the working sets. Example: squat 5×bar, 5×40 kg,
+  then working sets at 80 kg.
+
+Tell the user: "If short on time, never skip the ramp-up sets — they are how
+you avoid the first-set tweak."
+
+---
+
+## Program Templates
+
+Pick a template based on the user's **days per week** and **training age**.
+
+### Full Body (Beginner / 2–3 days/week)
+
+**Structure**: 5–6 exercises, 3 sets each, 45–60 min per session.
+
+Example day (beginner default — machines over free weights):
+
+| # | Exercise                              | Sets × Reps | Notes                       |
+|---|---------------------------------------|-------------|-----------------------------|
+| 1 | Leg Press                             | 3×8–10      | Compound, quad-dominant     |
+| 2 | Chest Press Machine                   | 3×8–10      | Compound, chest-dominant    |
+| 3 | Seated Cable Row or Machine Row       | 3×10–12     | Compound, back-dominant     |
+| 4 | Machine Shoulder Press                | 3×10–12     | Compound, shoulder-dominant |
+| 5 | Leg Curl                              | 3×12–15     | Isolation, hamstrings       |
+| 6 | Bicep Curl or Tricep Pushdown         | 3×12–15     | Isolation, arms             |
+| 7 | Plank or Crunches                     | 3×30–45 sec or 15–20 reps | Core              |
+
+Only swap to barbell/dumbbell variations if the user explicitly asks for free
+weights or demonstrates confident technique.
+
+### Upper/Lower Split (Intermediate / 4 days/week)
+
+**Upper A** (heavier):
+
+| # | Exercise                         | Sets × Reps |
+|---|----------------------------------|-------------|
+| 1 | Bench Press                      | 4×6–8       |
+| 2 | Barbell Row                      | 4×8–10      |
+| 3 | Overhead Press                   | 3×8–10      |
+| 4 | Lat Pulldown                     | 3×10–12     |
+| 5 | Incline Dumbbell Press           | 3×10–12     |
+| 6 | Face Pulls                       | 3×15–20     |
+| 7 | Bicep Curl                       | 3×10–12     |
+| 8 | Tricep Rope Pushdown             | 3×12–15     |
+
+**Lower A** (heavier):
+
+| # | Exercise                         | Sets × Reps |
+|---|----------------------------------|-------------|
+| 1 | Squat                            | 4×6–8       |
+| 2 | Romanian Deadlift                | 3×8–10      |
+| 3 | Leg Press                        | 3×10–12     |
+| 4 | Leg Curl                         | 3×12–15     |
+| 5 | Calf Raise                       | 4×12–15     |
+| 6 | Hanging Leg Raise or Ab Wheel    | 3×12–15     |
+
+**Upper B** / **Lower B**: rotate incline → flat, row variation, accessory swap.
+
+### Push / Pull / Legs (PPL) — 5–6 days/week
+
+**Push** (chest, shoulders, triceps):
+
+| # | Exercise                         | Sets × Reps |
+|---|----------------------------------|-------------|
+| 1 | Bench Press                      | 4×6–8       |
+| 2 | Incline Press                    | 3×8–10      |
+| 3 | Overhead Press                   | 3×8–10      |
+| 4 | Lateral Raise                    | 3×12–15     |
+| 5 | Tricep Pushdown                  | 3×12–15     |
+| 6 | Overhead Tricep Extension        | 3×10–12     |
+
+**Pull** (back, biceps, rear delts):
+
+| # | Exercise                         | Sets × Reps |
+|---|----------------------------------|-------------|
+| 1 | Deadlift or Rack Pull            | 3×5–6       |
+| 2 | Pull-Up or Lat Pulldown          | 4×8–10      |
+| 3 | Seated Cable Row                 | 3×10–12     |
+| 4 | Face Pull                        | 3×15–20     |
+| 5 | Barbell or Dumbbell Curl         | 3×10–12     |
+| 6 | Hammer Curl                      | 3×10–12     |
+
+**Legs** (quads, hamstrings, calves):
+
+| # | Exercise                         | Sets × Reps |
+|---|----------------------------------|-------------|
+| 1 | Squat                            | 4×6–8       |
+| 2 | Leg Press                        | 3×10–12     |
+| 3 | Romanian Deadlift                | 3×8–10      |
+| 4 | Leg Extension                    | 3×12–15     |
+| 5 | Leg Curl                         | 3×12–15     |
+| 6 | Standing Calf Raise              | 4×12–15     |
+
+---
+
+## Exercise Substitution Matrix
+
+When the primary exercise is unavailable (equipment busy, no barbell, injury),
+use the **first** viable alternative that matches the movement pattern and
+load profile. Full cues and pattern notes live in
+[`references/substitution-matrix.md`](references/substitution-matrix.md).
+
+| Primary                  | Substitutes                                                                 |
+|--------------------------|------------------------------------------------------------------------------|
+| Barbell Squat            | Goblet Squat · Leg Press · Hack Squat · Bulgarian Split Squat                |
+| Barbell Bench Press      | Dumbbell Press · Chest Press Machine · Incline Press                         |
+| Barbell Row              | Cable Row · Chest-Supported Row · Machine Row                                |
+| Deadlift                 | Romanian Deadlift · Rack Pull · Back Extension · Trap-Bar Deadlift           |
+| Overhead Press           | Machine Shoulder Press · Dumbbell Press · Landmine Press                    |
+| Pull-Up                  | Lat Pulldown · Assisted Pull-Up Machine · Machine Pull-Up                    |
+| Dip                      | Close-Grip Bench · Tricep Pushdown · Bench Dip                               |
+| Barbell Curl             | Dumbbell Curl · Cable Curl · Machine Curl · Preacher Curl                    |
+| Lat Pulldown             | Assisted Pull-Up · Machine Pull-Down · Single-Arm Cable Pulldown             |
+| Cable Row                | Chest-Supported Machine Row · Dumbbell Row · T-Bar Row                       |
+| Leg Press                | Hack Squat · Belt Squat · Bulgarian Split Squat                              |
+| Romanian Deadlift        | Good Morning · Cable Pull-Through · Glute-Ham Raise                          |
+| Leg Curl                 | Nordic Curl · Sliding Leg Curl · Standing Leg Curl Machine                   |
+| Calf Raise (standing)    | Leg Press Calf Raise · Smith Machine Calf Raise · Donkey Calf Raise          |
+
+**Rule of thumb**: substitution is safe when the new exercise hits the same
+primary muscle group with a similar range of motion. It is *not* safe when it
+shifts the stimulus to a different muscle (e.g. leg press for a hip-hinge
+movement, or curl for a row).
+
+---
+
+## Machine-First Adaptation for Beginners
+
+When the user expresses discomfort with free-weight technique, is new to the
+gym, or has a busy equipment situation, **default to machines**. Machines
+provide:
+
+- Fixed trajectory — less to think about
+- Built-in safety — no spotter needed
+- Easier form feedback — visible mechanics
+
+**Common machine swaps** (mirror the substitution matrix above):
+
+- Barbell squat → Leg press, hack squat machine, belt squat
+- Barbell bench → Chest press machine, dumbbell press on a flat bench
+- Barbell row → Seated cable row, chest-supported row machine
+- Overhead press → Machine shoulder press
+- Free-weight calf raise → Standing or seated calf raise machine
+
+Introduce free-weight variations one at a time, after the user has 2–3 months
+of consistent machine work and asks to progress. The free-weight version of a
+machine movement is **harder**, not equivalent — expect an initial drop in
+load of 20–30%.
+
+---
+
+## Equipment-Aware Weight Prescription
+
+The way you express the load depends on the equipment type. Default choices
+the user can override.
+
+| Equipment type                | Express as                                | Example                            |
+|-------------------------------|-------------------------------------------|------------------------------------|
+| Barbell, dumbbell, plate stack| kg or lb (whichever the user uses)        | "Squat 80 kg × 5"                  |
+| Selectorized pin-loaded machine| Pin number (1-based) on the weight stack | "Leg Press pin 18 × 12"            |
+| Cable machine with stack      | Pin number on the stack                   | "Cable Row pin 14 × 10"            |
+| Bodyweight / calisthenics     | Reps and progressions                     | "Pull-Up 3×6"                      |
+| Smith machine                 | Total bar + plate weight                  | "Smith Squat 60 kg × 8"            |
+| Kettlebell                    | kg or lb                                  | "KB Swing 24 kg × 15"              |
+
+**Always confirm per-arm vs total** before writing kg. "20 kg per arm" and
+"20 kg total" are very different loads. For dumbbell exercises, state the
+load per dumbbell; for selectorized machines that list the *total* moving
+mass (most commercial gyms), state pin number without "per arm".
+
+For a full framework on adapting to whatever equipment the user has (home
+gym, hotel, body-weight only, traveling), see
+[`references/equipment-aware-scaling.md`](references/equipment-aware-scaling.md).
+
+---
+
+## Weight Selection & Progression
+
+### Today — first time on an exercise
+
+If you do not know the user's starting weight, prescribe conservatively:
+
+- Target: top of the rep range with **2 reps in reserve (RIR)**.
+- For a 3×8–10 target: ask the user to find a weight they could do ~12 clean
+  reps with. If 10 is easy across all sets, increase next set.
+- Better to start light and add weight next session than to grind through
+  bad reps and learn to fear the movement.
+
+### Progression Methods
+
+Pick **one** method and apply it consistently for 6–8 weeks before switching.
+
+**1. Rep Range Method** (default for most lifters)
+- Set a target range (e.g. 3×8–10).
+- If you hit the **top of the range** on all sets with good form → add
+  weight next session (smallest increment: 2.5 kg for barbell compounds,
+  1.25 kg for dumbbell, 1 pin for selectorized machine).
+- If you fail to hit the **bottom of the range** on any set → keep the
+  weight, repeat, and only add weight once you can hit the bottom on all sets.
+- Deload trigger: two consecutive failed sessions at the same weight → drop
+  10% and work back up.
+
+**2. Double Progression** (good for hypertrophy accessories)
+- Add reps within the range first, then add weight and reset to the bottom.
+- Example: 3×8–10 → 3×8, 3×8, 3×9 → 3×9, 3×9, 3×10 → 3×10, 3×10, 3×10
+  → next session, add weight and start at 3×8.
+
+**3. Weekly / Linear Progression** (beginners, 3 days/week full-body)
+- Add ~2.5 kg to compound lifts (squat, bench, deadlift, row, press) every
+  session while form holds.
+- Smaller jumps for upper body (1–2.5 kg) and isolation work (0.5–1 kg).
+- Deload: any session where form breaks down → repeat the same weight, do
+  not add load.
+
+### Rest Between Sets
+
+| Movement type                       | Rest              |
+|-------------------------------------|-------------------|
+| Heavy compounds (squat, bench, DL)  | 2–3 min           |
+| Moderate compounds (row, OHP)       | 1.5–2 min         |
+| Isolation (curl, raise, leg curl)   | 60–90 sec         |
+| Warm-up / ramp-up sets              | 30–60 sec         |
+
+Short rest on isolation is fine; cutting rest on heavy compounds to "save
+time" reduces the load you can handle on the next set and slows strength
+gains.
+
+---
+
+## Deload Weeks
+
+Every 6–8 weeks of consistent progression, plan a deload:
+
+- Reduce volume to ~50–60% of normal (drop sets or drop reps, not both)
+- Keep intensity moderate (use ~70% of normal working weight)
+- Maintain frequency
+- 5–7 days, then resume progression
+
+Skip the deload if you are not actually fatigued. Signs you need one: stalled
+progress for 2+ weeks, joint achiness, poor sleep, dropping weight session
+to session, motivation crash.
+
+---
+
+## Program Generation Workflow
+
+When the user asks for a new program, gather these inputs first (ask in one
+message, not five):
+
+1. **Training age**: < 6 months (beginner), 6 months–2 years (intermediate),
+   2+ years (advanced).
+2. **Days per week available**: 2, 3, 4, 5, or 6.
+3. **Session length**: 30, 45, 60, 75+ minutes.
+4. **Goal**: general strength, hypertrophy, fat loss, sport-specific, return
+   from layoff, rehab-adjacent.
+5. **Equipment**: home (specify), commercial gym, machines only, free weights
+   only, full rack.
+6. **Injuries or limitations**: any current pain, old injuries, joint issues.
+   Do not program around these casually — refer out to a professional if acute.
+7. **Experience preference**: comfortable with barbell, prefers machines, or
+   no preference.
+
+Then:
+
+1. **Pick the split** based on days/week (Full Body 2–3d · Upper/Lower 4d · PPL 5–6d).
+2. **Pick the intensity profile** based on goal (strength 4–6 reps, hypertrophy
+   8–12 reps, endurance 12–20 reps, mixed 6–12).
+3. **Select exercises** — start with compounds, add 1–2 isolation pieces per
+   muscle group, leave 1–2 slots for user-preference swaps.
+4. **Assign sets** — 3–4 working sets per exercise; 10–20 total working sets
+   per muscle group per week for natural intermediates.
+5. **Add progression rule** — pick one method from §Weight Selection &
+   Progression, write it at the top of the plan.
+6. **State substitutions** — for the 2–3 exercises most likely to be busy
+   (squat rack, bench, cable station).
+7. **Add a deload** at week 6–8.
+
+For complete example programs (full body, upper/lower, PPL), see
+[`references/output-format-examples.md`](references/output-format-examples.md).
+
+---
+
+## Output Format
+
+When generating a workout, present it as:
+
+```markdown
+**Workout: [Name]** — [duration]
+
+**Warm-Up** (5–10 min): [briefly]
+
+1. **[Exercise]** — [sets]×[reps]
+   - Ramp-up: [weight] × [reps]
+   - Working: [weight] × [sets] × [reps]
+   - Substitute: [alternative if primary is busy]
+
+2. ...
+
+**Weight rule**: hit the top of the range on all sets → add [increment] next
+session. Miss the bottom → keep the weight, repeat.
+
+**Rest** between sets: [time]
+```
+
+Adapt the language to the user (concise / verbose / formatted tables) but
+keep the load numbers and progression rule explicit. A plan without a
+progression rule is just a list of exercises.
+
+---
+
+## Pitfalls
+
+These are the failure modes we see most often. Avoid them.
+
+- **Never prescribe 1-rep max testing to beginners.** A max-effort single
+  needs a spotter, a warm-up protocol, and technique that beginners do not
+  have. Test 3–5 RM instead if a max estimate is needed.
+- **Never skip the warm-up.** Always include or assume it. The ramp-up sets
+  on the first compound are how you avoid the first-set tweak.
+- **Never suggest the smith machine for squats as the primary option for
+  beginners learning free weights.** The fixed bar path teaches the wrong
+  motor pattern. Use it for partial-range accessory work, not as a squat
+  substitute for novices.
+- **Avoid "muscle confusion".** Consistency beats novelty for beginners and
+  intermediates. Stick to a split for 8–12 weeks before changing it.
+- **Do not overprogram beginners.** 3–4 working exercises per session is
+  plenty initially. More exercises with bad form is worse than fewer with
+  good form.
+- **Do not ignore pain.** Joint pain is a stop sign, not a "push through"
+  moment. Substitute the movement and refer to a professional if it
+  persists across sessions.
+- **No body-part splits for beginners.** Chest day / back day / arm day is
+  inefficient at low volume. Full-body or upper/lower produces better
+  results in the first 1–2 years.
+- **Never suggest an exercise that is not in the plan without flagging it.**
+  When the user is mid-workout and the planned machine is taken, the next
+  exercise is the **next item in the original plan**, not a random swap. Re-
+  verify against the plan before suggesting "next: X" — losing track of the
+  sequence mid-session is a real failure mode.
+- **Always confirm per-arm vs total weight before assigning kg.** Different
+  machines in the same gym have different conventions. If you are unsure
+  from the photo, ask the user — "5 kg per arm × 10" and "5 kg total × 10"
+  are very different loads.
+- **Do not invent exercises to fill a slot.** If the user's equipment list
+  cannot cover the planned slot, say so and either swap from the
+  substitution matrix or reduce the number of slots. Inventing an exercise
+  that is not actually in their gym is the most common cause of "the plan
+  fell apart at the gym" failures.
+- **No ego lifting prescriptions.** A plan that pushes load faster than the
+  user's recovery capacity will get injured or quit. Conservative is
+  correct; the user can always add weight on their own.
+
+---
+
+## Tracking & Logging
+
+Suggest the user log, at minimum, after each working set:
+
+- Exercise name
+- Weight used (or pin number for selectorized machines)
+- Sets and reps actually completed
+- RIR (reps in reserve) on the last set
+- Date
+
+This is the only way to make a real progression decision next session. "I
+think I did 3×8 last time" is not enough. If the user already keeps a
+training journal, read the last 3–5 sessions for actual deltas (sets × reps ×
+weight *completed*, not just *planned*) before prescribing the next session.
+
+---
+
+## When You Are Done
+
+After delivering a plan, in the same reply:
+
+1. State the **progression rule** explicitly. A plan without one is a list of
+   exercises, not a program.
+2. Note the **first-session weight selection method** (conservative, 2 RIR
+   at top of range).
+3. Flag the **most likely equipment conflict** (squat rack, bench, cable
+   station) and the substitute to use.
+4. Mention the **deload** at week 6–8.
+
+Keep the response concise. The user can ask for more detail on any exercise.

--- a/optional-skills/health/gym-workout-programmer/references/equipment-aware-scaling.md
+++ b/optional-skills/health/gym-workout-programmer/references/equipment-aware-scaling.md
@@ -1,0 +1,186 @@
+# Equipment-Aware Weight Scaling
+
+Different equipment types demand different ways of expressing the load. This
+reference gives a unified framework so the user can read the plan at the gym
+without translating units in their head.
+
+## Decision Tree
+
+```
+Is it bodyweight or external load?
+├─ Bodyweight → reps + progressions (deficit, band, weight vest, tempo)
+└─ External load
+   ├─ Selectorized pin-loaded machine → pin number (1-based) on the stack
+   ├─ Plate-loaded machine → total plates loaded (kg/lb)
+   ├─ Barbell or dumbbell → total weight (kg/lb)
+   ├─ Cable machine with stack → pin number on the stack
+   ├─ Smith machine → total bar + plates (kg/lb)
+   └─ Kettlebell → weight of the bell (kg/lb)
+```
+
+## Why This Matters
+
+A plan that says "Leg Press 80 kg × 10" is **useless** when the user is at a
+commercial gym where Leg Press is a selectorized pin machine and they have
+no idea what pin number corresponds to 80 kg. Conversely, a plan that says
+"Leg Press pin 14 × 10" is **useless** at a powerlifting gym with a plate-
+loaded leg press where the user wants to load 200 kg.
+
+Default to the **equipment the user actually has**. Ask if unclear.
+
+## Equipment Type Reference
+
+### Selectorized Pin-Loaded Machines (commercial gym default)
+
+- The weight stack has a magnetic pin. Inserting the pin at hole N loads the
+  weight plates from the bottom of the stack up to (and including) the
+  selected hole.
+- **Express the load as the pin number**, not as the kg equivalent. Most
+  stacks have a printed weight table, but the user does not need to read
+  it during the session — they just set the pin.
+- Pin numbers are **1-based**: pin 1 is the lightest hole, pin N is the
+  heaviest.
+- Stacks vary. A 200-lb (≈ 90 kg) stack typically has 15–20 holes,
+  incrementing 10 lb (≈ 4.5 kg) per pin. A 300-lb (≈ 135 kg) stack
+  typically has 15 holes at 20 lb (≈ 9 kg) per pin. **Do not assume the
+  increment is the same across machines.**
+- **Per-arm vs total**: most commercial selectorized machines list the
+  *total moving mass*, not per-arm. Do not write "per arm" unless the
+  machine is bilaterally independent (rare).
+- *Example*: "Leg Press pin 18 × 12" — pin 18 on the selectorized leg
+  press, 12 reps.
+
+### Plate-Loaded Machines
+
+- Load the machine by sliding plates onto its horns. Express the load as
+  the **total weight on the machine**, which usually equals the sum of
+  the plates plus the machine's starting resistance (the latter is
+  sometimes labeled on the machine — typically 5–25 kg).
+- *Example*: "Hammer Strength Row 50 kg × 10 per side" — 50 kg on each
+  side, plus the machine's starting weight (look it up once, then
+  remember it).
+
+### Barbell and Dumbbell
+
+- Total weight of the bar/plates. State the bar weight if it is non-
+  standard (an EZ-curl bar at 7.5 kg vs a 20 kg Olympic bar).
+- For dumbbells, state the **per-dumbbell** weight — the user picks up
+  two of them.
+- *Example*: "Squat 80 kg × 5" — barbell squat with 60 kg of plates on
+  a 20 kg bar. "Dumbbell Bench 30 kg × 8" — two 30 kg dumbbells.
+
+### Cable Machines with Weight Stack
+
+- Express the load as the **pin number** on the stack, same as
+  selectorized machines.
+- Most cable machines have a starting tension — the cable feels heavier
+  at pin 1 than the printed weight suggests. Adjust by feel.
+- *Example*: "Cable Row pin 14 × 10".
+
+### Smith Machine
+
+- Total bar + plate weight. The bar in a Smith machine is counter-
+  balanced, so the effective load is slightly less than the bar + plates.
+  Most users ignore this and add ~5–10 kg to their normal barbell load.
+- *Example*: "Smith Squat 60 kg × 8" — bar (~ 10–15 kg counterbalanced)
+  plus plates.
+
+### Bodyweight
+
+- Reps only for the first weeks. Add progression with:
+  - **Tempo**: 3-second eccentric, 1-second pause, 1-second concentric.
+  - **Deficit**: hands or feet elevated to increase ROM.
+  - **Band assistance / resistance**: reduces load (assistance) or adds
+    load (resistance).
+  - **Weight vest / dip belt**: adds absolute load to bodyweight
+    movements.
+- *Example*: "Pull-Up 3×6" — 3 sets of 6 reps. Next session, try 3×7 or
+  add a 5 kg dip belt.
+
+### Kettlebell
+
+- Weight of the bell. State the unit (kg or lb) the user uses.
+- *Example*: "KB Swing 24 kg × 15".
+
+---
+
+## Adapting to a Specific Gym
+
+When the user has a fixed gym (the common case), capture the **equipment
+profile** once and reuse it:
+
+- **Selectorized stack weight per pin** for each major machine
+  (chest press, row, leg press, shoulder press, lat pulldown, leg curl,
+  leg extension, calf raise).
+- **Starting resistance** of any plate-loaded machines.
+- **Available dumbbells** — max pair weight, whether the set goes in 1 kg
+  or 2.5 kg increments.
+- **Barbell inventory** — Olympic 20 kg, women's 15 kg, EZ-curl 7.5 kg,
+  trap bar, safety squat bar.
+- **Cable stacks** — pin increment, whether single or dual adjustable.
+- **Cardio machines** — bike, treadmill, elliptical, rower, stairclimber.
+
+This profile is what makes a plan executable. Without it, the plan is
+generic and the user has to translate at the gym.
+
+### Worked Example: Generic Commercial Gym
+
+The user lifts at a typical commercial gym. The plan calls for chest work
+3×10. Two options:
+
+**Option A — selectorized chest press machine**
+- Plan: "Chest Press pin 14 × 10"
+- User sets the pin to 14 on the chest press machine's stack.
+- 3 sets of 10 reps.
+
+**Option B — flat bench + dumbbells**
+- Plan: "Dumbbell Bench Press 25 kg × 10"
+- User picks up two 25 kg dumbbells, lies on a flat bench, 3×10.
+
+The agent picks one based on the user's stated equipment profile. If the
+profile is unknown, ask: "Are you at a commercial gym with selectorized
+machines, or somewhere with free weights and a bench?"
+
+### Worked Example: Powerlifting / Strength Gym
+
+The user has a powerlifting gym with a 20 kg Olympic bar, calibrated
+plates, a competition bench, and a power rack. The plan calls for
+squat 5×5.
+
+- Plan: "Back Squat 100 kg × 5"
+- User loads 40 kg per side on the bar, 3 ramp-up sets (40, 60, 80),
+  then 5 working sets of 5 at 100 kg.
+
+No translation needed. The plan can use precise barbell loads because the
+equipment is precise.
+
+### Worked Example: Home Gym (Bodyweight + Adjustable Dumbbells)
+
+The user has an adjustable dumbbell set (5–25 kg per side in 2.5 kg
+increments), a pull-up bar, and a resistance band set. The plan calls
+for a full-body workout.
+
+- Plan:
+  - "Goblet Squat 25 kg × 10" (one dumbbell held at chest)
+  - "Push-Up 3×12" (bodyweight; deficit once 3×15 is easy)
+  - "One-Arm Dumbbell Row 22.5 kg × 10 per side"
+  - "Pull-Up 3×6 (band-assisted if needed)"
+
+Adjust the plan to what the equipment supports. The progression rule
+still applies: hit the top of the range, add weight (2.5 kg per dumbbell)
+or remove band assistance.
+
+---
+
+## Hotel / Travel Adaptation
+
+When the user is traveling with no gym access:
+
+- Bodyweight circuit: 4–6 movements, 3 rounds, 30–60 sec work / 15–30 sec
+  rest. Movements: push-up variation, squat, lunge, plank, inverted row
+  (under a sturdy table), glute bridge.
+- Resistance band workout: 4–6 movements, 3 sets of 12–15 each. Bands
+  provide enough load for a maintenance week.
+- Do **not** try to maintain the same load as the home gym. The goal
+  during travel is to keep the movement patterns alive, not to progress
+  load.

--- a/optional-skills/health/gym-workout-programmer/references/output-format-examples.md
+++ b/optional-skills/health/gym-workout-programmer/references/output-format-examples.md
@@ -1,0 +1,239 @@
+# Output Format Examples
+
+Three complete example programs in the format `SKILL.md` recommends. Adapt
+the exercises, set/rep schemes, and progression rules to the user's level
+and equipment — the structure is the template.
+
+---
+
+## Example 1: Full-Body Beginner (3 days/week, 45 min per session)
+
+**User profile**: 4 months of lifting, 2× per week, full-time job, no
+injuries, commercial gym with selectorized machines and a free-weight
+section. Goal: general strength, lose 5 kg.
+
+**Progression rule**: Rep Range Method. Hit 3×10 on all sets with good
+form → add 1 pin (machines) or 2.5 kg (free weights) next session. Miss
+3×8 → keep the weight, repeat.
+
+**Deload**: week 6.
+
+### Day A — Full Body A
+
+**Warm-Up** (5 min): 2 min light bike, arm circles, leg swings, 1 ramp-up
+set on the first exercise (Leg Press pin 8 × 10).
+
+1. **Leg Press** — 3×10
+   - Ramp-up: pin 8 × 10
+   - Working: pin 14 × 3 × 10
+   - Substitute: Hack Squat, Belt Squat
+2. **Chest Press Machine** — 3×10
+   - Working: pin 10 × 3 × 10
+   - Substitute: Dumbbell Bench Press 18 kg × 10
+3. **Seated Cable Row** — 3×12
+   - Working: pin 12 × 3 × 12
+   - Substitute: Chest-Supported Row Machine
+4. **Machine Shoulder Press** — 3×10
+   - Working: pin 8 × 3 × 10
+   - Substitute: Dumbbell Shoulder Press 12 kg × 10
+5. **Leg Curl** — 3×12
+   - Working: pin 10 × 3 × 12
+6. **Plank** — 3×30 sec
+   - Substitute: Dead Bug 3×10 per side
+
+**Rest**: 90 sec between compound sets, 60 sec for isolation.
+
+### Day B — Full Body B (2–4 days after Day A)
+
+**Warm-Up** (5 min): same as Day A.
+
+1. **Goblet Squat** — 3×10
+   - Working: 20 kg × 3 × 10
+   - Substitute: Leg Press pin 16 × 10
+2. **Lat Pulldown** — 3×10
+   - Working: pin 12 × 3 × 10
+   - Substitute: Assisted Pull-Up
+3. **Dumbbell Bench Press** — 3×10
+   - Working: 18 kg × 3 × 10
+4. **Seated Cable Row** — 3×12 (same as Day A; if Day A is too easy, add
+   1 pin here too)
+5. **Leg Extension** — 3×12
+   - Substitute: Leg Curl (if no extension machine)
+6. **Tricep Pushdown** — 3×12
+   - Working: pin 8 × 3 × 12
+7. **Hanging Leg Raise** — 3×10
+   - Substitute: Lying Leg Raise, Cable Crunch
+
+**Rest**: same as Day A.
+
+### Day C — Full Body A repeat
+
+Same as Day A. If all three sessions in the week hit the top of the range
+on the main lifts, the user adds load on Day A of the next week.
+
+---
+
+## Example 2: Upper/Lower Intermediate (4 days/week, 60 min per session)
+
+**User profile**: 18 months of consistent lifting, 4× per week, home gym
+with barbell, rack, bench, dumbbells (5–40 kg), and a lat pulldown cable.
+Goal: hypertrophy, +3 kg of muscle.
+
+**Progression rule**: Double Progression. Each movement: hit the top of
+the rep range on all sets → add the smallest available increment next
+session, restart at the bottom of the range.
+
+**Deload**: week 7.
+
+### Upper A — Heavy
+
+**Warm-Up** (8 min): 3 min bike, dynamic mobility, 2 ramp-up sets on
+Bench Press (40 kg × 5, 60 kg × 3).
+
+1. **Bench Press** — 4×6–8
+   - Ramp-up: 40 × 5, 60 × 3
+   - Working: 80 kg × 4 × 6
+   - Substitute: Dumbbell Bench 30 kg × 8
+2. **Barbell Row** — 4×8–10
+   - Working: 70 kg × 4 × 8
+   - Substitute: Chest-Supported Row 60 kg × 10
+3. **Overhead Press** — 3×8–10
+   - Working: 45 kg × 3 × 8
+   - Substitute: Machine Shoulder Press pin 12 × 10
+4. **Lat Pulldown** — 3×10–12
+   - Working: pin 14 × 3 × 10
+5. **Incline Dumbbell Press** — 3×10–12
+   - Working: 24 kg × 3 × 10
+6. **Face Pull** — 3×15–20
+   - Working: 20 kg × 3 × 15
+7. **Barbell Curl** — 3×10–12
+   - Working: 30 kg × 3 × 10
+8. **Tricep Rope Pushdown** — 3×12–15
+   - Working: pin 10 × 3 × 12
+
+**Rest**: 2–3 min compounds, 90 sec accessories.
+
+### Lower A — Heavy
+
+**Warm-Up** (8 min): 3 min bike, dynamic mobility, 2 ramp-up sets on
+Squat (60 kg × 5, 90 kg × 3).
+
+1. **Squat** — 4×6–8
+   - Working: 110 kg × 4 × 6
+   - Substitute: Belt Squat 120 kg × 8
+2. **Romanian Deadlift** — 3×8–10
+   - Working: 90 kg × 3 × 8
+   - Substitute: Glute-Ham Raise × 8
+3. **Leg Press** — 3×10–12
+   - Working: 180 kg × 3 × 10
+4. **Leg Curl** — 3×12–15
+   - Substitute: Nordic Curl × 6
+5. **Standing Calf Raise** — 4×12–15
+   - Working: 80 kg × 4 × 12
+6. **Hanging Leg Raise** — 3×12–15
+   - Substitute: Ab Wheel × 10
+
+**Rest**: same as Upper A.
+
+### Upper B — Volume
+
+Same structure as Upper A, with these swaps:
+
+- Bench Press → Incline Barbell Press 4×8–10
+- Barbell Row → Pendlay Row 4×8
+- Overhead Press → Landmine Press 3×10
+- Incline DB Press → Cable Crossover 3×12
+- Add: Lateral Raise 3×15
+
+### Lower B — Volume
+
+Same structure as Lower A, with these swaps:
+
+- Squat → Front Squat 3×8
+- Romanian Deadlift → Good Morning 3×10
+- Add: Walking Lunge 3×10 per leg
+- Leg Press → Bulgarian Split Squat 3×10 per leg
+
+---
+
+## Example 3: Push/Pull/Legs (6 days/week, 60 min per session)
+
+**User profile**: 3 years of consistent lifting, 6× per week, commercial
+gym with both selectorized and free-weight equipment. Goal: push
+hypertrophy, accept that recovery limits volume to ~12 hard sets per
+muscle per week.
+
+**Progression rule**: Rep Range Method. Hit 3×12 on all sets → add
+weight. Miss 3×8 → keep weight, repeat.
+
+**Deload**: week 7 (1 week at 60% volume).
+
+### Push A — Heavy Compound
+
+1. **Bench Press** — 4×6–8 @ 90 kg
+2. **Overhead Press** — 3×8–10 @ 50 kg
+3. **Incline Dumbbell Press** — 3×10–12 @ 28 kg
+4. **Lateral Raise** — 3×12–15 @ 8 kg
+5. **Tricep Pushdown** — 3×12–15 @ pin 12
+6. **Overhead Tricep Extension** — 3×10–12 @ 25 kg
+
+**Rest**: 2–3 min on first 3, 90 sec on last 3.
+
+### Pull A — Heavy Compound
+
+1. **Deadlift** — 3×5–6 @ 140 kg
+2. **Pull-Up** — 4×8–10 (bodyweight; add 5 kg dip belt when 4×10 is easy)
+3. **Barbell Row** — 3×8–10 @ 75 kg
+4. **Face Pull** — 3×15–20 @ 22 kg
+5. **Barbell Curl** — 3×10–12 @ 32 kg
+6. **Hammer Curl** — 3×10–12 @ 14 kg
+
+**Rest**: 2–3 min on first 3, 90 sec on last 3.
+
+### Legs A — Heavy Compound
+
+1. **Squat** — 4×6–8 @ 120 kg
+2. **Romanian Deadlift** — 3×8–10 @ 100 kg
+3. **Leg Press** — 3×10–12 @ 200 kg
+4. **Leg Curl** — 3×12–15 @ pin 10
+5. **Standing Calf Raise** — 4×12–15 @ 90 kg
+6. **Hanging Leg Raise** — 3×12–15
+
+**Rest**: 2–3 min on first 3, 90 sec on last 3.
+
+### Push B / Pull B / Legs B — Volume
+
+Swap the heavy compounds for higher-rep variants, add isolation work,
+keep the rep ranges 8–15. Example Push B:
+
+1. **Incline Barbell Press** — 4×8–10 @ 65 kg
+2. **Machine Chest Press** — 3×10–12 @ pin 18
+3. **Cable Crossover** — 3×12–15 @ pin 14
+4. **Lateral Raise (cable)** — 3×12–15 @ pin 6
+5. **Tricep Rope Pushdown** — 3×12–15 @ pin 14
+6. **Skull Crusher** — 3×10–12 @ 20 kg EZ bar
+
+---
+
+## How to Adapt These Templates
+
+When the user asks for a plan, walk through this checklist:
+
+1. **Days per week** → pick the matching template.
+2. **Goal** → adjust rep ranges (strength 4–6, hypertrophy 8–12, mixed 6–10).
+3. **Equipment** → swap exercises that the user's gym does not have, using
+   the substitution matrix.
+4. **Injuries / limitations** → replace any aggravating movement; refer to
+   a professional for acute pain.
+5. **Add a progression rule** at the top of the plan. Without one, the plan
+   is a list, not a program.
+6. **Add a deload** at week 6–8. Specify what to do (drop sets by half,
+   keep intensity moderate, maintain frequency).
+7. **State the warm-up** — the first 5–10 minutes of the session. Ramp-up
+   sets on the first compound count.
+8. **Note the most likely equipment conflict** (squat rack, bench, cable
+   station) and the substitute to use.
+
+The output should be executable without translation. If the user has to
+stop and ask "what does pin 14 mean?" or "where is the chest press
+machine?", the plan is incomplete.

--- a/optional-skills/health/gym-workout-programmer/references/substitution-matrix.md
+++ b/optional-skills/health/gym-workout-programmer/references/substitution-matrix.md
@@ -1,0 +1,192 @@
+# Exercise Substitution Matrix (Extended)
+
+The condensed table in `SKILL.md` is for fast lookup. This reference expands
+each row with **movement pattern**, **primary muscles**, **load profile**, and
+**when to prefer the substitute** over the primary.
+
+## How to Use This Reference
+
+1. Identify the **primary** exercise in the plan and its row below.
+2. Confirm the substitute matches the **movement pattern** (squat hinge
+   push, pull, carry, isolation).
+3. Confirm it hits the **same primary muscle group** at similar activation.
+4. Adjust the load — most substitutes require a 10–20% reduction on the
+   first session because the motor pattern is unfamiliar even when the
+   muscles are the same.
+
+**Substitution is unsafe** when the new exercise shifts the stimulus to a
+different muscle group (e.g. leg press for a hip-hinge, curl for a row) or
+changes the range of motion so much that the user is no longer training the
+movement pattern the program is built around.
+
+---
+
+## Squat Pattern (knee-dominant, quad-dominant)
+
+| Primary            | Movement     | Primary muscles     | Substitutes                                                  | When to substitute                                  |
+|--------------------|--------------|---------------------|--------------------------------------------------------------|-----------------------------------------------------|
+| Barbell Back Squat | Knee-dominant| Quads, glutes       | Goblet Squat · Leg Press · Hack Squat · Belt Squat · Bulgarian Split Squat | Squat rack taken; user has wrist/shoulder mobility limit; novice |
+
+- **Goblet Squat** — best novice substitute. Easier to learn the pattern,
+  self-balancing, low load. Use 50–60% of the back-squat load.
+- **Leg Press** — easiest, safest. Allows heavy loading without balance
+  demand. **Does not train the trunk-stabilization demand of a real squat.**
+  Use as a primary squat substitute only if the user has a back issue.
+- **Hack Squat** — machine version of the squat pattern, glute/quad focused.
+  Closer to a real squat than leg press.
+- **Belt Squat** — pure quad/glute loading, no spinal load. Good for users
+  with back issues who still want to squat heavy.
+- **Bulgarian Split Squat** — unilateral, also adds a stability demand.
+  Excellent accessory or substitute; do not program at the same load as a
+  bilateral squat.
+
+## Bench Pattern (horizontal push, chest-dominant)
+
+| Primary               | Movement     | Primary muscles   | Substitutes                                                  | When to substitute                                  |
+|-----------------------|--------------|-------------------|--------------------------------------------------------------|-----------------------------------------------------|
+| Barbell Bench Press   | Horizontal push | Chest, front delts, triceps | Dumbbell Bench Press · Chest Press Machine · Incline Press · Push-Up (weighted) | Bench/rack taken; shoulder pain on barbell path; home gym with no barbell |
+
+- **Dumbbell Bench Press** — deeper range of motion at the bottom, more
+  shoulder-friendly for some users, but the load ceiling is much lower than
+  barbell. Use 60–70% of barbell load per dumbbell (total = 2× that).
+- **Chest Press Machine** — fixed path, easy on the shoulders, perfect for
+  beginners or when the bench is taken. Plate-loaded machines allow heavy
+  loading; selectorized pin machines cap at the stack weight.
+- **Incline Press** — emphasises upper chest. **Not** a direct substitute
+  for a flat bench — different stimulus. Use as a swap within an upper-push
+  day, not as a like-for-like replacement.
+- **Weighted Push-Up** — bodyweight substitute. Add a plate on the back or
+  use bands. ROM is limited by hand position; full-depth push-ups train more
+  chest than half-depth.
+
+## Row Pattern (horizontal pull, back-dominant)
+
+| Primary            | Movement     | Primary muscles     | Substitutes                                                  | When to substitute                                  |
+|--------------------|--------------|---------------------|--------------------------------------------------------------|-----------------------------------------------------|
+| Barbell Row        | Horizontal pull | Lats, mid-back, biceps | Pendlay Row · Cable Row · Chest-Supported Row · Machine Row · T-Bar Row · Dumbbell Row | Lower-back fatigue; user cannot maintain a hinged position |
+
+- **Pendlay Row** — strict form version of the barbell row; bar returns to
+  the floor each rep. Easier on the lower back, harder on the lats.
+- **Cable Row** — constant tension, easy on the lower back. Close grip =
+  more lats, wide grip = more mid-back. Best general substitute.
+- **Chest-Supported Row** — pad takes bodyweight off the lower back. Best
+  for users with back issues or who fatigue the erectors too quickly.
+- **Machine Row** — plate-loaded or selectorized. Plate-loaded allows heavy
+  loading; selectorized caps at the stack.
+- **Dumbbell Row** — unilateral, allows a fuller stretch. Each side works
+  independently — useful for fixing left/right imbalance.
+
+## Hinge Pattern (hip-dominant, posterior chain)
+
+| Primary          | Movement     | Primary muscles     | Substitutes                                                  | When to substitute                                  |
+|------------------|--------------|---------------------|--------------------------------------------------------------|-----------------------------------------------------|
+| Conventional Deadlift | Hip hinge | Glutes, hamstrings, erectors, lats, traps | Romanian Deadlift · Sumo Deadlift · Trap-Bar Deadlift · Rack Pull · Back Extension · Glute-Ham Raise · Cable Pull-Through | Lower-back fatigue; user lacks mobility for the conventional setup; grip limit |
+
+- **Romanian Deadlift** — reduced knee bend, more hamstring stretch. Easier
+  to learn and lower-back-friendly. Use 70–80% of conventional load.
+- **Sumo Deadlift** — wider stance, more quad involvement, different
+  motor pattern. Substitute only if the user is set up for sumo stance.
+- **Trap-Bar Deadlift** — neutral grip, hands by the sides. Less shear on
+  the lower back. Often the *easiest* deadlift to learn.
+- **Rack Pull** — partial-range deadlift from above the knee. Useful when
+  the lockout is the sticking point. **Not** a beginner substitute — the
+  range of motion is short and the load is high.
+- **Glute-Ham Raise** — bodyweight or loaded; trains hamstrings and glutes
+  with no spinal load. Excellent accessory and substitute.
+- **Cable Pull-Through** — light load, high-rep accessory. Good warm-up
+  movement, poor primary substitute for heavy deadlift work.
+
+## Vertical Push (shoulder-dominant, overhead)
+
+| Primary            | Movement     | Primary muscles     | Substitutes                                                  | When to substitute                                  |
+|--------------------|--------------|---------------------|--------------------------------------------------------------|-----------------------------------------------------|
+| Overhead Press (BB)| Vertical push | Front/side delts, triceps, upper chest | Machine Shoulder Press · Dumbbell Shoulder Press · Landmine Press · Seated DB Press | Shoulder impingement; barbell OHP is too unstable for the user; rack unavailable |
+
+- **Machine Shoulder Press** — fixed path, safe, easy to load. Best
+  beginner substitute. Plate-loaded allows heavy loading; selectorized
+  caps at the stack.
+- **Dumbbell Shoulder Press** — natural arc, deeper ROM, less load ceiling
+  than barbell. Use 50–60% of barbell load per dumbbell.
+- **Landmine Press** — angled press, shoulder-friendly for users with
+  impingement. Lower load ceiling.
+
+## Vertical Pull (back, lat-dominant)
+
+| Primary            | Movement     | Primary muscles     | Substitutes                                                  | When to substitute                                  |
+|--------------------|--------------|---------------------|--------------------------------------------------------------|-----------------------------------------------------|
+| Pull-Up            | Vertical pull | Lats, biceps, mid-back | Chin-Up · Lat Pulldown · Assisted Pull-Up · Machine Pull-Up · Single-Arm Cable Pulldown | User cannot do 5 strict reps; pull-up bar busy |
+
+- **Lat Pulldown** — easiest substitute. Close-grip = more lats,
+  wide-grip = more upper-back. Pin the load to a manageable weight.
+- **Assisted Pull-Up Machine** — kneeled or weighted; perfect for users
+  building toward their first bodyweight pull-up. Reduce assistance
+  progressively.
+- **Single-Arm Cable Pulldown** — unilateral version; useful for fixing
+  left/right imbalance and for users with shoulder issues that make a
+  bilateral pull painful.
+
+## Curl Pattern (bicep isolation)
+
+| Primary            | Movement     | Primary muscles     | Substitutes                                                  | When to substitute                                  |
+|--------------------|--------------|---------------------|--------------------------------------------------------------|-----------------------------------------------------|
+| Barbell Curl       | Elbow flexion | Biceps, brachialis  | Dumbbell Curl · Cable Curl · Machine Curl · Preacher Curl · Hammer Curl · Incline Curl | Barbell EZ-curl bar unavailable; user wants more stretch |
+
+- **Dumbbell Curl** — supinated or neutral grip. Supinated = more biceps,
+  neutral (hammer) = more brachialis and forearms.
+- **Cable Curl** — constant tension throughout the ROM. Excellent
+  substitute; allows a strong contracted position.
+- **Preacher Curl** — fixed arm path, isolates the biceps, removes cheat
+  momentum. Easy on the elbow at lighter loads, hard on it at heavy loads.
+- **Hammer Curl** — neutral grip, emphasises brachialis and forearms.
+  Different stimulus — use as accessory, not as a like-for-like substitute.
+- **Incline Curl** — long-head bias due to shoulder extension. Excellent
+  stretch variation.
+
+## Tricep Isolation
+
+| Primary            | Movement     | Primary muscles     | Substitutes                                                  | When to substitute                                  |
+|--------------------|--------------|---------------------|--------------------------------------------------------------|-----------------------------------------------------|
+| Tricep Pushdown    | Elbow extension | Triceps (lateral head) | Overhead Tricep Extension · Close-Grip Bench · Skull Crusher · Rope Pushdown · Machine Dip | Cable station busy; user wants a different angle |
+
+- **Overhead Tricep Extension** — long-head bias, different stimulus. Use
+  as a complement, not a like-for-like replacement for pushdowns.
+- **Close-Grip Bench** — compound tricep work. Heavier loading possible.
+  Not a strict isolation substitute.
+
+## Leg Curl (hamstring isolation)
+
+| Primary            | Movement     | Primary muscles     | Substitutes                                                  | When to substitute                                  |
+|--------------------|--------------|---------------------|--------------------------------------------------------------|-----------------------------------------------------|
+| Lying Leg Curl     | Knee flexion | Hamstrings          | Seated Leg Curl · Standing Leg Curl · Nordic Curl · Sliding Leg Curl | Lying curl machine busy; user wants a different angle |
+
+- **Seated Leg Curl** — short head bias, easier on the lower back.
+- **Standing Leg Curl** — single-leg, allows focused work on each side.
+- **Nordic Curl** — bodyweight, very high hamstring demand. Excellent
+  eccentric builder. Use a partner or anchored pad.
+
+## Calf Raise
+
+| Primary               | Movement     | Primary muscles | Substitutes                                                  | When to substitute                                  |
+|-----------------------|--------------|-----------------|--------------------------------------------------------------|-----------------------------------------------------|
+| Standing Calf Raise   | Plantar flexion | Gastrocnemius | Leg Press Calf Raise · Smith Machine Calf Raise · Donkey Calf Raise · Seated Calf Raise | Free-weight standing calf too unstable; user wants to bias soleus |
+
+- **Seated Calf Raise** — soleus bias. Different stimulus, not a like-for-
+  like substitute. Use as an accessory, not a replacement.
+- **Leg Press Calf Raise** — bodyweight load + plate. Easy to load, low
+  balance demand.
+
+---
+
+## Notes on Load Conversion
+
+When substituting across categories (e.g. barbell back squat → leg press),
+expect to handle 1.5–2× the absolute load on the machine because the machine
+takes balance out of the equation. Start at 60–70% of the machine's perceived
+maximum and ramp up.
+
+When substituting **within** a category (e.g. barbell bench → dumbbell
+bench), start at 60–70% of the barbell load per dumbbell (because each side
+is independent) and adjust by feel.
+
+When in doubt, ask the user to find a weight that puts them at 2 RIR at the
+top of the rep range on the first session with the new exercise.


### PR DESCRIPTION
## What

Adds a new `gym-workout-programmer` skill to `optional-skills/health/`. The
skill generates structured gym workout programs tailored to a user's training
age, days per week, equipment, goals, and injuries. It carries the
programming rules — split selection, rep ranges, progression method, and
substitution logic — so the agent does not have to reinvent them every time
the user asks for a plan.

## Why

A gap analysis of existing public skills for the same use case (OneWave-AI
catalog, openclaw/skills, mcpmarket, mattpocock/skills, ANPC86/claude-smart-gym-coach)
found:

- **Generic templates** (OneWave's `workout-program-designer`,
  OneWave's `training-log-analyzer`, mcpmarket's Workout Explainer / Workout
  Domain Logic) are short single-prompt scaffolds with no real progression
  logic, no substitution matrix, and no output format guidance.
- **Notion-locked single-purpose** (ANPC86's `smart-gym-workout-design-SKILL`
  + `smart-gym-session-review-SKILL`) is deep on intake and review, but tied
  to a specific smart cable gym + Notion data source. Not portable.
- **No skill** in the public catalogs covers the full programming + coaching
  loop: split templates, rep ranges, progression methods, substitution
  matrix, output format, pitfalls, deload. The closest generic skill is
  ~50 lines.

This skill fills that gap. It is generic — no per-user data, no specific
gym equipment, no external dependencies — and pairs with the existing
`fitness-nutrition` skill (which provides exercise search and macro
tracking) by adding the **programming and coaching layer** on top.

## What's in the skill

- **Three program templates**: full-body (beginner, 2–3d), upper/lower
  (intermediate, 4d), push/pull/legs (5–6d), each with example days.
- **Free-weight to machine exercise substitution matrix** (extended in
  `references/substitution-matrix.md`) covering squat, bench, row, hinge,
  overhead, pull, curl, tricep, leg curl, and calf patterns.
- **Three progression methods** (rep range, double, weekly/linear) with
  explicit deload triggers at week 6–8.
- **Equipment-aware weight prescription**: pin numbers for selectorized
  machines, kg for free weights, bodyweight progressions, plus a travel
  adaptation (`references/equipment-aware-scaling.md`).
- **Worked example programs** (`references/output-format-examples.md`) for
  all three splits at beginner and intermediate levels.
- **Pitfalls section** covering 1RM testing, smith-machine squats, muscle
  confusion, per-arm vs total weight confusion, mid-session equipment
  conflicts, and the "always confirm before prescribing" trap.

## Testing

To exercise the skill locally after merge:

1. `hermes skills install official/health/gym-workout-programmer`
2. Trigger phrases that should activate it: "give me a workout plan",
   "what should I do at the gym today", "the squat rack is taken, what
   else can I do", "when do I add weight on bench", "make me an upper-body
   day".
3. Verify the output includes: a warm-up, exercises with sets × reps and
   working weight, a progression rule, and the most likely equipment
   conflict + substitute.
4. Verify the skill does **not** trigger on: "how many calories in a
   banana" (fitness-nutrition), "is this a chest press machine" (vision),
   "I have a shoulder injury" (refer to professional, do not program).

## Checklist

- [x] `SKILL.md` has valid YAML frontmatter (`name`, `description`,
  `version`, `authors`, `license`, `metadata.hermes.tags/category/related_skills`).
- [x] `description` is 657 chars (well under the progressive-disclosure
  1024 char limit).
- [x] No per-user data (Obsidian paths, trainer personas, specific gym
  equipment lists, user-specific pin numbers).
- [x] No external dependencies (pure markdown, no Python, no API keys).
- [x] `related_skills` references the existing `fitness-nutrition`.
- [x] Generic enough to be useful in any commercial gym, home gym, or
  bodyweight-only context.
- [x] Generic pitfalls written to apply to any user, not derived from
  specific incidents.
