### PR TITLE
fix(cron): preserve local scheduling compatibility

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -412,7 +412,11 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         base_time = now
         if last_run_at:
             base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
-        cron = croniter(schedule["expr"], base_time)
+        # Accept "expr" (canonical) or legacy "cron" key (migration alias).
+        cron_expr = schedule.get("expr") or schedule.get("cron")
+        if not cron_expr:
+            return None
+        cron = croniter(cron_expr, base_time)
         next_run = cron.get_next(datetime)
         return next_run.isoformat()
 
@@ -1081,8 +1085,14 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             # For recurring jobs, check if the scheduled time is stale
             # (gateway was down and missed the window). Fast-forward to
             # the next future occurrence instead of firing a stale run.
+            # Never-fired jobs must still run on first pickup even when their
+            # next_run_at is older than the grace window.
             grace = _compute_grace_seconds(schedule)
-            if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
+            if (
+                kind in {"cron", "interval"}
+                and job.get("last_run_at") is not None
+                and (now - next_run_dt).total_seconds() > grace
+            ):
                 # Job is past its catch-up grace window — this is a stale missed run.
                 # Grace scales with schedule period: daily=2h, hourly=30m, 10min=5m.
                 new_next = compute_next_run(schedule, now.isoformat())

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -745,13 +745,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     # Optionally wrap the content with a header/footer so the user knows this
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
+    # in config.yaml for clean output, or set wrap_response: false on a job.
     wrap_response = True
     try:
         user_cfg = load_config()
         wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
     except Exception:
         pass
+    if "wrap_response" in job:
+        wrap_response = bool(job["wrap_response"])
 
     if wrap_response:
         task_name = job.get("name", job["id"])

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -169,6 +169,14 @@ class TestComputeNextRun:
         assert isinstance(next_dt, datetime)
         assert next_dt > datetime.now().astimezone()
 
+    def test_legacy_cron_key_returns_future(self):
+        pytest.importorskip("croniter")
+        schedule = {"kind": "cron", "cron": "* * * * *"}
+        result = compute_next_run(schedule)
+        assert isinstance(result, str)
+        next_dt = datetime.fromisoformat(result)
+        assert next_dt > datetime.now().astimezone()
+
     def test_unknown_kind_returns_none(self):
         assert compute_next_run({"kind": "unknown"}) is None
 
@@ -694,6 +702,7 @@ class TestGetDueJobs:
         # Force next_run_at to 35 minutes ago (beyond the 30-min grace for hourly)
         jobs = load_jobs()
         jobs[0]["next_run_at"] = (datetime.now() - timedelta(minutes=35)).isoformat()
+        jobs[0]["last_run_at"] = (datetime.now() - timedelta(hours=2)).isoformat()
         save_jobs(jobs)
 
         due = get_due_jobs()
@@ -703,6 +712,18 @@ class TestGetDueJobs:
         from cron.jobs import _ensure_aware, _hermes_now
         next_dt = _ensure_aware(datetime.fromisoformat(updated["next_run_at"]))
         assert next_dt > _hermes_now()
+
+    def test_never_run_stale_recurring_job_runs_once(self, tmp_cron_dir):
+        """Never-fired recurring jobs should run on first pickup even when stale."""
+        job = create_job(prompt="First pickup", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (datetime.now() - timedelta(hours=3)).isoformat()
+        jobs[0]["last_run_at"] = None
+        save_jobs(jobs)
+
+        due = get_due_jobs()
+
+        assert [item["id"] for item in due] == [job["id"]]
 
     def test_future_not_returned(self, tmp_cron_dir):
         create_job(prompt="Not yet", schedule="every 1h")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -575,6 +575,32 @@ class TestDeliverResultWrapping:
         assert "Cronjob Response" not in sent_content
         assert "The agent cannot see" not in sent_content
 
+    def test_delivery_skips_wrapping_when_job_disabled(self):
+        """A single job can opt out of the global cron response wrapper."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}):
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "wrap_response": False,
+            }
+            _deliver_result(job, "Clean output only.")
+
+        send_mock.assert_called_once()
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content == "Clean output only."
+        assert "Cronjob Response" not in sent_content
+
     def test_delivery_extracts_media_tags_before_send(self, tmp_path, monkeypatch):
         """Cron delivery should pass MEDIA attachments separately to the send helper."""
         from gateway.config import Platform


### PR DESCRIPTION
## Summary\n- accept legacy cron schedule payloads that use `schedule.cron` when `schedule.expr` is absent\n- let never-run recurring jobs fire once on first pickup even if their stored next_run_at is stale\n- allow individual cron jobs to disable response wrapping with `wrap_response: false`\n\n## Validation\n- `venv/bin/python -m pytest tests/cron/test_jobs.py::TestComputeNextRun tests/cron/test_jobs.py::TestGetDueJobs::test_never_run_stale_recurring_job_runs_once tests/cron/test_scheduler.py::TestDeliverResultWrapping::test_delivery_skips_wrapping_when_job_disabled -q` -> 11 passed\n- `venv/bin/python -m pytest tests/cron -q` -> 413 passed, 1 warning\n\nPorted selectively from local backup after upstream reset; intentionally excludes unrelated Telegram/local fitness callbacks and generated egg-info files.