### PR TITLE
fix(desktop): handle send-type command.dispatch response with notice

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -962,6 +962,30 @@ export function usePromptActions({
             return
           }
 
+          if (dispatch.type === 'send') {
+            if (dispatch.notice?.trim()) {
+              renderSlashOutput(dispatch.notice)
+            }
+
+            const sendMsg = dispatch.message?.trim()
+
+            if (!sendMsg) {
+              renderSlashOutput(`/${name}: empty message`)
+
+              return
+            }
+
+            if (busyRef.current) {
+              renderSlashOutput('session busy — /interrupt the current turn before sending this command')
+
+              return
+            }
+
+            await submitPromptText(sendMsg)
+
+            return
+          }
+
           if (dispatch.type === 'alias') {
             await runSlash(`/${dispatch.target}${arg ? ` ${arg}` : ''}`, sessionId, false)
 

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -80,6 +80,7 @@ export interface SkillCommandDispatchResponse {
 export interface SendCommandDispatchResponse {
   type: 'send'
   message: string
+  notice?: string
 }
 
 export type CommandDispatchResponse =

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
 
-import { coerceThinkingText, optimisticAttachmentRef } from './chat-runtime'
+import { coerceThinkingText, optimisticAttachmentRef, parseCommandDispatch } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
 
@@ -50,5 +50,54 @@ describe('coerceThinkingText', () => {
         "◉_◉ processing... I don't see any current rewritten thinking or next thinking to process. Could you provide the thinking content you'd like me to rewrite?"
       )
     ).toBe('')
+  })
+})
+
+describe('parseCommandDispatch', () => {
+  it('returns null for non-object input', () => {
+    expect(parseCommandDispatch(null)).toBeNull()
+    expect(parseCommandDispatch(undefined)).toBeNull()
+    expect(parseCommandDispatch('string')).toBeNull()
+  })
+
+  it('parses exec type with output', () => {
+    expect(parseCommandDispatch({ type: 'exec', output: 'result' })).toEqual({ type: 'exec', output: 'result' })
+  })
+
+  it('parses alias type with target', () => {
+    expect(parseCommandDispatch({ type: 'alias', target: 'other' })).toEqual({ type: 'alias', target: 'other' })
+  })
+
+  it('parses skill type with name and message', () => {
+    expect(parseCommandDispatch({ type: 'skill', name: 'foo', message: 'bar' })).toEqual({
+      type: 'skill',
+      name: 'foo',
+      message: 'bar'
+    })
+  })
+
+  it('parses send type with message only', () => {
+    expect(parseCommandDispatch({ type: 'send', message: 'hello' })).toEqual({ type: 'send', message: 'hello' })
+  })
+
+  it('parses send type with message and notice', () => {
+    const result = parseCommandDispatch({
+      type: 'send',
+      message: 'fix the login bug',
+      notice: '⊙ Goal set (20-turn budget): fix the login bug'
+    })
+    expect(result).toEqual({
+      type: 'send',
+      message: 'fix the login bug',
+      notice: '⊙ Goal set (20-turn budget): fix the login bug'
+    })
+  })
+
+  it('returns null for send type without message', () => {
+    expect(parseCommandDispatch({ type: 'send', notice: 'hi' })).toBeNull()
+  })
+
+  it('returns null for unknown type', () => {
+    expect(parseCommandDispatch({ type: 'unknown' })).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -230,8 +230,15 @@ export function parseCommandDispatch(raw: unknown): CommandDispatchResponse | nu
     case 'skill':
       return typeof row.name === 'string' ? { type: 'skill', name: row.name, message: str(row.message) } : null
 
-    case 'send':
-      return typeof row.message === 'string' ? { type: 'send', message: row.message } : null
+    case 'send': {
+      if (typeof row.message !== 'string') return null
+      const sendResult: { type: 'send'; message: string; notice?: string } = {
+        type: 'send',
+        message: row.message
+      }
+      if (typeof row.notice === 'string') sendResult.notice = row.notice
+      return sendResult
+    }
 
     default:
       return null


### PR DESCRIPTION
## Problem

The `command.dispatch` response for `/goal` returns `{type: "send", notice, message}`. Desktop's slash handler had no explicit branch for `send` type — it fell through to the generic message path, which submitted the goal text but **never displayed the notice** (`⊙ Goal set...`).

CLI and TUI both render the notice before submitting the message. Desktop was the only surface that swallowed it.

## Root Cause

In `use-prompt-actions.ts`, the `command.dispatch` handler has explicit branches for `exec`, `plugin`, `alias`, and `skill` types. The `send` type fell through to a generic path that:
1. Extracted `message` from the dispatch
2. Checked `busyRef`
3. Called `submitPromptText(message)`

The `notice` field was never read or rendered.

Additionally, `SendCommandDispatchResponse` in `types.ts` didn't include `notice`, and `parseCommandDispatch` in `chat-runtime.ts` dropped it during parsing.

## Fix

1. **`types.ts`** — Add `notice?: string` to `SendCommandDispatchResponse`
2. **`chat-runtime.ts`** — Parse `notice` in the `send` case of `parseCommandDispatch`
3. **`use-prompt-actions.ts`** — Add explicit `send` type handler that renders the notice via `renderSlashOutput` before calling `submitPromptText`, matching the TUI's behavior in `createSlashHandler.ts`

## Testing

- Added 7 unit tests for `parseCommandDispatch` covering all dispatch types including `send` with/without `notice`
- All 14 tests in `chat-runtime.test.ts` pass
- No new lint errors introduced

Fixes #43476
