### PR TITLE
fix(webhook): support Fireflies V2 signature header and event field

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -442,6 +442,7 @@ class WebhookAdapter(BasePlatformAdapter):
             request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
             or payload.get("event_type", "")
+            or payload.get("event", "")
             or payload.get("type", "")
             or "unknown"
         )
@@ -670,7 +671,8 @@ class WebhookAdapter(BasePlatformAdapter):
             )
 
         # GitHub: X-Hub-Signature-256 = sha256=<hex>
-        gh_sig = request.headers.get("X-Hub-Signature-256", "")
+        # Also check X-Hub-Signature (Fireflies V2 uses this header)
+        gh_sig = request.headers.get("X-Hub-Signature-256", "") or request.headers.get("X-Hub-Signature", "")
         if gh_sig:
             expected = "sha256=" + hmac.new(
                 secret.encode(), body, hashlib.sha256

--- a/tests/gateway/test_webhook_fireflies_v2.py
+++ b/tests/gateway/test_webhook_fireflies_v2.py
@@ -1,0 +1,120 @@
+"""Tests for webhook signature validation and event type extraction.
+
+Covers:
+- X-Hub-Signature (Fireflies V2) support alongside X-Hub-Signature-256
+- ``event`` field in payload for event type extraction (Fireflies V2 payloads)
+"""
+
+import hashlib
+import hmac
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class _FakeRequest:
+    """Minimal aiohttp-like request stub for _validate_signature."""
+
+    def __init__(self, headers: dict | None = None):
+        self.headers = headers or {}
+
+
+class TestWebhookSignatureFirefliesV2(unittest.TestCase):
+    """X-Hub-Signature (without -256 suffix) must be accepted."""
+
+    def _make_adapter(self):
+        """Create a minimal WebhookAdapter with _validate_signature accessible."""
+        from gateway.platforms.webhook import WebhookAdapter
+
+        adapter = object.__new__(WebhookAdapter)
+        return adapter
+
+    def test_x_hub_signature_without_256_suffix_accepted(self):
+        """Fireflies V2 sends sha256=<hex> in X-Hub-Signature (no -256)."""
+        adapter = self._make_adapter()
+        secret = "test-secret-123"
+        body = b'{"event": "meeting.completed"}'
+        expected_sig = "sha256=" + hmac.new(
+            secret.encode(), body, hashlib.sha256
+        ).hexdigest()
+
+        request = _FakeRequest(headers={"X-Hub-Signature": expected_sig})
+        result = adapter._validate_signature(request, body, secret)
+        assert result is True
+
+    def test_x_hub_signature_256_still_works(self):
+        """GitHub-style X-Hub-Signature-256 must continue to work."""
+        adapter = self._make_adapter()
+        secret = "test-secret-123"
+        body = b'{"action": "push"}'
+        expected_sig = "sha256=" + hmac.new(
+            secret.encode(), body, hashlib.sha256
+        ).hexdigest()
+
+        request = _FakeRequest(headers={"X-Hub-Signature-256": expected_sig})
+        result = adapter._validate_signature(request, body, secret)
+        assert result is True
+
+    def test_x_hub_signature_256_takes_precedence(self):
+        """When both headers are present, X-Hub-Signature-256 wins."""
+        adapter = self._make_adapter()
+        secret = "test-secret-123"
+        body = b'{"event": "test"}'
+        correct_sig = "sha256=" + hmac.new(
+            secret.encode(), body, hashlib.sha256
+        ).hexdigest()
+        wrong_sig = "sha256=deadbeef"
+
+        # X-Hub-Signature-256 is correct, X-Hub-Signature is wrong
+        request = _FakeRequest(headers={
+            "X-Hub-Signature-256": correct_sig,
+            "X-Hub-Signature": wrong_sig,
+        })
+        result = adapter._validate_signature(request, body, secret)
+        assert result is True
+
+    def test_x_hub_signature_wrong_value_rejected(self):
+        """Wrong X-Hub-Signature value must be rejected."""
+        adapter = self._make_adapter()
+        secret = "test-secret-123"
+        body = b'{"event": "test"}'
+
+        request = _FakeRequest(headers={"X-Hub-Signature": "sha256=wrong"})
+        result = adapter._validate_signature(request, body, secret)
+        assert result is False
+
+
+class TestWebhookEventTypeExtraction(unittest.TestCase):
+    """Event type extraction must include ``event`` field (Fireflies V2)."""
+
+    def test_event_field_from_payload(self):
+        """Fireflies V2 uses 'event' as the field name."""
+        # We test the extraction logic directly by checking the code path
+        # The extraction is inline in _handle_webhook_request, so we verify
+        # the code includes the right fallback chain
+        import inspect
+        from gateway.platforms.webhook import WebhookAdapter
+
+        source = inspect.getsource(WebhookAdapter._handle_webhook)
+        assert 'payload.get("event"' in source, (
+            "Event type extraction must include payload.get('event') "
+            "for Fireflies V2 compatibility"
+        )
+
+    def test_event_field_order_in_fallback_chain(self):
+        """'event' must come after 'event_type' but before 'type'."""
+        import inspect
+        from gateway.platforms.webhook import WebhookAdapter
+
+        source = inspect.getsource(WebhookAdapter._handle_webhook)
+        # Find the event type extraction block
+        idx_event_type = source.index('payload.get("event_type"')
+        idx_event = source.index('payload.get("event"')
+        idx_type = source.index('payload.get("type"')
+
+        assert idx_event_type < idx_event < idx_type, (
+            "Fallback order must be: event_type → event → type"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds support for Fireflies V2 webhook signature validation and event type extraction. Fireflies V2 sends its HMAC-SHA256 signature in `X-Hub-Signature` (without the `-256` suffix) and uses `"event"` as the payload field name for event type, both of which were previously unsupported.

## Related Issue

Fixes #43575

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/webhook.py`: Fall back to `X-Hub-Signature` header when `X-Hub-Signature-256` is absent; add `"event"` to the event type extraction fallback chain between `"event_type"` and `"type"`
- `tests/gateway/test_webhook_fireflies_v2.py`: 6 tests covering signature validation (X-Hub-Signature accepted, X-Hub-Signature-256 backward compat, precedence, wrong value rejected) and event type extraction (field presence, fallback order)

## How to Test

1. Run `pytest tests/gateway/test_webhook_fireflies_v2.py -v` — all 6 tests should pass
2. Verify existing webhook tests still pass: `pytest tests/gateway/ -v -k webhook`
3. Manual test: configure a webhook route with a secret, send a request with `X-Hub-Signature: sha256=<valid-hmac>` and `{"event": "meeting.completed"}` payload — should be accepted (202)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `gateway/platforms/webhook.py` `_validate_signature` (line 644) and `_handle_webhook` (line 354)
- Blast radius: LOW — changes are additive fallbacks, no existing behavior altered
- Related patterns: existing Svix/GitHub/GitLab signature validation chain (lines 655-693)
