### PR TITLE
fix(gateway): exit non-zero on macOS launchd restart path (#43475)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5951,7 +5951,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # systemd units use Restart=always, so a planned restart should
                 # exit cleanly and still be relaunched.  Using TEMPFAIL here
                 # makes systemd treat the operator-requested restart as a
-                # failure and can trip stepped restart backoff.  launchd's
+                # failure and can trip stepped restartbackoff.  launchd's
                 # KeepAlive.SuccessfulExit=false needs a non-zero exit to
                 # relaunch, so keep the old code on macOS.
                 self._exit_code = (
@@ -5959,6 +5959,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if sys.platform == "darwin" or not os.environ.get("INVOCATION_ID")
                     else 0
                 )
+                self._exit_reason = self._exit_reason or "Gateway restart requested"
+            elif self._restart_requested and sys.platform == "darwin":
+                # launchd uses KeepAlive.SuccessfulExit=false — a clean exit
+                # (code 0) is treated as success and launchd will NOT relaunch
+                # the process.  Force a non-zero exit so launchd revives us.
+                # This covers the detached-restart path used by `/restart` on
+                # macOS (via_service=False).  See #43475.
+                self._exit_code = GATEWAY_SERVICE_RESTART_EXIT_CODE
                 self._exit_reason = self._exit_reason or "Gateway restart requested"
 
             self._draining = False


### PR DESCRIPTION
Fixes #43475. On macOS, /restart used the detached path (via_service=False) which skipped setting the exit code. launchd's KeepAlive.SuccessfulExit=false requires a non-zero exit to relaunch the process. Added an elif branch to set exit code 75 on macOS when via_service is False.