### PR TITLE
refactor(gateway): remove dead Slack approval allowlist code (#36848)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3474,18 +3474,6 @@ class SlackAdapter(BasePlatformAdapter):
             )
             return
 
-        # Authorization — reuse the exec-approval allowlist.
-        allowed_csv = ""  # Interactive auth already ran above.
-        if allowed_csv:
-            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-            if "*" not in allowed_ids and user_id not in allowed_ids:
-                logger.warning(
-                    "[Slack] Unauthorized slash-confirm click by %s (%s) — ignoring",
-                    user_name,
-                    user_id,
-                )
-                return
-
         # Parse session_key|confirm_id back out
         if "|" not in value:
             logger.warning("[Slack] Malformed slash-confirm value: %s", value)
@@ -3592,20 +3580,6 @@ class SlackAdapter(BasePlatformAdapter):
                 user_name, user_id,
             )
             return
-
-        # Only authorized users may click approval buttons.  Button clicks
-        # bypass the normal message auth flow in gateway/run.py, so we must
-        # check here as well.
-        allowed_csv = ""  # Interactive auth already ran above.
-        if allowed_csv:
-            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-            if "*" not in allowed_ids and user_id not in allowed_ids:
-                logger.warning(
-                    "[Slack] Unauthorized approval click by %s (%s) — ignoring",
-                    user_name,
-                    user_id,
-                )
-                return
 
         # Map action_id to approval choice
         choice_map = {

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -305,6 +305,23 @@ class TestSlackInteractiveAuth:
         assert runner.seen_sources[0].chat_id == "C1"
         assert runner.seen_sources[0].chat_type == "group"
 
+    def test_approval_denied_when_no_allowlist_env_set(self, monkeypatch):
+        """Regression test: interactive auth must fail closed when no allowlist env vars are set."""
+        adapter = _make_adapter()
+        # Clear all relevant env vars to test fail-closed default
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        # Without any env vars and no runner auth, should return False
+        result = adapter._is_interactive_user_authorized(
+            "U_ANY_USER",
+            channel_id="C1",
+            user_name="someone",
+        )
+        assert result is False
+
 
 class TestSlackSlashConfirmAction:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The Slack Block-Kit approval handler (`_handle_approval_action`) and the slash-confirm handler (`_handle_slash_confirm_action`) each contain a dead authorization block left behind after a refactor introduced the unified `_is_interactive_user_authorized()` helper. The dead code sets `allowed_csv = ""` and then gates on `if allowed_csv:`, which never executes. This misleads security reviewers into thinking the approval path fails open when `SLACK_ALLOWED_USERS` is unset, when in reality `_is_interactive_user_authorized` already fails closed by default.

This PR removes both dead blocks and adds a regression test confirming the fail-closed default: when no allowlist env vars are set, approval button clicks are rejected.

## Changes

- `gateway/platforms/slack.py`: remove dead `allowed_csv = ""` / `if allowed_csv:` block from `_handle_approval_action` (-14 lines)
- `gateway/platforms/slack.py`: remove identical dead block from `_handle_slash_confirm_action` (-12 lines)
- `tests/gateway/test_slack_approval_buttons.py`: add `test_approval_denied_when_no_allowlist_env_set` verifying the fail-closed default (+17 lines)

## Validation

| Scenario | Before | After |
|---|---|---|
| SLACK_ALLOWED_USERS unset, GATEWAY_ALLOWED_USERS unset | Rejected by `_is_interactive_user_authorized` (dead code misleads) | Rejected by `_is_interactive_user_authorized` (dead code removed) |
| SLACK_ALLOWED_USERS set to valid ID | Authorized (unchanged) | Authorized (unchanged) |
| GATEWAY_ALLOW_ALL_USERS=true | Authorized (unchanged) | Authorized (unchanged) |

## Test plan

- `pytest tests/gateway/test_slack_approval_buttons.py -v` — 27 passed including new fail-closed regression

## Upstream

Closes #36848.
Reported by @dhyabi2.
