### PR TITLE
fix(skills): ignore reference docs during view lookup

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1287,3 +1287,35 @@ class TestSkillViewCollisionDetection:
         result = json.loads(raw)
         assert result["success"] is True
         assert "LOCAL BODY" in result["content"]
+
+    def test_reference_subdoc_does_not_collide_with_skill(self, tmp_path):
+        """A flat <name>.md inside another skill's references/ (or
+        templates/) folder is a sub-document, not a standalone skill, and
+        must not collide with a real same-named skill. Regression for the
+        autonomous-pipeline / figma / notion collisions seen live, where a
+        knowledge-base skill shipped references/<skill-name>.md docs."""
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+
+        # The real, standalone skill.
+        _make_skill(
+            local_dir, "pipeline", category="devops", body="REAL PIPELINE"
+        )
+
+        # A different skill that ships a references/pipeline.md sub-doc.
+        host = _make_skill(
+            local_dir, "audit", category="ops", body="AUDIT SKILL"
+        )
+        refs = host / "references"
+        refs.mkdir()
+        (refs / "pipeline.md").write_text("# just a reference note\n")
+
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("pipeline")
+
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert "REAL PIPELINE" in result["content"]

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1049,9 +1049,21 @@ def skill_view(
                     _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
+            # Skip files nested inside another skill's folder (any ancestor
+            # dir below search_dir that has its own SKILL.md) -- those are
+            # reference/template sub-documents, not standalone skills, and
+            # must not collide with a real same-named skill.
             for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md":
-                    _record(None, found_md)
+                if found_md.name == "SKILL.md":
+                    continue
+                rel_parents = found_md.relative_to(search_dir).parents
+                if any(
+                    (search_dir / a / "SKILL.md").exists()
+                    for a in rel_parents
+                    if str(a) != "."
+                ):
+                    continue
+                _record(None, found_md)
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]


### PR DESCRIPTION
## Summary\n- skip flat <name>.md files nested under another skill directory when resolving skill_view candidates\n- prevents references/ or templates/ sub-docs from colliding with real standalone skills\n- adds regression coverage for a references/pipeline.md sub-document next to a real pipeline skill\n\n## Validation\n- `venv/bin/python -m pytest tests/tools/test_skills_tool.py -q` -> 88 passed\n\nPorted selectively from local backup after upstream reset; intentionally excludes unrelated Telegram/local fitness callbacks, CLI supplement command wiring, and generated egg-info files.