### PR TITLE
docs: clarify Baoyu image generation workflow

### DIFF
--- a/optional-skills/creative/baoyu-article-illustrator/SKILL.md
+++ b/optional-skills/creative/baoyu-article-illustrator/SKILL.md
@@ -86,7 +86,7 @@ If the user asks for a different layout (e.g., images alongside the article, or 
 - [ ] Step 3: Confirm settings (clarify tool, one question at a time)
 - [ ] Step 4: Generate outline
 - [ ] Step 5: Generate prompts
-- [ ] Step 6: Generate images (image_generate)
+- [ ] Step 6: Generate images (raster backend, default `image_generate`)
 - [ ] Step 7: Finalize
 ```
 
@@ -157,14 +157,18 @@ For each illustration:
 
 ### Step 6: Generate Images
 
-For each prompt file:
+Use a real raster image-generation backend with the saved prompt files. Default to Hermes `image_generate`; if the current request explicitly selects another available raster backend, use that backend instead. Do not substitute code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text), and do not repair generated text by painting over the bitmap. If labels need to be exact, reduce the visible label set, revise the prompt, and regenerate.
+
+For the default `image_generate` path, for each prompt file:
 
 1. Call `image_generate(prompt=..., aspect_ratio=...)`. `image_generate` returns a JSON result containing an image URL; it does NOT write to disk and does NOT accept an output path.
 2. Map the prompt's `ASPECT` to `image_generate`'s enum: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`. Custom ratios → nearest named aspect.
 3. Download the returned URL to `{output-dir}/NN-{type}-{slug}.png` via `terminal` (e.g. `curl -sSL -o "{output-dir}/NN-{type}-{slug}.png" "{url}"`).
 4. On generation failure, auto-retry once.
 
-Note: the underlying image-generation backend is user-configured (default: FAL FLUX 2 Klein 9B) and is NOT agent-selectable via `image_generate`. Do not write model names into prompts expecting them to route.
+For an explicitly selected alternate raster backend, follow that backend's invocation and output contract, but still save and verify the final raster image files in the output directory.
+
+Note: the underlying `image_generate` backend is user-configured and is NOT agent-selectable by prompt text. Do not write model names into prompts expecting them to route.
 
 ### Step 7: Finalize
 
@@ -204,4 +208,5 @@ Images: X/N generated
 4. **Prompt files are mandatory** — no image generation without a saved prompt file. The file is what lets you regenerate or switch backends later.
 5. **`image_generate` aspect ratios** — the tool supports `landscape`, `portrait`, and `square`. Custom ratios map to the nearest option.
 6. **`image_generate` returns a URL, not a local file** — always download via `terminal` (`curl`) before inserting local image paths into the article.
-7. **No backend selection from the agent** — `image_generate` uses whatever model the user configured (default: FAL FLUX 2 Klein 9B). Don't write `"use <model> to generate this"` into prompts expecting it to route.
+7. **No backend routing by prompt** — for the default `image_generate` path, use the user's configured backend/model. Only switch away from `image_generate` when the user explicitly selects another available raster backend. Don't write `"use <model>"` into prompts expecting it to route.
+8. **No code/manual rendering or text repair** — do not use code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text) or bitmap paint-overs as a shortcut for Baoyu article images. Regenerate from corrected prompts unless the user explicitly asks for a non-Baoyu/manual fallback, and label that output honestly.

--- a/optional-skills/creative/baoyu-comic/SKILL.md
+++ b/optional-skills/creative/baoyu-comic/SKILL.md
@@ -105,9 +105,9 @@ Output directory: `comic/{topic-slug}/`
 | `analysis.md` | Content analysis |
 | `storyboard.md` | Storyboard with panel breakdown |
 | `characters/characters.md` | Character definitions |
-| `characters/characters.png` | Character reference sheet (downloaded from `image_generate`) |
+| `characters/characters.png` | Character reference sheet (generated/downloaded raster image) |
 | `prompts/NN-{cover\|page}-[slug].md` | Generation prompts |
-| `NN-{cover\|page}-[slug].png` | Generated images (downloaded from `image_generate`) |
+| `NN-{cover\|page}-[slug].png` | Generated raster images from the selected backend |
 | `refs/NN-ref-{slug}.{ext}` | User-supplied reference images (optional, for provenance) |
 
 ## Language Handling
@@ -178,11 +178,15 @@ Use the `clarify` tool to confirm options. Since `clarify` handles one question 
 
 ### Step 7: Image Generation
 
-Use Hermes' built-in `image_generate` tool for all image rendering. Its schema accepts only `prompt` and `aspect_ratio` (`landscape` | `portrait` | `square`); it **returns a URL**, not a local file. Every generated page or character sheet must therefore be downloaded to the output directory.
+Use a real raster image-generation backend for rendering. Default to Hermes `image_generate`; if the current request explicitly selects another available raster backend, use that backend instead.
 
-**Prompt file requirement (hard)**: write each image's full, final prompt to a standalone file under `prompts/` (naming: `NN-{type}-[slug].md`) BEFORE calling `image_generate`. The prompt file is the reproducibility record.
+Do not substitute code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text), and do not repair generated text by painting over the bitmap. If text or panel density fails, revise the prompt/storyboard and regenerate; manual comic pages are only explicit non-Baoyu fallbacks and must be labeled honestly.
 
-**Aspect ratio mapping** — the storyboard's `aspect_ratio` field maps to `image_generate`'s format as follows:
+For the default `image_generate` path, call `image_generate(prompt=..., aspect_ratio=...)`; it accepts only `prompt` and `aspect_ratio` (`landscape` | `portrait` | `square`) and returns a URL, not a local file, so download the result to the output directory. For an explicitly selected alternate raster backend, follow that backend's invocation and output contract, but still save and verify the final raster image files in the output directory.
+
+**Prompt file requirement (hard)**: write each image's full, final prompt to a standalone file under `prompts/` (naming: `NN-{type}-[slug].md`) BEFORE invoking any raster backend, including `image_generate`. The prompt file is the reproducibility record.
+
+**Aspect ratio mapping** — for the default `image_generate` path, the storyboard's `aspect_ratio` field maps to `image_generate`'s format as follows:
 
 | Storyboard ratio | `image_generate` format |
 |------------------|-------------------------|
@@ -198,9 +202,9 @@ Use Hermes' built-in `image_generate` tool for all image rendering. Its schema a
 
 **Never rely on shell CWD persistence for `-o` paths.** The terminal tool's persistent-shell CWD can change between batches (session expiry, `TERMINAL_LIFETIME_SECONDS`, a failed `cd` that leaves you in the wrong directory). `curl -o relative/path.png` is a silent footgun: if CWD has drifted, the file lands somewhere else with no error. **Always pass a fully-qualified absolute path to `-o`**, or pass `workdir=<abs path>` to the terminal tool. Incident Apr 2026: pages 06-09 of a 10-page comic landed at the repo root instead of `comic/<slug>/` because batch 3 inherited a stale CWD from batch 2 and `curl -o 06-page-skills.png` wrote to the wrong directory. The agent then spent several turns claiming the files existed where they didn't.
 
-**7.1 Character sheet** — generate it (to `characters/characters.png`, aspect `landscape`) when the comic is multi-page with recurring characters. Skip for simple presets (e.g., four-panel minimalist) or single-page comics. The prompt file at `characters/characters.md` must exist before invoking `image_generate`. The rendered PNG is a **human-facing review artifact** (so the user can visually verify character design) and a reference for later regenerations or manual prompt edits — it does **not** drive Step 7.2. Page prompts are already written in Step 5 from the **text descriptions** in `characters/characters.md`; `image_generate` cannot accept images as visual input.
+**7.1 Character sheet** — generate it (to `characters/characters.png`, aspect `landscape`) when the comic is multi-page with recurring characters. Skip for simple presets (e.g., four-panel minimalist) or single-page comics. The prompt file at `characters/characters.md` must exist before invoking any raster backend. The rendered PNG is a **human-facing review artifact** (so the user can visually verify character design) and a reference for later regenerations or manual prompt edits — it does **not** drive Step 7.2. Page prompts are already written in Step 5 from the **text descriptions** in `characters/characters.md`; `image_generate` cannot accept images as visual input.
 
-**7.2 Pages** — each page's prompt MUST already be at `prompts/NN-{cover|page}-[slug].md` before invoking `image_generate`. Because `image_generate` is prompt-only, character consistency is enforced by **embedding character descriptions (sourced from `characters/characters.md`) inline in every page prompt during Step 5**. The embedding is done uniformly whether or not a PNG sheet is produced in 7.1; the PNG is only a review/regeneration aid.
+**7.2 Pages** — each page's prompt MUST already be at `prompts/NN-{cover|page}-[slug].md` before invoking any raster backend. For the default `image_generate` path, character consistency is enforced by **embedding character descriptions (sourced from `characters/characters.md`) inline in every page prompt during Step 5**. The embedding is done uniformly whether or not a PNG sheet is produced in 7.1; the PNG is only a review/regeneration aid.
 
 **Backup rule**: existing `prompts/…md` and `…png` files → rename with `-backup-YYYYMMDD-HHMMSS` suffix before regenerating.
 
@@ -245,3 +249,4 @@ Full step-by-step workflow (analysis, storyboard, review gates, regeneration var
 - **Steps 4/6 conditional** - only if user requested in Step 2
 - **Step 7.1 character sheet** - recommended for multi-page comics, optional for simple presets. The PNG is a review/regeneration aid; page prompts (written in Step 5) use the text descriptions in `characters/characters.md`, not the PNG. `image_generate` does not accept images as visual input
 - **Strip secrets** — scan source content for API keys, tokens, or credentials before writing any output file
+- **No code/manual rendering or text repair** — do not use code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text) or bitmap paint-overs as a shortcut for Baoyu comic output. Regenerate from corrected prompts unless the user explicitly asks for a non-Baoyu/manual fallback, and label that output honestly.

--- a/skills/creative/baoyu-infographic/SKILL.md
+++ b/skills/creative/baoyu-infographic/SKILL.md
@@ -209,12 +209,14 @@ Save the assembled prompt to `prompts/infographic.md` using `write_file`.
 
 ### Step 6: Generate Image
 
-Use the `image_generate` tool with the assembled prompt from Step 5.
+Use a real raster image-generation backend with the assembled prompt from Step 5. Default to Hermes `image_generate`; if the current request explicitly selects another available raster backend, use that backend instead. Do not substitute code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text), and do not repair generated text by painting over the bitmap. If generated text is too dense or garbled, reduce the visible label set and regenerate through the same Baoyu layout/style.
 
-- Map aspect ratio to image_generate's format: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`
-- For custom ratios, pick the closest named aspect
+For the default `image_generate` path:
+- Map aspect ratio to image_generate's format: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`; custom ratios → nearest named aspect
 - On failure, auto-retry once
-- Save the resulting image URL/path to the output directory
+- Download the returned URL to the output directory and verify the file exists
+
+For an explicitly selected alternate raster backend, use that backend's supported aspect/output options, then save and verify the final raster file in the output directory.
 
 ### Step 7: Output Summary
 
@@ -235,3 +237,4 @@ Report: topic, layout, style, aspect, language, output path, files created.
 3. **One message per section** — each infographic section should convey one clear concept. Overloading sections reduces readability.
 4. **Style consistency** — the style definition from the references file must be applied consistently across the entire infographic. Don't mix styles.
 5. **image_generate aspect ratios** — the tool only supports `landscape`, `portrait`, and `square`. Custom ratios like `3:4` should map to the nearest option (portrait in that case).
+6. **No code/manual rendering or text repair** — do not use code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text) or bitmap paint-overs as a shortcut for Baoyu infographics. Regenerate from corrected prompts unless the user explicitly asks for a non-Baoyu/manual fallback, and label that output honestly.

--- a/website/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic.md
@@ -228,12 +228,14 @@ Save the assembled prompt to `prompts/infographic.md` using `write_file`.
 
 ### Step 6: Generate Image
 
-Use the `image_generate` tool with the assembled prompt from Step 5.
+Use a real raster image-generation backend with the assembled prompt from Step 5. Default to Hermes `image_generate`; if the current request explicitly selects another available raster backend, use that backend instead. Do not substitute code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text), and do not repair generated text by painting over the bitmap. If generated text is too dense or garbled, reduce the visible label set and regenerate through the same Baoyu layout/style.
 
-- Map aspect ratio to image_generate's format: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`
-- For custom ratios, pick the closest named aspect
+For the default `image_generate` path:
+- Map aspect ratio to image_generate's format: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`; custom ratios → nearest named aspect
 - On failure, auto-retry once
-- Save the resulting image URL/path to the output directory
+- Download the returned URL to the output directory and verify the file exists
+
+For an explicitly selected alternate raster backend, use that backend's supported aspect/output options, then save and verify the final raster file in the output directory.
 
 ### Step 7: Output Summary
 
@@ -254,3 +256,4 @@ Report: topic, layout, style, aspect, language, output path, files created.
 3. **One message per section** — each infographic section should convey one clear concept. Overloading sections reduces readability.
 4. **Style consistency** — the style definition from the references file must be applied consistently across the entire infographic. Don't mix styles.
 5. **image_generate aspect ratios** — the tool only supports `landscape`, `portrait`, and `square`. Custom ratios like `3:4` should map to the nearest option (portrait in that case).
+6. **No code/manual rendering or text repair** — do not use code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text) or bitmap paint-overs as a shortcut for Baoyu infographics. Regenerate from corrected prompts unless the user explicitly asks for a non-Baoyu/manual fallback, and label that output honestly.

--- a/website/docs/user-guide/skills/optional/creative/creative-baoyu-article-illustrator.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-baoyu-article-illustrator.md
@@ -104,7 +104,7 @@ If the user asks for a different layout (e.g., images alongside the article, or 
 - [ ] Step 3: Confirm settings (clarify tool, one question at a time)
 - [ ] Step 4: Generate outline
 - [ ] Step 5: Generate prompts
-- [ ] Step 6: Generate images (image_generate)
+- [ ] Step 6: Generate images (raster backend, default `image_generate`)
 - [ ] Step 7: Finalize
 ```
 
@@ -175,14 +175,18 @@ For each illustration:
 
 ### Step 6: Generate Images
 
-For each prompt file:
+Use a real raster image-generation backend with the saved prompt files. Default to Hermes `image_generate`; if the current request explicitly selects another available raster backend, use that backend instead. Do not substitute code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text), and do not repair generated text by painting over the bitmap. If labels need to be exact, reduce the visible label set, revise the prompt, and regenerate.
+
+For the default `image_generate` path, for each prompt file:
 
 1. Call `image_generate(prompt=..., aspect_ratio=...)`. `image_generate` returns a JSON result containing an image URL; it does NOT write to disk and does NOT accept an output path.
 2. Map the prompt's `ASPECT` to `image_generate`'s enum: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`. Custom ratios → nearest named aspect.
 3. Download the returned URL to `{output-dir}/NN-{type}-{slug}.png` via `terminal` (e.g. `curl -sSL -o "{output-dir}/NN-{type}-{slug}.png" "{url}"`).
 4. On generation failure, auto-retry once.
 
-Note: the underlying image-generation backend is user-configured (default: FAL FLUX 2 Klein 9B) and is NOT agent-selectable via `image_generate`. Do not write model names into prompts expecting them to route.
+For an explicitly selected alternate raster backend, follow that backend's invocation and output contract, but still save and verify the final raster image files in the output directory.
+
+Note: the underlying `image_generate` backend is user-configured and is NOT agent-selectable by prompt text. Do not write model names into prompts expecting them to route.
 
 ### Step 7: Finalize
 
@@ -222,4 +226,5 @@ Images: X/N generated
 4. **Prompt files are mandatory** — no image generation without a saved prompt file. The file is what lets you regenerate or switch backends later.
 5. **`image_generate` aspect ratios** — the tool supports `landscape`, `portrait`, and `square`. Custom ratios map to the nearest option.
 6. **`image_generate` returns a URL, not a local file** — always download via `terminal` (`curl`) before inserting local image paths into the article.
-7. **No backend selection from the agent** — `image_generate` uses whatever model the user configured (default: FAL FLUX 2 Klein 9B). Don't write `"use <model> to generate this"` into prompts expecting it to route.
+7. **No backend routing by prompt** — for the default `image_generate` path, use the user's configured backend/model. Only switch away from `image_generate` when the user explicitly selects another available raster backend. Don't write `"use <model>"` into prompts expecting it to route.
+8. **No code/manual rendering or text repair** — do not use code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text) or bitmap paint-overs as a shortcut for Baoyu article images. Regenerate from corrected prompts unless the user explicitly asks for a non-Baoyu/manual fallback, and label that output honestly.

--- a/website/docs/user-guide/skills/optional/creative/creative-baoyu-comic.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-baoyu-comic.md
@@ -122,9 +122,9 @@ Output directory: `comic/{topic-slug}/`
 | `analysis.md` | Content analysis |
 | `storyboard.md` | Storyboard with panel breakdown |
 | `characters/characters.md` | Character definitions |
-| `characters/characters.png` | Character reference sheet (downloaded from `image_generate`) |
+| `characters/characters.png` | Character reference sheet (generated/downloaded raster image) |
 | `prompts/NN-{cover\|page}-[slug].md` | Generation prompts |
-| `NN-{cover\|page}-[slug].png` | Generated images (downloaded from `image_generate`) |
+| `NN-{cover\|page}-[slug].png` | Generated raster images from the selected backend |
 | `refs/NN-ref-{slug}.{ext}` | User-supplied reference images (optional, for provenance) |
 
 ## Language Handling
@@ -195,11 +195,15 @@ Use the `clarify` tool to confirm options. Since `clarify` handles one question 
 
 ### Step 7: Image Generation
 
-Use Hermes' built-in `image_generate` tool for all image rendering. Its schema accepts only `prompt` and `aspect_ratio` (`landscape` | `portrait` | `square`); it **returns a URL**, not a local file. Every generated page or character sheet must therefore be downloaded to the output directory.
+Use a real raster image-generation backend for rendering. Default to Hermes `image_generate`; if the current request explicitly selects another available raster backend, use that backend instead.
 
-**Prompt file requirement (hard)**: write each image's full, final prompt to a standalone file under `prompts/` (naming: `NN-{type}-[slug].md`) BEFORE calling `image_generate`. The prompt file is the reproducibility record.
+Do not substitute code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text), and do not repair generated text by painting over the bitmap. If text or panel density fails, revise the prompt/storyboard and regenerate; manual comic pages are only explicit non-Baoyu fallbacks and must be labeled honestly.
 
-**Aspect ratio mapping** — the storyboard's `aspect_ratio` field maps to `image_generate`'s format as follows:
+For the default `image_generate` path, call `image_generate(prompt=..., aspect_ratio=...)`; it accepts only `prompt` and `aspect_ratio` (`landscape` | `portrait` | `square`) and returns a URL, not a local file, so download the result to the output directory. For an explicitly selected alternate raster backend, follow that backend's invocation and output contract, but still save and verify the final raster image files in the output directory.
+
+**Prompt file requirement (hard)**: write each image's full, final prompt to a standalone file under `prompts/` (naming: `NN-{type}-[slug].md`) BEFORE invoking any raster backend, including `image_generate`. The prompt file is the reproducibility record.
+
+**Aspect ratio mapping** — for the default `image_generate` path, the storyboard's `aspect_ratio` field maps to `image_generate`'s format as follows:
 
 | Storyboard ratio | `image_generate` format |
 |------------------|-------------------------|
@@ -215,9 +219,9 @@ Use Hermes' built-in `image_generate` tool for all image rendering. Its schema a
 
 **Never rely on shell CWD persistence for `-o` paths.** The terminal tool's persistent-shell CWD can change between batches (session expiry, `TERMINAL_LIFETIME_SECONDS`, a failed `cd` that leaves you in the wrong directory). `curl -o relative/path.png` is a silent footgun: if CWD has drifted, the file lands somewhere else with no error. **Always pass a fully-qualified absolute path to `-o`**, or pass `workdir=<abs path>` to the terminal tool. Incident Apr 2026: pages 06-09 of a 10-page comic landed at the repo root instead of `comic/<slug>/` because batch 3 inherited a stale CWD from batch 2 and `curl -o 06-page-skills.png` wrote to the wrong directory. The agent then spent several turns claiming the files existed where they didn't.
 
-**7.1 Character sheet** — generate it (to `characters/characters.png`, aspect `landscape`) when the comic is multi-page with recurring characters. Skip for simple presets (e.g., four-panel minimalist) or single-page comics. The prompt file at `characters/characters.md` must exist before invoking `image_generate`. The rendered PNG is a **human-facing review artifact** (so the user can visually verify character design) and a reference for later regenerations or manual prompt edits — it does **not** drive Step 7.2. Page prompts are already written in Step 5 from the **text descriptions** in `characters/characters.md`; `image_generate` cannot accept images as visual input.
+**7.1 Character sheet** — generate it (to `characters/characters.png`, aspect `landscape`) when the comic is multi-page with recurring characters. Skip for simple presets (e.g., four-panel minimalist) or single-page comics. The prompt file at `characters/characters.md` must exist before invoking any raster backend. The rendered PNG is a **human-facing review artifact** (so the user can visually verify character design) and a reference for later regenerations or manual prompt edits — it does **not** drive Step 7.2. Page prompts are already written in Step 5 from the **text descriptions** in `characters/characters.md`; `image_generate` cannot accept images as visual input.
 
-**7.2 Pages** — each page's prompt MUST already be at `prompts/NN-{cover|page}-[slug].md` before invoking `image_generate`. Because `image_generate` is prompt-only, character consistency is enforced by **embedding character descriptions (sourced from `characters/characters.md`) inline in every page prompt during Step 5**. The embedding is done uniformly whether or not a PNG sheet is produced in 7.1; the PNG is only a review/regeneration aid.
+**7.2 Pages** — each page's prompt MUST already be at `prompts/NN-{cover|page}-[slug].md` before invoking any raster backend. For the default `image_generate` path, character consistency is enforced by **embedding character descriptions (sourced from `characters/characters.md`) inline in every page prompt during Step 5**. The embedding is done uniformly whether or not a PNG sheet is produced in 7.1; the PNG is only a review/regeneration aid.
 
 **Backup rule**: existing `prompts/…md` and `…png` files → rename with `-backup-YYYYMMDD-HHMMSS` suffix before regenerating.
 
@@ -262,3 +266,4 @@ Full step-by-step workflow (analysis, storyboard, review gates, regeneration var
 - **Steps 4/6 conditional** - only if user requested in Step 2
 - **Step 7.1 character sheet** - recommended for multi-page comics, optional for simple presets. The PNG is a review/regeneration aid; page prompts (written in Step 5) use the text descriptions in `characters/characters.md`, not the PNG. `image_generate` does not accept images as visual input
 - **Strip secrets** — scan source content for API keys, tokens, or credentials before writing any output file
+- **No code/manual rendering or text repair** — do not use code-rendered/manual artifacts (SVG, HTML/CSS/canvas, Pillow, Mermaid, graphviz, hand-positioned layout/text) or bitmap paint-overs as a shortcut for Baoyu comic output. Regenerate from corrected prompts unless the user explicitly asks for a non-Baoyu/manual fallback, and label that output honestly.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/creative/creative-baoyu-infographic.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/creative/creative-baoyu-infographic.md
@@ -228,12 +228,14 @@ Slug：从主题中取 2-4 个单词，使用 kebab-case。冲突时追加 `-YYY
 
 ### 第6步：生成图像
 
-使用 `image_generate` 工具，传入第5步组装的 prompt。
+使用真正的栅格图像生成后端和第5步组装的 prompt。默认使用 Hermes `image_generate`；如果当前请求明确选择另一个可用的栅格后端，则使用该后端。不要用代码渲染/手工产物（SVG、HTML/CSS/canvas、Pillow、Mermaid、graphviz、手工布局/摆字）替代，也不要在生成位图上手工涂改文字。如果生成文本过密或乱码，应减少可见标签，并用同一 Baoyu layout/style 重新生成。
 
-- 将宽高比映射到 image_generate 的格式：`16:9` → `landscape`，`9:16` → `portrait`，`1:1` → `square`
-- 自定义比例时，选择最接近的命名宽高比
+默认使用 `image_generate` 时：
+- 将宽高比映射到 image_generate 的格式：`16:9` → `landscape`，`9:16` → `portrait`，`1:1` → `square`；自定义比例使用最接近的命名宽高比
 - 失败时自动重试一次
-- 将生成的图像 URL/路径保存至输出目录
+- 下载返回的 URL 到输出目录，并验证文件存在
+
+如果用户明确选择另一个可用的栅格后端，则使用该后端支持的宽高比/输出选项，然后保存并验证最终栅格文件。
 
 ### 第7步：输出摘要
 
@@ -254,3 +256,4 @@ Slug：从主题中取 2-4 个单词，使用 kebab-case。冲突时追加 `-YYY
 3. **每节一个信息点** — 信息图的每个节应传达一个清晰概念。内容过载会降低可读性。
 4. **风格一致性** — 参考文件中的风格定义必须在整个信息图中一致应用，不得混用风格。
 5. **image_generate 宽高比** — 该工具仅支持 `landscape`、`portrait` 和 `square`。自定义比例如 `3:4` 应映射到最接近的选项（此例为 portrait）。
+6. **不要代码/手工渲染或涂改文字** — 不要用代码渲染/手工产物（SVG、HTML/CSS/canvas、Pillow、Mermaid、graphviz、手工布局/摆字）或位图涂改作为 Baoyu 信息图捷径。应修正 prompt 后重新生成；只有用户明确要求非 Baoyu/手工 fallback 时才使用，并且必须如实标注。


### PR DESCRIPTION
## Summary

- clarify that the Hermes-adapted Baoyu article illustration, infographic, and comic skills use Hermes `image_generate` for generation
- add one consistent rule: no SVG/HTML/canvas/Pillow/Mermaid/graphviz/manual rendering and no bitmap text paint-overs; reduce labels and regenerate from corrected prompts instead
- sync the website docs, including the zh-Hans infographic page

Closes #43601

## Verification

- `git diff --check`
- `python3 website/scripts/generate-skill-docs.py`
- `uv run --with pytest --with pytest-xdist --with pyyaml python -m pytest tests/tools/test_skills_tool.py tests/tools/test_skill_manager_tool.py -q -o 'addopts='`
- `uv run --with pytest --with pyyaml python -m pytest tests/website/test_generate_skill_docs.py tests/website/test_extract_skills.py -q -o 'addopts='`
