### PR TITLE
fix(gateway): suppress empty quick command responses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7227,7 +7227,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             if output:
                                 from agent.redact import redact_sensitive_text
                                 output = redact_sensitive_text(output)
-                            return output if output else "Command returned no output."
+                            return output if output else ""
                         except asyncio.TimeoutError:
                             return "Quick command timed out (30s)."
                         except Exception as e:

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -161,6 +161,19 @@ class TestGatewayQuickCommands:
         assert result == "ok"
 
     @pytest.mark.asyncio
+    async def test_exec_command_empty_output_returns_empty_string(self):
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"empty": {"type": "exec", "command": "true"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("empty")
+        result = await runner._handle_message(event)
+        assert result == ""
+
+    @pytest.mark.asyncio
     async def test_exec_command_does_not_leak_credentials(self):
         """Quick command exec must sanitize env — API keys must not appear in output."""
         from gateway.run import GatewayRunner


### PR DESCRIPTION
## Summary\n- return an empty string for gateway quick commands that produce no stdout/stderr\n- avoids sending noisy `Command returned no output.` messages for intentionally silent quick commands\n- keeps CLI behavior unchanged; CLI still displays a local no-output fallback\n\n## Validation\n- `timeout 60 venv/bin/python -m pytest tests/cli/test_quick_commands.py -q` -> 19 passed, 1 warning\n\nPorted selectively from local backup after upstream reset; intentionally excludes unrelated Telegram/local fitness callbacks and supplement command wiring.