### PR TITLE
fix(cron): strip leading 'scripts/' to avoid double-path resolution

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -989,7 +989,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     if raw.is_absolute():
         path = raw.resolve()
     else:
-        path = (scripts_dir / raw).resolve()
+        # Strip 'scripts/' prefix if present — the path is already being
+        # resolved against scripts_dir, so a double prefix would produce
+        # .../scripts/scripts/script_name.py (a no-op double-path bug).
+        stripped = raw
+        if raw.parts and raw.parts[0] == "scripts":
+            stripped = Path(*raw.parts[1:]) if len(raw.parts) > 1 else Path(".")
+        path = (scripts_dir / stripped).resolve()
 
     # Guard against path traversal, absolute path injection, and symlink
     # escape — scripts MUST reside within HERMES_HOME/scripts/.


### PR DESCRIPTION
## What & Why

`_run_job_script()` in `cron/scheduler.py` resolves a relative `script_path` by joining it against `<HERMES_HOME>/scripts`. When a job is configured with a path like `scripts/foo.py` (a natural way to write it, since that's where scripts live), the join produces `<HERMES_HOME>/scripts/scripts/foo.py` — the `path.exists()` check fails and the job aborts before the path-traversal guard ever runs.

This patch strips a leading `scripts/` component from the relative path before joining, so both `foo.py` and `scripts/foo.py` resolve to the same in-tree file. The path-traversal / symlink-escape guard immediately below is unchanged and still enforces that the resolved path lives under `scripts_dir`.

## How to test

```python
# In a HERMES_HOME with scripts/hello.py:
from cron.scheduler import _run_job_script
_run_job_script("hello.py")           # works before and after
_run_job_script("scripts/hello.py")   # FileNotFoundError before, works after
```

Or via a cron job config:
```yaml
script_path: scripts/hello.py  # previously failed silently with no such file
```

## Platforms tested

- macOS 15 (Darwin 25.5.0), Python 3.11.15

The change is pure `pathlib.Path.parts` manipulation — behavior is identical across macOS/Linux/WSL2.

## Scope

Single-file, 7-line bug fix. No tests added because there is no existing `tests/cron/` directory or scheduler tests in the repo today — happy to add one if the maintainers want to set up that test target as part of this PR.
