### PR TITLE
fix(desktop): scan embedded images linearly to avoid regexp stack overflow

### DIFF
--- a/apps/desktop/src/lib/embedded-images.test.ts
+++ b/apps/desktop/src/lib/embedded-images.test.ts
@@ -32,4 +32,29 @@ describe('extractEmbeddedImages', () => {
     expect(result.cleanedText).toBe('first  mid  tail')
     expect(result.images).toEqual([SAMPLE_PNG_DATA_URL, second])
   })
+
+  it('lifts a JSON-wrapped envelope containing whitespace out of prose', () => {
+    const result = extractEmbeddedImages(
+      `before {"type": "image_url", "image_url": {"url": "${SAMPLE_PNG_DATA_URL}"}} after`
+    )
+
+    expect(result.cleanedText).toBe('before  after')
+    expect(result.images).toEqual([SAMPLE_PNG_DATA_URL])
+  })
+
+  it('ignores base64 runs shorter than 64 characters', () => {
+    const short = 'data:image/png;base64,' + 'A'.repeat(63)
+    const result = extractEmbeddedImages(`inline ${short} stays`)
+
+    expect(result.cleanedText).toBe(`inline ${short} stays`)
+    expect(result.images).toEqual([])
+  })
+
+  it('extracts a multi-megabyte payload without overflowing the regexp stack', () => {
+    const huge = 'data:image/png;base64,' + 'A'.repeat(6_000_000)
+    const result = extractEmbeddedImages(`screenshot incoming ${huge} done`)
+
+    expect(result.cleanedText).toBe('screenshot incoming  done')
+    expect(result.images).toEqual([huge])
+  })
 })

--- a/apps/desktop/src/lib/embedded-images.ts
+++ b/apps/desktop/src/lib/embedded-images.ts
@@ -1,6 +1,3 @@
-const EMBEDDED_IMAGE_RE =
-  /(\{\s*"type"\s*:\s*"image_url"\s*,\s*"image_url"\s*:\s*\{\s*"url"\s*:\s*")?(data:image\/[\w.+-]+;base64,[A-Za-z0-9+/=]{64,})("\s*\}\s*\})?/g
-
 const DATA_URL_RE = /^data:([\w./+-]+);base64,(.*)$/i
 
 export const DATA_IMAGE_URL_RE = /^data:image\/[\w.+-]+;base64,/i
@@ -31,19 +28,146 @@ export function dataUrlToBlob(dataUrl: string): Blob | null {
   }
 }
 
+const DATA_IMAGE_PREFIX = 'data:image/'
+const BASE64_MARKER = ';base64,'
+const MIN_BASE64_LENGTH = 64
+
+const MIME_CHAR_RE = /[\w.+-]/
+const WHITESPACE_RE = /\s/
+
+// `{"type": "image_url", "image_url": {"url": "<data url>"}}` with optional
+// whitespace between tokens; prefix and suffix are stripped independently.
+const WRAPPER_PREFIX_TOKENS = ['{', '"type"', ':', '"image_url"', ',', '"image_url"', ':', '{', '"url"', ':', '"']
+const WRAPPER_SUFFIX_TOKENS = ['"', '}', '}']
+
+function isBase64Code(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) || // 0-9
+    (code >= 65 && code <= 90) || // A-Z
+    (code >= 97 && code <= 122) || // a-z
+    code === 43 || // +
+    code === 47 || // /
+    code === 61 // =
+  )
+}
+
+function wrapperPrefixStart(text: string, urlStart: number): number {
+  let i = urlStart
+
+  for (let t = WRAPPER_PREFIX_TOKENS.length - 1; t >= 0; t -= 1) {
+    const token = WRAPPER_PREFIX_TOKENS[t]
+    const tokenStart = i - token.length
+
+    if (tokenStart < 0 || !text.startsWith(token, tokenStart)) {
+      return -1
+    }
+
+    i = tokenStart
+
+    if (t > 0) {
+      while (i > 0 && WHITESPACE_RE.test(text[i - 1])) {
+        i -= 1
+      }
+    }
+  }
+
+  return i
+}
+
+function wrapperSuffixEnd(text: string, urlEnd: number): number {
+  let i = urlEnd
+
+  for (let t = 0; t < WRAPPER_SUFFIX_TOKENS.length; t += 1) {
+    if (t > 0) {
+      while (i < text.length && WHITESPACE_RE.test(text[i])) {
+        i += 1
+      }
+    }
+
+    if (!text.startsWith(WRAPPER_SUFFIX_TOKENS[t], i)) {
+      return -1
+    }
+
+    i += WRAPPER_SUFFIX_TOKENS[t].length
+  }
+
+  return i
+}
+
+interface EmbeddedImageMatch {
+  start: number
+  end: number
+  dataUrl: string
+}
+
+// Linear scan replacing the previous whole-text regex, whose backtracking
+// overflowed V8's regexp stack on multi-megabyte base64 payloads.
+function findEmbeddedImage(text: string, from: number): EmbeddedImageMatch | null {
+  let searchFrom = from
+
+  while (searchFrom < text.length) {
+    const urlStart = text.indexOf(DATA_IMAGE_PREFIX, searchFrom)
+
+    if (urlStart === -1) {
+      return null
+    }
+
+    searchFrom = urlStart + 1
+
+    let i = urlStart + DATA_IMAGE_PREFIX.length
+    const mimeStart = i
+
+    while (i < text.length && MIME_CHAR_RE.test(text[i])) {
+      i += 1
+    }
+
+    if (i === mimeStart || !text.startsWith(BASE64_MARKER, i)) {
+      continue
+    }
+
+    const base64Start = i + BASE64_MARKER.length
+    let urlEnd = base64Start
+
+    while (urlEnd < text.length && isBase64Code(text.charCodeAt(urlEnd))) {
+      urlEnd += 1
+    }
+
+    if (urlEnd - base64Start < MIN_BASE64_LENGTH) {
+      continue
+    }
+
+    const prefixStart = wrapperPrefixStart(text, urlStart)
+    const suffixEnd = wrapperSuffixEnd(text, urlEnd)
+
+    return {
+      start: prefixStart === -1 ? urlStart : prefixStart,
+      end: suffixEnd === -1 ? urlEnd : suffixEnd,
+      dataUrl: text.slice(urlStart, urlEnd),
+    }
+  }
+
+  return null
+}
+
 export function extractEmbeddedImages(text: string): EmbeddedImageExtraction {
-  if (!text || !text.includes('data:image/')) {
+  if (!text || !text.includes(DATA_IMAGE_PREFIX)) {
     return { cleanedText: text, images: [] }
   }
 
   const images: string[] = []
+  const kept: string[] = []
+  let cursor = 0
 
-  const cleanedText = text
-    .replace(EMBEDDED_IMAGE_RE, (_match, _open, dataUrl: string) => {
-      images.push(dataUrl)
+  for (let match = findEmbeddedImage(text, 0); match; match = findEmbeddedImage(text, match.end)) {
+    images.push(match.dataUrl)
+    kept.push(text.slice(cursor, match.start))
+    cursor = match.end
+  }
 
-      return ''
-    })
+  kept.push(text.slice(cursor))
+
+  const cleanedText = kept
+    .join('')
     .replace(/[ \t]+\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim()


### PR DESCRIPTION
## Problem

`extractEmbeddedImages()` ran `EMBEDDED_IMAGE_RE` over the whole message text via `String.replace`. The unbounded greedy quantifier `[A-Za-z0-9+/=]{64,}` accumulates backtrack state across a single contiguous multi-megabyte base64 run, overflowing V8's regexp stack and throwing `RangeError: Maximum call stack size exceeded`.

Real-world impact: a full-resolution screenshot attachment (~9.6 MB PNG → ~12.85M-char `data:image/png;base64,…` previewUrl) persisted in the composer queue (`hermes.desktop.composerQueue.v1` in localStorage) is re-rendered on every launch. The throw happens inside `DirectiveContent`'s render, trips the root error boundary ("Something broke in the interface"), and since the queue never clears, the app crash-loops on every boot/reload.

Reproduction is deterministic: ≥ ~4 MB decoded payload (~5.6M base64 chars) throws 5/5 on Node v25 **and on the packaged app's own binary** (`ELECTRON_RUN_AS_NODE`). The renderer's regexp stack may be smaller than the Node CLI's, so a size-threshold guard would not be a reliable fix — the regex itself has to go.

## Fix

Replace the regex with a linear scanner: locate `data:image/` with `indexOf`, walk the mime type and base64 alphabet with `charCodeAt` (requiring ≥ 64 chars after `;base64,`), and independently strip the optional `{"type": "image_url", "image_url": {"url": …}}` wrapper around the match — preserving the previous `cleanedText`/`images` output contract exactly (independent optional prefix/suffix, `/g`-style sequential matching, identical whitespace tolerance).

## Testing

- TDD: the new regression test (`extracts a multi-megabyte payload without overflowing the regexp stack`) **fails with `RangeError: Maximum call stack size exceeded` against the old implementation** and passes now; added coverage for the JSON-wrapped envelope (with whitespace) and sub-64-char base64 runs.
- Behavior parity: a 1000-case randomized differential test (old regex as oracle on small inputs; mixed wrappers, partial wrappers, whitespace variants, 63/64/65 boundary lengths, `=` padding, multiple images, decoy prefixes) produced identical output for old and new implementations (run locally, not committed).
- `vitest run src/lib/` in `apps/desktop`: 19 files, 138 tests passed. `eslint` clean on both changed files.

## Follow-up (out of scope here)

The gateway side also inlines uncapped data URLs into resume/history text (`_coerce_message_text` in `tui_gateway/server.py`); the sibling `_content_display_text` already uses a safe `[image]` placeholder pattern. Capping or placeholder-ing on the producer side would be a sensible defense-in-depth follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)