### PR TITLE
fix: honor proxy env vars in whatsapp bridge

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -29,6 +29,15 @@ import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+function getProxyUrl() {
+  return process.env.HTTPS_PROXY || process.env.https_proxy ||
+    process.env.HTTP_PROXY || process.env.http_proxy || '';
+}
+const PROXY_URL = getProxyUrl();
+const proxyAgent = PROXY_URL ? new HttpsProxyAgent(PROXY_URL) : undefined;
+if (proxyAgent) console.log(`🌐 Using proxy for WhatsApp WebSocket: ${PROXY_URL}`);
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -185,6 +194,7 @@ async function startSocket() {
     version,
     auth: state,
     logger,
+    agent: proxyAgent,
     printQRInTerminal: false,
     browser: ['Hermes Agent', 'Chrome', '120.0'],
     syncFullHistory: false,

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
         "express": "^4.21.0",
+        "https-proxy-agent": "^7.0.6",
         "pino": "^9.0.0",
         "qrcode-terminal": "^0.12.0"
       }
@@ -777,6 +778,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1270,6 +1280,42 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -10,8 +10,9 @@
   "dependencies": {
     "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
     "express": "^4.21.0",
-    "qrcode-terminal": "^0.12.0",
-    "pino": "^9.0.0"
+    "https-proxy-agent": "^7.0.6",
+    "pino": "^9.0.0",
+    "qrcode-terminal": "^0.12.0"
   },
   "overrides": {
     "protobufjs": "^7.5.5"


### PR DESCRIPTION
## What does this PR do?

- Makes the Gateway WhatsApp bridge honor standard system proxy environment variables when connecting to WhatsApp via Baileys.
- This fixes WhatsApp pairing in environments where outbound network traffic must go through an HTTP(S) proxy. Without this, pairing can fail before the QR code appears, repeatedly disconnecting with reason 408.

## Related Issue
[#43603 ](https://github.com/NousResearch/hermes-agent/issues/43603)

## Type of Change


    - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
    - [x] ✨ New feature (non-breaking change that adds functionality)
    - [ ] 🔒 Security fix
    - [ ] 📝 Documentation update
    - [ ] ✅ Tests (adding or improving test coverage)
    - [ ] ♻️ Refactor (no behavior change)
    - [ ] 🎯 New skill (bundled or hub)

## Changes Made


    - Updated scripts/whatsapp-bridge/bridge.js
      - Reads standard proxy environment variables:
        - HTTPS_PROXY
        - https_proxy
        - HTTP_PROXY
        - http_proxy
      - Creates an HttpsProxyAgent when a proxy variable is present.
      - Passes the proxy agent into Baileys makeWASocket() via the agent option.
      - Logs when the WhatsApp bridge is using a proxy, without changing behavior when no proxy is configured.

    - Updated scripts/whatsapp-bridge/package.json
      - Adds https-proxy-agent as a WhatsApp bridge dependency.

    - Updated scripts/whatsapp-bridge/package-lock.json
      - Locks the new dependency and its transitive dependency metadata.

## How to Test


    1. From a machine or shell where outbound network traffic requires an HTTP(S) proxy, set one of the standard proxy environment variables:

       bash
       export HTTPS_PROXY=http://proxy-host:proxy-port
    or:
       export https_proxy=http://proxy-host:proxy-port
    or:
       export HTTP_PROXY=http://proxy-host:proxy-port
    or:
       export http_proxy=http://proxy-host:proxy-port


    2. Install/check WhatsApp bridge dependencies and validate syntax:

       bash
       cd scripts/whatsapp-bridge
       npm install
       node --check bridge.js
       npm list https-proxy-agent --depth=0


    3. Start WhatsApp pairing:

       bash
       WHATSAPP_DEBUG=true node bridge.js --pair-only --session /tmp/hermes-wa-proxy-test


    4. Confirm the bridge detects proxy configuration and reaches the QR-code pairing step:

       text
       Using proxy for WhatsApp WebSocket: ...
       Scan this QR code with WhatsApp on your phone:


    5. Optional full Hermes flow:

       bash
       hermes whatsapp
       hermes gateway


       Expected result:
       - hermes whatsapp reaches QR-code pairing instead of looping with Connection closed (reason: 408).
       - After scanning the QR code, hermes gateway can connect to WhatsApp normally.

## Checklist

    <!-- Complete these before requesting review. -->

## Code

    - [ ] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
    - [x] I searched for existing PRs to make sure this isn't a duplicate
    - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
    - [ ] I've run pytest tests/ -q and all tests pass
    - [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
    - [x] I've tested on my platform: Ubuntu Linux

## Documentation & Housekeeping

    <!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

    - [x] I've updated relevant documentation (README, docs/, docstrings) — N/A
    - [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A
    - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A
    - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
    - [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

##For New Skills

    <!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

    N/A — this PR does not add or change a skill.

## Screenshots / Logs

    Before this change, WhatsApp pairing in a proxied environment could loop before displaying a QR code:

    text
    Connection closed (reason: 408). Reconnecting in 3s...
    Connection closed (reason: 408). Reconnecting in 3s...
    Connection closed (reason: 408). Reconnecting in 3s...


    After this change, the bridge detects the configured proxy and usable