### PR TITLE
fix(feishu): stop using card action callback token as synthetic message_id

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3010,7 +3010,10 @@ class FeishuAdapter(BasePlatformAdapter):
             message_type=MessageType.COMMAND,
             source=source,
             raw_message=data,
-            message_id=token or str(uuid.uuid4()),
+            # Card callback tokens are short-lived card-update credentials,
+            # not IM message IDs.  Leave the synthetic event unanchored so
+            # downstream delivery creates a regular chat message.
+            message_id=None,
             channel_prompt=self._resolve_channel_prompt(chat_id),
             timestamp=datetime.now(),
         )

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -420,7 +420,7 @@ class TestNonApprovalCardAction:
 
         data = _make_card_action_data(
             action_value={"custom_action": "something_else"},
-            token="tok_normal",
+            token="c-card-update-credential",
         )
 
         with (
@@ -436,6 +436,7 @@ class TestNonApprovalCardAction:
         mock_handle.assert_called_once()
         event = mock_handle.call_args[0][0]
         assert "/card button" in event.text
+        assert event.message_id is None
 
 
 # ===========================================================================


### PR DESCRIPTION
## Problem

When an interactive card button is clicked, `_handle_card_action_event` builds a synthetic `COMMAND` event. Its callback `token` is a short-lived card-update credential, not a Feishu IM message ID.

Passing that token (or the previous random UUID fallback) as `event.message_id` makes `_reply_anchor_for_event()` use it as `reply_to`. Feishu rejects the response with error **99992354** (invalid message ID), so the result of a card-button command never reaches the chat.

## Fix

Set `message_id=None` on the synthetic event:

- the response is delivered as a regular message instead of an invalid reply;
- the processing-reaction path skips cleanly because reactions require a real message ID;
- deduplication is unchanged because card actions are already deduplicated by callback token before the synthetic event is built.

## Testing

- Updated the non-approval card-action test to use a realistic callback token and assert that the synthetic event has no message ID.
- `scripts/run_tests.sh tests/gateway/test_feishu_approval_buttons.py -q` — 38 passed.
- Ruff and `git diff --check` pass.
- Verified on a live Feishu bot: before this change, card-button responses failed with 99992354; after it, responses are delivered as new messages.
