### PR TITLE
feat(qqbot): log when dm/group policy drops an inbound message

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -159,6 +159,13 @@ class QQAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     _TYPING_INPUT_SECONDS = 60  # input_notify duration reported to QQ
     _TYPING_DEBOUNCE_SECONDS = 50  # refresh before it expires
+    # Intake policy failures are attacker-controlled. Keep the first useful
+    # diagnostic for each reason/subject while bounding both log volume and
+    # in-memory tracking when callers rotate sender or group IDs.
+    _POLICY_DROP_REPEAT_SECONDS = 300.0
+    _POLICY_DROP_WINDOW_SECONDS = 60.0
+    _POLICY_DROP_MAX_PER_WINDOW = 10
+    _POLICY_DROP_CACHE_SIZE = 1024
 
     @property
     def _log_tag(self) -> str:
@@ -231,6 +238,12 @@ class QQAdapter(BasePlatformAdapter):
         # Request/response correlation
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._seen_messages: Dict[str, float] = {}
+
+        # Bounded throttling state for unauthenticated intake diagnostics.
+        # Keyed by (reason, subject); per-reason windows also stop a caller
+        # from bypassing repeat suppression by continuously rotating IDs.
+        self._policy_drop_log_times: Dict[Tuple[str, str], float] = {}
+        self._policy_drop_log_windows: Dict[str, Tuple[float, int]] = {}
 
         # Last inbound message ID per chat — used by send_typing
         self._last_msg_id: Dict[str, str] = {}
@@ -1389,10 +1402,6 @@ class QQAdapter(BasePlatformAdapter):
         guild_id = str(d.get("guild_id", ""))
         author_id = str(author.get("id", ""))
         if not self._is_group_allowed(guild_id or channel_id, author_id):
-            logger.debug(
-                "[%s] Guild message blocked by ACL: channel=%s user=%s",
-                self._log_tag, channel_id, author_id,
-            )
             return
 
         member = d.get("member") if isinstance(d.get("member"), dict) else {}
@@ -1463,10 +1472,6 @@ class QQAdapter(BasePlatformAdapter):
         # bypass the configured allowlist via direct messages.
         author_id = str(author.get("id", ""))
         if not self._is_dm_intake_allowed(author_id):
-            logger.debug(
-                "[%s] Guild DM blocked by ACL: guild=%s user=%s",
-                self._log_tag, guild_id, author_id,
-            )
             return
 
         text = content
@@ -3163,6 +3168,59 @@ class QQAdapter(BasePlatformAdapter):
             return True
         return os.getenv("QQ_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 
+    def _log_policy_drop(
+        self,
+        level: int,
+        reason: str,
+        subject: str,
+        message: str,
+        *args: Any,
+    ) -> None:
+        """Emit a bounded intake-policy diagnostic.
+
+        Repeat messages for the same reason and subject are suppressed for a
+        short interval. A second per-reason budget bounds output even when an
+        unauthenticated caller rotates IDs, and the tracking cache is capped.
+        """
+        if not logger.isEnabledFor(level):
+            return
+
+        now = time.monotonic()
+        key = (reason, str(subject))
+        previous = self._policy_drop_log_times.get(key)
+        if previous is not None and 0.0 <= now - previous < self._POLICY_DROP_REPEAT_SECONDS:
+            return
+
+        window_started, emitted = self._policy_drop_log_windows.get(reason, (now, 0))
+        if now < window_started or now - window_started >= self._POLICY_DROP_WINDOW_SECONDS:
+            window_started, emitted = now, 0
+        if emitted >= self._POLICY_DROP_MAX_PER_WINDOW:
+            self._policy_drop_log_windows[reason] = (window_started, emitted)
+            return
+
+        if len(self._policy_drop_log_times) >= self._POLICY_DROP_CACHE_SIZE:
+            cutoff = now - self._POLICY_DROP_REPEAT_SECONDS
+            expired = [
+                cached_key
+                for cached_key, timestamp in self._policy_drop_log_times.items()
+                if timestamp <= cutoff or timestamp > now
+            ]
+            for cached_key in expired:
+                self._policy_drop_log_times.pop(cached_key, None)
+            if len(self._policy_drop_log_times) >= self._POLICY_DROP_CACHE_SIZE:
+                oldest = min(
+                    self._policy_drop_log_times,
+                    key=self._policy_drop_log_times.__getitem__,
+                )
+                self._policy_drop_log_times.pop(oldest, None)
+
+        # Reinsert elapsed keys so insertion order continues to approximate
+        # recency if the timestamp clock has coarse resolution.
+        self._policy_drop_log_times.pop(key, None)
+        self._policy_drop_log_times[key] = now
+        self._policy_drop_log_windows[reason] = (window_started, emitted + 1)
+        logger.log(level, message, *args)
+
     def _is_dm_allowed(self, user_id: str) -> bool:
         if self._dm_policy == "disabled":
             return False
@@ -3175,26 +3233,103 @@ class QQAdapter(BasePlatformAdapter):
     def _is_dm_intake_allowed(self, user_id: str) -> bool:
         principal = str(user_id or "").strip()
         if not principal:
+            self._log_policy_drop(
+                logging.DEBUG,
+                "dm-missing-sender",
+                "",
+                "[%s] DM dropped at intake: missing sender id",
+                self._log_tag,
+            )
             return False
         if self._dm_policy == "disabled":
+            self._log_policy_drop(
+                logging.DEBUG,
+                "dm-disabled",
+                "",
+                "[%s] DM dropped at intake: dm_policy is disabled",
+                self._log_tag,
+            )
             return False
         if self._dm_policy == "allowlist":
-            return self._entry_matches(self._allow_from, principal)
+            if self._entry_matches(self._allow_from, principal):
+                return True
+            self._log_policy_drop(
+                logging.INFO,
+                "dm-allowlist-miss",
+                principal,
+                "[%s] DM dropped at intake: sender=%r is not in allow_from",
+                self._log_tag,
+                principal,
+            )
+            return False
         if self._dm_policy == "pairing":
             return True
         if self._dm_policy == "open":
-            return self._open_dm_opted_in()
+            if self._open_dm_opted_in():
+                return True
+            self._log_policy_drop(
+                logging.WARNING,
+                "dm-open-without-opt-in",
+                "",
+                "[%s] DM dropped at intake: dm_policy is open but neither "
+                "GATEWAY_ALLOW_ALL_USERS nor QQ_ALLOW_ALL_USERS is enabled",
+                self._log_tag,
+            )
+            return False
+        self._log_policy_drop(
+            logging.WARNING,
+            "dm-unsupported-policy",
+            self._dm_policy,
+            "[%s] DM dropped at intake: unsupported dm_policy=%r",
+            self._log_tag,
+            self._dm_policy,
+        )
         return False
 
     def _is_group_allowed(self, group_id: str, user_id: str) -> bool:
         if self._group_policy == "disabled":
+            self._log_policy_drop(
+                logging.DEBUG,
+                "group-disabled",
+                "",
+                "[%s] Group message dropped at intake: group_policy is disabled",
+                self._log_tag,
+            )
             return False
         if self._group_policy == "allowlist":
-            return self._entry_matches(self._group_allow_from, group_id)
+            if self._entry_matches(self._group_allow_from, group_id):
+                return True
+            self._log_policy_drop(
+                logging.INFO,
+                "group-allowlist-miss",
+                group_id,
+                "[%s] Group message dropped at intake: group=%r is not in "
+                "group_allow_from",
+                self._log_tag,
+                group_id,
+            )
+            return False
         if self._group_policy == "pairing":
+            self._log_policy_drop(
+                logging.DEBUG,
+                "group-pairing",
+                group_id,
+                "[%s] Group message dropped at intake: group=%r; "
+                "group_policy pairing supports DMs only",
+                self._log_tag,
+                group_id,
+            )
             return False
         if self._group_policy == "open":
             return True
+        self._log_policy_drop(
+            logging.WARNING,
+            "group-unsupported-policy",
+            self._group_policy,
+            "[%s] Group message dropped at intake: unsupported group_policy=%r",
+            self._log_tag,
+            self._group_policy,
+        )
         return False
 
     @staticmethod

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1,6 +1,7 @@
 """Tests for the QQ Bot platform adapter."""
 
 import asyncio
+import logging
 import os
 from types import SimpleNamespace
 from unittest import mock
@@ -8,6 +9,15 @@ from unittest import mock
 import pytest
 
 from gateway.config import PlatformConfig
+
+
+QQBOT_LOGGER = "gateway.platforms.qqbot.adapter"
+
+
+def _single_qqbot_log(caplog):
+    records = [record for record in caplog.records if record.name == QQBOT_LOGGER]
+    assert len(records) == 1
+    return records[0]
 
 
 # ---------------------------------------------------------------------------
@@ -308,6 +318,108 @@ class TestDmAllowed:
         adapter = self._make_adapter(app_id="a", client_secret="b", dm_policy="allowlist", allow_from="*")
         assert adapter._is_dm_allowed("anyone") is True
 
+    @pytest.mark.parametrize(
+        ("policy", "user_id", "level", "expected", "hidden"),
+        [
+            pytest.param(
+                "allowlist", "user3", logging.INFO,
+                ("sender='user3'", "allow_from"), ("user1", "user2"),
+                id="allowlist-miss",
+            ),
+            pytest.param(
+                "disabled", "private-user-id", logging.DEBUG,
+                ("dm_policy is disabled",), ("private-user-id",), id="disabled",
+            ),
+            pytest.param(
+                "open", "private-user-id", logging.WARNING,
+                ("dm_policy is open", "GATEWAY_ALLOW_ALL_USERS", "QQ_ALLOW_ALL_USERS"),
+                ("private-user-id",),
+                id="open-without-opt-in",
+            ),
+            pytest.param(
+                "unexpected", "private-user-id", logging.WARNING,
+                ("unsupported dm_policy='unexpected'",), ("private-user-id",),
+                id="unknown-policy",
+            ),
+            pytest.param(
+                "pairing", "  ", logging.DEBUG, ("missing sender id",), (),
+                id="missing-sender",
+            ),
+        ],
+    )
+    def test_intake_denial_logs_reason_without_unneeded_ids(
+        self, caplog, monkeypatch, policy, user_id, level, expected, hidden
+    ):
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("QQ_ALLOW_ALL_USERS", raising=False)
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            dm_policy=policy,
+            allow_from="user1,user2",
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=QQBOT_LOGGER):
+            assert adapter._is_dm_intake_allowed(user_id) is False
+
+        record = _single_qqbot_log(caplog)
+        message = record.getMessage()
+        assert record.levelno == level
+        assert all(fragment in message for fragment in expected)
+        assert all(fragment not in message for fragment in hidden)
+
+    @pytest.mark.parametrize(
+        ("policy", "user_id", "allow_from", "opt_in"),
+        [
+            pytest.param("pairing", "unpaired-user", "", None, id="pairing"),
+            pytest.param("allowlist", "user1", "user1", None, id="allowlist"),
+            pytest.param(
+                "open", "any-user", "", "QQ_ALLOW_ALL_USERS", id="open-with-opt-in",
+            ),
+        ],
+    )
+    def test_intake_allowed_paths_do_not_log_drop(
+        self, caplog, monkeypatch, policy, user_id, allow_from, opt_in
+    ):
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("QQ_ALLOW_ALL_USERS", raising=False)
+        if opt_in:
+            monkeypatch.setenv(opt_in, "true")
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            dm_policy=policy,
+            allow_from=allow_from,
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=QQBOT_LOGGER):
+            assert adapter._is_dm_intake_allowed(user_id) is True
+
+        assert caplog.records == []
+
+    def test_intake_drop_log_suppresses_repeats_until_interval(
+        self, caplog, monkeypatch
+    ):
+        now = [100.0]
+        monkeypatch.setattr(
+            "gateway.platforms.qqbot.adapter.time.monotonic", lambda: now[0]
+        )
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            dm_policy="allowlist",
+            allow_from="user1",
+        )
+
+        with caplog.at_level(logging.INFO, logger=QQBOT_LOGGER):
+            assert adapter._is_dm_intake_allowed("blocked-user") is False
+            assert adapter._is_dm_intake_allowed("blocked-user") is False
+            now[0] += adapter._POLICY_DROP_REPEAT_SECONDS
+            assert adapter._is_dm_intake_allowed("blocked-user") is False
+
+        records = [record for record in caplog.records if record.name == QQBOT_LOGGER]
+        assert len(records) == 2
+
 
 # ---------------------------------------------------------------------------
 # _is_group_allowed
@@ -343,6 +455,99 @@ class TestGroupAllowed:
     def test_pairing_default_forwards_dm_to_gateway_intake(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
         assert adapter._is_dm_intake_allowed("any_user") is True
+
+    @pytest.mark.parametrize(
+        ("policy", "group_id", "level", "expected", "hidden"),
+        [
+            pytest.param(
+                "allowlist", "grp2", logging.INFO,
+                ("group='grp2'", "group_allow_from"), ("grp1", "private-user-id"),
+                id="allowlist-miss",
+            ),
+            pytest.param(
+                "disabled", "private-group-id", logging.DEBUG,
+                ("group_policy is disabled",), ("private-group-id", "private-user-id"),
+                id="disabled",
+            ),
+            pytest.param(
+                "pairing", "grp2", logging.DEBUG,
+                ("group='grp2'", "group_policy pairing supports DMs only"),
+                ("private-user-id",), id="pairing",
+            ),
+            pytest.param(
+                "unexpected", "private-group-id", logging.WARNING,
+                ("unsupported group_policy='unexpected'",),
+                ("private-group-id", "private-user-id"),
+                id="unknown-policy",
+            ),
+        ],
+    )
+    def test_denial_logs_reason_without_unneeded_ids(
+        self, caplog, policy, group_id, level, expected, hidden
+    ):
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            group_policy=policy,
+            group_allow_from="grp1",
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=QQBOT_LOGGER):
+            assert adapter._is_group_allowed(group_id, "private-user-id") is False
+
+        record = _single_qqbot_log(caplog)
+        message = record.getMessage()
+        assert record.levelno == level
+        assert all(fragment in message for fragment in expected)
+        assert all(fragment not in message for fragment in hidden)
+
+    @pytest.mark.parametrize(
+        ("policy", "group_id", "group_allow_from"),
+        [
+            pytest.param("open", "grp1", "", id="open"),
+            pytest.param("allowlist", "grp1", "grp1", id="allowlist"),
+        ],
+    )
+    def test_allowed_paths_do_not_log_drop(
+        self, caplog, policy, group_id, group_allow_from
+    ):
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            group_policy=policy,
+            group_allow_from=group_allow_from,
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=QQBOT_LOGGER):
+            assert adapter._is_group_allowed(group_id, "user1") is True
+
+        assert caplog.records == []
+
+    def test_drop_log_bounds_rotating_subjects_and_tracking_cache(
+        self, caplog, monkeypatch
+    ):
+        now = [100.0]
+        monkeypatch.setattr(
+            "gateway.platforms.qqbot.adapter.time.monotonic", lambda: now[0]
+        )
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            group_policy="allowlist",
+            group_allow_from="trusted-group",
+        )
+        monkeypatch.setattr(adapter, "_POLICY_DROP_MAX_PER_WINDOW", 3)
+        monkeypatch.setattr(adapter, "_POLICY_DROP_CACHE_SIZE", 2)
+
+        with caplog.at_level(logging.INFO, logger=QQBOT_LOGGER):
+            for index in range(5):
+                assert adapter._is_group_allowed(f"blocked-{index}", "user") is False
+            now[0] += adapter._POLICY_DROP_WINDOW_SECONDS
+            assert adapter._is_group_allowed("blocked-after-window", "user") is False
+
+        records = [record for record in caplog.records if record.name == QQBOT_LOGGER]
+        assert len(records) == 4
+        assert len(adapter._policy_drop_log_times) == 2
 
 # ---------------------------------------------------------------------------
 # _resolve_stt_config


### PR DESCRIPTION
## Problem

QQBot's live intake predicates silently return `False` when `dm_policy` or `group_policy` rejects a message. Operators cannot tell whether the event failed to arrive or was intentionally dropped, and an allowlist miss does not expose the sender/group ID needed to fix the configuration.

The original PR also targeted policy helpers that no longer cover every live ingress path on current `main`.

## Change

Log policy decisions in the live `_is_dm_intake_allowed()` and `_is_group_allowed()` predicates used by C2C, group, guild, and guild-DM events:

- **allowlist miss → INFO** with the actionable sender/group ID and config key;
- **disabled policy, missing DM sender ID, or group `pairing` drop → DEBUG**;
- **DM `open` without the required opt-in or unsupported policy → WARNING**.

Allowed paths and all policy return values are unchanged. Logs do not include message content, credentials, or allowlist contents, and the old guild call-site diagnostics are removed so policy drops are diagnosed in one place.

Because rejected traffic is externally controlled, diagnostics are bounded: the same reason/subject is emitted at most once per five minutes, each reason has a ten-per-minute budget even if IDs rotate, and the tracking cache is capped at 1024 entries.

## Testing

- Added parameterized DM/group matrices for denial reasons, log levels, privacy, and allowed paths.
- Added coverage for repeat suppression, rotating-ID rate limits, window recovery, and cache bounds.
- `scripts/run_tests.sh tests/gateway/test_qqbot.py -q` — 182 passed.
- Ruff and `git diff --check` pass.
