### PR TITLE
fix: respect reasoning_config for custom providers and fix OpenRouter…

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -421,7 +421,27 @@ class ChatCompletionsTransport(ProviderTransport):
                 if gh_reasoning is not None:
                     extra_body["reasoning"] = gh_reasoning
             else:
-                extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+                # Respect reasoning_config instead of hardcoding enabled: True
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    if reasoning_config.get("enabled") is False:
+                        extra_body["reasoning"] = {"enabled": False}
+                    else:
+                        effort = reasoning_config.get("effort", "medium")
+                        extra_body["reasoning"] = {"enabled": True, "effort": effort}
+                else:
+                    extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+
+        # For providers not detected as supporting reasoning (custom providers, etc.),
+        # still respect an explicit reasoning_config.
+        # Use top-level reasoning_effort (not extra_body) since most OpenAI-compat
+        # APIs (DeepSeek, ARK, etc.) expect it as a top-level param.
+        # Map "none" to "minimal" since some APIs reject "none" as invalid.
+        elif reasoning_config and isinstance(reasoning_config, dict):
+            if reasoning_config.get("enabled") is False:
+                api_kwargs["reasoning_effort"] = "minimal"
+            else:
+                effort = reasoning_config.get("effort", "medium")
+                api_kwargs["reasoning_effort"] = effort
 
         if provider_name == "gemini":
             raw_thinking_config = _build_gemini_thinking_config(model, reasoning_config)


### PR DESCRIPTION
… hardcoded reasoning

Two bugs fixed in _build_kwargs():

1. OpenRouter path (line 418): hardcoded extra_body.reasoning to {"enabled": True, "effort": "medium"} instead of reading the user's reasoning_config. Now respects the toggle switch.

2. Custom/unknown providers: reasoning_config was completely ignored because supports_reasoning was False for non-OpenRouter endpoints. Now sends top-level reasoning_effort param (which most OpenAI-compat APIs like DeepSeek/ARK expect). Maps "none" to "minimal" since some APIs reject "none" as invalid.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

