### PR TITLE
Order TUI tail as queue, todos, summary

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1316,8 +1316,37 @@ def _npm_lock_dependency_names(pkg: dict) -> set[str]:
     return names
 
 
+def _npm_lock_dependency_entries(
+    packages: dict,
+    installed: dict,
+    by_package_name: dict[str, list[str]],
+    parent: str,
+    dep_name: str,
+) -> list[str]:
+    root_entry = f"node_modules/{dep_name}"
+    nested_entry = f"{parent}/node_modules/{dep_name}"
+    candidates = []
+
+    if root_entry in packages:
+        candidates.append(root_entry)
+    if nested_entry in packages:
+        candidates.append(nested_entry)
+    candidates.extend(
+        entry
+        for entry in by_package_name.get(dep_name, [])
+        if entry not in candidates
+    )
+
+    installed_candidates = [entry for entry in candidates if entry in installed]
+    if installed_candidates:
+        return installed_candidates
+
+    return candidates
+
+
 def _tui_relevant_lock_entries(
     packages: dict,
+    installed: dict,
     root: Path,
     ws_root: Path,
 ) -> set[str]:
@@ -1358,7 +1387,13 @@ def _tui_relevant_lock_entries(
                 pending.append(resolved)
 
         for dep_name in _npm_lock_dependency_names(pkg):
-            for dep_entry in by_package_name.get(dep_name, []):
+            for dep_entry in _npm_lock_dependency_entries(
+                packages,
+                installed,
+                by_package_name,
+                name,
+                dep_name,
+            ):
                 if dep_entry not in relevant:
                     relevant.add(dep_entry)
                     pending.append(dep_entry)
@@ -1480,7 +1515,7 @@ def _tui_need_npm_install(root: Path) -> bool:
     def comparable(pkg: dict) -> dict:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
 
-    relevant = _tui_relevant_lock_entries(wanted, root, ws_root)
+    relevant = _tui_relevant_lock_entries(wanted, installed, root, ws_root)
     for name, pkg in wanted.items():
         if not name:
             continue
@@ -1715,6 +1750,8 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             [
                 npm,
                 "install",
+                "--prefix",
+                str(npm_cwd),
                 *npm_workspace_args,
                 "--silent",
                 "--no-fund",
@@ -1745,7 +1782,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         npm = _node_bin("npm")
         ink_dir = tui_dir / "packages" / "hermes-ink"
         result = subprocess.run(
-            [npm, "run", "build"],
+            [npm, "--prefix", str(ink_dir), "run", "build"],
             cwd=str(ink_dir),
             capture_output=True,
             text=True,
@@ -1761,7 +1798,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         tsx = tui_dir / "node_modules" / ".bin" / "tsx"
         if tsx.exists():
             return [str(tsx), "src/entry.tsx"], tui_dir
-        return [npm, "start"], tui_dir
+        return [npm, "--prefix", str(tui_dir), "start"], tui_dir
 
     # Desktop/dev launches retain the historical "always rebuild" behaviour.
     # Termux cold starts use the freshness check because esbuild startup is
@@ -1773,7 +1810,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     if should_build:
         npm = _node_bin("npm")
         result = subprocess.run(
-            [npm, "run", "build"],
+            [npm, "--prefix", str(tui_dir), "run", "build"],
             cwd=str(tui_dir),
             capture_output=True,
             text=True,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1288,6 +1288,84 @@ to avoid false-positive reinstalls on every launch.
 """
 
 
+def _npm_lock_path_package_name(path: str) -> str | None:
+    marker = "node_modules/"
+    if marker not in path:
+        return None
+
+    tail = path.rsplit(marker, 1)[1]
+    parts = tail.split("/")
+    if not parts or not parts[0]:
+        return None
+    if parts[0].startswith("@") and len(parts) >= 2:
+        return f"{parts[0]}/{parts[1]}"
+    return parts[0]
+
+
+def _npm_lock_dependency_names(pkg: dict) -> set[str]:
+    names: set[str] = set()
+    for field in (
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies",
+    ):
+        deps = pkg.get(field)
+        if isinstance(deps, dict):
+            names.update(str(name) for name in deps)
+    return names
+
+
+def _tui_relevant_lock_entries(
+    packages: dict,
+    root: Path,
+    ws_root: Path,
+) -> set[str]:
+    """Return package-lock entries covered by the TUI workspace install."""
+    if ws_root == root:
+        return set(packages)
+
+    try:
+        rel = root.relative_to(ws_root).as_posix()
+    except ValueError:
+        return set(packages)
+
+    by_package_name: dict[str, list[str]] = {}
+    for name, pkg in packages.items():
+        if not isinstance(name, str) or not isinstance(pkg, dict):
+            continue
+        package_name = _npm_lock_path_package_name(name)
+        if package_name:
+            by_package_name.setdefault(package_name, []).append(name)
+
+    relevant = {
+        name
+        for name in packages
+        if name == rel or name.startswith(f"{rel}/")
+    }
+    pending = list(relevant)
+
+    while pending:
+        name = pending.pop()
+        pkg = packages.get(name)
+        if not isinstance(pkg, dict):
+            continue
+
+        resolved = pkg.get("resolved")
+        if pkg.get("link") and isinstance(resolved, str) and resolved in packages:
+            if resolved not in relevant:
+                relevant.add(resolved)
+                pending.append(resolved)
+
+        for dep_name in _npm_lock_dependency_names(pkg):
+            for dep_entry in by_package_name.get(dep_name, []):
+                if dep_entry not in relevant:
+                    relevant.add(dep_entry)
+                    pending.append(dep_entry)
+
+    return relevant
+
+
 def _workspace_root(dir: Path) -> Path:
     """Return the npm workspace root for *dir*.
 
@@ -1361,7 +1439,7 @@ def _tui_need_npm_install(root: Path) -> bool:
     already match, which used to trigger a spurious "Installing TUI
     dependencies" on every launch.
 
-    For each entry in the root lock's ``packages`` map:
+    For each TUI-relevant entry in the root lock's ``packages`` map:
       - missing from hidden lock → reinstall (unless the entry is marked
         ``optional`` or ``peer``, which npm may intentionally skip per platform)
       - present but with differing fields (excluding npm-written runtime
@@ -1402,11 +1480,15 @@ def _tui_need_npm_install(root: Path) -> bool:
     def comparable(pkg: dict) -> dict:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
 
+    relevant = _tui_relevant_lock_entries(wanted, root, ws_root)
     for name, pkg in wanted.items():
         if not name:
             continue
 
         if not isinstance(pkg, dict):
+            continue
+
+        if name not in relevant:
             continue
 
         if name not in installed:

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -111,15 +111,24 @@ def test_workspace_tui_install_ignores_uninstalled_unrelated_workspaces(
             "apps/bootstrap-installer": {
               "name": "@hermes/bootstrap-installer",
               "version": "0.0.1",
-              "dependencies": {"@tauri-apps/api": "^2.0.0"}
+              "dependencies": {"@tauri-apps/api": "^2.0.0"},
+              "devDependencies": {"typescript": "^6.0.0"}
             },
             "node_modules/@tauri-apps/api": {"version": "2.0.0"},
+            "apps/bootstrap-installer/node_modules/typescript": {"version": "6.0.3"},
             "ui-tui": {
               "name": "hermes-tui",
               "version": "0.0.1",
-              "dependencies": {"foo": "1.0.0"}
+              "dependencies": {"foo": "1.0.0"},
+              "devDependencies": {"typescript": "^6.0.0"}
             },
-            "node_modules/foo": {"version": "1.0.0"}
+            "node_modules/foo": {
+              "version": "1.0.0",
+              "dependencies": {"nanoid": "^3.0.0"}
+            },
+            "node_modules/nanoid": {"version": "5.1.11"},
+            "node_modules/foo/node_modules/nanoid": {"version": "3.3.12"},
+            "node_modules/typescript": {"version": "6.0.3"}
           }
         }"""
     )
@@ -129,9 +138,15 @@ def test_workspace_tui_install_ignores_uninstalled_unrelated_workspaces(
             "ui-tui": {
               "name": "hermes-tui",
               "version": "0.0.1",
-              "dependencies": {"foo": "1.0.0"}
+              "dependencies": {"foo": "1.0.0"},
+              "devDependencies": {"typescript": "^6.0.0"}
             },
-            "node_modules/foo": {"version": "1.0.0"}
+            "node_modules/foo": {
+              "version": "1.0.0",
+              "dependencies": {"nanoid": "^3.0.0"}
+            },
+            "node_modules/foo/node_modules/nanoid": {"version": "3.3.12"},
+            "node_modules/typescript": {"version": "6.0.3"}
           }
         }"""
     )
@@ -298,12 +313,84 @@ def test_make_tui_argv_scopes_npm_install_on_termux_workspace(
     assert install_cmd[:7] == [
         "/bin/npm",
         "install",
+        "--prefix",
+        str(tmp_path),
         "--workspace",
         "ui-tui",
         "--workspace",
+    ]
+    assert install_cmd[7:11] == [
         "ui-tui/packages/hermes-ink",
         "--include-workspace-root=false",
+        "--silent",
+        "--no-fund",
     ]
+    assert calls[0][1]["cwd"] == str(tmp_path)
+
+
+def test_make_tui_argv_passes_prefix_for_desktop_workspace_install(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    install_cmd = calls[0][0][0]
+    assert install_cmd[:5] == [
+        "/bin/npm",
+        "install",
+        "--prefix",
+        str(tmp_path),
+        "--workspace",
+    ]
+    assert calls[0][1]["cwd"] == str(tmp_path)
+
+
+def test_make_tui_argv_scopes_npm_install_on_termux_workspace_args(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    ink_dir = tui_dir / "packages" / "hermes-ink"
+    ink_dir.mkdir(parents=True)
+    (ink_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    install_cmd = calls[0][0][0]
+    assert "--workspace" in install_cmd
+    assert "ui-tui" in install_cmd
+    assert "ui-tui/packages/hermes-ink" in install_cmd
+    assert "--include-workspace-root=false" in install_cmd
     assert calls[0][1]["cwd"] == str(tmp_path)
 
 
@@ -332,6 +419,8 @@ def test_make_tui_argv_keeps_desktop_workspace_install_behaviour(
     assert calls[0][0][0] == [
         "/bin/npm",
         "install",
+        "--prefix",
+        str(tmp_path),
         "--workspace",
         "ui-tui",
         "--silent",
@@ -362,7 +451,7 @@ def test_make_tui_argv_keeps_desktop_always_build_behaviour(
     main_mod._make_tui_argv(tmp_path, tui_dev=False)
 
     assert calls
-    assert calls[0][0][0] == ["/bin/npm", "run", "build"]
+    assert calls[0][0][0] == ["/bin/npm", "--prefix", str(tmp_path), "run", "build"]
 
 
 # ── _workspace_root helper ──────────────────────────────────────────

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -97,6 +97,83 @@ def test_install_when_version_differs_even_with_peer_drop(tmp_path: Path, main_m
     assert main_mod._tui_need_npm_install(tmp_path) is True
 
 
+def test_workspace_tui_install_ignores_uninstalled_unrelated_workspaces(
+    tmp_path: Path, main_mod
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        """{
+          "packages": {
+            "": {"workspaces": ["apps/*", "ui-tui"]},
+            "apps/bootstrap-installer": {
+              "name": "@hermes/bootstrap-installer",
+              "version": "0.0.1",
+              "dependencies": {"@tauri-apps/api": "^2.0.0"}
+            },
+            "node_modules/@tauri-apps/api": {"version": "2.0.0"},
+            "ui-tui": {
+              "name": "hermes-tui",
+              "version": "0.0.1",
+              "dependencies": {"foo": "1.0.0"}
+            },
+            "node_modules/foo": {"version": "1.0.0"}
+          }
+        }"""
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        """{
+          "packages": {
+            "ui-tui": {
+              "name": "hermes-tui",
+              "version": "0.0.1",
+              "dependencies": {"foo": "1.0.0"}
+            },
+            "node_modules/foo": {"version": "1.0.0"}
+          }
+        }"""
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_workspace_tui_install_detects_missing_tui_dependency(
+    tmp_path: Path, main_mod
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        """{
+          "packages": {
+            "": {"workspaces": ["apps/*", "ui-tui"]},
+            "ui-tui": {
+              "name": "hermes-tui",
+              "version": "0.0.1",
+              "dependencies": {"foo": "1.0.0"}
+            },
+            "node_modules/foo": {"version": "1.0.0"}
+          }
+        }"""
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        """{
+          "packages": {
+            "ui-tui": {
+              "name": "hermes-tui",
+              "version": "0.0.1",
+              "dependencies": {"foo": "1.0.0"}
+            }
+          }
+        }"""
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
 def test_no_install_when_lock_older_than_marker(tmp_path: Path, main_mod) -> None:
     _touch_ink(tmp_path)
     (tmp_path / "package-lock.json").write_text("{}")

--- a/ui-tui/src/__tests__/tailDock.test.ts
+++ b/ui-tui/src/__tests__/tailDock.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { transcriptTailSlots } from '../domain/tailDock.js'
+
+describe('transcriptTailSlots', () => {
+  it('keeps queued input above todos and the live assistant summary below todos', () => {
+    expect(transcriptTailSlots({ assistant: true, queue: true, todos: true })).toEqual([
+      'queue',
+      'todos',
+      'assistant'
+    ])
+  })
+
+  it('leaves todos at the bottom when there is no live assistant summary', () => {
+    expect(transcriptTailSlots({ assistant: false, queue: true, todos: true })).toEqual(['queue', 'todos'])
+  })
+
+  it('keeps the assistant summary at the bottom when it is the only tail item', () => {
+    expect(transcriptTailSlots({ assistant: true, queue: false, todos: false })).toEqual(['assistant'])
+  })
+})

--- a/ui-tui/src/__tests__/tailDock.test.ts
+++ b/ui-tui/src/__tests__/tailDock.test.ts
@@ -3,19 +3,19 @@ import { describe, expect, it } from 'vitest'
 import { transcriptTailSlots } from '../domain/tailDock.js'
 
 describe('transcriptTailSlots', () => {
-  it('keeps queued input above todos and the live assistant summary below todos', () => {
-    expect(transcriptTailSlots({ assistant: true, queue: true, todos: true })).toEqual([
+  it('keeps queued input above todos and the assistant summary below todos', () => {
+    expect(transcriptTailSlots({ queue: true, todos: true })).toEqual([
       'queue',
       'todos',
       'assistant'
     ])
   })
 
-  it('leaves todos at the bottom when there is no live assistant summary', () => {
-    expect(transcriptTailSlots({ assistant: false, queue: true, todos: true })).toEqual(['queue', 'todos'])
+  it('keeps todos above the always-mounted assistant area', () => {
+    expect(transcriptTailSlots({ queue: false, todos: true })).toEqual(['todos', 'assistant'])
   })
 
   it('keeps the assistant summary at the bottom when it is the only tail item', () => {
-    expect(transcriptTailSlots({ assistant: true, queue: false, todos: false })).toEqual(['assistant'])
+    expect(transcriptTailSlots({ queue: false, todos: false })).toEqual(['assistant'])
   })
 })

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -23,6 +23,7 @@ const DOUBLE_ENTER_MS = 450
 const SESSION_BUSY_RE = /session busy|waiting for model response/i
 
 const isSessionBusyError = (e: unknown) => e instanceof Error && SESSION_BUSY_RE.test(e.message)
+const quotedPreview = (text: string) => `"${text.slice(0, 50)}${text.length > 50 ? '…' : ''}"`
 
 const expandSnips = (snips: PasteSnippet[]) => {
   const byLabel = new Map<string, string[]>()
@@ -112,7 +113,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
             composerActions.enqueue(submitText)
             patchUiState({ busy: true, status: 'queued for next turn' })
 
-            return sys(`queued: "${submitText.slice(0, 50)}${submitText.length > 50 ? '…' : ''}"`)
+            return sys(`queued: ${quotedPreview(submitText)}`)
           }
 
           sys(`error: ${e.message}`)
@@ -256,7 +257,11 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
             if (r?.status !== 'queued') {
               fallback('steer rejected — message queued for next turn')
+
+              return
             }
+
+            sys(`steer queued — arrives after next tool call: ${quotedPreview(full)}`)
           })
           .catch(() => fallback('steer failed — message queued for next turn'))
 

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -21,9 +21,10 @@ import { getUiState, patchUiState } from './uiStore.js'
 
 const DOUBLE_ENTER_MS = 450
 const SESSION_BUSY_RE = /session busy|waiting for model response/i
+const QUEUED_PREVIEW_CHARS = 50
 
 const isSessionBusyError = (e: unknown) => e instanceof Error && SESSION_BUSY_RE.test(e.message)
-const quotedPreview = (text: string) => `"${text.slice(0, 50)}${text.length > 50 ? '…' : ''}"`
+const quotedPreview = (text: string) => `"${text.slice(0, QUEUED_PREVIEW_CHARS)}${text.length > QUEUED_PREVIEW_CHARS ? '…' : ''}"`
 
 const expandSnips = (snips: PasteSnippet[]) => {
   const byLabel = new Map<string, string[]>()

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -5,10 +5,12 @@ import { Fragment, memo, useMemo, useRef } from 'react'
 import { useGateway } from '../app/gatewayContext.js'
 import type { AppLayoutProps } from '../app/interfaces.js'
 import { $isBlocked, $overlayState, patchOverlayState } from '../app/overlayStore.js'
+import { useTurnSelector } from '../app/turnStore.js'
 import { $uiState } from '../app/uiStore.js'
 import { INLINE_MODE, SHOW_FPS, TERMUX_TUI_MODE } from '../config/env.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import { prevRenderedMsg } from '../domain/blockLayout.js'
+import { transcriptTailSlots } from '../domain/tailDock.js'
 import {
   COMPOSER_PROMPT_GAP_WIDTH,
   composerPromptWidth,
@@ -61,21 +63,13 @@ const TranscriptPane = memo(function TranscriptPane({
   transcript
 }: Pick<AppLayoutProps, 'actions' | 'composer' | 'progress' | 'transcript'>) {
   const ui = useStore($uiState)
-
-  // LiveTodoPanel rides as a child of the latest user-message row so it
-  // visually belongs to the prompt and follows it during scroll. -1 when
-  // empty → row.index === -1 is always false → no render.
-  const lastUserIdx = useMemo(() => {
-    const items = transcript.historyItems
-
-    for (let i = items.length - 1; i >= 0; i--) {
-      if (items[i].role === 'user') {
-        return i
-      }
-    }
-
-    return -1
-  }, [transcript.historyItems])
+  const liveTodoCount = useTurnSelector(state => state.todos.length)
+  const tailSlots = transcriptTailSlots({
+    assistant: progress.showProgressArea,
+    queue: composer.queuedDisplay.length > 0,
+    todos: liveTodoCount > 0
+  })
+  const showTailDock = tailSlots.length > 0
 
   // Index of the first user-role message; every later user message gets a
   // small dash above it so multi-turn transcripts visually segment by
@@ -100,7 +94,7 @@ const TranscriptPane = memo(function TranscriptPane({
         ref={transcript.scrollRef}
         stickyScroll
       >
-        <Box flexDirection="column" paddingX={1}>
+        <Box flexDirection="column" flexGrow={1} paddingX={1}>
           {transcript.virtualHistory.topSpacer > 0 ? <Box height={transcript.virtualHistory.topSpacer} /> : null}
 
           {transcript.virtualRows.slice(transcript.virtualHistory.start, transcript.virtualHistory.end).map(row => (
@@ -135,22 +129,37 @@ const TranscriptPane = memo(function TranscriptPane({
                   t={ui.theme}
                 />
               )}
-
-              {row.index === lastUserIdx && <LiveTodoPanel />}
             </Box>
           ))}
 
           {transcript.virtualHistory.bottomSpacer > 0 ? <Box height={transcript.virtualHistory.bottomSpacer} /> : null}
 
-          <StreamingAssistant
-            cols={composer.cols}
-            compact={ui.compact}
-            detailsMode={ui.detailsMode}
-            detailsModeCommandOverride={ui.detailsModeCommandOverride}
-            prevMsg={transcript.historyItems[transcript.historyItems.length - 1]}
-            progress={progress}
-            sections={ui.sections}
-          />
+          {showTailDock ? <Box flexGrow={1} /> : null}
+
+          {tailSlots.map(slot =>
+            slot === 'queue' ? (
+              <QueuedMessages
+                cols={composer.cols}
+                key="queue"
+                queued={composer.queuedDisplay}
+                queueEditIdx={composer.queueEditIdx}
+                t={ui.theme}
+              />
+            ) : slot === 'todos' ? (
+              <LiveTodoPanel key="todos" />
+            ) : (
+              <StreamingAssistant
+                cols={composer.cols}
+                compact={ui.compact}
+                detailsMode={ui.detailsMode}
+                detailsModeCommandOverride={ui.detailsModeCommandOverride}
+                key="assistant"
+                prevMsg={transcript.historyItems[transcript.historyItems.length - 1]}
+                progress={progress}
+                sections={ui.sections}
+              />
+            )
+          )}
         </Box>
       </ScrollBox>
 
@@ -229,13 +238,6 @@ const ComposerPane = memo(function ComposerPane({
       }}
       paddingX={1}
     >
-      <QueuedMessages
-        cols={composer.cols}
-        queued={composer.queuedDisplay}
-        queueEditIdx={composer.queueEditIdx}
-        t={ui.theme}
-      />
-
       {ui.bgTasks.size > 0 && (
         <Text color={ui.theme.color.muted}>
           {ui.bgTasks.size} background {ui.bgTasks.size === 1 ? 'task' : 'tasks'} running

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -10,7 +10,7 @@ import { $uiState } from '../app/uiStore.js'
 import { INLINE_MODE, SHOW_FPS, TERMUX_TUI_MODE } from '../config/env.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import { prevRenderedMsg } from '../domain/blockLayout.js'
-import { transcriptTailSlots } from '../domain/tailDock.js'
+import { type TranscriptTailSlot, transcriptTailSlots } from '../domain/tailDock.js'
 import {
   COMPOSER_PROMPT_GAP_WIDTH,
   composerPromptWidth,
@@ -65,11 +65,43 @@ const TranscriptPane = memo(function TranscriptPane({
   const ui = useStore($uiState)
   const liveTodoCount = useTurnSelector(state => state.todos.length)
   const tailSlots = transcriptTailSlots({
-    assistant: progress.showProgressArea,
     queue: composer.queuedDisplay.length > 0,
     todos: liveTodoCount > 0
   })
-  const showTailDock = tailSlots.length > 0
+
+  const renderTailSlot = (slot: TranscriptTailSlot) => {
+    switch (slot) {
+      case 'queue':
+        return (
+          <QueuedMessages
+            cols={composer.cols}
+            key="queue"
+            queued={composer.queuedDisplay}
+            queueEditIdx={composer.queueEditIdx}
+            t={ui.theme}
+          />
+        )
+      case 'todos':
+        return <LiveTodoPanel key="todos" />
+      case 'assistant':
+        return (
+          <StreamingAssistant
+            cols={composer.cols}
+            compact={ui.compact}
+            detailsMode={ui.detailsMode}
+            detailsModeCommandOverride={ui.detailsModeCommandOverride}
+            key="assistant"
+            prevMsg={transcript.historyItems[transcript.historyItems.length - 1]}
+            progress={progress}
+            sections={ui.sections}
+          />
+        )
+      default: {
+        const exhaustive: never = slot
+        return exhaustive
+      }
+    }
+  }
 
   // Index of the first user-role message; every later user message gets a
   // small dash above it so multi-turn transcripts visually segment by
@@ -134,32 +166,9 @@ const TranscriptPane = memo(function TranscriptPane({
 
           {transcript.virtualHistory.bottomSpacer > 0 ? <Box height={transcript.virtualHistory.bottomSpacer} /> : null}
 
-          {showTailDock ? <Box flexGrow={1} /> : null}
+          <Box flexGrow={1} />
 
-          {tailSlots.map(slot =>
-            slot === 'queue' ? (
-              <QueuedMessages
-                cols={composer.cols}
-                key="queue"
-                queued={composer.queuedDisplay}
-                queueEditIdx={composer.queueEditIdx}
-                t={ui.theme}
-              />
-            ) : slot === 'todos' ? (
-              <LiveTodoPanel key="todos" />
-            ) : (
-              <StreamingAssistant
-                cols={composer.cols}
-                compact={ui.compact}
-                detailsMode={ui.detailsMode}
-                detailsModeCommandOverride={ui.detailsModeCommandOverride}
-                key="assistant"
-                prevMsg={transcript.historyItems[transcript.historyItems.length - 1]}
-                progress={progress}
-                sections={ui.sections}
-              />
-            )
-          )}
+          {tailSlots.map(renderTailSlot)}
         </Box>
       </ScrollBox>
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -64,6 +64,7 @@ const TranscriptPane = memo(function TranscriptPane({
 }: Pick<AppLayoutProps, 'actions' | 'composer' | 'progress' | 'transcript'>) {
   const ui = useStore($uiState)
   const liveTodoCount = useTurnSelector(state => state.todos.length)
+
   const tailSlots = transcriptTailSlots({
     queue: composer.queuedDisplay.length > 0,
     todos: liveTodoCount > 0
@@ -81,8 +82,10 @@ const TranscriptPane = memo(function TranscriptPane({
             t={ui.theme}
           />
         )
+
       case 'todos':
         return <LiveTodoPanel key="todos" />
+
       case 'assistant':
         return (
           <StreamingAssistant
@@ -98,6 +101,7 @@ const TranscriptPane = memo(function TranscriptPane({
         )
       default: {
         const exhaustive: never = slot
+
         return exhaustive
       }
     }

--- a/ui-tui/src/domain/tailDock.ts
+++ b/ui-tui/src/domain/tailDock.ts
@@ -1,0 +1,25 @@
+export type TranscriptTailSlot = 'assistant' | 'queue' | 'todos'
+
+export interface TranscriptTailState {
+  assistant: boolean
+  queue: boolean
+  todos: boolean
+}
+
+export const transcriptTailSlots = ({ assistant, queue, todos }: TranscriptTailState): TranscriptTailSlot[] => {
+  const slots: TranscriptTailSlot[] = []
+
+  if (queue) {
+    slots.push('queue')
+  }
+
+  if (todos) {
+    slots.push('todos')
+  }
+
+  if (assistant) {
+    slots.push('assistant')
+  }
+
+  return slots
+}

--- a/ui-tui/src/domain/tailDock.ts
+++ b/ui-tui/src/domain/tailDock.ts
@@ -1,12 +1,11 @@
 export type TranscriptTailSlot = 'assistant' | 'queue' | 'todos'
 
 export interface TranscriptTailState {
-  assistant: boolean
   queue: boolean
   todos: boolean
 }
 
-export const transcriptTailSlots = ({ assistant, queue, todos }: TranscriptTailState): TranscriptTailSlot[] => {
+export const transcriptTailSlots = ({ queue, todos }: TranscriptTailState): TranscriptTailSlot[] => {
   const slots: TranscriptTailSlot[] = []
 
   if (queue) {
@@ -17,9 +16,7 @@ export const transcriptTailSlots = ({ assistant, queue, todos }: TranscriptTailS
     slots.push('todos')
   }
 
-  if (assistant) {
-    slots.push('assistant')
-  }
+  slots.push('assistant')
 
   return slots
 }


### PR DESCRIPTION
## Scope

- Keep queued/control input in the transcript tail above the todo panel.
- Keep the live todo panel above the assistant tail.
- Keep the assistant/final-summary area mounted as the last tail slot so it stays at the bottom.
- Keep queued input visible until it is read, then let the real submitted message enter normal transcript history.
- Add transcript feedback for successful steer-mode enqueue, matching the explicit `/steer` command path.
- Replace the tail-slot nested ternary with an explicit render helper and exhaustive slot handling.
- Scope TUI dependency freshness checks and npm launch commands to the TUI workspace so unrelated workspaces do not force reinstall and Windows npm shims do not look for `C:\Users\Jaime\package.json`.

## Validation

- `C:\Users\Jaime\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe -m pytest tests/hermes_cli/test_tui_npm_install.py`
- `npm --prefix ui-tui run typecheck`
- `npm exec eslint -- src/app/useSubmission.ts src/components/appLayout.tsx src/domain/tailDock.ts src/__tests__/tailDock.test.ts` from `ui-tui`
- `npm --prefix ui-tui test -- tailDock`
- `npm --prefix ui-tui run build`

## Runtime Smoke

- Live Hermes install is on upstream `07ac18590` plus this branch.
- `npm install --prefix C:\Users\Jaime\AppData\Local\hermes\hermes-agent --workspaces=false` completed.
- `npm install --prefix C:\Users\Jaime\AppData\Local\hermes\hermes-agent --workspace ui-tui --workspace web` completed.
- `npm --prefix C:\Users\Jaime\AppData\Local\hermes\hermes-agent run build --workspace web` completed.
- `npm --prefix C:\Users\Jaime\AppData\Local\hermes\hermes-agent\ui-tui run build` completed.
- `npm install --prefix C:\Users\Jaime\AppData\Local\hermes\hermes-agent --workspace apps/desktop` completed.
- `npm --prefix C:\Users\Jaime\AppData\Local\hermes\hermes-agent run build --workspace apps/desktop` completed.
- TUI launcher smoke returns `need_install False`, cwd `ui-tui`, and entry `ui-tui/dist/entry.js`.

## Notes

Full `npm --prefix ui-tui run lint` still reports existing repo-wide lint errors outside this branch. The touched files lint clean.
