### PR TITLE
fix(tui_gateway): cap inline image data URLs in history payloads

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -828,6 +828,42 @@ def test_history_to_messages_renders_multimodal_content():
     ]
 
 
+def test_history_to_messages_caps_oversized_inline_image_urls():
+    # Multi-megabyte data: URLs used to be inlined verbatim, bloating every
+    # resume/history payload and crashing older desktop renderers (V8 regexp
+    # stack overflow while extracting them — see the renderer-side fix in
+    # apps/desktop/src/lib/embedded-images.ts). Oversized URLs degrade to the
+    # existing "[image]" placeholder; small ones stay inline so the desktop
+    # keeps rendering thumbnails.
+    giant = "data:image/png;base64," + "A" * 1_000_001
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look here"},
+                {"type": "image_url", "image_url": {"url": giant}},
+            ],
+        },
+    ]
+
+    assert server._history_to_messages(history) == [
+        {"role": "user", "text": "look here\n[image]"},
+    ]
+
+
+def test_coerce_message_text_caps_oversized_dict_image_url():
+    giant = "data:image/png;base64," + "A" * 1_000_001
+
+    assert server._coerce_message_text({"type": "image_url", "image_url": giant}) == "[image]"
+
+
+def test_coerce_message_text_inlines_image_url_at_cap_boundary():
+    prefix = "data:image/png;base64,"
+    at_cap = prefix + "A" * (1_000_000 - len(prefix))
+
+    assert server._coerce_message_text({"type": "image_url", "image_url": {"url": at_cap}}) == at_cap
+
+
 def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
     captured = {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3153,6 +3153,21 @@ def _content_display_text(content: Any) -> str:
     return str(content)
 
 
+# Inline image URLs longer than this degrade to the "[image]" placeholder.
+# Uncapped data: URLs (a native-size screenshot is easily >10M chars of
+# base64) bloat every resume/history payload shipped over the gateway and
+# have crashed desktop renderers that extract them with a regex (V8 regexp
+# stack overflow at roughly 5.6M chars). 1M chars ≈ a 750KB image keeps
+# typical pasted screenshots inline with a wide safety margin.
+_INLINE_IMAGE_URL_MAX_CHARS = 1_000_000
+
+
+def _inline_image_url_or_placeholder(url: str) -> str:
+    if url and len(url) <= _INLINE_IMAGE_URL_MAX_CHARS:
+        return url
+    return "[image]"
+
+
 def _coerce_message_text(content: Any) -> str:
     """Render ``message['content']`` as a plain string for transport.
 
@@ -3168,6 +3183,8 @@ def _coerce_message_text(content: Any) -> str:
     instead of the URL — and it stops the resume payload from disagreeing
     with the cached message (which would otherwise cause the inline image
     to flash, then disappear when the resume payload overwrites the cache).
+    URLs longer than ``_INLINE_IMAGE_URL_MAX_CHARS`` degrade to the
+    ``[image]`` placeholder instead of being inlined.
 
     Other structured dict shapes (audio, unknown types) fall back to a
     bracketed placeholder so resume doesn't drop the message entirely.
@@ -3205,10 +3222,7 @@ def _coerce_message_text(content: Any) -> str:
                         url = candidate
                 elif isinstance(image_url, str):
                     url = image_url
-                if url:
-                    chunks.append(f"\n{url}")
-                else:
-                    chunks.append("\n[image]")
+                chunks.append(f"\n{_inline_image_url_or_placeholder(url)}")
                 continue
             if kind in {"input_audio", "audio"}:
                 chunks.append("\n[audio]")
@@ -3229,7 +3243,7 @@ def _coerce_message_text(content: Any) -> str:
                     url = candidate
             elif isinstance(image_url, str):
                 url = image_url
-            return url or "[image]"
+            return _inline_image_url_or_placeholder(url)
         if kind in {"input_audio", "audio"}:
             return "[audio]"
         if kind:


### PR DESCRIPTION
## Problem

`_coerce_message_text()` inlines image part URLs verbatim into the flattened text that `_history_to_messages()` ships in `session.create` / `session.resume` / `session.activate` / `session.history` responses. There is no size cap anywhere on this path (`_file_to_data_url` deliberately encodes at native size), so a full-resolution screenshot becomes a single >10M-char base64 line inside **every** one of those payloads:

- Desktop renderers that pull the URLs back out with a regex crashed on them — V8's regexp stack overflows at roughly 5.6M chars, throwing `RangeError: Maximum call stack size exceeded` and crash-looping the app on boot. The renderer side is fixed in #43606; this is the producer-side defense-in-depth, protecting clients that haven't updated.
- The Ink TUI has no extractor and prints the raw base64 outright.
- Session exports and resume payloads carry the full blobs even when nothing renders them.

## Fix

Inline only URLs up to `_INLINE_IMAGE_URL_MAX_CHARS = 1_000_000` (~750KB decoded — typical pasted screenshots keep rendering as thumbnails) and degrade anything larger to the existing `[image]` placeholder, the same convention `_content_display_text` already uses for the in-flight turn echo and `_coerce_message_text` itself uses when an image part has no URL. One constant, one helper, both call sites (list-shaped and dict-shaped content).

Known trade-off, called out deliberately: for an oversized image the resume payload now intentionally disagrees with the optimistic cached message, so after a resume that message shows the `[image]` placeholder instead of a thumbnail. Those messages previously shipped multi-MB strings and crashed un-patched renderers; if thumbnail persistence matters there, a follow-up could teach the desktop's `reconcileResumeMessages` to treat the placeholder as compatible, or emit an `@image:<path>` reference for files under the media-relay roots.

## Testing

- TDD: the two new cap tests fail against the previous implementation (giant URL inlined verbatim) and pass now; a boundary test pins that URLs at exactly the cap still inline, and the existing `test_history_to_messages_renders_multimodal_content` (small-URL inlining contract) passes unchanged.
- `pytest tests/test_tui_gateway_server.py`: 255 passed; the single failure (`test_browser_manage_connect_default_local_reports_launch_hint`) is pre-existing and environmental (locally installed browser plugins change the launch-hint text) — it fails identically on an unmodified checkout.
- `ruff check` clean on both files; `scripts/check-windows-footguns.py` clean.

## Side observation (not touched here)

`_content_display_text` is defined twice with identical bodies (~lines 3126 and 3316); the second shadows the first at import time. Behavior-neutral today, but worth a cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
