### PR TITLE
feat(mcp): add authenticated Streamable HTTP serving

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -1092,6 +1092,7 @@ def mcp_command(args):
                 oauth_client_secret_env=getattr(args, "oauth_client_secret_env", None),
                 token_ttl_seconds=getattr(args, "oauth_token_ttl_seconds", 2592000),
                 code_ttl_seconds=getattr(args, "oauth_code_ttl_seconds", 300),
+                oauth_redirect_uris=getattr(args, "oauth_redirect_uri", []) or [],
                 allowed_hosts=getattr(args, "allowed_host", []) or [],
                 allowed_origins=getattr(args, "allowed_origin", []) or [],
                 expose_toolsets=getattr(args, "expose_toolset", []) or [],

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -1075,8 +1075,37 @@ def mcp_command(args):
     action = getattr(args, "mcp_action", None)
 
     if action == "serve":
-        from mcp_serve import run_mcp_server
-        run_mcp_server(verbose=getattr(args, "verbose", False))
+        from mcp_serve import run_mcp_http_server, run_mcp_server
+        transport = getattr(args, "transport", "stdio") or "stdio"
+        if transport == "streamable-http":
+            run_mcp_http_server(
+                verbose=getattr(args, "verbose", False),
+                host=getattr(args, "host", "127.0.0.1"),
+                port=getattr(args, "port", 8666),
+                path=getattr(args, "path", "/mcp"),
+                public_base_url=getattr(args, "public_base_url", None),
+                auth_token_env=getattr(args, "auth_token_env", None),
+                auth_header=getattr(args, "auth_header", "X-Hermes-MCP-PSK"),
+                allow_query_token=getattr(args, "allow_query_token", False),
+                oauth_compatible=getattr(args, "oauth_compatible", False),
+                oauth_client_id_env=getattr(args, "oauth_client_id_env", None),
+                oauth_client_secret_env=getattr(args, "oauth_client_secret_env", None),
+                token_ttl_seconds=getattr(args, "oauth_token_ttl_seconds", 2592000),
+                code_ttl_seconds=getattr(args, "oauth_code_ttl_seconds", 300),
+                allowed_hosts=getattr(args, "allowed_host", []) or [],
+                allowed_origins=getattr(args, "allowed_origin", []) or [],
+                expose_toolsets=getattr(args, "expose_toolset", []) or [],
+                expose_tools=getattr(args, "expose_tool", []) or [],
+                expose_plugin_tools=getattr(args, "expose_plugin_tools", False),
+                health_path=getattr(args, "health_path", "/health"),
+            )
+        else:
+            run_mcp_server(
+                verbose=getattr(args, "verbose", False),
+                expose_toolsets=getattr(args, "expose_toolset", []) or [],
+                expose_tools=getattr(args, "expose_tool", []) or [],
+                expose_plugin_tools=getattr(args, "expose_plugin_tools", False),
+            )
         return
 
     # Catalog subcommands live in mcp_picker / mcp_catalog. Import lazily so

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -1087,6 +1087,7 @@ def mcp_command(args):
                 auth_token_env=getattr(args, "auth_token_env", None),
                 auth_header=getattr(args, "auth_header", "X-Hermes-MCP-PSK"),
                 allow_query_token=getattr(args, "allow_query_token", False),
+                allow_insecure_http=getattr(args, "allow_insecure_http", False),
                 oauth_compatible=getattr(args, "oauth_compatible", False),
                 oauth_client_id_env=getattr(args, "oauth_client_id_env", None),
                 oauth_client_secret_env=getattr(args, "oauth_client_secret_env", None),

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -879,8 +879,39 @@ def mcp_command(args):
     """Main dispatcher for ``hermes mcp`` subcommands."""
     action = getattr(args, "mcp_action", None)
     if action == "serve":
-        from mcp_serve import run_mcp_server
-        run_mcp_server(verbose=getattr(args, "verbose", False))
+        from mcp_serve import run_mcp_http_server, run_mcp_server
+        transport = getattr(args, "transport", "stdio") or "stdio"
+        if transport == "streamable-http":
+            run_mcp_http_server(
+                verbose=getattr(args, "verbose", False),
+                host=getattr(args, "host", "127.0.0.1"),
+                port=getattr(args, "port", 8666),
+                path=getattr(args, "path", "/mcp"),
+                public_base_url=getattr(args, "public_base_url", None),
+                auth_token_env=getattr(args, "auth_token_env", None),
+                auth_header=getattr(args, "auth_header", "X-Hermes-MCP-PSK"),
+                allow_query_token=getattr(args, "allow_query_token", False),
+                allow_insecure_http=getattr(args, "allow_insecure_http", False),
+                oauth_compatible=getattr(args, "oauth_compatible", False),
+                oauth_client_id_env=getattr(args, "oauth_client_id_env", None),
+                oauth_client_secret_env=getattr(args, "oauth_client_secret_env", None),
+                token_ttl_seconds=getattr(args, "oauth_token_ttl_seconds", 3600),
+                code_ttl_seconds=getattr(args, "oauth_code_ttl_seconds", 300),
+                oauth_redirect_uris=getattr(args, "oauth_redirect_uri", []) or [],
+                allowed_hosts=getattr(args, "allowed_host", []) or [],
+                allowed_origins=getattr(args, "allowed_origin", []) or [],
+                expose_toolsets=getattr(args, "expose_toolset", []) or [],
+                expose_tools=getattr(args, "expose_tool", []) or [],
+                expose_plugin_tools=getattr(args, "expose_plugin_tools", False),
+                health_path=getattr(args, "health_path", "/health"),
+            )
+        else:
+            run_mcp_server(
+                verbose=getattr(args, "verbose", False),
+                expose_toolsets=getattr(args, "expose_toolset", []) or [],
+                expose_tools=getattr(args, "expose_tool", []) or [],
+                expose_plugin_tools=getattr(args, "expose_plugin_tools", False),
+            )
         return
     if action in ("picker", "catalog", "install"):
         # Catalog subcommands live in mcp_picker / mcp_catalog; import lazily to keep this module cheap.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2018,6 +2018,10 @@ class PluginManager:
             )
         return result
 
+    def get_registered_tool_names(self) -> Set[str]:
+        """Return a snapshot of tool names registered by enabled plugins."""
+        return set(self._plugin_tool_names)
+
     # -----------------------------------------------------------------------
     # Plugin skill lookups
     # -----------------------------------------------------------------------

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -419,7 +419,7 @@ class PluginContext:
         description: str = "",
         emoji: str = "",
         override: bool = False,
-    ) -> None:
+    ) -> bool:
         """Register a tool in the global registry **and** track it as plugin-provided.
 
         Pass ``override=True`` to replace an existing built-in tool with the
@@ -446,7 +446,7 @@ class PluginContext:
 
         from tools.registry import registry
 
-        registry.register(
+        registered = registry.register(
             name=name,
             toolset=toolset,
             schema=schema,
@@ -458,11 +458,22 @@ class PluginContext:
             emoji=emoji,
             override=override,
         )
+        if not registered:
+            logger.warning(
+                "Plugin %s tool registration was rejected: %s",
+                self.manifest.name,
+                name,
+            )
+            return False
+
         self._manager._plugin_tool_names.add(name)
         logger.debug(
             "Plugin %s registered tool: %s%s",
-            self.manifest.name, name, " (override)" if override else "",
+            self.manifest.name,
+            name,
+            " (override)" if override else "",
         )
+        return True
 
     # -- override trust gate ------------------------------------------------
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1438,6 +1438,10 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
             } for _key, p in sorted(self._plugins.items())
         ]
 
+    def get_registered_tool_names(self) -> Set[str]:
+        """Return a snapshot of tool names registered by enabled plugins."""
+        return set(self._plugin_tool_names)
+
     def find_plugin_skill(self, qualified_name: str) -> Optional[Path]:
         """Return the ``Path`` to a plugin skill's SKILL.md, or ``None``."""
         entry = self._plugin_skills.get(qualified_name)

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -31,6 +31,92 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         help="Run Hermes as an MCP server (expose conversations to other agents)",
     )
     mcp_serve_p.add_argument(
+        "--transport",
+        choices=["stdio", "streamable-http"],
+        default="stdio",
+        help="MCP transport to serve (default: stdio)",
+    )
+    mcp_serve_p.add_argument("--host", default="127.0.0.1", help="HTTP host to bind")
+    mcp_serve_p.add_argument("--port", type=int, default=8666, help="HTTP port to bind")
+    mcp_serve_p.add_argument("--path", default="/mcp", help="HTTP MCP endpoint path")
+    mcp_serve_p.add_argument(
+        "--public-base-url",
+        help="Externally visible base URL for OAuth metadata (for reverse proxies/Tailscale)",
+    )
+    mcp_serve_p.add_argument(
+        "--auth-token-env",
+        help="Environment variable containing the shared MCP HTTP auth token/PSK",
+    )
+    mcp_serve_p.add_argument(
+        "--auth-header",
+        default="X-Hermes-MCP-PSK",
+        help="Additional PSK header name accepted by HTTP auth",
+    )
+    mcp_serve_p.add_argument(
+        "--allow-query-token",
+        action="store_true",
+        help="Accept ?access_token= or ?psk= auth for clients that cannot send headers; disables access logs",
+    )
+    mcp_serve_p.add_argument(
+        "--oauth-compatible",
+        action="store_true",
+        help="Expose OAuth-compatible metadata plus /mcp/authorize and /mcp/token endpoints",
+    )
+    mcp_serve_p.add_argument(
+        "--oauth-client-id-env",
+        help="Environment variable containing the OAuth client id (defaults to auth token when omitted)",
+    )
+    mcp_serve_p.add_argument(
+        "--oauth-client-secret-env",
+        help="Optional environment variable containing the OAuth client secret",
+    )
+    mcp_serve_p.add_argument(
+        "--oauth-token-ttl-seconds",
+        type=int,
+        default=2592000,
+        help="Issued OAuth bearer token lifetime in seconds",
+    )
+    mcp_serve_p.add_argument(
+        "--oauth-code-ttl-seconds",
+        type=int,
+        default=300,
+        help="Authorization code lifetime in seconds",
+    )
+    mcp_serve_p.add_argument(
+        "--allowed-host",
+        action="append",
+        default=[],
+        help="Allowed HTTP Host value for Streamable HTTP transport security; repeat or comma-separate",
+    )
+    mcp_serve_p.add_argument(
+        "--allowed-origin",
+        action="append",
+        default=[],
+        help="Allowed Origin value for Streamable HTTP transport security; repeat or comma-separate",
+    )
+    mcp_serve_p.add_argument(
+        "--health-path",
+        default="/health",
+        help="Health check endpoint path for HTTP transport",
+    )
+    mcp_serve_p.add_argument(
+        "--expose-toolset",
+        action="append",
+        default=[],
+        help="Expose registered Hermes tools from a toolset over this MCP server; repeat or comma-separate",
+    )
+    mcp_serve_p.add_argument(
+        "--expose-tool",
+        action="append",
+        default=[],
+        help="Expose an individual registered Hermes tool over this MCP server; repeat or comma-separate",
+    )
+    mcp_serve_p.add_argument(
+        "--expose-plugin-tools",
+        action="store_true",
+        help="Expose all tools registered by enabled Hermes plugins over this MCP server",
+    )
+    mcp_serve_p.add_argument(
         "-v",
         "--verbose",
         action="store_true",

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -58,23 +58,28 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         help="Accept ?access_token= or ?psk= auth for clients that cannot send headers; disables access logs",
     )
     mcp_serve_p.add_argument(
+        "--allow-insecure-http",
+        action="store_true",
+        help="Explicitly allow cleartext non-loopback serving (still requires auth)",
+    )
+    mcp_serve_p.add_argument(
         "--oauth-compatible",
         action="store_true",
         help="Expose OAuth-compatible metadata plus /mcp/authorize and /mcp/token endpoints",
     )
     mcp_serve_p.add_argument(
         "--oauth-client-id-env",
-        help="Environment variable containing the OAuth client id (defaults to auth token when omitted)",
+        help="Environment variable containing the OAuth client id (default: hermes-mcp)",
     )
     mcp_serve_p.add_argument(
         "--oauth-client-secret-env",
-        help="Optional environment variable containing the OAuth client secret",
+        help="OAuth client-secret environment variable (required with a custom client id; otherwise uses the PSK)",
     )
     mcp_serve_p.add_argument(
         "--oauth-token-ttl-seconds",
         type=int,
-        default=2592000,
-        help="Issued OAuth bearer token lifetime in seconds",
+        default=3600,
+        help="Issued OAuth bearer token lifetime in seconds (default: 3600)",
     )
     mcp_serve_p.add_argument(
         "--oauth-code-ttl-seconds",
@@ -86,7 +91,7 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         "--oauth-redirect-uri",
         action="append",
         default=[],
-        help="Allowed non-loopback HTTPS OAuth redirect URI; repeat or comma-separate",
+        help="Registered HTTP-loopback or HTTPS OAuth redirect URI; repeat or comma-separate",
     )
     mcp_serve_p.add_argument(
         "--allowed-host",

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -83,6 +83,12 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         help="Authorization code lifetime in seconds",
     )
     mcp_serve_p.add_argument(
+        "--oauth-redirect-uri",
+        action="append",
+        default=[],
+        help="Allowed non-loopback HTTPS OAuth redirect URI; repeat or comma-separate",
+    )
+    mcp_serve_p.add_argument(
         "--allowed-host",
         action="append",
         default=[],

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -21,7 +21,108 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_serve_p = mcp_sub.add_parser(
         "serve", help="Run Hermes as an MCP server (expose conversations to other agents)")
     mcp_serve_p.add_argument(
-        "-v", "--verbose", action="store_true", help="Enable verbose logging on stderr")
+        "--transport",
+        choices=["stdio", "streamable-http"],
+        default="stdio",
+        help="MCP transport to serve (default: stdio)",
+    )
+    mcp_serve_p.add_argument("--host", default="127.0.0.1", help="HTTP host to bind")
+    mcp_serve_p.add_argument("--port", type=int, default=8666, help="HTTP port to bind")
+    mcp_serve_p.add_argument("--path", default="/mcp", help="HTTP MCP endpoint path")
+    mcp_serve_p.add_argument(
+        "--public-base-url",
+        help="Externally visible base URL for OAuth metadata (for reverse proxies/Tailscale)",
+    )
+    mcp_serve_p.add_argument(
+        "--auth-token-env",
+        help="Environment variable containing the shared MCP HTTP auth token/PSK",
+    )
+    mcp_serve_p.add_argument(
+        "--auth-header",
+        default="X-Hermes-MCP-PSK",
+        help="Additional PSK header name accepted by HTTP auth",
+    )
+    mcp_serve_p.add_argument(
+        "--allow-query-token",
+        action="store_true",
+        help="Accept ?access_token= or ?psk= auth for clients that cannot send headers; disables access logs",
+    )
+    mcp_serve_p.add_argument(
+        "--allow-insecure-http",
+        action="store_true",
+        help="Explicitly allow cleartext non-loopback serving (still requires auth)",
+    )
+    mcp_serve_p.add_argument(
+        "--oauth-compatible",
+        action="store_true",
+        help="Expose OAuth-compatible metadata plus /mcp/authorize and /mcp/token endpoints",
+    )
+    mcp_serve_p.add_argument(
+        "--oauth-client-id-env",
+        help="Environment variable containing the OAuth client id (default: hermes-mcp)",
+    )
+    mcp_serve_p.add_argument(
+        "--oauth-client-secret-env",
+        help="OAuth client-secret environment variable (required with a custom client id; otherwise uses the PSK)",
+    )
+    mcp_serve_p.add_argument(
+        "--oauth-token-ttl-seconds",
+        type=int,
+        default=3600,
+        help="Issued OAuth bearer token lifetime in seconds (default: 3600)",
+    )
+    mcp_serve_p.add_argument(
+        "--oauth-code-ttl-seconds",
+        type=int,
+        default=300,
+        help="Authorization code lifetime in seconds",
+    )
+    mcp_serve_p.add_argument(
+        "--oauth-redirect-uri",
+        action="append",
+        default=[],
+        help="Registered HTTP-loopback or HTTPS OAuth redirect URI; repeat or comma-separate",
+    )
+    mcp_serve_p.add_argument(
+        "--allowed-host",
+        action="append",
+        default=[],
+        help="Allowed HTTP Host value for Streamable HTTP transport security; repeat or comma-separate",
+    )
+    mcp_serve_p.add_argument(
+        "--allowed-origin",
+        action="append",
+        default=[],
+        help="Allowed Origin value for Streamable HTTP transport security; repeat or comma-separate",
+    )
+    mcp_serve_p.add_argument(
+        "--health-path",
+        default="/health",
+        help="Health check endpoint path for HTTP transport",
+    )
+    mcp_serve_p.add_argument(
+        "--expose-toolset",
+        action="append",
+        default=[],
+        help="Expose registered Hermes tools from a toolset over this MCP server; repeat or comma-separate",
+    )
+    mcp_serve_p.add_argument(
+        "--expose-tool",
+        action="append",
+        default=[],
+        help="Expose an individual registered Hermes tool over this MCP server; repeat or comma-separate",
+    )
+    mcp_serve_p.add_argument(
+        "--expose-plugin-tools",
+        action="store_true",
+        help="Expose all tools registered by enabled Hermes plugins over this MCP server",
+    )
+    mcp_serve_p.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging on stderr",
+    )
     add_accept_hooks_flag(mcp_serve_p)
 
     mcp_add_p = mcp_sub.add_parser("add", help="Add an MCP server (discovery-first install)")

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -29,7 +29,10 @@ MCP client config (e.g. claude_desktop_config.json):
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import inspect
+import ipaddress
 import json
 import logging
 import os
@@ -565,8 +568,19 @@ def _safe_identifier(name: str) -> str:
 
 def _make_registry_tool_wrapper(tool_name: str):
     def _tool(**kwargs):
-        from tools.registry import registry
-        return registry.dispatch(tool_name, dict(kwargs))
+        # Registry tools exposed through MCP must follow the same guarded
+        # execution path as model-issued tool calls. Calling registry.dispatch
+        # directly would bypass request/execution middleware, plugin approval
+        # hooks, ACP edit approval, post-call hooks, and result transforms.
+        from model_tools import handle_function_call
+
+        return handle_function_call(
+            function_name=tool_name,
+            function_args=dict(kwargs),
+            task_id="mcp-serve",
+            tool_call_id=f"mcp-{secrets.token_hex(8)}",
+            session_id="mcp-serve",
+        )
 
     _tool.__name__ = f"_mcp_registry_tool_{_safe_identifier(tool_name)}"
     return _tool
@@ -1130,6 +1144,8 @@ class _AuthorizationCode:
     client_id: str
     redirect_uri: str
     expires_at: float
+    code_challenge: Optional[str] = None
+    code_challenge_method: Optional[str] = None
 
 
 class _OAuthTokenStore:
@@ -1160,7 +1176,15 @@ class _OAuthTokenStore:
                 return False
             return True
 
-    def issue_code(self, client_id: str, redirect_uri: str, ttl_seconds: int) -> str:
+    def issue_code(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        ttl_seconds: int,
+        *,
+        code_challenge: Optional[str] = None,
+        code_challenge_method: Optional[str] = None,
+    ) -> str:
         code = secrets.token_urlsafe(24)
         with self._lock:
             self._codes[code] = _AuthorizationCode(
@@ -1168,17 +1192,35 @@ class _OAuthTokenStore:
                 client_id=client_id,
                 redirect_uri=redirect_uri,
                 expires_at=time.time() + ttl_seconds,
+                code_challenge=code_challenge,
+                code_challenge_method=code_challenge_method,
             )
         return code
 
-    def consume_code(self, code: str, client_id: str) -> bool:
+    def consume_code(
+        self,
+        code: str,
+        client_id: str,
+        redirect_uri: str,
+        code_verifier: Optional[str] = None,
+    ) -> bool:
         with self._lock:
-            issued = self._codes.pop(code, None)
+            issued = self._codes.get(code)
             if not issued:
                 return False
-            if issued.client_id != client_id:
+            if issued.expires_at < time.time():
+                self._codes.pop(code, None)
                 return False
-            return issued.expires_at >= time.time()
+            if not secrets.compare_digest(issued.client_id, client_id):
+                return False
+            if not secrets.compare_digest(issued.redirect_uri, redirect_uri):
+                return False
+            if issued.code_challenge:
+                derived = _pkce_challenge(code_verifier, issued.code_challenge_method)
+                if not derived or not secrets.compare_digest(issued.code_challenge, derived):
+                    return False
+            self._codes.pop(code, None)
+            return True
 
 
 def _normalize_path(path: str) -> str:
@@ -1222,6 +1264,32 @@ def _constant_time_equals(left: Optional[str], right: Optional[str]) -> bool:
     if not left or not right:
         return False
     return secrets.compare_digest(str(left), str(right))
+
+
+def _pkce_challenge(verifier: Optional[str], method: Optional[str]) -> Optional[str]:
+    """Return the RFC 7636 challenge for a verifier and supported method."""
+    if not verifier:
+        return None
+    if method in (None, "plain"):
+        return verifier
+    if method == "S256":
+        try:
+            digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        except UnicodeEncodeError:
+            return None
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return None
+
+
+def _is_loopback_host(host: str) -> bool:
+    """Return whether *host* binds only to the local machine."""
+    value = (host or "").strip().strip("[]")
+    if value.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return False
 
 
 def _client_secret_valid(config: McpHttpAuthConfig, supplied: Optional[str]) -> bool:
@@ -1296,6 +1364,12 @@ def create_streamable_http_app(
     if not hasattr(server, "streamable_http_app"):
         raise RuntimeError("Installed MCP SDK does not support Streamable HTTP")
 
+    bind_host = str(getattr(getattr(server, "settings", None), "host", "127.0.0.1"))
+    if auth_config is None and not _is_loopback_host(bind_host):
+        raise ValueError(
+            "Unauthenticated MCP HTTP serving is restricted to loopback hosts"
+        )
+
     from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import JSONResponse, PlainTextResponse, RedirectResponse
 
@@ -1336,6 +1410,8 @@ def create_streamable_http_app(
             redirect_uri = params.get("redirect_uri")
             response_type = params.get("response_type")
             state = params.get("state")
+            code_challenge = params.get("code_challenge")
+            code_challenge_method = params.get("code_challenge_method")
 
             if response_type != "code":
                 return JSONResponse({"error": "unsupported_response_type"}, status_code=400)
@@ -1343,8 +1419,32 @@ def create_streamable_http_app(
                 return JSONResponse({"error": "invalid_client"}, status_code=401)
             if not redirect_uri:
                 return JSONResponse({"error": "invalid_request", "error_description": "redirect_uri is required"}, status_code=400)
+            if code_challenge:
+                code_challenge_method = code_challenge_method or "plain"
+                if code_challenge_method not in {"plain", "S256"}:
+                    return JSONResponse(
+                        {
+                            "error": "invalid_request",
+                            "error_description": "unsupported code_challenge_method",
+                        },
+                        status_code=400,
+                    )
+            elif code_challenge_method:
+                return JSONResponse(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "code_challenge is required with code_challenge_method",
+                    },
+                    status_code=400,
+                )
 
-            code = store.issue_code(client_id or "", redirect_uri, config.code_ttl_seconds)
+            code = store.issue_code(
+                client_id or "",
+                redirect_uri,
+                config.code_ttl_seconds,
+                code_challenge=code_challenge,
+                code_challenge_method=code_challenge_method,
+            )
             query = {"code": code}
             if state is not None:
                 query["state"] = state
@@ -1366,7 +1466,14 @@ def create_streamable_http_app(
                 access_token = store.issue_token(client_id or "", config.token_ttl_seconds)
             elif grant_type == "authorization_code":
                 code = form.get("code")
-                if not store.consume_code(str(code or ""), str(client_id or "")):
+                redirect_uri = form.get("redirect_uri")
+                code_verifier = form.get("code_verifier")
+                if not store.consume_code(
+                    str(code or ""),
+                    str(client_id or ""),
+                    str(redirect_uri or ""),
+                    str(code_verifier) if code_verifier is not None else None,
+                ):
                     return JSONResponse({"error": "invalid_grant"}, status_code=400)
                 access_token = store.issue_token(client_id or "", config.token_ttl_seconds)
             else:
@@ -1447,6 +1554,15 @@ def run_mcp_http_server(
     if (auth_token_env or oauth_compatible) and not psk and not oauth_client_id:
         print(
             "Error: HTTP auth requested but no auth token/client id was found in the configured environment variables.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    has_auth = bool(psk or (oauth_compatible and oauth_client_id))
+    if not has_auth and not _is_loopback_host(host):
+        print(
+            "Error: unauthenticated MCP HTTP serving is restricted to loopback hosts. "
+            "Configure a PSK/OAuth credential or bind to 127.0.0.1, ::1, or localhost.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -45,7 +45,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Set
-from urllib.parse import parse_qs, urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 logger = logging.getLogger("hermes.mcp_serve")
 
@@ -1123,12 +1123,19 @@ class McpHttpAuthConfig:
     path: str = "/mcp"
     token_ttl_seconds: int = 2_592_000
     code_ttl_seconds: int = 300
+    allowed_redirect_uris: Sequence[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.path = _normalize_path(self.path)
         self.public_base_url = self.public_base_url.rstrip("/")
+        self.allowed_redirect_uris = tuple(_comma_values(self.allowed_redirect_uris))
         if self.oauth_compatible and not self.oauth_client_id:
-            self.oauth_client_id = self.psk
+            # Keep the PSK out of authorization URLs, browser history, proxy
+            # logs, and redirect traces.  The default OAuth client id is public;
+            # the existing PSK becomes its confidential token-endpoint secret.
+            self.oauth_client_id = "hermes-mcp"
+        if self.oauth_compatible and not self.oauth_client_secret:
+            self.oauth_client_secret = self.psk
 
 
 @dataclass
@@ -1205,11 +1212,10 @@ class _OAuthTokenStore:
         code_verifier: Optional[str] = None,
     ) -> bool:
         with self._lock:
-            issued = self._codes.get(code)
+            issued = self._codes.pop(code, None)
             if not issued:
                 return False
             if issued.expires_at < time.time():
-                self._codes.pop(code, None)
                 return False
             if not secrets.compare_digest(issued.client_id, client_id):
                 return False
@@ -1219,7 +1225,6 @@ class _OAuthTokenStore:
                 derived = _pkce_challenge(code_verifier, issued.code_challenge_method)
                 if not derived or not secrets.compare_digest(issued.code_challenge, derived):
                     return False
-            self._codes.pop(code, None)
             return True
 
 
@@ -1293,8 +1298,6 @@ def _is_loopback_host(host: str) -> bool:
 
 
 def _client_secret_valid(config: McpHttpAuthConfig, supplied: Optional[str]) -> bool:
-    if not config.oauth_client_secret:
-        return True
     return _constant_time_equals(config.oauth_client_secret, supplied)
 
 
@@ -1310,6 +1313,36 @@ def _auth_challenge(config: McpHttpAuthConfig) -> str:
     if config.oauth_compatible:
         return f'Bearer resource_metadata="{_metadata_url(config)}"'
     return "Bearer"
+
+
+def _oauth_redirect_uri_allowed(config: McpHttpAuthConfig, redirect_uri: Optional[str]) -> bool:
+    if not redirect_uri:
+        return False
+    parsed = urlparse(redirect_uri)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return False
+    if parsed.fragment or parsed.username is not None or parsed.password is not None:
+        return False
+    if parsed.hostname and _is_loopback_host(parsed.hostname):
+        return True
+    if parsed.scheme != "https":
+        return False
+    return redirect_uri in set(config.allowed_redirect_uris)
+
+
+def _is_protected_mcp_http_path(config: McpHttpAuthConfig, request_path: str) -> bool:
+    path = request_path.rstrip("/") or "/"
+    mcp_path = config.path.rstrip("/") or "/"
+    if path == mcp_path:
+        return True
+    if mcp_path == "/" or not path.startswith(f"{mcp_path}/"):
+        return False
+    if config.oauth_compatible and path in {
+        f"{mcp_path}/authorize",
+        f"{mcp_path}/token",
+    }:
+        return False
+    return True
 
 
 def _is_authenticated(request, config: McpHttpAuthConfig, store: _OAuthTokenStore) -> bool:
@@ -1370,7 +1403,7 @@ def create_streamable_http_app(
             "Unauthenticated MCP HTTP serving is restricted to loopback hosts"
         )
 
-    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.requests import Request
     from starlette.responses import JSONResponse, PlainTextResponse, RedirectResponse
 
     store = _OAuthTokenStore()
@@ -1391,7 +1424,7 @@ def create_streamable_http_app(
                 "token_endpoint": f"{config.public_base_url}{config.path}/token",
                 "response_types_supported": ["code"],
                 "grant_types_supported": ["authorization_code", "client_credentials"],
-                "token_endpoint_auth_methods_supported": ["none", "client_secret_post"],
+                "token_endpoint_auth_methods_supported": ["client_secret_post"],
                 "code_challenge_methods_supported": ["plain", "S256"],
                 "scopes_supported": ["mcp"],
             })
@@ -1419,6 +1452,14 @@ def create_streamable_http_app(
                 return JSONResponse({"error": "invalid_client"}, status_code=401)
             if not redirect_uri:
                 return JSONResponse({"error": "invalid_request", "error_description": "redirect_uri is required"}, status_code=400)
+            if not _oauth_redirect_uri_allowed(config, redirect_uri):
+                return JSONResponse(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "redirect_uri is not allowed",
+                    },
+                    status_code=400,
+                )
             if code_challenge:
                 code_challenge_method = code_challenge_method or "plain"
                 if code_challenge_method not in {"plain", "S256"}:
@@ -1492,12 +1533,21 @@ def create_streamable_http_app(
         app.add_route(f"{config.path}/token", token, methods=["POST"])
 
     if config:
-        class McpAuthMiddleware(BaseHTTPMiddleware):
-            async def dispatch(self, request, call_next):
-                path = request.url.path.rstrip("/") or "/"
-                mcp_path = config.path.rstrip("/") or "/"
-                if path == mcp_path and not _is_authenticated(request, config, store):
-                    return JSONResponse(
+        class McpAuthMiddleware:
+            def __init__(self, asgi_app):
+                self.app = asgi_app
+
+            async def __call__(self, scope, receive, send):
+                if scope.get("type") != "http":
+                    await self.app(scope, receive, send)
+                    return
+
+                request = Request(scope, receive=receive)
+                if (
+                    _is_protected_mcp_http_path(config, request.url.path)
+                    and not _is_authenticated(request, config, store)
+                ):
+                    response = JSONResponse(
                         {
                             "error": "unauthorized",
                             "hint": "Authenticate with OAuth bearer token, bearer/header PSK, or an enabled query token.",
@@ -1505,7 +1555,9 @@ def create_streamable_http_app(
                         status_code=401,
                         headers={"WWW-Authenticate": _auth_challenge(config)},
                     )
-                return await call_next(request)
+                    await response(scope, receive, send)
+                    return
+                await self.app(scope, receive, send)
 
         app.add_middleware(McpAuthMiddleware)
 
@@ -1527,6 +1579,7 @@ def run_mcp_http_server(
     oauth_client_secret_env: Optional[str] = None,
     token_ttl_seconds: int = 2_592_000,
     code_ttl_seconds: int = 300,
+    oauth_redirect_uris: Optional[Sequence[str]] = None,
     allowed_hosts: Optional[Sequence[str]] = None,
     allowed_origins: Optional[Sequence[str]] = None,
     expose_toolsets: Optional[Sequence[str]] = None,
@@ -1554,6 +1607,12 @@ def run_mcp_http_server(
     if (auth_token_env or oauth_compatible) and not psk and not oauth_client_id:
         print(
             "Error: HTTP auth requested but no auth token/client id was found in the configured environment variables.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if oauth_compatible and oauth_client_id and not oauth_client_secret:
+        print(
+            "Error: --oauth-client-id-env requires --oauth-client-secret-env.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -1599,6 +1658,7 @@ def run_mcp_http_server(
             path=path,
             token_ttl_seconds=token_ttl_seconds,
             code_ttl_seconds=code_ttl_seconds,
+            allowed_redirect_uris=_comma_values(oauth_redirect_uris),
         )
 
     app = create_streamable_http_app(server, auth_config=auth_config, health_path=health_path)

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -680,13 +680,6 @@ def _register_registry_tools_as_mcp(
         "permissions_list_open",
         "permissions_respond",
     }
-    reserved_requests = include_tools & reserved_names
-    if reserved_requests:
-        raise RuntimeError(
-            "MCP tool selectors collide with built-in server tools: "
-            + ", ".join(sorted(reserved_requests))
-        )
-
     try:
         from tools.registry import registry
         from hermes_cli.plugins import discover_plugins, get_plugin_manager
@@ -724,6 +717,13 @@ def _register_registry_tools_as_mcp(
             )
             continue
         candidate_entries[name] = entry
+
+    reserved_candidates = set(candidate_entries) & reserved_names
+    if reserved_candidates:
+        raise RuntimeError(
+            "MCP tool selectors collide with built-in server tools: "
+            + ", ".join(sorted(reserved_candidates))
+        )
 
     # Use the same authoritative schema/availability path as the agent. This
     # applies dynamic_schema_overrides and the cached, transient-failure-safe
@@ -1294,16 +1294,16 @@ class _OAuthTokenStore:
                 entries.pop(key, None)
 
     @staticmethod
-    def _make_room(entries: Dict[str, Any], maximum: int) -> None:
-        while len(entries) >= maximum:
-            entries.pop(next(iter(entries)))
+    def _require_room(entries: Dict[str, Any], maximum: int) -> None:
+        if len(entries) >= maximum:
+            raise OverflowError("OAuth state capacity reached")
 
     def issue_token(self, client_id: str, ttl_seconds: int) -> str:
         token = secrets.token_urlsafe(32)
         with self._lock:
             now = time.time()
             self._prune_expired(self._tokens, now)
-            self._make_room(self._tokens, self._max_tokens)
+            self._require_room(self._tokens, self._max_tokens)
             self._tokens[token] = _IssuedToken(
                 token=token,
                 client_id=client_id,
@@ -1342,9 +1342,9 @@ class _OAuthTokenStore:
             ]
             if len(self._code_issuance_times) >= self._max_code_issuance_per_minute:
                 raise OverflowError("authorization-code issuance rate exceeded")
-            self._code_issuance_times.append(monotonic_now)
             self._prune_expired(self._codes, now)
-            self._make_room(self._codes, self._max_codes)
+            self._require_room(self._codes, self._max_codes)
+            self._code_issuance_times.append(monotonic_now)
             self._codes[code] = _AuthorizationCode(
                 code=code,
                 client_id=client_id,
@@ -1740,11 +1740,11 @@ def create_streamable_http_app(
                     code_challenge_method="S256",
                     resource=expected_resource,
                 )
-            except OverflowError:
+            except OverflowError as exc:
                 return JSONResponse(
                     {
                         "error": "temporarily_unavailable",
-                        "error_description": "authorization-code issuance rate exceeded",
+                        "error_description": str(exc),
                     },
                     status_code=429,
                     headers={"Retry-After": "60"},
@@ -1805,24 +1805,35 @@ def create_streamable_http_app(
             if form.get("scope") not in {None, "", "mcp"}:
                 return _token_response({"error": "invalid_scope"}, 400)
 
-            if grant_type == "client_credentials":
-                access_token = store.issue_token(client_id or "", config.token_ttl_seconds)
-            elif grant_type == "authorization_code":
-                code = form.get("code")
-                redirect_uri = form.get("redirect_uri")
-                code_verifier = form.get("code_verifier")
-                resource = requested_resource or expected_resource
-                if not _valid_pkce_value(code_verifier) or not store.consume_code(
-                    str(code or ""),
-                    str(client_id or ""),
-                    str(redirect_uri or ""),
-                    str(code_verifier),
-                    str(resource),
-                ):
-                    return _token_response({"error": "invalid_grant"}, 400)
-                access_token = store.issue_token(client_id or "", config.token_ttl_seconds)
-            else:
-                return _token_response({"error": "unsupported_grant_type"}, 400)
+            try:
+                if grant_type == "client_credentials":
+                    access_token = store.issue_token(client_id or "", config.token_ttl_seconds)
+                elif grant_type == "authorization_code":
+                    code = form.get("code")
+                    redirect_uri = form.get("redirect_uri")
+                    code_verifier = form.get("code_verifier")
+                    resource = requested_resource or expected_resource
+                    if not _valid_pkce_value(code_verifier) or not store.consume_code(
+                        str(code or ""),
+                        str(client_id or ""),
+                        str(redirect_uri or ""),
+                        str(code_verifier),
+                        str(resource),
+                    ):
+                        return _token_response({"error": "invalid_grant"}, 400)
+                    access_token = store.issue_token(
+                        client_id or "", config.token_ttl_seconds
+                    )
+                else:
+                    return _token_response({"error": "unsupported_grant_type"}, 400)
+            except OverflowError as exc:
+                return _token_response(
+                    {
+                        "error": "temporarily_unavailable",
+                        "error_description": str(exc),
+                    },
+                    503,
+                )
 
             return _token_response(
                 {

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -29,17 +29,20 @@ MCP client config (e.g. claude_desktop_config.json):
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import os
 import re
+import secrets
 import sys
 import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Set
+from urllib.parse import parse_qs, urlencode
 
 logger = logging.getLogger("hermes.mcp_serve")
 
@@ -532,7 +535,144 @@ class EventBridge:
 # MCP Server
 # ---------------------------------------------------------------------------
 
-def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
+def _schema_property_to_annotation(prop: dict) -> Any:
+    prop_type = prop.get("type") if isinstance(prop, dict) else None
+    if isinstance(prop_type, list):
+        prop_type = next((item for item in prop_type if item != "null"), None)
+    if prop_type == "string":
+        return str
+    if prop_type == "integer":
+        return int
+    if prop_type == "number":
+        return float
+    if prop_type == "boolean":
+        return bool
+    if prop_type == "array":
+        return list
+    if prop_type == "object":
+        return dict
+    return Any
+
+
+def _safe_identifier(name: str) -> str:
+    cleaned = re.sub(r"\W", "_", name or "arg")
+    if not cleaned or cleaned[0].isdigit():
+        cleaned = f"arg_{cleaned}"
+    if cleaned in {"class", "def", "from", "global", "lambda", "pass", "return"}:
+        cleaned = f"{cleaned}_"
+    return cleaned
+
+
+def _make_registry_tool_wrapper(tool_name: str):
+    def _tool(**kwargs):
+        from tools.registry import registry
+        return registry.dispatch(tool_name, dict(kwargs))
+
+    _tool.__name__ = f"_mcp_registry_tool_{_safe_identifier(tool_name)}"
+    return _tool
+
+
+def _apply_schema_signature(wrapper, schema: dict) -> Any:
+    parameters_schema = schema.get("parameters") or {}
+    properties = parameters_schema.get("properties") or {}
+    required = set(parameters_schema.get("required") or [])
+    params = []
+    name_map: dict[str, str] = {}
+
+    for raw_name, prop in properties.items():
+        param_name = _safe_identifier(str(raw_name))
+        while param_name in name_map:
+            param_name = f"{param_name}_"
+        name_map[param_name] = str(raw_name)
+        default = inspect.Parameter.empty if raw_name in required else None
+        params.append(
+            inspect.Parameter(
+                param_name,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=_schema_property_to_annotation(prop if isinstance(prop, dict) else {}),
+            )
+        )
+
+    if name_map:
+        original = wrapper
+
+        def _mapped_tool(**kwargs):
+            return original(**{name_map.get(key, key): value for key, value in kwargs.items()})
+
+        _mapped_tool.__name__ = wrapper.__name__
+        wrapper = _mapped_tool
+
+    wrapper.__signature__ = inspect.Signature(params)  # type: ignore[attr-defined]
+    return wrapper
+
+
+def _register_registry_tools_as_mcp(
+    mcp,
+    *,
+    expose_toolsets: Optional[Sequence[str]] = None,
+    expose_tools: Optional[Sequence[str]] = None,
+    expose_plugin_tools: bool = False,
+) -> List[str]:
+    include_toolsets: Set[str] = set(_comma_values(expose_toolsets))
+    include_tools: Set[str] = set(_comma_values(expose_tools))
+    if not include_toolsets and not include_tools and not expose_plugin_tools:
+        return []
+
+    try:
+        from tools.registry import registry
+        from hermes_cli.plugins import discover_plugins, get_plugin_manager
+        discover_plugins()
+    except Exception as exc:
+        logger.warning("Could not discover plugin tools for MCP serving: %s", exc)
+        return []
+
+    plugin_tool_names = set(getattr(get_plugin_manager(), "_plugin_tool_names", set()))
+    registered: List[str] = []
+    for name in registry.get_all_tool_names():
+        entry = registry.get_entry(name)
+        if not entry:
+            continue
+        should_expose = (
+            name in include_tools
+            or entry.toolset in include_toolsets
+            or (expose_plugin_tools and name in plugin_tool_names)
+        )
+        if not should_expose:
+            continue
+        if entry.check_fn:
+            try:
+                if not entry.check_fn():
+                    continue
+            except Exception:
+                logger.debug("Skipping MCP-exposed tool %s because check_fn failed", name, exc_info=True)
+                continue
+
+        schema = {**(entry.schema or {}), "name": entry.name}
+        wrapper = _make_registry_tool_wrapper(entry.name)
+        wrapper = _apply_schema_signature(wrapper, schema)
+        mcp.add_tool(
+            wrapper,
+            name=entry.name,
+            description=entry.description or schema.get("description") or "Hermes tool",
+        )
+        tool = mcp._tool_manager.get_tool(entry.name)
+        if tool is not None:
+            tool.parameters = schema.get("parameters") or tool.parameters
+        registered.append(entry.name)
+
+    if registered:
+        logger.info("Exposed %d Hermes registry tools over MCP", len(registered))
+    return registered
+
+
+def create_mcp_server(
+    event_bridge: Optional[EventBridge] = None,
+    *,
+    expose_toolsets: Optional[Sequence[str]] = None,
+    expose_tools: Optional[Sequence[str]] = None,
+    expose_plugin_tools: bool = False,
+) -> "FastMCP":
     """Create and return the Hermes MCP server with all tools registered."""
     if not _MCP_SERVER_AVAILABLE:
         raise ImportError(
@@ -941,14 +1081,437 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
         result = bridge.respond_to_approval(id, decision)
         return json.dumps(result, indent=2)
 
+    _register_registry_tools_as_mcp(
+        mcp,
+        expose_toolsets=expose_toolsets,
+        expose_tools=expose_tools,
+        expose_plugin_tools=expose_plugin_tools,
+    )
+
     return mcp
+
+
+# ---------------------------------------------------------------------------
+# Streamable HTTP authentication helpers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class McpHttpAuthConfig:
+    """Authentication and OAuth-compatibility settings for HTTP MCP serving."""
+
+    psk: Optional[str] = None
+    psk_header: str = "X-Hermes-MCP-PSK"
+    allow_query_token: bool = False
+    oauth_compatible: bool = False
+    oauth_client_id: Optional[str] = None
+    oauth_client_secret: Optional[str] = None
+    public_base_url: str = "http://127.0.0.1:8666"
+    path: str = "/mcp"
+    token_ttl_seconds: int = 2_592_000
+    code_ttl_seconds: int = 300
+
+    def __post_init__(self) -> None:
+        self.path = _normalize_path(self.path)
+        self.public_base_url = self.public_base_url.rstrip("/")
+        if self.oauth_compatible and not self.oauth_client_id:
+            self.oauth_client_id = self.psk
+
+
+@dataclass
+class _IssuedToken:
+    token: str
+    client_id: str
+    expires_at: float
+
+
+@dataclass
+class _AuthorizationCode:
+    code: str
+    client_id: str
+    redirect_uri: str
+    expires_at: float
+
+
+class _OAuthTokenStore:
+    """Small in-memory token/code store for single-process HTTP MCP servers."""
+
+    def __init__(self) -> None:
+        self._tokens: Dict[str, _IssuedToken] = {}
+        self._codes: Dict[str, _AuthorizationCode] = {}
+        self._lock = threading.Lock()
+
+    def issue_token(self, client_id: str, ttl_seconds: int) -> str:
+        token = secrets.token_urlsafe(32)
+        with self._lock:
+            self._tokens[token] = _IssuedToken(
+                token=token,
+                client_id=client_id,
+                expires_at=time.time() + ttl_seconds,
+            )
+        return token
+
+    def validate_token(self, token: str) -> bool:
+        with self._lock:
+            issued = self._tokens.get(token)
+            if not issued:
+                return False
+            if issued.expires_at < time.time():
+                self._tokens.pop(token, None)
+                return False
+            return True
+
+    def issue_code(self, client_id: str, redirect_uri: str, ttl_seconds: int) -> str:
+        code = secrets.token_urlsafe(24)
+        with self._lock:
+            self._codes[code] = _AuthorizationCode(
+                code=code,
+                client_id=client_id,
+                redirect_uri=redirect_uri,
+                expires_at=time.time() + ttl_seconds,
+            )
+        return code
+
+    def consume_code(self, code: str, client_id: str) -> bool:
+        with self._lock:
+            issued = self._codes.pop(code, None)
+            if not issued:
+                return False
+            if issued.client_id != client_id:
+                return False
+            return issued.expires_at >= time.time()
+
+
+def _normalize_path(path: str) -> str:
+    path = (path or "/mcp").strip()
+    if not path.startswith("/"):
+        path = f"/{path}"
+    if len(path) > 1:
+        path = path.rstrip("/")
+    return path
+
+
+def _read_env_secret(env_name: Optional[str]) -> Optional[str]:
+    if not env_name:
+        return None
+    value = os.environ.get(env_name)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _comma_values(values: Optional[Sequence[str]]) -> List[str]:
+    result: List[str] = []
+    for item in values or []:
+        for part in str(item).split(","):
+            part = part.strip()
+            if part:
+                result.append(part)
+    return result
+
+
+def _extract_bearer_token(headers) -> Optional[str]:
+    auth = headers.get("authorization", "")
+    if auth.lower().startswith("bearer "):
+        token = auth[7:].strip()
+        return token or None
+    return None
+
+
+def _constant_time_equals(left: Optional[str], right: Optional[str]) -> bool:
+    if not left or not right:
+        return False
+    return secrets.compare_digest(str(left), str(right))
+
+
+def _client_secret_valid(config: McpHttpAuthConfig, supplied: Optional[str]) -> bool:
+    if not config.oauth_client_secret:
+        return True
+    return _constant_time_equals(config.oauth_client_secret, supplied)
+
+
+def _client_id_valid(config: McpHttpAuthConfig, supplied: Optional[str]) -> bool:
+    return _constant_time_equals(config.oauth_client_id, supplied)
+
+
+def _metadata_url(config: McpHttpAuthConfig) -> str:
+    return f"{config.public_base_url}/.well-known/oauth-protected-resource{config.path}"
+
+
+def _auth_challenge(config: McpHttpAuthConfig) -> str:
+    if config.oauth_compatible:
+        return f'Bearer resource_metadata="{_metadata_url(config)}"'
+    return "Bearer"
+
+
+def _is_authenticated(request, config: McpHttpAuthConfig, store: _OAuthTokenStore) -> bool:
+    bearer = _extract_bearer_token(request.headers)
+    if bearer:
+        if _constant_time_equals(config.psk, bearer):
+            return True
+        if config.oauth_compatible and store.validate_token(bearer):
+            return True
+
+    header_token = request.headers.get(config.psk_header)
+    if _constant_time_equals(config.psk, header_token):
+        return True
+
+    if config.allow_query_token:
+        query_token = request.query_params.get("access_token") or request.query_params.get("psk")
+        if _constant_time_equals(config.psk, query_token):
+            return True
+        if config.oauth_compatible and query_token and store.validate_token(query_token):
+            return True
+
+    return False
+
+
+def _configure_transport_security(server, host: str, allowed_hosts: Sequence[str], allowed_origins: Sequence[str]) -> None:
+    hosts = list(dict.fromkeys([host, "127.0.0.1", "localhost", *allowed_hosts]))
+    origins = list(dict.fromkeys([*allowed_origins]))
+    if origins and "null" not in origins:
+        origins.append("null")
+    try:
+        from mcp.server.transport_security import TransportSecuritySettings
+        server.settings.transport_security = TransportSecuritySettings(
+            allowed_hosts=hosts,
+            allowed_origins=origins,
+        )
+    except Exception as exc:  # pragma: no cover - depends on MCP SDK version
+        logger.debug("Could not configure MCP transport security: %s", exc)
+
+
+def create_streamable_http_app(
+    server,
+    *,
+    auth_config: Optional[McpHttpAuthConfig] = None,
+    health_path: str = "/health",
+):
+    """Create the Starlette app for Streamable HTTP, including optional auth.
+
+    The returned app serves the MCP endpoint at ``server.settings.streamable_http_path``.
+    If ``auth_config`` is provided, the MCP path requires either a PSK bearer/header
+    token or an OAuth-compatible bearer token issued by the local token endpoint.
+    """
+    if not hasattr(server, "streamable_http_app"):
+        raise RuntimeError("Installed MCP SDK does not support Streamable HTTP")
+
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.responses import JSONResponse, PlainTextResponse, RedirectResponse
+
+    store = _OAuthTokenStore()
+    app = server.streamable_http_app()
+    health_path = _normalize_path(health_path)
+    config = auth_config
+
+    async def health(_request):
+        return PlainTextResponse("ok")
+
+    app.add_route(health_path, health, methods=["GET", "HEAD"])
+
+    if config and config.oauth_compatible:
+        async def authorization_server_metadata(_request):
+            return JSONResponse({
+                "issuer": config.public_base_url,
+                "authorization_endpoint": f"{config.public_base_url}{config.path}/authorize",
+                "token_endpoint": f"{config.public_base_url}{config.path}/token",
+                "response_types_supported": ["code"],
+                "grant_types_supported": ["authorization_code", "client_credentials"],
+                "token_endpoint_auth_methods_supported": ["none", "client_secret_post"],
+                "code_challenge_methods_supported": ["plain", "S256"],
+                "scopes_supported": ["mcp"],
+            })
+
+        async def protected_resource_metadata(_request):
+            return JSONResponse({
+                "resource": f"{config.public_base_url}{config.path}",
+                "authorization_servers": [config.public_base_url],
+                "bearer_methods_supported": ["header"],
+                "scopes_supported": ["mcp"],
+            })
+
+        async def authorize(request):
+            params = request.query_params
+            client_id = params.get("client_id")
+            redirect_uri = params.get("redirect_uri")
+            response_type = params.get("response_type")
+            state = params.get("state")
+
+            if response_type != "code":
+                return JSONResponse({"error": "unsupported_response_type"}, status_code=400)
+            if not _client_id_valid(config, client_id):
+                return JSONResponse({"error": "invalid_client"}, status_code=401)
+            if not redirect_uri:
+                return JSONResponse({"error": "invalid_request", "error_description": "redirect_uri is required"}, status_code=400)
+
+            code = store.issue_code(client_id or "", redirect_uri, config.code_ttl_seconds)
+            query = {"code": code}
+            if state is not None:
+                query["state"] = state
+            separator = "&" if "?" in redirect_uri else "?"
+            return RedirectResponse(f"{redirect_uri}{separator}{urlencode(query)}", status_code=302)
+
+        async def token(request):
+            body = (await request.body()).decode("utf-8")
+            parsed = parse_qs(body, keep_blank_values=True)
+            form = {key: values[-1] if values else "" for key, values in parsed.items()}
+            grant_type = form.get("grant_type")
+            client_id = form.get("client_id")
+            client_secret = form.get("client_secret")
+
+            if not _client_id_valid(config, client_id) or not _client_secret_valid(config, client_secret):
+                return JSONResponse({"error": "invalid_client"}, status_code=401)
+
+            if grant_type == "client_credentials":
+                access_token = store.issue_token(client_id or "", config.token_ttl_seconds)
+            elif grant_type == "authorization_code":
+                code = form.get("code")
+                if not store.consume_code(str(code or ""), str(client_id or "")):
+                    return JSONResponse({"error": "invalid_grant"}, status_code=400)
+                access_token = store.issue_token(client_id or "", config.token_ttl_seconds)
+            else:
+                return JSONResponse({"error": "unsupported_grant_type"}, status_code=400)
+
+            return JSONResponse({
+                "access_token": access_token,
+                "token_type": "Bearer",
+                "expires_in": config.token_ttl_seconds,
+                "scope": "mcp",
+            })
+
+        app.add_route("/.well-known/oauth-authorization-server", authorization_server_metadata, methods=["GET"])
+        app.add_route(f"/.well-known/oauth-protected-resource{config.path}", protected_resource_metadata, methods=["GET"])
+        app.add_route(f"{config.path}/authorize", authorize, methods=["GET"])
+        app.add_route(f"{config.path}/token", token, methods=["POST"])
+
+    if config:
+        class McpAuthMiddleware(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                path = request.url.path.rstrip("/") or "/"
+                mcp_path = config.path.rstrip("/") or "/"
+                if path == mcp_path and not _is_authenticated(request, config, store):
+                    return JSONResponse(
+                        {
+                            "error": "unauthorized",
+                            "hint": "Authenticate with OAuth bearer token, bearer/header PSK, or an enabled query token.",
+                        },
+                        status_code=401,
+                        headers={"WWW-Authenticate": _auth_challenge(config)},
+                    )
+                return await call_next(request)
+
+        app.add_middleware(McpAuthMiddleware)
+
+    return app
+
+
+def run_mcp_http_server(
+    *,
+    verbose: bool = False,
+    host: str = "127.0.0.1",
+    port: int = 8666,
+    path: str = "/mcp",
+    public_base_url: Optional[str] = None,
+    auth_token_env: Optional[str] = None,
+    auth_header: str = "X-Hermes-MCP-PSK",
+    allow_query_token: bool = False,
+    oauth_compatible: bool = False,
+    oauth_client_id_env: Optional[str] = None,
+    oauth_client_secret_env: Optional[str] = None,
+    token_ttl_seconds: int = 2_592_000,
+    code_ttl_seconds: int = 300,
+    allowed_hosts: Optional[Sequence[str]] = None,
+    allowed_origins: Optional[Sequence[str]] = None,
+    expose_toolsets: Optional[Sequence[str]] = None,
+    expose_tools: Optional[Sequence[str]] = None,
+    expose_plugin_tools: bool = False,
+    health_path: str = "/health",
+) -> None:
+    """Start the Hermes MCP server over Streamable HTTP."""
+    if not _MCP_SERVER_AVAILABLE:
+        print(
+            "Error: MCP HTTP server requires the 'mcp' package.\n"
+            f"Install with: {sys.executable} -m pip install 'mcp'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    logging.basicConfig(level=logging.DEBUG if verbose else logging.WARNING, stream=sys.stderr)
+
+    path = _normalize_path(path)
+    base_url = (public_base_url or f"http://{host}:{port}").rstrip("/")
+    psk = _read_env_secret(auth_token_env)
+    oauth_client_id = _read_env_secret(oauth_client_id_env) if oauth_client_id_env else None
+    oauth_client_secret = _read_env_secret(oauth_client_secret_env) if oauth_client_secret_env else None
+
+    if (auth_token_env or oauth_compatible) and not psk and not oauth_client_id:
+        print(
+            "Error: HTTP auth requested but no auth token/client id was found in the configured environment variables.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    bridge = EventBridge()
+    bridge.start()
+    server = create_mcp_server(
+        event_bridge=bridge,
+        expose_toolsets=expose_toolsets,
+        expose_tools=expose_tools,
+        expose_plugin_tools=expose_plugin_tools,
+    )
+    server.settings.host = host
+    server.settings.port = int(port)
+    server.settings.streamable_http_path = path
+    server.settings.json_response = True
+    _configure_transport_security(
+        server,
+        host,
+        _comma_values(allowed_hosts),
+        _comma_values(allowed_origins),
+    )
+
+    auth_config = None
+    if psk or oauth_compatible:
+        auth_config = McpHttpAuthConfig(
+            psk=psk,
+            psk_header=auth_header,
+            allow_query_token=allow_query_token,
+            oauth_compatible=oauth_compatible,
+            oauth_client_id=oauth_client_id,
+            oauth_client_secret=oauth_client_secret,
+            public_base_url=base_url,
+            path=path,
+            token_ttl_seconds=token_ttl_seconds,
+            code_ttl_seconds=code_ttl_seconds,
+        )
+
+    app = create_streamable_http_app(server, auth_config=auth_config, health_path=health_path)
+
+    import uvicorn
+
+    try:
+        uvicorn.run(
+            app,
+            host=host,
+            port=int(port),
+            log_level="debug" if verbose else "warning",
+            access_log=not allow_query_token,
+        )
+    finally:
+        bridge.stop()
 
 
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
-def run_mcp_server(verbose: bool = False) -> None:
+def run_mcp_server(
+    verbose: bool = False,
+    *,
+    expose_toolsets: Optional[Sequence[str]] = None,
+    expose_tools: Optional[Sequence[str]] = None,
+    expose_plugin_tools: bool = False,
+) -> None:
     """Start the Hermes MCP server on stdio."""
     if not _MCP_SERVER_AVAILABLE:
         print(
@@ -966,7 +1529,12 @@ def run_mcp_server(verbose: bool = False) -> None:
     bridge = EventBridge()
     bridge.start()
 
-    server = create_mcp_server(event_bridge=bridge)
+    server = create_mcp_server(
+        event_bridge=bridge,
+        expose_toolsets=expose_toolsets,
+        expose_tools=expose_tools,
+        expose_plugin_tools=expose_plugin_tools,
+    )
 
     import asyncio
 

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -1365,11 +1365,14 @@ class _OAuthTokenStore:
         resource: Optional[str] = None,
     ) -> bool:
         with self._lock:
-            issued = self._codes.get(code)
+            # An authorization code is a one-shot credential. Consume it on
+            # the first exchange attempt, including attempts with a bad
+            # redirect URI or PKCE verifier, so callers cannot retry guesses
+            # against the same code.
+            issued = self._codes.pop(code, None)
             if not issued:
                 return False
             if issued.expires_at < time.time():
-                self._codes.pop(code, None)
                 return False
             if not secrets.compare_digest(issued.client_id, client_id):
                 return False
@@ -1381,7 +1384,6 @@ class _OAuthTokenStore:
                 derived = _pkce_challenge(code_verifier, issued.code_challenge_method)
                 if not derived or not secrets.compare_digest(issued.code_challenge, derived):
                     return False
-            self._codes.pop(code, None)
             return True
 
 

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -705,7 +705,7 @@ def _register_registry_tools_as_mcp(
         )
 
     plugin_tool_names = get_plugin_manager().get_registered_tool_names()
-    registered: List[str] = []
+    candidate_entries = {}
     for name in registry.get_all_tool_names():
         entry = registry.get_entry(name)
         if not entry:
@@ -723,15 +723,22 @@ def _register_registry_tools_as_mcp(
                 name,
             )
             continue
-        if entry.check_fn:
-            try:
-                if not entry.check_fn():
-                    continue
-            except Exception:
-                logger.debug("Skipping MCP-exposed tool %s because check_fn failed", name, exc_info=True)
-                continue
+        candidate_entries[name] = entry
 
-        schema = {**(entry.schema or {}), "name": entry.name}
+    # Use the same authoritative schema/availability path as the agent. This
+    # applies dynamic_schema_overrides and the cached, transient-failure-safe
+    # check_fn policy. Reading ToolEntry.schema or calling check_fn directly
+    # would expose stale schemas and let one flaky probe hide a tool from MCP.
+    definitions = {
+        definition["function"]["name"]: definition["function"]
+        for definition in registry.get_definitions(set(candidate_entries), quiet=True)
+    }
+
+    registered: List[str] = []
+    for name, entry in candidate_entries.items():
+        schema = definitions.get(name)
+        if schema is None:
+            continue
         parameters_schema = schema.get("parameters") or {}
         properties = parameters_schema.get("properties") or {}
         required = set(parameters_schema.get("required") or [])
@@ -741,14 +748,12 @@ def _register_registry_tools_as_mcp(
             if property_name not in required
             and not _schema_allows_null(property_schema)
         }
-        wrapper = _make_registry_tool_wrapper(
-            entry.name, omit_none_for=omit_none_for
-        )
+        wrapper = _make_registry_tool_wrapper(entry.name, omit_none_for=omit_none_for)
         wrapper = _apply_schema_signature(wrapper, schema)
         mcp.add_tool(
             wrapper,
             name=entry.name,
-            description=entry.description or schema.get("description") or "Hermes tool",
+            description=schema.get("description") or entry.description or "Hermes tool",
         )
         tool = mcp._tool_manager.get_tool(entry.name)
         if tool is not None:

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -34,6 +34,7 @@ import hashlib
 import inspect
 import ipaddress
 import json
+import keyword
 import logging
 import os
 import re
@@ -566,7 +567,11 @@ def _safe_identifier(name: str) -> str:
     return cleaned
 
 
-def _make_registry_tool_wrapper(tool_name: str):
+def _make_registry_tool_wrapper(
+    tool_name: str, *, omit_none_for: Optional[Set[str]] = None
+):
+    omitted_optional_names = set(omit_none_for or set())
+
     def _tool(**kwargs):
         # Registry tools exposed through MCP must follow the same guarded
         # execution path as model-issued tool calls. Calling registry.dispatch
@@ -574,12 +579,20 @@ def _make_registry_tool_wrapper(tool_name: str):
         # hooks, ACP edit approval, post-call hooks, and result transforms.
         from model_tools import handle_function_call
 
+        call_id = secrets.token_hex(8)
+        function_args = {
+            key: value
+            for key, value in kwargs.items()
+            if value is not None or key not in omitted_optional_names
+        }
         return handle_function_call(
             function_name=tool_name,
-            function_args=dict(kwargs),
-            task_id="mcp-serve",
-            tool_call_id=f"mcp-{secrets.token_hex(8)}",
-            session_id="mcp-serve",
+            function_args=function_args,
+            task_id=f"mcp-serve-{call_id}",
+            tool_call_id=f"mcp-{call_id}",
+            session_id=f"mcp-serve-{call_id}",
+            turn_id=f"mcp-turn-{call_id}",
+            api_request_id=f"mcp-request-{call_id}",
         )
 
     _tool.__name__ = f"_mcp_registry_tool_{_safe_identifier(tool_name)}"
@@ -594,6 +607,10 @@ def _apply_schema_signature(wrapper, schema: dict) -> Any:
     name_map: dict[str, str] = {}
 
     for raw_name, prop in properties.items():
+        if not str(raw_name).isidentifier() or keyword.iskeyword(str(raw_name)):
+            raise ValueError(
+                f"MCP-exposed tool property {raw_name!r} is not a valid Python identifier"
+            )
         param_name = _safe_identifier(str(raw_name))
         while param_name in name_map:
             param_name = f"{param_name}_"
@@ -621,6 +638,24 @@ def _apply_schema_signature(wrapper, schema: dict) -> Any:
     return wrapper
 
 
+def _schema_allows_null(prop: Any) -> bool:
+    if not isinstance(prop, dict):
+        return False
+    prop_type = prop.get("type")
+    if prop_type == "null" or (
+        isinstance(prop_type, list) and "null" in prop_type
+    ):
+        return True
+    for branch_key in ("anyOf", "oneOf"):
+        branches = prop.get(branch_key)
+        if isinstance(branches, list) and any(
+            isinstance(branch, dict) and branch.get("type") == "null"
+            for branch in branches
+        ):
+            return True
+    return False
+
+
 def _register_registry_tools_as_mcp(
     mcp,
     *,
@@ -633,15 +668,43 @@ def _register_registry_tools_as_mcp(
     if not include_toolsets and not include_tools and not expose_plugin_tools:
         return []
 
+    reserved_names = {
+        "conversations_list",
+        "conversation_get",
+        "messages_read",
+        "attachments_fetch",
+        "events_poll",
+        "events_wait",
+        "messages_send",
+        "channels_list",
+        "permissions_list_open",
+        "permissions_respond",
+    }
+    reserved_requests = include_tools & reserved_names
+    if reserved_requests:
+        raise RuntimeError(
+            "MCP tool selectors collide with built-in server tools: "
+            + ", ".join(sorted(reserved_requests))
+        )
+
     try:
         from tools.registry import registry
         from hermes_cli.plugins import discover_plugins, get_plugin_manager
+        from model_tools import _AGENT_LOOP_TOOLS
         discover_plugins()
     except Exception as exc:
-        logger.warning("Could not discover plugin tools for MCP serving: %s", exc)
-        return []
+        raise RuntimeError(
+            f"Could not discover requested Hermes tools for MCP serving: {exc}"
+        ) from exc
 
-    plugin_tool_names = set(getattr(get_plugin_manager(), "_plugin_tool_names", set()))
+    unsupported_requests = include_tools & set(_AGENT_LOOP_TOOLS)
+    if unsupported_requests:
+        raise RuntimeError(
+            "Agent-loop tools cannot be exposed by the stateless MCP server: "
+            + ", ".join(sorted(unsupported_requests))
+        )
+
+    plugin_tool_names = get_plugin_manager().get_registered_tool_names()
     registered: List[str] = []
     for name in registry.get_all_tool_names():
         entry = registry.get_entry(name)
@@ -654,6 +717,12 @@ def _register_registry_tools_as_mcp(
         )
         if not should_expose:
             continue
+        if name in _AGENT_LOOP_TOOLS:
+            logger.warning(
+                "Skipping MCP exposure for agent-loop tool %s; it requires live agent state",
+                name,
+            )
+            continue
         if entry.check_fn:
             try:
                 if not entry.check_fn():
@@ -663,7 +732,18 @@ def _register_registry_tools_as_mcp(
                 continue
 
         schema = {**(entry.schema or {}), "name": entry.name}
-        wrapper = _make_registry_tool_wrapper(entry.name)
+        parameters_schema = schema.get("parameters") or {}
+        properties = parameters_schema.get("properties") or {}
+        required = set(parameters_schema.get("required") or [])
+        omit_none_for = {
+            str(property_name)
+            for property_name, property_schema in properties.items()
+            if property_name not in required
+            and not _schema_allows_null(property_schema)
+        }
+        wrapper = _make_registry_tool_wrapper(
+            entry.name, omit_none_for=omit_none_for
+        )
         wrapper = _apply_schema_signature(wrapper, schema)
         mcp.add_tool(
             wrapper,
@@ -677,6 +757,29 @@ def _register_registry_tools_as_mcp(
 
     if registered:
         logger.info("Exposed %d Hermes registry tools over MCP", len(registered))
+    missing_tools = include_tools - set(registered)
+    if missing_tools:
+        raise RuntimeError(
+            "Requested MCP tools are unknown or unavailable: "
+            + ", ".join(sorted(missing_tools))
+        )
+    empty_toolsets = {
+        toolset
+        for toolset in include_toolsets
+        if not any(
+            (entry := registry.get_entry(name))
+            and entry.toolset == toolset
+            and name in registered
+            for name in registry.get_all_tool_names()
+        )
+    }
+    if empty_toolsets:
+        raise RuntimeError(
+            "Requested MCP toolsets have no available tools: "
+            + ", ".join(sorted(empty_toolsets))
+        )
+    if expose_plugin_tools and not (set(registered) & plugin_tool_names):
+        raise RuntimeError("No enabled plugin tools are available for MCP exposure")
     return registered
 
 
@@ -1121,7 +1224,7 @@ class McpHttpAuthConfig:
     oauth_client_secret: Optional[str] = None
     public_base_url: str = "http://127.0.0.1:8666"
     path: str = "/mcp"
-    token_ttl_seconds: int = 2_592_000
+    token_ttl_seconds: int = 3_600
     code_ttl_seconds: int = 300
     allowed_redirect_uris: Sequence[str] = field(default_factory=list)
 
@@ -1153,23 +1256,53 @@ class _AuthorizationCode:
     expires_at: float
     code_challenge: Optional[str] = None
     code_challenge_method: Optional[str] = None
+    resource: Optional[str] = None
+
+
+_OAUTH_FORM_BODY_LIMIT = 16 * 1024
 
 
 class _OAuthTokenStore:
     """Small in-memory token/code store for single-process HTTP MCP servers."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        max_tokens: int = 1024,
+        max_codes: int = 1024,
+        max_code_issuance_per_minute: int = 120,
+    ) -> None:
         self._tokens: Dict[str, _IssuedToken] = {}
         self._codes: Dict[str, _AuthorizationCode] = {}
         self._lock = threading.Lock()
+        self._max_tokens = max(1, int(max_tokens))
+        self._max_codes = max(1, int(max_codes))
+        self._max_code_issuance_per_minute = max(
+            1, int(max_code_issuance_per_minute)
+        )
+        self._code_issuance_times: List[float] = []
+
+    @staticmethod
+    def _prune_expired(entries: Dict[str, Any], now: float) -> None:
+        for key, value in list(entries.items()):
+            if value.expires_at < now:
+                entries.pop(key, None)
+
+    @staticmethod
+    def _make_room(entries: Dict[str, Any], maximum: int) -> None:
+        while len(entries) >= maximum:
+            entries.pop(next(iter(entries)))
 
     def issue_token(self, client_id: str, ttl_seconds: int) -> str:
         token = secrets.token_urlsafe(32)
         with self._lock:
+            now = time.time()
+            self._prune_expired(self._tokens, now)
+            self._make_room(self._tokens, self._max_tokens)
             self._tokens[token] = _IssuedToken(
                 token=token,
                 client_id=client_id,
-                expires_at=time.time() + ttl_seconds,
+                expires_at=now + ttl_seconds,
             )
         return token
 
@@ -1191,16 +1324,30 @@ class _OAuthTokenStore:
         *,
         code_challenge: Optional[str] = None,
         code_challenge_method: Optional[str] = None,
+        resource: Optional[str] = None,
     ) -> str:
         code = secrets.token_urlsafe(24)
         with self._lock:
+            now = time.time()
+            monotonic_now = time.monotonic()
+            self._code_issuance_times = [
+                issued_at
+                for issued_at in self._code_issuance_times
+                if issued_at > monotonic_now - 60
+            ]
+            if len(self._code_issuance_times) >= self._max_code_issuance_per_minute:
+                raise OverflowError("authorization-code issuance rate exceeded")
+            self._code_issuance_times.append(monotonic_now)
+            self._prune_expired(self._codes, now)
+            self._make_room(self._codes, self._max_codes)
             self._codes[code] = _AuthorizationCode(
                 code=code,
                 client_id=client_id,
                 redirect_uri=redirect_uri,
-                expires_at=time.time() + ttl_seconds,
+                expires_at=now + ttl_seconds,
                 code_challenge=code_challenge,
                 code_challenge_method=code_challenge_method,
+                resource=resource,
             )
         return code
 
@@ -1210,21 +1357,26 @@ class _OAuthTokenStore:
         client_id: str,
         redirect_uri: str,
         code_verifier: Optional[str] = None,
+        resource: Optional[str] = None,
     ) -> bool:
         with self._lock:
-            issued = self._codes.pop(code, None)
+            issued = self._codes.get(code)
             if not issued:
                 return False
             if issued.expires_at < time.time():
+                self._codes.pop(code, None)
                 return False
             if not secrets.compare_digest(issued.client_id, client_id):
                 return False
             if not secrets.compare_digest(issued.redirect_uri, redirect_uri):
                 return False
+            if issued.resource and resource not in {None, issued.resource}:
+                return False
             if issued.code_challenge:
                 derived = _pkce_challenge(code_verifier, issued.code_challenge_method)
                 if not derived or not secrets.compare_digest(issued.code_challenge, derived):
                     return False
+            self._codes.pop(code, None)
             return True
 
 
@@ -1235,6 +1387,11 @@ def _normalize_path(path: str) -> str:
     if len(path) > 1:
         path = path.rstrip("/")
     return path
+
+
+def _mcp_child_path(path: str, child: str) -> str:
+    normalized = _normalize_path(path)
+    return f"/{child.lstrip('/')}" if normalized == "/" else f"{normalized}/{child.lstrip('/')}"
 
 
 def _read_env_secret(env_name: Optional[str]) -> Optional[str]:
@@ -1286,6 +1443,13 @@ def _pkce_challenge(verifier: Optional[str], method: Optional[str]) -> Optional[
     return None
 
 
+_PKCE_VALUE_RE = re.compile(r"^[A-Za-z0-9._~-]{43,128}$")
+
+
+def _valid_pkce_value(value: Optional[str]) -> bool:
+    return bool(value and _PKCE_VALUE_RE.fullmatch(value))
+
+
 def _is_loopback_host(host: str) -> bool:
     """Return whether *host* binds only to the local machine."""
     value = (host or "").strip().strip("[]")
@@ -1295,6 +1459,34 @@ def _is_loopback_host(host: str) -> bool:
         return ipaddress.ip_address(value).is_loopback
     except ValueError:
         return False
+
+
+def _http_host_literal(host: str) -> str:
+    bare_host = str(host).strip().strip("[]")
+    return f"[{bare_host}]" if ":" in bare_host else bare_host
+
+
+def _default_http_base_url(host: str, port: int) -> str:
+    return f"http://{_http_host_literal(host)}:{int(port)}"
+
+
+def _oauth_public_base_url_is_safe(public_base_url: str) -> bool:
+    """Require HTTPS for remote OAuth metadata and allow HTTP only on loopback."""
+    try:
+        parsed = urlparse(public_base_url)
+        hostname = parsed.hostname
+    except ValueError:
+        return False
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        return False
+    return parsed.scheme == "https" or _is_loopback_host(hostname)
 
 
 def _client_secret_valid(config: McpHttpAuthConfig, supplied: Optional[str]) -> bool:
@@ -1316,18 +1508,18 @@ def _auth_challenge(config: McpHttpAuthConfig) -> str:
 
 
 def _oauth_redirect_uri_allowed(config: McpHttpAuthConfig, redirect_uri: Optional[str]) -> bool:
-    if not redirect_uri:
+    if not redirect_uri or redirect_uri not in set(config.allowed_redirect_uris):
         return False
-    parsed = urlparse(redirect_uri)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+    try:
+        parsed = urlparse(redirect_uri)
+        hostname = parsed.hostname
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or not hostname:
         return False
     if parsed.fragment or parsed.username is not None or parsed.password is not None:
         return False
-    if parsed.hostname and _is_loopback_host(parsed.hostname):
-        return True
-    if parsed.scheme != "https":
-        return False
-    return redirect_uri in set(config.allowed_redirect_uris)
+    return parsed.scheme == "https" or _is_loopback_host(hostname)
 
 
 def _is_protected_mcp_http_path(config: McpHttpAuthConfig, request_path: str) -> bool:
@@ -1338,8 +1530,8 @@ def _is_protected_mcp_http_path(config: McpHttpAuthConfig, request_path: str) ->
     if mcp_path == "/" or not path.startswith(f"{mcp_path}/"):
         return False
     if config.oauth_compatible and path in {
-        f"{mcp_path}/authorize",
-        f"{mcp_path}/token",
+        _mcp_child_path(mcp_path, "authorize"),
+        _mcp_child_path(mcp_path, "token"),
     }:
         return False
     return True
@@ -1367,19 +1559,49 @@ def _is_authenticated(request, config: McpHttpAuthConfig, store: _OAuthTokenStor
     return False
 
 
-def _configure_transport_security(server, host: str, allowed_hosts: Sequence[str], allowed_origins: Sequence[str]) -> None:
-    hosts = list(dict.fromkeys([host, "127.0.0.1", "localhost", *allowed_hosts]))
-    origins = list(dict.fromkeys([*allowed_origins]))
-    if origins and "null" not in origins:
-        origins.append("null")
-    try:
-        from mcp.server.transport_security import TransportSecuritySettings
-        server.settings.transport_security = TransportSecuritySettings(
-            allowed_hosts=hosts,
-            allowed_origins=origins,
-        )
-    except Exception as exc:  # pragma: no cover - depends on MCP SDK version
-        logger.debug("Could not configure MCP transport security: %s", exc)
+def _configure_transport_security(
+    server,
+    host: str,
+    port: int,
+    allowed_hosts: Sequence[str],
+    allowed_origins: Sequence[str],
+) -> None:
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    header_host = _http_host_literal(host)
+    default_hosts = [
+        header_host,
+        f"{header_host}:{int(port)}",
+        "127.0.0.1",
+        f"127.0.0.1:{int(port)}",
+        "localhost",
+        f"localhost:{int(port)}",
+        "[::1]",
+        f"[::1]:{int(port)}",
+    ]
+    hosts = list(dict.fromkeys([*default_hosts, *allowed_hosts]))
+    origins = list(dict.fromkeys(allowed_origins))
+    server.settings.transport_security = TransportSecuritySettings(
+        allowed_hosts=hosts,
+        allowed_origins=origins,
+    )
+
+
+async def _read_request_body_limited(request, limit: int) -> bytes:
+    """Read an ASGI request body without allowing an unbounded allocation."""
+    stream = getattr(request, "stream", None)
+    if not callable(stream):
+        body = await request.body()
+        if len(body) > limit:
+            raise OverflowError("request body too large")
+        return body
+
+    body = bytearray()
+    async for chunk in stream():
+        body.extend(chunk)
+        if len(body) > limit:
+            raise OverflowError("request body too large")
+    return bytes(body)
 
 
 def create_streamable_http_app(
@@ -1418,16 +1640,28 @@ def create_streamable_http_app(
 
     if config and config.oauth_compatible:
         async def authorization_server_metadata(_request):
-            return JSONResponse({
+            authorization_code_enabled = bool(config.allowed_redirect_uris)
+            metadata = {
                 "issuer": config.public_base_url,
-                "authorization_endpoint": f"{config.public_base_url}{config.path}/authorize",
-                "token_endpoint": f"{config.public_base_url}{config.path}/token",
-                "response_types_supported": ["code"],
-                "grant_types_supported": ["authorization_code", "client_credentials"],
+                "token_endpoint": f"{config.public_base_url}{_mcp_child_path(config.path, 'token')}",
+                "response_types_supported": [],
+                "grant_types_supported": ["client_credentials"],
                 "token_endpoint_auth_methods_supported": ["client_secret_post"],
-                "code_challenge_methods_supported": ["plain", "S256"],
                 "scopes_supported": ["mcp"],
-            })
+            }
+            if authorization_code_enabled:
+                metadata.update(
+                    {
+                        "authorization_endpoint": f"{config.public_base_url}{_mcp_child_path(config.path, 'authorize')}",
+                        "response_types_supported": ["code"],
+                        "grant_types_supported": [
+                            "authorization_code",
+                            "client_credentials",
+                        ],
+                        "code_challenge_methods_supported": ["S256"],
+                    }
+                )
+            return JSONResponse(metadata)
 
         async def protected_resource_metadata(_request):
             return JSONResponse({
@@ -1443,9 +1677,20 @@ def create_streamable_http_app(
             redirect_uri = params.get("redirect_uri")
             response_type = params.get("response_type")
             state = params.get("state")
+            scope = params.get("scope")
             code_challenge = params.get("code_challenge")
             code_challenge_method = params.get("code_challenge_method")
+            expected_resource = f"{config.public_base_url}{config.path}"
+            resource = params.get("resource") or expected_resource
 
+            if not config.allowed_redirect_uris:
+                return JSONResponse(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "authorization-code grant is not configured",
+                    },
+                    status_code=400,
+                )
             if response_type != "code":
                 return JSONResponse({"error": "unsupported_response_type"}, status_code=400)
             if not _client_id_valid(config, client_id):
@@ -1460,48 +1705,98 @@ def create_streamable_http_app(
                     },
                     status_code=400,
                 )
-            if code_challenge:
-                code_challenge_method = code_challenge_method or "plain"
-                if code_challenge_method not in {"plain", "S256"}:
-                    return JSONResponse(
-                        {
-                            "error": "invalid_request",
-                            "error_description": "unsupported code_challenge_method",
-                        },
-                        status_code=400,
-                    )
-            elif code_challenge_method:
+            if resource != expected_resource:
+                return JSONResponse(
+                    {
+                        "error": "invalid_target",
+                        "error_description": "resource does not match this MCP server",
+                    },
+                    status_code=400,
+                )
+            if scope not in {None, "", "mcp"}:
+                return JSONResponse({"error": "invalid_scope"}, status_code=400)
+            if code_challenge_method != "S256" or not _valid_pkce_value(code_challenge):
                 return JSONResponse(
                     {
                         "error": "invalid_request",
-                        "error_description": "code_challenge is required with code_challenge_method",
+                        "error_description": "PKCE S256 code_challenge is required",
                     },
                     status_code=400,
                 )
 
-            code = store.issue_code(
-                client_id or "",
-                redirect_uri,
-                config.code_ttl_seconds,
-                code_challenge=code_challenge,
-                code_challenge_method=code_challenge_method,
-            )
+            try:
+                code = store.issue_code(
+                    client_id or "",
+                    redirect_uri,
+                    config.code_ttl_seconds,
+                    code_challenge=code_challenge,
+                    code_challenge_method="S256",
+                    resource=expected_resource,
+                )
+            except OverflowError:
+                return JSONResponse(
+                    {
+                        "error": "temporarily_unavailable",
+                        "error_description": "authorization-code issuance rate exceeded",
+                    },
+                    status_code=429,
+                    headers={"Retry-After": "60"},
+                )
             query = {"code": code}
             if state is not None:
                 query["state"] = state
             separator = "&" if "?" in redirect_uri else "?"
-            return RedirectResponse(f"{redirect_uri}{separator}{urlencode(query)}", status_code=302)
+            response = RedirectResponse(
+                f"{redirect_uri}{separator}{urlencode(query)}", status_code=302
+            )
+            response.headers["Cache-Control"] = "no-store"
+            response.headers["Pragma"] = "no-cache"
+            return response
+
+        def _token_response(payload, status_code=200):
+            return JSONResponse(
+                payload,
+                status_code=status_code,
+                headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+            )
 
         async def token(request):
-            body = (await request.body()).decode("utf-8")
+            try:
+                raw_body = await _read_request_body_limited(
+                    request, _OAUTH_FORM_BODY_LIMIT
+                )
+            except OverflowError:
+                return _token_response(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "request body is too large",
+                    },
+                    413,
+                )
+            try:
+                body = raw_body.decode("utf-8")
+            except UnicodeDecodeError:
+                return _token_response(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "request body must be UTF-8",
+                    },
+                    400,
+                )
             parsed = parse_qs(body, keep_blank_values=True)
             form = {key: values[-1] if values else "" for key, values in parsed.items()}
             grant_type = form.get("grant_type")
             client_id = form.get("client_id")
             client_secret = form.get("client_secret")
+            expected_resource = f"{config.public_base_url}{config.path}"
+            requested_resource = form.get("resource")
 
             if not _client_id_valid(config, client_id) or not _client_secret_valid(config, client_secret):
-                return JSONResponse({"error": "invalid_client"}, status_code=401)
+                return _token_response({"error": "invalid_client"}, 401)
+            if requested_resource and requested_resource != expected_resource:
+                return _token_response({"error": "invalid_target"}, 400)
+            if form.get("scope") not in {None, "", "mcp"}:
+                return _token_response({"error": "invalid_scope"}, 400)
 
             if grant_type == "client_credentials":
                 access_token = store.issue_token(client_id or "", config.token_ttl_seconds)
@@ -1509,28 +1804,32 @@ def create_streamable_http_app(
                 code = form.get("code")
                 redirect_uri = form.get("redirect_uri")
                 code_verifier = form.get("code_verifier")
-                if not store.consume_code(
+                resource = requested_resource or expected_resource
+                if not _valid_pkce_value(code_verifier) or not store.consume_code(
                     str(code or ""),
                     str(client_id or ""),
                     str(redirect_uri or ""),
-                    str(code_verifier) if code_verifier is not None else None,
+                    str(code_verifier),
+                    str(resource),
                 ):
-                    return JSONResponse({"error": "invalid_grant"}, status_code=400)
+                    return _token_response({"error": "invalid_grant"}, 400)
                 access_token = store.issue_token(client_id or "", config.token_ttl_seconds)
             else:
-                return JSONResponse({"error": "unsupported_grant_type"}, status_code=400)
+                return _token_response({"error": "unsupported_grant_type"}, 400)
 
-            return JSONResponse({
-                "access_token": access_token,
-                "token_type": "Bearer",
-                "expires_in": config.token_ttl_seconds,
-                "scope": "mcp",
-            })
+            return _token_response(
+                {
+                    "access_token": access_token,
+                    "token_type": "Bearer",
+                    "expires_in": config.token_ttl_seconds,
+                    "scope": "mcp",
+                }
+            )
 
         app.add_route("/.well-known/oauth-authorization-server", authorization_server_metadata, methods=["GET"])
         app.add_route(f"/.well-known/oauth-protected-resource{config.path}", protected_resource_metadata, methods=["GET"])
-        app.add_route(f"{config.path}/authorize", authorize, methods=["GET"])
-        app.add_route(f"{config.path}/token", token, methods=["POST"])
+        app.add_route(_mcp_child_path(config.path, "authorize"), authorize, methods=["GET"])
+        app.add_route(_mcp_child_path(config.path, "token"), token, methods=["POST"])
 
     if config:
         class McpAuthMiddleware:
@@ -1561,6 +1860,32 @@ def create_streamable_http_app(
 
         app.add_middleware(McpAuthMiddleware)
 
+    transport_security = getattr(server.settings, "transport_security", None)
+    if transport_security is not None:
+        from mcp.server.transport_security import TransportSecurityMiddleware
+
+        validator = TransportSecurityMiddleware(transport_security)
+
+        class AllRouteTransportSecurityMiddleware:
+            def __init__(self, inner_app):
+                self.app = inner_app
+
+            def __getattr__(self, name):
+                return getattr(self.app, name)
+
+            async def __call__(self, scope, receive, send):
+                if scope.get("type") == "http":
+                    request = Request(scope, receive=receive)
+                    rejection = await validator.validate_request(
+                        request, is_post=False
+                    )
+                    if rejection is not None:
+                        await rejection(scope, receive, send)
+                        return
+                await self.app(scope, receive, send)
+
+        app = AllRouteTransportSecurityMiddleware(app)
+
     return app
 
 
@@ -1574,10 +1899,11 @@ def run_mcp_http_server(
     auth_token_env: Optional[str] = None,
     auth_header: str = "X-Hermes-MCP-PSK",
     allow_query_token: bool = False,
+    allow_insecure_http: bool = False,
     oauth_compatible: bool = False,
     oauth_client_id_env: Optional[str] = None,
     oauth_client_secret_env: Optional[str] = None,
-    token_ttl_seconds: int = 2_592_000,
+    token_ttl_seconds: int = 3_600,
     code_ttl_seconds: int = 300,
     oauth_redirect_uris: Optional[Sequence[str]] = None,
     allowed_hosts: Optional[Sequence[str]] = None,
@@ -1598,11 +1924,28 @@ def run_mcp_http_server(
 
     logging.basicConfig(level=logging.DEBUG if verbose else logging.WARNING, stream=sys.stderr)
 
+    if not 1 <= int(port) <= 65535:
+        print("Error: --port must be between 1 and 65535.", file=sys.stderr)
+        sys.exit(1)
+
     path = _normalize_path(path)
-    base_url = (public_base_url or f"http://{host}:{port}").rstrip("/")
+    base_url = (public_base_url or _default_http_base_url(host, port)).rstrip("/")
     psk = _read_env_secret(auth_token_env)
     oauth_client_id = _read_env_secret(oauth_client_id_env) if oauth_client_id_env else None
     oauth_client_secret = _read_env_secret(oauth_client_secret_env) if oauth_client_secret_env else None
+
+    if oauth_compatible and oauth_client_id_env and not oauth_client_id:
+        print(
+            f"Error: OAuth client id environment variable {oauth_client_id_env!r} is empty or unset.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if oauth_compatible and oauth_client_secret_env and not oauth_client_secret:
+        print(
+            f"Error: OAuth client secret environment variable {oauth_client_secret_env!r} is empty or unset.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     if (auth_token_env or oauth_compatible) and not psk and not oauth_client_id:
         print(
@@ -1616,8 +1959,34 @@ def run_mcp_http_server(
             file=sys.stderr,
         )
         sys.exit(1)
+    if oauth_compatible and not _oauth_public_base_url_is_safe(base_url):
+        print(
+            "Error: OAuth public base URL must use HTTPS or a loopback HTTP host.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if oauth_compatible and not (1 <= int(token_ttl_seconds) <= 31_536_000):
+        print(
+            "Error: OAuth token TTL must be between 1 second and 1 year.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if oauth_compatible and not (1 <= int(code_ttl_seconds) <= 3_600):
+        print(
+            "Error: OAuth code TTL must be between 1 second and 1 hour.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     has_auth = bool(psk or (oauth_compatible and oauth_client_id))
+    if not _is_loopback_host(host) and not allow_insecure_http:
+        print(
+            "Error: cleartext HTTP serving is restricted to loopback hosts. "
+            "Bind to loopback behind HTTPS ingress, or explicitly pass "
+            "--allow-insecure-http for a trusted network.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     if not has_auth and not _is_loopback_host(host):
         print(
             "Error: unauthenticated MCP HTTP serving is restricted to loopback hosts. "
@@ -1625,25 +1994,6 @@ def run_mcp_http_server(
             file=sys.stderr,
         )
         sys.exit(1)
-
-    bridge = EventBridge()
-    bridge.start()
-    server = create_mcp_server(
-        event_bridge=bridge,
-        expose_toolsets=expose_toolsets,
-        expose_tools=expose_tools,
-        expose_plugin_tools=expose_plugin_tools,
-    )
-    server.settings.host = host
-    server.settings.port = int(port)
-    server.settings.streamable_http_path = path
-    server.settings.json_response = True
-    _configure_transport_security(
-        server,
-        host,
-        _comma_values(allowed_hosts),
-        _comma_values(allowed_origins),
-    )
 
     auth_config = None
     if psk or oauth_compatible:
@@ -1660,12 +2010,45 @@ def run_mcp_http_server(
             code_ttl_seconds=code_ttl_seconds,
             allowed_redirect_uris=_comma_values(oauth_redirect_uris),
         )
+        invalid_redirects = [
+            uri
+            for uri in auth_config.allowed_redirect_uris
+            if not _oauth_redirect_uri_allowed(auth_config, uri)
+        ]
+        if invalid_redirects:
+            print(
+                "Error: OAuth redirect URIs must be exact HTTP-loopback or HTTPS URLs without fragments.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
-    app = create_streamable_http_app(server, auth_config=auth_config, health_path=health_path)
-
-    import uvicorn
-
+    bridge = EventBridge()
+    bridge.start()
     try:
+        server = create_mcp_server(
+            event_bridge=bridge,
+            expose_toolsets=expose_toolsets,
+            expose_tools=expose_tools,
+            expose_plugin_tools=expose_plugin_tools,
+        )
+        server.settings.host = host
+        server.settings.port = int(port)
+        server.settings.streamable_http_path = path
+        server.settings.json_response = True
+        _configure_transport_security(
+            server,
+            host,
+            int(port),
+            _comma_values(allowed_hosts),
+            _comma_values(allowed_origins),
+        )
+
+        app = create_streamable_http_app(
+            server, auth_config=auth_config, health_path=health_path
+        )
+
+        import uvicorn
+
         uvicorn.run(
             app,
             host=host,
@@ -1702,25 +2085,26 @@ def run_mcp_server(
     else:
         logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
 
+    os.environ.setdefault("HERMES_QUIET", "1")
+    os.environ.setdefault("HERMES_REDACT_SECRETS", "true")
+
     bridge = EventBridge()
     bridge.start()
-
-    server = create_mcp_server(
-        event_bridge=bridge,
-        expose_toolsets=expose_toolsets,
-        expose_tools=expose_tools,
-        expose_plugin_tools=expose_plugin_tools,
-    )
-
-    import asyncio
-
-    async def _run():
-        try:
-            await server.run_stdio_async()
-        finally:
-            bridge.stop()
-
     try:
+        server = create_mcp_server(
+            event_bridge=bridge,
+            expose_toolsets=expose_toolsets,
+            expose_tools=expose_tools,
+            expose_plugin_tools=expose_plugin_tools,
+        )
+
+        import asyncio
+
+        async def _run():
+            await server.run_stdio_async()
+
         asyncio.run(_run())
     except KeyboardInterrupt:
+        pass
+    finally:
         bridge.stop()

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -1,7 +1,7 @@
 """
 Hermes MCP Server — expose messaging conversations as MCP tools (`hermes mcp serve`).
 
-A stdio MCP server letting any MCP client (Claude Code, Cursor, Codex, ...) list
+A stdio or authenticated Streamable HTTP MCP server letting any MCP client (Claude Code, Cursor, Codex, ...) list
 conversations, read history, send messages, poll live events, and manage approvals.
 Matches OpenClaw's 9-tool channel bridge surface plus the Hermes-specific
 channels_list. Client config: {"mcpServers": {"hermes": {"command": "hermes", "args": ["mcp", "serve"]}}}
@@ -9,17 +9,24 @@ channels_list. Client config: {"mcpServers": {"hermes": {"command": "hermes", "a
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import inspect
+import ipaddress
 import json
+import keyword
 import logging
 import os
 import re
+import secrets
 import sys
 import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Set
+from urllib.parse import parse_qs, urlencode, urlparse
 
 logger = logging.getLogger("hermes.mcp_serve")
 
@@ -689,7 +696,262 @@ _TOOL_NAMES = (
 )
 
 
-def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "MCPServer":
+def _schema_property_to_annotation(prop: dict) -> Any:
+    prop_type = prop.get("type") if isinstance(prop, dict) else None
+    if isinstance(prop_type, list):
+        prop_type = next((item for item in prop_type if item != "null"), None)
+    if prop_type == "string":
+        return str
+    if prop_type == "integer":
+        return int
+    if prop_type == "number":
+        return float
+    if prop_type == "boolean":
+        return bool
+    if prop_type == "array":
+        return list
+    if prop_type == "object":
+        return dict
+    return Any
+
+
+def _safe_identifier(name: str) -> str:
+    cleaned = re.sub(r"\W", "_", name or "arg")
+    if not cleaned or cleaned[0].isdigit():
+        cleaned = f"arg_{cleaned}"
+    if cleaned in {"class", "def", "from", "global", "lambda", "pass", "return"}:
+        cleaned = f"{cleaned}_"
+    return cleaned
+
+
+def _make_registry_tool_wrapper(
+    tool_name: str, *, omit_none_for: Optional[Set[str]] = None
+):
+    omitted_optional_names = set(omit_none_for or set())
+
+    def _tool(**kwargs):
+        # Registry tools exposed through MCP must follow the same guarded
+        # execution path as model-issued tool calls. Calling registry.dispatch
+        # directly would bypass request/execution middleware, plugin approval
+        # hooks, ACP edit approval, post-call hooks, and result transforms.
+        from model_tools import handle_function_call
+
+        call_id = secrets.token_hex(8)
+        function_args = {
+            key: value
+            for key, value in kwargs.items()
+            if value is not None or key not in omitted_optional_names
+        }
+        return handle_function_call(
+            function_name=tool_name,
+            function_args=function_args,
+            task_id=f"mcp-serve-{call_id}",
+            tool_call_id=f"mcp-{call_id}",
+            session_id=f"mcp-serve-{call_id}",
+            turn_id=f"mcp-turn-{call_id}",
+            api_request_id=f"mcp-request-{call_id}",
+        )
+
+    _tool.__name__ = f"_mcp_registry_tool_{_safe_identifier(tool_name)}"
+    return _tool
+
+
+def _apply_schema_signature(wrapper, schema: dict) -> Any:
+    parameters_schema = schema.get("parameters") or {}
+    properties = parameters_schema.get("properties") or {}
+    required = set(parameters_schema.get("required") or [])
+    params = []
+    name_map: dict[str, str] = {}
+
+    for raw_name, prop in properties.items():
+        if not str(raw_name).isidentifier() or keyword.iskeyword(str(raw_name)):
+            raise ValueError(
+                f"MCP-exposed tool property {raw_name!r} is not a valid Python identifier"
+            )
+        param_name = _safe_identifier(str(raw_name))
+        while param_name in name_map:
+            param_name = f"{param_name}_"
+        name_map[param_name] = str(raw_name)
+        default = inspect.Parameter.empty if raw_name in required else None
+        params.append(
+            inspect.Parameter(
+                param_name,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=_schema_property_to_annotation(prop if isinstance(prop, dict) else {}),
+            )
+        )
+
+    if name_map:
+        original = wrapper
+
+        def _mapped_tool(**kwargs):
+            return original(**{name_map.get(key, key): value for key, value in kwargs.items()})
+
+        _mapped_tool.__name__ = wrapper.__name__
+        wrapper = _mapped_tool
+
+    wrapper.__signature__ = inspect.Signature(params)  # type: ignore[attr-defined]
+    return wrapper
+
+
+def _schema_allows_null(prop: Any) -> bool:
+    if not isinstance(prop, dict):
+        return False
+    prop_type = prop.get("type")
+    if prop_type == "null" or (
+        isinstance(prop_type, list) and "null" in prop_type
+    ):
+        return True
+    for branch_key in ("anyOf", "oneOf"):
+        branches = prop.get(branch_key)
+        if isinstance(branches, list) and any(
+            isinstance(branch, dict) and branch.get("type") == "null"
+            for branch in branches
+        ):
+            return True
+    return False
+
+
+def _register_registry_tools_as_mcp(
+    mcp,
+    *,
+    expose_toolsets: Optional[Sequence[str]] = None,
+    expose_tools: Optional[Sequence[str]] = None,
+    expose_plugin_tools: bool = False,
+) -> List[str]:
+    include_toolsets: Set[str] = set(_comma_values(expose_toolsets))
+    include_tools: Set[str] = set(_comma_values(expose_tools))
+    if not include_toolsets and not include_tools and not expose_plugin_tools:
+        return []
+
+    reserved_names = {
+        "conversations_list",
+        "conversation_get",
+        "messages_read",
+        "attachments_fetch",
+        "events_poll",
+        "events_wait",
+        "messages_send",
+        "channels_list",
+        "permissions_list_open",
+        "permissions_respond",
+    }
+    try:
+        from tools.registry import registry
+        from hermes_cli.plugins import discover_plugins, get_plugin_manager
+        from model_tools import _AGENT_LOOP_TOOLS
+        discover_plugins()
+    except Exception as exc:
+        raise RuntimeError(
+            f"Could not discover requested Hermes tools for MCP serving: {exc}"
+        ) from exc
+
+    unsupported_requests = include_tools & set(_AGENT_LOOP_TOOLS)
+    if unsupported_requests:
+        raise RuntimeError(
+            "Agent-loop tools cannot be exposed by the stateless MCP server: "
+            + ", ".join(sorted(unsupported_requests))
+        )
+
+    plugin_tool_names = get_plugin_manager().get_registered_tool_names()
+    candidate_entries = {}
+    for name in registry.get_all_tool_names():
+        entry = registry.get_entry(name)
+        if not entry:
+            continue
+        should_expose = (
+            name in include_tools
+            or entry.toolset in include_toolsets
+            or (expose_plugin_tools and name in plugin_tool_names)
+        )
+        if not should_expose:
+            continue
+        if name in _AGENT_LOOP_TOOLS:
+            logger.warning(
+                "Skipping MCP exposure for agent-loop tool %s; it requires live agent state",
+                name,
+            )
+            continue
+        candidate_entries[name] = entry
+
+    reserved_candidates = set(candidate_entries) & reserved_names
+    if reserved_candidates:
+        raise RuntimeError(
+            "MCP tool selectors collide with built-in server tools: "
+            + ", ".join(sorted(reserved_candidates))
+        )
+
+    # Use the same authoritative schema/availability path as the agent. This
+    # applies dynamic_schema_overrides and the cached, transient-failure-safe
+    # check_fn policy. Reading ToolEntry.schema or calling check_fn directly
+    # would expose stale schemas and let one flaky probe hide a tool from MCP.
+    definitions = {
+        definition["function"]["name"]: definition["function"]
+        for definition in registry.get_definitions(set(candidate_entries), quiet=True)
+    }
+
+    registered: List[str] = []
+    for name, entry in candidate_entries.items():
+        schema = definitions.get(name)
+        if schema is None:
+            continue
+        parameters_schema = schema.get("parameters") or {}
+        properties = parameters_schema.get("properties") or {}
+        required = set(parameters_schema.get("required") or [])
+        omit_none_for = {
+            str(property_name)
+            for property_name, property_schema in properties.items()
+            if property_name not in required
+            and not _schema_allows_null(property_schema)
+        }
+        wrapper = _make_registry_tool_wrapper(entry.name, omit_none_for=omit_none_for)
+        wrapper = _apply_schema_signature(wrapper, schema)
+        mcp.add_tool(
+            wrapper,
+            name=entry.name,
+            description=schema.get("description") or entry.description or "Hermes tool",
+        )
+        tool = mcp._tool_manager.get_tool(entry.name)
+        if tool is not None:
+            tool.parameters = schema.get("parameters") or tool.parameters
+        registered.append(entry.name)
+
+    if registered:
+        logger.info("Exposed %d Hermes registry tools over MCP", len(registered))
+    missing_tools = include_tools - set(registered)
+    if missing_tools:
+        raise RuntimeError(
+            "Requested MCP tools are unknown or unavailable: "
+            + ", ".join(sorted(missing_tools))
+        )
+    empty_toolsets = {
+        toolset
+        for toolset in include_toolsets
+        if not any(
+            (entry := registry.get_entry(name))
+            and entry.toolset == toolset
+            and name in registered
+            for name in registry.get_all_tool_names()
+        )
+    }
+    if empty_toolsets:
+        raise RuntimeError(
+            "Requested MCP toolsets have no available tools: "
+            + ", ".join(sorted(empty_toolsets))
+        )
+    if expose_plugin_tools and not (set(registered) & plugin_tool_names):
+        raise RuntimeError("No enabled plugin tools are available for MCP exposure")
+    return registered
+
+
+def create_mcp_server(
+    event_bridge: Optional[EventBridge] = None,
+    *,
+    expose_toolsets: Optional[Sequence[str]] = None,
+    expose_tools: Optional[Sequence[str]] = None,
+    expose_plugin_tools: bool = False,
+) -> "MCPServer":
     """Create and return the Hermes MCP server with all tools registered."""
     if not _MCP_SERVER_AVAILABLE:
         raise ImportError(f"MCP server requires the 'mcp' package. Install with: {sys.executable} -m pip install 'mcp'")
@@ -701,28 +963,951 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "MCPServer"
     handlers = _ToolHandlers(event_bridge or EventBridge())
     for name in _TOOL_NAMES:
         mcp.tool()(getattr(handlers, name))
+    _register_registry_tools_as_mcp(
+        mcp, expose_toolsets=expose_toolsets, expose_tools=expose_tools,
+        expose_plugin_tools=expose_plugin_tools,
+    )
     return mcp
 
 
-def run_mcp_server(verbose: bool = False) -> None:
-    """Start the Hermes MCP server on stdio."""
+@dataclass
+class McpHttpAuthConfig:
+    """Authentication and OAuth-compatibility settings for HTTP MCP serving."""
+
+    psk: Optional[str] = None
+    psk_header: str = "X-Hermes-MCP-PSK"
+    allow_query_token: bool = False
+    oauth_compatible: bool = False
+    oauth_client_id: Optional[str] = None
+    oauth_client_secret: Optional[str] = None
+    public_base_url: str = "http://127.0.0.1:8666"
+    path: str = "/mcp"
+    token_ttl_seconds: int = 3_600
+    code_ttl_seconds: int = 300
+    allowed_redirect_uris: Sequence[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.path = _normalize_path(self.path)
+        self.public_base_url = self.public_base_url.rstrip("/")
+        self.allowed_redirect_uris = tuple(_comma_values(self.allowed_redirect_uris))
+        if self.oauth_compatible and not self.oauth_client_id:
+            # Keep the PSK out of authorization URLs, browser history, proxy
+            # logs, and redirect traces.  The default OAuth client id is public;
+            # the existing PSK becomes its confidential token-endpoint secret.
+            self.oauth_client_id = "hermes-mcp"
+        if self.oauth_compatible and not self.oauth_client_secret:
+            self.oauth_client_secret = self.psk
+
+
+@dataclass
+class _IssuedToken:
+    token: str
+    client_id: str
+    expires_at: float
+
+
+@dataclass
+class _AuthorizationCode:
+    code: str
+    client_id: str
+    redirect_uri: str
+    expires_at: float
+    code_challenge: Optional[str] = None
+    code_challenge_method: Optional[str] = None
+    resource: Optional[str] = None
+
+
+_OAUTH_FORM_BODY_LIMIT = 16 * 1024
+
+
+class _OAuthTokenStore:
+    """Small in-memory token/code store for single-process HTTP MCP servers."""
+
+    def __init__(
+        self,
+        *,
+        max_tokens: int = 1024,
+        max_codes: int = 1024,
+        max_code_issuance_per_minute: int = 120,
+    ) -> None:
+        self._tokens: Dict[str, _IssuedToken] = {}
+        self._codes: Dict[str, _AuthorizationCode] = {}
+        self._lock = threading.Lock()
+        self._max_tokens = max(1, int(max_tokens))
+        self._max_codes = max(1, int(max_codes))
+        self._max_code_issuance_per_minute = max(
+            1, int(max_code_issuance_per_minute)
+        )
+        self._code_issuance_times: List[float] = []
+
+    @staticmethod
+    def _prune_expired(entries: Dict[str, Any], now: float) -> None:
+        for key, value in list(entries.items()):
+            if value.expires_at < now:
+                entries.pop(key, None)
+
+    @staticmethod
+    def _require_room(entries: Dict[str, Any], maximum: int) -> None:
+        if len(entries) >= maximum:
+            raise OverflowError("OAuth state capacity reached")
+
+    def issue_token(self, client_id: str, ttl_seconds: int) -> str:
+        token = secrets.token_urlsafe(32)
+        with self._lock:
+            now = time.time()
+            self._prune_expired(self._tokens, now)
+            self._require_room(self._tokens, self._max_tokens)
+            self._tokens[token] = _IssuedToken(
+                token=token,
+                client_id=client_id,
+                expires_at=now + ttl_seconds,
+            )
+        return token
+
+    def validate_token(self, token: str) -> bool:
+        with self._lock:
+            issued = self._tokens.get(token)
+            if not issued:
+                return False
+            if issued.expires_at < time.time():
+                self._tokens.pop(token, None)
+                return False
+            return True
+
+    def issue_code(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        ttl_seconds: int,
+        *,
+        code_challenge: Optional[str] = None,
+        code_challenge_method: Optional[str] = None,
+        resource: Optional[str] = None,
+    ) -> str:
+        code = secrets.token_urlsafe(24)
+        with self._lock:
+            now = time.time()
+            monotonic_now = time.monotonic()
+            self._code_issuance_times = [
+                issued_at
+                for issued_at in self._code_issuance_times
+                if issued_at > monotonic_now - 60
+            ]
+            if len(self._code_issuance_times) >= self._max_code_issuance_per_minute:
+                raise OverflowError("authorization-code issuance rate exceeded")
+            self._prune_expired(self._codes, now)
+            self._require_room(self._codes, self._max_codes)
+            self._code_issuance_times.append(monotonic_now)
+            self._codes[code] = _AuthorizationCode(
+                code=code,
+                client_id=client_id,
+                redirect_uri=redirect_uri,
+                expires_at=now + ttl_seconds,
+                code_challenge=code_challenge,
+                code_challenge_method=code_challenge_method,
+                resource=resource,
+            )
+        return code
+
+    def consume_code(
+        self,
+        code: str,
+        client_id: str,
+        redirect_uri: str,
+        code_verifier: Optional[str] = None,
+        resource: Optional[str] = None,
+    ) -> bool:
+        with self._lock:
+            # An authorization code is a one-shot credential. Consume it on
+            # the first exchange attempt, including attempts with a bad
+            # redirect URI or PKCE verifier, so callers cannot retry guesses
+            # against the same code.
+            issued = self._codes.pop(code, None)
+            if not issued:
+                return False
+            if issued.expires_at < time.time():
+                return False
+            if not _constant_time_equals(issued.client_id, client_id):
+                return False
+            if not _constant_time_equals(issued.redirect_uri, redirect_uri):
+                return False
+            if issued.resource and resource not in {None, issued.resource}:
+                return False
+            if issued.code_challenge:
+                if not _valid_pkce_value(code_verifier):
+                    return False
+                derived = _pkce_challenge(code_verifier, issued.code_challenge_method)
+                if not derived or not secrets.compare_digest(issued.code_challenge, derived):
+                    return False
+            return True
+
+
+def _normalize_path(path: str) -> str:
+    path = (path or "/mcp").strip()
+    if not path.startswith("/"):
+        path = f"/{path}"
+    if len(path) > 1:
+        path = path.rstrip("/")
+    return path
+
+
+def _mcp_child_path(path: str, child: str) -> str:
+    normalized = _normalize_path(path)
+    return f"/{child.lstrip('/')}" if normalized == "/" else f"{normalized}/{child.lstrip('/')}"
+
+
+def _read_env_secret(env_name: Optional[str]) -> Optional[str]:
+    if not env_name:
+        return None
+    value = os.environ.get(env_name)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _comma_values(values: Optional[Sequence[str]]) -> List[str]:
+    result: List[str] = []
+    for item in values or []:
+        for part in str(item).split(","):
+            part = part.strip()
+            if part:
+                result.append(part)
+    return result
+
+
+def _extract_bearer_token(headers) -> Optional[str]:
+    auth = headers.get("authorization", "")
+    if auth.lower().startswith("bearer "):
+        token = auth[7:].strip()
+        return token or None
+    return None
+
+
+def _constant_time_equals(left: Optional[str], right: Optional[str]) -> bool:
+    if not left or not right:
+        return False
+    # compare_digest(str, str) rejects non-ASCII input. HTTP credentials
+    # are untrusted text; compare encoded bytes so invalid values get 401.
+    return secrets.compare_digest(str(left).encode("utf-8"), str(right).encode("utf-8"))
+
+
+def _pkce_challenge(verifier: Optional[str], method: Optional[str]) -> Optional[str]:
+    """Return the RFC 7636 challenge for a verifier and supported method."""
+    if not verifier:
+        return None
+    if method in (None, "plain"):
+        return verifier
+    if method == "S256":
+        try:
+            digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        except UnicodeEncodeError:
+            return None
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return None
+
+
+_PKCE_VALUE_RE = re.compile(r"^[A-Za-z0-9._~-]{43,128}$")
+
+
+def _valid_pkce_value(value: Optional[str]) -> bool:
+    return bool(value and _PKCE_VALUE_RE.fullmatch(value))
+
+
+def _is_loopback_host(host: str) -> bool:
+    """Return whether *host* binds only to the local machine."""
+    value = (host or "").strip().strip("[]")
+    if value.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return False
+
+
+def _http_host_literal(host: str) -> str:
+    bare_host = str(host).strip().strip("[]")
+    return f"[{bare_host}]" if ":" in bare_host else bare_host
+
+
+def _default_http_base_url(host: str, port: int) -> str:
+    return f"http://{_http_host_literal(host)}:{int(port)}"
+
+
+def _oauth_public_base_url_is_safe(public_base_url: str) -> bool:
+    """Require HTTPS for remote OAuth metadata and allow HTTP only on loopback."""
+    try:
+        parsed = urlparse(public_base_url)
+        hostname = parsed.hostname
+    except ValueError:
+        return False
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        return False
+    return parsed.scheme == "https" or _is_loopback_host(hostname)
+
+
+def _client_secret_valid(config: McpHttpAuthConfig, supplied: Optional[str]) -> bool:
+    return _constant_time_equals(config.oauth_client_secret, supplied)
+
+
+def _client_id_valid(config: McpHttpAuthConfig, supplied: Optional[str]) -> bool:
+    return _constant_time_equals(config.oauth_client_id, supplied)
+
+
+def _metadata_url(config: McpHttpAuthConfig) -> str:
+    return f"{config.public_base_url}/.well-known/oauth-protected-resource{config.path}"
+
+
+def _auth_challenge(config: McpHttpAuthConfig) -> str:
+    if config.oauth_compatible:
+        return f'Bearer resource_metadata="{_metadata_url(config)}"'
+    return "Bearer"
+
+
+def _oauth_redirect_uri_allowed(config: McpHttpAuthConfig, redirect_uri: Optional[str]) -> bool:
+    if not redirect_uri or redirect_uri not in set(config.allowed_redirect_uris):
+        return False
+    try:
+        parsed = urlparse(redirect_uri)
+        hostname = parsed.hostname
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or not hostname:
+        return False
+    if parsed.fragment or parsed.username is not None or parsed.password is not None:
+        return False
+    return parsed.scheme == "https" or _is_loopback_host(hostname)
+
+
+def _is_protected_mcp_http_path(config: McpHttpAuthConfig, request_path: str) -> bool:
+    path = request_path.rstrip("/") or "/"
+    mcp_path = config.path.rstrip("/") or "/"
+    if path == mcp_path:
+        return True
+    if mcp_path == "/" or not path.startswith(f"{mcp_path}/"):
+        return False
+    if config.oauth_compatible and path in {
+        _mcp_child_path(mcp_path, "authorize"),
+        _mcp_child_path(mcp_path, "token"),
+    }:
+        return False
+    return True
+
+
+def _is_authenticated(request, config: McpHttpAuthConfig, store: _OAuthTokenStore) -> bool:
+    bearer = _extract_bearer_token(request.headers)
+    if bearer:
+        if _constant_time_equals(config.psk, bearer):
+            return True
+        if config.oauth_compatible and store.validate_token(bearer):
+            return True
+
+    header_token = request.headers.get(config.psk_header)
+    if _constant_time_equals(config.psk, header_token):
+        return True
+
+    if config.allow_query_token:
+        query_token = request.query_params.get("access_token") or request.query_params.get("psk")
+        if _constant_time_equals(config.psk, query_token):
+            return True
+        if config.oauth_compatible and query_token and store.validate_token(query_token):
+            return True
+
+    return False
+
+
+def _configure_transport_security(
+    server,
+    host: str,
+    port: int,
+    allowed_hosts: Sequence[str],
+    allowed_origins: Sequence[str],
+) -> None:
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    header_host = _http_host_literal(host)
+    default_hosts = [
+        header_host,
+        f"{header_host}:{int(port)}",
+        "127.0.0.1",
+        f"127.0.0.1:{int(port)}",
+        "localhost",
+        f"localhost:{int(port)}",
+        "[::1]",
+        f"[::1]:{int(port)}",
+    ]
+    hosts = list(dict.fromkeys([*default_hosts, *allowed_hosts]))
+    origins = list(dict.fromkeys(allowed_origins))
+    security = TransportSecuritySettings(
+        allowed_hosts=hosts,
+        allowed_origins=origins,
+    )
+    # FastMCP 1.x stored transport options on ``server.settings``. MCP 2.x
+    # accepts them directly in ``streamable_http_app`` and its Settings model
+    # rejects unknown attributes. Retain the assignment only for compatible
+    # servers while returning the settings for the MCP 2.x call path.
+    settings = getattr(server, "settings", None)
+    if settings is not None and hasattr(settings, "transport_security"):
+        settings.transport_security = security
+    return security
+
+
+async def _read_request_body_limited(request, limit: int) -> bytes:
+    """Read an ASGI request body without allowing an unbounded allocation."""
+    stream = getattr(request, "stream", None)
+    if not callable(stream):
+        body = await request.body()
+        if len(body) > limit:
+            raise OverflowError("request body too large")
+        return body
+
+    body = bytearray()
+    async for chunk in stream():
+        body.extend(chunk)
+        if len(body) > limit:
+            raise OverflowError("request body too large")
+    return bytes(body)
+
+
+def create_streamable_http_app(
+    server,
+    *,
+    auth_config: Optional[McpHttpAuthConfig] = None,
+    health_path: str = "/health",
+    host: Optional[str] = None,
+    path: Optional[str] = None,
+    json_response: Optional[bool] = None,
+    transport_security=None,
+):
+    """Create the Starlette app for Streamable HTTP, including optional auth.
+
+    The returned app serves the MCP endpoint at ``path`` (default ``/mcp``).
+    If ``auth_config`` is provided, the MCP path requires either a PSK bearer/header
+    token or an OAuth-compatible bearer token issued by the local token endpoint.
+    """
+    if not hasattr(server, "streamable_http_app"):
+        raise RuntimeError("Installed MCP SDK does not support Streamable HTTP")
+
+    settings = getattr(server, "settings", None)
+    bind_host = str(host or getattr(settings, "host", "127.0.0.1"))
+    streamable_http_path = _normalize_path(
+        path or (auth_config.path if auth_config is not None else None)
+        or getattr(settings, "streamable_http_path", "/mcp")
+    )
+    if auth_config is not None and auth_config.path != streamable_http_path:
+        raise ValueError("MCP auth path must match the served HTTP path")
+    use_json_response = (
+        bool(json_response)
+        if json_response is not None
+        else bool(getattr(settings, "json_response", False))
+    )
+    if transport_security is None:
+        transport_security = getattr(settings, "transport_security", None)
+    if auth_config is None and not _is_loopback_host(bind_host):
+        raise ValueError(
+            "Unauthenticated MCP HTTP serving is restricted to loopback hosts"
+        )
+
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, PlainTextResponse, RedirectResponse
+
+    store = _OAuthTokenStore()
+    app = server.streamable_http_app(
+        streamable_http_path=streamable_http_path,
+        json_response=use_json_response,
+        transport_security=transport_security,
+        host=bind_host,
+    )
+    health_path = _normalize_path(health_path)
+    config = auth_config
+
+    async def health(_request):
+        return PlainTextResponse("ok")
+
+    app.add_route(health_path, health, methods=["GET", "HEAD"])
+
+    if config and config.oauth_compatible:
+        async def authorization_server_metadata(_request):
+            authorization_code_enabled = bool(config.allowed_redirect_uris)
+            metadata = {
+                "issuer": config.public_base_url,
+                "token_endpoint": f"{config.public_base_url}{_mcp_child_path(config.path, 'token')}",
+                "response_types_supported": [],
+                "grant_types_supported": ["client_credentials"],
+                "token_endpoint_auth_methods_supported": ["client_secret_post"],
+                "scopes_supported": ["mcp"],
+            }
+            if authorization_code_enabled:
+                metadata.update(
+                    {
+                        "authorization_endpoint": f"{config.public_base_url}{_mcp_child_path(config.path, 'authorize')}",
+                        "response_types_supported": ["code"],
+                        "grant_types_supported": [
+                            "authorization_code",
+                            "client_credentials",
+                        ],
+                        "code_challenge_methods_supported": ["S256"],
+                    }
+                )
+            return JSONResponse(metadata)
+
+        async def protected_resource_metadata(_request):
+            return JSONResponse({
+                "resource": f"{config.public_base_url}{config.path}",
+                "authorization_servers": [config.public_base_url],
+                "bearer_methods_supported": ["header"],
+                "scopes_supported": ["mcp"],
+            })
+
+        async def authorize(request):
+            params = request.query_params
+            client_id = params.get("client_id")
+            redirect_uri = params.get("redirect_uri")
+            response_type = params.get("response_type")
+            state = params.get("state")
+            scope = params.get("scope")
+            code_challenge = params.get("code_challenge")
+            code_challenge_method = params.get("code_challenge_method")
+            expected_resource = f"{config.public_base_url}{config.path}"
+            resource = params.get("resource") or expected_resource
+
+            if not config.allowed_redirect_uris:
+                return JSONResponse(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "authorization-code grant is not configured",
+                    },
+                    status_code=400,
+                )
+            if response_type != "code":
+                return JSONResponse({"error": "unsupported_response_type"}, status_code=400)
+            if not _client_id_valid(config, client_id):
+                return JSONResponse({"error": "invalid_client"}, status_code=401)
+            if not redirect_uri:
+                return JSONResponse({"error": "invalid_request", "error_description": "redirect_uri is required"}, status_code=400)
+            if not _oauth_redirect_uri_allowed(config, redirect_uri):
+                return JSONResponse(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "redirect_uri is not allowed",
+                    },
+                    status_code=400,
+                )
+            if resource != expected_resource:
+                return JSONResponse(
+                    {
+                        "error": "invalid_target",
+                        "error_description": "resource does not match this MCP server",
+                    },
+                    status_code=400,
+                )
+            if scope not in {None, "", "mcp"}:
+                return JSONResponse({"error": "invalid_scope"}, status_code=400)
+            if code_challenge_method != "S256" or not _valid_pkce_value(code_challenge):
+                return JSONResponse(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "PKCE S256 code_challenge is required",
+                    },
+                    status_code=400,
+                )
+
+            try:
+                code = store.issue_code(
+                    client_id or "",
+                    redirect_uri,
+                    config.code_ttl_seconds,
+                    code_challenge=code_challenge,
+                    code_challenge_method="S256",
+                    resource=expected_resource,
+                )
+            except OverflowError as exc:
+                return JSONResponse(
+                    {
+                        "error": "temporarily_unavailable",
+                        "error_description": str(exc),
+                    },
+                    status_code=429,
+                    headers={"Retry-After": "60"},
+                )
+            query = {"code": code}
+            if state is not None:
+                query["state"] = state
+            separator = "&" if "?" in redirect_uri else "?"
+            response = RedirectResponse(
+                f"{redirect_uri}{separator}{urlencode(query)}", status_code=302
+            )
+            response.headers["Cache-Control"] = "no-store"
+            response.headers["Pragma"] = "no-cache"
+            return response
+
+        def _token_response(payload, status_code=200):
+            return JSONResponse(
+                payload,
+                status_code=status_code,
+                headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+            )
+
+        async def token(request):
+            try:
+                raw_body = await _read_request_body_limited(
+                    request, _OAUTH_FORM_BODY_LIMIT
+                )
+            except OverflowError:
+                return _token_response(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "request body is too large",
+                    },
+                    413,
+                )
+            try:
+                body = raw_body.decode("utf-8")
+            except UnicodeDecodeError:
+                return _token_response(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "request body must be UTF-8",
+                    },
+                    400,
+                )
+            parsed = parse_qs(body, keep_blank_values=True)
+            form = {key: values[-1] if values else "" for key, values in parsed.items()}
+            grant_type = form.get("grant_type")
+            client_id = form.get("client_id")
+            client_secret = form.get("client_secret")
+            expected_resource = f"{config.public_base_url}{config.path}"
+            requested_resource = form.get("resource")
+
+            if not _client_id_valid(config, client_id) or not _client_secret_valid(config, client_secret):
+                return _token_response({"error": "invalid_client"}, 401)
+            if requested_resource and requested_resource != expected_resource:
+                return _token_response({"error": "invalid_target"}, 400)
+            if form.get("scope") not in {None, "", "mcp"}:
+                return _token_response({"error": "invalid_scope"}, 400)
+
+            try:
+                if grant_type == "client_credentials":
+                    access_token = store.issue_token(client_id or "", config.token_ttl_seconds)
+                elif grant_type == "authorization_code":
+                    code = form.get("code")
+                    redirect_uri = form.get("redirect_uri")
+                    code_verifier = form.get("code_verifier")
+                    resource = requested_resource or expected_resource
+                    if not store.consume_code(
+                        str(code or ""),
+                        str(client_id or ""),
+                        str(redirect_uri or ""),
+                        str(code_verifier),
+                        str(resource),
+                    ):
+                        return _token_response({"error": "invalid_grant"}, 400)
+                    access_token = store.issue_token(
+                        client_id or "", config.token_ttl_seconds
+                    )
+                else:
+                    return _token_response({"error": "unsupported_grant_type"}, 400)
+            except OverflowError as exc:
+                return _token_response(
+                    {
+                        "error": "temporarily_unavailable",
+                        "error_description": str(exc),
+                    },
+                    503,
+                )
+
+            return _token_response(
+                {
+                    "access_token": access_token,
+                    "token_type": "Bearer",
+                    "expires_in": config.token_ttl_seconds,
+                    "scope": "mcp",
+                }
+            )
+
+        app.add_route("/.well-known/oauth-authorization-server", authorization_server_metadata, methods=["GET"])
+        app.add_route(f"/.well-known/oauth-protected-resource{config.path}", protected_resource_metadata, methods=["GET"])
+        app.add_route(_mcp_child_path(config.path, "authorize"), authorize, methods=["GET"])
+        app.add_route(_mcp_child_path(config.path, "token"), token, methods=["POST"])
+
+    if config:
+        class McpAuthMiddleware:
+            def __init__(self, asgi_app):
+                self.app = asgi_app
+
+            async def __call__(self, scope, receive, send):
+                if scope.get("type") != "http":
+                    await self.app(scope, receive, send)
+                    return
+
+                request = Request(scope, receive=receive)
+                if (
+                    _is_protected_mcp_http_path(config, request.url.path)
+                    and not _is_authenticated(request, config, store)
+                ):
+                    response = JSONResponse(
+                        {
+                            "error": "unauthorized",
+                            "hint": "Authenticate with OAuth bearer token, bearer/header PSK, or an enabled query token.",
+                        },
+                        status_code=401,
+                        headers={"WWW-Authenticate": _auth_challenge(config)},
+                    )
+                    await response(scope, receive, send)
+                    return
+                await self.app(scope, receive, send)
+
+        app.add_middleware(McpAuthMiddleware)
+
+    if transport_security is not None:
+        from mcp.server.transport_security import TransportSecurityMiddleware
+
+        validator = TransportSecurityMiddleware(transport_security)
+
+        class AllRouteTransportSecurityMiddleware:
+            def __init__(self, inner_app):
+                self.app = inner_app
+
+            def __getattr__(self, name):
+                return getattr(self.app, name)
+
+            async def __call__(self, scope, receive, send):
+                if scope.get("type") == "http":
+                    request = Request(scope, receive=receive)
+                    rejection = await validator.validate_request(
+                        request, is_post=False
+                    )
+                    if rejection is not None:
+                        await rejection(scope, receive, send)
+                        return
+                await self.app(scope, receive, send)
+
+        app = AllRouteTransportSecurityMiddleware(app)
+
+    return app
+
+
+def run_mcp_http_server(
+    *,
+    verbose: bool = False,
+    host: str = "127.0.0.1",
+    port: int = 8666,
+    path: str = "/mcp",
+    public_base_url: Optional[str] = None,
+    auth_token_env: Optional[str] = None,
+    auth_header: str = "X-Hermes-MCP-PSK",
+    allow_query_token: bool = False,
+    allow_insecure_http: bool = False,
+    oauth_compatible: bool = False,
+    oauth_client_id_env: Optional[str] = None,
+    oauth_client_secret_env: Optional[str] = None,
+    token_ttl_seconds: int = 3_600,
+    code_ttl_seconds: int = 300,
+    oauth_redirect_uris: Optional[Sequence[str]] = None,
+    allowed_hosts: Optional[Sequence[str]] = None,
+    allowed_origins: Optional[Sequence[str]] = None,
+    expose_toolsets: Optional[Sequence[str]] = None,
+    expose_tools: Optional[Sequence[str]] = None,
+    expose_plugin_tools: bool = False,
+    health_path: str = "/health",
+) -> None:
+    """Start the Hermes MCP server over Streamable HTTP."""
     if not _MCP_SERVER_AVAILABLE:
-        print("Error: MCP server requires the 'mcp' package.\n"
-              f"Install with: {sys.executable} -m pip install 'mcp'", file=sys.stderr)
+        print(
+            "Error: MCP HTTP server requires the 'mcp' package.\n"
+            f"Install with: {sys.executable} -m pip install 'mcp'",
+            file=sys.stderr,
+        )
         sys.exit(1)
+
     logging.basicConfig(level=logging.DEBUG if verbose else logging.WARNING, stream=sys.stderr)
+
+    if not 1 <= int(port) <= 65535:
+        print("Error: --port must be between 1 and 65535.", file=sys.stderr)
+        sys.exit(1)
+
+    path = _normalize_path(path)
+    base_url = (public_base_url or _default_http_base_url(host, port)).rstrip("/")
+    psk = _read_env_secret(auth_token_env)
+    oauth_client_id = _read_env_secret(oauth_client_id_env) if oauth_client_id_env else None
+    oauth_client_secret = _read_env_secret(oauth_client_secret_env) if oauth_client_secret_env else None
+
+    if oauth_compatible and oauth_client_id_env and not oauth_client_id:
+        print(
+            f"Error: OAuth client id environment variable {oauth_client_id_env!r} is empty or unset.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if oauth_compatible and oauth_client_secret_env and not oauth_client_secret:
+        print(
+            f"Error: OAuth client secret environment variable {oauth_client_secret_env!r} is empty or unset.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if (auth_token_env or oauth_compatible) and not psk and not oauth_client_id:
+        print(
+            "Error: HTTP auth requested but no auth token/client id was found in the configured environment variables.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if oauth_compatible and oauth_client_id and not oauth_client_secret:
+        print(
+            "Error: --oauth-client-id-env requires --oauth-client-secret-env.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if oauth_compatible and not _oauth_public_base_url_is_safe(base_url):
+        print(
+            "Error: OAuth public base URL must use HTTPS or a loopback HTTP host.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if oauth_compatible and not (1 <= int(token_ttl_seconds) <= 31_536_000):
+        print(
+            "Error: OAuth token TTL must be between 1 second and 1 year.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if oauth_compatible and not (1 <= int(code_ttl_seconds) <= 3_600):
+        print(
+            "Error: OAuth code TTL must be between 1 second and 1 hour.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    has_auth = bool(psk or (oauth_compatible and oauth_client_id))
+    if not _is_loopback_host(host) and not allow_insecure_http:
+        print(
+            "Error: cleartext HTTP serving is restricted to loopback hosts. "
+            "Bind to loopback behind HTTPS ingress, or explicitly pass "
+            "--allow-insecure-http for a trusted network.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not has_auth and not _is_loopback_host(host):
+        print(
+            "Error: unauthenticated MCP HTTP serving is restricted to loopback hosts. "
+            "Configure a PSK/OAuth credential or bind to 127.0.0.1, ::1, or localhost.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    auth_config = None
+    if psk or oauth_compatible:
+        auth_config = McpHttpAuthConfig(
+            psk=psk,
+            psk_header=auth_header,
+            allow_query_token=allow_query_token,
+            oauth_compatible=oauth_compatible,
+            oauth_client_id=oauth_client_id,
+            oauth_client_secret=oauth_client_secret,
+            public_base_url=base_url,
+            path=path,
+            token_ttl_seconds=token_ttl_seconds,
+            code_ttl_seconds=code_ttl_seconds,
+            allowed_redirect_uris=_comma_values(oauth_redirect_uris),
+        )
+        invalid_redirects = [
+            uri
+            for uri in auth_config.allowed_redirect_uris
+            if not _oauth_redirect_uri_allowed(auth_config, uri)
+        ]
+        if invalid_redirects:
+            print(
+                "Error: OAuth redirect URIs must be exact HTTP-loopback or HTTPS URLs without fragments.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
     bridge = EventBridge()
     bridge.start()
-    server = create_mcp_server(event_bridge=bridge)
-    import asyncio
-
-    async def _run():
-        try:
-            await server.run_stdio_async()
-        finally:
-            bridge.stop()
-
     try:
+        server = create_mcp_server(
+            event_bridge=bridge,
+            expose_toolsets=expose_toolsets,
+            expose_tools=expose_tools,
+            expose_plugin_tools=expose_plugin_tools,
+        )
+        transport_security = _configure_transport_security(
+            server,
+            host,
+            int(port),
+            _comma_values(allowed_hosts),
+            _comma_values(allowed_origins),
+        )
+
+        app = create_streamable_http_app(
+            server,
+            auth_config=auth_config,
+            health_path=health_path,
+            host=host,
+            path=path,
+            json_response=True,
+            transport_security=transport_security,
+        )
+
+        import uvicorn
+
+        uvicorn.run(
+            app,
+            host=host,
+            port=int(port),
+            log_level="debug" if verbose else "warning",
+            access_log=not allow_query_token,
+        )
+    finally:
+        bridge.stop()
+
+
+def run_mcp_server(
+    verbose: bool = False,
+    *,
+    expose_toolsets: Optional[Sequence[str]] = None,
+    expose_tools: Optional[Sequence[str]] = None,
+    expose_plugin_tools: bool = False,
+) -> None:
+    """Start the Hermes MCP server on stdio."""
+    if not _MCP_SERVER_AVAILABLE:
+        print(
+            "Error: MCP server requires the 'mcp' package.\n"
+            f"Install with: {sys.executable} -m pip install 'mcp'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+    else:
+        logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+
+    os.environ.setdefault("HERMES_QUIET", "1")
+    os.environ.setdefault("HERMES_REDACT_SECRETS", "true")
+
+    bridge = EventBridge()
+    bridge.start()
+    try:
+        server = create_mcp_server(
+            event_bridge=bridge,
+            expose_toolsets=expose_toolsets,
+            expose_tools=expose_tools,
+            expose_plugin_tools=expose_plugin_tools,
+        )
+
+        import asyncio
+
+        async def _run():
+            await server.run_stdio_async()
+
         asyncio.run(_run())
     except KeyboardInterrupt:
+        pass
+    finally:
         bridge.stop()

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -543,7 +543,46 @@ class TestThreadToolWhitelist:
 class TestPluginContext:
     """Tests for the PluginContext facade."""
 
+    def test_rejected_tool_collision_is_not_tracked_as_plugin_tool(self):
+        """A rejected cross-toolset collision must not gain plugin provenance."""
+        from hermes_cli.plugins import PluginContext, PluginManifest
+        from tools.registry import registry
 
+        tool_name = "test_plugin_collision_target"
+        registry.register(
+            name=tool_name,
+            toolset="builtin-test-toolset",
+            schema={
+                "name": tool_name,
+                "description": "Built-in",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kw: "built-in",
+        )
+        try:
+            manager = PluginManager()
+            context = PluginContext(
+                manager=manager,
+                manifest=PluginManifest(name="collision-plugin", source="user"),
+            )
+
+            context.register_tool(
+                name=tool_name,
+                toolset="plugin-collision-toolset",
+                schema={
+                    "name": tool_name,
+                    "description": "Plugin collision",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                handler=lambda args, **kw: "plugin",
+            )
+
+            entry = registry.get_entry(tool_name)
+            assert entry is not None
+            assert entry.toolset == "builtin-test-toolset"
+            assert manager.get_registered_tool_names() == set()
+        finally:
+            registry.deregister(tool_name)
 
 
     def test_register_tool_override_blocked_without_operator_opt_in(self, tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1676,7 +1676,46 @@ class TestThreadToolWhitelist:
 class TestPluginContext:
     """Tests for the PluginContext facade."""
 
+    def test_rejected_tool_collision_is_not_tracked_as_plugin_tool(self):
+        """A rejected cross-toolset collision must not gain plugin provenance."""
+        from hermes_cli.plugins import PluginContext, PluginManifest
+        from tools.registry import registry
 
+        tool_name = "test_plugin_collision_target"
+        registry.register(
+            name=tool_name,
+            toolset="builtin-test-toolset",
+            schema={
+                "name": tool_name,
+                "description": "Built-in",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kw: "built-in",
+        )
+        try:
+            manager = PluginManager()
+            context = PluginContext(
+                manager=manager,
+                manifest=PluginManifest(name="collision-plugin", source="user"),
+            )
+
+            context.register_tool(
+                name=tool_name,
+                toolset="plugin-collision-toolset",
+                schema={
+                    "name": tool_name,
+                    "description": "Plugin collision",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                handler=lambda args, **kw: "plugin",
+            )
+
+            entry = registry.get_entry(tool_name)
+            assert entry is not None
+            assert entry.toolset == "builtin-test-toolset"
+            assert manager.get_registered_tool_names() == set()
+        finally:
+            registry.deregister(tool_name)
 
 
     def test_register_tool_override_blocked_without_operator_opt_in(self, tmp_path, monkeypatch):

--- a/tests/test_mcp_http_auth_boundaries.py
+++ b/tests/test_mcp_http_auth_boundaries.py
@@ -1,0 +1,102 @@
+"""HTTP authentication boundaries exercised through the real MCP/ASGI app."""
+
+from contextlib import asynccontextmanager
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+import mcp_serve
+
+
+@asynccontextmanager
+async def _client(config):
+    app = mcp_serve.create_streamable_http_app(
+        mcp_serve.create_mcp_server(), auth_config=config, json_response=True,
+    )
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://127.0.0.1:8666",
+            headers={"Accept": "application/json, text/event-stream"},
+        ) as client:
+            yield client
+
+
+def _initialize():
+    return {
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18", "capabilities": {},
+            "clientInfo": {"name": "auth-boundary-test", "version": "1"},
+        },
+    }
+
+
+def test_auth_path_mismatch_fails_before_serving():
+    with pytest.raises(ValueError, match="path"):
+        mcp_serve.create_streamable_http_app(
+            mcp_serve.create_mcp_server(),
+            auth_config=mcp_serve.McpHttpAuthConfig(psk="test-secret", path="/mcp"),
+            path="/rpc",
+        )
+
+
+@pytest.mark.asyncio
+async def test_custom_auth_path_is_the_served_protected_endpoint():
+    config = mcp_serve.McpHttpAuthConfig(psk="test-secret", path="/rpc")
+    async with _client(config) as client:
+        denied = await client.post("/rpc", json=_initialize())
+        accepted = await client.post(
+            "/rpc", json=_initialize(), headers={"Authorization": "Bearer test-secret"},
+        )
+        old_path = await client.post("/mcp", json=_initialize())
+    assert denied.status_code == 401
+    assert accepted.status_code == 200
+    assert accepted.json()["result"]["serverInfo"]["name"] == "hermes"
+    assert old_path.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_credentials_are_rejected_without_server_error():
+    config = mcp_serve.McpHttpAuthConfig(
+        psk="test-secret", allow_query_token=True, oauth_compatible=True,
+    )
+    async with _client(config) as client:
+        query = await client.post("/mcp", params={"access_token": "wrong-é"}, json=_initialize())
+        client_id = await client.post(
+            "/mcp/token", data={"grant_type": "client_credentials", "client_id": "wrong-é"},
+        )
+        secret = await client.post("/mcp/token", data={
+            "grant_type": "client_credentials", "client_id": "hermes-mcp",
+            "client_secret": "wrong-é",
+        })
+    assert [query.status_code, client_id.status_code, secret.status_code] == [401, 401, 401]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_verifier", ["", "too-short", "é" * 43])
+async def test_malformed_verifier_consumes_authorization_code(bad_verifier):
+    verifier = "v" * 43
+    redirect_uri = "https://client.example/callback"
+    config = mcp_serve.McpHttpAuthConfig(
+        psk="test-secret", oauth_compatible=True, allowed_redirect_uris=[redirect_uri],
+    )
+    async with _client(config) as client:
+        authorization = await client.get("/mcp/authorize", params={
+            "client_id": "hermes-mcp", "response_type": "code", "redirect_uri": redirect_uri,
+            "code_challenge_method": "S256",
+            "code_challenge": mcp_serve._pkce_challenge(verifier, "S256"),
+        })
+        assert authorization.status_code == 302
+        code = parse_qs(urlparse(authorization.headers["location"]).query)["code"][0]
+        grant = {
+            "grant_type": "authorization_code", "client_id": "hermes-mcp",
+            "client_secret": "test-secret", "redirect_uri": redirect_uri, "code": code,
+        }
+        failed = await client.post("/mcp/token", data={**grant, "code_verifier": bad_verifier})
+        replay = await client.post("/mcp/token", data={**grant, "code_verifier": verifier})
+    assert failed.status_code == 400
+    assert failed.json()["error"] == "invalid_grant"
+    assert replay.status_code == 400
+    assert replay.json()["error"] == "invalid_grant"

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -212,6 +212,7 @@ class _FakeTool:
         self.name = fn.__name__
         self.description = inspect.getdoc(fn) or ""
         self.fn = fn
+        self.parameters = {}
 
 
 class _FakeToolManager:
@@ -220,6 +221,9 @@ class _FakeToolManager:
 
     def add_tool(self, fn):
         self._tools[fn.__name__] = _FakeTool(fn)
+
+    def get_tool(self, name):
+        return self._tools.get(name)
 
     async def call_tool(self, name, args=None):
         return self._tools[name].fn(**(args or {}))
@@ -251,6 +255,11 @@ class _FakeMCPServer:
         which the real server would reject before the handler ever ran.
         """
         return await self._tool_manager.call_tool(name, args)
+
+    def add_tool(self, fn, name=None, description=None, **_kwargs):
+        self._tool_manager._tools[name or fn.__name__] = _FakeTool(fn)
+        self._tool_manager._tools[name or fn.__name__].name = name or fn.__name__
+        self._tool_manager._tools[name or fn.__name__].description = description or ""
 
 
 @pytest.fixture
@@ -1000,6 +1009,321 @@ class TestServerCreation:
         bridge = mcp_serve.EventBridge()
         assert mcp_serve.create_mcp_server(event_bridge=bridge) is not None
 
+    def test_create_exposes_selected_registry_toolset(self, populated_sessions_dir, monkeypatch):
+        pytest.importorskip("mcp", reason="MCP SDK not installed")
+        import mcp_serve
+        from tools.registry import registry
+
+        tool_name = "test_mcp_exposed_plugin_tool"
+        registry.register(
+            name=tool_name,
+            toolset="test-mcp-expose",
+            schema={
+                "name": tool_name,
+                "description": "Test exposed plugin-style tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "message": {"type": "string", "description": "Message to echo"},
+                        "confirm": {"type": "boolean", "description": "Safety acknowledgement"},
+                    },
+                    "required": ["message"],
+                    "additionalProperties": False,
+                },
+            },
+            handler=lambda args, **_kwargs: json.dumps({"echo": args}),
+        )
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: populated_sessions_dir)
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda force=False: None)
+        try:
+            server = mcp_serve.create_mcp_server(expose_toolsets=["test-mcp-expose"])
+            tool = server._tool_manager.get_tool(tool_name)
+            assert tool is not None
+            assert tool.parameters["properties"]["message"]["type"] == "string"
+        finally:
+            registry.deregister(tool_name)
+
+    def test_plugin_only_exposure_ignores_rejected_builtin_collision(self, monkeypatch):
+        import model_tools  # noqa: F401 - ensure built-in registry discovery ran
+        import mcp_serve
+        import hermes_cli.plugins as plugins_mod
+        from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+        from tools.registry import registry
+
+        assert registry.get_entry("terminal") is not None
+        manager = PluginManager()
+        context = PluginContext(
+            manager=manager,
+            manifest=PluginManifest(name="collision-plugin", source="user"),
+        )
+        context.register_tool(
+            name="terminal",
+            toolset="plugin-collision-toolset",
+            schema={
+                "name": "terminal",
+                "description": "Plugin collision",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kw: "plugin",
+        )
+        monkeypatch.setattr(plugins_mod, "discover_plugins", lambda force=False: None)
+        monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+        server = _FakeMCPServer()
+
+        with pytest.raises(
+            RuntimeError, match="No enabled plugin tools are available for MCP exposure"
+        ):
+            mcp_serve._register_registry_tools_as_mcp(server, expose_plugin_tools=True)
+
+        assert manager.get_registered_tool_names() == set()
+        assert server._tool_manager.get_tool("terminal") is None
+
+    def test_toolset_exposure_rejects_builtin_mcp_name_collision(self, monkeypatch):
+        import mcp_serve
+        from tools.registry import registry
+
+        tool_name = "messages_send"
+        registry.register(
+            name=tool_name,
+            toolset="test-mcp-reserved-collision",
+            schema={
+                "name": tool_name,
+                "description": "Must not replace the built-in MCP tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"evil": {"type": "string"}},
+                },
+            },
+            handler=lambda args, **_kwargs: "plugin",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.discover_plugins", lambda force=False: None
+        )
+        try:
+            with pytest.raises(RuntimeError, match="collide with built-in server tools"):
+                mcp_serve._register_registry_tools_as_mcp(
+                    _FakeMCPServer(),
+                    expose_toolsets=["test-mcp-reserved-collision"],
+                )
+        finally:
+            registry.deregister(tool_name)
+
+    def test_registry_exposure_uses_dynamic_schema_and_cached_check(self, monkeypatch):
+        import mcp_serve
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        tool_name = "test_mcp_dynamic_registry_schema"
+        check_calls = 0
+
+        def check_fn():
+            nonlocal check_calls
+            check_calls += 1
+            return check_calls == 1
+
+        registry.register(
+            name=tool_name,
+            toolset="test-mcp-dynamic",
+            schema={
+                "name": tool_name,
+                "description": "static placeholder",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **_kwargs: json.dumps({"ok": True}),
+            check_fn=check_fn,
+            dynamic_schema_overrides=lambda: {
+                "description": "runtime authoritative description",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"runtime_value": {"type": "integer"}},
+                    "required": ["runtime_value"],
+                },
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.discover_plugins", lambda force=False: None
+        )
+        invalidate_check_fn_cache()
+        try:
+            # Prime the authoritative cache. A raw second check_fn call would
+            # return False and incorrectly hide the tool.
+            assert registry.get_definitions({tool_name}, quiet=True)
+
+            server = _FakeMCPServer()
+            registered = mcp_serve._register_registry_tools_as_mcp(
+                server, expose_tools=[tool_name]
+            )
+            tool = server._tool_manager.get_tool(tool_name)
+
+            assert registered == [tool_name]
+            assert check_calls == 1
+            assert tool.description == "runtime authoritative description"
+            assert tool.parameters["properties"]["runtime_value"]["type"] == "integer"
+        finally:
+            registry.deregister(tool_name)
+            invalidate_check_fn_cache()
+
+    def test_video_generate_exposure_does_not_publish_placeholder(self, monkeypatch):
+        import model_tools  # noqa: F401 - ensure video_generate is registered
+        import mcp_serve
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        entry = registry.get_entry("video_generate")
+        assert entry is not None
+        original_check_fn = entry.check_fn
+        monkeypatch.setattr(entry, "check_fn", lambda: True)
+        monkeypatch.setattr(
+            "hermes_cli.plugins.discover_plugins", lambda force=False: None
+        )
+        invalidate_check_fn_cache()
+        try:
+            server = _FakeMCPServer()
+            mcp_serve._register_registry_tools_as_mcp(
+                server, expose_tools=["video_generate"]
+            )
+            tool = server._tool_manager.get_tool("video_generate")
+
+            assert tool is not None
+            assert "rebuilt at get_definitions() time" not in tool.description
+            assert "Generate a video" in tool.description
+        finally:
+            entry.check_fn = original_check_fn
+            invalidate_check_fn_cache()
+
+    def test_registry_tool_wrapper_uses_guarded_dispatch(self, monkeypatch):
+        import mcp_serve
+        import model_tools
+
+        calls = []
+
+        def fake_handle_function_call(**kwargs):
+            calls.append(kwargs)
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr(model_tools, "handle_function_call", fake_handle_function_call)
+        wrapper = mcp_serve._make_registry_tool_wrapper("test_guarded_tool")
+
+        assert json.loads(wrapper(message="hello")) == {"ok": True}
+        assert json.loads(wrapper(message="again")) == {"ok": True}
+        assert calls[0]["function_name"] == "test_guarded_tool"
+        assert calls[0]["function_args"] == {"message": "hello"}
+        assert calls[0]["task_id"].startswith("mcp-serve-")
+        assert calls[0]["session_id"].startswith("mcp-serve-")
+        assert calls[0]["tool_call_id"].startswith("mcp-")
+        assert calls[0]["turn_id"].startswith("mcp-turn-")
+        assert calls[0]["api_request_id"].startswith("mcp-request-")
+        assert calls[0]["task_id"].removeprefix("mcp-serve-") == calls[0][
+            "session_id"
+        ].removeprefix("mcp-serve-")
+        assert calls[0]["task_id"] != calls[1]["task_id"]
+        assert calls[0]["session_id"] != calls[1]["session_id"]
+
+    def test_registry_tool_wrapper_respects_plugin_block(self, monkeypatch):
+        import mcp_serve
+        from tools.registry import registry
+
+        handler = MagicMock(side_effect=AssertionError("blocked handler must not run"))
+        tool_name = "test_mcp_blocked_registry_tool"
+        registry.register(
+            name=tool_name,
+            toolset="test-mcp-expose",
+            schema={
+                "name": tool_name,
+                "description": "Blocked MCP tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=handler,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            lambda *_args, **_kwargs: ("Blocked by MCP test policy", None),
+        )
+        try:
+            result = json.loads(mcp_serve._make_registry_tool_wrapper(tool_name)())
+        finally:
+            registry.deregister(tool_name)
+
+        assert "Blocked by MCP test policy" in result["error"]
+        handler.assert_not_called()
+
+    def test_registry_wrapper_omits_optional_non_nullable_none(self, monkeypatch):
+        import mcp_serve
+        import model_tools
+
+        calls = []
+
+        def fake_handle_function_call(**kwargs):
+            calls.append(kwargs)
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr(
+            model_tools, "handle_function_call", fake_handle_function_call
+        )
+        wrapper = mcp_serve._make_registry_tool_wrapper(
+            "test_optional_args", omit_none_for={"optional"}
+        )
+
+        wrapper(optional=None, nullable=None, required="value")
+
+        assert calls[0]["function_args"] == {
+            "nullable": None,
+            "required": "value",
+        }
+
+    def test_registry_schema_rejects_unexecutable_property_names(self):
+        import mcp_serve
+
+        with pytest.raises(ValueError, match="not a valid Python identifier"):
+            mcp_serve._apply_schema_signature(
+                lambda **_kwargs: None,
+                {
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"foo-bar": {"type": "string"}},
+                    }
+                },
+            )
+
+    def test_agent_loop_tools_are_not_exposed_without_agent_context(
+        self, populated_sessions_dir, monkeypatch
+    ):
+        pytest.importorskip("mcp", reason="MCP SDK not installed")
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: populated_sessions_dir)
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda force=False: None)
+
+        with pytest.raises(RuntimeError, match="Agent-loop tools cannot be exposed"):
+            mcp_serve.create_mcp_server(expose_tools=["memory", "todo"])
+
+    def test_fresh_process_discovers_requested_builtin_tool(self, tmp_path):
+        import os
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        env = os.environ.copy()
+        env["HERMES_HOME"] = str(tmp_path / "hermes-home")
+        env["HERMES_QUIET"] = "1"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import mcp_serve; "
+                    "server=mcp_serve.create_mcp_server(expose_tools=['read_file']); "
+                    "assert server._tool_manager.get_tool('read_file') is not None"
+                ),
+            ],
+            cwd=str(Path(__file__).resolve().parents[1]),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+
     def test_create_without_mcp_sdk(self, monkeypatch):
         import mcp_serve
         monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", False)
@@ -1014,6 +1338,137 @@ class TestRunMcpServer:
         with pytest.raises(SystemExit) as exc_info:
             mcp_serve.run_mcp_server()
         assert exc_info.value.code == 1
+
+    def test_stdio_startup_failure_stops_event_bridge(self, monkeypatch):
+        import mcp_serve
+
+        class FakeBridge:
+            instance = None
+
+            def __init__(self):
+                self.started = False
+                self.stopped = False
+                FakeBridge.instance = self
+
+            def start(self):
+                self.started = True
+
+            def stop(self):
+                self.stopped = True
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setattr(mcp_serve, "EventBridge", FakeBridge)
+        monkeypatch.setattr(
+            mcp_serve,
+            "create_mcp_server",
+            lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("startup failed")),
+        )
+
+        with pytest.raises(RuntimeError, match="startup failed"):
+            mcp_serve.run_mcp_server()
+
+        assert FakeBridge.instance is not None
+        assert FakeBridge.instance.started
+        assert FakeBridge.instance.stopped
+
+    def test_http_rejects_unauthenticated_non_loopback_bind(self, monkeypatch, capsys):
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        with pytest.raises(SystemExit) as exc_info:
+            mcp_serve.run_mcp_http_server(host="0.0.0.0")
+
+        assert exc_info.value.code == 1
+        assert "restricted to loopback hosts" in capsys.readouterr().err
+
+    def test_http_requires_explicit_override_for_authenticated_cleartext_bind(
+        self, monkeypatch, capsys
+    ):
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setenv("TEST_MCP_PSK", "long-test-secret")
+
+        with pytest.raises(SystemExit) as exc_info:
+            mcp_serve.run_mcp_http_server(
+                host="0.0.0.0", auth_token_env="TEST_MCP_PSK"
+            )
+
+        assert exc_info.value.code == 1
+        assert "--allow-insecure-http" in capsys.readouterr().err
+
+    def test_oauth_rejects_insecure_remote_public_base_url(self, monkeypatch, capsys):
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setenv("TEST_MCP_PSK", "long-test-secret")
+        monkeypatch.setattr(
+            mcp_serve,
+            "EventBridge",
+            lambda: (_ for _ in ()).throw(AssertionError("server startup must not begin")),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            mcp_serve.run_mcp_http_server(
+                host="127.0.0.1",
+                public_base_url="http://mcp.example.com",
+                auth_token_env="TEST_MCP_PSK",
+                oauth_compatible=True,
+            )
+
+        assert exc_info.value.code == 1
+        assert "HTTPS or a loopback" in capsys.readouterr().err
+
+    def test_oauth_rejects_missing_explicit_client_id_secret(self, monkeypatch, capsys):
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setenv("TEST_MCP_PSK", "long-test-secret")
+        monkeypatch.delenv("MISSING_MCP_CLIENT_ID", raising=False)
+        monkeypatch.delenv("MISSING_MCP_CLIENT_SECRET", raising=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            mcp_serve.run_mcp_http_server(
+                auth_token_env="TEST_MCP_PSK",
+                oauth_compatible=True,
+                oauth_client_id_env="MISSING_MCP_CLIENT_ID",
+                oauth_client_secret_env="MISSING_MCP_CLIENT_SECRET",
+            )
+
+        assert exc_info.value.code == 1
+        assert "MISSING_MCP_CLIENT_ID" in capsys.readouterr().err
+
+    def test_http_startup_failure_stops_event_bridge(self, monkeypatch):
+        import mcp_serve
+
+        events = []
+
+        class Bridge:
+            def start(self):
+                events.append("start")
+
+            def stop(self):
+                events.append("stop")
+
+        class Settings:
+            pass
+
+        class Server:
+            settings = Settings()
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setattr(mcp_serve, "EventBridge", Bridge)
+        monkeypatch.setattr(mcp_serve, "create_mcp_server", lambda **_kwargs: Server())
+        monkeypatch.setattr(
+            mcp_serve,
+            "_configure_transport_security",
+            lambda *_args: (_ for _ in ()).throw(RuntimeError("security setup failed")),
+        )
+
+        with pytest.raises(RuntimeError, match="security setup failed"):
+            mcp_serve.run_mcp_http_server()
+
+        assert events == ["start", "stop"]
 
 
 class TestCliIntegration:
@@ -1051,7 +1506,903 @@ class TestCliIntegration:
         args = argparse.Namespace(mcp_action="serve", verbose=True)
         from hermes_cli.mcp_config import mcp_command
         mcp_command(args)
-        mock_run.assert_called_once_with(verbose=True)
+        mock_run.assert_called_once_with(
+            verbose=True,
+            expose_toolsets=[],
+            expose_tools=[],
+            expose_plugin_tools=False,
+        )
+
+    def test_dispatcher_routes_streamable_http(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        mock_http = MagicMock()
+        monkeypatch.setattr("mcp_serve.run_mcp_http_server", mock_http)
+
+        import argparse
+        args = argparse.Namespace(
+            mcp_action="serve",
+            transport="streamable-http",
+            verbose=True,
+            host="127.0.0.1",
+            port=9999,
+            path="/mcp",
+            public_base_url="https://example.com",
+            auth_token_env="HERMES_MCP_PSK",
+            auth_header="X-Test-PSK",
+            allow_query_token=True,
+            allow_insecure_http=True,
+            oauth_compatible=True,
+            oauth_client_id_env="HERMES_MCP_CLIENT_ID",
+            oauth_client_secret_env="HERMES_MCP_CLIENT_SECRET",
+            oauth_token_ttl_seconds=600,
+            oauth_code_ttl_seconds=60,
+            oauth_redirect_uri=["https://client.example/cb"],
+            allowed_host=["example.com"],
+            allowed_origin=["https://example.com"],
+            expose_toolset=["tescmd"],
+            expose_tool=["custom_tool"],
+            expose_plugin_tools=True,
+            health_path="/healthz",
+        )
+        from hermes_cli.mcp_config import mcp_command
+        mcp_command(args)
+        mock_http.assert_called_once_with(
+            verbose=True,
+            host="127.0.0.1",
+            port=9999,
+            path="/mcp",
+            public_base_url="https://example.com",
+            auth_token_env="HERMES_MCP_PSK",
+            auth_header="X-Test-PSK",
+            allow_query_token=True,
+            allow_insecure_http=True,
+            oauth_compatible=True,
+            oauth_client_id_env="HERMES_MCP_CLIENT_ID",
+            oauth_client_secret_env="HERMES_MCP_CLIENT_SECRET",
+            token_ttl_seconds=600,
+            code_ttl_seconds=60,
+            oauth_redirect_uris=["https://client.example/cb"],
+            allowed_hosts=["example.com"],
+            allowed_origins=["https://example.com"],
+            expose_toolsets=["tescmd"],
+            expose_tools=["custom_tool"],
+            expose_plugin_tools=True,
+            health_path="/healthz",
+        )
+
+
+class TestHttpAuthHelpers:
+    class _Request:
+        def __init__(self, params=None, data=None):
+            from starlette.datastructures import QueryParams
+            from urllib.parse import urlencode
+
+            self.query_params = QueryParams(params or {})
+            self._body = urlencode(data or {}).encode("utf-8")
+
+        async def body(self):
+            return self._body
+
+    def _route_endpoint(self, app, path):
+        for route in app.routes:
+            if getattr(route, "path", None) == path:
+                return route.endpoint
+        raise AssertionError(f"Route not found: {path}")
+
+    def _call_route(self, app, path, request=None):
+        return asyncio.get_event_loop().run_until_complete(
+            self._route_endpoint(app, path)(request or self._Request())
+        )
+
+    def _json_response(self, response):
+        return json.loads(response.body.decode("utf-8"))
+
+    def test_transport_security_accepts_default_host_headers_with_ports(self):
+        import mcp_serve
+        from mcp.server.transport_security import TransportSecurityMiddleware
+
+        class Settings:
+            transport_security = None
+
+        class Server:
+            settings = Settings()
+
+        server = Server()
+        mcp_serve._configure_transport_security(
+            server,
+            "127.0.0.1",
+            8666,
+            [],
+            [],
+        )
+        middleware = TransportSecurityMiddleware(server.settings.transport_security)
+
+        assert middleware._validate_host("127.0.0.1:8666")
+        assert middleware._validate_host("localhost:8666")
+        security = server.settings.transport_security
+        assert security is not None
+        assert "null" not in getattr(security, "allowed_origins")
+
+    @pytest.mark.asyncio
+    async def test_real_streamable_http_initialize_accepts_default_host_with_port(self):
+        import httpx
+        import mcp_serve
+
+        pytest.importorskip("mcp", reason="MCP SDK not installed")
+        server = mcp_serve.create_mcp_server()
+        transport_security = mcp_serve._configure_transport_security(
+            server, "127.0.0.1", 8666, [], []
+        )
+        app = mcp_serve.create_streamable_http_app(
+            server,
+            host="127.0.0.1",
+            path="/mcp",
+            json_response=True,
+            transport_security=transport_security,
+        )
+
+        async with app.router.lifespan_context(app):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://127.0.0.1:8666",
+            ) as client:
+                response = await client.post(
+                    "/mcp",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2025-06-18",
+                            "capabilities": {},
+                            "clientInfo": {"name": "test-client", "version": "1"},
+                        },
+                    },
+                    headers={"Accept": "application/json, text/event-stream"},
+                )
+
+        assert response.status_code == 200
+        assert response.json()["result"]["serverInfo"]["name"] == "hermes"
+
+    @pytest.mark.asyncio
+    async def test_real_streamable_http_auth_host_and_origin_boundaries(self):
+        import httpx
+        import mcp_serve
+
+        pytest.importorskip("mcp", reason="MCP SDK not installed")
+        server = mcp_serve.create_mcp_server()
+        transport_security = mcp_serve._configure_transport_security(
+            server,
+            "127.0.0.1",
+            8666,
+            ["mcp.example.com"],
+            ["https://trusted.example"],
+        )
+        app = mcp_serve.create_streamable_http_app(
+            server,
+            auth_config=mcp_serve.McpHttpAuthConfig(psk="test-server-psk"),
+            host="127.0.0.1",
+            path="/mcp",
+            json_response=True,
+            transport_security=transport_security,
+        )
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1"},
+            },
+        }
+        accept = "application/json, text/event-stream"
+
+        async with app.router.lifespan_context(app):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://127.0.0.1:8666",
+            ) as client:
+                unauthenticated = await client.post(
+                    "/mcp", json=initialize, headers={"Accept": accept}
+                )
+                bad_host = await client.post(
+                    "/mcp",
+                    json=initialize,
+                    headers={
+                        "Accept": accept,
+                        "Authorization": "Bearer test-server-psk",
+                        "Host": "attacker.example",
+                    },
+                )
+                bad_origin = await client.post(
+                    "/mcp",
+                    json=initialize,
+                    headers={
+                        "Accept": accept,
+                        "Authorization": "Bearer test-server-psk",
+                        "Origin": "https://attacker.example",
+                    },
+                )
+                accepted = await client.post(
+                    "/mcp",
+                    json=initialize,
+                    headers={
+                        "Accept": accept,
+                        "Authorization": "Bearer test-server-psk",
+                        "Origin": "https://trusted.example",
+                        "Host": "mcp.example.com",
+                    },
+                )
+
+        assert unauthenticated.status_code == 401
+        assert bad_host.status_code == 421
+        assert bad_origin.status_code == 403
+        assert accepted.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_real_streamable_http_oauth_token_initializes_mcp(self):
+        import httpx
+        import mcp_serve
+
+        pytest.importorskip("mcp", reason="MCP SDK not installed")
+        server = mcp_serve.create_mcp_server()
+        transport_security = mcp_serve._configure_transport_security(
+            server, "127.0.0.1", 8666, [], []
+        )
+        app = mcp_serve.create_streamable_http_app(
+            server,
+            auth_config=mcp_serve.McpHttpAuthConfig(
+                psk="oauth-test-secret",
+                oauth_compatible=True,
+                public_base_url="http://127.0.0.1:8666",
+                path="/mcp",
+            ),
+            host="127.0.0.1",
+            path="/mcp",
+            json_response=True,
+            transport_security=transport_security,
+        )
+
+        async with app.router.lifespan_context(app):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://127.0.0.1:8666",
+            ) as client:
+                rejected_token_response = await client.post(
+                    "/mcp/token",
+                    data={
+                        "grant_type": "client_credentials",
+                        "client_id": "hermes-mcp",
+                        "client_secret": "oauth-test-secret",
+                    },
+                    headers={"Host": "attacker.example"},
+                )
+                token_response = await client.post(
+                    "/mcp/token",
+                    data={
+                        "grant_type": "client_credentials",
+                        "client_id": "hermes-mcp",
+                        "client_secret": "oauth-test-secret",
+                    },
+                )
+                token = token_response.json()["access_token"]
+                initialize_response = await client.post(
+                    "/mcp",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2025-06-18",
+                            "capabilities": {},
+                            "clientInfo": {"name": "oauth-test", "version": "1"},
+                        },
+                    },
+                    headers={
+                        "Accept": "application/json, text/event-stream",
+                        "Authorization": f"Bearer {token}",
+                    },
+                )
+
+        assert rejected_token_response.status_code == 421
+        assert token_response.status_code == 200
+        assert initialize_response.status_code == 200
+
+    def test_transport_security_formats_ipv6_host_headers(self):
+        import mcp_serve
+        from mcp.server.transport_security import TransportSecurityMiddleware
+
+        class Settings:
+            transport_security = None
+
+        class Server:
+            settings = Settings()
+
+        server = Server()
+        mcp_serve._configure_transport_security(server, "::1", 8666, [], [])
+        middleware = TransportSecurityMiddleware(server.settings.transport_security)
+
+        assert middleware._validate_host("[::1]:8666")
+        assert mcp_serve._default_http_base_url("::1", 8666) == "http://[::1]:8666"
+
+    def test_transport_security_configuration_fails_closed(self):
+        import mcp_serve
+
+        class Settings:
+            @property
+            def transport_security(self):
+                return None
+
+            @transport_security.setter
+            def transport_security(self, _value):
+                raise RuntimeError("cannot install transport security")
+
+        class Server:
+            settings = Settings()
+
+        with pytest.raises(RuntimeError, match="cannot install transport security"):
+            mcp_serve._configure_transport_security(
+                Server(),
+                "127.0.0.1",
+                8666,
+                [],
+                [],
+            )
+
+    def test_pkce_challenge_methods(self):
+        import mcp_serve
+
+        assert mcp_serve._pkce_challenge("verifier", "plain") == "verifier"
+        assert (
+            mcp_serve._pkce_challenge("verifier", "S256")
+            == "iMnq5o6zALKXGivsnlom_0F5_WYda32GHkxlV7mq7hQ"
+        )
+        assert mcp_serve._pkce_challenge("verifier", "unsupported") is None
+        assert mcp_serve._pkce_challenge("☃", "S256") is None
+
+    def test_default_oauth_identity_keeps_psk_out_of_public_client_id(self):
+        import mcp_serve
+
+        config = mcp_serve.McpHttpAuthConfig(
+            psk="server-psk",
+            oauth_compatible=True,
+        )
+
+        assert config.oauth_client_id == "hermes-mcp"
+        assert config.oauth_client_id != config.psk
+        assert config.oauth_client_secret == "server-psk"
+
+    def test_oauth_store_bounds_public_authorization_codes(self):
+        import mcp_serve
+
+        store = mcp_serve._OAuthTokenStore(max_codes=2)
+        first = store.issue_code("client", "http://127.0.0.1/cb", 300)
+        second = store.issue_code("client", "http://127.0.0.1/cb", 300)
+        with pytest.raises(OverflowError, match="capacity reached"):
+            store.issue_code("client", "http://127.0.0.1/cb", 300)
+
+        assert store.consume_code(first, "client", "http://127.0.0.1/cb")
+        assert store.consume_code(second, "client", "http://127.0.0.1/cb")
+
+        rate_limited = mcp_serve._OAuthTokenStore(max_code_issuance_per_minute=2)
+        rate_limited.issue_code("client", "https://client.example/cb", 300)
+        rate_limited.issue_code("client", "https://client.example/cb", 300)
+        with pytest.raises(OverflowError, match="rate exceeded"):
+            rate_limited.issue_code("client", "https://client.example/cb", 300)
+
+    def test_oauth_store_capacity_preserves_live_credentials(self):
+        import mcp_serve
+
+        token_store = mcp_serve._OAuthTokenStore(max_tokens=1)
+        first_token = token_store.issue_token("client", 300)
+        with pytest.raises(OverflowError, match="capacity reached"):
+            token_store.issue_token("client", 300)
+        assert token_store.validate_token(first_token)
+
+        code_store = mcp_serve._OAuthTokenStore(max_codes=1)
+        first_code = code_store.issue_code("client", "https://client.example/cb", 300)
+        with pytest.raises(OverflowError, match="capacity reached"):
+            code_store.issue_code("client", "https://client.example/cb", 300)
+        assert code_store.consume_code(
+            first_code, "client", "https://client.example/cb"
+        )
+
+    def _make_app(self, auth_config, host="127.0.0.1"):
+        pytest.importorskip("starlette")
+        from starlette.applications import Starlette
+        from starlette.responses import JSONResponse
+        import mcp_serve
+
+        class Settings:
+            streamable_http_path = "/mcp"
+
+            def __init__(self):
+                self.host = host
+
+        class FakeServer:
+            settings = Settings()
+
+            def streamable_http_app(
+                self, *, streamable_http_path="/mcp", **_kwargs
+            ):
+                app = Starlette()
+
+                async def mcp(_request):
+                    return JSONResponse({"ok": True})
+
+                app.add_route(streamable_http_path, mcp, methods=["GET", "POST"])
+                return app
+
+        return mcp_serve.create_streamable_http_app(
+            FakeServer(),
+            auth_config=auth_config,
+            health_path="/health",
+        )
+
+    def test_app_rejects_unauthenticated_non_loopback_bind(self):
+        with pytest.raises(ValueError, match="restricted to loopback hosts"):
+            self._make_app(None, host="0.0.0.0")
+
+    def test_psk_auth_accepts_bearer_header_and_query(self):
+        from starlette.datastructures import Headers, QueryParams
+        import mcp_serve
+
+        class Request:
+            def __init__(self, headers=None, query_string=""):
+                self.headers = Headers(headers or {})
+                self.query_params = QueryParams(query_string)
+
+        config = mcp_serve.McpHttpAuthConfig(
+            psk="test-psk",
+            psk_header="X-Test-PSK",
+            allow_query_token=True,
+            path="/mcp",
+        )
+        store = mcp_serve._OAuthTokenStore()
+
+        assert not mcp_serve._is_authenticated(Request(), config, store)
+        assert mcp_serve._is_authenticated(
+            Request(headers={"Authorization": "Bearer test-psk"}),
+            config,
+            store,
+        )
+        assert mcp_serve._is_authenticated(
+            Request(headers={"X-Test-PSK": "test-psk"}),
+            config,
+            store,
+        )
+        assert mcp_serve._is_authenticated(
+            Request(query_string="access_token=test-psk"),
+            config,
+            store,
+        )
+        assert mcp_serve._auth_challenge(config) == "Bearer"
+
+    @pytest.mark.asyncio
+    async def test_http_auth_middleware_enforces_real_asgi_boundary(self):
+        import httpx
+        import mcp_serve
+
+        app = self._make_app(
+            mcp_serve.McpHttpAuthConfig(
+                psk="test-psk",
+                oauth_compatible=True,
+                public_base_url="https://mcp.example.com",
+                path="/mcp",
+            )
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="https://mcp.example.com",
+        ) as client:
+            unauthenticated = await client.get("/mcp/subpath")
+            authenticated = await client.get(
+                "/mcp",
+                headers={"Authorization": "Bearer test-psk"},
+            )
+            health = await client.get("/health")
+            metadata = await client.get("/.well-known/oauth-authorization-server")
+
+        assert unauthenticated.status_code == 401
+        assert authenticated.status_code == 200
+        assert authenticated.json() == {"ok": True}
+        assert health.status_code == 200
+        assert metadata.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_oauth_token_endpoint_rejects_oversized_form_body(self):
+        import httpx
+        import mcp_serve
+
+        app = self._make_app(
+            mcp_serve.McpHttpAuthConfig(
+                psk="test-psk",
+                oauth_compatible=True,
+                public_base_url="https://mcp.example.com",
+                path="/mcp",
+            )
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="https://mcp.example.com",
+        ) as client:
+            response = await client.post(
+                "/mcp/token",
+                content=b"x" * (mcp_serve._OAUTH_FORM_BODY_LIMIT + 1),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+
+        assert response.status_code == 413
+        assert response.json()["error"] == "invalid_request"
+
+    def test_mcp_auth_boundary_covers_subpaths_but_not_oauth_endpoints(self):
+        import mcp_serve
+
+        config = mcp_serve.McpHttpAuthConfig(
+            psk="test-psk",
+            oauth_compatible=True,
+            path="/mcp",
+        )
+
+        assert mcp_serve._is_protected_mcp_http_path(config, "/mcp")
+        assert mcp_serve._is_protected_mcp_http_path(config, "/mcp/")
+        assert mcp_serve._is_protected_mcp_http_path(config, "/mcp/subpath")
+        assert not mcp_serve._is_protected_mcp_http_path(config, "/mcp/authorize")
+        assert not mcp_serve._is_protected_mcp_http_path(config, "/mcp/token")
+        assert not mcp_serve._is_protected_mcp_http_path(config, "/health")
+
+    def test_oauth_compatible_metadata_and_token_flows(self):
+        pytest.importorskip("starlette")
+        import mcp_serve
+
+        app = self._make_app(mcp_serve.McpHttpAuthConfig(
+            psk="client-as-psk",
+            allow_query_token=False,
+            oauth_compatible=True,
+            public_base_url="https://mcp.example.com",
+            path="/mcp",
+            token_ttl_seconds=600,
+            code_ttl_seconds=60,
+            allowed_redirect_uris=["https://client.example/cb"],
+        ))
+
+        meta = self._call_route(app, "/.well-known/oauth-authorization-server")
+        assert meta.status_code == 200
+        meta_json = self._json_response(meta)
+        assert meta_json["authorization_endpoint"] == "https://mcp.example.com/mcp/authorize"
+        assert "client_credentials" in meta_json["grant_types_supported"]
+        assert meta_json["code_challenge_methods_supported"] == ["S256"]
+
+        resource = self._call_route(app, "/.well-known/oauth-protected-resource/mcp")
+        assert resource.status_code == 200
+        assert self._json_response(resource)["resource"] == "https://mcp.example.com/mcp"
+
+        assert "resource_metadata=" in mcp_serve._auth_challenge(
+            mcp_serve.McpHttpAuthConfig(
+                psk="client-as-psk",
+                oauth_compatible=True,
+                public_base_url="https://mcp.example.com",
+                path="/mcp",
+            )
+        )
+
+        token_response = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={
+                "grant_type": "client_credentials",
+                "client_id": "hermes-mcp",
+                "client_secret": "client-as-psk",
+            }),
+        )
+        assert token_response.status_code == 200
+        bearer = self._json_response(token_response)["access_token"]
+        assert bearer
+        assert token_response.headers["cache-control"] == "no-store"
+        assert token_response.headers["pragma"] == "no-cache"
+
+        verifier = "v" * 43
+        challenge = mcp_serve._pkce_challenge(verifier, "S256")
+        authorize = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(params={
+                "response_type": "code",
+                "client_id": "hermes-mcp",
+                "redirect_uri": "https://client.example/cb",
+                "state": "abc",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            }),
+        )
+        assert authorize.status_code == 302
+        assert "code=" in authorize.headers["location"]
+        assert "state=abc" in authorize.headers["location"]
+        code = authorize.headers["location"].split("code=", 1)[1].split("&", 1)[0]
+        code_token = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={
+                "grant_type": "authorization_code",
+                "client_id": "hermes-mcp",
+                "client_secret": "client-as-psk",
+                "code": code,
+                "redirect_uri": "https://client.example/cb",
+                "code_verifier": verifier,
+            }),
+        )
+        assert code_token.status_code == 200
+
+    def test_oauth_authorize_rejects_unlisted_redirect_uri(self):
+        pytest.importorskip("starlette")
+        import mcp_serve
+
+        app = self._make_app(mcp_serve.McpHttpAuthConfig(
+            psk="client-as-psk",
+            oauth_compatible=True,
+            public_base_url="https://mcp.example.com",
+            path="/mcp",
+            allowed_redirect_uris=["https://client.example/cb"],
+        ))
+
+        response = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(params={
+                "response_type": "code",
+                "client_id": "hermes-mcp",
+                "redirect_uri": "https://attacker.example/cb",
+            }),
+        )
+        assert response.status_code == 400
+        assert self._json_response(response)["error_description"] == "redirect_uri is not allowed"
+
+    def test_oauth_authorize_requires_s256_pkce(self):
+        pytest.importorskip("starlette")
+        import mcp_serve
+
+        redirect_uri = "https://client.example/cb"
+        app = self._make_app(
+            mcp_serve.McpHttpAuthConfig(
+                psk="client-as-psk",
+                oauth_compatible=True,
+                public_base_url="https://mcp.example.com",
+                path="/mcp",
+                allowed_redirect_uris=[redirect_uri],
+            )
+        )
+
+        base = {
+            "response_type": "code",
+            "client_id": "hermes-mcp",
+            "redirect_uri": redirect_uri,
+        }
+        missing = self._call_route(
+            app, "/mcp/authorize", self._Request(params=base)
+        )
+        plain = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(
+                params={
+                    **base,
+                    "code_challenge": "c" * 43,
+                    "code_challenge_method": "plain",
+                }
+            ),
+        )
+
+        assert missing.status_code == 400
+        assert plain.status_code == 400
+        assert "PKCE S256" in self._json_response(missing)["error_description"]
+
+    def test_oauth_authorize_rejects_loopback_redirect_without_registration(self):
+        pytest.importorskip("starlette")
+        import mcp_serve
+
+        app = self._make_app(mcp_serve.McpHttpAuthConfig(
+            psk="client-as-psk",
+            oauth_compatible=True,
+            public_base_url="https://mcp.example.com",
+            path="/mcp",
+        ))
+
+        metadata = self._call_route(app, "/.well-known/oauth-authorization-server")
+        metadata_json = self._json_response(metadata)
+        assert metadata_json["grant_types_supported"] == ["client_credentials"]
+        assert "authorization_endpoint" not in metadata_json
+
+        response = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(params={
+                "response_type": "code",
+                "client_id": "hermes-mcp",
+                "redirect_uri": "http://127.0.0.1:54321/callback",
+                "code_challenge": "c" * 43,
+                "code_challenge_method": "S256",
+            }),
+        )
+        assert response.status_code == 400
+        assert "not configured" in self._json_response(response)["error_description"]
+
+    def test_oauth_redirect_validation_rejects_insecure_remote_and_fragments(self):
+        import mcp_serve
+
+        config = mcp_serve.McpHttpAuthConfig(
+            psk="server-psk",
+            oauth_compatible=True,
+            allowed_redirect_uris=[
+                "http://client.example/cb",
+                "https://client.example/cb#fragment",
+            ],
+        )
+
+        assert not mcp_serve._oauth_redirect_uri_allowed(
+            config, "http://client.example/cb"
+        )
+        assert not mcp_serve._oauth_redirect_uri_allowed(
+            config, "https://client.example/cb#fragment"
+        )
+
+    def test_oauth_explicit_client_id_without_secret_cannot_get_token(self):
+        pytest.importorskip("starlette")
+        import mcp_serve
+
+        app = self._make_app(mcp_serve.McpHttpAuthConfig(
+            psk="server-psk",
+            oauth_compatible=True,
+            oauth_client_id="public-client",
+            public_base_url="https://mcp.example.com",
+            path="/mcp",
+            allowed_redirect_uris=["https://client.example/cb"],
+        ))
+
+        token_response = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={"grant_type": "client_credentials", "client_id": "public-client"}),
+        )
+        assert token_response.status_code == 401
+        assert self._json_response(token_response)["error"] == "invalid_client"
+        assert token_response.headers["cache-control"] == "no-store"
+        assert token_response.headers["pragma"] == "no-cache"
+
+    def test_oauth_authorization_code_s256_pkce_and_redirect_binding(self):
+        pytest.importorskip("starlette")
+        from urllib.parse import parse_qs, urlparse
+        import mcp_serve
+
+        verifier = "v" * 43
+        challenge = mcp_serve._pkce_challenge(verifier, "S256")
+        redirect_uri = "https://client.example/cb"
+        app = self._make_app(
+            mcp_serve.McpHttpAuthConfig(
+                psk="client-as-psk",
+                oauth_compatible=True,
+                public_base_url="https://mcp.example.com",
+                path="/mcp",
+                token_ttl_seconds=600,
+                code_ttl_seconds=60,
+                allowed_redirect_uris=[redirect_uri],
+            )
+        )
+
+        authorize = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(params={
+                "response_type": "code",
+                "client_id": "hermes-mcp",
+                "redirect_uri": redirect_uri,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            }),
+        )
+        assert authorize.status_code == 302
+        code = parse_qs(urlparse(authorize.headers["location"]).query)["code"][0]
+        grant = {
+            "grant_type": "authorization_code",
+            "client_id": "hermes-mcp",
+            "client_secret": "client-as-psk",
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+
+        wrong_redirect = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={**grant, "redirect_uri": "https://attacker.example/cb", "code_verifier": verifier}),
+        )
+        assert wrong_redirect.status_code == 400
+        assert self._json_response(wrong_redirect)["error"] == "invalid_grant"
+
+        wrong_resource = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(
+                data={
+                    **grant,
+                    "code_verifier": verifier,
+                    "resource": "https://attacker.example/mcp",
+                }
+            ),
+        )
+        assert wrong_resource.status_code == 400
+        assert self._json_response(wrong_resource)["error"] == "invalid_target"
+
+        replay_after_wrong_redirect = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={**grant, "code_verifier": verifier}),
+        )
+        assert replay_after_wrong_redirect.status_code == 400
+        assert self._json_response(replay_after_wrong_redirect)["error"] == "invalid_grant"
+
+        authorize = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(params={
+                "response_type": "code",
+                "client_id": "hermes-mcp",
+                "redirect_uri": redirect_uri,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            }),
+        )
+        assert authorize.status_code == 302
+        code = parse_qs(urlparse(authorize.headers["location"]).query)["code"][0]
+        grant["code"] = code
+
+        wrong_verifier = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={**grant, "code_verifier": "x" * 43}),
+        )
+        assert wrong_verifier.status_code == 400
+        assert self._json_response(wrong_verifier)["error"] == "invalid_grant"
+
+        replay_after_wrong_verifier = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={**grant, "code_verifier": verifier}),
+        )
+        assert replay_after_wrong_verifier.status_code == 400
+        assert self._json_response(replay_after_wrong_verifier)["error"] == "invalid_grant"
+
+        authorize = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(params={
+                "response_type": "code",
+                "client_id": "hermes-mcp",
+                "redirect_uri": redirect_uri,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            }),
+        )
+        assert authorize.status_code == 302
+        code = parse_qs(urlparse(authorize.headers["location"]).query)["code"][0]
+        grant["code"] = code
+
+        token = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={**grant, "code_verifier": verifier}),
+        )
+        assert token.status_code == 200
+        assert self._json_response(token)["token_type"] == "Bearer"
+
+        replay = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={**grant, "code_verifier": verifier}),
+        )
+        assert replay.status_code == 400
+        assert self._json_response(replay)["error"] == "invalid_grant"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -2001,12 +2001,13 @@ class TestHttpAuthHelpers:
         assert wrong_resource.status_code == 400
         assert self._json_response(wrong_resource)["error"] == "invalid_target"
 
-        valid_after_wrong_redirect = self._call_route(
+        replay_after_wrong_redirect = self._call_route(
             app,
             "/mcp/token",
             self._Request(data={**grant, "code_verifier": verifier}),
         )
-        assert valid_after_wrong_redirect.status_code == 200
+        assert replay_after_wrong_redirect.status_code == 400
+        assert self._json_response(replay_after_wrong_redirect)["error"] == "invalid_grant"
 
         authorize = self._call_route(
             app,
@@ -2031,12 +2032,13 @@ class TestHttpAuthHelpers:
         assert wrong_verifier.status_code == 400
         assert self._json_response(wrong_verifier)["error"] == "invalid_grant"
 
-        valid_after_wrong_verifier = self._call_route(
+        replay_after_wrong_verifier = self._call_route(
             app,
             "/mcp/token",
             self._Request(data={**grant, "code_verifier": verifier}),
         )
-        assert valid_after_wrong_verifier.status_code == 200
+        assert replay_after_wrong_verifier.status_code == 400
+        assert self._json_response(replay_after_wrong_verifier)["error"] == "invalid_grant"
 
         authorize = self._call_route(
             app,

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -775,11 +775,126 @@ class TestServerCreation:
         wrapper = mcp_serve._make_registry_tool_wrapper("test_guarded_tool")
 
         assert json.loads(wrapper(message="hello")) == {"ok": True}
+        assert json.loads(wrapper(message="again")) == {"ok": True}
         assert calls[0]["function_name"] == "test_guarded_tool"
         assert calls[0]["function_args"] == {"message": "hello"}
-        assert calls[0]["task_id"] == "mcp-serve"
-        assert calls[0]["session_id"] == "mcp-serve"
+        assert calls[0]["task_id"].startswith("mcp-serve-")
+        assert calls[0]["session_id"].startswith("mcp-serve-")
         assert calls[0]["tool_call_id"].startswith("mcp-")
+        assert calls[0]["turn_id"].startswith("mcp-turn-")
+        assert calls[0]["api_request_id"].startswith("mcp-request-")
+        assert calls[0]["task_id"].removeprefix("mcp-serve-") == calls[0][
+            "session_id"
+        ].removeprefix("mcp-serve-")
+        assert calls[0]["task_id"] != calls[1]["task_id"]
+        assert calls[0]["session_id"] != calls[1]["session_id"]
+
+    def test_registry_tool_wrapper_respects_plugin_block(self, monkeypatch):
+        import mcp_serve
+        from tools.registry import registry
+
+        handler = MagicMock(side_effect=AssertionError("blocked handler must not run"))
+        tool_name = "test_mcp_blocked_registry_tool"
+        registry.register(
+            name=tool_name,
+            toolset="test-mcp-expose",
+            schema={
+                "name": tool_name,
+                "description": "Blocked MCP tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=handler,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *_args, **_kwargs: "Blocked by MCP test policy",
+        )
+        try:
+            result = json.loads(mcp_serve._make_registry_tool_wrapper(tool_name)())
+        finally:
+            registry.deregister(tool_name)
+
+        assert "Blocked by MCP test policy" in result["error"]
+        handler.assert_not_called()
+
+    def test_registry_wrapper_omits_optional_non_nullable_none(self, monkeypatch):
+        import mcp_serve
+        import model_tools
+
+        calls = []
+
+        def fake_handle_function_call(**kwargs):
+            calls.append(kwargs)
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr(
+            model_tools, "handle_function_call", fake_handle_function_call
+        )
+        wrapper = mcp_serve._make_registry_tool_wrapper(
+            "test_optional_args", omit_none_for={"optional"}
+        )
+
+        wrapper(optional=None, nullable=None, required="value")
+
+        assert calls[0]["function_args"] == {
+            "nullable": None,
+            "required": "value",
+        }
+
+    def test_registry_schema_rejects_unexecutable_property_names(self):
+        import mcp_serve
+
+        with pytest.raises(ValueError, match="not a valid Python identifier"):
+            mcp_serve._apply_schema_signature(
+                lambda **_kwargs: None,
+                {
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"foo-bar": {"type": "string"}},
+                    }
+                },
+            )
+
+    def test_agent_loop_tools_are_not_exposed_without_agent_context(
+        self, populated_sessions_dir, monkeypatch
+    ):
+        pytest.importorskip("mcp", reason="MCP SDK not installed")
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: populated_sessions_dir)
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda force=False: None)
+
+        with pytest.raises(RuntimeError, match="Agent-loop tools cannot be exposed"):
+            mcp_serve.create_mcp_server(expose_tools=["memory", "todo"])
+
+    def test_fresh_process_discovers_requested_builtin_tool(self, tmp_path):
+        import os
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        env = os.environ.copy()
+        env["HERMES_HOME"] = str(tmp_path / "hermes-home")
+        env["HERMES_QUIET"] = "1"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import mcp_serve; "
+                    "server=mcp_serve.create_mcp_server(expose_tools=['read_file']); "
+                    "assert server._tool_manager.get_tool('read_file') is not None"
+                ),
+            ],
+            cwd=str(Path(__file__).resolve().parents[1]),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
 
     def test_create_without_mcp_sdk(self, monkeypatch):
         import mcp_serve
@@ -796,6 +911,38 @@ class TestRunMcpServer:
             mcp_serve.run_mcp_server()
         assert exc_info.value.code == 1
 
+    def test_stdio_startup_failure_stops_event_bridge(self, monkeypatch):
+        import mcp_serve
+
+        class FakeBridge:
+            instance = None
+
+            def __init__(self):
+                self.started = False
+                self.stopped = False
+                FakeBridge.instance = self
+
+            def start(self):
+                self.started = True
+
+            def stop(self):
+                self.stopped = True
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setattr(mcp_serve, "EventBridge", FakeBridge)
+        monkeypatch.setattr(
+            mcp_serve,
+            "create_mcp_server",
+            lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("startup failed")),
+        )
+
+        with pytest.raises(RuntimeError, match="startup failed"):
+            mcp_serve.run_mcp_server()
+
+        assert FakeBridge.instance is not None
+        assert FakeBridge.instance.started
+        assert FakeBridge.instance.stopped
+
     def test_http_rejects_unauthenticated_non_loopback_bind(self, monkeypatch, capsys):
         import mcp_serve
 
@@ -805,6 +952,95 @@ class TestRunMcpServer:
 
         assert exc_info.value.code == 1
         assert "restricted to loopback hosts" in capsys.readouterr().err
+
+    def test_http_requires_explicit_override_for_authenticated_cleartext_bind(
+        self, monkeypatch, capsys
+    ):
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setenv("TEST_MCP_PSK", "long-test-secret")
+
+        with pytest.raises(SystemExit) as exc_info:
+            mcp_serve.run_mcp_http_server(
+                host="0.0.0.0", auth_token_env="TEST_MCP_PSK"
+            )
+
+        assert exc_info.value.code == 1
+        assert "--allow-insecure-http" in capsys.readouterr().err
+
+    def test_oauth_rejects_insecure_remote_public_base_url(self, monkeypatch, capsys):
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setenv("TEST_MCP_PSK", "long-test-secret")
+        monkeypatch.setattr(
+            mcp_serve,
+            "EventBridge",
+            lambda: (_ for _ in ()).throw(AssertionError("server startup must not begin")),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            mcp_serve.run_mcp_http_server(
+                host="127.0.0.1",
+                public_base_url="http://mcp.example.com",
+                auth_token_env="TEST_MCP_PSK",
+                oauth_compatible=True,
+            )
+
+        assert exc_info.value.code == 1
+        assert "HTTPS or a loopback" in capsys.readouterr().err
+
+    def test_oauth_rejects_missing_explicit_client_id_secret(self, monkeypatch, capsys):
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setenv("TEST_MCP_PSK", "long-test-secret")
+        monkeypatch.delenv("MISSING_MCP_CLIENT_ID", raising=False)
+        monkeypatch.delenv("MISSING_MCP_CLIENT_SECRET", raising=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            mcp_serve.run_mcp_http_server(
+                auth_token_env="TEST_MCP_PSK",
+                oauth_compatible=True,
+                oauth_client_id_env="MISSING_MCP_CLIENT_ID",
+                oauth_client_secret_env="MISSING_MCP_CLIENT_SECRET",
+            )
+
+        assert exc_info.value.code == 1
+        assert "MISSING_MCP_CLIENT_ID" in capsys.readouterr().err
+
+    def test_http_startup_failure_stops_event_bridge(self, monkeypatch):
+        import mcp_serve
+
+        events = []
+
+        class Bridge:
+            def start(self):
+                events.append("start")
+
+            def stop(self):
+                events.append("stop")
+
+        class Settings:
+            pass
+
+        class Server:
+            settings = Settings()
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setattr(mcp_serve, "EventBridge", Bridge)
+        monkeypatch.setattr(mcp_serve, "create_mcp_server", lambda **_kwargs: Server())
+        monkeypatch.setattr(
+            mcp_serve,
+            "_configure_transport_security",
+            lambda *_args: (_ for _ in ()).throw(RuntimeError("security setup failed")),
+        )
+
+        with pytest.raises(RuntimeError, match="security setup failed"):
+            mcp_serve.run_mcp_http_server()
+
+        assert events == ["start", "stop"]
 
 
 class TestCliIntegration:
@@ -866,6 +1102,7 @@ class TestCliIntegration:
             auth_token_env="HERMES_MCP_PSK",
             auth_header="X-Test-PSK",
             allow_query_token=True,
+            allow_insecure_http=True,
             oauth_compatible=True,
             oauth_client_id_env="HERMES_MCP_CLIENT_ID",
             oauth_client_secret_env="HERMES_MCP_CLIENT_SECRET",
@@ -890,6 +1127,7 @@ class TestCliIntegration:
             auth_token_env="HERMES_MCP_PSK",
             auth_header="X-Test-PSK",
             allow_query_token=True,
+            allow_insecure_http=True,
             oauth_compatible=True,
             oauth_client_id_env="HERMES_MCP_CLIENT_ID",
             oauth_client_secret_env="HERMES_MCP_CLIENT_SECRET",
@@ -931,6 +1169,257 @@ class TestHttpAuthHelpers:
     def _json_response(self, response):
         return json.loads(response.body.decode("utf-8"))
 
+    def test_transport_security_accepts_default_host_headers_with_ports(self):
+        import mcp_serve
+        from mcp.server.transport_security import TransportSecurityMiddleware
+
+        class Settings:
+            transport_security = None
+
+        class Server:
+            settings = Settings()
+
+        server = Server()
+        mcp_serve._configure_transport_security(
+            server,
+            "127.0.0.1",
+            8666,
+            [],
+            [],
+        )
+        middleware = TransportSecurityMiddleware(server.settings.transport_security)
+
+        assert middleware._validate_host("127.0.0.1:8666")
+        assert middleware._validate_host("localhost:8666")
+        security = server.settings.transport_security
+        assert security is not None
+        assert "null" not in getattr(security, "allowed_origins")
+
+    @pytest.mark.asyncio
+    async def test_real_streamable_http_initialize_accepts_default_host_with_port(self):
+        import httpx
+        import mcp_serve
+
+        pytest.importorskip("mcp", reason="MCP SDK not installed")
+        server = mcp_serve.create_mcp_server()
+        server.settings.host = "127.0.0.1"
+        server.settings.port = 8666
+        server.settings.streamable_http_path = "/mcp"
+        server.settings.json_response = True
+        mcp_serve._configure_transport_security(
+            server, "127.0.0.1", 8666, [], []
+        )
+        app = mcp_serve.create_streamable_http_app(server)
+
+        async with app.router.lifespan_context(app):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://127.0.0.1:8666",
+            ) as client:
+                response = await client.post(
+                    "/mcp",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2025-06-18",
+                            "capabilities": {},
+                            "clientInfo": {"name": "test-client", "version": "1"},
+                        },
+                    },
+                    headers={"Accept": "application/json, text/event-stream"},
+                )
+
+        assert response.status_code == 200
+        assert response.json()["result"]["serverInfo"]["name"] == "hermes"
+
+    @pytest.mark.asyncio
+    async def test_real_streamable_http_auth_host_and_origin_boundaries(self):
+        import httpx
+        import mcp_serve
+
+        pytest.importorskip("mcp", reason="MCP SDK not installed")
+        server = mcp_serve.create_mcp_server()
+        server.settings.host = "127.0.0.1"
+        server.settings.port = 8666
+        server.settings.streamable_http_path = "/mcp"
+        server.settings.json_response = True
+        mcp_serve._configure_transport_security(
+            server,
+            "127.0.0.1",
+            8666,
+            ["mcp.example.com"],
+            ["https://trusted.example"],
+        )
+        app = mcp_serve.create_streamable_http_app(
+            server,
+            auth_config=mcp_serve.McpHttpAuthConfig(psk="test-server-psk"),
+        )
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1"},
+            },
+        }
+        accept = "application/json, text/event-stream"
+
+        async with app.router.lifespan_context(app):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://127.0.0.1:8666",
+            ) as client:
+                unauthenticated = await client.post(
+                    "/mcp", json=initialize, headers={"Accept": accept}
+                )
+                bad_host = await client.post(
+                    "/mcp",
+                    json=initialize,
+                    headers={
+                        "Accept": accept,
+                        "Authorization": "Bearer test-server-psk",
+                        "Host": "attacker.example",
+                    },
+                )
+                bad_origin = await client.post(
+                    "/mcp",
+                    json=initialize,
+                    headers={
+                        "Accept": accept,
+                        "Authorization": "Bearer test-server-psk",
+                        "Origin": "https://attacker.example",
+                    },
+                )
+                accepted = await client.post(
+                    "/mcp",
+                    json=initialize,
+                    headers={
+                        "Accept": accept,
+                        "Authorization": "Bearer test-server-psk",
+                        "Origin": "https://trusted.example",
+                        "Host": "mcp.example.com",
+                    },
+                )
+
+        assert unauthenticated.status_code == 401
+        assert bad_host.status_code == 421
+        assert bad_origin.status_code == 403
+        assert accepted.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_real_streamable_http_oauth_token_initializes_mcp(self):
+        import httpx
+        import mcp_serve
+
+        pytest.importorskip("mcp", reason="MCP SDK not installed")
+        server = mcp_serve.create_mcp_server()
+        server.settings.host = "127.0.0.1"
+        server.settings.port = 8666
+        server.settings.streamable_http_path = "/mcp"
+        server.settings.json_response = True
+        mcp_serve._configure_transport_security(
+            server, "127.0.0.1", 8666, [], []
+        )
+        app = mcp_serve.create_streamable_http_app(
+            server,
+            auth_config=mcp_serve.McpHttpAuthConfig(
+                psk="oauth-test-secret",
+                oauth_compatible=True,
+                public_base_url="http://127.0.0.1:8666",
+                path="/mcp",
+            ),
+        )
+
+        async with app.router.lifespan_context(app):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://127.0.0.1:8666",
+            ) as client:
+                rejected_token_response = await client.post(
+                    "/mcp/token",
+                    data={
+                        "grant_type": "client_credentials",
+                        "client_id": "hermes-mcp",
+                        "client_secret": "oauth-test-secret",
+                    },
+                    headers={"Host": "attacker.example"},
+                )
+                token_response = await client.post(
+                    "/mcp/token",
+                    data={
+                        "grant_type": "client_credentials",
+                        "client_id": "hermes-mcp",
+                        "client_secret": "oauth-test-secret",
+                    },
+                )
+                token = token_response.json()["access_token"]
+                initialize_response = await client.post(
+                    "/mcp",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2025-06-18",
+                            "capabilities": {},
+                            "clientInfo": {"name": "oauth-test", "version": "1"},
+                        },
+                    },
+                    headers={
+                        "Accept": "application/json, text/event-stream",
+                        "Authorization": f"Bearer {token}",
+                    },
+                )
+
+        assert rejected_token_response.status_code == 421
+        assert token_response.status_code == 200
+        assert initialize_response.status_code == 200
+
+    def test_transport_security_formats_ipv6_host_headers(self):
+        import mcp_serve
+        from mcp.server.transport_security import TransportSecurityMiddleware
+
+        class Settings:
+            transport_security = None
+
+        class Server:
+            settings = Settings()
+
+        server = Server()
+        mcp_serve._configure_transport_security(server, "::1", 8666, [], [])
+        middleware = TransportSecurityMiddleware(server.settings.transport_security)
+
+        assert middleware._validate_host("[::1]:8666")
+        assert mcp_serve._default_http_base_url("::1", 8666) == "http://[::1]:8666"
+
+    def test_transport_security_configuration_fails_closed(self):
+        import mcp_serve
+
+        class Settings:
+            @property
+            def transport_security(self):
+                return None
+
+            @transport_security.setter
+            def transport_security(self, _value):
+                raise RuntimeError("cannot install transport security")
+
+        class Server:
+            settings = Settings()
+
+        with pytest.raises(RuntimeError, match="cannot install transport security"):
+            mcp_serve._configure_transport_security(
+                Server(),
+                "127.0.0.1",
+                8666,
+                [],
+                [],
+            )
+
     def test_pkce_challenge_methods(self):
         import mcp_serve
 
@@ -953,6 +1442,24 @@ class TestHttpAuthHelpers:
         assert config.oauth_client_id == "hermes-mcp"
         assert config.oauth_client_id != config.psk
         assert config.oauth_client_secret == "server-psk"
+
+    def test_oauth_store_bounds_public_authorization_codes(self):
+        import mcp_serve
+
+        store = mcp_serve._OAuthTokenStore(max_codes=2)
+        first = store.issue_code("client", "http://127.0.0.1/cb", 300)
+        second = store.issue_code("client", "http://127.0.0.1/cb", 300)
+        third = store.issue_code("client", "http://127.0.0.1/cb", 300)
+
+        assert not store.consume_code(first, "client", "http://127.0.0.1/cb")
+        assert store.consume_code(second, "client", "http://127.0.0.1/cb")
+        assert store.consume_code(third, "client", "http://127.0.0.1/cb")
+
+        rate_limited = mcp_serve._OAuthTokenStore(max_code_issuance_per_minute=2)
+        rate_limited.issue_code("client", "https://client.example/cb", 300)
+        rate_limited.issue_code("client", "https://client.example/cb", 300)
+        with pytest.raises(OverflowError, match="rate exceeded"):
+            rate_limited.issue_code("client", "https://client.example/cb", 300)
 
     def _make_app(self, auth_config, host="127.0.0.1"):
         pytest.importorskip("starlette")
@@ -1055,6 +1562,33 @@ class TestHttpAuthHelpers:
         assert health.status_code == 200
         assert metadata.status_code == 200
 
+    @pytest.mark.asyncio
+    async def test_oauth_token_endpoint_rejects_oversized_form_body(self):
+        import httpx
+        import mcp_serve
+
+        app = self._make_app(
+            mcp_serve.McpHttpAuthConfig(
+                psk="test-psk",
+                oauth_compatible=True,
+                public_base_url="https://mcp.example.com",
+                path="/mcp",
+            )
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="https://mcp.example.com",
+        ) as client:
+            response = await client.post(
+                "/mcp/token",
+                content=b"x" * (mcp_serve._OAUTH_FORM_BODY_LIMIT + 1),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+
+        assert response.status_code == 413
+        assert response.json()["error"] == "invalid_request"
+
     def test_mcp_auth_boundary_covers_subpaths_but_not_oauth_endpoints(self):
         import mcp_serve
 
@@ -1091,7 +1625,7 @@ class TestHttpAuthHelpers:
         meta_json = self._json_response(meta)
         assert meta_json["authorization_endpoint"] == "https://mcp.example.com/mcp/authorize"
         assert "client_credentials" in meta_json["grant_types_supported"]
-        assert meta_json["code_challenge_methods_supported"] == ["plain", "S256"]
+        assert meta_json["code_challenge_methods_supported"] == ["S256"]
 
         resource = self._call_route(app, "/.well-known/oauth-protected-resource/mcp")
         assert resource.status_code == 200
@@ -1118,7 +1652,11 @@ class TestHttpAuthHelpers:
         assert token_response.status_code == 200
         bearer = self._json_response(token_response)["access_token"]
         assert bearer
+        assert token_response.headers["cache-control"] == "no-store"
+        assert token_response.headers["pragma"] == "no-cache"
 
+        verifier = "v" * 43
+        challenge = mcp_serve._pkce_challenge(verifier, "S256")
         authorize = self._call_route(
             app,
             "/mcp/authorize",
@@ -1127,6 +1665,8 @@ class TestHttpAuthHelpers:
                 "client_id": "hermes-mcp",
                 "redirect_uri": "https://client.example/cb",
                 "state": "abc",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
             }),
         )
         assert authorize.status_code == 302
@@ -1142,6 +1682,7 @@ class TestHttpAuthHelpers:
                 "client_secret": "client-as-psk",
                 "code": code,
                 "redirect_uri": "https://client.example/cb",
+                "code_verifier": verifier,
             }),
         )
         assert code_token.status_code == 200
@@ -1170,7 +1711,46 @@ class TestHttpAuthHelpers:
         assert response.status_code == 400
         assert self._json_response(response)["error_description"] == "redirect_uri is not allowed"
 
-    def test_oauth_authorize_allows_loopback_redirect_without_allowlist(self):
+    def test_oauth_authorize_requires_s256_pkce(self):
+        pytest.importorskip("starlette")
+        import mcp_serve
+
+        redirect_uri = "https://client.example/cb"
+        app = self._make_app(
+            mcp_serve.McpHttpAuthConfig(
+                psk="client-as-psk",
+                oauth_compatible=True,
+                public_base_url="https://mcp.example.com",
+                path="/mcp",
+                allowed_redirect_uris=[redirect_uri],
+            )
+        )
+
+        base = {
+            "response_type": "code",
+            "client_id": "hermes-mcp",
+            "redirect_uri": redirect_uri,
+        }
+        missing = self._call_route(
+            app, "/mcp/authorize", self._Request(params=base)
+        )
+        plain = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(
+                params={
+                    **base,
+                    "code_challenge": "c" * 43,
+                    "code_challenge_method": "plain",
+                }
+            ),
+        )
+
+        assert missing.status_code == 400
+        assert plain.status_code == 400
+        assert "PKCE S256" in self._json_response(missing)["error_description"]
+
+    def test_oauth_authorize_rejects_loopback_redirect_without_registration(self):
         pytest.importorskip("starlette")
         import mcp_serve
 
@@ -1181,6 +1761,11 @@ class TestHttpAuthHelpers:
             path="/mcp",
         ))
 
+        metadata = self._call_route(app, "/.well-known/oauth-authorization-server")
+        metadata_json = self._json_response(metadata)
+        assert metadata_json["grant_types_supported"] == ["client_credentials"]
+        assert "authorization_endpoint" not in metadata_json
+
         response = self._call_route(
             app,
             "/mcp/authorize",
@@ -1188,10 +1773,12 @@ class TestHttpAuthHelpers:
                 "response_type": "code",
                 "client_id": "hermes-mcp",
                 "redirect_uri": "http://127.0.0.1:54321/callback",
+                "code_challenge": "c" * 43,
+                "code_challenge_method": "S256",
             }),
         )
-        assert response.status_code == 302
-        assert response.headers["location"].startswith("http://127.0.0.1:54321/callback?code=")
+        assert response.status_code == 400
+        assert "not configured" in self._json_response(response)["error_description"]
 
     def test_oauth_redirect_validation_rejects_insecure_remote_and_fragments(self):
         import mcp_serve
@@ -1232,6 +1819,8 @@ class TestHttpAuthHelpers:
         )
         assert token_response.status_code == 401
         assert self._json_response(token_response)["error"] == "invalid_client"
+        assert token_response.headers["cache-control"] == "no-store"
+        assert token_response.headers["pragma"] == "no-cache"
 
     def test_oauth_authorization_code_s256_pkce_and_redirect_binding(self):
         pytest.importorskip("starlette")
@@ -1282,13 +1871,26 @@ class TestHttpAuthHelpers:
         assert wrong_redirect.status_code == 400
         assert self._json_response(wrong_redirect)["error"] == "invalid_grant"
 
-        replay_after_wrong_redirect = self._call_route(
+        wrong_resource = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(
+                data={
+                    **grant,
+                    "code_verifier": verifier,
+                    "resource": "https://attacker.example/mcp",
+                }
+            ),
+        )
+        assert wrong_resource.status_code == 400
+        assert self._json_response(wrong_resource)["error"] == "invalid_target"
+
+        valid_after_wrong_redirect = self._call_route(
             app,
             "/mcp/token",
             self._Request(data={**grant, "code_verifier": verifier}),
         )
-        assert replay_after_wrong_redirect.status_code == 400
-        assert self._json_response(replay_after_wrong_redirect)["error"] == "invalid_grant"
+        assert valid_after_wrong_redirect.status_code == 200
 
         authorize = self._call_route(
             app,
@@ -1313,13 +1915,12 @@ class TestHttpAuthHelpers:
         assert wrong_verifier.status_code == 400
         assert self._json_response(wrong_verifier)["error"] == "invalid_grant"
 
-        replay_after_wrong_verifier = self._call_route(
+        valid_after_wrong_verifier = self._call_route(
             app,
             "/mcp/token",
             self._Request(data={**grant, "code_verifier": verifier}),
         )
-        assert replay_after_wrong_verifier.status_code == 400
-        assert self._json_response(replay_after_wrong_verifier)["error"] == "invalid_grant"
+        assert valid_after_wrong_verifier.status_code == 200
 
         authorize = self._call_route(
             app,

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -212,6 +212,7 @@ class _FakeTool:
         self.name = fn.__name__
         self.description = inspect.getdoc(fn) or ""
         self.fn = fn
+        self.parameters = {}
 
 
 class _FakeToolManager:
@@ -220,6 +221,9 @@ class _FakeToolManager:
 
     def add_tool(self, fn):
         self._tools[fn.__name__] = _FakeTool(fn)
+
+    def get_tool(self, name):
+        return self._tools.get(name)
 
     async def call_tool(self, name, args=None):
         return self._tools[name].fn(**(args or {}))
@@ -238,6 +242,11 @@ class _FakeFastMCP:
             return fn
 
         return decorator
+
+    def add_tool(self, fn, name=None, description=None, **_kwargs):
+        self._tool_manager._tools[name or fn.__name__] = _FakeTool(fn)
+        self._tool_manager._tools[name or fn.__name__].name = name or fn.__name__
+        self._tool_manager._tools[name or fn.__name__].description = description or ""
 
 
 @pytest.fixture
@@ -718,6 +727,40 @@ class TestServerCreation:
         bridge = mcp_serve.EventBridge()
         assert mcp_serve.create_mcp_server(event_bridge=bridge) is not None
 
+    def test_create_exposes_selected_registry_toolset(self, populated_sessions_dir, monkeypatch):
+        pytest.importorskip("mcp", reason="MCP SDK not installed")
+        import mcp_serve
+        from tools.registry import registry
+
+        tool_name = "test_mcp_exposed_plugin_tool"
+        registry.register(
+            name=tool_name,
+            toolset="test-mcp-expose",
+            schema={
+                "name": tool_name,
+                "description": "Test exposed plugin-style tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "message": {"type": "string", "description": "Message to echo"},
+                        "confirm": {"type": "boolean", "description": "Safety acknowledgement"},
+                    },
+                    "required": ["message"],
+                    "additionalProperties": False,
+                },
+            },
+            handler=lambda args, **_kwargs: json.dumps({"echo": args}),
+        )
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: populated_sessions_dir)
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda force=False: None)
+        try:
+            server = mcp_serve.create_mcp_server(expose_toolsets=["test-mcp-expose"])
+            tool = server._tool_manager.get_tool(tool_name)
+            assert tool is not None
+            assert tool.parameters["properties"]["message"]["type"] == "string"
+        finally:
+            registry.deregister(tool_name)
+
     def test_create_without_mcp_sdk(self, monkeypatch):
         import mcp_serve
         monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", False)
@@ -769,7 +812,166 @@ class TestCliIntegration:
         args = argparse.Namespace(mcp_action="serve", verbose=True)
         from hermes_cli.mcp_config import mcp_command
         mcp_command(args)
-        mock_run.assert_called_once_with(verbose=True)
+        mock_run.assert_called_once_with(
+            verbose=True,
+            expose_toolsets=[],
+            expose_tools=[],
+            expose_plugin_tools=False,
+        )
+
+    def test_dispatcher_routes_streamable_http(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        mock_http = MagicMock()
+        monkeypatch.setattr("mcp_serve.run_mcp_http_server", mock_http)
+
+        import argparse
+        args = argparse.Namespace(
+            mcp_action="serve",
+            transport="streamable-http",
+            verbose=True,
+            host="127.0.0.1",
+            port=9999,
+            path="/mcp",
+            public_base_url="https://example.com",
+            auth_token_env="HERMES_MCP_PSK",
+            auth_header="X-Test-PSK",
+            allow_query_token=True,
+            oauth_compatible=True,
+            oauth_client_id_env="HERMES_MCP_CLIENT_ID",
+            oauth_client_secret_env="HERMES_MCP_CLIENT_SECRET",
+            oauth_token_ttl_seconds=600,
+            oauth_code_ttl_seconds=60,
+            allowed_host=["example.com"],
+            allowed_origin=["https://example.com"],
+            expose_toolset=["tescmd"],
+            expose_tool=["custom_tool"],
+            expose_plugin_tools=True,
+            health_path="/healthz",
+        )
+        from hermes_cli.mcp_config import mcp_command
+        mcp_command(args)
+        mock_http.assert_called_once_with(
+            verbose=True,
+            host="127.0.0.1",
+            port=9999,
+            path="/mcp",
+            public_base_url="https://example.com",
+            auth_token_env="HERMES_MCP_PSK",
+            auth_header="X-Test-PSK",
+            allow_query_token=True,
+            oauth_compatible=True,
+            oauth_client_id_env="HERMES_MCP_CLIENT_ID",
+            oauth_client_secret_env="HERMES_MCP_CLIENT_SECRET",
+            token_ttl_seconds=600,
+            code_ttl_seconds=60,
+            allowed_hosts=["example.com"],
+            allowed_origins=["https://example.com"],
+            expose_toolsets=["tescmd"],
+            expose_tools=["custom_tool"],
+            expose_plugin_tools=True,
+            health_path="/healthz",
+        )
+
+
+class TestHttpAuthHelpers:
+    def _make_app(self, auth_config):
+        pytest.importorskip("starlette")
+        from starlette.applications import Starlette
+        from starlette.responses import JSONResponse
+        import mcp_serve
+
+        class Settings:
+            streamable_http_path = "/mcp"
+
+        class FakeServer:
+            settings = Settings()
+
+            def streamable_http_app(self):
+                app = Starlette()
+
+                async def mcp(_request):
+                    return JSONResponse({"ok": True})
+
+                app.add_route("/mcp", mcp, methods=["GET", "POST"])
+                return app
+
+        return mcp_serve.create_streamable_http_app(
+            FakeServer(),
+            auth_config=auth_config,
+            health_path="/health",
+        )
+
+    def test_psk_auth_accepts_bearer_header_and_query(self):
+        pytest.importorskip("starlette")
+        from starlette.testclient import TestClient
+        import mcp_serve
+
+        app = self._make_app(mcp_serve.McpHttpAuthConfig(
+            psk="test-psk",
+            psk_header="X-Test-PSK",
+            allow_query_token=True,
+            path="/mcp",
+        ))
+        client = TestClient(app)
+
+        response = client.get("/mcp")
+        assert response.status_code == 401
+        assert response.headers["www-authenticate"] == "Bearer"
+
+        assert client.get("/mcp", headers={"Authorization": "Bearer test-psk"}).status_code == 200
+        assert client.get("/mcp", headers={"X-Test-PSK": "test-psk"}).status_code == 200
+        assert client.get("/mcp?access_token=test-psk").status_code == 200
+        assert client.get("/health").text == "ok"
+
+    def test_oauth_compatible_metadata_and_token_flows(self):
+        pytest.importorskip("starlette")
+        from starlette.testclient import TestClient
+        import mcp_serve
+
+        app = self._make_app(mcp_serve.McpHttpAuthConfig(
+            psk="client-as-psk",
+            allow_query_token=False,
+            oauth_compatible=True,
+            public_base_url="https://mcp.example.com",
+            path="/mcp",
+            token_ttl_seconds=600,
+            code_ttl_seconds=60,
+        ))
+        client = TestClient(app, follow_redirects=False)
+
+        meta = client.get("/.well-known/oauth-authorization-server")
+        assert meta.status_code == 200
+        assert meta.json()["authorization_endpoint"] == "https://mcp.example.com/mcp/authorize"
+        assert "client_credentials" in meta.json()["grant_types_supported"]
+
+        resource = client.get("/.well-known/oauth-protected-resource/mcp")
+        assert resource.status_code == 200
+        assert resource.json()["resource"] == "https://mcp.example.com/mcp"
+
+        unauth = client.get("/mcp")
+        assert unauth.status_code == 401
+        assert "resource_metadata=" in unauth.headers["www-authenticate"]
+
+        token_response = client.post(
+            "/mcp/token",
+            data={"grant_type": "client_credentials", "client_id": "client-as-psk"},
+        )
+        assert token_response.status_code == 200
+        bearer = token_response.json()["access_token"]
+        assert client.get("/mcp", headers={"Authorization": f"Bearer {bearer}"}).status_code == 200
+
+        authorize = client.get(
+            "/mcp/authorize?response_type=code&client_id=client-as-psk&redirect_uri=https%3A%2F%2Fclient.example%2Fcb&state=abc"
+        )
+        assert authorize.status_code == 302
+        assert "code=" in authorize.headers["location"]
+        assert "state=abc" in authorize.headers["location"]
+        code = authorize.headers["location"].split("code=", 1)[1].split("&", 1)[0]
+        code_token = client.post(
+            "/mcp/token",
+            data={"grant_type": "authorization_code", "client_id": "client-as-psk", "code": code},
+        )
+        assert code_token.status_code == 200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -871,6 +871,7 @@ class TestCliIntegration:
             oauth_client_secret_env="HERMES_MCP_CLIENT_SECRET",
             oauth_token_ttl_seconds=600,
             oauth_code_ttl_seconds=60,
+            oauth_redirect_uri=["https://client.example/cb"],
             allowed_host=["example.com"],
             allowed_origin=["https://example.com"],
             expose_toolset=["tescmd"],
@@ -894,6 +895,7 @@ class TestCliIntegration:
             oauth_client_secret_env="HERMES_MCP_CLIENT_SECRET",
             token_ttl_seconds=600,
             code_ttl_seconds=60,
+            oauth_redirect_uris=["https://client.example/cb"],
             allowed_hosts=["example.com"],
             allowed_origins=["https://example.com"],
             expose_toolsets=["tescmd"],
@@ -904,6 +906,31 @@ class TestCliIntegration:
 
 
 class TestHttpAuthHelpers:
+    class _Request:
+        def __init__(self, params=None, data=None):
+            from starlette.datastructures import QueryParams
+            from urllib.parse import urlencode
+
+            self.query_params = QueryParams(params or {})
+            self._body = urlencode(data or {}).encode("utf-8")
+
+        async def body(self):
+            return self._body
+
+    def _route_endpoint(self, app, path):
+        for route in app.routes:
+            if getattr(route, "path", None) == path:
+                return route.endpoint
+        raise AssertionError(f"Route not found: {path}")
+
+    def _call_route(self, app, path, request=None):
+        return asyncio.get_event_loop().run_until_complete(
+            self._route_endpoint(app, path)(request or self._Request())
+        )
+
+    def _json_response(self, response):
+        return json.loads(response.body.decode("utf-8"))
+
     def test_pkce_challenge_methods(self):
         import mcp_serve
 
@@ -914,6 +941,18 @@ class TestHttpAuthHelpers:
         )
         assert mcp_serve._pkce_challenge("verifier", "unsupported") is None
         assert mcp_serve._pkce_challenge("☃", "S256") is None
+
+    def test_default_oauth_identity_keeps_psk_out_of_public_client_id(self):
+        import mcp_serve
+
+        config = mcp_serve.McpHttpAuthConfig(
+            psk="server-psk",
+            oauth_compatible=True,
+        )
+
+        assert config.oauth_client_id == "hermes-mcp"
+        assert config.oauth_client_id != config.psk
+        assert config.oauth_client_secret == "server-psk"
 
     def _make_app(self, auth_config, host="127.0.0.1"):
         pytest.importorskip("starlette")
@@ -950,30 +989,90 @@ class TestHttpAuthHelpers:
             self._make_app(None, host="0.0.0.0")
 
     def test_psk_auth_accepts_bearer_header_and_query(self):
-        pytest.importorskip("starlette")
-        from starlette.testclient import TestClient
+        from starlette.datastructures import Headers, QueryParams
         import mcp_serve
 
-        app = self._make_app(mcp_serve.McpHttpAuthConfig(
+        class Request:
+            def __init__(self, headers=None, query_string=""):
+                self.headers = Headers(headers or {})
+                self.query_params = QueryParams(query_string)
+
+        config = mcp_serve.McpHttpAuthConfig(
             psk="test-psk",
             psk_header="X-Test-PSK",
             allow_query_token=True,
             path="/mcp",
-        ))
-        client = TestClient(app)
+        )
+        store = mcp_serve._OAuthTokenStore()
 
-        response = client.get("/mcp")
-        assert response.status_code == 401
-        assert response.headers["www-authenticate"] == "Bearer"
+        assert not mcp_serve._is_authenticated(Request(), config, store)
+        assert mcp_serve._is_authenticated(
+            Request(headers={"Authorization": "Bearer test-psk"}),
+            config,
+            store,
+        )
+        assert mcp_serve._is_authenticated(
+            Request(headers={"X-Test-PSK": "test-psk"}),
+            config,
+            store,
+        )
+        assert mcp_serve._is_authenticated(
+            Request(query_string="access_token=test-psk"),
+            config,
+            store,
+        )
+        assert mcp_serve._auth_challenge(config) == "Bearer"
 
-        assert client.get("/mcp", headers={"Authorization": "Bearer test-psk"}).status_code == 200
-        assert client.get("/mcp", headers={"X-Test-PSK": "test-psk"}).status_code == 200
-        assert client.get("/mcp?access_token=test-psk").status_code == 200
-        assert client.get("/health").text == "ok"
+    @pytest.mark.asyncio
+    async def test_http_auth_middleware_enforces_real_asgi_boundary(self):
+        import httpx
+        import mcp_serve
+
+        app = self._make_app(
+            mcp_serve.McpHttpAuthConfig(
+                psk="test-psk",
+                oauth_compatible=True,
+                public_base_url="https://mcp.example.com",
+                path="/mcp",
+            )
+        )
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="https://mcp.example.com",
+        ) as client:
+            unauthenticated = await client.get("/mcp/subpath")
+            authenticated = await client.get(
+                "/mcp",
+                headers={"Authorization": "Bearer test-psk"},
+            )
+            health = await client.get("/health")
+            metadata = await client.get("/.well-known/oauth-authorization-server")
+
+        assert unauthenticated.status_code == 401
+        assert authenticated.status_code == 200
+        assert authenticated.json() == {"ok": True}
+        assert health.status_code == 200
+        assert metadata.status_code == 200
+
+    def test_mcp_auth_boundary_covers_subpaths_but_not_oauth_endpoints(self):
+        import mcp_serve
+
+        config = mcp_serve.McpHttpAuthConfig(
+            psk="test-psk",
+            oauth_compatible=True,
+            path="/mcp",
+        )
+
+        assert mcp_serve._is_protected_mcp_http_path(config, "/mcp")
+        assert mcp_serve._is_protected_mcp_http_path(config, "/mcp/")
+        assert mcp_serve._is_protected_mcp_http_path(config, "/mcp/subpath")
+        assert not mcp_serve._is_protected_mcp_http_path(config, "/mcp/authorize")
+        assert not mcp_serve._is_protected_mcp_http_path(config, "/mcp/token")
+        assert not mcp_serve._is_protected_mcp_http_path(config, "/health")
 
     def test_oauth_compatible_metadata_and_token_flows(self):
         pytest.importorskip("starlette")
-        from starlette.testclient import TestClient
         import mcp_serve
 
         app = self._make_app(mcp_serve.McpHttpAuthConfig(
@@ -984,57 +1083,164 @@ class TestHttpAuthHelpers:
             path="/mcp",
             token_ttl_seconds=600,
             code_ttl_seconds=60,
+            allowed_redirect_uris=["https://client.example/cb"],
         ))
-        client = TestClient(app, follow_redirects=False)
 
-        meta = client.get("/.well-known/oauth-authorization-server")
+        meta = self._call_route(app, "/.well-known/oauth-authorization-server")
         assert meta.status_code == 200
-        assert meta.json()["authorization_endpoint"] == "https://mcp.example.com/mcp/authorize"
-        assert "client_credentials" in meta.json()["grant_types_supported"]
-        assert meta.json()["code_challenge_methods_supported"] == ["plain", "S256"]
+        meta_json = self._json_response(meta)
+        assert meta_json["authorization_endpoint"] == "https://mcp.example.com/mcp/authorize"
+        assert "client_credentials" in meta_json["grant_types_supported"]
+        assert meta_json["code_challenge_methods_supported"] == ["plain", "S256"]
 
-        resource = client.get("/.well-known/oauth-protected-resource/mcp")
+        resource = self._call_route(app, "/.well-known/oauth-protected-resource/mcp")
         assert resource.status_code == 200
-        assert resource.json()["resource"] == "https://mcp.example.com/mcp"
+        assert self._json_response(resource)["resource"] == "https://mcp.example.com/mcp"
 
-        unauth = client.get("/mcp")
-        assert unauth.status_code == 401
-        assert "resource_metadata=" in unauth.headers["www-authenticate"]
+        assert "resource_metadata=" in mcp_serve._auth_challenge(
+            mcp_serve.McpHttpAuthConfig(
+                psk="client-as-psk",
+                oauth_compatible=True,
+                public_base_url="https://mcp.example.com",
+                path="/mcp",
+            )
+        )
 
-        token_response = client.post(
+        token_response = self._call_route(
+            app,
             "/mcp/token",
-            data={"grant_type": "client_credentials", "client_id": "client-as-psk"},
+            self._Request(data={
+                "grant_type": "client_credentials",
+                "client_id": "hermes-mcp",
+                "client_secret": "client-as-psk",
+            }),
         )
         assert token_response.status_code == 200
-        bearer = token_response.json()["access_token"]
-        assert client.get("/mcp", headers={"Authorization": f"Bearer {bearer}"}).status_code == 200
+        bearer = self._json_response(token_response)["access_token"]
+        assert bearer
 
-        authorize = client.get(
-            "/mcp/authorize?response_type=code&client_id=client-as-psk&redirect_uri=https%3A%2F%2Fclient.example%2Fcb&state=abc"
+        authorize = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(params={
+                "response_type": "code",
+                "client_id": "hermes-mcp",
+                "redirect_uri": "https://client.example/cb",
+                "state": "abc",
+            }),
         )
         assert authorize.status_code == 302
         assert "code=" in authorize.headers["location"]
         assert "state=abc" in authorize.headers["location"]
         code = authorize.headers["location"].split("code=", 1)[1].split("&", 1)[0]
-        code_token = client.post(
+        code_token = self._call_route(
+            app,
             "/mcp/token",
-            data={
+            self._Request(data={
                 "grant_type": "authorization_code",
-                "client_id": "client-as-psk",
+                "client_id": "hermes-mcp",
+                "client_secret": "client-as-psk",
                 "code": code,
                 "redirect_uri": "https://client.example/cb",
-            },
+            }),
         )
         assert code_token.status_code == 200
 
+    def test_oauth_authorize_rejects_unlisted_redirect_uri(self):
+        pytest.importorskip("starlette")
+        import mcp_serve
+
+        app = self._make_app(mcp_serve.McpHttpAuthConfig(
+            psk="client-as-psk",
+            oauth_compatible=True,
+            public_base_url="https://mcp.example.com",
+            path="/mcp",
+            allowed_redirect_uris=["https://client.example/cb"],
+        ))
+
+        response = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(params={
+                "response_type": "code",
+                "client_id": "hermes-mcp",
+                "redirect_uri": "https://attacker.example/cb",
+            }),
+        )
+        assert response.status_code == 400
+        assert self._json_response(response)["error_description"] == "redirect_uri is not allowed"
+
+    def test_oauth_authorize_allows_loopback_redirect_without_allowlist(self):
+        pytest.importorskip("starlette")
+        import mcp_serve
+
+        app = self._make_app(mcp_serve.McpHttpAuthConfig(
+            psk="client-as-psk",
+            oauth_compatible=True,
+            public_base_url="https://mcp.example.com",
+            path="/mcp",
+        ))
+
+        response = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(params={
+                "response_type": "code",
+                "client_id": "hermes-mcp",
+                "redirect_uri": "http://127.0.0.1:54321/callback",
+            }),
+        )
+        assert response.status_code == 302
+        assert response.headers["location"].startswith("http://127.0.0.1:54321/callback?code=")
+
+    def test_oauth_redirect_validation_rejects_insecure_remote_and_fragments(self):
+        import mcp_serve
+
+        config = mcp_serve.McpHttpAuthConfig(
+            psk="server-psk",
+            oauth_compatible=True,
+            allowed_redirect_uris=[
+                "http://client.example/cb",
+                "https://client.example/cb#fragment",
+            ],
+        )
+
+        assert not mcp_serve._oauth_redirect_uri_allowed(
+            config, "http://client.example/cb"
+        )
+        assert not mcp_serve._oauth_redirect_uri_allowed(
+            config, "https://client.example/cb#fragment"
+        )
+
+    def test_oauth_explicit_client_id_without_secret_cannot_get_token(self):
+        pytest.importorskip("starlette")
+        import mcp_serve
+
+        app = self._make_app(mcp_serve.McpHttpAuthConfig(
+            psk="server-psk",
+            oauth_compatible=True,
+            oauth_client_id="public-client",
+            public_base_url="https://mcp.example.com",
+            path="/mcp",
+            allowed_redirect_uris=["https://client.example/cb"],
+        ))
+
+        token_response = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={"grant_type": "client_credentials", "client_id": "public-client"}),
+        )
+        assert token_response.status_code == 401
+        assert self._json_response(token_response)["error"] == "invalid_client"
+
     def test_oauth_authorization_code_s256_pkce_and_redirect_binding(self):
         pytest.importorskip("starlette")
-        from starlette.testclient import TestClient
         from urllib.parse import parse_qs, urlparse
         import mcp_serve
 
         verifier = "v" * 43
         challenge = mcp_serve._pkce_challenge(verifier, "S256")
+        redirect_uri = "https://client.example/cb"
         app = self._make_app(
             mcp_serve.McpHttpAuthConfig(
                 psk="client-as-psk",
@@ -1043,57 +1249,108 @@ class TestHttpAuthHelpers:
                 path="/mcp",
                 token_ttl_seconds=600,
                 code_ttl_seconds=60,
+                allowed_redirect_uris=[redirect_uri],
             )
         )
-        client = TestClient(app, follow_redirects=False)
-        redirect_uri = "https://client.example/cb"
 
-        authorize = client.get(
+        authorize = self._call_route(
+            app,
             "/mcp/authorize",
-            params={
+            self._Request(params={
                 "response_type": "code",
-                "client_id": "client-as-psk",
+                "client_id": "hermes-mcp",
                 "redirect_uri": redirect_uri,
                 "code_challenge": challenge,
                 "code_challenge_method": "S256",
-            },
+            }),
         )
         assert authorize.status_code == 302
         code = parse_qs(urlparse(authorize.headers["location"]).query)["code"][0]
         grant = {
             "grant_type": "authorization_code",
-            "client_id": "client-as-psk",
+            "client_id": "hermes-mcp",
+            "client_secret": "client-as-psk",
             "code": code,
             "redirect_uri": redirect_uri,
         }
 
-        wrong_redirect = client.post(
+        wrong_redirect = self._call_route(
+            app,
             "/mcp/token",
-            data={**grant, "redirect_uri": "https://attacker.example/cb", "code_verifier": verifier},
+            self._Request(data={**grant, "redirect_uri": "https://attacker.example/cb", "code_verifier": verifier}),
         )
         assert wrong_redirect.status_code == 400
-        assert wrong_redirect.json()["error"] == "invalid_grant"
+        assert self._json_response(wrong_redirect)["error"] == "invalid_grant"
 
-        wrong_verifier = client.post(
+        replay_after_wrong_redirect = self._call_route(
+            app,
             "/mcp/token",
-            data={**grant, "code_verifier": "x" * 43},
+            self._Request(data={**grant, "code_verifier": verifier}),
+        )
+        assert replay_after_wrong_redirect.status_code == 400
+        assert self._json_response(replay_after_wrong_redirect)["error"] == "invalid_grant"
+
+        authorize = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(params={
+                "response_type": "code",
+                "client_id": "hermes-mcp",
+                "redirect_uri": redirect_uri,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            }),
+        )
+        assert authorize.status_code == 302
+        code = parse_qs(urlparse(authorize.headers["location"]).query)["code"][0]
+        grant["code"] = code
+
+        wrong_verifier = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={**grant, "code_verifier": "x" * 43}),
         )
         assert wrong_verifier.status_code == 400
-        assert wrong_verifier.json()["error"] == "invalid_grant"
+        assert self._json_response(wrong_verifier)["error"] == "invalid_grant"
 
-        token = client.post(
+        replay_after_wrong_verifier = self._call_route(
+            app,
             "/mcp/token",
-            data={**grant, "code_verifier": verifier},
+            self._Request(data={**grant, "code_verifier": verifier}),
+        )
+        assert replay_after_wrong_verifier.status_code == 400
+        assert self._json_response(replay_after_wrong_verifier)["error"] == "invalid_grant"
+
+        authorize = self._call_route(
+            app,
+            "/mcp/authorize",
+            self._Request(params={
+                "response_type": "code",
+                "client_id": "hermes-mcp",
+                "redirect_uri": redirect_uri,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            }),
+        )
+        assert authorize.status_code == 302
+        code = parse_qs(urlparse(authorize.headers["location"]).query)["code"][0]
+        grant["code"] = code
+
+        token = self._call_route(
+            app,
+            "/mcp/token",
+            self._Request(data={**grant, "code_verifier": verifier}),
         )
         assert token.status_code == 200
-        assert token.json()["token_type"] == "Bearer"
+        assert self._json_response(token)["token_type"] == "Bearer"
 
-        replay = client.post(
+        replay = self._call_route(
+            app,
             "/mcp/token",
-            data={**grant, "code_verifier": verifier},
+            self._Request(data={**grant, "code_verifier": verifier}),
         )
         assert replay.status_code == 400
-        assert replay.json()["error"] == "invalid_grant"
+        assert self._json_response(replay)["error"] == "invalid_grant"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -761,6 +761,122 @@ class TestServerCreation:
         finally:
             registry.deregister(tool_name)
 
+    def test_plugin_only_exposure_ignores_rejected_builtin_collision(self, monkeypatch):
+        import model_tools  # noqa: F401 - ensure built-in registry discovery ran
+        import mcp_serve
+        import hermes_cli.plugins as plugins_mod
+        from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+        from tools.registry import registry
+
+        assert registry.get_entry("terminal") is not None
+        manager = PluginManager()
+        context = PluginContext(
+            manager=manager,
+            manifest=PluginManifest(name="collision-plugin", source="user"),
+        )
+        context.register_tool(
+            name="terminal",
+            toolset="plugin-collision-toolset",
+            schema={
+                "name": "terminal",
+                "description": "Plugin collision",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kw: "plugin",
+        )
+        monkeypatch.setattr(plugins_mod, "discover_plugins", lambda force=False: None)
+        monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+        server = _FakeFastMCP()
+
+        with pytest.raises(
+            RuntimeError, match="No enabled plugin tools are available for MCP exposure"
+        ):
+            mcp_serve._register_registry_tools_as_mcp(server, expose_plugin_tools=True)
+
+        assert manager.get_registered_tool_names() == set()
+        assert server._tool_manager.get_tool("terminal") is None
+
+    def test_registry_exposure_uses_dynamic_schema_and_cached_check(self, monkeypatch):
+        import mcp_serve
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        tool_name = "test_mcp_dynamic_registry_schema"
+        check_calls = 0
+
+        def check_fn():
+            nonlocal check_calls
+            check_calls += 1
+            return check_calls == 1
+
+        registry.register(
+            name=tool_name,
+            toolset="test-mcp-dynamic",
+            schema={
+                "name": tool_name,
+                "description": "static placeholder",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **_kwargs: json.dumps({"ok": True}),
+            check_fn=check_fn,
+            dynamic_schema_overrides=lambda: {
+                "description": "runtime authoritative description",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"runtime_value": {"type": "integer"}},
+                    "required": ["runtime_value"],
+                },
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.discover_plugins", lambda force=False: None
+        )
+        invalidate_check_fn_cache()
+        try:
+            # Prime the authoritative cache. A raw second check_fn call would
+            # return False and incorrectly hide the tool.
+            assert registry.get_definitions({tool_name}, quiet=True)
+
+            server = _FakeFastMCP()
+            registered = mcp_serve._register_registry_tools_as_mcp(
+                server, expose_tools=[tool_name]
+            )
+            tool = server._tool_manager.get_tool(tool_name)
+
+            assert registered == [tool_name]
+            assert check_calls == 1
+            assert tool.description == "runtime authoritative description"
+            assert tool.parameters["properties"]["runtime_value"]["type"] == "integer"
+        finally:
+            registry.deregister(tool_name)
+            invalidate_check_fn_cache()
+
+    def test_video_generate_exposure_does_not_publish_placeholder(self, monkeypatch):
+        import model_tools  # noqa: F401 - ensure video_generate is registered
+        import mcp_serve
+        from tools.registry import invalidate_check_fn_cache, registry
+
+        entry = registry.get_entry("video_generate")
+        assert entry is not None
+        original_check_fn = entry.check_fn
+        monkeypatch.setattr(entry, "check_fn", lambda: True)
+        monkeypatch.setattr(
+            "hermes_cli.plugins.discover_plugins", lambda force=False: None
+        )
+        invalidate_check_fn_cache()
+        try:
+            server = _FakeFastMCP()
+            mcp_serve._register_registry_tools_as_mcp(
+                server, expose_tools=["video_generate"]
+            )
+            tool = server._tool_manager.get_tool("video_generate")
+
+            assert tool is not None
+            assert "rebuilt at get_definitions() time" not in tool.description
+            assert "Generate a video" in tool.description
+        finally:
+            entry.check_fn = original_check_fn
+            invalidate_check_fn_cache()
+
     def test_registry_tool_wrapper_uses_guarded_dispatch(self, monkeypatch):
         import mcp_serve
         import model_tools

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -761,6 +761,26 @@ class TestServerCreation:
         finally:
             registry.deregister(tool_name)
 
+    def test_registry_tool_wrapper_uses_guarded_dispatch(self, monkeypatch):
+        import mcp_serve
+        import model_tools
+
+        calls = []
+
+        def fake_handle_function_call(**kwargs):
+            calls.append(kwargs)
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr(model_tools, "handle_function_call", fake_handle_function_call)
+        wrapper = mcp_serve._make_registry_tool_wrapper("test_guarded_tool")
+
+        assert json.loads(wrapper(message="hello")) == {"ok": True}
+        assert calls[0]["function_name"] == "test_guarded_tool"
+        assert calls[0]["function_args"] == {"message": "hello"}
+        assert calls[0]["task_id"] == "mcp-serve"
+        assert calls[0]["session_id"] == "mcp-serve"
+        assert calls[0]["tool_call_id"].startswith("mcp-")
+
     def test_create_without_mcp_sdk(self, monkeypatch):
         import mcp_serve
         monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", False)
@@ -775,6 +795,16 @@ class TestRunMcpServer:
         with pytest.raises(SystemExit) as exc_info:
             mcp_serve.run_mcp_server()
         assert exc_info.value.code == 1
+
+    def test_http_rejects_unauthenticated_non_loopback_bind(self, monkeypatch, capsys):
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        with pytest.raises(SystemExit) as exc_info:
+            mcp_serve.run_mcp_http_server(host="0.0.0.0")
+
+        assert exc_info.value.code == 1
+        assert "restricted to loopback hosts" in capsys.readouterr().err
 
 
 class TestCliIntegration:
@@ -874,7 +904,18 @@ class TestCliIntegration:
 
 
 class TestHttpAuthHelpers:
-    def _make_app(self, auth_config):
+    def test_pkce_challenge_methods(self):
+        import mcp_serve
+
+        assert mcp_serve._pkce_challenge("verifier", "plain") == "verifier"
+        assert (
+            mcp_serve._pkce_challenge("verifier", "S256")
+            == "iMnq5o6zALKXGivsnlom_0F5_WYda32GHkxlV7mq7hQ"
+        )
+        assert mcp_serve._pkce_challenge("verifier", "unsupported") is None
+        assert mcp_serve._pkce_challenge("☃", "S256") is None
+
+    def _make_app(self, auth_config, host="127.0.0.1"):
         pytest.importorskip("starlette")
         from starlette.applications import Starlette
         from starlette.responses import JSONResponse
@@ -882,6 +923,9 @@ class TestHttpAuthHelpers:
 
         class Settings:
             streamable_http_path = "/mcp"
+
+            def __init__(self):
+                self.host = host
 
         class FakeServer:
             settings = Settings()
@@ -900,6 +944,10 @@ class TestHttpAuthHelpers:
             auth_config=auth_config,
             health_path="/health",
         )
+
+    def test_app_rejects_unauthenticated_non_loopback_bind(self):
+        with pytest.raises(ValueError, match="restricted to loopback hosts"):
+            self._make_app(None, host="0.0.0.0")
 
     def test_psk_auth_accepts_bearer_header_and_query(self):
         pytest.importorskip("starlette")
@@ -943,6 +991,7 @@ class TestHttpAuthHelpers:
         assert meta.status_code == 200
         assert meta.json()["authorization_endpoint"] == "https://mcp.example.com/mcp/authorize"
         assert "client_credentials" in meta.json()["grant_types_supported"]
+        assert meta.json()["code_challenge_methods_supported"] == ["plain", "S256"]
 
         resource = client.get("/.well-known/oauth-protected-resource/mcp")
         assert resource.status_code == 200
@@ -969,9 +1018,82 @@ class TestHttpAuthHelpers:
         code = authorize.headers["location"].split("code=", 1)[1].split("&", 1)[0]
         code_token = client.post(
             "/mcp/token",
-            data={"grant_type": "authorization_code", "client_id": "client-as-psk", "code": code},
+            data={
+                "grant_type": "authorization_code",
+                "client_id": "client-as-psk",
+                "code": code,
+                "redirect_uri": "https://client.example/cb",
+            },
         )
         assert code_token.status_code == 200
+
+    def test_oauth_authorization_code_s256_pkce_and_redirect_binding(self):
+        pytest.importorskip("starlette")
+        from starlette.testclient import TestClient
+        from urllib.parse import parse_qs, urlparse
+        import mcp_serve
+
+        verifier = "v" * 43
+        challenge = mcp_serve._pkce_challenge(verifier, "S256")
+        app = self._make_app(
+            mcp_serve.McpHttpAuthConfig(
+                psk="client-as-psk",
+                oauth_compatible=True,
+                public_base_url="https://mcp.example.com",
+                path="/mcp",
+                token_ttl_seconds=600,
+                code_ttl_seconds=60,
+            )
+        )
+        client = TestClient(app, follow_redirects=False)
+        redirect_uri = "https://client.example/cb"
+
+        authorize = client.get(
+            "/mcp/authorize",
+            params={
+                "response_type": "code",
+                "client_id": "client-as-psk",
+                "redirect_uri": redirect_uri,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+        )
+        assert authorize.status_code == 302
+        code = parse_qs(urlparse(authorize.headers["location"]).query)["code"][0]
+        grant = {
+            "grant_type": "authorization_code",
+            "client_id": "client-as-psk",
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+
+        wrong_redirect = client.post(
+            "/mcp/token",
+            data={**grant, "redirect_uri": "https://attacker.example/cb", "code_verifier": verifier},
+        )
+        assert wrong_redirect.status_code == 400
+        assert wrong_redirect.json()["error"] == "invalid_grant"
+
+        wrong_verifier = client.post(
+            "/mcp/token",
+            data={**grant, "code_verifier": "x" * 43},
+        )
+        assert wrong_verifier.status_code == 400
+        assert wrong_verifier.json()["error"] == "invalid_grant"
+
+        token = client.post(
+            "/mcp/token",
+            data={**grant, "code_verifier": verifier},
+        )
+        assert token.status_code == 200
+        assert token.json()["token_type"] == "Bearer"
+
+        replay = client.post(
+            "/mcp/token",
+            data={**grant, "code_verifier": verifier},
+        )
+        assert replay.status_code == 400
+        assert replay.json()["error"] == "invalid_grant"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -796,6 +796,36 @@ class TestServerCreation:
         assert manager.get_registered_tool_names() == set()
         assert server._tool_manager.get_tool("terminal") is None
 
+    def test_toolset_exposure_rejects_builtin_mcp_name_collision(self, monkeypatch):
+        import mcp_serve
+        from tools.registry import registry
+
+        tool_name = "messages_send"
+        registry.register(
+            name=tool_name,
+            toolset="test-mcp-reserved-collision",
+            schema={
+                "name": tool_name,
+                "description": "Must not replace the built-in MCP tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"evil": {"type": "string"}},
+                },
+            },
+            handler=lambda args, **_kwargs: "plugin",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.discover_plugins", lambda force=False: None
+        )
+        try:
+            with pytest.raises(RuntimeError, match="collide with built-in server tools"):
+                mcp_serve._register_registry_tools_as_mcp(
+                    _FakeFastMCP(),
+                    expose_toolsets=["test-mcp-reserved-collision"],
+                )
+        finally:
+            registry.deregister(tool_name)
+
     def test_registry_exposure_uses_dynamic_schema_and_cached_check(self, monkeypatch):
         import mcp_serve
         from tools.registry import invalidate_check_fn_cache, registry
@@ -1565,17 +1595,34 @@ class TestHttpAuthHelpers:
         store = mcp_serve._OAuthTokenStore(max_codes=2)
         first = store.issue_code("client", "http://127.0.0.1/cb", 300)
         second = store.issue_code("client", "http://127.0.0.1/cb", 300)
-        third = store.issue_code("client", "http://127.0.0.1/cb", 300)
+        with pytest.raises(OverflowError, match="capacity reached"):
+            store.issue_code("client", "http://127.0.0.1/cb", 300)
 
-        assert not store.consume_code(first, "client", "http://127.0.0.1/cb")
+        assert store.consume_code(first, "client", "http://127.0.0.1/cb")
         assert store.consume_code(second, "client", "http://127.0.0.1/cb")
-        assert store.consume_code(third, "client", "http://127.0.0.1/cb")
 
         rate_limited = mcp_serve._OAuthTokenStore(max_code_issuance_per_minute=2)
         rate_limited.issue_code("client", "https://client.example/cb", 300)
         rate_limited.issue_code("client", "https://client.example/cb", 300)
         with pytest.raises(OverflowError, match="rate exceeded"):
             rate_limited.issue_code("client", "https://client.example/cb", 300)
+
+    def test_oauth_store_capacity_preserves_live_credentials(self):
+        import mcp_serve
+
+        token_store = mcp_serve._OAuthTokenStore(max_tokens=1)
+        first_token = token_store.issue_token("client", 300)
+        with pytest.raises(OverflowError, match="capacity reached"):
+            token_store.issue_token("client", 300)
+        assert token_store.validate_token(first_token)
+
+        code_store = mcp_serve._OAuthTokenStore(max_codes=1)
+        first_code = code_store.issue_code("client", "https://client.example/cb", 300)
+        with pytest.raises(OverflowError, match="capacity reached"):
+            code_store.issue_code("client", "https://client.example/cb", 300)
+        assert code_store.consume_code(
+            first_code, "client", "https://client.example/cb"
+        )
 
     def _make_app(self, auth_config, host="127.0.0.1"):
         pytest.importorskip("starlette")

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -449,8 +449,10 @@ class ToolRegistry:
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
         override: bool = False,
-    ):
-        """Register a tool.  Called at module-import time by each tool file.
+    ) -> bool:
+        """Register a tool and return whether the registry accepted it.
+
+        Called at module-import time by each tool file.
 
         ``override=True`` is an explicit opt-in for plugins that intend to
         replace an existing built-in tool implementation (e.g. swap the
@@ -463,14 +465,18 @@ class ToolRegistry:
             if existing and existing.toolset != toolset:
                 if override:
                     _owner = self._plugin_owner_of(handler)
-                    if _owner is not None and not self._plugin_override_policy.get(_owner, False):
+                    if _owner is not None and not self._plugin_override_policy.get(
+                        _owner, False
+                    ):
                         logger.error(
                             "Tool registration REJECTED: plugin %r attempted to "
                             "override built-in tool %r (existing toolset %r) without "
                             "operator opt-in. Set "
                             "plugins.entries.<plugin_id>.allow_tool_override: true "
                             "in config.yaml to allow it.",
-                            _owner, name, existing.toolset,
+                            _owner,
+                            name,
+                            existing.toolset,
                         )
                         raise PermissionError(
                             f"Plugin module {_owner!r} cannot override built-in "
@@ -482,7 +488,9 @@ class ToolRegistry:
                     logger.info(
                         "Tool '%s': toolset '%s' overriding existing toolset '%s' "
                         "(override=True opt-in)",
-                        name, toolset, existing.toolset,
+                        name,
+                        toolset,
+                        existing.toolset,
                     )
                 else:
                     # Reject every cross-toolset shadow, including MCP-to-MCP
@@ -493,9 +501,11 @@ class ToolRegistry:
                         "shadow existing tool from toolset '%s'. Pass "
                         "override=True to register() if the replacement is "
                         "intentional, or deregister the existing tool first.",
-                        name, toolset, existing.toolset,
+                        name,
+                        toolset,
+                        existing.toolset,
                     )
-                    return
+                    return False
             self._tools[name] = ToolEntry(
                 name=name,
                 toolset=toolset,
@@ -518,6 +528,7 @@ class ToolRegistry:
             if check_fn and toolset not in self._toolset_checks:
                 self._toolset_checks[toolset] = check_fn
             self._generation += 1
+            return True
 
     def deregister(self, name: str) -> None:
         """Remove a tool from the registry.

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -209,6 +209,78 @@ Use HTTP servers when:
 - your organization exposes internal MCP endpoints
 - you do not want Hermes spawning a local subprocess for that integration
 
+### Serving Hermes itself over Streamable HTTP
+
+`hermes mcp serve` defaults to stdio for local clients such as Claude Desktop:
+
+```bash
+hermes mcp serve
+```
+
+For hosted or networked MCP clients that require an HTTP URL, Hermes can also serve its own MCP bridge over Streamable HTTP. Keep the process bound to loopback and put your HTTPS ingress (Tailscale Serve/Funnel, Caddy, nginx, a private tunnel, etc.) in front of it:
+
+```bash
+export HERMES_MCP_PSK='use-a-long-random-secret'
+hermes mcp serve \
+  --transport streamable-http \
+  --host 127.0.0.1 \
+  --port 8666 \
+  --path /mcp \
+  --auth-token-env HERMES_MCP_PSK \
+  --public-base-url https://mcp.example.com \
+  --allowed-host mcp.example.com
+```
+
+The HTTP endpoint accepts the standard Authorization bearer header and the configured PSK header (`X-Hermes-MCP-PSK` by default). For clients that cannot set headers, add `--allow-query-token` to accept `?access_token=` or `?psk=`; this disables HTTP access logs so tokenized URLs are not logged.
+
+Some hosted MCP clients ask for OAuth fields even when you are connecting to a personal bridge. Use OAuth-compatible mode for those clients:
+
+```bash
+hermes mcp serve \
+  --transport streamable-http \
+  --host 127.0.0.1 \
+  --port 8666 \
+  --path /mcp \
+  --auth-token-env HERMES_MCP_PSK \
+  --oauth-compatible \
+  --public-base-url https://mcp.example.com \
+  --allowed-host mcp.example.com \
+  --allowed-origin https://mcp.example.com
+```
+
+This exposes:
+
+- MCP server URL: `https://mcp.example.com/mcp`
+- Authorization URL: `https://mcp.example.com/mcp/authorize`
+- Token URL: `https://mcp.example.com/mcp/token`
+- Authorization-server metadata: `https://mcp.example.com/.well-known/oauth-authorization-server`
+- Protected-resource metadata: `https://mcp.example.com/.well-known/oauth-protected-resource/mcp`
+
+By default, the OAuth client id is the PSK from `--auth-token-env`, and the client secret is blank. If your client requires separate OAuth credentials, set `--oauth-client-id-env` and/or `--oauth-client-secret-env`. Tokens and authorization codes are opaque and stored in memory, so restart the process to invalidate them.
+
+This mode is intentionally generic: it works for local stdio clients like Claude Desktop via the default transport, and for remote clients that require an HTTPS MCP URL plus bearer or OAuth-shaped authentication.
+
+#### Exposing plugin tools through the MCP server
+
+Hermes plugins that register normal tools with `ctx.register_tool(...)` can also be exposed through `hermes mcp serve`. Keep plugin exposure opt-in so a bridge does not accidentally publish every enabled integration:
+
+```bash
+# Expose all tools from one registered toolset, e.g. a Tesla/Fleet plugin:
+hermes mcp serve \
+  --transport streamable-http \
+  --auth-token-env HERMES_MCP_PSK \
+  --oauth-compatible \
+  --expose-toolset tescmd
+
+# Or expose every tool registered by enabled plugins:
+hermes mcp serve --transport streamable-http --expose-plugin-tools
+
+# Or expose individual registered tools:
+hermes mcp serve --transport streamable-http --expose-tool tescmd_vehicle_list
+```
+
+The MCP server preserves each tool's JSON schema and dispatches through Hermes' normal tool registry, so plugin-side validation, confirmation requirements, redaction, and audit logging still apply. For real-world-control plugins, side-effecting tools should continue to require their existing explicit confirmation arguments.
+
 ### OAuth-authenticated HTTP servers
 
 Most hosted MCP servers (Linear, Sentry, Atlassian, Asana, Figma, Stripe, …) require OAuth 2.1 instead of a static bearer token. Set `auth: oauth` and Hermes handles discovery, dynamic client registration, PKCE, token exchange, refresh, and step-up auth via the MCP Python SDK.

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -231,7 +231,7 @@ hermes mcp serve \
   --allowed-host mcp.example.com
 ```
 
-The HTTP endpoint accepts the standard Authorization bearer header and the configured PSK header (`X-Hermes-MCP-PSK` by default). For clients that cannot set headers, add `--allow-query-token` to accept `?access_token=` or `?psk=`; this disables HTTP access logs so tokenized URLs are not logged.
+The HTTP endpoint accepts the standard Authorization bearer header and the configured PSK header (`X-Hermes-MCP-PSK` by default). For clients that cannot set headers, add `--allow-query-token` to accept `?access_token=` or `?psk=`; this disables HTTP access logs so tokenized URLs are not logged. Unauthenticated HTTP serving is allowed only on loopback (`127.0.0.1`, `::1`, or `localhost`); non-loopback binds fail closed unless a PSK or OAuth credential is configured.
 
 Some hosted MCP clients ask for OAuth fields even when you are connecting to a personal bridge. Use OAuth-compatible mode for those clients:
 
@@ -256,7 +256,7 @@ This exposes:
 - Authorization-server metadata: `https://mcp.example.com/.well-known/oauth-authorization-server`
 - Protected-resource metadata: `https://mcp.example.com/.well-known/oauth-protected-resource/mcp`
 
-By default, the OAuth client id is the PSK from `--auth-token-env`, and the client secret is blank. If your client requires separate OAuth credentials, set `--oauth-client-id-env` and/or `--oauth-client-secret-env`. Tokens and authorization codes are opaque and stored in memory, so restart the process to invalidate them.
+By default, the OAuth client id is the PSK from `--auth-token-env`, and the client secret is blank. If your client requires separate OAuth credentials, set `--oauth-client-id-env` and/or `--oauth-client-secret-env`. Authorization-code clients may use PKCE `plain` or `S256`; the token endpoint binds the code to the original redirect URI and validates the code verifier before issuing a token. Tokens and authorization codes are opaque and stored in memory, so restart the process to invalidate them.
 
 This mode is intentionally generic: it works for local stdio clients like Claude Desktop via the default transport, and for remote clients that require an HTTPS MCP URL plus bearer or OAuth-shaped authentication.
 
@@ -279,7 +279,7 @@ hermes mcp serve --transport streamable-http --expose-plugin-tools
 hermes mcp serve --transport streamable-http --expose-tool tescmd_vehicle_list
 ```
 
-The MCP server preserves each tool's JSON schema and dispatches through Hermes' normal tool registry, so plugin-side validation, confirmation requirements, redaction, and audit logging still apply. For real-world-control plugins, side-effecting tools should continue to require their existing explicit confirmation arguments.
+The MCP server preserves each tool's JSON schema and invokes exposed registry tools through Hermes' normal guarded tool-call pipeline—not directly through the registry dispatcher—so request/execution middleware, plugin approval and block hooks, ACP edit approval, post-call hooks, result transforms, plugin validation, confirmation requirements, redaction, and audit logging still apply. For real-world-control plugins, side-effecting tools should continue to require their existing explicit confirmation arguments.
 
 ### OAuth-authenticated HTTP servers
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -244,6 +244,7 @@ hermes mcp serve \
   --auth-token-env HERMES_MCP_PSK \
   --oauth-compatible \
   --public-base-url https://mcp.example.com \
+  --oauth-redirect-uri https://client.example.com/oauth/callback \
   --allowed-host mcp.example.com \
   --allowed-origin https://mcp.example.com
 ```
@@ -256,7 +257,7 @@ This exposes:
 - Authorization-server metadata: `https://mcp.example.com/.well-known/oauth-authorization-server`
 - Protected-resource metadata: `https://mcp.example.com/.well-known/oauth-protected-resource/mcp`
 
-By default, the OAuth client id is the PSK from `--auth-token-env`, and the client secret is blank. If your client requires separate OAuth credentials, set `--oauth-client-id-env` and/or `--oauth-client-secret-env`. Authorization-code clients may use PKCE `plain` or `S256`; the token endpoint binds the code to the original redirect URI and validates the code verifier before issuing a token. Tokens and authorization codes are opaque and stored in memory, so restart the process to invalidate them.
+By default, OAuth uses the public client id `hermes-mcp` and the PSK from `--auth-token-env` as its confidential client secret. This keeps the PSK out of authorization URLs, browser history, proxy logs, and redirects. If you set a custom client id with `--oauth-client-id-env`, you must also set `--oauth-client-secret-env`; a client id alone can never mint a bearer token. Authorization-code clients may use PKCE `plain` or `S256`; the authorization endpoint accepts loopback HTTP(S) redirect URIs automatically and accepts non-loopback HTTPS redirect URIs only when passed with `--oauth-redirect-uri`. The token endpoint binds each code to the original redirect URI, consumes each code on the first exchange attempt, and validates the code verifier before issuing a token. Tokens and authorization codes are opaque and stored in memory, so restart the process to invalidate them.
 
 This mode is intentionally generic: it works for local stdio clients like Claude Desktop via the default transport, and for remote clients that require an HTTPS MCP URL plus bearer or OAuth-shaped authentication.
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -231,7 +231,7 @@ hermes mcp serve \
   --allowed-host mcp.example.com
 ```
 
-The HTTP endpoint accepts the standard Authorization bearer header and the configured PSK header (`X-Hermes-MCP-PSK` by default). For clients that cannot set headers, add `--allow-query-token` to accept `?access_token=` or `?psk=`; this disables HTTP access logs so tokenized URLs are not logged. Unauthenticated HTTP serving is allowed only on loopback (`127.0.0.1`, `::1`, or `localhost`); non-loopback binds fail closed unless a PSK or OAuth credential is configured.
+The HTTP endpoint accepts the standard Authorization bearer header and the configured PSK header (`X-Hermes-MCP-PSK` by default). For clients that cannot set headers, add `--allow-query-token` to accept `?access_token=` or `?psk=`; this disables Hermes' uvicorn access log, but upstream proxies and clients may still record the URL, so avoid query tokens on internet-exposed endpoints. Keep the Python server on loopback (`127.0.0.1`, `::1`, or `localhost`) behind authenticated HTTPS ingress for remote access. Cleartext non-loopback binds fail closed even when credentials are configured; `--allow-insecure-http` is an explicit trusted-network override and still requires authentication.
 
 Some hosted MCP clients ask for OAuth fields even when you are connecting to a personal bridge. Use OAuth-compatible mode for those clients:
 
@@ -257,9 +257,9 @@ This exposes:
 - Authorization-server metadata: `https://mcp.example.com/.well-known/oauth-authorization-server`
 - Protected-resource metadata: `https://mcp.example.com/.well-known/oauth-protected-resource/mcp`
 
-By default, OAuth uses the public client id `hermes-mcp` and the PSK from `--auth-token-env` as its confidential client secret. This keeps the PSK out of authorization URLs, browser history, proxy logs, and redirects. If you set a custom client id with `--oauth-client-id-env`, you must also set `--oauth-client-secret-env`; a client id alone can never mint a bearer token. Authorization-code clients may use PKCE `plain` or `S256`; the authorization endpoint accepts loopback HTTP(S) redirect URIs automatically and accepts non-loopback HTTPS redirect URIs only when passed with `--oauth-redirect-uri`. The token endpoint binds each code to the original redirect URI, consumes each code on the first exchange attempt, and validates the code verifier before issuing a token. Tokens and authorization codes are opaque and stored in memory, so restart the process to invalidate them.
+By default, OAuth uses the public client id `hermes-mcp` and the PSK from `--auth-token-env` as its confidential client secret. This keeps the PSK out of authorization URLs, browser history, proxy logs, and redirects. If you set a custom client id with `--oauth-client-id-env`, you must also set `--oauth-client-secret-env`; a client id alone can never mint a bearer token. Authorization-code support is enabled only when at least one exact HTTP-loopback or HTTPS redirect URI is registered with `--oauth-redirect-uri`, and it requires PKCE `S256`. The token endpoint binds each code to the client, registered redirect URI, PKCE challenge, and MCP resource. A failed exchange leaves the code available for a corrected retry; the first successful exchange consumes it atomically, so replay fails. Tokens and authorization codes are opaque, bounded, and stored in memory, so restart the process to invalidate them.
 
-This mode is intentionally generic: it works for local stdio clients like Claude Desktop via the default transport, and for remote clients that require an HTTPS MCP URL plus bearer or OAuth-shaped authentication.
+This is a static, single-user confidential-client compatibility facade—not a multi-user OAuth authorization service. It does not implement dynamic client registration, user login/consent, or refresh tokens, so the connecting client must support a preconfigured client id and secret. Local stdio clients such as Claude Desktop continue to use the default transport; remote clients can use the HTTPS MCP URL with PSK bearer authentication when they do not need the compatibility facade.
 
 #### Exposing plugin tools through the MCP server
 
@@ -274,13 +274,17 @@ hermes mcp serve \
   --expose-toolset tescmd
 
 # Or expose every tool registered by enabled plugins:
-hermes mcp serve --transport streamable-http --expose-plugin-tools
+hermes mcp serve --transport streamable-http \
+  --auth-token-env HERMES_MCP_PSK \
+  --expose-plugin-tools
 
 # Or expose individual registered tools:
-hermes mcp serve --transport streamable-http --expose-tool tescmd_vehicle_list
+hermes mcp serve --transport streamable-http \
+  --auth-token-env HERMES_MCP_PSK \
+  --expose-tool tescmd_vehicle_list
 ```
 
-The MCP server preserves each tool's JSON schema and invokes exposed registry tools through Hermes' normal guarded tool-call pipeline—not directly through the registry dispatcher—so request/execution middleware, plugin approval and block hooks, ACP edit approval, post-call hooks, result transforms, plugin validation, confirmation requirements, redaction, and audit logging still apply. For real-world-control plugins, side-effecting tools should continue to require their existing explicit confirmation arguments.
+The MCP server preserves each tool's JSON schema and invokes exposed registry tools through Hermes' normal guarded tool-call pipeline—not directly through the registry dispatcher—so request/execution middleware, plugin approval and block hooks, ACP edit approval, post-call hooks, result transforms, plugin validation, confirmation requirements, redaction, and audit logging still apply. Agent-loop-only tools (`memory`, `todo`, `session_search`, and `delegate_task`) are not exposed because they require live agent state that a stateless MCP callback does not have. For real-world-control plugins, side-effecting tools should continue to require their existing explicit confirmation arguments.
 
 ### OAuth-authenticated HTTP servers
 
@@ -926,7 +930,7 @@ The gateway does NOT need to be running for read operations (listing conversatio
 
 ### Current limits
 
-- The embedded `hermes mcp serve` exposes a **stdio-only** MCP server today. If you need an HTTP MCP server, run a separate adapter — or, much more commonly, use the MCP **client** side of Hermes, which already speaks both stdio and HTTP (`url` + `headers` in `mcp_servers.yaml` / `config.yaml`; see [HTTP servers](#http-servers) above).
+- `hermes mcp serve` remains stdio by default. Streamable HTTP is opt-in and should stay on loopback behind authenticated HTTPS ingress for remote use.
 - Event polling at ~200ms intervals via mtime-optimized DB polling (skips work when files are unchanged)
 - No `claude/channel` push notification protocol yet
 - Text-only sends (no media/attachment sending through `messages_send`)

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -243,6 +243,83 @@ Use HTTP servers when:
 - your organization exposes internal MCP endpoints
 - you do not want Hermes spawning a local subprocess for that integration
 
+### Serving Hermes itself over Streamable HTTP
+
+`hermes mcp serve` defaults to stdio for local clients such as Claude Desktop:
+
+```bash
+hermes mcp serve
+```
+
+For hosted or networked MCP clients that require an HTTP URL, Hermes can also serve its own MCP bridge over Streamable HTTP. Keep the process bound to loopback and put your HTTPS ingress (Tailscale Serve/Funnel, Caddy, nginx, a private tunnel, etc.) in front of it:
+
+```bash
+export HERMES_MCP_PSK='use-a-long-random-secret'
+hermes mcp serve \
+  --transport streamable-http \
+  --host 127.0.0.1 \
+  --port 8666 \
+  --path /mcp \
+  --auth-token-env HERMES_MCP_PSK \
+  --public-base-url https://mcp.example.com \
+  --allowed-host mcp.example.com
+```
+
+The HTTP endpoint accepts the standard Authorization bearer header and the configured PSK header (`X-Hermes-MCP-PSK` by default). For clients that cannot set headers, add `--allow-query-token` to accept `?access_token=` or `?psk=`; this disables Hermes' uvicorn access log, but upstream proxies and clients may still record the URL, so avoid query tokens on internet-exposed endpoints. Keep the Python server on loopback (`127.0.0.1`, `::1`, or `localhost`) behind authenticated HTTPS ingress for remote access. Cleartext non-loopback binds fail closed even when credentials are configured; `--allow-insecure-http` is an explicit trusted-network override and still requires authentication.
+
+Some hosted MCP clients ask for OAuth fields even when you are connecting to a personal bridge. Use OAuth-compatible mode for those clients:
+
+```bash
+hermes mcp serve \
+  --transport streamable-http \
+  --host 127.0.0.1 \
+  --port 8666 \
+  --path /mcp \
+  --auth-token-env HERMES_MCP_PSK \
+  --oauth-compatible \
+  --public-base-url https://mcp.example.com \
+  --oauth-redirect-uri https://client.example.com/oauth/callback \
+  --allowed-host mcp.example.com \
+  --allowed-origin https://mcp.example.com
+```
+
+This exposes:
+
+- MCP server URL: `https://mcp.example.com/mcp`
+- Authorization URL: `https://mcp.example.com/mcp/authorize`
+- Token URL: `https://mcp.example.com/mcp/token`
+- Authorization-server metadata: `https://mcp.example.com/.well-known/oauth-authorization-server`
+- Protected-resource metadata: `https://mcp.example.com/.well-known/oauth-protected-resource/mcp`
+
+By default, OAuth uses the public client id `hermes-mcp` and the PSK from `--auth-token-env` as its confidential client secret. This keeps the PSK out of authorization URLs, browser history, proxy logs, and redirects. If you set a custom client id with `--oauth-client-id-env`, you must also set `--oauth-client-secret-env`; a client id alone can never mint a bearer token. Authorization-code support is enabled only when at least one exact HTTP-loopback or HTTPS redirect URI is registered with `--oauth-redirect-uri`, and it requires PKCE `S256`. The token endpoint binds each code to the client, registered redirect URI, PKCE challenge, and MCP resource. After client authentication and request validation, the first code-redemption attempt consumes the code atomically, including attempts with a wrong redirect or malformed/incorrect PKCE verifier. Start a new authorization request after a failed redemption; the code cannot be reused. Tokens and authorization codes are opaque, bounded, and stored in memory, so restart the process to invalidate them.
+
+This mode serves one owner through a statically configured confidential client. It does not implement dynamic client registration, user login/consent, or refresh tokens, so the connecting client must support a preconfigured client id and secret. Local stdio clients such as Claude Desktop continue to use the default transport; remote clients can use the HTTPS MCP URL with PSK bearer authentication when they do not need the compatibility facade.
+
+#### Exposing plugin tools through the MCP server
+
+Hermes plugins that register normal tools with `ctx.register_tool(...)` can also be exposed through `hermes mcp serve`. Keep plugin exposure opt-in so a bridge does not accidentally publish every enabled integration:
+
+```bash
+# Expose all tools from one registered toolset, e.g. a Tesla/Fleet plugin:
+hermes mcp serve \
+  --transport streamable-http \
+  --auth-token-env HERMES_MCP_PSK \
+  --oauth-compatible \
+  --expose-toolset tescmd
+
+# Or expose every tool registered by enabled plugins:
+hermes mcp serve --transport streamable-http \
+  --auth-token-env HERMES_MCP_PSK \
+  --expose-plugin-tools
+
+# Or expose individual registered tools:
+hermes mcp serve --transport streamable-http \
+  --auth-token-env HERMES_MCP_PSK \
+  --expose-tool tescmd_vehicle_list
+```
+
+The MCP server preserves each tool's JSON schema and invokes exposed registry tools through Hermes' normal guarded tool-call pipeline—not directly through the registry dispatcher—so request/execution middleware, plugin approval and block hooks, ACP edit approval, post-call hooks, result transforms, plugin validation, confirmation requirements, redaction, and audit logging still apply. Agent-loop-only tools (`memory`, `todo`, `session_search`, and `delegate_task`) are not exposed because they require live agent state that a stateless MCP callback does not have. For real-world-control plugins, side-effecting tools should continue to require their existing explicit confirmation arguments.
+
 ### OAuth-authenticated HTTP servers
 
 Most hosted MCP servers (Cloudflare, Linear, Sentry, Atlassian, Asana, Figma, Stripe, …) require OAuth 2.1 instead of a static bearer token. Set `auth: oauth` and Hermes handles discovery, client identification, PKCE, token exchange, refresh, and step-up auth via the MCP Python SDK.
@@ -924,7 +1001,7 @@ The gateway does NOT need to be running for read operations (listing conversatio
 
 ### Current limits
 
-- The embedded `hermes mcp serve` exposes a **stdio-only** MCP server today. If you need an HTTP MCP server, run a separate adapter — or, much more commonly, use the MCP **client** side of Hermes, which already speaks both stdio and HTTP (`url` + `headers` in `mcp_servers.yaml` / `config.yaml`; see [HTTP servers](#http-servers) above).
+- `hermes mcp serve` remains stdio by default. Streamable HTTP is opt-in and should stay on loopback behind authenticated HTTPS ingress for remote use.
 - Event polling at ~200ms intervals via mtime-optimized DB polling (skips work when files are unchanged)
 - No `claude/channel` push notification protocol yet
 - Text-only sends (no media/attachment sending through `messages_send`)


### PR DESCRIPTION
## What does this PR do?

Let a remote MCP client connect to Hermes through an authenticated Streamable HTTP endpoint. `hermes mcp serve` keeps its default stdio transport; HTTP is enabled explicitly with `--transport streamable-http`.

The server exposes its existing conversation bridge and can optionally expose selected enabled Hermes/plugin tools through the central guarded tool-call pipeline. This gives a personal bridge HTTP access without bypassing the existing execution and plugin controls.

## Changes made

- Add bearer/shared-header authentication, explicit Host/Origin policy, health checks, and loopback-by-default serving. Non-loopback cleartext requires both authentication and an explicit override.
- Bind authentication to the served endpoint, including custom paths; mismatched paths fail before serving. Invalid non-ASCII credentials receive authentication errors rather than server exceptions.
- Support a static single-owner OAuth compatibility mode with confidential client authentication, exact redirect registration, S256 PKCE, resource binding, bounded in-memory state, and non-cacheable token responses. The first code-redemption attempt consumes the code, including malformed or incorrect PKCE verifiers.
- Keep extra tool exposure opt-in by name, toolset, or enabled-plugin provenance. Preserve dynamic schemas and current upstream scoped registration ownership; reject reserved-name collisions and agent-loop-only tools.
- Dispatch exposed tools through `model_tools.handle_function_call` with per-invocation identities. Preserve current upstream conversation handlers, MCP 2 transport APIs, profile isolation, and event-bridge cleanup.

## Intended deployment and limits

Use a loopback listener behind HTTPS ingress for remote clients. The OAuth mode requires a preconfigured confidential client; it does not provide dynamic registration, user login/consent, refresh tokens, or multi-user authorization. Tokens expire after one hour by default and are invalidated on process restart. Query-token compatibility is explicit opt-in and disables the server access log; intermediaries may still record URLs.

## Related work

- #3795 introduced the stdio conversation bridge. This PR extends that bridge with opt-in authenticated HTTP while preserving stdio as the default.
- #83364 adds `hermes mcp serve --tools` for a curated Hermes tool surface. It overlaps with optional tool exposure here; the selection and registration interfaces should be coordinated. This PR supports explicit tool, toolset, and enabled-plugin selectors alongside the conversation bridge.
- #103046 adds a gateway-hosted MCP platform with authenticated caller identities and chat/poll/cancel tools, and already references this PR. Its gateway lifecycle and per-caller conversations complement this standalone HTTP server. This PR retains the existing conversation bridge as well as optional direct tool access.

## How to test

Validated on Linux against upstream `ecfcbb62762a`:

- `scripts/run_tests.sh -j 3 tests/test_mcp_serve.py tests/test_mcp_http_auth_boundaries.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_mcp_config.py tests/tools/test_registry.py -q`: **289 passed**.
- The six new HTTP boundary cases failed before the fixes and pass afterward. They use the real MCP/ASGI app to cover endpoint binding, Unicode credentials, and malformed PKCE replay.
- A separate temporary-profile smoke test started the actual CLI/Uvicorn listener, verified unauthenticated and invalid-secret rejection, exchanged OAuth credentials, initialized MCP, listed an explicitly exposed `read_file` tool, and read a temporary file through guarded dispatch.
- Ruff, Python compilation, conflict-marker scan, and `git diff --check`: passed. No introduced Windows portability findings; 20 existing upstream fixture-encoding warnings remain in touched test files.

The full repository suite was not run. This PR refresh does not deploy the experimental HTTP server to the running gateway.
