### PR TITLE
feat(cli): .hermes/ project directory — commands, skills, and discovery

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -98,6 +98,52 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     return None
 
 
+# Cache: (cwd_resolved, Optional[Path]) — lives for the process lifetime
+# because a project directory doesn't move during a Hermes session.
+_project_dir_cache: Optional[tuple] = None
+
+
+def _find_hermes_project_dir(cwd: Path) -> Optional[Path]:
+    """Discover the nearest ``.hermes/`` project directory.
+
+    Walk *cwd* and its parents up to (and including) the git repository
+    root, returning the first ``.hermes/`` directory found.  Returns
+    ``None`` if no such directory exists.
+
+    This is independent of ``_find_hermes_md`` — a project can have
+    ``.hermes.md``, ``.hermes/``, both, or neither.
+    """
+    stop_at = _find_git_root(cwd)
+    current = cwd.resolve()
+
+    for directory in [current, *current.parents]:
+        candidate = directory / ".hermes"
+        if candidate.is_dir():
+            return candidate
+        # Stop walking at the git root (or filesystem root).
+        if stop_at and directory == stop_at:
+            break
+    return None
+
+
+def _get_cached_hermes_project_dir(cwd: Optional[Path] = None) -> Optional[Path]:
+    """Cached wrapper around ``_find_hermes_project_dir``.
+
+    The cache is invalidated when *cwd* changes (e.g. the user does
+    ``cd`` inside a running session via the terminal tool) — at that
+    point a new project directory may apply.
+    """
+    global _project_dir_cache
+    if cwd is None:
+        cwd = Path.cwd()
+    cwd_resolved = str(cwd.resolve())
+    if _project_dir_cache is not None and _project_dir_cache[0] == cwd_resolved:
+        return _project_dir_cache[1]
+    result = _find_hermes_project_dir(cwd)
+    _project_dir_cache = (cwd_resolved, result)
+    return result
+
+
 def _strip_yaml_frontmatter(content: str) -> str:
     """Remove optional YAML frontmatter (``---`` delimited) from *content*.
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -461,14 +461,39 @@ def get_external_skills_dirs() -> List[Path]:
     return result
 
 
+def get_project_skills_dir() -> Optional[Path]:
+    """Return the project-local ``.hermes/skills/`` directory, or ``None``.
+
+    Uses the cached project-dir discovery from prompt_builder so we don't
+    re-walk the filesystem on every call.  Returns ``None`` when there is
+    no ``.hermes/`` directory above cwd.
+    """
+    try:
+        from agent.prompt_builder import _get_cached_hermes_project_dir
+    except ImportError:
+        return None
+    project_dir = _get_cached_hermes_project_dir()
+    if project_dir:
+        skills_dir = project_dir / "skills"
+        if skills_dir.is_dir():
+            return skills_dir
+    return None
+
+
 def get_all_skills_dirs() -> List[Path]:
-    """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
+    """Return all skill directories: local ``~/.hermes/skills/`` first, then external
+    and project-local ``.hermes/skills/``.
 
     The local dir is always first (and always included even if it doesn't exist
     yet — callers handle that).  External dirs follow in config order.
+    Project-local skills (from ``.hermes/skills/``) come last so user-global and
+    external dirs take precedence on name collisions.
     """
     dirs = [get_skills_dir()]
     dirs.extend(get_external_skills_dirs())
+    project = get_project_skills_dir()
+    if project:
+        dirs.append(project)
     return dirs
 
 

--- a/cli.py
+++ b/cli.py
@@ -3103,6 +3103,41 @@ def get_skill_bundles() -> dict:
     return _skill_bundles
 
 
+def _get_project_cmd_names() -> set:
+    """Return project-local command names for dispatch matching."""
+    try:
+        from hermes_cli.project_commands import load_project_commands
+        return {c.name for c in load_project_commands()}
+    except ImportError:
+        return set()
+
+
+def _parse_project_cmd_args(
+    user_args: str, arg_defs: list,
+) -> dict:
+    """Parse positional command arguments into a dict.
+
+    Each positional word is assigned to the corresponding arg definition
+    in order.  Extra words are appended to the last arg's value with a
+    space separator (greedy last-arg semantics).
+    """
+    if not user_args.strip():
+        return {}
+    words = user_args.strip().split()
+    result: dict = {}
+    for i, arg_def in enumerate(arg_defs):
+        name = arg_def.get("name", "")
+        if i < len(words):
+            result[name] = words[i]
+        else:
+            break
+    # Greedy: append remaining words to the last defined arg
+    if len(words) > len(arg_defs) and arg_defs:
+        last_name = arg_defs[-1].get("name", "")
+        result[last_name] = " ".join(words[len(arg_defs) - 1:])
+    return result
+
+
 def build_bundle_invocation_message(*args, **kwargs):
     from agent.skill_bundles import build_bundle_invocation_message as _impl
 
@@ -7741,6 +7776,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     ChatConsole().print(
                         f"[bold red]Failed to load bundle for {base_cmd}[/]"
                     )
+            # Project-local slash commands (``.hermes/commands/*.md``).
+            # Checked before skill commands so a project can define a
+            # command that overrides a skill of the same name.
+            elif base_cmd.lstrip("/") in _get_project_cmd_names():
+                try:
+                    from hermes_cli.project_commands import (
+                        resolve_project_command,
+                        render_command,
+                    )
+                    project_cmd = resolve_project_command(base_cmd.lstrip("/"))
+                    if project_cmd:
+                        user_args = cmd_original[len(base_cmd):].strip()
+                        parsed = _parse_project_cmd_args(user_args, project_cmd.args)
+                        msg = render_command(project_cmd, parsed)
+                        if msg and hasattr(self, '_pending_input'):
+                            self._pending_input.put(msg)
+                except Exception:
+                    pass
             # Check for skill slash commands (/gif-search, /axolotl, etc.)
             elif base_cmd in skill_commands:
                 user_instruction = cmd_original[len(base_cmd):].strip()

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -237,6 +237,55 @@ COMMAND_REGISTRY: list[CommandDef] = [
 ]
 
 
+def _register_project_commands() -> None:
+    """Append project-local ``.hermes/commands/*.md`` to ``COMMAND_REGISTRY``.
+
+    Project commands that collide with a built-in command name are skipped
+    unless the frontmatter declares ``override: true``.  This ensures a
+    malicious project repo cannot shadow a security-sensitive command
+    (e.g. ``/yolo``) without the user's explicit opt-in.
+
+    Called once at module import time.  All exceptions are caught so a
+    broken project-commands setup never prevents Hermes from starting.
+    """
+    try:
+        from hermes_cli.project_commands import load_project_commands
+    except ImportError:
+        return
+
+    try:
+        raw_commands = load_project_commands()
+    except Exception:
+        return  # don't let a bad .hermes/commands/ file crash startup
+
+    if not raw_commands:
+        return
+
+    builtin_names = {cmd.name for cmd in COMMAND_REGISTRY}
+
+    for cmd in raw_commands:
+        if cmd.name in builtin_names and not cmd.override:
+            continue
+
+        # Build args_hint from arg definitions
+        hint_parts = []
+        for a in cmd.args:
+            name = a.get("name", "")
+            if name:
+                hint_parts.append(f"<{name}>")
+        args_hint = " ".join(hint_parts) if hint_parts else ""
+
+        COMMAND_REGISTRY.append(CommandDef(
+            name=cmd.name,
+            description=cmd.description,
+            category=cmd.category,
+            args_hint=args_hint,
+        ))
+
+
+_register_project_commands()
+
+
 # ---------------------------------------------------------------------------
 # Derived lookups -- rebuilt once at import time, refreshed by rebuild_lookups()
 # ---------------------------------------------------------------------------

--- a/hermes_cli/project_commands.py
+++ b/hermes_cli/project_commands.py
@@ -1,0 +1,212 @@
+"""
+Project-local slash commands (``.hermes/commands/*.md``).
+
+Each ``.md`` file in the project-local ``.hermes/commands/`` directory
+becomes a slash command whose name is the filename (without the ``.md``
+extension).  YAML frontmatter provides metadata (description, args,
+category); the markdown body is the prompt template injected into the
+conversation when the command is invoked.
+
+Template variables in the body (``{{var_name}}``) are substituted with
+user-provided arguments or frontmatter defaults.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Limit individual command file size to prevent abuse.
+_MAX_COMMAND_FILE_BYTES = 20_000
+
+
+@dataclass
+class ProjectCommand:
+    """Parsed project-local slash command."""
+
+    name: str                          # command name (filename without .md)
+    description: str                   # from frontmatter (required)
+    category: str = "项目命令"          # from frontmatter or default
+    args: List[Dict[str, str]] = field(default_factory=list)
+    override: bool = False             # if True, replaces built-in command
+    template: str = ""                 # markdown body (without frontmatter)
+    source_path: Optional[Path] = None
+
+
+# ── Discovery ────────────────────────────────────────────────────────────
+
+
+def _get_project_commands_dir() -> Optional[Path]:
+    """Return the project-local commands directory, or None."""
+    try:
+        from agent.prompt_builder import _get_cached_hermes_project_dir
+    except ImportError:
+        return None
+    project_dir = _get_cached_hermes_project_dir()
+    if project_dir:
+        return project_dir / "commands"
+    return None
+
+
+# ── Parsing ───────────────────────────────────────────────────────────────
+
+
+def _parse_command_file(filepath: Path) -> Optional[ProjectCommand]:
+    """Parse a single ``.hermes/commands/<name>.md`` file.
+
+    Returns a ``ProjectCommand`` on success, or ``None`` if the file is
+    missing required fields, too large, or otherwise invalid.
+    """
+    # Name = filename without .md extension
+    name = filepath.stem
+    if not name or not re.match(r"^[a-zA-Z0-9_-]+$", name):
+        logger.debug("Skipping project command with invalid name: %s", filepath)
+        return None
+
+    # Size guard
+    try:
+        size = filepath.stat().st_size
+        if size > _MAX_COMMAND_FILE_BYTES:
+            logger.warning(
+                "Project command %s is %d bytes (max %d), skipping",
+                filepath, size, _MAX_COMMAND_FILE_BYTES,
+            )
+            return None
+    except OSError:
+        return None
+
+    try:
+        raw = filepath.read_text(encoding="utf-8").strip()
+    except OSError as e:
+        logger.debug("Could not read project command %s: %s", filepath, e)
+        return None
+
+    if not raw:
+        return None
+
+    # Parse YAML frontmatter
+    try:
+        from agent.skill_utils import parse_frontmatter
+    except ImportError:
+        logger.debug("Cannot import parse_frontmatter; project commands disabled")
+        return None
+
+    frontmatter, body = parse_frontmatter(raw)
+
+    # description is required
+    description = frontmatter.get("description", "").strip()
+    if not description:
+        logger.debug(
+            "Project command %s missing required 'description' in frontmatter, skipping",
+            filepath,
+        )
+        return None
+
+    # args
+    args_raw = frontmatter.get("args")
+    args: List[Dict[str, str]] = []
+    if isinstance(args_raw, list):
+        for a in args_raw:
+            if isinstance(a, dict) and "name" in a:
+                args.append({
+                    "name": str(a.get("name", "")),
+                    "description": str(a.get("description", "")),
+                    "default": str(a.get("default", "")),
+                })
+
+    # category
+    category = str(frontmatter.get("category", "项目命令")).strip() or "项目命令"
+
+    # override
+    override = bool(frontmatter.get("override", False))
+
+    return ProjectCommand(
+        name=name,
+        description=description,
+        category=category,
+        args=args,
+        override=override,
+        template=body.strip(),
+        source_path=filepath,
+    )
+
+
+# ── Loading ───────────────────────────────────────────────────────────────
+
+# In-process cache so we don't re-scan on every /help or tab-completion.
+_commands_cache: Optional[List[ProjectCommand]] = None
+_commands_cache_dir: Optional[str] = None
+
+
+def load_project_commands() -> List[ProjectCommand]:
+    """Scan ``.hermes/commands/*.md`` and return parsed project commands.
+
+    Results are cached in-process.  The cache is invalidated when the
+    commands directory path changes (e.g. a ``cd`` in the terminal tool).
+    """
+    global _commands_cache, _commands_cache_dir
+
+    commands_dir = _get_project_commands_dir()
+    dir_key = str(commands_dir) if commands_dir else None
+
+    if _commands_cache is not None and _commands_cache_dir == dir_key:
+        return _commands_cache
+
+    if not commands_dir or not commands_dir.is_dir():
+        _commands_cache = []
+        _commands_cache_dir = dir_key
+        return []
+
+    commands: List[ProjectCommand] = []
+    try:
+        for md_file in sorted(commands_dir.glob("*.md")):
+            cmd = _parse_command_file(md_file)
+            if cmd:
+                commands.append(cmd)
+    except OSError:
+        pass
+
+    _commands_cache = commands
+    _commands_cache_dir = dir_key
+    return commands
+
+
+# ── Lookup & rendering ────────────────────────────────────────────────────
+
+
+def resolve_project_command(name: str) -> Optional[ProjectCommand]:
+    """Find a project command by name.  Returns None if not found."""
+    for cmd in load_project_commands():
+        if cmd.name == name:
+            return cmd
+    return None
+
+
+_TEMPLATE_RE = re.compile(r"\{\{(\w+)\}\}")
+
+
+def render_command(command: ProjectCommand, args: Dict[str, str]) -> str:
+    """Render a command template by substituting ``{{var}}`` placeholders.
+
+    Variables come from *args* (user-provided) with fallback to frontmatter
+    defaults.  Unmatched placeholders are left as-is so the LLM can ask
+    the user for missing values.
+    """
+    # Build substitution map: user args > frontmatter defaults
+    subs: Dict[str, str] = {}
+    for arg_def in command.args:
+        name = arg_def.get("name", "")
+        if name:
+            subs[name] = arg_def.get("default", "")
+    subs.update(args)
+
+    def _replace(match: re.Match) -> str:
+        var = match.group(1)
+        return subs.get(var, match.group(0))
+
+    return _TEMPLATE_RE.sub(_replace, command.template)

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -263,3 +263,98 @@ class TestSkillMatchesPlatformTermux:
             "agent.skill_utils.is_termux", return_value=False
         ):
             assert skill_matches_platform(fm) is True
+
+
+# ── Project-local skills (.hermes/skills/) ─────────────────────────────
+
+
+class TestProjectSkillsDir:
+    """Tests for get_project_skills_dir() and get_all_skills_dirs()."""
+
+    def test_no_hermes_dir_returns_none(self, monkeypatch):
+        """Without a .hermes/ directory, get_project_skills_dir returns None."""
+        from agent.skill_utils import _external_dirs_cache_clear as _clear
+        _clear()
+        monkeypatch.setattr(
+            "agent.skill_utils.get_project_skills_dir",
+            lambda: None,
+        )
+        from agent.skill_utils import get_project_skills_dir, get_all_skills_dirs
+
+        assert get_project_skills_dir() is None
+        # get_all_skills_dirs should NOT include any project dir
+        dirs = get_all_skills_dirs()
+        # The project dir (None) is not appended
+        assert all(d is not None for d in dirs)
+
+    def test_hermes_dir_without_skills_subdir(self, monkeypatch, tmp_path):
+        """.hermes/ exists but .hermes/skills/ doesn't — returns None."""
+        from agent.skill_utils import _external_dirs_cache_clear as _clear
+        _clear()
+        project_dir = tmp_path / ".hermes"
+        project_dir.mkdir()
+        # no skills/ subdir
+
+        monkeypatch.setattr(
+            "agent.prompt_builder._get_cached_hermes_project_dir",
+            lambda cwd=None: project_dir,
+        )
+        from agent.skill_utils import get_project_skills_dir
+
+        assert get_project_skills_dir() is None
+
+    def test_hermes_skills_dir_exists(self, monkeypatch, tmp_path):
+        """.hermes/skills/ exists — returns the path."""
+        from agent.skill_utils import _external_dirs_cache_clear as _clear
+        _clear()
+        project_dir = tmp_path / ".hermes"
+        skills_dir = project_dir / "skills"
+        skills_dir.mkdir(parents=True)
+
+        monkeypatch.setattr(
+            "agent.prompt_builder._get_cached_hermes_project_dir",
+            lambda cwd=None: project_dir,
+        )
+        from agent.skill_utils import get_project_skills_dir
+
+        result = get_project_skills_dir()
+        assert result == skills_dir
+
+    def test_get_all_skills_dirs_includes_project(self, monkeypatch, tmp_path):
+        """get_all_skills_dirs() appends project skills dir when it exists."""
+        from agent.skill_utils import _external_dirs_cache_clear as _clear
+        _clear()
+        project_dir = tmp_path / ".hermes"
+        skills_dir = project_dir / "skills"
+        skills_dir.mkdir(parents=True)
+
+        monkeypatch.setattr(
+            "agent.prompt_builder._get_cached_hermes_project_dir",
+            lambda cwd=None: project_dir,
+        )
+        import agent.skill_utils as su
+        su._external_dirs_cache_clear()
+
+        dirs = su.get_all_skills_dirs()
+        # Project skills dir should be last
+        assert dirs[-1] == skills_dir
+
+    def test_import_error_fallback(self, monkeypatch):
+        """If prompt_builder import fails, returns None gracefully."""
+        from agent.skill_utils import _external_dirs_cache_clear as _clear
+        _clear()
+        import builtins
+        _orig_import = builtins.__import__
+
+        def _block_import(name, *args, **kwargs):
+            if name == "agent.prompt_builder":
+                raise ImportError("blocked")
+            return _orig_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _block_import)
+        # Reload skill_utils to pick up the patched import
+        import importlib
+        import agent.skill_utils
+        importlib.reload(agent.skill_utils)
+
+        assert agent.skill_utils.get_project_skills_dir() is None

--- a/tests/hermes_cli/test_project_commands.py
+++ b/tests/hermes_cli/test_project_commands.py
@@ -1,0 +1,285 @@
+"""Tests for project-local slash commands (``.hermes/commands/*.md``)."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.project_commands import (
+    ProjectCommand,
+    _parse_command_file,
+    load_project_commands,
+    resolve_project_command,
+    render_command,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _write_md(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+# ── _parse_command_file ──────────────────────────────────────────────
+
+
+class TestParseCommandFile:
+    def test_basic_valid(self, tmp_path):
+        _write_md(tmp_path / "hello.md", """\
+            ---
+            description: Say hello to the user.
+            category: 项目命令
+            args:
+              - name: target
+                description: Who to greet
+                default: world
+            ---
+            # Hello
+
+            Say hello to {{target}}!
+            """)
+        cmd = _parse_command_file(tmp_path / "hello.md")
+        assert cmd is not None
+        assert cmd.name == "hello"
+        assert cmd.description == "Say hello to the user."
+        assert cmd.category == "项目命令"
+        assert len(cmd.args) == 1
+        assert cmd.args[0]["name"] == "target"
+        assert cmd.args[0]["default"] == "world"
+        assert cmd.override is False
+        assert "{{target}}" in cmd.template
+
+    def test_missing_description(self, tmp_path):
+        _write_md(tmp_path / "no_desc.md", """\
+            ---
+            category: test
+            ---
+            body
+            """)
+        assert _parse_command_file(tmp_path / "no_desc.md") is None
+
+    def test_invalid_name(self, tmp_path):
+        _write_md(tmp_path / "bad name!.md", """\
+            ---
+            description: Invalid name test.
+            ---
+            body
+            """)
+        assert _parse_command_file(tmp_path / "bad name!.md") is None
+
+    def test_override_flag(self, tmp_path):
+        _write_md(tmp_path / "yolo.md", """\
+            ---
+            description: Override the built-in yolo command.
+            override: true
+            ---
+            Overridden yolo!
+            """)
+        cmd = _parse_command_file(tmp_path / "yolo.md")
+        assert cmd is not None
+        assert cmd.override is True
+
+    def test_empty_file(self, tmp_path):
+        p = tmp_path / "empty.md"
+        p.write_text("", encoding="utf-8")
+        assert _parse_command_file(p) is None
+
+    def test_no_frontmatter(self, tmp_path):
+        _write_md(tmp_path / "nofm.md", """\
+            Just some text without frontmatter.
+            """)
+        # No frontmatter → no description → None
+        assert _parse_command_file(tmp_path / "nofm.md") is None
+
+    def test_missing_file(self, tmp_path):
+        assert _parse_command_file(tmp_path / "nonexistent.md") is None
+
+    def test_file_too_large(self, tmp_path, monkeypatch):
+        import hermes_cli.project_commands as pc
+        monkeypatch.setattr(pc, "_MAX_COMMAND_FILE_BYTES", 100)
+        _write_md(tmp_path / "big.md", f"""\
+            ---
+            description: A very large command.
+            ---
+            {'x' * 200}
+            """)
+        assert _parse_command_file(tmp_path / "big.md") is None
+
+
+# ── render_command ───────────────────────────────────────────────────
+
+
+class TestRenderCommand:
+    def test_substitutes_variables(self):
+        cmd = ProjectCommand(
+            name="greet",
+            description="Greet someone.",
+            args=[
+                {"name": "who", "description": "Who to greet", "default": "world"},
+            ],
+            template="Hello, {{who}}!",
+        )
+        result = render_command(cmd, {"who": "Alice"})
+        assert result == "Hello, Alice!"
+
+    def test_fallback_to_default(self):
+        cmd = ProjectCommand(
+            name="greet",
+            description="Greet someone.",
+            args=[
+                {"name": "who", "description": "Who to greet", "default": "world"},
+            ],
+            template="Hello, {{who}}!",
+        )
+        result = render_command(cmd, {})
+        assert result == "Hello, world!"
+
+    def test_user_arg_overrides_default(self):
+        cmd = ProjectCommand(
+            name="greet",
+            description="Greet someone.",
+            args=[
+                {"name": "who", "description": "Who to greet", "default": "world"},
+            ],
+            template="Hello, {{who}}!",
+        )
+        result = render_command(cmd, {"who": "Bob"})
+        assert result == "Hello, Bob!"
+
+    def test_unmatched_placeholder_left_as_is(self):
+        cmd = ProjectCommand(
+            name="query",
+            description="Query something.",
+            template="Looking up {{thing}}...",
+        )
+        result = render_command(cmd, {})
+        assert result == "Looking up {{thing}}..."
+
+    def test_multiple_variables(self):
+        cmd = ProjectCommand(
+            name="build",
+            description="Build something.",
+            args=[
+                {"name": "target", "description": "Build target", "default": "all"},
+                {"name": "config", "description": "Build config", "default": "Debug"},
+            ],
+            template="Building {{target}} with {{config}}...",
+        )
+        result = render_command(cmd, {"target": "server"})
+        assert result == "Building server with Debug..."
+
+
+# ── load_project_commands (mocked) ───────────────────────────────────
+
+
+class TestLoadProjectCommands:
+    def test_empty_directory(self, tmp_path, monkeypatch):
+        import hermes_cli.project_commands as pc
+        monkeypatch.setattr(pc, "_get_project_commands_dir", lambda: tmp_path)
+        # Reset cache
+        monkeypatch.setattr(pc, "_commands_cache", None)
+        monkeypatch.setattr(pc, "_commands_cache_dir", None)
+
+        commands = load_project_commands()
+        assert commands == []
+
+    def test_loads_valid_commands(self, tmp_path, monkeypatch):
+        import hermes_cli.project_commands as pc
+
+        _write_md(tmp_path / "greet.md", """\
+            ---
+            description: Greet someone.
+            ---
+            Hello!
+            """)
+        _write_md(tmp_path / "build.md", """\
+            ---
+            description: Build the project.
+            args:
+              - name: target
+                description: What to build
+            ---
+            Building {{target}}...
+            """)
+
+        monkeypatch.setattr(pc, "_get_project_commands_dir", lambda: tmp_path)
+        monkeypatch.setattr(pc, "_commands_cache", None)
+        monkeypatch.setattr(pc, "_commands_cache_dir", None)
+
+        commands = load_project_commands()
+        assert len(commands) == 2
+        names = {c.name for c in commands}
+        assert names == {"greet", "build"}
+
+    def test_skips_invalid_commands(self, tmp_path, monkeypatch):
+        import hermes_cli.project_commands as pc
+
+        _write_md(tmp_path / "valid.md", """\
+            ---
+            description: A valid command.
+            ---
+            Body
+            """)
+        # Missing description — should be skipped
+        _write_md(tmp_path / "invalid.md", """\
+            ---
+            category: test
+            ---
+            Body
+            """)
+
+        monkeypatch.setattr(pc, "_get_project_commands_dir", lambda: tmp_path)
+        monkeypatch.setattr(pc, "_commands_cache", None)
+        monkeypatch.setattr(pc, "_commands_cache_dir", None)
+
+        commands = load_project_commands()
+        assert len(commands) == 1
+        assert commands[0].name == "valid"
+
+
+# ── resolve_project_command ──────────────────────────────────────────
+
+
+class TestResolveProjectCommand:
+    def test_found(self, tmp_path, monkeypatch):
+        import hermes_cli.project_commands as pc
+
+        _write_md(tmp_path / "greet.md", """\
+            ---
+            description: Greet someone.
+            ---
+            Hi!
+            """)
+
+        monkeypatch.setattr(pc, "_get_project_commands_dir", lambda: tmp_path)
+        monkeypatch.setattr(pc, "_commands_cache", None)
+        monkeypatch.setattr(pc, "_commands_cache_dir", None)
+
+        cmd = resolve_project_command("greet")
+        assert cmd is not None
+        assert cmd.name == "greet"
+
+    def test_not_found(self, tmp_path, monkeypatch):
+        import hermes_cli.project_commands as pc
+
+        monkeypatch.setattr(pc, "_get_project_commands_dir", lambda: tmp_path)
+        monkeypatch.setattr(pc, "_commands_cache", None)
+        monkeypatch.setattr(pc, "_commands_cache_dir", None)
+
+        assert resolve_project_command("nonexistent") is None
+
+
+# ── No hermes project directory ──────────────────────────────────────
+
+
+class TestNoProjectDir:
+    def test_load_returns_empty(self, monkeypatch):
+        import hermes_cli.project_commands as pc
+
+        monkeypatch.setattr(pc, "_get_project_commands_dir", lambda: None)
+        monkeypatch.setattr(pc, "_commands_cache", None)
+        monkeypatch.setattr(pc, "_commands_cache_dir", None)
+
+        assert load_project_commands() == []

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -607,7 +607,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     Returns:
         List of skill metadata dicts (name, description, category).
     """
-    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+    from agent.skill_utils import get_external_skills_dirs, get_project_skills_dir, iter_skill_index_files
 
     skills = []
     seen_names: set = set()
@@ -615,11 +615,14 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Load disabled set once (not per-skill)
     disabled = set() if skip_disabled else _get_disabled_skill_names()
 
-    # Scan local dir first, then external dirs (local takes precedence)
+    # Scan local dir first, then external dirs, then project-local dir
     dirs_to_scan = []
     if SKILLS_DIR.exists():
         dirs_to_scan.append(SKILLS_DIR)
     dirs_to_scan.extend(get_external_skills_dirs())
+    project_skills = get_project_skills_dir()
+    if project_skills:
+        dirs_to_scan.append(project_skills)
 
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
@@ -977,11 +980,16 @@ def skill_view(
                     ensure_ascii=False,
                 )
 
+        from agent.skill_utils import get_external_skills_dirs, get_project_skills_dir
+
         # Build list of all skill directories to search
         all_dirs = []
         if SKILLS_DIR.exists():
             all_dirs.append(SKILLS_DIR)
         all_dirs.extend(get_external_skills_dirs())
+        project_skills = get_project_skills_dir()
+        if project_skills:
+            all_dirs.append(project_skills)
 
         if not all_dirs:
             return json.dumps(


### PR DESCRIPTION
## What does this PR do?

Adds `.hermes/` project directory support — a project-local counterpart to `~/.hermes/`. Hermes walks from `cwd` up to the git root to find `.hermes/`, then loads all recognized content from it. This is a general-purpose foundation; the first two consumers are:

### `.hermes/commands/*.md` — project-local slash commands

Each `.md` file becomes a first-class slash command. YAML frontmatter provides metadata; the markdown body is a prompt template with `{{var}}` substitution:

```yaml
---
description: Review the latest git diff
category: Code Review
args:
  - name: files
    description: Files to review
    default: .
---
Review the changes in {{files}}. Focus on bugs, security issues, and style problems.
```

Type `/review` in the project and the rendered template is injected as a user message. Commands appear in `/help` and autocomplete. Name collisions with built-in commands are skipped unless `override: true`.

### `.hermes/skills/` — project-local skills

Skills placed under `.hermes/skills/` (standard `SKILL.md` format) are auto-discovered alongside `~/.hermes/skills/` and `external_dirs`. They appear in `skills_list()`, are loadable via `skill_view()`, and invokable as `/skill-name` — exactly like user-global skills. On name collisions, user-global skills take precedence.

### Other `.hermes/` content

The `.hermes/` discovery path is designed to support future extensions: `.hermes/AGENTS.md` overrides, project-local config, etc. — all building on the same directory-walk infrastructure.

## Changes Made

- `agent/prompt_builder.py` — `_find_hermes_project_dir()` and `_get_cached_hermes_project_dir()` for cached `.hermes/` discovery
- `agent/skill_utils.py` — `get_project_skills_dir()` and updated `get_all_skills_dirs()` to include project skills
- `tools/skills_tool.py` — `_find_all_skills()` and `skill_view()` scan the project skills dir
- `hermes_cli/project_commands.py` (new) — scan `.hermes/commands/*.md`, parse YAML frontmatter, render `{{var}}` templates
- `hermes_cli/commands.py` — register project commands into `COMMAND_REGISTRY` with collision protection
- `cli.py` — dispatch project commands (before skill commands, so a project can shadow a skill)
- `tests/hermes_cli/test_project_commands.py` (new) — 19 unit tests for command parsing, rendering, loading, lookup
- `tests/agent/test_skill_utils.py` — 5 new tests for project skills discovery

## How to Test

1. Create a `.hermes/commands/` directory in any git repo:

```bash
mkdir -p .hermes/commands
cat > .hermes/commands/hello.md << 'EOF'
---
description: Say hello
args:
  - name: name
    default: world
---
Hello, {{name}}!
EOF
```

2. Start Hermes in that directory and type `/hello` — should render "Hello, world!"
3. Type `/hello Hermes` — should render "Hello, Hermes!"
4. Create a `.hermes/skills/my-skill/` with a `SKILL.md` — should appear in `/skills` list and be loadable
5. Run tests: `pytest tests/hermes_cli/test_project_commands.py tests/agent/test_skill_utils.py::TestProjectSkillsDir -v`
