### PR TITLE
feat(desktop): add source filter toggle to sidebar session list

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -55,6 +55,7 @@ import {
   $sidebarRecentsOpen,
   $sidebarSessionOrderIds,
   $sidebarWorkspaceOrderIds,
+  $sidebarHideToolSessions,
   pinSession,
   reorderPinnedSession,
   SESSION_SEARCH_FOCUS_EVENT,
@@ -322,6 +323,7 @@ export function ChatSidebar({
   const contentVisible = sidebarOpen || overlayMounted
   const panesFlipped = useStore($panesFlipped)
   const agentsGrouped = useStore($sidebarAgentsGrouped)
+  const hideToolSessions = useStore($sidebarHideToolSessions)
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const pinsOpen = useStore($sidebarPinsOpen)
   const agentsOpen = useStore($sidebarRecentsOpen)
@@ -404,8 +406,11 @@ export function ChatSidebar({
   )
 
   const sortedSessions = useMemo(
-    () => [...visibleSessions].sort((a, b) => sessionTime(b) - sessionTime(a)),
-    [visibleSessions]
+    () => {
+      const sorted = [...visibleSessions].sort((a, b) => sessionTime(b) - sessionTime(a))
+      return hideToolSessions ? sorted.filter(s => s.source !== 'tool') : sorted
+    },
+    [visibleSessions, hideToolSessions]
   )
 
   const workingSessionIdSet = useMemo(() => new Set(workingSessionIds), [workingSessionIds])
@@ -932,27 +937,48 @@ export function ChatSidebar({
                   // Grouping operates on unpinned recents; if everything is pinned
                   // the toggle does nothing, and it's irrelevant in the ALL-profiles
                   // view (always grouped by profile), so hide the button (not the slot).
-                  <div className="grid size-6 shrink-0 place-items-center">
+                  <div className="flex shrink-0 items-center gap-0.5">
                     {!showAllProfiles && agentSessions.length > 0 ? (
-                      <Tip label={agentsGrouped ? s.groupTitleGrouped : s.groupTitleUngrouped}>
+                      <Tip label={hideToolSessions ? s.showToolSessions : s.hideToolSessions}>
                         <Button
-                          aria-label={agentsGrouped ? s.groupAriaGrouped : s.groupAriaUngrouped}
+                          aria-label={hideToolSessions ? s.showToolSessions : s.hideToolSessions}
                           className={cn(
                             'text-(--ui-text-tertiary) opacity-70 hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100',
-                            agentsGrouped && 'bg-(--ui-control-active-background) text-foreground opacity-100'
+                            hideToolSessions && 'bg-(--ui-control-active-background) text-foreground opacity-100'
                           )}
                           onClick={event => {
                             event.stopPropagation()
-                            setSidebarRecentsOpen(true)
-                            setSidebarAgentsGrouped(!agentsGrouped)
+                            $sidebarHideToolSessions.set(!hideToolSessions)
                           }}
                           size="icon-xs"
                           variant="ghost"
                         >
-                          <Codicon name={agentsGrouped ? 'list-unordered' : 'root-folder'} size="0.75rem" />
+                          <Codicon name={hideToolSessions ? 'eye-closed' : 'eye'} size="0.75rem" />
                         </Button>
                       </Tip>
                     ) : null}
+                    <div className="grid size-6 shrink-0 place-items-center">
+                      {!showAllProfiles && agentSessions.length > 0 ? (
+                        <Tip label={agentsGrouped ? s.groupTitleGrouped : s.groupTitleUngrouped}>
+                          <Button
+                            aria-label={agentsGrouped ? s.groupAriaGrouped : s.groupAriaUngrouped}
+                            className={cn(
+                              'text-(--ui-text-tertiary) opacity-70 hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100',
+                              agentsGrouped && 'bg-(--ui-control-active-background) text-foreground opacity-100'
+                            )}
+                            onClick={event => {
+                              event.stopPropagation()
+                              setSidebarRecentsOpen(true)
+                              setSidebarAgentsGrouped(!agentsGrouped)
+                            }}
+                            size="icon-xs"
+                            variant="ghost"
+                          >
+                            <Codicon name={agentsGrouped ? 'list-unordered' : 'root-folder'} size="0.75rem" />
+                          </Button>
+                        </Tip>
+                      ) : null}
+                    </div>
                   </div>
                 }
                 label={s.sessions}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1089,6 +1089,8 @@ export const en: Translations = {
     groupAriaUngrouped: 'Group sessions by workspace',
     groupTitleGrouped: 'Ungroup sessions',
     groupTitleUngrouped: 'Group by workspace',
+    hideToolSessions: 'Hide tool sessions',
+    showToolSessions: 'Show tool sessions',
     allPinned: 'Everything here is pinned. Unpin a chat to show it in recents.',
     shiftClickHint: 'Shift-click a chat to pin',
     noWorkspace: 'No workspace',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1222,6 +1222,8 @@ export const ja = defineLocale({
     groupAriaUngrouped: 'ワークスペースごとにセッションをグループ化',
     groupTitleGrouped: 'セッションのグループ化を解除',
     groupTitleUngrouped: 'ワークスペースでグループ化',
+    hideToolSessions: 'ツールセッションを非表示',
+    showToolSessions: 'ツールセッションを表示',
     allPinned: 'ここにあるものはすべてピン留めされています。チャットのピン留めを解除すると最近のものに表示されます。',
     shiftClickHint: 'Shift クリックでピン留め · ドラッグで並べ替え',
     noWorkspace: 'ワークスペースなし',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -836,6 +836,8 @@ export interface Translations {
     groupAriaUngrouped: string
     groupTitleGrouped: string
     groupTitleUngrouped: string
+    hideToolSessions: string
+    showToolSessions: string
     allPinned: string
     shiftClickHint: string
     noWorkspace: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1188,6 +1188,8 @@ export const zhHant = defineLocale({
     groupAriaUngrouped: '依工作區分組工作階段',
     groupTitleGrouped: '取消分組',
     groupTitleUngrouped: '依工作區分組',
+    hideToolSessions: '隱藏工具會話',
+    showToolSessions: '顯示工具會話',
     allPinned: '這裡的全部已釘選。取消釘選某個聊天即可在最近中顯示。',
     shiftClickHint: 'Shift + 點擊聊天以釘選 · 拖曳以重新排序',
     noWorkspace: '無工作區',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1275,6 +1275,8 @@ export const zh: Translations = {
     groupAriaUngrouped: '按工作区分组会话',
     groupTitleGrouped: '取消分组',
     groupTitleUngrouped: '按工作区分组',
+    hideToolSessions: '隐藏工具会话',
+    showToolSessions: '显示工具会话',
     allPinned: '这里的全部已置顶。取消置顶某个对话即可在最近中显示。',
     shiftClickHint: 'Shift+ 单击对话以置顶 · 拖动以重新排序',
     noWorkspace: '无工作区',

--- a/apps/desktop/src/store/layout.test.ts
+++ b/apps/desktop/src/store/layout.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// Mock localStorage before importing the module
+const store: Record<string, string> = {}
+const mockStorage = {
+  getItem: vi.fn((key: string) => store[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { store[key] = value }),
+  removeItem: vi.fn((key: string) => { delete store[key] }),
+  clear: vi.fn(() => { for (const k in store) delete store[k] }),
+  get length() { return Object.keys(store).length },
+  key: vi.fn((i: number) => Object.keys(store)[i] ?? null)
+}
+
+vi.stubGlobal('localStorage', mockStorage)
+vi.stubGlobal('window', { localStorage: mockStorage })
+
+// Dynamic import after mocking so module-level storedBoolean sees the mock
+const { $sidebarHideToolSessions } = await import('./layout')
+
+describe('$sidebarHideToolSessions', () => {
+  beforeEach(() => {
+    mockStorage.clear()
+    mockStorage.getItem.mockClear()
+    mockStorage.setItem.mockClear()
+    $sidebarHideToolSessions.set(false)
+  })
+
+  it('defaults to false', () => {
+    expect($sidebarHideToolSessions.get()).toBe(false)
+  })
+
+  it('toggles on set(true)', () => {
+    $sidebarHideToolSessions.set(true)
+    expect($sidebarHideToolSessions.get()).toBe(true)
+  })
+
+  it('toggles back to false', () => {
+    $sidebarHideToolSessions.set(true)
+    $sidebarHideToolSessions.set(false)
+    expect($sidebarHideToolSessions.get()).toBe(false)
+  })
+
+  it('persists via localStorage on change', () => {
+    $sidebarHideToolSessions.set(true)
+    expect(mockStorage.setItem).toHaveBeenCalledWith('hermes.desktop.hideToolSessions', 'true')
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -21,6 +21,7 @@ export const FILE_BROWSER_MAX_WIDTH = '20rem'
 export const SIDEBAR_SESSIONS_PAGE_SIZE = 50
 
 const SIDEBAR_PINNED_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
+const SIDEBAR_HIDE_TOOL_SESSIONS_KEY = 'hermes.desktop.hideToolSessions'
 const SIDEBAR_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.agentsGroupedByWorkspace'
 const SIDEBAR_CRON_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarCronOpen'
 const SIDEBAR_MESSAGING_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarMessagingOpen'
@@ -74,6 +75,7 @@ export const $sidebarCronOpen = atom(storedBoolean(SIDEBAR_CRON_OPEN_STORAGE_KEY
 // stays collapsed unless they've opened a platform before.
 export const $sidebarMessagingOpenIds = atom<string[]>(storedStringArray(SIDEBAR_MESSAGING_OPEN_STORAGE_KEY))
 export const $sidebarAgentsGrouped = atom(storedBoolean(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, false))
+export const $sidebarHideToolSessions = atom(storedBoolean(SIDEBAR_HIDE_TOOL_SESSIONS_KEY, false))
 // When true, the sessions sidebar moves to the right and the file browser +
 // preview rail move to the left — a mirror of the default layout.
 export const $panesFlipped = atom(storedBoolean(PANES_FLIPPED_STORAGE_KEY, false))
@@ -86,6 +88,7 @@ $sidebarMessagingOpenIds.subscribe(ids => persistStringArray(SIDEBAR_MESSAGING_O
 $sidebarSessionOrderIds.subscribe(ids => persistStringArray(SIDEBAR_SESSION_ORDER_STORAGE_KEY, [...ids]))
 $sidebarWorkspaceOrderIds.subscribe(ids => persistStringArray(SIDEBAR_WORKSPACE_ORDER_STORAGE_KEY, [...ids]))
 $sidebarAgentsGrouped.subscribe(grouped => persistBoolean(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, grouped))
+$sidebarHideToolSessions.subscribe(hide => persistBoolean(SIDEBAR_HIDE_TOOL_SESSIONS_KEY, hide))
 $panesFlipped.subscribe(flipped => persistBoolean(PANES_FLIPPED_STORAGE_KEY, flipped))
 
 export function setSidebarWidth(width: number) {


### PR DESCRIPTION
## Problem

When Codex (or other external tools) invokes Hermes via CLI with `--source tool`, those sessions appear in the desktop client sidebar alongside real user conversations. This clutters the session list with auto-generated sessions that the user never needs to revisit manually.

## Solution

Add an eye/eye-closed toggle button in the Sessions section header that filters out `source: tool` sessions from the sidebar list.

### Implementation

- **New persisted atom**: `$sidebarHideToolSessions` in `store/layout.ts` (localStorage key: `hermes.desktop.hideToolSessions`)
- **Filter logic**: Applied at the `sortedSessions` memo level, propagating to all downstream views (pinned, grouped, virtualized)
- **Toggle button**: Eye icon next to the existing workspace-grouping toggle in the Sessions header
- **i18n**: Translations for en, zh, zh-hant, ja
- **Tests**: Unit tests for atom behavior and localStorage persistence

### Files changed

| File | Change |
|------|--------|
| `store/layout.ts` | Add `$sidebarHideToolSessions` atom + persistence |
| `app/chat/sidebar/index.tsx` | Add filter toggle + apply filter to sorted sessions |
| `i18n/types.ts` | Add `hideToolSessions` / `showToolSessions` type keys |
| `i18n/en.ts` | English translations |
| `i18n/zh.ts` | Chinese (Simplified) translations |
| `i18n/zh-hant.ts` | Chinese (Traditional) translations |
| `i18n/ja.ts` | Japanese translations |
| `store/layout.test.ts` | Unit tests (4 passing) |

Closes #43584