### PR TITLE
fix(desktop): stop dead remote profiles from stalling the session list for 45s

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -166,6 +166,13 @@ import {
   revalidateRemoteConnection
 } from './remote-liveness'
 import {
+  REMOTE_PROBE_ATTEMPT_TIMEOUT_MS,
+  REMOTE_PROBE_DEADLINE_MS,
+  createRemoteAvailability,
+  spliceRemoteSessions,
+  waitForBackendReady
+} from './remote-sessions'
+import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
   createSessionWindowRegistry,
@@ -1047,7 +1054,12 @@ let softRehomeInProgress = false
 // backends spawned lazily when a session belongs to a different profile. A user
 // with no named profiles never populates this map, so their experience is
 // byte-for-byte the single-backend behavior.
-const backendPool = new Map() // profile -> { process, port, token, connectionPromise, lastActiveAt }
+const backendPool = new Map() // profile -> { process, port, token, connectionPromise, lastActiveAt, ready }
+// Cooldown registry for remote-profile backends that failed their reachability
+// probe. The session-list splice consults this so a dead remote is skipped
+// instantly instead of stalling every sidebar refresh; explicit user actions
+// (opening a remote session, switching profiles) still probe for real.
+const remoteAvailability = createRemoteAvailability({ log: line => rememberLog(line) })
 // Keep the pool light: cap concurrent profile backends (LRU eviction) and reap
 // idle ones. A user idles at exactly the primary backend; pool backends only
 // exist while a non-primary profile is actively being chatted through.
@@ -4188,6 +4200,17 @@ function fetchJson(url, token, options: any = {}) {
       return
     }
 
+    let settled = false
+    let timeoutTimer = null
+    const timeoutError = () => new Error(`Timed out connecting to Hermes backend after ${timeoutMs}ms`)
+    const finish = (fn, value) => {
+      if (settled) return
+      settled = true
+      if (timeoutTimer) clearTimeout(timeoutTimer)
+      fn(value)
+    }
+    const fail = error => finish(reject, error)
+    const succeed = value => finish(resolve, value)
     const req = client.request(
       parsed,
       {
@@ -4206,20 +4229,19 @@ function fetchJson(url, token, options: any = {}) {
       },
       res => {
         const chunks = []
-        res.on('error', reject)
+        res.on('error', fail)
         res.on('data', chunk => chunks.push(chunk))
         res.on('end', () => {
+          if (settled) return
           const text = Buffer.concat(chunks).toString('utf8')
 
           if ((res.statusCode || 500) >= 400) {
-            reject(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
-
+            fail(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
             return
           }
 
           if (!text) {
-            resolve(null)
-
+            succeed(null)
             return
           }
 
@@ -4231,7 +4253,7 @@ function fetchJson(url, token, options: any = {}) {
           const contentType = String(res.headers['content-type'] || '')
 
           if (looksHtml || contentType.includes('text/html')) {
-            reject(
+            fail(
               new Error(
                 `Expected JSON from ${url} but got HTML (status ${res.statusCode}). ` +
                   'The endpoint is likely missing on the Hermes backend.'
@@ -4242,18 +4264,24 @@ function fetchJson(url, token, options: any = {}) {
           }
 
           try {
-            resolve(JSON.parse(text))
+            succeed(JSON.parse(text))
           } catch {
-            reject(new Error(`Invalid JSON from ${url} (status ${res.statusCode}): ${text.slice(0, 200)}`))
+            fail(new Error(`Invalid JSON from ${url} (status ${res.statusCode}): ${text.slice(0, 200)}`))
           }
         })
       }
     )
 
-    req.on('error', reject)
-    req.setTimeout(timeoutMs, () => {
-      req.destroy(new Error(`Timed out connecting to Hermes backend after ${timeoutMs}ms`))
-    })
+    const abortForTimeout = () => {
+      const error = timeoutError()
+      req.destroy(error)
+      fail(error)
+    }
+    // ClientRequest#setTimeout only covers the assigned socket's idle timeout;
+    // keep a wall-clock guard too so DNS/pre-connect hangs honor timeoutMs.
+    timeoutTimer = setTimeout(abortForTimeout, timeoutMs)
+    req.on('error', fail)
+    req.setTimeout(timeoutMs, abortForTimeout)
 
     if (body) {
       req.write(body)
@@ -4290,6 +4318,17 @@ function fetchPublicJson(url, options: any = {}) {
       return
     }
 
+    let settled = false
+    let timeoutTimer = null
+    const timeoutError = () => new Error(`Timed out connecting to Hermes backend after ${timeoutMs}ms`)
+    const finish = (fn, value) => {
+      if (settled) return
+      settled = true
+      if (timeoutTimer) clearTimeout(timeoutTimer)
+      fn(value)
+    }
+    const fail = error => finish(reject, error)
+    const succeed = value => finish(resolve, value)
     const req = client.request(
       parsed,
       {
@@ -4303,17 +4342,16 @@ function fetchPublicJson(url, options: any = {}) {
         const chunks = []
         res.on('data', chunk => chunks.push(chunk))
         res.on('end', () => {
+          if (settled) return
           const text = Buffer.concat(chunks).toString('utf8')
 
           if ((res.statusCode || 500) >= 400) {
-            reject(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
-
+            fail(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
             return
           }
 
           if (!text) {
-            resolve(null)
-
+            succeed(null)
             return
           }
 
@@ -4321,7 +4359,7 @@ function fetchPublicJson(url, options: any = {}) {
           const contentType = String(res.headers['content-type'] || '')
 
           if (looksHtml || contentType.includes('text/html')) {
-            reject(
+            fail(
               new Error(
                 `Expected JSON from ${url} but got HTML (status ${res.statusCode}). ` +
                   'The endpoint is likely missing on the Hermes backend.'
@@ -4332,18 +4370,24 @@ function fetchPublicJson(url, options: any = {}) {
           }
 
           try {
-            resolve(JSON.parse(text))
+            succeed(JSON.parse(text))
           } catch {
-            reject(new Error(`Invalid JSON from ${url} (status ${res.statusCode}): ${text.slice(0, 200)}`))
+            fail(new Error(`Invalid JSON from ${url} (status ${res.statusCode}): ${text.slice(0, 200)}`))
           }
         })
       }
     )
 
-    req.on('error', reject)
-    req.setTimeout(timeoutMs, () => {
-      req.destroy(new Error(`Timed out connecting to Hermes backend after ${timeoutMs}ms`))
-    })
+    const abortForTimeout = () => {
+      const error = timeoutError()
+      req.destroy(error)
+      fail(error)
+    }
+    // ClientRequest#setTimeout only covers the assigned socket's idle timeout;
+    // keep a wall-clock guard too so DNS/pre-connect hangs honor timeoutMs.
+    timeoutTimer = setTimeout(abortForTimeout, timeoutMs)
+    req.on('error', fail)
+    req.setTimeout(timeoutMs, abortForTimeout)
 
     if (body) {
       req.write(body)
@@ -7942,6 +7986,7 @@ async function ensureBackend(profile) {
     token: null,
     connectionPromise: null,
     lastActiveAt: Date.now(),
+    ready: false,
     remoteBaseUrl: null
   }
 
@@ -7949,6 +7994,14 @@ async function ensureBackend(profile) {
     backendPool.delete(key)
     throw error
   })
+  // Warmness powers the session-splice budget: an established connection gets
+  // more time than a cold spawn/probe (which must never stall the sidebar).
+  entry.connectionPromise.then(
+    () => {
+      entry.ready = true
+    },
+    () => {}
+  )
   backendPool.set(key, entry)
   startPoolIdleReaper()
 
@@ -8039,7 +8092,28 @@ async function spawnPoolBackend(profile, entry) {
   const remote = await resolveRemoteBackend(profile)
 
   if (remote) {
+    // The remote backend is supposed to ALREADY be running — this is a
+    // reachability check, not a boot wait. Fail in milliseconds when nothing
+    // is listening (dead tunnel, sleeping host) instead of polling for the
+    // 45s local-boot deadline, and remember the failure so the session-list
+    // splice skips this profile until the cooldown lapses. Only a hard
+    // "nothing is listening" is fatal here — a gated/slow remote that
+    // answers at all still goes through the full readiness handshake below.
+    try {
+      await waitForBackendReady(
+        () => fetchJson(`${remote.baseUrl}/api/status`, remote.token, { timeoutMs: REMOTE_PROBE_ATTEMPT_TIMEOUT_MS }),
+        { deadlineMs: REMOTE_PROBE_DEADLINE_MS, failFast: true }
+      )
+    } catch (error) {
+      if (String(error?.message || '').startsWith('Hermes backend is not listening')) {
+        remoteAvailability.markDown(profile, error?.message)
+
+        throw error
+      }
+    }
+
     await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
+    remoteAvailability.markUp(profile)
 
     // Recorded on the entry so revalidation can probe this descriptor without
     // awaiting connectionPromise, which may still be pending for a sibling.
@@ -9789,11 +9863,16 @@ ipcMain.handle('hermes:connection-config:save', async (_event, payload) => {
   const config = coerceDesktopConnectionConfig(payload)
   writeDesktopConnectionConfig(config)
 
+  // The user may have just fixed a dead remote's URL/token — forget any
+  // unreachable-remote cooldowns so the next refresh probes the new target.
+  remoteAvailability.clear()
+
   return sanitizeDesktopConnectionConfig(config, payload?.profile)
 })
 ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
   const config = coerceDesktopConnectionConfig(payload)
   writeDesktopConnectionConfig(config)
+  remoteAvailability.clear()
 
   const key = connectionScopeKey(payload?.profile)
   const scope = key || ''
@@ -10040,8 +10119,11 @@ async function fetchProfilesSessionSlice(searchParams, remoteProfiles) {
 
 // Unified list: primary's local aggregate, with each remote profile's stale local
 // rows/totals swapped for the remote's real ones, re-sorted by recency and
-// re-windowed to the requested page. A dead remote contributes nothing rather
-// than breaking the sidebar.
+// re-windowed to the requested page. A dead or slow remote contributes nothing
+// rather than breaking — or stalling — the sidebar: unreachable remotes sit in
+// a cooldown and are skipped instantly, and a remote that can't answer within
+// its splice budget is deferred to the next refresh (its fetch keeps running
+// in the background, warming the pool). See remote-sessions.cjs.
 async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const limit = Math.max(1, Number(searchParams.get('limit')) || 20)
   const offset = Math.max(0, Number(searchParams.get('offset')) || 0)
@@ -10055,33 +10137,17 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   remoteParams.set('limit', String(limit + offset))
   remoteParams.set('offset', '0')
 
-  const remoteSet = new Set(remoteProfiles)
-  const merged = rowsOf(base).filter(s => !remoteSet.has(s?.profile))
-  const profileTotals = { ...(base.profile_totals || {}) }
-  let total = (Number(base.total) || 0) - remoteProfiles.reduce((n, p) => n + (profileTotals[p] || 0), 0)
-
-  // Swap each remote profile's stale local rows/total for the remote's real ones.
-  await Promise.all(
-    remoteProfiles.map(async name => {
-      const list = await remoteSessionList(name, remoteParams).catch(() => null)
-
-      if (!list) {
-        delete profileTotals[name] // dead remote → drop its stale local total too
-
-        return
-      }
-
-      const rows = rowsOf(list)
-      merged.push(...rows)
-      profileTotals[name] = Number(list.total) || rows.length
-      total += profileTotals[name]
-    })
-  )
-
-  const recency = s => s?.[order] ?? s?.started_at ?? 0
-  merged.sort((a, b) => recency(b) - recency(a))
-
-  return { ...(base as any), sessions: merged.slice(offset, offset + limit), total, profile_totals: profileTotals }
+  return spliceRemoteSessions({
+    base,
+    remoteProfiles,
+    limit,
+    offset,
+    order,
+    availability: remoteAvailability,
+    isWarm: name => Boolean(backendPool.get(String(name ?? '').trim())?.ready),
+    fetchRemote: name => remoteSessionList(name, remoteParams),
+    log: line => rememberLog(line)
+  })
 }
 
 ipcMain.handle('hermes:api', async (_event, request) => {

--- a/apps/desktop/electron/remote-sessions.test.ts
+++ b/apps/desktop/electron/remote-sessions.test.ts
@@ -1,0 +1,414 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  BUDGET_EXCEEDED,
+  createRemoteAvailability,
+  isNothingListeningError,
+  raceWithBudget,
+  spliceRemoteSessions,
+  waitForBackendReady
+} from './remote-sessions'
+
+const tick = () => new Promise(resolve => setImmediate(resolve))
+
+function codedError(code, message = code) {
+  const error: any = new Error(message)
+  error.code = code
+  return error
+}
+
+// ---------------------------------------------------------------------------
+// waitForBackendReady
+// ---------------------------------------------------------------------------
+
+test('waitForBackendReady resolves as soon as the probe succeeds', async () => {
+  let calls = 0
+  await waitForBackendReady(async () => {
+    calls += 1
+  }, { deadlineMs: 1_000, intervalMs: 0 })
+  assert.equal(calls, 1)
+})
+
+test('waitForBackendReady retries refused connections for local boots (no failFast)', async () => {
+  let calls = 0
+  await waitForBackendReady(
+    async () => {
+      calls += 1
+      if (calls < 3) throw codedError('ECONNREFUSED', 'connect ECONNREFUSED 127.0.0.1:9120')
+    },
+    { deadlineMs: 5_000, intervalMs: 0 }
+  )
+  assert.equal(calls, 3)
+})
+
+test('waitForBackendReady with failFast rejects on the first refused connection', async () => {
+  let calls = 0
+  await assert.rejects(
+    waitForBackendReady(
+      async () => {
+        calls += 1
+        throw codedError('ECONNREFUSED', 'connect ECONNREFUSED 127.0.0.1:19119')
+      },
+      { deadlineMs: 45_000, intervalMs: 0, failFast: true }
+    ),
+    /not listening/
+  )
+  assert.equal(calls, 1)
+})
+
+test('waitForBackendReady with failFast still retries non-final errors until the deadline', async () => {
+  // A timeout/5xx means the server may still be coming up — failFast must not
+  // short-circuit those, only "nothing is listening" errors.
+  let now = 0
+  let calls = 0
+  await assert.rejects(
+    waitForBackendReady(
+      async () => {
+        calls += 1
+        throw new Error('Timed out connecting to Hermes backend after 1500ms')
+      },
+      {
+        deadlineMs: 3_000,
+        intervalMs: 500,
+        failFast: true,
+        now: () => now,
+        sleep: async ms => {
+          now += ms
+        }
+      }
+    ),
+    /did not become ready/
+  )
+  assert.ok(calls >= 2, `expected multiple attempts, got ${calls}`)
+})
+
+test('waitForBackendReady enforces the deadline with an injected clock', async () => {
+  let now = 0
+  let calls = 0
+  await assert.rejects(
+    waitForBackendReady(
+      async () => {
+        calls += 1
+        throw new Error('boom')
+      },
+      {
+        deadlineMs: 2_000,
+        intervalMs: 500,
+        now: () => now,
+        sleep: async ms => {
+          now += ms
+        }
+      }
+    ),
+    /did not become ready: boom/
+  )
+  assert.equal(calls, 4) // t=0, 500, 1000, 1500 — t=2000 is past the deadline
+})
+
+// ---------------------------------------------------------------------------
+// createRemoteAvailability
+// ---------------------------------------------------------------------------
+
+test('availability cooldown opens after markDown and expires after cooldownMs', () => {
+  let now = 0
+  const availability = createRemoteAvailability({ cooldownMs: 30_000, now: () => now })
+
+  assert.equal(availability.inCooldown('taro'), false)
+  availability.markDown('taro', 'connect ECONNREFUSED')
+  assert.equal(availability.inCooldown('taro'), true)
+
+  now = 29_999
+  assert.equal(availability.inCooldown('taro'), true)
+
+  now = 30_000
+  assert.equal(availability.inCooldown('taro'), false)
+})
+
+test('availability markUp and clear lift the cooldown immediately', () => {
+  let now = 0
+  const availability = createRemoteAvailability({ cooldownMs: 30_000, now: () => now })
+
+  availability.markDown('taro')
+  availability.markUp('taro')
+  assert.equal(availability.inCooldown('taro'), false)
+
+  availability.markDown('taro')
+  availability.clear()
+  assert.equal(availability.inCooldown('taro'), false)
+})
+
+test('availability keys are trimmed and empty keys ignored', () => {
+  const availability = createRemoteAvailability({ cooldownMs: 30_000, now: () => 0 })
+  availability.markDown(' taro ')
+  assert.equal(availability.inCooldown('taro'), true)
+  availability.markDown('')
+  assert.equal(availability.inCooldown(''), false)
+})
+
+// ---------------------------------------------------------------------------
+// raceWithBudget
+// ---------------------------------------------------------------------------
+
+test('raceWithBudget returns the settled value within budget and clears its timer', async () => {
+  let cleared = false
+  const result = await raceWithBudget(
+    Promise.resolve('rows'),
+    1_000,
+    setTimeout,
+    timer => {
+      cleared = true
+      clearTimeout(timer)
+    }
+  )
+  assert.equal(result, 'rows')
+  assert.equal(cleared, true)
+})
+
+test('raceWithBudget resolves BUDGET_EXCEEDED when the promise is slower than the budget', async () => {
+  const never = new Promise(() => {})
+  const result = await raceWithBudget(never, 5)
+  assert.equal(result, BUDGET_EXCEEDED)
+})
+
+// ---------------------------------------------------------------------------
+// isNothingListeningError
+// ---------------------------------------------------------------------------
+
+test('isNothingListeningError recognizes dead-listener codes only', () => {
+  assert.equal(isNothingListeningError(codedError('ECONNREFUSED')), true)
+  assert.equal(isNothingListeningError(codedError('ENOTFOUND')), true)
+  assert.equal(isNothingListeningError(codedError('ETIMEDOUT')), false)
+  assert.equal(isNothingListeningError(new Error('plain')), false)
+  assert.equal(isNothingListeningError(null), false)
+})
+
+// ---------------------------------------------------------------------------
+// spliceRemoteSessions
+// ---------------------------------------------------------------------------
+
+const row = (id, profile, lastActive) => ({ id, profile, last_active: lastActive, started_at: lastActive })
+
+function baseFixture() {
+  return {
+    sessions: [row('local-1', 'default', 100), row('stale-taro', 'taro', 50)],
+    total: 12, // 10 local + 2 stale local rows for taro
+    profile_totals: { default: 10, taro: 2 }
+  }
+}
+
+test('splice swaps a healthy remote profile rows in, re-sorts, and fixes totals', async () => {
+  const availability = createRemoteAvailability({ now: () => 0 })
+  const result = await spliceRemoteSessions({
+    base: baseFixture(),
+    remoteProfiles: ['taro'],
+    limit: 10,
+    offset: 0,
+    order: 'last_active',
+    availability,
+    fetchRemote: async () => ({ sessions: [row('taro-1', 'taro', 200), row('taro-2', 'taro', 10)], total: 7 })
+  })
+
+  assert.deepEqual(result.sessions.map(s => s.id), ['taro-1', 'local-1', 'taro-2'])
+  assert.equal(result.total, 17) // 10 local + 7 real remote
+  assert.equal(result.profile_totals.taro, 7)
+  // stale local copy of the remote's rows must not survive the splice
+  assert.ok(!result.sessions.some(s => s.id === 'stale-taro'))
+})
+
+test('splice skips a remote in cooldown instantly without calling fetchRemote', async () => {
+  let now = 0
+  const availability = createRemoteAvailability({ cooldownMs: 30_000, now: () => now })
+  availability.markDown('taro', 'connect ECONNREFUSED')
+
+  let fetchCalls = 0
+  const result = await spliceRemoteSessions({
+    base: baseFixture(),
+    remoteProfiles: ['taro'],
+    limit: 10,
+    offset: 0,
+    order: 'last_active',
+    availability,
+    fetchRemote: async () => {
+      fetchCalls += 1
+      return { sessions: [], total: 0 }
+    }
+  })
+
+  assert.equal(fetchCalls, 0)
+  assert.deepEqual(result.sessions.map(s => s.id), ['local-1'])
+  assert.equal(result.total, 10) // remote contributes nothing
+  assert.equal('taro' in result.profile_totals, false)
+})
+
+test('splice tolerates a rejecting remote: local rows render, totals drop the remote', async () => {
+  const availability = createRemoteAvailability({ now: () => 0 })
+  const result = await spliceRemoteSessions({
+    base: baseFixture(),
+    remoteProfiles: ['taro'],
+    limit: 10,
+    offset: 0,
+    order: 'last_active',
+    availability,
+    fetchRemote: async () => {
+      throw codedError('ECONNREFUSED', 'connect ECONNREFUSED 127.0.0.1:19119')
+    }
+  })
+
+  assert.deepEqual(result.sessions.map(s => s.id), ['local-1'])
+  assert.equal(result.total, 10)
+  assert.equal('taro' in result.profile_totals, false)
+})
+
+test('splice gives up after the budget but leaves the slow fetch running for the next refresh', async () => {
+  const availability = createRemoteAvailability({ now: () => 0 })
+  let settleLate
+  const slow = new Promise(resolve => {
+    settleLate = resolve
+  })
+
+  const result = await spliceRemoteSessions({
+    base: baseFixture(),
+    remoteProfiles: ['taro'],
+    limit: 10,
+    offset: 0,
+    order: 'last_active',
+    availability,
+    coldBudgetMs: 5,
+    fetchRemote: () => slow
+  })
+
+  assert.deepEqual(result.sessions.map(s => s.id), ['local-1'])
+  assert.equal('taro' in result.profile_totals, false)
+
+  // Late settle must not throw or corrupt anything (fetch kept running).
+  settleLate({ sessions: [row('taro-1', 'taro', 200)], total: 1 })
+  await tick()
+})
+
+test('splice late REJECTION after budget does not produce an unhandled rejection', async () => {
+  const availability = createRemoteAvailability({ now: () => 0 })
+  let rejectLate
+  const slow = new Promise((_resolve, reject) => {
+    rejectLate = reject
+  })
+
+  const unhandled = []
+  const onUnhandled = reason => unhandled.push(reason)
+  process.on('unhandledRejection', onUnhandled)
+
+  try {
+    await spliceRemoteSessions({
+      base: baseFixture(),
+      remoteProfiles: ['taro'],
+      limit: 10,
+      offset: 0,
+      order: 'last_active',
+      availability,
+      coldBudgetMs: 5,
+      fetchRemote: () => slow
+    })
+
+    rejectLate(codedError('ECONNREFUSED', 'late failure'))
+    await tick()
+    await tick()
+    assert.deepEqual(unhandled, [])
+  } finally {
+    process.off('unhandledRejection', onUnhandled)
+  }
+})
+
+test('splice clears the cooldown via markUp when a remote answers again', async () => {
+  let now = 0
+  const availability = createRemoteAvailability({ cooldownMs: 30_000, now: () => now })
+  availability.markDown('taro')
+  now = 31_000 // cooldown expired → splice probes again
+
+  const result = await spliceRemoteSessions({
+    base: baseFixture(),
+    remoteProfiles: ['taro'],
+    limit: 10,
+    offset: 0,
+    order: 'last_active',
+    availability,
+    fetchRemote: async () => ({ sessions: [row('taro-1', 'taro', 200)], total: 1 })
+  })
+
+  assert.equal(result.profile_totals.taro, 1)
+  assert.equal(availability.inCooldown('taro'), false)
+})
+
+test('splice uses the warm budget for warm profiles', async () => {
+  const availability = createRemoteAvailability({ now: () => 0 })
+  const budgets = []
+
+  await spliceRemoteSessions({
+    base: baseFixture(),
+    remoteProfiles: ['taro'],
+    limit: 10,
+    offset: 0,
+    order: 'last_active',
+    availability,
+    isWarm: () => true,
+    coldBudgetMs: 1,
+    warmBudgetMs: 50,
+    setTimeoutFn: (fn, ms) => {
+      budgets.push(ms)
+      return setTimeout(fn, ms)
+    },
+    fetchRemote: async () => ({ sessions: [], total: 0 })
+  })
+
+  assert.deepEqual(budgets, [50])
+})
+
+test('splice windows the merged list to limit/offset', async () => {
+  const availability = createRemoteAvailability({ now: () => 0 })
+  const base = {
+    sessions: [row('l1', 'default', 400), row('l2', 'default', 300)],
+    total: 2,
+    profile_totals: { default: 2 }
+  }
+
+  const result = await spliceRemoteSessions({
+    base,
+    remoteProfiles: ['taro'],
+    limit: 2,
+    offset: 1,
+    order: 'last_active',
+    availability,
+    fetchRemote: async () => ({ sessions: [row('t1', 'taro', 500), row('t2', 'taro', 100)], total: 2 })
+  })
+
+  // recency order: t1(500), l1(400), l2(300), t2(100) → offset 1, limit 2
+  assert.deepEqual(result.sessions.map(s => s.id), ['l1', 'l2'])
+  assert.equal(result.total, 4)
+})
+
+test('splice handles several remotes independently (one down, one up)', async () => {
+  const availability = createRemoteAvailability({ now: () => 0 })
+  availability.markDown('dead-rig')
+
+  const result = await spliceRemoteSessions({
+    base: {
+      sessions: [row('l1', 'default', 100)],
+      total: 1,
+      profile_totals: { default: 1 }
+    },
+    remoteProfiles: ['dead-rig', 'taro'],
+    limit: 10,
+    offset: 0,
+    order: 'last_active',
+    availability,
+    fetchRemote: async name => {
+      assert.equal(name, 'taro')
+      return { sessions: [row('t1', 'taro', 200)], total: 3 }
+    }
+  })
+
+  assert.deepEqual(result.sessions.map(s => s.id), ['t1', 'l1'])
+  assert.equal(result.total, 4)
+  assert.equal(result.profile_totals.taro, 3)
+  assert.equal('dead-rig' in result.profile_totals, false)
+})

--- a/apps/desktop/electron/remote-sessions.ts
+++ b/apps/desktop/electron/remote-sessions.ts
@@ -1,0 +1,281 @@
+// Remote-profile session helpers for the desktop main process.
+//
+// Why this module exists: the sidebar's session list is the first thing the
+// user sees, and it must never be held hostage by remote I/O. A profile that
+// points at a remote backend (connection.json `profiles[name]`) participates
+// in the unified session list, but a dead tunnel or sleeping host used to
+// stall every sidebar refresh for the full local-boot readiness deadline
+// (45s) — on boot AND on every subsequent refresh, because a failed pool
+// entry is dropped and re-probed from scratch each time.
+//
+// The contract enforced here:
+//   - Reachability probes against a REMOTE backend fail fast: short deadline,
+//     short per-attempt timeout, and an immediate reject on "nothing is
+//     listening" errors (ECONNREFUSED & co). The long deadline only makes
+//     sense for freshly spawned LOCAL children, where the port stays refused
+//     until uvicorn binds mid-boot.
+//   - A remote that failed its probe enters a cooldown window. While in
+//     cooldown the session splice skips it instantly instead of re-probing.
+//   - The splice itself runs on a budget: a remote that cannot produce rows
+//     within its budget contributes nothing to THIS refresh. Its fetch keeps
+//     running in the background (warming the pool), so the next refresh picks
+//     the rows up without paying the cold-start cost again.
+
+// Reachability probe for an already-running remote backend. A healthy remote
+// answers /api/status in tens of milliseconds; 3s absorbs a tailnet hiccup
+// without making a human wait on a dead one.
+const REMOTE_PROBE_DEADLINE_MS = 3_000
+const REMOTE_PROBE_ATTEMPT_TIMEOUT_MS = 1_500
+// How long a failed remote is skipped by the session splice before the next
+// real probe. Long enough to stop per-refresh stalls, short enough that a
+// revived tunnel reappears without user action.
+const REMOTE_DOWN_COOLDOWN_MS = 30_000
+// Sidebar wait ceilings for the remote splice. "Cold" = the profile's backend
+// connection is not established yet (probe + fetch must both fit); "warm" =
+// an established connection where only the list fetch remains. These are
+// intentionally conservative for interactive sidebar refreshes: a slow WAN
+// remote may miss one refresh cycle, but the in-flight fetch keeps warming the
+// pool so a later refresh can pick it up without blocking the local list.
+const COLD_REMOTE_SPLICE_BUDGET_MS = 2_000
+const WARM_REMOTE_SPLICE_BUDGET_MS = 5_000
+
+// Local readiness loop defaults (historic waitForHermes behavior).
+const LOCAL_BOOT_DEADLINE_MS = 45_000
+const READINESS_RETRY_INTERVAL_MS = 500
+
+// Errors that mean "no server is listening at this address" rather than "the
+// server exists but is still coming up". For a remote probe these are final:
+// retrying cannot succeed until something rebinds the port, and that never
+// happens within a 3s window. (EHOSTDOWN is the macOS cousin of EHOSTUNREACH.)
+const NOTHING_LISTENING_CODES = new Set([
+  'ECONNREFUSED',
+  'EHOSTDOWN',
+  'EHOSTUNREACH',
+  'ENETDOWN',
+  'ENETUNREACH',
+  'ENOTFOUND'
+])
+
+const BUDGET_EXCEEDED = Symbol('remote-splice-budget-exceeded')
+
+function isNothingListeningError(error) {
+  return Boolean(error && NOTHING_LISTENING_CODES.has(error.code))
+}
+
+/**
+ * Poll `probe()` until it resolves or the deadline passes. This is the core
+ * of waitForHermes, extracted so the deadline/fail-fast behavior is unit
+ * testable without a real HTTP server.
+ *
+ * Options:
+ *   deadlineMs   — total wall-clock budget (default 45s: local child boot).
+ *   intervalMs   — sleep between attempts (default 500ms).
+ *   failFast     — reject on the FIRST "nothing is listening" error instead
+ *                  of retrying. Correct for remotes (already supposed to be
+ *                  up); wrong for local children (port is refused until the
+ *                  server binds mid-boot).
+ *   now / sleep  — injectable clocks for tests.
+ */
+async function waitForBackendReady(probe, options: any = {}) {
+  const deadlineMs = Number.isFinite(options.deadlineMs) && options.deadlineMs > 0
+    ? options.deadlineMs
+    : LOCAL_BOOT_DEADLINE_MS
+  const intervalMs = Number.isFinite(options.intervalMs) && options.intervalMs >= 0
+    ? options.intervalMs
+    : READINESS_RETRY_INTERVAL_MS
+  const failFast = Boolean(options.failFast)
+  const now = options.now || Date.now
+  const sleep = options.sleep || (ms => new Promise(resolve => setTimeout(resolve, ms)))
+
+  const deadline = now() + deadlineMs
+  let lastError = null
+
+  while (now() < deadline) {
+    try {
+      await probe()
+      return
+    } catch (error) {
+      lastError = error
+      if (failFast && isNothingListeningError(error)) {
+        throw new Error(`Hermes backend is not listening: ${error.message || error.code}`)
+      }
+      await sleep(intervalMs)
+    }
+  }
+
+  throw new Error(`Hermes backend did not become ready: ${lastError?.message || 'timeout'}`)
+}
+
+/**
+ * Cooldown registry for unreachable remote backends, keyed by profile name.
+ * Purely in-memory: a restart of the app retries every remote once.
+ */
+function createRemoteAvailability(options: any = {}) {
+  const cooldownMs = Number.isFinite(options.cooldownMs) && options.cooldownMs > 0
+    ? options.cooldownMs
+    : REMOTE_DOWN_COOLDOWN_MS
+  const now = options.now || Date.now
+  const log = options.log || (() => {})
+  const downUntil = new Map()
+
+  const keyOf = profile => String(profile ?? '').trim()
+
+  return {
+    markDown(profile, reason = null) {
+      const key = keyOf(profile)
+      if (!key) return
+      const until = now() + cooldownMs
+      downUntil.set(key, { until, reason: reason || 'unreachable' })
+      log(
+        `[remote-sessions] remote profile "${key}" marked unreachable for ${Math.round(cooldownMs / 1000)}s` +
+          (reason ? ` (${reason})` : '')
+      )
+    },
+    markUp(profile) {
+      const key = keyOf(profile)
+      if (downUntil.delete(key)) {
+        log(`[remote-sessions] remote profile "${key}" is reachable again`)
+      }
+    },
+    inCooldown(profile) {
+      const key = keyOf(profile)
+      const entry = downUntil.get(key)
+      if (!entry) return false
+      if (now() >= entry.until) {
+        downUntil.delete(key)
+        return false
+      }
+      return true
+    },
+    clear() {
+      downUntil.clear()
+    }
+  }
+}
+
+/** Resolve to BUDGET_EXCEEDED if `promise` doesn't settle within budgetMs. */
+async function raceWithBudget(promise, budgetMs, setTimeoutFn = setTimeout, clearTimeoutFn = clearTimeout) {
+  let timer = null
+  try {
+    return await Promise.race([
+      promise,
+      new Promise(resolve => {
+        timer = setTimeoutFn(() => resolve(BUDGET_EXCEEDED), budgetMs)
+      })
+    ])
+  } finally {
+    if (timer !== null) clearTimeoutFn(timer)
+  }
+}
+
+const rowsOf = data => (Array.isArray(data?.sessions) ? data.sessions : [])
+
+/**
+ * Merge each remote profile's session rows into the primary's local aggregate,
+ * re-sort by recency, and re-window to the requested page — without ever
+ * letting a dead or slow remote stall the result.
+ *
+ * Per remote profile, in parallel:
+ *   - in cooldown            → skip instantly (and drop its stale local total).
+ *   - fetch settles in budget → splice its rows, record its real total.
+ *   - fetch fails            → contributes nothing; the probe layer
+ *                              (spawnPoolBackend) owns marking it down.
+ *   - budget exceeded        → contributes nothing THIS refresh; the fetch
+ *                              keeps warming the pool for the next one.
+ *
+ * `base` is consumed as-is: callers pass the primary's response (already
+ * containing every LOCAL profile's rows plus possibly-stale rows for remote
+ * profiles, which are swapped out here).
+ */
+async function spliceRemoteSessions({
+  base,
+  remoteProfiles,
+  limit,
+  offset,
+  order,
+  fetchRemote,
+  availability,
+  isWarm = () => false,
+  coldBudgetMs = COLD_REMOTE_SPLICE_BUDGET_MS,
+  warmBudgetMs = WARM_REMOTE_SPLICE_BUDGET_MS,
+  log = () => {},
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout
+}: any) {
+  const safeLimit = Math.max(1, Number(limit) || 20)
+  const safeOffset = Math.max(0, Number(offset) || 0)
+  const recencyField = order === 'started_at' ? 'started_at' : 'last_active'
+
+  const remoteSet = new Set(remoteProfiles)
+  const merged = rowsOf(base).filter(s => !remoteSet.has(s?.profile))
+  const profileTotals = { ...(base?.profile_totals || {}) }
+  let total = (Number(base?.total) || 0) - remoteProfiles.reduce((n, p) => n + (profileTotals[p] || 0), 0)
+
+  await Promise.all(
+    remoteProfiles.map(async name => {
+      if (availability?.inCooldown(name)) {
+        log(`[remote-sessions] splice skipping "${name}" (in unreachable cooldown)`)
+        delete profileTotals[name]
+        return
+      }
+
+      const budgetMs = isWarm(name) ? warmBudgetMs : coldBudgetMs
+      const pending = fetchRemote(name)
+      let list = null
+      try {
+        const settled = await raceWithBudget(pending, budgetMs, setTimeoutFn, clearTimeoutFn)
+        if (settled === BUDGET_EXCEEDED) {
+          // Leave the fetch running: it is warming the profile's backend
+          // connection, so the NEXT refresh gets the rows instantly. Swallow
+          // its eventual outcome so a late rejection can't crash the process.
+          pending.catch(() => {})
+          log(`[remote-sessions] splice timed out waiting ${budgetMs}ms for "${name}"; deferring to next refresh`)
+          delete profileTotals[name]
+          return
+        }
+        list = settled
+      } catch (error) {
+        log(`[remote-sessions] splice fetch for "${name}" failed: ${error?.message || error}`)
+        delete profileTotals[name]
+        return
+      }
+
+      if (!list) {
+        delete profileTotals[name]
+        return
+      }
+
+      availability?.markUp(name)
+      const rows = rowsOf(list)
+      merged.push(...rows)
+      profileTotals[name] = Number(list.total) || rows.length
+      total += profileTotals[name]
+    })
+  )
+
+  const recency = s => s?.[recencyField] ?? s?.started_at ?? 0
+  merged.sort((a, b) => recency(b) - recency(a))
+
+  return {
+    ...base,
+    sessions: merged.slice(safeOffset, safeOffset + safeLimit),
+    total,
+    profile_totals: profileTotals
+  }
+}
+
+export {
+  BUDGET_EXCEEDED,
+  COLD_REMOTE_SPLICE_BUDGET_MS,
+  LOCAL_BOOT_DEADLINE_MS,
+  READINESS_RETRY_INTERVAL_MS,
+  REMOTE_DOWN_COOLDOWN_MS,
+  REMOTE_PROBE_ATTEMPT_TIMEOUT_MS,
+  REMOTE_PROBE_DEADLINE_MS,
+  WARM_REMOTE_SPLICE_BUDGET_MS,
+  createRemoteAvailability,
+  isNothingListeningError,
+  raceWithBudget,
+  spliceRemoteSessions,
+  waitForBackendReady
+}


### PR DESCRIPTION
## Why

With a remote profile configured in `connection.json` (`profiles[name].mode: "remote"`), the desktop sidebar's session list could wait the full local-backend boot deadline whenever that remote was unreachable. A dead SSH tunnel or sleeping host made the app look broken: the gateway was connected, cron sections loaded, but the session rows stayed skeletal for roughly 45 seconds on boot and on later refreshes.

Mechanism: `GET /api/profiles/sessions` called `mergeRemoteProfileSessions`, which waited on `ensureBackend(remoteProfile)` -> `spawnPoolBackend` -> `waitForHermes`. The 45s readiness loop is correct for a freshly spawned local child, but wrong for a remote backend that should already be listening. The failed pool entry was also deleted, so the next refresh started the same long probe again.

## What changed

- Added `apps/desktop/electron/remote-sessions.cjs`, a dependency-injected helper module for remote readiness probing, cooldowns, and bounded session splicing.
- Kept local backend boot behavior unchanged through the default `waitForHermes` path.
- Made remote profile probes short and fail-fast for "nothing is listening" errors, with a cooldown so repeated sidebar refreshes skip known-down remotes immediately.
- Let remote session fetches keep warming in the background when they exceed the sidebar splice budget, so reachable-but-slow remotes can appear on the next refresh without blocking the current local rows.
- Added the remote-sessions platform tests and kept the newer `update-remote.test.cjs` in the desktop platform script.

## Repair note

This PR branch was repaired after drifting into conflicts with current `upstream/main`. The current head is a clean cherry-pick onto `955fa4006`: `bc388b5f60c5f06faa1b803821bb7fcf208eed9c`. The PR is mergeable and the diff is limited to the four desktop/electron files shown here.

## Verification

- `npm ci --workspace apps/desktop`
- `node --check apps/desktop/electron/main.cjs`
- `node --check apps/desktop/electron/remote-sessions.cjs`
- `npm --prefix apps/desktop run test:desktop:platforms` -> `145/145` tests passed
- `npm --prefix apps/desktop run typecheck`
- `git diff --check upstream/main..HEAD`

Notes: `npm ci` reports the existing Node engine warning for `@icons-pack/react-simple-icons` under Node v22.22.3 plus pre-existing package deprecation warnings.