### PR TITLE
feat(api-server): gate reasoning output behind show_reasoning

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1743,6 +1743,29 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.debug("SessionDB unavailable for API server: %s", e)
             return None
 
+    def _reasoning_items_enabled(self) -> bool:
+        """True when /v1/responses should emit ``reasoning`` output items.
+
+        Honors ``display.platforms.api_server.show_reasoning`` via the
+        standard per-platform display resolver (#7556).  Defaults to False
+        so the wire format is unchanged for existing clients (#21655).
+        """
+        try:
+            from gateway.display_config import resolve_display_setting
+            from gateway.run import _load_gateway_config
+
+            return bool(resolve_display_setting(
+                _load_gateway_config(), "api_server", "show_reasoning", False,
+            ))
+        except Exception as exc:
+            # Broad on purpose — config load can raise import/parse/IO errors,
+            # and a broken config must not 500 every /v1/responses request — but
+            # never silently: surface why the gate fell back to off.
+            logger.debug(
+                "show_reasoning gate resolution failed; defaulting to off: %s", exc
+            )
+            return False
+
     # ------------------------------------------------------------------
     # Agent creation helper
     # ------------------------------------------------------------------
@@ -1827,6 +1850,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        reasoning_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
     ) -> Any:
@@ -1946,6 +1970,7 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
+            reasoning_callback=reasoning_callback,
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
@@ -3279,6 +3304,7 @@ class APIServerAdapter(BasePlatformAdapter):
         conversation: Optional[str],
         store: bool,
         session_id: str,
+        show_reasoning: bool = False,
         gateway_session_key: Optional[str] = None,
     ) -> "web.StreamResponse":
         """Write an SSE stream for POST /v1/responses (OpenAI Responses API).
@@ -3578,6 +3604,86 @@ class APIServerAdapter(BasePlatformAdapter):
                     "item": output_item,
                 })
 
+            # ── Reasoning item state (#21655, #7556) ──
+            # Real reasoning streams as deltas (``delta.reasoning_content``
+            # / thinking blocks) via the agent's ``reasoning_callback``.
+            # Deltas accumulate into one open ``reasoning`` output item per
+            # burst; the item closes when the model moves on (tool start,
+            # answer text, or end of stream).  Clients that render
+            # Responses reasoning items (e.g. Open WebUI) show it live as
+            # a collapsible thinking block.
+            _open_reasoning: Optional[Dict[str, Any]] = None
+
+            async def _emit_reasoning_delta(text: str) -> None:
+                """Open (if needed) the current reasoning item and append a delta."""
+                nonlocal _open_reasoning, output_index
+                if _open_reasoning is None:
+                    if not text.strip():
+                        return  # never open an item for leading whitespace
+                    idx = output_index
+                    output_index += 1
+                    _open_reasoning = {
+                        "id": f"rs_{uuid.uuid4().hex[:24]}",
+                        "idx": idx,
+                        "parts": [],
+                    }
+                    await _write_event("response.output_item.added", {
+                        "type": "response.output_item.added",
+                        "output_index": idx,
+                        "item": {
+                            "id": _open_reasoning["id"],
+                            "type": "reasoning",
+                            "summary": [],
+                            "status": "in_progress",
+                        },
+                    })
+                    await _write_event("response.reasoning_summary_part.added", {
+                        "type": "response.reasoning_summary_part.added",
+                        "item_id": _open_reasoning["id"],
+                        "output_index": idx,
+                        "summary_index": 0,
+                        "part": {"type": "summary_text", "text": ""},
+                    })
+                _open_reasoning["parts"].append(text)
+                await _write_event("response.reasoning_summary_text.delta", {
+                    "type": "response.reasoning_summary_text.delta",
+                    "item_id": _open_reasoning["id"],
+                    "output_index": _open_reasoning["idx"],
+                    "summary_index": 0,
+                    "delta": text,
+                })
+
+            async def _close_reasoning() -> None:
+                """Finalize the open reasoning item, if any."""
+                nonlocal _open_reasoning
+                if _open_reasoning is None:
+                    return
+                text = "".join(_open_reasoning["parts"])
+                await _write_event("response.reasoning_summary_text.done", {
+                    "type": "response.reasoning_summary_text.done",
+                    "item_id": _open_reasoning["id"],
+                    "output_index": _open_reasoning["idx"],
+                    "summary_index": 0,
+                    "text": text,
+                })
+                done_item = {
+                    "id": _open_reasoning["id"],
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": text}],
+                    "status": "completed",
+                }
+                await _write_event("response.output_item.done", {
+                    "type": "response.output_item.done",
+                    "output_index": _open_reasoning["idx"],
+                    "item": done_item,
+                })
+                # Incremental events carry the full reasoning text; the final_items
+                # pass trims this same item for response.completed / the store,
+                # exactly like function_call arguments (clients already received
+                # the full text via the live events above).
+                emitted_items.append(done_item)
+                _open_reasoning = None
+
             # Main drain loop — thread-safe queue fed by agent callbacks.
             async def _dispatch(it) -> None:
                 """Route a queue item to the correct SSE emitter.
@@ -3595,10 +3701,15 @@ class APIServerAdapter(BasePlatformAdapter):
                     if _batch_buf:
                         await _flush_batch()
                     if tag == "__tool_started__":
+                        await _close_reasoning()
                         await _emit_tool_started(payload)
                     elif tag == "__tool_completed__":
                         await _emit_tool_completed(payload)
+                    elif tag == "__reasoning_delta__":
+                        await _emit_reasoning_delta(payload)
                 elif isinstance(it, str):
+                    # Answer text means the current reasoning burst is over.
+                    await _close_reasoning()
                     # Batch text deltas — append to buffer, flush on timer
                     _batch_buf.append(it)
                     if _batch_timer is None:
@@ -3668,6 +3779,8 @@ class APIServerAdapter(BasePlatformAdapter):
             # Flush any final batched text before processing result
             if _batch_buf:
                 await _flush_batch()
+            # A reasoning-only tail (no text/tool after it) closes here.
+            await _close_reasoning()
 
             # Pick up agent result + usage from the completed task
             try:
@@ -3684,6 +3797,43 @@ class APIServerAdapter(BasePlatformAdapter):
                     final_response_text = agent_final
                 if isinstance(result, dict) and result.get("error") and not final_response_text:
                     agent_error = _redact_api_error_text(result["error"])
+                if show_reasoning and not any(
+                    item.get("type") == "reasoning" for item in emitted_items
+                ):
+                    start_index = self._response_messages_turn_start_index(
+                        conversation_history,
+                        user_message,
+                        result,
+                    )
+                    for msg in result.get("messages", [])[start_index:]:
+                        if msg.get("role") != "assistant":
+                            continue
+                        reasoning_text = msg.get("reasoning_content") or msg.get("reasoning")
+                        if not isinstance(reasoning_text, str) or not reasoning_text.strip():
+                            continue
+                        await _emit_reasoning_delta(reasoning_text)
+                        await _close_reasoning()
+                        # The live SSE events are necessarily emitted after the
+                        # tool events that already streamed; reposition the
+                        # recovered item in front of this message's own
+                        # function_call so the stored/completed output interleaves
+                        # reasoning -> tool -> result -> reasoning, matching the
+                        # non-streaming _extract_output_items path.
+                        recovered = emitted_items.pop()
+                        anchor_id = next(
+                            (tc.get("id") for tc in (msg.get("tool_calls") or [])),
+                            None,
+                        )
+                        insert_at = len(emitted_items)
+                        if anchor_id is not None:
+                            for idx, existing in enumerate(emitted_items):
+                                if (
+                                    existing.get("type") == "function_call"
+                                    and existing.get("call_id") == anchor_id
+                                ):
+                                    insert_at = idx
+                                    break
+                        emitted_items.insert(insert_at, recovered)
             except Exception as e:  # noqa: BLE001
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
                 agent_error = _redact_api_error_text(e)
@@ -3743,6 +3893,8 @@ class APIServerAdapter(BasePlatformAdapter):
                             if len(_text) > 1000:
                                 _first["text"] = _text[:500] + "...[" + str(len(_text) - 500) + " more chars]"
                                 _item["output"] = [_first]
+                elif _item.get("type") == "reasoning":
+                    APIServerAdapter._trim_reasoning_item_for_terminal(_item)
 
             final_items.append({
                 "type": "message",
@@ -3916,6 +4068,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 if isinstance(item, str):
                     input_messages.append({"role": "user", "content": item})
                 elif isinstance(item, dict):
+                    # Spec-compliant clients may echo ``reasoning`` output
+                    # items back in input.  They carry no role/content —
+                    # treating them as messages injects empty user turns
+                    # (or a 400 when last), so skip them outright (#21655).
+                    if str(item.get("type") or "").strip().lower() == "reasoning":
+                        continue
                     role = item.get("role", "user")
                     try:
                         content = _normalize_multimodal_content(item.get("content", ""))
@@ -3938,6 +4096,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=400,
                 )
             for i, entry in enumerate(raw_history):
+                # Echoed reasoning output items carry no role/content —
+                # skip them here exactly like the input array does, instead
+                # of rejecting the whole request (#21655).
+                if isinstance(entry, dict) and str(entry.get("type") or "").strip().lower() == "reasoning":
+                    continue
                 if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
                     return web.json_response(
                         _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
@@ -3983,6 +4146,9 @@ class APIServerAdapter(BasePlatformAdapter):
         route = self._resolve_route(body.get("model"))
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
+        # Resolved once per request so the streamed events and the final
+        # envelope can never disagree on the gate.
+        show_reasoning = self._reasoning_items_enabled()
         if stream:
             # Streaming branch — emit OpenAI Responses SSE events as the
             # agent runs so frontends can render text deltas and tool
@@ -4002,9 +4168,23 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 The structured Responses stream uses ``tool_start_callback``
                 and ``tool_complete_callback`` for exact call-id correlation,
-                so progress events are currently ignored here.
+                so progress events are ignored here.  Note in particular
+                that ``reasoning.available`` is NOT forwarded: it carries
+                the assistant message *content* (see conversation_loop), not
+                the model's reasoning — real reasoning arrives through
+                ``reasoning_callback`` below (#21655, #7556).
                 """
                 return
+
+            _on_reasoning = None
+            if show_reasoning:
+                def _on_reasoning(text):
+                    """Forward real reasoning deltas (``delta.reasoning_content``
+                    / thinking blocks) into the SSE stream, where they
+                    accumulate into spec-shaped ``reasoning`` output items.
+                    Gated by ``display.platforms.api_server.show_reasoning``."""
+                    if text:
+                        _stream_q.put(("__reasoning_delta__", str(text)))
 
             def _on_tool_start(tool_call_id, function_name, function_args):
                 """Queue a started tool for live function_call streaming."""
@@ -4033,6 +4213,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_progress_callback=_on_tool_progress,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
+                reasoning_callback=_on_reasoning,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 route=route,
@@ -4058,6 +4239,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 instructions=instructions,
                 conversation=conversation,
                 store=store,
+                show_reasoning=show_reasoning,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
             )
@@ -4130,7 +4312,11 @@ class APIServerAdapter(BasePlatformAdapter):
             user_message,
             result,
         )
-        output_items = self._extract_output_items(result, start_index=output_start_index)
+        output_items = self._extract_output_items(
+            result,
+            start_index=output_start_index,
+            include_reasoning=show_reasoning,
+        )
 
         response_data = {
             "id": response_id,
@@ -4618,11 +4804,16 @@ class APIServerAdapter(BasePlatformAdapter):
         return out
 
     @staticmethod
-    def _extract_output_items(result: Dict[str, Any], start_index: int = 0) -> List[Dict[str, Any]]:
+    def _extract_output_items(
+        result: Dict[str, Any], start_index: int = 0, include_reasoning: bool = False,
+    ) -> List[Dict[str, Any]]:
         """
         Build the output item array from the agent's messages.
 
         Walks *result["messages"]* starting at *start_index* and emits:
+        - ``reasoning`` items for assistant messages carrying reasoning,
+          when *include_reasoning* is True (#21655; gated by
+          ``display.platforms.api_server.show_reasoning``)
         - ``function_call`` items for each tool_call on assistant messages
         - ``function_call_output`` items for each tool-role message
         - a final ``message`` item with the assistant's text reply
@@ -4634,8 +4825,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         for msg in messages:
             role = msg.get("role")
-            if role == "assistant" and msg.get("tool_calls"):
-                for tc in msg["tool_calls"]:
+            if role == "assistant":
+                if include_reasoning:
+                    items.extend(APIServerAdapter._extract_reasoning_items([msg]))
+                for tc in msg.get("tool_calls", []):
                     func = tc.get("function", {})
                     items.append({
                         "type": "function_call",
@@ -4666,6 +4859,35 @@ class APIServerAdapter(BasePlatformAdapter):
             ],
         })
         return items
+
+    @staticmethod
+    def _extract_reasoning_items(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Return completed Responses-style reasoning items from assistant messages."""
+        items: List[Dict[str, Any]] = []
+        for msg in messages:
+            if msg.get("role") != "assistant":
+                continue
+            reasoning_text = msg.get("reasoning_content") or msg.get("reasoning")
+            if isinstance(reasoning_text, str) and reasoning_text.strip():
+                items.append({
+                    "id": f"rs_{uuid.uuid4().hex[:24]}",
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": reasoning_text}],
+                    "status": "completed",
+                })
+        return items
+
+    @staticmethod
+    def _trim_reasoning_item_for_terminal(item: Dict[str, Any]) -> Dict[str, Any]:
+        """Trim large reasoning summaries for terminal envelope/storage surfaces."""
+        summary = item.get("summary", [])
+        if isinstance(summary, list) and summary:
+            first = summary[0]
+            if isinstance(first, dict):
+                text = first.get("text", "")
+                if len(text) > 1000:
+                    first["text"] = text[:500] + "...[" + str(len(text) - 500) + " more chars]"
+        return item
 
     # ------------------------------------------------------------------
     # Agent execution
@@ -4745,6 +4967,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        reasoning_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
@@ -4787,6 +5010,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_progress_callback=tool_progress_callback,
                         tool_start_callback=tool_start_callback,
                         tool_complete_callback=tool_complete_callback,
+                        reasoning_callback=reasoning_callback,
                         gateway_session_key=gateway_session_key,
                         route=route,
                     )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -67,8 +67,6 @@ _BROWSER_CONTROL_PROTOCOL_VERSION = 1
 _STATIC_FEATURE_FLAGS = {
     "run_status": True, "run_events_sse": True, "run_stop": True, "run_steer": True,
     "run_approval_response": True, "tool_progress_events": True, "approval_events": True,
-    # Reasoning-capable providers stream thinking separately from assistant text.
-    "reasoning_streaming": True,
     "session_resources": True, "model_options": True, "session_chat": True,
     "session_chat_streaming": True, "session_fork": True, "session_model_lock": True,
     "admin_config_rw": False, "jobs_admin": False, "memory_write_api": False,
@@ -2099,6 +2097,10 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         model = self._recover_or_record_model(model, runtime_kwargs, gateway_session_key)
         return model, session_override, request_model, request_provider
 
+    def _reasoning_enabled(self) -> bool:
+        from gateway.run import _load_gateway_config, _resolve_gateway_display_bool
+        return _resolve_gateway_display_bool(_load_gateway_config(), "api_server", "show_reasoning")
+
     def _create_agent(
         self, ephemeral_system_prompt: Optional[str] = None, session_id: Optional[str] = None,
         stream_delta_callback=None, reasoning_callback=None, tool_progress_callback=None, tool_start_callback=None,
@@ -2152,7 +2154,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             "enabled_toolsets": enabled_toolsets, "session_id": session_id,
             "platform": "api_server",
             "stream_delta_callback": stream_delta_callback,
-            "reasoning_callback": reasoning_callback,
+            "reasoning_callback": reasoning_callback if self._reasoning_enabled() else None,
             "tool_progress_callback": tool_progress_callback,
             "tool_start_callback": tool_start_callback,
             "tool_complete_callback": tool_complete_callback,
@@ -2262,6 +2264,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 "responses_api": True, "responses_streaming": True, "run_submission": True,
                 "runs_idempotency": _api_runs._idempotency_capabilities(self, store_type=RunIdempotencyStore),
                 **_STATIC_FEATURE_FLAGS,
+                "reasoning_streaming": self._reasoning_enabled(),
                 "cors": bool(self._cors_origins),
                 # Always advertised for feature-detection; enabled follows config.
                 "browser_extension_control": {

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -67,6 +67,8 @@ _BROWSER_CONTROL_PROTOCOL_VERSION = 1
 _STATIC_FEATURE_FLAGS = {
     "run_status": True, "run_events_sse": True, "run_stop": True, "run_steer": True,
     "run_approval_response": True, "tool_progress_events": True, "approval_events": True,
+    # Reasoning-capable providers stream thinking separately from assistant text.
+    "reasoning_streaming": True,
     "session_resources": True, "model_options": True, "session_chat": True,
     "session_chat_streaming": True, "session_fork": True, "session_model_lock": True,
     "admin_config_rw": False, "jobs_admin": False, "memory_write_api": False,
@@ -2099,7 +2101,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
 
     def _create_agent(
         self, ephemeral_system_prompt: Optional[str] = None, session_id: Optional[str] = None,
-        stream_delta_callback=None, tool_progress_callback=None, tool_start_callback=None,
+        stream_delta_callback=None, reasoning_callback=None, tool_progress_callback=None, tool_start_callback=None,
         tool_complete_callback=None, gateway_session_key: Optional[str] = None,
         requested_model: Optional[str] = None, requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None, route: Optional[Dict[str, Any]] = None,
@@ -2150,6 +2152,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             "enabled_toolsets": enabled_toolsets, "session_id": session_id,
             "platform": "api_server",
             "stream_delta_callback": stream_delta_callback,
+            "reasoning_callback": reasoning_callback,
             "tool_progress_callback": tool_progress_callback,
             "tool_start_callback": tool_start_callback,
             "tool_complete_callback": tool_complete_callback,
@@ -3128,10 +3131,15 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             if delta:
                 events.enqueue("assistant.delta", {"message_id": message_id, "delta": delta})
 
+        def _reasoning(delta: str) -> None:
+            """Emit live model reasoning separately from assistant text."""
+            if delta:
+                events.enqueue("reasoning.delta", {"message_id": message_id, "delta": delta})
+
         def _tool_progress(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs) -> None:
-            if event_type == "reasoning.available":
-                events.enqueue("tool.progress", {"message_id": message_id, "tool_name": tool_name or "_thinking", "delta": preview or ""})
-            elif event_type in {"tool.started", "tool.completed", "tool.failed"}:
+            # Completion-time reasoning previews may contain assistant text; live reasoning
+            # is delivered through the dedicated callback above instead of a fake tool event.
+            if event_type in {"tool.started", "tool.completed", "tool.failed"}:
                 events.enqueue(event_type, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
 
         async def _run_and_signal() -> None:
@@ -3144,6 +3152,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 history = await self._conversation_history_for_session(session_id)
                 result, usage = await self._run_agent(
                     conversation_history=history, stream_delta_callback=_delta,
+                    reasoning_callback=_reasoning,
                     tool_progress_callback=_tool_progress, active_run_id=run_id, **ctx["run_kwargs"])
                 is_dict = isinstance(result, dict)
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if is_dict else "")
@@ -3623,7 +3632,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
     async def _run_agent(
         self, user_message: str, conversation_history: List[Dict[str, str]],
         ephemeral_system_prompt: Optional[str] = None, session_id: Optional[str] = None,
-        stream_delta_callback=None, tool_progress_callback=None, tool_start_callback=None,
+        stream_delta_callback=None, reasoning_callback=None, tool_progress_callback=None, tool_start_callback=None,
         tool_complete_callback=None, agent_ref: Optional[list] = None, active_run_id: Optional[str] = None,
         gateway_session_key: Optional[str] = None, requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None, model_options: Optional[Dict[str, Any]] = None,
@@ -3652,7 +3661,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 try:
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt, session_id=session_id,
-                        stream_delta_callback=stream_delta_callback, tool_progress_callback=tool_progress_callback,
+                        stream_delta_callback=stream_delta_callback, reasoning_callback=reasoning_callback,
+                        tool_progress_callback=tool_progress_callback,
                         tool_start_callback=tool_start_callback, tool_complete_callback=tool_complete_callback,
                         gateway_session_key=gateway_session_key, requested_model=requested_model,
                         requested_provider=requested_provider, model_options=model_options, route=route,

--- a/gateway/platforms/api_server_openai_routes.py
+++ b/gateway/platforms/api_server_openai_routes.py
@@ -145,6 +145,7 @@ class _ResponsesStream:
         self.reasoning_parts: List[str] = []
         self.reasoning_item: Optional[Dict[str, Any]] = None
         self.reasoning_opened = False
+        self.reasoning_enabled = adapter._reasoning_enabled()
         self.final_response_text = ""
         self.agent_error: Optional[str] = None
         self.usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
@@ -381,7 +382,7 @@ class _ResponsesStream:
             if agent_final and not self.final_response_text:
                 self.final_response_text = agent_final
             # Completed-message reasoning is only a compatibility fallback; live deltas win.
-            if isinstance(result, dict) and not self.reasoning_parts:
+            if self.reasoning_enabled and isinstance(result, dict) and not self.reasoning_parts:
                 turn_start = self.adapter._response_messages_turn_start_index(
                     self.conversation_history, self.user_message, result)
                 completed_reasoning = self.adapter._extract_reasoning_text(
@@ -965,7 +966,8 @@ class OpenAICompatRoutesMixin:
         response_data = {
             "id": response_id, "object": "response", "status": "completed",
             "created_at": created_at, "model": body.get("model", self._model_name),
-            "output": self._extract_output_items(result, start_index=output_start_index),
+            "output": self._extract_output_items(
+                result, start_index=output_start_index, include_reasoning=self._reasoning_enabled()),
             "usage": _responses_usage_payload(usage)}
         if store:
             self._response_store.put(response_id, {
@@ -1086,12 +1088,13 @@ class OpenAICompatRoutesMixin:
         return "\n\n".join(parts)
 
     @staticmethod
-    def _extract_output_items(result: Dict[str, Any], start_index: int = 0) -> List[Dict[str, Any]]:
-        """Build output items for the current turn, including one aggregated reasoning item."""
+    def _extract_output_items(
+        result: Dict[str, Any], start_index: int = 0, *, include_reasoning: bool,
+    ) -> List[Dict[str, Any]]:
         from gateway.platforms.api_server import _redact_api_error_text
         items: List[Dict[str, Any]] = []
         reasoning_text = OpenAICompatRoutesMixin._extract_reasoning_text(
-            result, start_index=start_index)
+            result, start_index=start_index) if include_reasoning else ""
         messages = result.get("messages", [])
         if start_index > 0:
             messages = messages[start_index:]

--- a/gateway/platforms/api_server_openai_routes.py
+++ b/gateway/platforms/api_server_openai_routes.py
@@ -140,6 +140,11 @@ class _ResponsesStream:
         self.message_item_id = f"msg_{uuid.uuid4().hex[:24]}"
         self.message_output_index: Optional[int] = None
         self.message_opened = False
+        self.reasoning_item_id = f"rs_{uuid.uuid4().hex[:24]}"
+        self.reasoning_output_index: Optional[int] = None
+        self.reasoning_parts: List[str] = []
+        self.reasoning_item: Optional[Dict[str, Any]] = None
+        self.reasoning_opened = False
         self.final_response_text = ""
         self.agent_error: Optional[str] = None
         self.usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
@@ -189,6 +194,17 @@ class _ResponsesStream:
             return
         text = "".join(self.final_text_parts) or self.final_response_text
         items = list(self.emitted_items)
+        if self.reasoning_item is not None and self.reasoning_parts:
+            reasoning_text = "".join(self.reasoning_parts)
+            incomplete_reasoning = {
+                **self.reasoning_item,
+                "summary": [{"type": "summary_text", "text": reasoning_text}],
+                "content": [{"type": "reasoning_text", "text": reasoning_text}],
+            }
+            items = [
+                incomplete_reasoning if item is self.reasoning_item else item
+                for item in items
+            ]
         history = self._history_with_user()
         if text:
             items.append(_message_item(text))
@@ -220,6 +236,53 @@ class _ResponsesStream:
             "type": "response.output_text.delta", "item_id": self.message_item_id,
             "output_index": self.message_output_index, "content_index": 0, "delta": delta_text,
             "logprobs": []})
+
+    async def _open_reasoning_item(self) -> None:
+        """Create the Responses reasoning item before its first live delta."""
+        if self.reasoning_opened:
+            return
+        self.reasoning_opened = True
+        self.reasoning_output_index = self.output_index
+        self.output_index += 1
+        self.reasoning_item = {
+            "id": self.reasoning_item_id,
+            "type": "reasoning",
+            "status": "in_progress",
+            "summary": [],
+            "content": [],
+        }
+        self.emitted_items.append(self.reasoning_item)
+        await self.write_event("response.output_item.added", {
+            "type": "response.output_item.added",
+            "output_index": self.reasoning_output_index,
+            "item": dict(self.reasoning_item),
+        })
+
+    async def emit_reasoning_delta(self, delta_text: str) -> None:
+        """Emit one live Responses reasoning delta in its own output item."""
+        await self._open_reasoning_item()
+        self.reasoning_parts.append(delta_text)
+        await self.write_event("response.reasoning_text.delta", {
+            "type": "response.reasoning_text.delta",
+            "item_id": self.reasoning_item_id,
+            "output_index": self.reasoning_output_index,
+            "content_index": 0,
+            "delta": delta_text,
+        })
+
+    async def close_reasoning_item(self) -> None:
+        """Finalize the reasoning output item after all live deltas are received."""
+        if not self.reasoning_opened or self.reasoning_item is None:
+            return
+        text = "".join(self.reasoning_parts)
+        self.reasoning_item["status"] = "completed"
+        self.reasoning_item["summary"] = [{"type": "summary_text", "text": text}]
+        self.reasoning_item["content"] = [{"type": "reasoning_text", "text": text}]
+        await self.write_event("response.output_item.done", {
+            "type": "response.output_item.done",
+            "output_index": self.reasoning_output_index,
+            "item": dict(self.reasoning_item),
+        })
 
     async def emit_tool_started(self, payload: Dict[str, Any]) -> None:
         """function_call ``output_item.added``; the agent's tool_call_id beats a generated call id."""
@@ -270,7 +333,9 @@ class _ResponsesStream:
         if isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], str):
             tag, payload = item
             await self.flush_batch()
-            if tag == "__tool_started__":
+            if tag == "__reasoning__":
+                await self.emit_reasoning_delta(payload)
+            elif tag == "__tool_started__":
                 await self.emit_tool_started(payload)
             elif tag == "__tool_completed__":
                 await self.emit_tool_completed(payload)
@@ -315,6 +380,14 @@ class _ResponsesStream:
                 await self.emit_text_delta(agent_final)
             if agent_final and not self.final_response_text:
                 self.final_response_text = agent_final
+            # Completed-message reasoning is only a compatibility fallback; live deltas win.
+            if isinstance(result, dict) and not self.reasoning_parts:
+                turn_start = self.adapter._response_messages_turn_start_index(
+                    self.conversation_history, self.user_message, result)
+                completed_reasoning = self.adapter._extract_reasoning_text(
+                    result, start_index=turn_start)
+                if completed_reasoning:
+                    await self.emit_reasoning_delta(completed_reasoning)
             if isinstance(result, dict) and result.get("error") and not self.final_response_text:
                 self.agent_error = self._api._redact_api_error_text(result["error"])
         except Exception as e:  # noqa: BLE001
@@ -322,6 +395,7 @@ class _ResponsesStream:
             self.agent_error = self._api._redact_api_error_text(e)
 
     async def close_message_item(self) -> None:
+        await self.close_reasoning_item()
         self.final_response_text = "".join(self.final_text_parts) or self.final_response_text
         if not self.message_opened:
             return
@@ -400,9 +474,16 @@ class OpenAICompatRoutesMixin:
             # the stream early. Called from the run_conversation worker thread: put_threadsafe.
             if delta is not None:
                 stream_q.put_threadsafe(delta)
+
+        def _on_reasoning(delta):
+            """Queue live reasoning separately from assistant answer text."""
+            if delta:
+                stream_q.put_threadsafe(("__reasoning__", delta))
+
         agent_ref = [None]
         agent_task = asyncio.ensure_future(self._run_agent(
-            stream_delta_callback=_on_delta, agent_ref=agent_ref, **run_kwargs))
+            stream_delta_callback=_on_delta, reasoning_callback=_on_reasoning,
+            agent_ref=agent_ref, **run_kwargs))
         agent_task.add_done_callback(lambda _fut: stream_q.put_nowait(None))
         return agent_task, agent_ref
 
@@ -983,11 +1064,31 @@ class OpenAICompatRoutesMixin:
         return out
 
     @staticmethod
+    def _extract_reasoning_text(result: Dict[str, Any], start_index: int = 0) -> str:
+        """Return completed-message reasoning for providers without live deltas.
+
+        Live ``reasoning_callback`` output is authoritative when available; this helper is
+        only a compatibility fallback for providers that expose reasoning on completion.
+        """
+        messages = result.get("messages", []) if isinstance(result, dict) else []
+        if start_index > 0:
+            messages = messages[start_index:]
+        parts: List[str] = []
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            reasoning = msg.get("reasoning_content") or msg.get("reasoning")
+            if isinstance(reasoning, str) and reasoning.strip():
+                parts.append(reasoning)
+        return "\n\n".join(parts)
+
+    @staticmethod
     def _extract_output_items(result: Dict[str, Any], start_index: int = 0) -> List[Dict[str, Any]]:
-        """Output items from ``result["messages"][start_index:]``: ``function_call`` per assistant
-        tool_call, ``function_call_output`` per tool message, then the final ``message``."""
+        """Build output items for the current turn, including one aggregated reasoning item."""
         from gateway.platforms.api_server import _redact_api_error_text
         items: List[Dict[str, Any]] = []
+        reasoning_text = OpenAICompatRoutesMixin._extract_reasoning_text(
+            result, start_index=start_index)
         messages = result.get("messages", [])
         if start_index > 0:
             messages = messages[start_index:]
@@ -1008,6 +1109,13 @@ class OpenAICompatRoutesMixin:
                     "id": f"fco_{uuid.uuid4().hex[:24]}", "type": "function_call_output",
                     "status": "completed", "call_id": msg.get("tool_call_id", ""),
                     "output": msg.get("content", "")})
+        if reasoning_text:
+            items.append({
+                "id": f"rs_{uuid.uuid4().hex[:24]}", "type": "reasoning",
+                "status": "completed",
+                "summary": [{"type": "summary_text", "text": reasoning_text}],
+                "content": [{"type": "reasoning_text", "text": reasoning_text}],
+            })
         final = result.get("final_response", "") or _redact_api_error_text(
             result.get("error", "(No response generated)"))
         items.append(_message_item(final))

--- a/gateway/platforms/api_server_openai_routes.py
+++ b/gateway/platforms/api_server_openai_routes.py
@@ -713,6 +713,9 @@ class OpenAICompatRoutesMixin:
                 if isinstance(delta, tuple) and len(delta) == 2 and delta[0] == "__tool_progress__":
                     # Custom event: tool lifecycle for frontends without markers in history.
                     await response.write(_sse_frame(delta[1], event="hermes.tool.progress"))
+                elif isinstance(delta, tuple) and len(delta) == 2 and delta[0] == "__reasoning__":
+                    # Keep live reasoning in its own OpenAI-compatible delta field.
+                    await response.write(_sse_frame(_chunk({"reasoning_content": delta[1]})))
                 else:
                     await response.write(_sse_frame(_chunk({"content": delta})))
             # The agent can fail after the queue drains (task raises / result flagged failed or

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -41,8 +41,7 @@ _USAGE_FIELDS = (
 _FIXED_EVENT_FIELDS = {
     "tool.started": lambda tool, preview, kw: {"tool": tool, "preview": preview},
     "tool.completed": lambda tool, preview, kw: {
-        "tool": tool, "duration": round(kw.get("duration", 0), 3), "error": kw.get("is_error", False)},
-    "reasoning.available": lambda tool, preview, kw: {"text": preview or ""}}
+        "tool": tool, "duration": round(kw.get("duration", 0), 3), "error": kw.get("is_error", False)}}
 
 
 def _remember_room_retention(request: "web.Request", claims: dict[str, Any]) -> None:
@@ -550,6 +549,13 @@ async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
         with suppress(Exception):
             loop.call_soon_threadsafe(run.put_event, _run_event(run_id, "message.delta", delta=delta))
 
+    def _reasoning_cb(delta: Optional[str]) -> None:
+        """Push live reasoning without mixing it into ``message.delta``."""
+        if not delta or run_id not in self._run_streams:
+            return
+        with suppress(Exception):
+            loop.call_soon_threadsafe(run.put_event, _run_event(run_id, "reasoning.delta", delta=delta))
+
     def _finish(status: str, extra: Optional[dict] = None, **fields: Any) -> None:
         """Terminal status, then best-effort ``run.<status>`` event; key order is wire shape."""
         extra = extra or {}
@@ -564,7 +570,8 @@ async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
             return
         with self._profile_scope(run.request_profile):
             agent = self._create_agent(
-                stream_delta_callback=_text_cb, tool_progress_callback=self._make_run_event_callback(run_id, loop),
+                stream_delta_callback=_text_cb, reasoning_callback=_reasoning_cb,
+                tool_progress_callback=self._make_run_event_callback(run_id, loop),
                 **run.agent_kwargs)
         self._active_run_agents[run_id] = agent
         approval_notify = _make_approval_notify(self, run, _api_server=_api_server)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -4407,6 +4407,585 @@ class TestSessionKeyHeader:
 
 
 # ---------------------------------------------------------------------------
+# Reasoning output items on /v1/responses (#21655, #7556)
+# ---------------------------------------------------------------------------
+
+
+def _parse_sse_events(body: str):
+    """Parse an SSE body into a list of (event_name, data_dict) tuples.
+
+    Spec-correct: multiple ``data:`` lines in one block are concatenated
+    with newlines before parsing; non-JSON payloads (e.g. ``[DONE]``
+    sentinels) are skipped rather than raising.
+    """
+    events = []
+    for block in body.split("\n\n"):
+        name, data_lines = None, []
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                name = line[len("event: "):]
+            elif line.startswith("data: "):
+                data_lines.append(line[len("data: "):])
+        if name is None or not data_lines:
+            continue
+        try:
+            events.append((name, json.loads("\n".join(data_lines))))
+        except ValueError:
+            continue
+    return events
+
+
+class TestResponsesReasoningItems:
+    """Reasoning output items are gated by display.platforms.api_server.show_reasoning.
+
+    Default off — existing Responses behavior must be byte-identical. When
+    enabled, the agent's ``reasoning.available`` events surface as
+    spec-shaped ``reasoning`` output items (streamed + final envelope).
+    """
+
+    @staticmethod
+    async def _agent_with_reasoning(reasoning_text, **kwargs):
+        reasoning_cb = kwargs.get("reasoning_callback")
+        text_cb = kwargs.get("stream_delta_callback")
+        if reasoning_cb:
+            reasoning_cb(reasoning_text)
+        if text_cb:
+            text_cb("Done.")
+        return (
+            {"final_response": "Done.", "messages": [], "api_calls": 1},
+            {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        )
+
+    def test_reasoning_items_enabled_reads_display_config(self, adapter):
+        with patch(
+            "gateway.run._load_gateway_config",
+            return_value={"display": {"platforms": {"api_server": {"show_reasoning": True}}}},
+        ):
+            assert adapter._reasoning_items_enabled() is True
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            assert adapter._reasoning_items_enabled() is False
+
+    def test_reasoning_items_enabled_logs_and_defaults_off_on_error(self, adapter, caplog):
+        import logging
+
+        with (
+            patch("gateway.run._load_gateway_config", side_effect=RuntimeError("config exploded")),
+            caplog.at_level(logging.DEBUG, logger="gateway.platforms.api_server"),
+        ):
+            assert adapter._reasoning_items_enabled() is False
+        assert any("show_reasoning" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_stream_gate_off_omits_reasoning_items(self, adapter):
+        """Default behavior is unchanged: no reasoning events, text untouched."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            seen_kwargs = {}
+
+            async def _mock_run_agent(**kwargs):
+                seen_kwargs.update(kwargs)
+                return await self._agent_with_reasoning("Plan: check the dates first.", **kwargs)
+
+            with (
+                patch.object(adapter, "_reasoning_items_enabled", return_value=False),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert '"type": "reasoning"' not in body
+                assert "reasoning_summary" not in body
+                assert "Plan: check the dates first." not in body
+                assert "Done." in body
+                # Gate off => the agent is not even wired for reasoning deltas.
+                assert seen_kwargs.get("reasoning_callback") is None
+
+    @pytest.mark.asyncio
+    async def test_stream_gate_on_emits_reasoning_item_events(self, adapter):
+        """Gate on → spec-shaped reasoning item events + final envelope item."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                return await self._agent_with_reasoning("Plan: check the dates first.", **kwargs)
+
+            with (
+                patch.object(adapter, "_reasoning_items_enabled", return_value=True),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            events = _parse_sse_events(body)
+            names = [n for n, _ in events]
+            assert "response.reasoning_summary_part.added" in names
+            assert "response.reasoning_summary_text.delta" in names
+            assert "response.reasoning_summary_text.done" in names
+
+            added_items = [
+                d["item"] for n, d in events
+                if n == "response.output_item.added" and d.get("item", {}).get("type") == "reasoning"
+            ]
+            assert len(added_items) == 1
+            assert added_items[0]["status"] == "in_progress"
+
+            done_items = [
+                d["item"] for n, d in events
+                if n == "response.output_item.done" and d.get("item", {}).get("type") == "reasoning"
+            ]
+            assert len(done_items) == 1
+            assert done_items[0]["status"] == "completed"
+            assert done_items[0]["summary"] == [
+                {"type": "summary_text", "text": "Plan: check the dates first."}
+            ]
+
+            completed = [d for n, d in events if n == "response.completed"]
+            assert len(completed) == 1
+            output = completed[0]["response"]["output"]
+            reasoning_items = [it for it in output if it.get("type") == "reasoning"]
+            assert len(reasoning_items) == 1
+            assert reasoning_items[0]["summary"][0]["text"] == "Plan: check the dates first."
+            # Envelope item carries the same correlation fields as the streamed item.
+            assert reasoning_items[0]["id"] == done_items[0]["id"]
+            assert reasoning_items[0]["status"] == "completed"
+            message_items = [it for it in output if it.get("type") == "message"]
+            assert message_items and message_items[-1]["content"][0]["text"] == "Done."
+
+            # Stored response (store=True default) carries the reasoning item too.
+            response_id = completed[0]["response"]["id"]
+            stored = adapter._response_store.get(response_id)
+            assert stored is not None
+            stored_reasoning = [
+                it for it in stored["response"]["output"] if it.get("type") == "reasoning"
+            ]
+            assert len(stored_reasoning) == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_reasoning_trimmed_in_completed_envelope(self, adapter):
+        """Incremental reasoning events carry the full text; only response.completed
+        and the store trim it (same policy as function_call args)."""
+        long_text = "R" * 2000
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                return await self._agent_with_reasoning(long_text, **kwargs)
+
+            with (
+                patch.object(adapter, "_reasoning_items_enabled", return_value=True),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            events = _parse_sse_events(body)
+            deltas = [d for n, d in events if n == "response.reasoning_summary_text.delta"]
+            assert any(d.get("delta") == long_text for d in deltas)
+
+            # Incremental "done" events carry the FULL reasoning text, consistent
+            # with the deltas above and with how function_call args stream.
+            summary_done = [d for n, d in events if n == "response.reasoning_summary_text.done"]
+            assert len(summary_done) == 1
+            assert summary_done[0]["text"] == long_text
+
+            done_items = [
+                d["item"] for n, d in events
+                if n == "response.output_item.done" and d.get("item", {}).get("type") == "reasoning"
+            ]
+            assert len(done_items) == 1
+            assert done_items[0]["summary"][0]["text"] == long_text
+
+            completed = [d for n, d in events if n == "response.completed"][0]
+            reasoning_items = [
+                it for it in completed["response"]["output"] if it.get("type") == "reasoning"
+            ]
+            assert len(reasoning_items) == 1
+            envelope_text = reasoning_items[0]["summary"][0]["text"]
+            assert len(envelope_text) < 700
+            assert "more chars" in envelope_text
+
+            stored = adapter._response_store.get(completed["response"]["id"])
+            assert stored is not None
+            stored_reasoning = [
+                it for it in stored["response"]["output"] if it.get("type") == "reasoning"
+            ]
+            assert len(stored_reasoning) == 1
+            assert stored_reasoning[0]["summary"][0]["text"] == envelope_text
+
+    @pytest.mark.asyncio
+    async def test_stream_falls_back_to_final_reasoning_when_callback_is_silent(self, adapter):
+        """If the provider only reports reasoning in final messages, stream mode still includes it."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                text_cb = kwargs.get("stream_delta_callback")
+                if text_cb:
+                    text_cb("Done.")
+                return (
+                    {
+                        "final_response": "Done.",
+                        "messages": [
+                            {"role": "user", "content": "hi"},
+                            {"role": "assistant", "content": "Done.", "reasoning_content": "thought about it"},
+                        ],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with (
+                patch.object(adapter, "_reasoning_items_enabled", return_value=True),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            events = _parse_sse_events(body)
+            event_names = [name for name, _ in events]
+            assert "response.reasoning_summary_part.added" in event_names
+            assert "response.reasoning_summary_text.delta" in event_names
+            assert "response.reasoning_summary_text.done" in event_names
+            fallback_added = [
+                data["item"]
+                for name, data in events
+                if name == "response.output_item.added"
+                and data.get("item", {}).get("type") == "reasoning"
+            ]
+            fallback_done = [
+                data["item"]
+                for name, data in events
+                if name == "response.output_item.done"
+                and data.get("item", {}).get("type") == "reasoning"
+            ]
+            assert len(fallback_added) == 1
+            assert len(fallback_done) == 1
+            assert fallback_added[0]["id"] == fallback_done[0]["id"]
+            assert fallback_done[0]["summary"] == [
+                {"type": "summary_text", "text": "thought about it"}
+            ]
+            completed = [d for n, d in events if n == "response.completed"]
+            assert len(completed) == 1
+            output = completed[0]["response"]["output"]
+            reasoning_items = [it for it in output if it.get("type") == "reasoning"]
+            assert len(reasoning_items) == 1
+            assert reasoning_items[0]["summary"][0]["text"] == "thought about it"
+
+            stored = adapter._response_store.get(completed[0]["response"]["id"])
+            assert stored is not None
+            stored_reasoning = [
+                it for it in stored["response"]["output"] if it.get("type") == "reasoning"
+            ]
+            assert len(stored_reasoning) == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_fallback_reasoning_interleaves_like_batch(self, adapter):
+        """Silent-callback fallback interleaves reasoning per message in the stored
+        output (reasoning -> tool -> result -> reasoning), matching the
+        non-streaming _extract_output_items order rather than clustering all
+        reasoning after the tool items."""
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "reasoning_content": "First inspect the journal.",
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "search", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "one entry"},
+            {"role": "assistant", "reasoning_content": "Now answer.", "content": "Answer."},
+        ]
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                # Tool lifecycle fires live; the reasoning callback stays silent
+                # so the final-message fallback path is exercised.
+                ts = kwargs.get("tool_start_callback")
+                tc = kwargs.get("tool_complete_callback")
+                if ts:
+                    ts("call_1", "search", {})
+                if tc:
+                    tc("call_1", "search", {}, "one entry")
+                text_cb = kwargs.get("stream_delta_callback")
+                if text_cb:
+                    text_cb("Answer.")
+                return (
+                    {"final_response": "Answer.", "messages": messages, "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with (
+                patch.object(adapter, "_reasoning_items_enabled", return_value=True),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            events = _parse_sse_events(body)
+            completed = [d for n, d in events if n == "response.completed"][0]
+            stream_types = [it["type"] for it in completed["response"]["output"]]
+
+            batch = APIServerAdapter._extract_output_items(
+                {"messages": messages, "final_response": "Answer."},
+                start_index=1,
+                include_reasoning=True,
+            )
+            assert stream_types == [it["type"] for it in batch]
+            assert stream_types == [
+                "reasoning",
+                "function_call",
+                "function_call_output",
+                "reasoning",
+                "message",
+            ]
+
+    @pytest.mark.asyncio
+    async def test_input_ignores_echoed_reasoning_items(self, adapter):
+        """Spec-compliant clients may echo reasoning items back; they must be skipped."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                return (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent) as mock_run:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {"role": "user", "content": "first question"},
+                            {"type": "reasoning", "id": "rs_1",
+                             "summary": [{"type": "summary_text", "text": "earlier thinking"}]},
+                            {"role": "assistant", "content": "earlier answer"},
+                            {"type": "reasoning", "id": "rs_2", "summary": []},
+                            {"role": "user", "content": "actual question"},
+                        ],
+                    },
+                )
+                assert resp.status == 200
+                kwargs = mock_run.call_args.kwargs
+                assert kwargs["user_message"] == "actual question"
+                # No empty turns injected by the skipped reasoning items.
+                assert all(m.get("content") for m in kwargs["conversation_history"])
+
+            # Reasoning item in LAST position must not shadow the real user message.
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent) as mock_run:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {"role": "user", "content": "hello"},
+                            {"type": "reasoning", "id": "rs_3", "summary": []},
+                        ],
+                    },
+                )
+                assert resp.status == 200
+                assert mock_run.call_args.kwargs["user_message"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_stream_reasoning_deltas_accumulate_into_one_item(self, adapter):
+        """Multiple reasoning deltas before text form a single reasoning item."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                reasoning_cb = kwargs.get("reasoning_callback")
+                text_cb = kwargs.get("stream_delta_callback")
+                if reasoning_cb:
+                    reasoning_cb("Plan: check ")
+                    reasoning_cb("the dates first.")
+                if text_cb:
+                    text_cb("Done.")
+                return (
+                    {"final_response": "Done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with (
+                patch.object(adapter, "_reasoning_items_enabled", return_value=True),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            events = _parse_sse_events(body)
+            deltas = [d for n, d in events if n == "response.reasoning_summary_text.delta"]
+            assert [d["delta"] for d in deltas] == ["Plan: check ", "the dates first."]
+            done_items = [
+                d["item"] for n, d in events
+                if n == "response.output_item.done" and d.get("item", {}).get("type") == "reasoning"
+            ]
+            assert len(done_items) == 1
+            assert done_items[0]["summary"] == [
+                {"type": "summary_text", "text": "Plan: check the dates first."}
+            ]
+
+    @pytest.mark.asyncio
+    async def test_stream_whitespace_only_reasoning_is_skipped(self, adapter):
+        """Whitespace-only reasoning text emits nothing (matches the batch strip check)."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                return await self._agent_with_reasoning("  \n\t ", **kwargs)
+
+            with (
+                patch.object(adapter, "_reasoning_items_enabled", return_value=True),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert '"type": "reasoning"' not in body
+                assert "reasoning_summary" not in body
+
+    @pytest.mark.asyncio
+    async def test_conversation_history_ignores_echoed_reasoning_items(self, adapter):
+        """Echoed reasoning items in conversation_history are skipped, not 400ed."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                return (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent) as mock_run:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "actual question",
+                        "conversation_history": [
+                            {"role": "user", "content": "first question"},
+                            {"type": "reasoning", "id": "rs_1",
+                             "summary": [{"type": "summary_text", "text": "earlier thinking"}]},
+                            {"role": "assistant", "content": "earlier answer"},
+                        ],
+                    },
+                )
+                assert resp.status == 200
+                history = mock_run.call_args.kwargs["conversation_history"]
+                assert all(m.get("content") for m in history)
+                assert all(m.get("type") != "reasoning" for m in history)
+
+    @pytest.mark.asyncio
+    async def test_batch_envelope_includes_reasoning_item_when_enabled(self, adapter):
+        """Non-streaming envelope mirrors the gate: reasoning item from message fields."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                return (
+                    {
+                        "final_response": "Done.",
+                        "messages": [
+                            {"role": "user", "content": "hi"},
+                            {"role": "assistant", "content": "Done.",
+                             "reasoning_content": "thought about it"},
+                        ],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with (
+                patch.object(adapter, "_reasoning_items_enabled", return_value=True),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                reasoning_items = [it for it in data["output"] if it.get("type") == "reasoning"]
+                assert len(reasoning_items) == 1
+                assert reasoning_items[0]["summary"][0]["text"] == "thought about it"
+                assert reasoning_items[0]["id"].startswith("rs_")
+                assert reasoning_items[0]["status"] == "completed"
+
+            with (
+                patch.object(adapter, "_reasoning_items_enabled", return_value=False),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert all(it.get("type") != "reasoning" for it in data["output"])
+
+    def test_batch_output_preserves_reasoning_tool_result_order(self):
+        """Reasoning stays beside the assistant message that produced it."""
+        result = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "reasoning_content": "First inspect the journal.",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "function": {
+                                "name": "mcp__journal__search",
+                                "arguments": '{"query":"Ithaca"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": "one matching entry",
+                },
+                {
+                    "role": "assistant",
+                    "reasoning_content": "Now answer from that evidence.",
+                    "content": "Ken wrote about Ithaca.",
+                },
+            ],
+            "final_response": "Ken wrote about Ithaca.",
+        }
+
+        items = APIServerAdapter._extract_output_items(result, include_reasoning=True)
+
+        assert [item["type"] for item in items] == [
+            "reasoning",
+            "function_call",
+            "function_call_output",
+            "reasoning",
+            "message",
+        ]
+        assert items[0]["summary"][0]["text"] == "First inspect the journal."
+        assert items[3]["summary"][0]["text"] == "Now answer from that evidence."
+
+
 # Per-client model routing (model_routes)
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1476,14 +1476,30 @@ class TestResponsesEndpoint:
 
     @pytest.mark.asyncio
     async def test_batch_preserves_reasoning_output_item(self, adapter):
-        """Non-streaming Responses output must not discard stored reasoning."""
+        """Non-streaming Responses aggregates turn reasoning into one item."""
         result = {
             "final_response": "answer",
-            "messages": [{
-                "role": "assistant",
-                "content": "answer",
-                "reasoning_content": "check facts",
-            }],
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning_content": "check facts",
+                    "tool_calls": [{
+                        "id": "call_lookup",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_lookup",
+                    "content": "facts",
+                },
+                {
+                    "role": "assistant",
+                    "content": "answer",
+                    "reasoning": "form answer",
+                },
+            ],
             "session_id": "responses-batch-reasoning-session",
         }
         app = _create_app(adapter)
@@ -1504,10 +1520,14 @@ class TestResponsesEndpoint:
                 payload = await resp.json()
 
         assert [item["type"] for item in payload["output"]] == [
-            "reasoning", "message"
+            "function_call", "function_call_output", "reasoning", "message"
         ]
-        assert payload["output"][0]["summary"] == [
-            {"type": "summary_text", "text": "check facts"}
+        reasoning_items = [
+            item for item in payload["output"] if item["type"] == "reasoning"
+        ]
+        assert len(reasoning_items) == 1
+        assert reasoning_items[0]["summary"] == [
+            {"type": "summary_text", "text": "check facts\n\nform answer"}
         ]
 
 
@@ -1910,7 +1930,8 @@ class TestResponsesStreaming:
 
         async def _agent_coro():
             # Feed partial reasoning and answer deltas into the stream queue...
-            stream_q.put_nowait(("__reasoning__", "partial thought"))
+            stream_q.put_nowait(("__reasoning__", "partial "))
+            stream_q.put_nowait(("__reasoning__", "thought"))
             stream_q.put_nowait("partial output")
             # ...then give the drain loop a moment to pick it up before
             # raising CancelledError to simulate a server-side cancel.
@@ -1952,13 +1973,15 @@ class TestResponsesStreaming:
             for part in item.get("content", [])
         )
         assert "partial output" in output_text
-        reasoning_text = "".join(
-            part.get("text", "")
+        reasoning_items = [
+            item
             for item in stored["response"].get("output", [])
             if item.get("type") == "reasoning"
-            for part in item.get("content", [])
-        )
-        assert reasoning_text == "partial thought"
+        ]
+        assert len(reasoning_items) == 1
+        assert reasoning_items[0]["content"] == [
+            {"type": "reasoning_text", "text": "partial thought"}
+        ]
 
     @pytest.mark.asyncio
     async def test_stream_client_disconnect_persists_incomplete_snapshot(self, adapter):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -650,6 +650,7 @@ class TestRunEventCallback:
 
             def run_conversation(self, user_message, conversation_history, task_id):
                 del user_message, conversation_history, task_id
+                self.reasoning_callback("")
                 self.reasoning_callback("check facts")
                 self.tool_progress_callback(
                     "reasoning.available", "_thinking", "answer misclassified", None
@@ -1103,6 +1104,7 @@ class TestChatCompletionsEndpoint:
     async def test_stream_emits_reasoning_content_before_answer(self, adapter):
         """OpenAI-compatible SSE keeps reasoning separate from answer text."""
         async def fake_run(**kwargs):
+            kwargs["reasoning_callback"]("")
             kwargs["reasoning_callback"]("check ")
             kwargs["reasoning_callback"]("facts")
             kwargs["stream_delta_callback"]("answer")
@@ -1783,6 +1785,7 @@ class TestResponsesStreaming:
     async def test_stream_emits_reasoning_item_and_live_deltas(self, adapter):
         """Responses SSE must stream reasoning and retain it in output items."""
         async def fake_run(**kwargs):
+            kwargs["reasoning_callback"]("")
             kwargs["reasoning_callback"]("check ")
             kwargs["reasoning_callback"]("facts")
             kwargs["stream_delta_callback"]("answer")
@@ -1791,7 +1794,9 @@ class TestResponsesStreaming:
                 "messages": [{
                     "role": "assistant",
                     "content": "answer",
-                    "reasoning_content": "check facts",
+                    # Live deltas are authoritative when the completed
+                    # provider payload contains an augmented representation.
+                    "reasoning_content": "check facts plus final-only detail",
                 }],
                 "session_id": "responses-reasoning-session",
             }, {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -180,6 +180,7 @@ class TestAdapterInit:
 
     def test_create_agent_forwards_runtime_config(self, monkeypatch):
         captured = {}
+        reasoning_callback = MagicMock()
 
         class FakeAgent:
             def __init__(self, **kwargs):
@@ -217,9 +218,13 @@ class TestAdapterInit:
         adapter = APIServerAdapter(PlatformConfig(enabled=True))
         monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
 
-        agent = adapter._create_agent(session_id="api-session")
+        agent = adapter._create_agent(
+            session_id="api-session",
+            reasoning_callback=reasoning_callback,
+        )
 
         assert isinstance(agent, FakeAgent)
+        assert captured["reasoning_callback"] is reasoning_callback
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
         assert captured["checkpoints_enabled"] is True
         assert captured["checkpoint_max_snapshots"] == 7
@@ -363,6 +368,7 @@ class TestAgentExecution:
         mock_agent.session_prompt_tokens = 1
         mock_agent.session_completion_tokens = 2
         mock_agent.session_total_tokens = 3
+        reasoning_callback = MagicMock()
 
         model_options = {"reasoning": {"enabled": False}, "fast": False}
         with patch.object(adapter, "_create_agent", return_value=mock_agent) as mock_create_agent:
@@ -373,6 +379,7 @@ class TestAgentExecution:
                 requested_model="MiniMax-M3",
                 requested_provider="minimax",
                 model_options=model_options,
+                reasoning_callback=reasoning_callback,
             )
 
         # _run_agent annotates result with the effective agent.session_id
@@ -386,6 +393,7 @@ class TestAgentExecution:
         assert create_kwargs["requested_model"] == "MiniMax-M3"
         assert create_kwargs["requested_provider"] == "minimax"
         assert create_kwargs["model_options"] == model_options
+        assert create_kwargs["reasoning_callback"] is reasoning_callback
         mock_agent.run_conversation.assert_called_once_with(
             user_message="hello",
             conversation_history=[],
@@ -625,6 +633,57 @@ class TestDisconnectedAgentReap:
 
 
 class TestRunEventCallback:
+
+    @pytest.mark.asyncio
+    async def test_run_emits_live_reasoning_not_completion_preview(self, adapter, monkeypatch):
+        """Run events must use model deltas, not completed assistant text."""
+        class FakeAgent:
+            session_prompt_tokens = 1
+            session_completion_tokens = 2
+            session_total_tokens = 3
+
+            def __init__(self, **kwargs):
+                self.session_id = kwargs["session_id"]
+                self.reasoning_callback = kwargs["reasoning_callback"]
+                self.stream_delta_callback = kwargs["stream_delta_callback"]
+                self.tool_progress_callback = kwargs["tool_progress_callback"]
+
+            def run_conversation(self, user_message, conversation_history, task_id):
+                del user_message, conversation_history, task_id
+                self.reasoning_callback("check facts")
+                self.tool_progress_callback(
+                    "reasoning.available", "_thinking", "answer misclassified", None
+                )
+                self.stream_delta_callback("answer")
+                return {"final_response": "answer"}
+
+        monkeypatch.setattr(adapter, "_create_agent", lambda **kwargs: FakeAgent(**kwargs))
+        app = web.Application()
+        app.router.add_post("/v1/runs", adapter._handle_runs)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/runs", json={"input": "reason first"})
+            assert resp.status == 202
+            run_id = (await resp.json())["run_id"]
+
+            events = []
+            queue = adapter._run_streams[run_id]
+            while True:
+                event = await asyncio.wait_for(queue.get(), timeout=2)
+                if event is None:
+                    break
+                events.append(event)
+
+        streamed = [
+            (event["event"], event.get("delta"))
+            for event in events
+            if event["event"] in {"reasoning.delta", "message.delta"}
+        ]
+        assert streamed == [
+            ("reasoning.delta", "check facts"),
+            ("message.delta", "answer"),
+        ]
+        assert not any(event["event"] == "reasoning.available" for event in events)
+        assert "answer misclassified" not in str(events)
 
     @pytest.mark.asyncio
     async def test_subagent_events_redact_secrets_and_carry_child_session(self, adapter):
@@ -873,6 +932,7 @@ class TestCapabilitiesEndpoint:
             assert data["runtime"]["split_runtime"] is False
             assert "API-server host" in data["runtime"]["description"]
             assert data["features"]["chat_completions"] is True
+            assert data["features"]["reasoning_streaming"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["runs_idempotency"] == {
@@ -1038,6 +1098,51 @@ class TestChatCompletionsEndpoint:
         assert kwargs["requested_model"] == "MiniMax-M3"
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
+
+    @pytest.mark.asyncio
+    async def test_stream_emits_reasoning_content_before_answer(self, adapter):
+        """OpenAI-compatible SSE keeps reasoning separate from answer text."""
+        async def fake_run(**kwargs):
+            kwargs["reasoning_callback"]("check ")
+            kwargs["reasoning_callback"]("facts")
+            kwargs["stream_delta_callback"]("answer")
+            return {
+                "final_response": "answer",
+                "session_id": "chat-reasoning-session",
+            }, {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+
+        app = _create_app(adapter)
+        with patch.object(adapter, "_run_agent", side_effect=fake_run):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": adapter._model_name,
+                        "messages": [{"role": "user", "content": "reason first"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        deltas = []
+        for line in body.splitlines():
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            payload = json.loads(line[len("data: "):])
+            choices = payload.get("choices") or []
+            if choices:
+                delta = choices[0].get("delta") or {}
+                if "reasoning_content" in delta:
+                    deltas.append(("reasoning", delta["reasoning_content"]))
+                if "content" in delta:
+                    deltas.append(("content", delta["content"]))
+
+        assert deltas == [
+            ("reasoning", "check "),
+            ("reasoning", "facts"),
+            ("content", "answer"),
+        ]
 
 
     @pytest.mark.asyncio
@@ -1369,6 +1474,42 @@ class TestResponsesEndpoint:
             assert data["output"][0]["content"][0]["type"] == "output_text"
             assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
 
+    @pytest.mark.asyncio
+    async def test_batch_preserves_reasoning_output_item(self, adapter):
+        """Non-streaming Responses output must not discard stored reasoning."""
+        result = {
+            "final_response": "answer",
+            "messages": [{
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_content": "check facts",
+            }],
+            "session_id": "responses-batch-reasoning-session",
+        }
+        app = _create_app(adapter)
+        with patch.object(
+            adapter,
+            "_run_agent",
+            new=AsyncMock(return_value=(
+                result,
+                {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+            )),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"input": "reason first", "store": False},
+                )
+                assert resp.status == 200
+                payload = await resp.json()
+
+        assert [item["type"] for item in payload["output"]] == [
+            "reasoning", "message"
+        ]
+        assert payload["output"][0]["summary"] == [
+            {"type": "summary_text", "text": "check facts"}
+        ]
+
 
     @pytest.mark.asyncio
     async def test_previous_response_id_stores_compressed_transcript_directly(self, adapter):
@@ -1618,6 +1759,74 @@ class TestResponsesEndpoint:
 
 class TestResponsesStreaming:
 
+    @pytest.mark.asyncio
+    async def test_stream_emits_reasoning_item_and_live_deltas(self, adapter):
+        """Responses SSE must stream reasoning and retain it in output items."""
+        async def fake_run(**kwargs):
+            kwargs["reasoning_callback"]("check ")
+            kwargs["reasoning_callback"]("facts")
+            kwargs["stream_delta_callback"]("answer")
+            return {
+                "final_response": "answer",
+                "messages": [{
+                    "role": "assistant",
+                    "content": "answer",
+                    "reasoning_content": "check facts",
+                }],
+                "session_id": "responses-reasoning-session",
+            }, {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+
+        app = _create_app(adapter)
+        with patch.object(adapter, "_run_agent", side_effect=fake_run):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"input": "reason first", "stream": True, "store": False},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        events = []
+        for block in body.split("\n\n"):
+            event_name = None
+            payload = None
+            for line in block.splitlines():
+                if line.startswith("event: "):
+                    event_name = line[len("event: "):]
+                elif line.startswith("data: "):
+                    payload = json.loads(line[len("data: "):])
+            if event_name and payload is not None:
+                events.append((event_name, payload))
+
+        live = [
+            payload["delta"]
+            for name, payload in events
+            if name == "response.reasoning_text.delta"
+        ]
+        assert live == ["check ", "facts"]
+
+        reasoning_added = next(
+            payload for name, payload in events
+            if name == "response.output_item.added"
+            and payload["item"]["type"] == "reasoning"
+        )
+        message_added = next(
+            payload for name, payload in events
+            if name == "response.output_item.added"
+            and payload["item"]["type"] == "message"
+        )
+        assert reasoning_added["output_index"] < message_added["output_index"]
+
+        completed = next(
+            payload["response"] for name, payload in events
+            if name == "response.completed"
+        )
+        assert [item["type"] for item in completed["output"]] == [
+            "reasoning", "message"
+        ]
+        assert completed["output"][0]["content"] == [
+            {"type": "reasoning_text", "text": "check facts"}
+        ]
 
     @pytest.mark.asyncio
     async def test_stream_task_done_callback_enqueues_eos_for_responses(self, adapter):
@@ -1700,7 +1909,8 @@ class TestResponsesStreaming:
         stream_q = api_mod.ThreadSafeAsyncQueue()
 
         async def _agent_coro():
-            # Feed one partial delta into the stream queue...
+            # Feed partial reasoning and answer deltas into the stream queue...
+            stream_q.put_nowait(("__reasoning__", "partial thought"))
             stream_q.put_nowait("partial output")
             # ...then give the drain loop a moment to pick it up before
             # raising CancelledError to simulate a server-side cancel.
@@ -1742,6 +1952,13 @@ class TestResponsesStreaming:
             for part in item.get("content", [])
         )
         assert "partial output" in output_text
+        reasoning_text = "".join(
+            part.get("text", "")
+            for item in stored["response"].get("output", [])
+            if item.get("type") == "reasoning"
+            for part in item.get("content", [])
+        )
+        assert reasoning_text == "partial thought"
 
     @pytest.mark.asyncio
     async def test_stream_client_disconnect_persists_incomplete_snapshot(self, adapter):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -187,33 +187,16 @@ class TestAdapterInit:
                 captured.update(kwargs)
 
         monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
-        monkeypatch.setattr(
-            "gateway.run._resolve_runtime_agent_kwargs",
-            lambda: {
-                "provider": "openai-codex",
-                "base_url": "https://example.test/v1",
-                "api_mode": "codex_responses",
+        _stub_agent_runtime(monkeypatch, {
+            "agent": {"reasoning_effort": "xhigh"},
+            "display": {"platforms": {"api_server": {"show_reasoning": True}}},
+            "checkpoints": {
+                "enabled": True,
+                "max_snapshots": 7,
+                "max_total_size_mb": 321,
+                "max_file_size_mb": 4,
             },
-        )
-        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "gpt-5.5")
-        monkeypatch.setattr(
-            "gateway.run._load_gateway_config",
-            lambda: {
-                "agent": {"reasoning_effort": "xhigh"},
-                "checkpoints": {
-                    "enabled": True,
-                    "max_snapshots": 7,
-                    "max_total_size_mb": 321,
-                    "max_file_size_mb": 4,
-                },
-            },
-        )
-        monkeypatch.setattr(
-            "gateway.run.GatewayRunner._load_reasoning_config",
-            staticmethod(lambda model="": {"enabled": True, "effort": "xhigh"}),
-        )
-        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
-        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+        })
 
         adapter = APIServerAdapter(PlatformConfig(enabled=True))
         monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
@@ -353,6 +336,26 @@ def adapter():
 @pytest.fixture
 def auth_adapter():
     return _make_adapter(api_key="sk-secret")
+
+
+@pytest.fixture
+def reasoning_enabled(adapter, monkeypatch):
+    monkeypatch.setattr(adapter, "_reasoning_enabled", lambda: True)
+
+
+def _stub_agent_runtime(monkeypatch, config):
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {"provider": "openai-codex", "base_url": "https://example.test/v1", "api_mode": "codex_responses"},
+    )
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "gpt-5.5")
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: config)
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_reasoning_config",
+        staticmethod(lambda model="": {"enabled": True, "effort": "xhigh"}),
+    )
+    monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+    monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
 
 
 # ---------------------------------------------------------------------------
@@ -917,7 +920,7 @@ class TestModelsEndpoint:
 
 class TestCapabilitiesEndpoint:
     @pytest.mark.asyncio
-    async def test_capabilities_advertises_plugin_safe_contract(self, adapter):
+    async def test_capabilities_advertises_plugin_safe_contract(self, adapter, reasoning_enabled):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/v1/capabilities")
@@ -1477,7 +1480,7 @@ class TestResponsesEndpoint:
             assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
 
     @pytest.mark.asyncio
-    async def test_batch_preserves_reasoning_output_item(self, adapter):
+    async def test_batch_preserves_reasoning_output_item(self, adapter, reasoning_enabled):
         """Non-streaming Responses aggregates turn reasoning into one item."""
         result = {
             "final_response": "answer",
@@ -3332,3 +3335,74 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="s2", gateway_session_key="ch")
         assert captured[1]["model"] == "anthropic/claude-opus-4.6"
+
+
+class TestReasoningGate:
+    @pytest.mark.asyncio
+    async def test_capabilities_follow_config_yaml(self, adapter, monkeypatch, tmp_path):
+        monkeypatch.setattr("gateway.run._gateway_config_home", lambda: tmp_path)
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            data = await (await cli.get("/v1/capabilities")).json()
+            assert data["features"]["reasoning_streaming"] is False
+            (tmp_path / "config.yaml").write_text(
+                "display:\n  platforms:\n    api_server:\n      show_reasoning: true\n", encoding="utf-8")
+            data = await (await cli.get("/v1/capabilities")).json()
+            assert data["features"]["reasoning_streaming"] is True
+
+    def test_create_agent_drops_callback_when_config_is_off(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        _stub_agent_runtime(monkeypatch, {"agent": {"reasoning_effort": "xhigh"}})
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        adapter._create_agent(session_id="api-session", reasoning_callback=MagicMock())
+        assert captured["reasoning_callback"] is None
+
+    @pytest.mark.asyncio
+    async def test_responses_stream_gate_off_skips_completed_reasoning_fallback(self, adapter):
+        async def fake_run(**kwargs):
+            kwargs["stream_delta_callback"]("answer")
+            return {
+                "final_response": "answer",
+                "messages": [{"role": "assistant", "content": "answer", "reasoning_content": "secret plan"}],
+                "session_id": "gate-off-stream",
+            }, {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+
+        app = _create_app(adapter)
+        with (
+            patch.object(adapter, "_reasoning_enabled", return_value=False),
+            patch.object(adapter, "_run_agent", side_effect=fake_run),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post("/v1/responses", json={"input": "hi", "stream": True, "store": False})
+                assert resp.status == 200
+                body = await resp.text()
+        assert '"type": "reasoning"' not in body
+        assert "secret plan" not in body
+        assert "answer" in body
+
+    @pytest.mark.asyncio
+    async def test_responses_batch_gate_off_omits_reasoning_item(self, adapter):
+        result = {
+            "final_response": "answer",
+            "messages": [{"role": "assistant", "content": "answer", "reasoning_content": "secret plan"}],
+            "session_id": "gate-off-batch",
+        }
+        app = _create_app(adapter)
+        with (
+            patch.object(adapter, "_reasoning_enabled", return_value=False),
+            patch.object(adapter, "_run_agent", new=AsyncMock(return_value=(
+                result, {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}))),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post("/v1/responses", json={"input": "hi", "store": False})
+                assert resp.status == 200
+                payload = await resp.json()
+        assert [item["type"] for item in payload["output"]] == ["message"]
+        assert "secret plan" not in json.dumps(payload)

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -374,6 +374,7 @@ async def test_session_chat_stream_emits_live_reasoning_deltas(adapter, session_
     session_id = session_db.create_session("reasoning-stream-session", "api_server")
 
     async def fake_run(**kwargs):
+        kwargs["reasoning_callback"]("")
         kwargs["reasoning_callback"]("check ")
         kwargs["reasoning_callback"]("evidence")
         # This legacy completion-time callback contains assistant content, not

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -366,6 +366,63 @@ async def test_session_chat_stream_run_completed_carries_turn_transcript(adapter
     assert any(m.get("tool_calls") for m in messages)
 
 
+@pytest.mark.asyncio
+async def test_session_chat_stream_emits_live_reasoning_deltas(adapter, session_db):
+    """Reasoning must stream before answer text and must not be a fake tool."""
+    import json as _json
+
+    session_id = session_db.create_session("reasoning-stream-session", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["reasoning_callback"]("check ")
+        kwargs["reasoning_callback"]("evidence")
+        # This legacy completion-time callback contains assistant content, not
+        # a real reasoning delta.  The API adapter must ignore it.
+        kwargs["tool_progress_callback"](
+            "reasoning.available", "_thinking", "final answer misclassified", None
+        )
+        kwargs["stream_delta_callback"]("answer")
+        return {
+            "final_response": "answer",
+            "session_id": session_id,
+        }, {"total_tokens": 3}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "reason out loud"},
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    events = []
+    for block in body.split("\n\n"):
+        event_name = None
+        payload = None
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                event_name = line[len("event: "):]
+            elif line.startswith("data: "):
+                payload = _json.loads(line[len("data: "):])
+        if event_name and payload is not None:
+            events.append((event_name, payload))
+
+    streamed = [
+        (name, payload["delta"])
+        for name, payload in events
+        if name in {"reasoning.delta", "assistant.delta"}
+    ]
+    assert streamed == [
+        ("reasoning.delta", "check "),
+        ("reasoning.delta", "evidence"),
+        ("assistant.delta", "answer"),
+    ]
+    assert not any(name == "tool.progress" for name, _ in events)
+    assert "final answer misclassified" not in body
+
+
 # ---------------------------------------------------------------------------
 # Session-persisted model threading + provider-auth failure surfacing
 # (salvaged from PR #57947 by @FvanW and PR #59941 by @kaishi00)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2135,7 +2135,7 @@ display:
 
 From the CLI, use the canonical path — `hermes config set display.platforms.telegram.streaming false`. The shorthand `hermes config set platforms.telegram.streaming false` is accepted too: because per-platform *display* settings (`streaming`, `show_reasoning`, `tool_progress`, …) are only ever read from `display.platforms`, `config set`/`get`/`unset` redirect that shorthand to the canonical key and print a note. Connection keys under the top-level `platforms.<name>` block (`token`, `enabled`, `reply_to_mode`, `extra`) are not redirected.
 
-Platforms without an override fall back to the global `tool_progress` value. Valid platform keys: `telegram`, `discord`, `slack`, `signal`, `whatsapp`, `matrix`, `mattermost`, `email`, `sms`, `homeassistant`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`. The legacy `display.tool_progress_overrides` key still loads for backward compatibility but is deprecated and migrated into `display.platforms` on first load.
+Platforms without an override fall back to the global `tool_progress` value. Valid platform keys: `telegram`, `discord`, `slack`, `signal`, `whatsapp`, `matrix`, `mattermost`, `email`, `sms`, `homeassistant`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, `api_server`. The legacy `display.tool_progress_overrides` key still loads for backward compatibility but is deprecated and migrated into `display.platforms` on first load.
 
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -112,6 +112,8 @@ Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs re
 - **Chat Completions**: Hermes emits `event: hermes.tool.progress` for tool-start visibility without polluting persisted assistant text.
 - **Responses**: Hermes emits spec-native `function_call` and `function_call_output` output items during the SSE stream, so clients can render structured tool UI in real time.
 
+**Reasoning in streams**: Reasoning-capable providers keep thinking separate from assistant output. Chat Completions emits `choices[0].delta.reasoning_content`; Responses emits a `reasoning` output item with `response.reasoning_text.delta` events. The non-streaming Responses payload also preserves reasoning in `output[]`.
+
 ### POST /v1/responses
 
 OpenAI Responses API format. Supports server-side conversation state via `previous_response_id` — the server stores full conversation history (including tool calls and results) so multi-turn context is preserved without the client managing it.
@@ -471,7 +473,7 @@ Statuses are retained briefly after terminal states (`completed`, `failed`, or `
 
 ### GET /v1/runs/\{run_id\}/events
 
-Server-Sent Events stream of the run's tool-call progress, token deltas, and lifecycle events. Designed for dashboards and thick clients that want to attach/detach without losing state.
+Server-Sent Events stream of the run's tool-call progress, answer token deltas, reasoning deltas, and lifecycle events. Answer text uses `message.delta`; model thinking uses the separate `reasoning.delta` event. Designed for dashboards and thick clients that want to attach/detach without losing state.
 
 When the agent delegates work to background subagents, the stream also carries
 `subagent.start` and `subagent.complete` lifecycle events, so clients can
@@ -552,7 +554,7 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `GET` | `/api/sessions/{id}/messages` | Message history for a session |
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
 | `POST` | `/api/sessions/{id}/chat` | Run one synchronous agent turn |
-| `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
+| `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `reasoning.delta`, `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -250,7 +250,10 @@ Returns a machine-readable description of the API server's stable surface for ex
   "auth": {"type": "bearer", "required": true},
   "features": {
     "chat_completions": true,
+    "chat_completions_streaming": true,
     "responses_api": true,
+    "responses_streaming": true,
+    "reasoning_streaming": true,
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
@@ -260,6 +263,14 @@ Returns a machine-readable description of the API server's stable surface for ex
 ```
 
 Use this endpoint when integrating dashboards, browser UIs, or control planes so they can discover whether the running Hermes version supports runs, streaming, cancellation, and session continuity without depending on private Python internals.
+
+Clients that render model thinking should check `features.reasoning_streaming`
+before subscribing to reasoning events. When it is `true`, consume the
+surface-specific reasoning channel (`reasoning.delta`,
+`choices[0].delta.reasoning_content`, or `response.reasoning_text.delta`)
+instead of the legacy synthetic `_thinking` tool-progress event. If the flag is
+absent or `false`, fall back to rendering assistant text without a live
+reasoning view.
 
 ## Browser-extension control
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -112,7 +112,7 @@ Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs re
 - **Chat Completions**: Hermes emits `event: hermes.tool.progress` for tool-start visibility without polluting persisted assistant text.
 - **Responses**: Hermes emits spec-native `function_call` and `function_call_output` output items during the SSE stream, so clients can render structured tool UI in real time.
 
-**Reasoning in streams**: Reasoning-capable providers keep thinking separate from assistant output. Chat Completions emits `choices[0].delta.reasoning_content`; Responses emits a `reasoning` output item with `response.reasoning_text.delta` events. The non-streaming Responses payload also preserves reasoning in `output[]`.
+**Reasoning in streams**: Reasoning-capable providers keep thinking separate from assistant output. Chat Completions emits `choices[0].delta.reasoning_content`; Responses emits a `reasoning` output item with `response.reasoning_text.delta` events. The non-streaming Responses payload also preserves reasoning in `output[]`. Reasoning streams and output items on these endpoints are gated by `display.platforms.api_server.show_reasoning` (falling back to `display.show_reasoning`), default off. With the gate off no reasoning callback is installed and no reasoning is emitted.
 
 ### POST /v1/responses
 
@@ -253,7 +253,7 @@ Returns a machine-readable description of the API server's stable surface for ex
     "chat_completions_streaming": true,
     "responses_api": true,
     "responses_streaming": true,
-    "reasoning_streaming": true,
+    "reasoning_streaming": false,
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
@@ -268,9 +268,10 @@ Clients that render model thinking should check `features.reasoning_streaming`
 before subscribing to reasoning events. When it is `true`, consume the
 surface-specific reasoning channel (`reasoning.delta`,
 `choices[0].delta.reasoning_content`, or `response.reasoning_text.delta`)
-instead of the legacy synthetic `_thinking` tool-progress event. If the flag is
-absent or `false`, fall back to rendering assistant text without a live
-reasoning view.
+instead of the legacy synthetic `_thinking` tool-progress event. The flag
+reflects the resolved `display.platforms.api_server.show_reasoning` gate, so it
+stays `false` until an operator opts in. If the flag is absent or `false`, fall
+back to rendering assistant text without a live reasoning view.
 
 ## Browser-extension control
 


### PR DESCRIPTION
Stacked on #93730. Review the last commit only until that lands.

## What does this PR do?

#93730 wires `reasoning_callback` through the API server and emits reasoning on every surface unconditionally. This PR makes those surfaces honor `display.platforms.api_server.show_reasoning`, resolved through the gateway's display-bool resolver like every other platform. `api_server` defaults off via `_TIER_HIGH`, so an operator opts in with one config key, and `display.show_reasoning: true` enables it too.

The callback is gated once, where the agent is built (`_create_agent`), so Chat Completions, Responses, Runs SSE, and session SSE inherit it. The Responses batch item and the completed-message stream fallback read reasoning from the result messages, so those two are gated at their own sites. `/v1/capabilities` reports `reasoning_streaming` from the resolved gate instead of a static `true`, so a client can trust the flag before it subscribes.

Stored transcripts are not filtered. `GET /api/sessions/{id}/messages` and the session-chat `run.completed` payload still return the `reasoning_content` the agent persisted. The gate covers what the API server emits during a run, not what the session store holds.

## Related Issue

Related: #7556. It asks for reasoning in the non-streaming `/v1/chat/completions` payload when `show_reasoning` is on. Neither #93730 nor this PR adds that. This PR makes the surfaces #93730 added honor the same key.

Related: #21655 (carried by #93730)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`: `_reasoning_enabled()` resolves the gate. `_create_agent` passes `reasoning_callback` only when it is on. `reasoning_streaming` leaves `_STATIC_FEATURE_FLAGS` and is computed per request in `_handle_capabilities`.
- `gateway/platforms/api_server_openai_routes.py`: `_ResponsesStream` skips the completed-message reasoning fallback when the gate is off. `_extract_output_items` takes `include_reasoning` and the batch handler passes the gate.
- `tests/gateway/test_api_server.py`: four invariants. A real `config.yaml` in a temp home flips `/v1/capabilities` both ways. `_create_agent` drops the callback through the real resolver with an empty config. The Responses stream fallback and the batch envelope stay silent with the gate off. The existing runtime-forwarding test now sets the gate in its patched config.
- `website/docs/user-guide/features/api-server.md`: the reasoning paragraph and the capabilities section say the surfaces are gated, the sample shows the default `false`, and the flag reflects the gate.
- `website/docs/user-guide/configuration.md`: `api_server` joins the valid `display.platforms` keys.

## How to Test

1. `PYTHONPATH=$PWD .venv/bin/pytest -q tests/gateway/test_api_server.py tests/gateway/test_session_api.py` on this head: 139 passed.
2. Start the API server with a reasoning-capable model and no `show_reasoning` config. `GET /v1/capabilities` returns `"reasoning_streaming": false`, and a `POST /v1/responses` stream carries no `reasoning` items.
3. `hermes config set display.platforms.api_server.show_reasoning true`, restart. The flag flips to `true` and reasoning items appear on the same request.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the two gateway files above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, no filesystem or subprocess changes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
