### PR TITLE
fix: propagate CLI command exit codes

### DIFF
--- a/hermes
+++ b/hermes
@@ -8,4 +8,5 @@ subcommands such as `gateway`, `cron`, and `doctor`.
 
 if __name__ == "__main__":
     from hermes_cli.main import main
-    main()
+
+    raise SystemExit(main())

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4582,7 +4582,7 @@ def cmd_cron(args):
     """Cron job management."""
     from hermes_cli.cron import cron_command
 
-    cron_command(args)
+    return cron_command(args)
 
 
 def cmd_sync(args):
@@ -11155,6 +11155,11 @@ def cmd_claw(args):
     claw_command(args)
 
 
+def _normalize_exit_code(result: object) -> int:
+    """Map command handler results to process exit codes without treating bool as int."""
+    return result if type(result) is int else 0
+
+
 def main():
     """Main entry point for hermes CLI."""
     # Cosmetic: make the process show up as 'hermes' instead of 'python3.11'
@@ -11199,9 +11204,9 @@ def main():
         pass
 
     if _try_termux_fast_tui_launch():
-        return
+        return 0
     if _try_termux_fast_cli_launch():
-        return
+        return 0
 
     from hermes_cli._parser import build_top_level_parser
 
@@ -12495,7 +12500,7 @@ def main():
     # Handle --version flag
     if args.version:
         cmd_version(args)
-        return
+        return 0
 
     # --yolo: set HERMES_YOLO_MODE *before* plugin discovery.  The call to
     # _prepare_agent_startup() below triggers discover_plugins() → tool
@@ -12537,8 +12542,7 @@ def main():
         ]:
             if not hasattr(args, attr):
                 setattr(args, attr, default)
-        result = cmd_chat(args)
-        return int(result) if isinstance(result, int) else 0
+        return _normalize_exit_code(cmd_chat(args))
 
     # Default to chat if no command specified
     if args.command is None:
@@ -12554,8 +12558,7 @@ def main():
         ]:
             if not hasattr(args, attr):
                 setattr(args, attr, default)
-        result = cmd_chat(args)
-        return int(result) if isinstance(result, int) else 0
+        return _normalize_exit_code(cmd_chat(args))
 
     # Execute the command.  Propagate the handler's return code as the
     # process exit code so subcommands that signal failure (e.g.
@@ -12563,8 +12566,7 @@ def main():
     # is misconfigured) actually exit non-zero.  Handlers that return
     # None are treated as success (exit 0).
     if hasattr(args, "func"):
-        result = args.func(args)
-        return int(result) if isinstance(result, int) else 0
+        return _normalize_exit_code(args.func(args))
     else:
         parser.print_help()
         return 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12537,8 +12537,8 @@ def main():
         ]:
             if not hasattr(args, attr):
                 setattr(args, attr, default)
-        cmd_chat(args)
-        return
+        result = cmd_chat(args)
+        return int(result) if isinstance(result, int) else 0
 
     # Default to chat if no command specified
     if args.command is None:
@@ -12554,8 +12554,8 @@ def main():
         ]:
             if not hasattr(args, attr):
                 setattr(args, attr, default)
-        cmd_chat(args)
-        return
+        result = cmd_chat(args)
+        return int(result) if isinstance(result, int) else 0
 
     # Execute the command.  Propagate the handler's return code as the
     # process exit code so subcommands that signal failure (e.g.
@@ -12563,12 +12563,12 @@ def main():
     # is misconfigured) actually exit non-zero.  Handlers that return
     # None are treated as success (exit 0).
     if hasattr(args, "func"):
-        rc = args.func(args)
-        if isinstance(rc, int) and rc != 0:
-            sys.exit(rc)
+        result = args.func(args)
+        return int(result) if isinstance(result, int) else 0
     else:
         parser.print_help()
+        return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/hermes_cli/test_kanban_cli_exit_codes.py
+++ b/tests/hermes_cli/test_kanban_cli_exit_codes.py
@@ -1,0 +1,36 @@
+"""Kanban CLI process-level exit-code tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def test_missing_board_json_command_exits_nonzero(tmp_path):
+    """A missing --board must fail the shell command, not just print stderr."""
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "kanban",
+            "--board",
+            "definitely-missing-board",
+            "list",
+            "--json",
+        ],
+        cwd=os.environ.get("HERMES_REPO_UNDER_TEST", os.getcwd()),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "kanban: board 'definitely-missing-board' does not exist" in result.stderr

--- a/tests/hermes_cli/test_kanban_cli_exit_codes.py
+++ b/tests/hermes_cli/test_kanban_cli_exit_codes.py
@@ -7,8 +7,8 @@ import subprocess
 import sys
 
 
-def test_missing_board_json_command_exits_nonzero(tmp_path):
-    """A missing --board must fail the shell command, not just print stderr."""
+def test_nonexistent_board_json_command_exits_nonzero(tmp_path):
+    """A nonexistent board must fail the shell command, not just print stderr."""
     env = os.environ.copy()
     env["HERMES_HOME"] = str(tmp_path)
 
@@ -31,6 +31,5 @@ def test_missing_board_json_command_exits_nonzero(tmp_path):
         check=False,
     )
 
-    assert result.returncode != 0
-    assert result.stdout == ""
+    assert result.returncode == 1
     assert "kanban: board 'definitely-missing-board' does not exist" in result.stderr

--- a/tests/hermes_cli/test_launcher.py
+++ b/tests/hermes_cli/test_launcher.py
@@ -1,9 +1,13 @@
 """Tests for the top-level `./hermes` launcher script."""
 
+import os
 import runpy
+import subprocess
 import sys
 import types
 from pathlib import Path
+
+import pytest
 
 
 def test_launcher_delegates_to_argparse_entrypoint(monkeypatch):
@@ -15,6 +19,7 @@ def test_launcher_delegates_to_argparse_entrypoint(monkeypatch):
 
     def fake_main():
         called.append("hermes_cli.main")
+        return 7
 
     fake_main_module.main = fake_main
     monkeypatch.setitem(sys.modules, "hermes_cli.main", fake_main_module)
@@ -37,6 +42,29 @@ def test_launcher_delegates_to_argparse_entrypoint(monkeypatch):
 
     monkeypatch.setattr(sys, "argv", [str(launcher_path), "gateway", "status"])
 
-    runpy.run_path(str(launcher_path), run_name="__main__")
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_path(str(launcher_path), run_name="__main__")
 
     assert called == ["hermes_cli.main"]
+    assert exc.value.code == 7
+
+
+def test_launcher_propagates_cron_failure(tmp_path):
+    """The tracked launcher must preserve failures returned by delegated commands."""
+    repo_root = Path(__file__).resolve().parents[2]
+    launcher_path = repo_root / "hermes"
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(launcher_path), "cron", "pause", "definitely-missing-job"],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Job with ID or name 'definitely-missing-job' not found" in result.stdout

--- a/tests/hermes_cli/test_main_exit_codes.py
+++ b/tests/hermes_cli/test_main_exit_codes.py
@@ -1,0 +1,47 @@
+"""CLI entrypoint exit-code propagation tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_main_returns_integer_status_from_dispatched_command(monkeypatch):
+    """Console-script wrappers must receive integer command failures."""
+    from hermes_cli import main as main_mod
+
+    def fake_cmd_kanban(args):
+        return 7
+
+    monkeypatch.setattr(main_mod, "cmd_kanban", fake_cmd_kanban)
+    monkeypatch.setattr("sys.argv", ["hermes", "kanban", "list"])
+
+    assert main_mod.main() == 7
+
+
+def test_main_preserves_none_return_as_success(monkeypatch):
+    """Commands that historically returned None should still mean success."""
+    from hermes_cli import main as main_mod
+
+    def fake_cmd_config(args):
+        return None
+
+    monkeypatch.setattr(main_mod, "cmd_config", fake_cmd_config)
+    monkeypatch.setattr("sys.argv", ["hermes", "config"])
+
+    assert main_mod.main() == 0
+
+
+def test_main_preserves_system_exit_from_dispatched_command(monkeypatch):
+    """Commands that already raise SystemExit should keep owning their exit."""
+    from hermes_cli import main as main_mod
+
+    def fake_cmd_config(args):
+        raise SystemExit(3)
+
+    monkeypatch.setattr(main_mod, "cmd_config", fake_cmd_config)
+    monkeypatch.setattr("sys.argv", ["hermes", "config"])
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 3

--- a/tests/hermes_cli/test_main_exit_codes.py
+++ b/tests/hermes_cli/test_main_exit_codes.py
@@ -5,6 +5,32 @@ from __future__ import annotations
 import pytest
 
 
+@pytest.mark.parametrize(
+    "fast_path",
+    ["_try_termux_fast_tui_launch", "_try_termux_fast_cli_launch"],
+)
+def test_main_fast_launch_success_returns_zero(monkeypatch, fast_path):
+    """Successful fast-launch shortcuts should return an explicit zero status."""
+    from hermes_cli import main as main_mod
+
+    monkeypatch.setattr(main_mod, "_try_termux_fast_tui_launch", lambda: False)
+    monkeypatch.setattr(main_mod, "_try_termux_fast_cli_launch", lambda: False)
+    monkeypatch.setattr(main_mod, fast_path, lambda: True)
+    monkeypatch.setattr("sys.argv", ["hermes"])
+
+    assert main_mod.main() == 0
+
+
+def test_main_version_success_returns_zero(monkeypatch):
+    """Top-level version handling should return an explicit zero status."""
+    from hermes_cli import main as main_mod
+
+    monkeypatch.setattr(main_mod, "cmd_version", lambda args: None)
+    monkeypatch.setattr("sys.argv", ["hermes", "--version"])
+
+    assert main_mod.main() == 0
+
+
 def test_main_returns_integer_status_from_dispatched_command(monkeypatch):
     """Console-script wrappers must receive integer command failures."""
     from hermes_cli import main as main_mod
@@ -24,6 +50,19 @@ def test_main_preserves_none_return_as_success(monkeypatch):
 
     def fake_cmd_config(args):
         return None
+
+    monkeypatch.setattr(main_mod, "cmd_config", fake_cmd_config)
+    monkeypatch.setattr("sys.argv", ["hermes", "config"])
+
+    assert main_mod.main() == 0
+
+
+def test_main_preserves_boolean_return_as_success(monkeypatch):
+    """Truth-valued handler results are not process exit codes."""
+    from hermes_cli import main as main_mod
+
+    def fake_cmd_config(args):
+        return True
 
     monkeypatch.setattr(main_mod, "cmd_config", fake_cmd_config)
     monkeypatch.setattr("sys.argv", ["hermes", "config"])


### PR DESCRIPTION
## Summary
- propagate exact integer return values from top-level CLI command handlers out of `hermes_cli.main.main()`
- preserve success for handlers that return `None`, booleans, or other non-status values
- forward delegated cron return codes through `cmd_cron()`
- make both `python -m hermes_cli.main` and the tracked `./hermes` launcher exit through `main()`
- return explicit zero statuses from successful top-level fast-launch, version, chat, and help paths

## Why
`hermes kanban --board <missing> list --json` printed a real missing-board error to stderr but exited `0`, because `cmd_kanban()` returned `1` and top-level `main()` discarded it. That silently breaks automation that trusts shell exit codes.

The same bug class affected other integer-returning handlers, including cron failures, and the tracked repository launcher also discarded the status returned by `main()`.

## Review feedback addressed
- normalize only exact `int` results so `True` remains success instead of becoming exit code `1`
- centralize normalization in `_normalize_exit_code()`
- propagate `cron_command()` failures
- update the tracked launcher and its tests
- make successful top-level returns explicitly `0`
- rename the nonexistent-board test and remove its brittle empty-stdout assertion

## Verification
- RED: the focused suite failed on the pre-review implementation with 6 expected failures covering boolean normalization, explicit success returns, launcher propagation, and cron propagation
- GREEN: `bash scripts/run_tests.sh tests/hermes_cli/test_main_exit_codes.py tests/hermes_cli/test_kanban_cli_exit_codes.py tests/hermes_cli/test_launcher.py`
  - `10 passed, 0 failed`
- Adjacent regression set: `bash scripts/run_tests.sh tests/hermes_cli/test_cron.py tests/hermes_cli/test_cron_parser_builder.py tests/hermes_cli/test_setup_noninteractive.py tests/hermes_cli/test_startup_plugin_gating.py`
  - `66 passed, 0 failed`
- Full repository gate: `bash scripts/run_tests.sh`
  - `39,161 passed, 15 failed`
  - none of the 11 failing test files or 15 timeout/import-error files overlap the five changed files; the focused and adjacent suites above are green
- `python -m py_compile` on the changed Python files
- Ruff lint on the changed Python files: clean
- `git diff --check`: clean
