### PR TITLE
fix(skills): add global skills dir to trusted dirs for symlink fix (#43551)

### DIFF
--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1112,6 +1112,17 @@ def skill_view(
             _trusted_dirs.extend(d.resolve() for d in all_dirs[1:])
         except Exception:
             pass
+        # Also trust the global ~/.hermes/skills/ directory so symlinks from
+        # user-specific HERMES_HOME/skills/ to the global dir don't trigger
+        # false-positive security warnings (issue #43551).
+        try:
+            _global_skills = Path.home() / ".hermes" / "skills"
+            if _global_skills.is_dir():
+                _global_skills_resolved = _global_skills.resolve()
+                if _global_skills_resolved not in _trusted_dirs:
+                    _trusted_dirs.append(_global_skills_resolved)
+        except Exception:
+            pass
         for _td in _trusted_dirs:
             try:
                 skill_md.resolve().relative_to(_td)


### PR DESCRIPTION
Fixes #43551. Skills loaded via symlink from the global skills directory (~/.hermes/skills/) triggered a false security warning. Added the global skills directory to the trusted dirs list in the security check so symlinked skills are recognized as legitimate.