### PR TITLE
fix(cron): release tick lock before job execution

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1886,6 +1886,26 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
             lock_fd.close()
         return 0
 
+    lock_released = False
+
+    def _release_tick_lock():
+        """Release the cross-process tick lock exactly once."""
+        nonlocal lock_released
+        if lock_released or lock_fd is None:
+            return
+        if fcntl:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except (OSError, IOError):
+                pass
+        elif msvcrt:
+            try:
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+            except (OSError, IOError):
+                pass
+        lock_fd.close()
+        lock_released = True
+
     try:
         due_jobs = get_due_jobs()
 
@@ -1900,6 +1920,12 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         # before any execution begins.  This preserves at-most-once semantics.
         for job in due_jobs:
             advance_next_run(job["id"])
+
+        # The lock only guards due-job selection and pre-run advancement.  Do
+        # not hold it while jobs execute: a long-running job would otherwise
+        # block later gateway ticks, leaving newly-due jobs stuck scheduled with
+        # next_run_at in the past until the long job exits.
+        _release_tick_lock()
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
@@ -2022,17 +2048,7 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
 
         return sum(_results)
     finally:
-        if fcntl:
-            try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
-                pass
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+        _release_tick_lock()
 
 
 if __name__ == "__main__":

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import threading
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
@@ -1268,6 +1269,56 @@ class TestRunJobSessionPersistence:
         assert success is True
         assert error is None
         assert final_response == "all good"
+
+    def test_tick_releases_scheduler_lock_before_executing_long_jobs(self, tmp_path):
+        """A long-running due job must not keep the global tick lock held.
+
+        Regression: the gateway ticker held ``.tick.lock`` for the entire job
+        execution. While a long cron job was still running, later ticks skipped
+        entirely, so newly-due jobs stayed ``scheduled`` with ``last_run_at=None``.
+        The lock should protect due-job selection/advance only; job execution can
+        continue while the next tick selects and starts other due jobs.
+        """
+        import cron.scheduler as sched
+
+        long_job = {"id": "long-job", "name": "long", "prompt": "slow"}
+        smoke_job = {"id": "smoke-job", "name": "smoke", "prompt": "quick"}
+        long_entered = threading.Event()
+        release_long = threading.Event()
+        calls = []
+
+        def fake_get_due_jobs():
+            # First tick sees a long job. A subsequent tick, while that job is
+            # still in run_job(), must be able to acquire the tick lock and see
+            # the smoke job instead of skipping due to the old long-held lock.
+            return [long_job] if len(calls) == 0 else [smoke_job]
+
+        def fake_run_job(job):
+            calls.append(job["id"])
+            if job["id"] == "long-job":
+                long_entered.set()
+                assert release_long.wait(5), "test timed out waiting to release long job"
+            return True, f"output {job['id']}", f"response {job['id']}", None
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", side_effect=fake_get_due_jobs), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.run_job", side_effect=fake_run_job), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.mark_job_run"), \
+             patch("cron.scheduler._deliver_result", return_value=None):
+            first_tick = threading.Thread(target=sched.tick, kwargs={"verbose": False})
+            first_tick.start()
+            assert long_entered.wait(5), "first tick never started the long job"
+
+            second_count = sched.tick(verbose=False)
+
+            release_long.set()
+            first_tick.join(timeout=5)
+            assert not first_tick.is_alive(), "first tick did not finish"
+
+        assert second_count == 1
+        assert calls == ["long-job", "smoke-job"]
 
     def test_tick_marks_empty_response_as_error(self, tmp_path):
         """When run_job returns success=True but final_response is empty,


### PR DESCRIPTION
## Summary\n- release the cross-process cron tick lock after due-job selection and pre-run advancement instead of holding it through job execution\n- keep the existing at-most-once recurring-job advancement semantics\n- add a regression test proving a second tick can run a newly-due job while a previous long-running cron job is still executing\n\n## Test plan\n- python -m pytest tests/cron -q -o 'addopts='\n\n## Context\nObserved in gateway: a smoke-test cron job stayed scheduled with next_run_at in the past and last_run_at=null while another long-running cron job held ~/.hermes/cron/.tick.lock.