### PR TITLE
fix(context_compressor): prevent stale active_task poisoning in deterministic fallback

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1143,7 +1143,7 @@ class ContextCompressor(ContextEngine):
             completed.append(f"{idx}. {item}")
 
         active_task = (
-            f"User asked: {user_asks[-1]!r}"
+            "Indeterminate from compacted history — refer to the latest user message in the protected tail below."
             if user_asks
             else "Unknown from deterministic fallback."
         )


### PR DESCRIPTION
## Problem

When the LLM context summarizer times out or fails, the deterministic fallback path grabs  — the LAST user message from the compacted middle section. This message is typically 10-30 turns stale and gets injected into:
- '## Active Task'
- '## In Progress'  
- '## Pending User Asks'

The model then treats this stale task as current, overriding the actual latest user message in the protected tail.

## Impact

Users with long, tool-heavy sessions (like our production pipeline) see the agent repeatedly chasing old tasks from 20+ turns ago, even after explicit topic changes in live messages.

## Fix

Replace the stale  with neutral text directing the model to infer the active task from the protected tail messages instead.

### Before:


### After:


## Testing

- Verified the patched fallback summary no longer anchors stale tasks.
- Confirmed  and  stop inheriting the stale active_task variable.
- Searched codebase for additional  references — none found.