### PR TITLE
fix(whatsapp): honor proxy env vars during pairing

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -29,6 +29,7 @@ import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { buildSocketProxyOptions } from './proxy.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -196,6 +197,7 @@ async function startSocket() {
       // This is enough for Baileys to complete the retry handshake.
       return { conversation: '' };
     },
+    ...buildSocketProxyOptions(),
   });
 
   sock.ev.on('creds.update', () => { saveCreds(); lidToPhone = buildLidMap(); });

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -10,8 +10,18 @@
       "dependencies": {
         "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
         "express": "^4.21.0",
+        "https-proxy-agent": "^7.0.6",
         "pino": "^9.0.0",
         "qrcode-terminal": "^0.12.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@borewit/text-codec": {
@@ -1270,6 +1280,42 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2A4b5LY/NcI8h1wrt1AAJ2dZAX3T6iV3Czso4H16/7FlM30jCikmJp5mJDjT1mB5W6W0zN9bVQ==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
     "express": "^4.21.0",
+    "https-proxy-agent": "^7.0.6",
     "qrcode-terminal": "^0.12.0",
     "pino": "^9.0.0"
   },

--- a/scripts/whatsapp-bridge/proxy.js
+++ b/scripts/whatsapp-bridge/proxy.js
@@ -1,0 +1,38 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const PROXY_ENV_KEYS = [
+  'HTTPS_PROXY',
+  'https_proxy',
+  'HTTP_PROXY',
+  'http_proxy',
+];
+
+export function resolveProxyUrl(env = process.env) {
+  for (const key of PROXY_ENV_KEYS) {
+    const value = env?.[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return '';
+}
+
+function loadHttpsProxyAgent() {
+  return require('https-proxy-agent').HttpsProxyAgent;
+}
+
+export function createProxyAgent(env = process.env, ProxyAgentCtor = undefined) {
+  const proxyUrl = resolveProxyUrl(env);
+  if (!proxyUrl) {
+    return undefined;
+  }
+  const AgentCtor = ProxyAgentCtor || loadHttpsProxyAgent();
+  return new AgentCtor(proxyUrl);
+}
+
+export function buildSocketProxyOptions(env = process.env, ProxyAgentCtor = undefined) {
+  const agent = createProxyAgent(env, ProxyAgentCtor);
+  return agent ? { agent } : {};
+}

--- a/scripts/whatsapp-bridge/proxy.test.mjs
+++ b/scripts/whatsapp-bridge/proxy.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildSocketProxyOptions, createProxyAgent, resolveProxyUrl } from './proxy.js';
+
+class FakeProxyAgent {
+  constructor(proxyUrl) {
+    this.proxyUrl = proxyUrl;
+  }
+}
+
+test('resolveProxyUrl prefers HTTPS proxy variables first', () => {
+  const env = {
+    HTTP_PROXY: 'http://http-proxy.example:8080',
+    HTTPS_PROXY: 'http://https-proxy.example:8443',
+  };
+
+  assert.equal(resolveProxyUrl(env), 'http://https-proxy.example:8443');
+});
+
+test('resolveProxyUrl falls back across lowercase and HTTP variants', () => {
+  assert.equal(
+    resolveProxyUrl({ http_proxy: 'http://lower-http.example:8080' }),
+    'http://lower-http.example:8080',
+  );
+  assert.equal(
+    resolveProxyUrl({ HTTP_PROXY: 'http://upper-http.example:8080' }),
+    'http://upper-http.example:8080',
+  );
+  assert.equal(resolveProxyUrl({ HTTPS_PROXY: '   ' }), '');
+});
+
+test('createProxyAgent returns undefined when no proxy is configured', () => {
+  assert.equal(createProxyAgent({}), undefined);
+});
+
+test('buildSocketProxyOptions wires an HttpsProxyAgent for Baileys', () => {
+  const proxyUrl = 'http://proxy.example:3128';
+  const options = buildSocketProxyOptions({ HTTPS_PROXY: proxyUrl }, FakeProxyAgent);
+
+  assert.ok(options.agent instanceof FakeProxyAgent);
+  assert.equal(options.agent.proxyUrl, proxyUrl);
+});


### PR DESCRIPTION
## What does this PR do?

Teach the WhatsApp bridge to honor standard `HTTPS_PROXY` / `HTTP_PROXY` environment variables when Baileys opens its WebSocket connection. In proxied environments this lets pairing reach the QR-code step instead of looping on disconnect reason 408 before the bridge is usable.

## Related Issue

Fixes #43603

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/whatsapp-bridge/bridge.js`: pass proxy-derived socket options into `makeWASocket()` so Baileys uses proxy env vars during pairing and reconnect.
- `scripts/whatsapp-bridge/proxy.js`: add a narrow helper that resolves `HTTPS_PROXY` / `https_proxy` before `HTTP_PROXY` / `http_proxy` and lazily constructs the proxy agent.
- `scripts/whatsapp-bridge/proxy.test.mjs`: cover proxy env precedence and agent wiring without needing a live WhatsApp session.
- `scripts/whatsapp-bridge/package.json`: add the direct `https-proxy-agent` dependency the bridge now uses at runtime.
- `scripts/whatsapp-bridge/package-lock.json`: lock the new bridge dependency and its transitive packages for repo-local installs.

## How to Test

1. Run `npm install --prefix scripts/whatsapp-bridge`.
2. Run `node --test scripts/whatsapp-bridge/allowlist.test.mjs scripts/whatsapp-bridge/proxy.test.mjs`.
3. In a proxied environment, export `HTTPS_PROXY=http://proxy.example:3128` (or one of the lowercase / HTTP variants) and start the WhatsApp pairing flow; verify it reaches the QR-code step instead of repeating `Connection closed (reason: 408). Reconnecting in 3s...`.
4. Run `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` to exercise the repo test suite. In my local shared environment this aborted during collection because `fastapi` is missing (`tests/hermes_cli/test_dashboard_auth_401_reauth.py`), so CI or a fully provisioned local env should cover the Python suite.

## What platforms tested on

- macOS `darwin-arm64`
- Node.js `v26.0.0` for the bridge regression tests

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS `darwin-arm64`, Node.js `v26.0.0`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `node --test scripts/whatsapp-bridge/allowlist.test.mjs scripts/whatsapp-bridge/proxy.test.mjs` passed locally.
- The required broad pytest command aborted during collection with `ModuleNotFoundError: No module named 'fastapi'` in `tests/hermes_cli/test_dashboard_auth_401_reauth.py` before it reached any WhatsApp bridge code.

<!-- autocontrib:worker-id=issue-new-8a508c55 kind=pr-open -->