### PR TITLE
fix(desktop): persist composer drafts across reloads

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -23,7 +23,14 @@ import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
-import { $composerAttachments, clearComposerAttachments, type ComposerAttachment } from '@/store/composer'
+import {
+  $composerAttachments,
+  clearComposerAttachments,
+  clearPersistedComposerDraft,
+  type ComposerAttachment,
+  readPersistedComposerDraft,
+  writePersistedComposerDraft
+} from '@/store/composer'
 import {
   browseBackward,
   browseForward,
@@ -134,6 +141,7 @@ export function ChatBar({
   const scrolledUp = useStore($threadScrolledUp)
   const sessionMessages = useStore($messages)
   const activeQueueSessionKey = queueSessionKey || sessionId || null
+  const draftPersistenceScope = activeQueueSessionKey || null
 
   const queuedPrompts = useMemo(
     () => (activeQueueSessionKey ? (queuedPromptsBySession[activeQueueSessionKey] ?? []) : []),
@@ -145,6 +153,7 @@ export function ChatBar({
   const editorRef = useRef<HTMLDivElement | null>(null)
   const draftRef = useRef(draft)
   const previousBusyRef = useRef(busy)
+  const skipNextDraftPersistScopeRef = useRef<string | null>(null)
   const drainingQueueRef = useRef(false)
   const urlInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -171,10 +180,12 @@ export function ChatBar({
   const canSubmit = busy || hasComposerPayload
   const editingQueuedPrompt = queueEdit ? (queuedPrompts.find(entry => entry.id === queueEdit.entryId) ?? null) : null
   const busyAction = busy && hasComposerPayload ? 'queue' : 'stop'
+
   // Steer only makes sense mid-turn, text-only (the gateway can't carry images
   // into a tool result) and never for a slash command (those execute inline).
   const canSteer =
     busy && !!onSteer && attachments.length === 0 && trimmedDraft.length > 0 && !SLASH_COMMAND_RE.test(trimmedDraft)
+
   const showHelpHint = draft === '?'
 
   const { t } = useI18n()
@@ -1022,6 +1033,22 @@ export function ChatBar({
     }
   }
 
+  useEffect(() => {
+    const persisted = readPersistedComposerDraft(draftPersistenceScope)
+    skipNextDraftPersistScopeRef.current = draftPersistenceScope
+    loadIntoComposer(persisted, [])
+  }, [draftPersistenceScope]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (skipNextDraftPersistScopeRef.current === draftPersistenceScope) {
+      skipNextDraftPersistScopeRef.current = null
+
+      return
+    }
+
+    writePersistedComposerDraft(draftPersistenceScope, draft)
+  }, [draft, draftPersistenceScope])
+
   const beginQueuedEdit = (entry: QueuedPromptEntry) => {
     if (!activeQueueSessionKey || queueEdit) {
       return
@@ -1248,8 +1275,10 @@ export function ChatBar({
     // input event; refresh it from the editor once more to also cover an
     // in-flight keystroke that hasn't fired its input event yet.
     const editor = editorRef.current
+
     if (editor) {
       const domText = composerPlainText(editor)
+
       if (domText !== draftRef.current) {
         draftRef.current = domText
         aui.composer().setText(domText)
@@ -1273,7 +1302,17 @@ export function ChatBar({
         const submitted = text
         triggerHaptic('submit')
         clearDraft()
-        void onSubmit(submitted)
+        void Promise.resolve(onSubmit(submitted)).then(accepted => {
+          if (accepted === false) {
+            loadIntoComposer(submitted, [])
+            writePersistedComposerDraft(draftPersistenceScope, submitted)
+          } else {
+            clearPersistedComposerDraft(draftPersistenceScope)
+          }
+        }).catch(() => {
+          loadIntoComposer(submitted, [])
+          writePersistedComposerDraft(draftPersistenceScope, submitted)
+        })
       } else if (payloadPresent) {
         queueCurrentDraft()
       } else {
@@ -1286,11 +1325,22 @@ export function ChatBar({
       void drainNextQueued()
     } else if (payloadPresent) {
       const submitted = text
+      const submittedAttachments = cloneAttachments(attachments)
       triggerHaptic('submit')
       resetBrowseState(sessionId)
       clearDraft()
       clearComposerAttachments()
-      void onSubmit(submitted, { attachments })
+      void Promise.resolve(onSubmit(submitted, { attachments: submittedAttachments })).then(accepted => {
+        if (accepted === false) {
+          loadIntoComposer(submitted, submittedAttachments)
+          writePersistedComposerDraft(draftPersistenceScope, submitted)
+        } else {
+          clearPersistedComposerDraft(draftPersistenceScope)
+        }
+      }).catch(() => {
+        loadIntoComposer(submitted, submittedAttachments)
+        writePersistedComposerDraft(draftPersistenceScope, submitted)
+      })
     }
 
     focusInput()

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -3,9 +3,13 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   $composerAttachments,
   addComposerAttachment,
+  clearPersistedComposerDraft,
   type ComposerAttachment,
+  composerDraftStorageKey,
+  readPersistedComposerDraft,
   removeComposerAttachment,
-  updateComposerAttachment
+  updateComposerAttachment,
+  writePersistedComposerDraft
 } from './composer'
 
 function attachment(overrides: Partial<ComposerAttachment> & Pick<ComposerAttachment, 'id'>): ComposerAttachment {
@@ -39,5 +43,41 @@ describe('updateComposerAttachment', () => {
 
     expect(updated).toBe(false)
     expect($composerAttachments.get()).toHaveLength(0)
+  })
+})
+
+describe('persisted composer drafts', () => {
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('stores and restores text drafts per session scope', () => {
+    writePersistedComposerDraft('session-a', 'almost submitted prompt')
+    writePersistedComposerDraft('session-b', 'other draft')
+
+    expect(readPersistedComposerDraft('session-a')).toBe('almost submitted prompt')
+    expect(readPersistedComposerDraft('session-b')).toBe('other draft')
+  })
+
+  it('uses a stable new-session key when no session id exists yet', () => {
+    writePersistedComposerDraft(null, 'first prompt draft')
+
+    expect(window.localStorage.getItem(composerDraftStorageKey(null))).toBe('first prompt draft')
+    expect(readPersistedComposerDraft(undefined)).toBe('first prompt draft')
+  })
+
+  it('removes empty drafts instead of leaving stale text behind', () => {
+    writePersistedComposerDraft('session-a', 'saved')
+    writePersistedComposerDraft('session-a', '')
+
+    expect(readPersistedComposerDraft('session-a')).toBe('')
+    expect(window.localStorage.getItem(composerDraftStorageKey('session-a'))).toBeNull()
+  })
+
+  it('can explicitly clear a saved draft after submit', () => {
+    writePersistedComposerDraft('session-a', 'saved')
+    clearPersistedComposerDraft('session-a')
+
+    expect(readPersistedComposerDraft('session-a')).toBe('')
   })
 })

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -21,6 +21,68 @@ export const $composerDraft = atom('')
 export const $composerAttachments = atom<ComposerAttachment[]>([])
 export const $composerTerminalSelections = atom<Record<string, string>>({})
 
+const COMPOSER_DRAFT_STORAGE_PREFIX = 'hermes:composer-draft:v1:'
+const NEW_SESSION_DRAFT_SCOPE = '__new__'
+
+function storageScope(scope: string | null | undefined): string {
+  const trimmed = scope?.trim()
+
+  return trimmed || NEW_SESSION_DRAFT_SCOPE
+}
+
+function browserStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export function composerDraftStorageKey(scope: string | null | undefined): string {
+  return `${COMPOSER_DRAFT_STORAGE_PREFIX}${encodeURIComponent(storageScope(scope))}`
+}
+
+export function readPersistedComposerDraft(scope: string | null | undefined): string {
+  try {
+    return browserStorage()?.getItem(composerDraftStorageKey(scope)) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+export function writePersistedComposerDraft(scope: string | null | undefined, value: string) {
+  try {
+    const storage = browserStorage()
+
+    if (!storage) {
+      return
+    }
+
+    const key = composerDraftStorageKey(scope)
+
+    if (value.length === 0) {
+      storage.removeItem(key)
+    } else {
+      storage.setItem(key, value)
+    }
+  } catch {
+    // Draft persistence is a safety net only; storage quota/private-mode errors
+    // must never break typing or submission.
+  }
+}
+
+export function clearPersistedComposerDraft(scope: string | null | undefined) {
+  try {
+    browserStorage()?.removeItem(composerDraftStorageKey(scope))
+  } catch {
+    // Best-effort only.
+  }
+}
+
 export function setComposerDraft(value: string) {
   $composerDraft.set(value)
 }


### PR DESCRIPTION
## Problem

Hermes Desktop currently keeps the in-progress composer text only in React/editor state. If the app reloads, the gateway connection drops, the desktop shell restarts, or a submit attempt fails after the composer has already cleared, the user's almost-submitted prompt can disappear.

That failure mode is especially painful for long prompts: the user has not submitted the message yet, so there is no session transcript entry to recover from, and backend/session persistence cannot help.

## Solution

Persist the desktop composer draft at the UI layer, where the unsubmitted text actually lives:

- Add small localStorage helpers for composer draft persistence.
- Scope saved drafts by session/queue key so switching chats does not leak one chat's draft into another.
- Use a stable `__new__` draft scope before a first message has created a backend session id.
- Restore any saved draft when the composer mounts or switches scope.
- Keep draft persistence best-effort: localStorage quota/private-mode failures are swallowed so typing and submitting are never blocked.
- Clear the persisted draft only after `onSubmit` is accepted.
- If `onSubmit` rejects or returns `false`, restore the submitted text back into the composer and keep it persisted.

Attachments are still in-memory-only; this PR focuses on the text-draft loss that affects almost-submitted prompts.

## Test plan

- `cd apps/desktop && ../../node_modules/.bin/eslint src/store/composer.ts src/store/composer.test.ts src/app/chat/composer/index.tsx`
- `cd apps/desktop && npm run test:ui -- src/store/composer.test.ts src/app/chat/composer/enter-submit-dom-race.test.tsx`
- `cd apps/desktop && ./node_modules/.bin/tsc -b`

## Notes

This is intentionally a core Desktop composer fix rather than a plugin. Plugins/backend tools cannot reliably save text that has not left the browser/editor yet.
